### PR TITLE
feat: add project-scoped AI agent config as code

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -1,7 +1,10 @@
 import {
+    AgentAsCode,
     AiAgentThreadFilters,
     AiArtifactTSOACompat,
     AiClonedThreadCreatedFrom,
+    ApiAgentAsCodeListResponse,
+    ApiAgentAsCodeUpsertResponse,
     ApiAgentReadinessScoreResponse,
     ApiAgentSuggestionsResponse,
     ApiAiAgentArtifactResponseTSOACompat,
@@ -93,6 +96,7 @@ import {
 } from '../../controllers/authentication';
 import { BaseController } from '../../controllers/baseController';
 import Logger from '../../logging/logger';
+import { type AiAgentCoderService } from '../services/AiAgentCoderService/AiAgentCoderService';
 import { type AiAgentService } from '../services/AiAgentService/AiAgentService';
 
 @Route('/api/v1/projects/{projectUuid}/aiAgents')
@@ -125,6 +129,58 @@ export class AiAgentController extends BaseController {
             results: await this.getAiAgentService().listAgents(
                 toSessionUser(req.account),
                 projectUuid,
+            ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/code')
+    @OperationId('getAiAgentsAsCode')
+    async getAiAgentsAsCode(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Query() ids?: string[],
+        @Query() offset?: number,
+    ): Promise<ApiAgentAsCodeListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+
+        return {
+            status: 'ok',
+            results: await this.getAiAgentCoderService().downloadAgents(
+                toSessionUser(req.account),
+                projectUuid,
+                ids,
+                offset,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/code')
+    @OperationId('upsertAiAgentsAsCode')
+    async upsertAiAgentsAsCode(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Body() body: { agents: AgentAsCode[] },
+        @Query() force?: boolean,
+    ): Promise<ApiAgentAsCodeUpsertResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+
+        return {
+            status: 'ok',
+            results: await this.getAiAgentCoderService().upsertAgents(
+                toSessionUser(req.account),
+                projectUuid,
+                body.agents,
+                force,
             ),
         };
     }
@@ -2036,5 +2092,9 @@ export class AiAgentController extends BaseController {
 
     protected getAiAgentService() {
         return this.services.getAiAgentService<AiAgentService>();
+    }
+
+    protected getAiAgentCoderService() {
+        return this.services.getAiAgentCoderService<AiAgentCoderService>();
     }
 }

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -58,6 +58,7 @@ import { OrgAiCopilotConfigResolver } from './services/ai/OrgAiCopilotConfigReso
 import { BuiltInSkills } from './services/ai/skills/builtInSkills';
 import { AiAgentContentValidation } from './services/ai/utils/AiAgentContentValidation';
 import { AiAgentAdminService } from './services/AiAgentAdminService';
+import { AiAgentCoderService } from './services/AiAgentCoderService/AiAgentCoderService';
 import { AiAgentDocumentService } from './services/AiAgentDocumentService';
 import { AiAgentReviewClassifierService } from './services/AiAgentReviewClassifierService';
 import { AiAgentReviewNotificationService } from './services/AiAgentReviewNotificationService';
@@ -280,6 +281,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         featureFlagService: repository.getFeatureFlagService(),
                         aiModelCatalog,
                     }),
+                }),
+            aiAgentCoderService: ({ models, context }) =>
+                new AiAgentCoderService({
+                    lightdashConfig: context.lightdashConfig,
+                    aiAgentModel: models.getAiAgentModel(),
+                    projectModel: models.getProjectModel(),
                 }),
             aiAgentToolsService: ({ models, repository, context }) =>
                 new AiAgentToolsService({

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -75,6 +75,7 @@ import {
     UpdateSlackResponse,
     UpdateSlackResponseTs,
     UpdateWebAppResponse,
+    type AgentAsCode,
     type AiAgent,
     type AiAgentIntegration,
     type VerifiedContentListItem,
@@ -650,6 +651,90 @@ export class AiAgentModel {
         const rows = await query;
 
         return rows;
+    }
+
+    async findAgentsForCode({
+        organizationUuid,
+        projectUuid,
+        slugs,
+        agentUuids,
+    }: {
+        organizationUuid: string;
+        projectUuid: string;
+        slugs?: string[];
+        agentUuids?: string[];
+    }): Promise<
+        Array<
+            Pick<
+                AgentAsCode,
+                | 'slug'
+                | 'agentVersion'
+                | 'name'
+                | 'description'
+                | 'imageUrl'
+                | 'instruction'
+                | 'tags'
+                | 'enableDataAccess'
+                | 'enableSelfImprovement'
+                | 'enableContentTools'
+                | 'enableUserContext'
+                | 'modelConfig'
+                | 'updatedAt'
+            > & { uuid: string }
+        >
+    > {
+        const latestInstruction = this.database
+            .from(AiAgentInstructionVersionsTableName)
+            .select(
+                'ai_agent_uuid',
+                this.database.raw('instruction'),
+                this.database.raw(
+                    'ROW_NUMBER() OVER (PARTITION BY ai_agent_uuid ORDER BY created_at DESC) as rn',
+                ),
+            );
+
+        const query = this.database
+            .with('latest_instruction', latestInstruction)
+            .from(AiAgentTableName)
+            .select({
+                uuid: `${AiAgentTableName}.ai_agent_uuid`,
+                slug: `${AiAgentTableName}.slug`,
+                agentVersion: `${AiAgentTableName}.version`,
+                name: `${AiAgentTableName}.name`,
+                description: `${AiAgentTableName}.description`,
+                imageUrl: `${AiAgentTableName}.image_url`,
+                tags: `${AiAgentTableName}.tags`,
+                enableDataAccess: `${AiAgentTableName}.enable_data_access`,
+                enableSelfImprovement: `${AiAgentTableName}.enable_self_improvement`,
+                enableContentTools: `${AiAgentTableName}.enable_content_tools`,
+                enableUserContext: `${AiAgentTableName}.enable_user_context`,
+                modelConfig: `${AiAgentTableName}.model_config`,
+                updatedAt: `${AiAgentTableName}.updated_at`,
+                instruction: this.database.raw(`
+                    (SELECT instruction FROM latest_instruction
+                     WHERE ai_agent_uuid = ${AiAgentTableName}.ai_agent_uuid AND rn = 1)
+                `),
+            })
+            .where(`${AiAgentTableName}.organization_uuid`, organizationUuid)
+            .where(`${AiAgentTableName}.project_uuid`, projectUuid)
+            .where(`${AiAgentTableName}.is_system`, false)
+            .orderBy(`${AiAgentTableName}.slug`, 'asc');
+
+        if ((slugs?.length ?? 0) > 0 || (agentUuids?.length ?? 0) > 0) {
+            void query.where((builder) => {
+                if (slugs?.length) {
+                    void builder.whereIn(`${AiAgentTableName}.slug`, slugs);
+                }
+                if (agentUuids?.length) {
+                    void builder.orWhereIn(
+                        `${AiAgentTableName}.ai_agent_uuid`,
+                        agentUuids,
+                    );
+                }
+            });
+        }
+
+        return query;
     }
 
     async getAgentBySlackChannelId({
@@ -1790,14 +1875,18 @@ export class AiAgentModel {
         > & {
             organizationUuid: string;
             isSystem?: boolean;
+            slug?: string;
+            imageUrl?: string | null;
         },
     ): Promise<AiAgent> {
         return this.database.transaction(async (trx) => {
-            const slug = await AiAgentModel.generateUniqueSlug(
-                trx,
-                args.projectUuid,
-                args.name,
-            );
+            const slug =
+                args.slug ??
+                (await AiAgentModel.generateUniqueSlug(
+                    trx,
+                    args.projectUuid,
+                    args.name,
+                ));
 
             const [agent] = await trx(AiAgentTableName)
                 .insert({
@@ -1807,8 +1896,8 @@ export class AiAgentModel {
                     organization_uuid: args.organizationUuid,
                     tags: args.tags,
                     description: args.description ?? null,
-                    image_url: null,
-                    image_url_source: null,
+                    image_url: args.imageUrl ?? null,
+                    image_url_source: args.imageUrl ? 'url' : null,
                     enable_data_access: args.enableDataAccess,
                     enable_self_improvement: args.enableSelfImprovement,
                     enable_content_tools: args.enableContentTools ?? false,

--- a/packages/backend/src/ee/services/AiAgentCoderService/AiAgentCoderService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentCoderService/AiAgentCoderService.test.ts
@@ -1,0 +1,303 @@
+import { Ability } from '@casl/ability';
+import {
+    ContentAsCodeType,
+    OrganizationMemberRole,
+    type AgentAsCode,
+    type PossibleAbilities,
+    type SessionUser,
+} from '@lightdash/common';
+import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
+import { AiAgentCoderService } from './AiAgentCoderService';
+
+const projectUuid = 'project-uuid';
+const organizationUuid = 'organization-uuid';
+
+const buildUser = (ability: Ability<PossibleAbilities>): SessionUser => ({
+    userUuid: 'user-uuid',
+    email: 'admin@example.com',
+    firstName: 'Agent',
+    lastName: 'Admin',
+    organizationUuid,
+    organizationName: 'Test organization',
+    organizationCreatedAt: new Date(),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    avatarUrl: null,
+    avatarGradient: null,
+    timezone: null,
+    isSetupComplete: true,
+    userId: 1,
+    role: OrganizationMemberRole.ADMIN,
+    isActive: true,
+    abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ability,
+});
+
+const user = buildUser(
+    new Ability<PossibleAbilities>([
+        {
+            action: ['view', 'manage'],
+            subject: 'ContentAsCode',
+            conditions: { projectUuid, organizationUuid },
+        },
+        {
+            action: 'manage',
+            subject: 'AiAgent',
+            conditions: { projectUuid, organizationUuid },
+        },
+    ]),
+);
+
+const agentRow = {
+    uuid: 'agent-uuid',
+    slug: 'revenue-agent',
+    agentVersion: 2 as const,
+    name: 'Revenue agent',
+    description: 'Answers revenue questions',
+    imageUrl: null,
+    instruction: 'Use certified metrics.',
+    tags: ['sales', 'certified'],
+    enableDataAccess: true,
+    enableSelfImprovement: false,
+    enableContentTools: true,
+    enableUserContext: false,
+    modelConfig: null,
+    updatedAt: new Date('2026-07-14T08:00:00.000Z'),
+};
+
+const agentAsCode: AgentAsCode = {
+    contentType: ContentAsCodeType.AI_AGENT,
+    version: 1,
+    agentVersion: 2,
+    slug: 'revenue-agent',
+    name: 'Revenue agent',
+    description: 'Answers revenue questions',
+    imageUrl: null,
+    instruction: 'Use certified metrics.',
+    tags: ['certified', 'sales'],
+    enableDataAccess: true,
+    enableSelfImprovement: false,
+    enableContentTools: true,
+    enableUserContext: false,
+    modelConfig: null,
+};
+
+const buildService = ({ existing = [agentRow] } = {}) => {
+    const aiAgentModel = {
+        findAgentsForCode: vi.fn(async () => existing),
+        updateAgent: vi.fn(async () => undefined),
+        createAgent: vi.fn(async () => undefined),
+    };
+    const service = new AiAgentCoderService({
+        aiAgentModel: aiAgentModel as never,
+        projectModel: {
+            getSummary: vi.fn(async () => ({
+                projectUuid,
+                organizationUuid,
+            })),
+        } as never,
+        lightdashConfig: lightdashConfigMock,
+    });
+
+    return { service, aiAgentModel };
+};
+
+describe('AiAgentCoderService', () => {
+    it('exports project-scoped agent configuration with deterministic tags', async () => {
+        const { service, aiAgentModel } = buildService();
+
+        const result = await service.downloadAgents(user, projectUuid, [
+            'revenue-agent',
+        ]);
+
+        expect(result.agents).toEqual([
+            {
+                ...agentAsCode,
+                updatedAt: agentRow.updatedAt,
+            },
+        ]);
+        expect(result.missingIds).toEqual([]);
+        expect(aiAgentModel.findAgentsForCode).toHaveBeenCalledWith({
+            organizationUuid,
+            projectUuid,
+            slugs: ['revenue-agent'],
+            agentUuids: undefined,
+        });
+    });
+
+    it('looks up UUID-shaped identifiers as both slugs and UUIDs', async () => {
+        const uuidIdentifier = '550e8400-e29b-41d4-a716-446655440000';
+        const { service, aiAgentModel } = buildService({ existing: [] });
+
+        await service.downloadAgents(user, projectUuid, [uuidIdentifier]);
+
+        expect(aiAgentModel.findAgentsForCode).toHaveBeenCalledWith({
+            organizationUuid,
+            projectUuid,
+            slugs: [uuidIdentifier],
+            agentUuids: [uuidIdentifier],
+        });
+    });
+
+    it('does not update an unchanged agent', async () => {
+        const { service, aiAgentModel } = buildService();
+
+        const result = await service.upsertAgents(user, projectUuid, [
+            agentAsCode,
+        ]);
+
+        expect(result).toEqual({
+            created: [],
+            updated: [],
+            unchanged: ['revenue-agent'],
+            deleted: [],
+        });
+        expect(aiAgentModel.updateAgent).not.toHaveBeenCalled();
+    });
+
+    it('updates the managed project configuration without touching access or integrations', async () => {
+        const { service, aiAgentModel } = buildService();
+
+        const result = await service.upsertAgents(user, projectUuid, [
+            { ...agentAsCode, name: 'Revenue specialist' },
+        ]);
+
+        expect(result.updated).toEqual(['revenue-agent']);
+        expect(aiAgentModel.updateAgent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                agentUuid: 'agent-uuid',
+                name: 'Revenue specialist',
+                version: 2,
+                projectUuid,
+                organizationUuid,
+            }),
+        );
+        expect(aiAgentModel.updateAgent).toHaveBeenCalledWith(
+            expect.not.objectContaining({
+                groupAccess: expect.anything(),
+                userAccess: expect.anything(),
+                spaceAccess: expect.anything(),
+                integrations: expect.anything(),
+                mcpServerUuids: expect.anything(),
+            }),
+        );
+        expect(aiAgentModel.updateAgent).toHaveBeenCalledWith(
+            expect.not.objectContaining({
+                imageUrl: expect.anything(),
+                imageUrlSource: expect.anything(),
+            }),
+        );
+    });
+
+    it('updates avatar provenance only when the managed image URL changes', async () => {
+        const { service, aiAgentModel } = buildService();
+
+        await service.upsertAgents(user, projectUuid, [
+            {
+                ...agentAsCode,
+                imageUrl: 'https://example.com/avatar.png',
+            },
+        ]);
+
+        expect(aiAgentModel.updateAgent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                imageUrl: 'https://example.com/avatar.png',
+                imageUrlSource: 'url',
+            }),
+        );
+    });
+
+    it('preserves avatar provenance on a forced update when the URL is unchanged', async () => {
+        const { service, aiAgentModel } = buildService();
+
+        await service.upsertAgents(user, projectUuid, [agentAsCode], true);
+
+        expect(aiAgentModel.updateAgent).toHaveBeenCalledWith(
+            expect.not.objectContaining({
+                imageUrl: expect.anything(),
+                imageUrlSource: expect.anything(),
+            }),
+        );
+    });
+
+    it('creates a new agent with its declared slug, agent version, and safe empty access defaults', async () => {
+        const { service, aiAgentModel } = buildService({ existing: [] });
+
+        const result = await service.upsertAgents(user, projectUuid, [
+            { ...agentAsCode, agentVersion: 1 },
+        ]);
+
+        expect(result.created).toEqual(['revenue-agent']);
+        expect(aiAgentModel.createAgent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                slug: 'revenue-agent',
+                projectUuid,
+                organizationUuid,
+                integrations: [],
+                groupAccess: [],
+                userAccess: [],
+                spaceAccess: [],
+                mcpServerUuids: [],
+                version: 1,
+            }),
+        );
+    });
+
+    it('rejects duplicate slugs before changing agents', async () => {
+        const { service, aiAgentModel } = buildService();
+
+        await expect(
+            service.upsertAgents(user, projectUuid, [agentAsCode, agentAsCode]),
+        ).rejects.toThrow('Duplicate AI agent slugs in upload: revenue-agent');
+        expect(aiAgentModel.updateAgent).not.toHaveBeenCalled();
+        expect(aiAgentModel.createAgent).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        {
+            agent: { ...agentAsCode, version: 2 },
+            error: 'Unsupported AI agent as-code version 2',
+        },
+        {
+            agent: {
+                ...agentAsCode,
+                enableDataAccess: false,
+                enableContentTools: true,
+            },
+            error: 'must enable data access before enabling content tools',
+        },
+    ])(
+        'rejects invalid agent configuration: $error',
+        async ({ agent, error }) => {
+            const { service, aiAgentModel } = buildService();
+
+            await expect(
+                service.upsertAgents(user, projectUuid, [agent]),
+            ).rejects.toThrow(error);
+            expect(aiAgentModel.updateAgent).not.toHaveBeenCalled();
+            expect(aiAgentModel.createAgent).not.toHaveBeenCalled();
+        },
+    );
+
+    it('requires both content-as-code and AI-agent permissions', async () => {
+        const forbiddenUser = buildUser(
+            new Ability<PossibleAbilities>([
+                {
+                    action: 'manage',
+                    subject: 'AiAgent',
+                    conditions: { projectUuid, organizationUuid },
+                },
+            ]),
+        );
+        const { service } = buildService();
+
+        await expect(
+            service.downloadAgents(forbiddenUser, projectUuid),
+        ).rejects.toThrow('You are not allowed to download AI agents as code');
+        await expect(
+            service.upsertAgents(forbiddenUser, projectUuid, [agentAsCode]),
+        ).rejects.toThrow('You are not allowed to upload AI agents as code');
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentCoderService/AiAgentCoderService.ts
+++ b/packages/backend/src/ee/services/AiAgentCoderService/AiAgentCoderService.ts
@@ -1,0 +1,309 @@
+import { subject } from '@casl/ability';
+import {
+    ContentAsCodeType,
+    ForbiddenError,
+    ParameterError,
+    type AgentAsCode,
+    type AgentAsCodeUpsertChanges,
+    type SessionUser,
+} from '@lightdash/common';
+import isEqual from 'lodash/isEqual';
+import { validate as isValidUuid } from 'uuid';
+import { type LightdashConfig } from '../../../config/parseConfig';
+import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { BaseService } from '../../../services/BaseService';
+import { paginateAsCode } from '../../../services/CoderService/pagination';
+import { type AiAgentModel } from '../../models/AiAgentModel';
+
+const AGENT_AS_CODE_VERSION = 1;
+const AGENT_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+type AgentForCode = Awaited<
+    ReturnType<AiAgentModel['findAgentsForCode']>
+>[number];
+
+const toAgentAsCode = (agent: AgentForCode): AgentAsCode => ({
+    contentType: ContentAsCodeType.AI_AGENT,
+    version: AGENT_AS_CODE_VERSION,
+    agentVersion: agent.agentVersion,
+    slug: agent.slug,
+    name: agent.name,
+    description: agent.description,
+    imageUrl: agent.imageUrl,
+    instruction: agent.instruction || null,
+    tags: agent.tags ? [...agent.tags].sort() : null,
+    enableDataAccess: agent.enableDataAccess,
+    enableSelfImprovement: agent.enableSelfImprovement,
+    enableContentTools: agent.enableContentTools,
+    enableUserContext: agent.enableUserContext,
+    modelConfig: agent.modelConfig,
+    updatedAt: agent.updatedAt,
+});
+
+const getComparableAgent = (agent: AgentAsCode) => ({
+    agentVersion: agent.agentVersion,
+    slug: agent.slug,
+    name: agent.name,
+    description: agent.description,
+    imageUrl: agent.imageUrl,
+    instruction: agent.instruction || null,
+    tags: agent.tags ? [...agent.tags].sort() : null,
+    enableDataAccess: agent.enableDataAccess,
+    enableSelfImprovement: agent.enableSelfImprovement,
+    enableContentTools: agent.enableContentTools,
+    enableUserContext: agent.enableUserContext,
+    modelConfig: agent.modelConfig,
+});
+
+type Dependencies = {
+    aiAgentModel: AiAgentModel;
+    projectModel: ProjectModel;
+    lightdashConfig: LightdashConfig;
+};
+
+export class AiAgentCoderService extends BaseService {
+    private readonly aiAgentModel: AiAgentModel;
+
+    private readonly projectModel: ProjectModel;
+
+    private readonly lightdashConfig: LightdashConfig;
+
+    constructor({ aiAgentModel, projectModel, lightdashConfig }: Dependencies) {
+        super({ serviceName: 'AiAgentCoderService' });
+        this.aiAgentModel = aiAgentModel;
+        this.projectModel = projectModel;
+        this.lightdashConfig = lightdashConfig;
+    }
+
+    private async getProjectOrganizationUuid(
+        projectUuid: string,
+    ): Promise<string> {
+        const project = await this.projectModel.getSummary(projectUuid);
+        return project.organizationUuid;
+    }
+
+    private async assertCanDownloadAgents(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<string> {
+        const organizationUuid =
+            await this.getProjectOrganizationUuid(projectUuid);
+        const ability = this.createAuditedAbility(user);
+
+        if (
+            ability.cannot(
+                'view',
+                subject('ContentAsCode', { organizationUuid, projectUuid }),
+            ) ||
+            ability.cannot(
+                'manage',
+                subject('AiAgent', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You are not allowed to download AI agents as code',
+            );
+        }
+
+        return organizationUuid;
+    }
+
+    private async assertCanUploadAgents(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<string> {
+        const organizationUuid =
+            await this.getProjectOrganizationUuid(projectUuid);
+        const ability = this.createAuditedAbility(user);
+
+        if (
+            ability.cannot(
+                'manage',
+                subject('ContentAsCode', { organizationUuid, projectUuid }),
+            ) ||
+            ability.cannot(
+                'manage',
+                subject('AiAgent', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You are not allowed to upload AI agents as code',
+            );
+        }
+
+        return organizationUuid;
+    }
+
+    async downloadAgents(
+        user: SessionUser,
+        projectUuid: string,
+        ids?: string[],
+        offset?: number,
+    ): Promise<{
+        agents: AgentAsCode[];
+        missingIds: string[];
+        total: number;
+        offset: number;
+    }> {
+        const organizationUuid = await this.assertCanDownloadAgents(
+            user,
+            projectUuid,
+        );
+        const agentUuids = ids?.filter(isValidUuid) ?? [];
+        const slugs = ids ?? [];
+        const agents = await this.aiAgentModel.findAgentsForCode({
+            organizationUuid,
+            projectUuid,
+            slugs: slugs.length > 0 ? slugs : undefined,
+            agentUuids: agentUuids.length > 0 ? agentUuids : undefined,
+        });
+        const missingIds =
+            ids?.filter(
+                (id) =>
+                    !agents.some(
+                        (agent) => agent.slug === id || agent.uuid === id,
+                    ),
+            ) ?? [];
+        const page = paginateAsCode({
+            items: agents,
+            offset,
+            pageSize: this.lightdashConfig.contentAsCode.maxDownloads,
+        });
+
+        return {
+            agents: page.page.map(toAgentAsCode),
+            missingIds,
+            total: page.total,
+            offset: page.offset,
+        };
+    }
+
+    async upsertAgents(
+        user: SessionUser,
+        projectUuid: string,
+        agents: AgentAsCode[],
+        force = false,
+    ): Promise<AgentAsCodeUpsertChanges> {
+        const organizationUuid = await this.assertCanUploadAgents(
+            user,
+            projectUuid,
+        );
+        const duplicateSlugs = agents
+            .map(({ slug }) => slug)
+            .filter((slug, index, slugs) => slugs.indexOf(slug) !== index);
+
+        if (duplicateSlugs.length > 0) {
+            throw new ParameterError(
+                `Duplicate AI agent slugs in upload: ${[
+                    ...new Set(duplicateSlugs),
+                ].join(', ')}`,
+            );
+        }
+
+        agents.forEach((agent) => {
+            if (agent.contentType !== ContentAsCodeType.AI_AGENT) {
+                throw new ParameterError(
+                    `Invalid content type for AI agent '${agent.slug}'`,
+                );
+            }
+            if (agent.version !== AGENT_AS_CODE_VERSION) {
+                throw new ParameterError(
+                    `Unsupported AI agent as-code version ${agent.version}`,
+                );
+            }
+            if (!AGENT_SLUG_PATTERN.test(agent.slug)) {
+                throw new ParameterError(
+                    `Invalid AI agent slug '${agent.slug}'`,
+                );
+            }
+            if (agent.enableContentTools && !agent.enableDataAccess) {
+                throw new ParameterError(
+                    `AI agent '${agent.slug}' must enable data access before enabling content tools`,
+                );
+            }
+        });
+
+        const existingAgents = await this.aiAgentModel.findAgentsForCode({
+            organizationUuid,
+            projectUuid,
+            slugs: agents.map(({ slug }) => slug),
+        });
+        const existingBySlug = new Map(
+            existingAgents.map((agent) => [agent.slug, agent]),
+        );
+        const changes: AgentAsCodeUpsertChanges = {
+            created: [],
+            updated: [],
+            unchanged: [],
+            deleted: [],
+        };
+
+        for (const agent of agents) {
+            const existing = existingBySlug.get(agent.slug);
+            if (existing) {
+                const imageUrlChanged = existing.imageUrl !== agent.imageUrl;
+                const isUnchanged =
+                    !force &&
+                    isEqual(
+                        getComparableAgent(toAgentAsCode(existing)),
+                        getComparableAgent(agent),
+                    );
+
+                if (isUnchanged) {
+                    changes.unchanged.push(agent.slug);
+                } else {
+                    // eslint-disable-next-line no-await-in-loop
+                    await this.aiAgentModel.updateAgent({
+                        agentUuid: existing.uuid,
+                        organizationUuid,
+                        projectUuid,
+                        version: agent.agentVersion,
+                        name: agent.name,
+                        description: agent.description,
+                        ...(imageUrlChanged
+                            ? {
+                                  imageUrl: agent.imageUrl,
+                                  imageUrlSource: agent.imageUrl ? 'url' : null,
+                              }
+                            : {}),
+                        instruction: agent.instruction,
+                        tags: agent.tags,
+                        enableDataAccess: agent.enableDataAccess,
+                        enableSelfImprovement: agent.enableSelfImprovement,
+                        enableContentTools: agent.enableContentTools,
+                        enableUserContext: agent.enableUserContext,
+                        modelConfig: agent.modelConfig,
+                    });
+                    changes.updated.push(agent.slug);
+                }
+            } else {
+                // eslint-disable-next-line no-await-in-loop
+                await this.aiAgentModel.createAgent({
+                    slug: agent.slug,
+                    organizationUuid,
+                    projectUuid,
+                    name: agent.name,
+                    description: agent.description,
+                    imageUrl: agent.imageUrl,
+                    instruction: agent.instruction,
+                    tags: agent.tags,
+                    enableDataAccess: agent.enableDataAccess,
+                    enableSelfImprovement: agent.enableSelfImprovement,
+                    enableContentTools: agent.enableContentTools,
+                    enableUserContext: agent.enableUserContext,
+                    modelConfig: agent.modelConfig,
+                    integrations: [],
+                    groupAccess: [],
+                    userAccess: [],
+                    spaceAccess: [],
+                    mcpServerUuids: [],
+                    adminOnly: false,
+                    version: agent.agentVersion,
+                });
+                changes.created.push(agent.slug);
+            }
+        }
+
+        return changes;
+    }
+}

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -2845,6 +2845,7 @@ export class AiAgentService extends BaseService {
             tags: body.tags,
             integrations: body.integrations,
             instruction: body.instruction,
+            imageUrl: body.imageUrl,
             // Admin-only agents ignore the user/group lists; clear them so the
             // contradictory "admin-only + specific users" state never persists.
             groupAccess: body.adminOnly ? [] : body.groupAccess,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12576,8 +12576,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: ['upload'] },
+                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -12632,6 +12632,153 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'refAlias', ref: 'AiAgentSummary' },
                     required: true,
                 },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ContentAsCodeType.AI_AGENT': {
+        dataType: 'refEnum',
+        enums: ['ai_agent'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AgentAsCode: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                downloadedAt: { dataType: 'datetime' },
+                updatedAt: { dataType: 'datetime' },
+                modelConfig: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiAgentModelConfig' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                enableUserContext: { dataType: 'boolean', required: true },
+                enableContentTools: { dataType: 'boolean', required: true },
+                enableSelfImprovement: { dataType: 'boolean', required: true },
+                enableDataAccess: { dataType: 'boolean', required: true },
+                tags: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                instruction: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                imageUrl: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+                slug: { dataType: 'string', required: true },
+                agentVersion: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: [1] },
+                        { dataType: 'enum', enums: [2] },
+                    ],
+                    required: true,
+                },
+                version: { dataType: 'double', required: true },
+                contentType: {
+                    ref: 'ContentAsCodeType.AI_AGENT',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAgentAsCodeListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        offset: { dataType: 'double', required: true },
+                        total: { dataType: 'double', required: true },
+                        missingIds: {
+                            dataType: 'array',
+                            array: { dataType: 'string' },
+                            required: true,
+                        },
+                        agents: {
+                            dataType: 'array',
+                            array: { dataType: 'refAlias', ref: 'AgentAsCode' },
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AgentAsCodeUpsertChanges: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                deleted: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                unchanged: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                updated: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                created: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAgentAsCodeUpsertResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AgentAsCodeUpsertChanges', required: true },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
             },
             validators: {},
@@ -13235,8 +13382,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: ['upload'] },
+                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -15069,6 +15216,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['resolveUrl'] },
                 { dataType: 'enum', enums: ['editContent'] },
                 { dataType: 'enum', enums: ['createContent'] },
+                { dataType: 'enum', enums: ['createScheduledDelivery'] },
                 { dataType: 'enum', enums: ['runContentQuery'] },
                 { dataType: 'enum', enums: ['improveContext'] },
                 { dataType: 'enum', enums: ['listProjects'] },
@@ -15287,17 +15435,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -15326,29 +15474,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 requiredFilters:
                                                                                                     {
                                                                                                         dataType:
@@ -15393,6 +15518,12 @@ const models: TsoaRoute.Models = {
                                                                                                                                             'boolean',
                                                                                                                                         required: true,
                                                                                                                                     },
+                                                                                                                                operator:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
                                                                                                                                 tableName:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -15406,12 +15537,6 @@ const models: TsoaRoute.Models = {
                                                                                                                                         required: true,
                                                                                                                                     },
                                                                                                                                 fieldId:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                operator:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
@@ -15439,6 +15564,29 @@ const models: TsoaRoute.Models = {
                                                                                                                         dataType:
                                                                                                                             'string',
                                                                                                                     },
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -15685,17 +15833,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -15855,6 +16003,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -15899,18 +16066,23 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldValueType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
                                                                                 fieldFilterType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 fieldType:
                                                                                     {
                                                                                         dataType:
@@ -15934,6 +16106,17 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -15954,22 +16137,6 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -15977,25 +16144,6 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
-                                                                    required: true,
-                                                                },
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 explore: {
@@ -16047,6 +16195,12 @@ const models: TsoaRoute.Models = {
                                                                                                                         'boolean',
                                                                                                                     required: true,
                                                                                                                 },
+                                                                                                            operator:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
                                                                                                             tableName:
                                                                                                                 {
                                                                                                                     dataType:
@@ -16065,12 +16219,6 @@ const models: TsoaRoute.Models = {
                                                                                                                         'string',
                                                                                                                     required: true,
                                                                                                                 },
-                                                                                                            operator:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
                                                                                                         },
                                                                                                 },
                                                                                             },
@@ -16080,6 +16228,12 @@ const models: TsoaRoute.Models = {
                                                                                             },
                                                                                         ],
                                                                                 },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                             joinedTables:
                                                                                 {
                                                                                     dataType:
@@ -16088,12 +16242,6 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'string',
                                                                                     },
-                                                                                    required: true,
-                                                                                },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
                                                                                     required: true,
                                                                                 },
                                                                             label: {
@@ -16137,17 +16285,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -16261,10 +16409,6 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
-                                                href: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 warnings: {
                                                     dataType: 'array',
                                                     array: {
@@ -16272,20 +16416,24 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
+                                                href: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                uuid: {
-                                                    dataType: 'string',
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                                 name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
+                                                uuid: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
@@ -16433,18 +16581,6 @@ const models: TsoaRoute.Models = {
                                                                                 ],
                                                                             required: true,
                                                                         },
-                                                                        isPrimary:
-                                                                            {
-                                                                                dataType:
-                                                                                    'boolean',
-                                                                                required: true,
-                                                                            },
-                                                                        projectDbtSourceUuid:
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
                                                                         repository:
                                                                             {
                                                                                 dataType:
@@ -16463,6 +16599,18 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         },
                                                                                     ],
+                                                                                required: true,
+                                                                            },
+                                                                        isPrimary:
+                                                                            {
+                                                                                dataType:
+                                                                                    'boolean',
+                                                                                required: true,
+                                                                            },
+                                                                        projectDbtSourceUuid:
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
                                                                                 required: true,
                                                                             },
                                                                         name: {
@@ -16487,6 +16635,77 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'union',
                                                     subSchemas: [
                                                         { dataType: 'boolean' },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
+                                                steps: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'array',
+                                                            array: {
+                                                                dataType:
+                                                                    'nestedObjectLiteral',
+                                                                nestedProperties:
+                                                                    {
+                                                                        kind: {
+                                                                            dataType:
+                                                                                'union',
+                                                                            subSchemas:
+                                                                                [
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'read',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'edit',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'compile',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'stage',
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
+                                                                    },
+                                                            },
+                                                        },
                                                         {
                                                             dataType: 'enum',
                                                             enums: [null],
@@ -16574,77 +16793,6 @@ const models: TsoaRoute.Models = {
                                                         },
                                                     ],
                                                 },
-                                                steps: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'array',
-                                                            array: {
-                                                                dataType:
-                                                                    'nestedObjectLiteral',
-                                                                nestedProperties:
-                                                                    {
-                                                                        kind: {
-                                                                            dataType:
-                                                                                'union',
-                                                                            subSchemas:
-                                                                                [
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'read',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'compile',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'stage',
-                                                                                        ],
-                                                                                    },
-                                                                                ],
-                                                                            required: true,
-                                                                        },
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
-                                                                    },
-                                                            },
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
-                                                        },
-                                                    ],
-                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -16676,12 +16824,6 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
-                                                                'unsupported_source_control',
-                                                            ],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [
                                                                 'github_not_installed',
                                                             ],
                                                         },
@@ -16689,6 +16831,12 @@ const models: TsoaRoute.Models = {
                                                             dataType: 'enum',
                                                             enums: [
                                                                 'gitlab_not_installed',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
+                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -16756,13 +16904,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                slug: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
-                                                    required: true,
-                                                },
-                                                slug: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
@@ -16879,25 +17027,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -16958,17 +17087,17 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 tableName:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -16976,6 +17105,25 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
+                                                                    required: true,
+                                                                },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 type: {
@@ -34193,7 +34341,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34203,7 +34351,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34213,7 +34361,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -34226,7 +34374,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -34895,7 +35043,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34905,7 +35053,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34915,7 +35063,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -34928,7 +35076,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -53806,6 +53954,145 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'listAgents',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_getAiAgentsAsCode: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        ids: {
+            in: 'query',
+            name: 'ids',
+            dataType: 'array',
+            array: { dataType: 'string' },
+        },
+        offset: { in: 'query', name: 'offset', dataType: 'double' },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/code',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.getAiAgentsAsCode,
+        ),
+
+        async function AiAgentController_getAiAgentsAsCode(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_getAiAgentsAsCode,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentController>(AiAgentController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getAiAgentsAsCode',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_upsertAiAgentsAsCode: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                agents: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'AgentAsCode' },
+                    required: true,
+                },
+            },
+        },
+        force: { in: 'query', name: 'force', dataType: 'boolean' },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/aiAgents/code',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.upsertAiAgentsAsCode,
+        ),
+
+        async function AiAgentController_upsertAiAgentsAsCode(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_upsertAiAgentsAsCode,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentController>(AiAgentController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'upsertAiAgentsAsCode',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14215,7 +14215,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["url", "upload", null],
+                        "enum": ["upload", "url", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -14295,6 +14295,176 @@
                             "$ref": "#/components/schemas/AiAgentSummary"
                         },
                         "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ContentAsCodeType.AI_AGENT": {
+                "enum": ["ai_agent"],
+                "type": "string"
+            },
+            "AgentAsCode": {
+                "properties": {
+                    "downloadedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "modelConfig": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AiAgentModelConfig"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "enableUserContext": {
+                        "type": "boolean"
+                    },
+                    "enableContentTools": {
+                        "type": "boolean"
+                    },
+                    "enableSelfImprovement": {
+                        "type": "boolean"
+                    },
+                    "enableDataAccess": {
+                        "type": "boolean"
+                    },
+                    "tags": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "nullable": true
+                    },
+                    "instruction": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "imageUrl": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "slug": {
+                        "type": "string"
+                    },
+                    "agentVersion": {
+                        "type": "number",
+                        "enum": [1, 2]
+                    },
+                    "version": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "contentType": {
+                        "$ref": "#/components/schemas/ContentAsCodeType.AI_AGENT"
+                    }
+                },
+                "required": [
+                    "modelConfig",
+                    "enableUserContext",
+                    "enableContentTools",
+                    "enableSelfImprovement",
+                    "enableDataAccess",
+                    "tags",
+                    "instruction",
+                    "imageUrl",
+                    "description",
+                    "name",
+                    "slug",
+                    "agentVersion",
+                    "version",
+                    "contentType"
+                ],
+                "type": "object"
+            },
+            "ApiAgentAsCodeListResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "offset": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "total": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "missingIds": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "agents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/AgentAsCode"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["offset", "total", "missingIds", "agents"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "AgentAsCodeUpsertChanges": {
+                "properties": {
+                    "deleted": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "unchanged": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "updated": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "created": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["deleted", "unchanged", "updated", "created"],
+                "type": "object"
+            },
+            "ApiAgentAsCodeUpsertResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AgentAsCodeUpsertChanges"
                     },
                     "status": {
                         "type": "string",
@@ -14859,7 +15029,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["url", "upload", null],
+                        "enum": ["upload", "url", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -16722,6 +16892,7 @@
                     "resolveUrl",
                     "editContent",
                     "createContent",
+                    "createScheduledDelivery",
                     "runContentQuery",
                     "improveContext",
                     "listProjects",
@@ -16797,10 +16968,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -16809,8 +16980,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -16820,11 +16991,6 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "requiredFilters": {
                                                                             "items": {
                                                                                 "properties": {
@@ -16836,6 +17002,9 @@
                                                                                     "required": {
                                                                                         "type": "boolean"
                                                                                     },
+                                                                                    "operator": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "tableName": {
                                                                                         "type": "string"
                                                                                     },
@@ -16844,17 +17013,14 @@
                                                                                     },
                                                                                     "fieldId": {
                                                                                         "type": "string"
-                                                                                    },
-                                                                                    "operator": {
-                                                                                        "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
                                                                                     "required",
+                                                                                    "operator",
                                                                                     "tableName",
                                                                                     "fieldRef",
-                                                                                    "fieldId",
-                                                                                    "operator"
+                                                                                    "fieldId"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -16865,6 +17031,11 @@
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -16967,10 +17138,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -16979,8 +17150,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -17082,6 +17253,10 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
@@ -17096,10 +17271,13 @@
                                                                                         "not_applicable"
                                                                                     ]
                                                                                 },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
                                                                                 "fieldValueType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldFilterType": {
+                                                                                "table": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldType": {
@@ -17109,18 +17287,15 @@
                                                                                         "metric"
                                                                                     ]
                                                                                 },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
+                                                                                "fieldId": {
+                                                                                    "type": "string"
                                                                                 },
                                                                                 "label": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
                                                                                 },
                                                                                 "name": {
                                                                                     "type": "string"
@@ -17129,22 +17304,18 @@
                                                                             "required": [
                                                                                 "isFromJoinedTable",
                                                                                 "caseSensitiveFilters",
-                                                                                "fieldValueType",
                                                                                 "fieldFilterType",
-                                                                                "fieldType",
-                                                                                "description",
-                                                                                "label",
-                                                                                "fieldId",
+                                                                                "fieldValueType",
                                                                                 "table",
+                                                                                "fieldType",
+                                                                                "fieldId",
+                                                                                "label",
+                                                                                "description",
                                                                                 "name"
                                                                             ],
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
-                                                                    },
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
                                                                     },
                                                                     "explore": {
                                                                         "properties": {
@@ -17159,6 +17330,9 @@
                                                                                         "required": {
                                                                                             "type": "boolean"
                                                                                         },
+                                                                                        "operator": {
+                                                                                            "type": "string"
+                                                                                        },
                                                                                         "tableName": {
                                                                                             "type": "string"
                                                                                         },
@@ -17167,30 +17341,27 @@
                                                                                         },
                                                                                         "fieldId": {
                                                                                             "type": "string"
-                                                                                        },
-                                                                                        "operator": {
-                                                                                            "type": "string"
                                                                                         }
                                                                                     },
                                                                                     "required": [
                                                                                         "required",
+                                                                                        "operator",
                                                                                         "tableName",
                                                                                         "fieldRef",
-                                                                                        "fieldId",
-                                                                                        "operator"
+                                                                                        "fieldId"
                                                                                     ],
                                                                                     "type": "object"
                                                                                 },
                                                                                 "type": "array"
+                                                                            },
+                                                                            "baseTable": {
+                                                                                "type": "string"
                                                                             },
                                                                             "joinedTables": {
                                                                                 "items": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "type": "array"
-                                                                            },
-                                                                            "baseTable": {
-                                                                                "type": "string"
                                                                             },
                                                                             "label": {
                                                                                 "type": "string"
@@ -17200,8 +17371,8 @@
                                                                             }
                                                                         },
                                                                         "required": [
-                                                                            "joinedTables",
                                                                             "baseTable",
+                                                                            "joinedTables",
                                                                             "label",
                                                                             "name"
                                                                         ],
@@ -17216,8 +17387,8 @@
                                                                     }
                                                                 },
                                                                 "required": [
-                                                                    "fields",
                                                                     "rationale",
+                                                                    "fields",
                                                                     "explore",
                                                                     "status"
                                                                 ],
@@ -17231,10 +17402,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -17242,8 +17413,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "exploreLabel",
                                                                                 "reason",
+                                                                                "exploreLabel",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -17317,38 +17488,38 @@
                                                         ],
                                                         "type": "object"
                                                     },
-                                                    "href": {
-                                                        "type": "string"
-                                                    },
                                                     "warnings": {
                                                         "items": {
                                                             "type": "string"
                                                         },
                                                         "type": "array"
                                                     },
+                                                    "href": {
+                                                        "type": "string"
+                                                    },
+                                                    "slug": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
                                                     },
-                                                    "slug": {
+                                                    "name": {
                                                         "type": "string"
                                                     },
                                                     "uuid": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
                                                         "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "versionUuids",
-                                                    "href",
                                                     "warnings",
-                                                    "status",
+                                                    "href",
                                                     "slug",
-                                                    "uuid",
-                                                    "name"
+                                                    "status",
+                                                    "name",
+                                                    "uuid"
                                                 ],
                                                 "type": "object"
                                             },
@@ -17382,15 +17553,15 @@
                                                                     "type": "string",
                                                                     "nullable": true
                                                                 },
+                                                                "repository": {
+                                                                    "type": "string",
+                                                                    "nullable": true
+                                                                },
                                                                 "isPrimary": {
                                                                     "type": "boolean"
                                                                 },
                                                                 "projectDbtSourceUuid": {
                                                                     "type": "string"
-                                                                },
-                                                                "repository": {
-                                                                    "type": "string",
-                                                                    "nullable": true
                                                                 },
                                                                 "name": {
                                                                     "type": "string"
@@ -17399,9 +17570,9 @@
                                                             "required": [
                                                                 "projectSubPath",
                                                                 "branch",
+                                                                "repository",
                                                                 "isPrimary",
                                                                 "projectDbtSourceUuid",
-                                                                "repository",
                                                                 "name"
                                                             ],
                                                             "type": "object"
@@ -17411,6 +17582,32 @@
                                                     },
                                                     "needsDbtSourceSelection": {
                                                         "type": "boolean",
+                                                        "nullable": true
+                                                    },
+                                                    "steps": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "kind": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "read",
+                                                                        "edit",
+                                                                        "search",
+                                                                        "compile",
+                                                                        "stage"
+                                                                    ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kind",
+                                                                "label"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
                                                         "nullable": true
                                                     },
                                                     "previewUrl": {
@@ -17440,32 +17637,6 @@
                                                         ],
                                                         "nullable": true
                                                     },
-                                                    "steps": {
-                                                        "items": {
-                                                            "properties": {
-                                                                "kind": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "search",
-                                                                        "read",
-                                                                        "edit",
-                                                                        "compile",
-                                                                        "stage"
-                                                                    ]
-                                                                },
-                                                                "label": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "kind",
-                                                                "label"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array",
-                                                        "nullable": true
-                                                    },
                                                     "prUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -17485,9 +17656,9 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "unknown",
-                                                            "unsupported_source_control",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
+                                                            "unsupported_source_control",
                                                             "pull_request_not_open",
                                                             "git_write_permission",
                                                             null
@@ -17508,13 +17679,13 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
+                                                    "slug": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
@@ -17522,8 +17693,8 @@
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "status",
                                                     "slug",
+                                                    "status",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -17564,10 +17735,6 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -17584,10 +17751,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -17596,13 +17763,17 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
                                                                 },
                                                                 "type": "array"
+                                                            },
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
                                                             },
                                                             "type": {
                                                                 "type": "string",
@@ -17615,8 +17786,8 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "searchQuery",
                                                             "fields",
+                                                            "searchQuery",
                                                             "type"
                                                         ],
                                                         "type": "object"
@@ -34644,22 +34815,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -35227,22 +35398,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -45905,7 +46076,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3371.3",
+        "version": "0.3374.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -48288,6 +48459,127 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/ApiCreateAiAgent"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/aiAgents/code": {
+            "get": {
+                "operationId": "getAiAgentsAsCode",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAgentAsCodeListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "ids",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "offset",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "upsertAiAgentsAsCode",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAgentAsCodeUpsertResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "force",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "agents": {
+                                        "items": {
+                                            "$ref": "#/components/schemas/AgentAsCode"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": ["agents"],
+                                "type": "object"
                             }
                         }
                     }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -155,6 +155,7 @@ interface ServiceManifest {
     appGenerateService: unknown;
     embedService: unknown;
     aiService: unknown;
+    aiAgentCoderService: unknown;
     aiAgentService: unknown;
     aiAgentToolsService: unknown;
     aiAgentAdminService: unknown;
@@ -1381,6 +1382,12 @@ export class ServiceRepository
 
     public getAiService<AiServiceImplT>(): AiServiceImplT {
         return this.getService('aiService');
+    }
+
+    public getAiAgentCoderService<
+        AiAgentCoderServiceImplT,
+    >(): AiAgentCoderServiceImplT {
+        return this.getService('aiAgentCoderService');
     }
 
     public getAiAgentService<AiAgentServiceImplT>(): AiAgentServiceImplT {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,6 +22,24 @@ Commands:
 
 eg: `ligthdash test` Runs `dbt test`
 
+## AI agents as code
+
+AI-agent project configuration can be downloaded into
+`lightdash/ai-agents/<slug>.yml` and applied to another project:
+
+```shell
+lightdash download --include-agents
+lightdash upload
+```
+
+Use `--agents <slugs...>` on either command to select specific agents. The
+files manage the agent name, description, image URL, instructions, semantic
+tags, data/content/user-context flags, self-improvement flag, and model config.
+The YAML `version` identifies the as-code schema, while `agentVersion` preserves
+the AI agent runtime version.
+Access lists, Slack integrations, MCP servers, documents, conversations, and
+other runtime state stay managed in the target environment.
+
 ## Development
 
 First build the package

--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -19,8 +19,13 @@ vi.mock('./dbt/apiClient', async (importOriginal) => ({
     lightdashApi: vi.fn(),
 }));
 
-const { getDashboardChartSlugs, sanitizeChartForDownload, upsertVirtualViews } =
-    testHelpers;
+const {
+    getDashboardChartSlugs,
+    readAiAgentFiles,
+    sanitizeChartForDownload,
+    shouldDownloadAiAgents,
+    upsertVirtualViews,
+} = testHelpers;
 
 type LooseDashboard = DashboardAsCode & { needsUpdating: boolean };
 
@@ -345,5 +350,60 @@ version: 1
         expect(logSpy).toHaveBeenCalledWith(
             expect.stringContaining('Error uploading virtual views'),
         );
+    });
+});
+
+describe('readAiAgentFiles', () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-code-test-'));
+        await fs.mkdir(path.join(tmpDir, 'ai-agents'));
+    });
+
+    afterEach(async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('rejects YAML files with an invalid AI agent content type', async () => {
+        await fs.writeFile(
+            path.join(tmpDir, 'ai-agents', 'invalid.yml'),
+            'contentType: ai_agnet\nslug: invalid-agent\n',
+        );
+
+        await expect(readAiAgentFiles(tmpDir)).rejects.toThrow(
+            'Invalid contentType in AI agent file',
+        );
+    });
+});
+
+describe('shouldDownloadAiAgents', () => {
+    it('does not download AI agents by default', () => {
+        expect(
+            shouldDownloadAiAgents({
+                agents: [],
+                includeAgents: false,
+                includeAll: false,
+            }),
+        ).toBe(false);
+    });
+
+    it.each([
+        { agents: [], includeAgents: true, includeAll: false },
+        { agents: ['sales-agent'], includeAgents: false, includeAll: false },
+        { agents: [], includeAgents: false, includeAll: true },
+    ])('downloads AI agents when explicitly selected', (options) => {
+        expect(shouldDownloadAiAgents(options)).toBe(true);
+    });
+
+    it('does not download AI agents in apps-only mode', () => {
+        expect(
+            shouldDownloadAiAgents({
+                agents: ['sales-agent'],
+                includeAgents: true,
+                includeAll: true,
+                appsOnly: true,
+            }),
+        ).toBe(false);
     });
 });

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -1,7 +1,10 @@
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-param-reassign */
 import {
+    AgentAsCode,
     AlertAsCode,
+    ApiAgentAsCodeListResponse,
+    ApiAgentAsCodeUpsertResponse,
     ApiAlertAsCodeListResponse,
     ApiAlertAsCodeUpsertResponse,
     ApiChartAsCodeListResponse,
@@ -102,10 +105,12 @@ export type DownloadHandlerOptions = {
     charts: string[]; // These can be slugs, uuids or urls
     dashboards: string[]; // These can be slugs, uuids or urls
     alerts: string[];
+    agents: string[];
     googleSheets: string[];
     scheduledDeliveries: string[];
     virtualViews: string[];
     apps?: string[]; // specific app UUIDs (enterprise); absent = no explicit selection
+    includeAgents?: boolean;
     includeApps?: boolean; // download: all of the project's apps, capped at --apps-limit; upload: all app folders on disk
     appsLimit?: string; // download only: cap for the --include-apps listing (default 50); raw string from commander
     createNew?: boolean; // upload only: always create a new app instead of updating the manifest's app
@@ -121,6 +126,7 @@ export type DownloadHandlerOptions = {
     skipCharts: boolean; // Skip downloading charts and SQL charts
     skipDashboards: boolean; // Skip downloading dashboards
     skipAlerts: boolean;
+    skipAgents: boolean;
     skipGoogleSheets: boolean;
     skipScheduledDeliveries: boolean;
     skipVirtualViews: boolean;
@@ -146,6 +152,18 @@ const getDownloadFolder = (customPath?: string): string => {
     }
     return path.join(process.cwd(), 'lightdash');
 };
+
+const shouldDownloadAiAgents = ({
+    includeAll,
+    includeAgents,
+    agents,
+    appsOnly,
+}: Pick<
+    DownloadHandlerOptions,
+    'includeAll' | 'includeAgents' | 'agents' | 'appsOnly'
+>): boolean =>
+    appsOnly !== true &&
+    (includeAll === true || includeAgents === true || agents.length > 0);
 
 /*
     This function is used to parse the content filters.
@@ -881,6 +899,9 @@ export const downloadContent = async (
 const getScheduledDeliveriesFolder = (customPath?: string): string =>
     path.join(getDownloadFolder(customPath), 'scheduled-deliveries');
 
+const getAiAgentsFolder = (customPath?: string): string =>
+    path.join(getDownloadFolder(customPath), 'ai-agents');
+
 const getAlertsFolder = (customPath?: string): string =>
     path.join(getDownloadFolder(customPath), 'alerts');
 
@@ -1093,6 +1114,152 @@ const getScheduledContentConfig = (
     }
 };
 
+const downloadAiAgents = async (
+    projectId: string,
+    ids: string[],
+    customPath?: string,
+): Promise<number> => {
+    const outputDir = getAiAgentsFolder(customPath);
+    await fs.mkdir(outputDir, { recursive: true });
+    const idQuery = ids.map((id) => ['ids', id] as [string, string]);
+    let offset = 0;
+    let total = 0;
+    let downloaded = 0;
+
+    do {
+        const query = new URLSearchParams([
+            ...idQuery,
+            ['offset', String(offset)],
+        ]).toString();
+        const results = await lightdashApi<
+            ApiAgentAsCodeListResponse['results']
+        >({
+            method: 'GET',
+            url: `/api/v1/projects/${projectId}/aiAgents/code?${query}`,
+            body: undefined,
+        });
+
+        for (const agent of results.agents) {
+            const { updatedAt, downloadedAt, ...agentConfig } = agent;
+            // eslint-disable-next-line no-await-in-loop
+            await fs.writeFile(
+                path.join(outputDir, `${agent.slug}.yml`),
+                yaml.dump(agentConfig, { quotingType: '"', sortKeys: true }),
+            );
+        }
+
+        results.missingIds.forEach((id) =>
+            GlobalState.debug(`No AI agent with id "${id}"`),
+        );
+        downloaded += results.agents.length;
+        offset = results.offset;
+        total = results.total;
+    } while (offset < total);
+
+    return downloaded;
+};
+
+const readAiAgentFiles = async (
+    customPath?: string,
+): Promise<AgentAsCode[]> => {
+    const folder = getAiAgentsFolder(customPath);
+    try {
+        const entries = await fs.readdir(folder, {
+            recursive: true,
+            withFileTypes: true,
+        });
+        const agents: AgentAsCode[] = [];
+
+        for (const entry of entries) {
+            if (
+                entry.isFile() &&
+                (entry.name.endsWith('.yml') || entry.name.endsWith('.yaml'))
+            ) {
+                const filePath = path.join(entry.parentPath, entry.name);
+                // eslint-disable-next-line no-await-in-loop
+                const parsed = yaml.load(await fs.readFile(filePath, 'utf-8'));
+                if (
+                    typeof parsed !== 'object' ||
+                    parsed === null ||
+                    Array.isArray(parsed)
+                ) {
+                    throw new ParameterError(
+                        `Invalid AI agent file "${filePath}": expected a YAML object`,
+                    );
+                }
+                if (
+                    !('contentType' in parsed) ||
+                    parsed.contentType !== ContentAsCodeTypeEnum.AI_AGENT
+                ) {
+                    throw new ParameterError(
+                        `Invalid contentType in AI agent file "${filePath}": expected "${ContentAsCodeTypeEnum.AI_AGENT}"`,
+                    );
+                }
+                agents.push(parsed as AgentAsCode);
+            }
+        }
+
+        return agents;
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+        throw error;
+    }
+};
+
+class AiAgentAsCodeUploadError extends Error {
+    readonly originalError: Error;
+
+    constructor(error: unknown) {
+        const originalError =
+            error instanceof Error ? error : new Error(getErrorMessage(error));
+        super(originalError.message);
+        this.name = 'AiAgentAsCodeUploadError';
+        this.originalError = originalError;
+    }
+}
+
+const upsertAiAgents = async (
+    projectId: string,
+    slugs: string[],
+    changes: Record<string, number>,
+    force: boolean,
+    customPath?: string,
+): Promise<Record<string, number>> => {
+    const agents = await readAiAgentFiles(customPath);
+    const filteredAgents = slugs.length
+        ? agents.filter((agent) => slugs.includes(agent.slug))
+        : agents;
+
+    if (filteredAgents.length === 0) {
+        if (slugs.length > 0) {
+            GlobalState.log(
+                styles.warning(`No matching AI agent files found, skipping`),
+            );
+        }
+        return changes;
+    }
+    GlobalState.log(`Found ${filteredAgents.length} AI agent files`);
+
+    const results = await lightdashApi<ApiAgentAsCodeUpsertResponse['results']>(
+        {
+            method: 'POST',
+            url: `/api/v1/projects/${projectId}/aiAgents/code?force=${force}`,
+            body: JSON.stringify({ agents: filteredAgents }),
+        },
+    );
+
+    const counts = {
+        'AI agents created': results.created.length,
+        'AI agents updated': results.updated.length,
+        'AI agents skipped': results.unchanged.length,
+    };
+    Object.entries(counts).forEach(([key, value]) => {
+        if (value > 0) changes[key] = (changes[key] ?? 0) + value;
+    });
+
+    return changes;
+};
+
 const downloadScheduledContent = async (
     projectId: string,
     slugs: string[],
@@ -1288,12 +1455,13 @@ export const downloadHandler = async (
         });
         if (appsOnlySelection.mode === 'none') {
             throw new ParameterError(
-                'Nothing to download: --apps-only requires --apps <appUuids...> or --include-apps.',
+                'Nothing to download: --apps-only requires --apps <appUuids...>, --include-apps, or --include-all.',
             );
         }
         options.skipCharts = true;
         options.skipDashboards = true;
         options.skipSpaces = true;
+        options.includeAgents = false;
         options.includeAlerts = false;
         options.includeGoogleSheets = false;
         options.includeScheduledDeliveries = false;
@@ -1351,6 +1519,7 @@ export const downloadHandler = async (
         const hasFilters =
             options.charts.length > 0 ||
             options.dashboards.length > 0 ||
+            options.agents.length > 0 ||
             options.alerts.length > 0 ||
             options.googleSheets.length > 0 ||
             options.scheduledDeliveries.length > 0 ||
@@ -1511,6 +1680,16 @@ export const downloadHandler = async (
                     );
                 }
             }
+        }
+
+        if (shouldDownloadAiAgents(options)) {
+            spinner.start(`Downloading AI agents`);
+            const agentTotal = await downloadAiAgents(
+                projectId,
+                options.agents,
+                options.path,
+            );
+            spinner.succeed(`Downloaded ${agentTotal} AI agents`);
         }
 
         if (
@@ -2266,6 +2445,7 @@ export const uploadHandler = async (
         const hasFilters =
             options.charts.length > 0 ||
             options.dashboards.length > 0 ||
+            options.agents.length > 0 ||
             options.alerts.length > 0 ||
             options.googleSheets.length > 0 ||
             options.scheduledDeliveries.length > 0 ||
@@ -2392,6 +2572,27 @@ export const uploadHandler = async (
                 );
             changes = dashboardChanges;
             dashboardTotal = total;
+        }
+
+        if (!options.skipAgents) {
+            if (hasFilters && options.agents.length === 0) {
+                GlobalState.log(
+                    styles.warning(`No AI agent filters provided, skipping`),
+                );
+            } else {
+                uploadResource = 'AI agents';
+                try {
+                    changes = await upsertAiAgents(
+                        projectId,
+                        options.agents,
+                        changes,
+                        options.force,
+                        options.path,
+                    );
+                } catch (error) {
+                    throw new AiAgentAsCodeUploadError(error);
+                }
+            }
         }
 
         if (!options.skipAlerts) {
@@ -2803,11 +3004,16 @@ export const uploadHandler = async (
                 error: getErrorMessage(error),
             },
         });
+        if (error instanceof AiAgentAsCodeUploadError) {
+            throw error.originalError;
+        }
     }
 };
 
 export const testHelpers = {
     getDashboardChartSlugs,
+    readAiAgentFiles,
     sanitizeChartForDownload,
+    shouldDownloadAiAgents,
     upsertVirtualViews,
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -728,6 +728,12 @@ program
         'specify dashboard slugs, uuids or urls to download',
         [],
     )
+    .option('--agents <slugs...>', 'specify AI agent slugs to download', [])
+    .option(
+        '--include-agents',
+        "include all of the project's AI agents (enterprise)",
+        false,
+    )
     .option('--alerts <slugs...>', 'specify alert slugs to download', [])
     .option(
         '--virtual-views <slugs...>',
@@ -833,6 +839,7 @@ program
         'specify dashboard slugs to force upload',
         [],
     )
+    .option('--agents <slugs...>', 'specify AI agent slugs to upload', [])
     .option('--alerts <slugs...>', 'specify alert slugs to upload', [])
     .option(
         '--virtual-views <slugs...>',
@@ -871,6 +878,7 @@ program
         false,
     )
     .option('--public', 'Create new spaces as public instead of private', false)
+    .option('--skip-agents', 'skip uploading AI agents', false)
     .option('--skip-alerts', 'skip uploading alerts', false)
     .option('--skip-virtual-views', 'skip uploading virtual views', false)
     .option('--skip-google-sheets', 'skip uploading Google Sheets syncs', false)

--- a/packages/common/src/ee/AiAgent/coder.ts
+++ b/packages/common/src/ee/AiAgent/coder.ts
@@ -1,0 +1,43 @@
+import type { ContentAsCodeType } from '../../types/coder';
+import type { AiAgentModelConfig } from './requestTypes';
+
+export type AgentAsCode = {
+    contentType: ContentAsCodeType.AI_AGENT;
+    version: number;
+    agentVersion: 1 | 2;
+    slug: string;
+    name: string;
+    description: string | null;
+    imageUrl: string | null;
+    instruction: string | null;
+    tags: string[] | null;
+    enableDataAccess: boolean;
+    enableSelfImprovement: boolean;
+    enableContentTools: boolean;
+    enableUserContext: boolean;
+    modelConfig: AiAgentModelConfig | null;
+    updatedAt?: Date;
+    downloadedAt?: Date;
+};
+
+export type AgentAsCodeUpsertChanges = {
+    created: string[];
+    updated: string[];
+    unchanged: string[];
+    deleted: string[];
+};
+
+export type ApiAgentAsCodeListResponse = {
+    status: 'ok';
+    results: {
+        agents: AgentAsCode[];
+        missingIds: string[];
+        total: number;
+        offset: number;
+    };
+};
+
+export type ApiAgentAsCodeUpsertResponse = {
+    status: 'ok';
+    results: AgentAsCodeUpsertChanges;
+};

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -31,6 +31,7 @@ export * from './aiEvalAssessment';
 export * from './chartConfig/slack';
 export * from './chartConfig/web';
 export * from './constants';
+export * from './coder';
 export * from './aiAgentReviewClassifierTypes';
 export * from './documentTypes';
 export * from './filterExploreByTags';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -2,6 +2,8 @@ import { type ExploreWarningReport } from '../compiler/compilationReport';
 // Note: EE types removed from direct import to avoid circular module resolution
 // They are still available via the re-export below: export * from './ee';
 import type {
+    ApiAgentAsCodeListResponse,
+    ApiAgentAsCodeUpsertResponse,
     ApiAgentSuggestionsResponse,
     ApiAiAgentAdminConversationsResponse,
     ApiAiAgentAdminPromptActivityResponse,
@@ -1116,6 +1118,8 @@ type ApiResults =
     | ApiGroupListResponse['results']
     | ApiPullRequestsResponse['results']
     | ApiCreateTagResponse['results']
+    | ApiAgentAsCodeListResponse['results']
+    | ApiAgentAsCodeUpsertResponse['results']
     | ApiAlertAsCodeListResponse['results']
     | ApiAlertAsCodeUpsertResponse['results']
     | ApiChartAsCodeListResponse['results']

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -37,6 +37,7 @@ export enum ContentAsCodeType {
     DASHBOARD = 'dashboard',
     SQL_CHART = 'sql_chart',
     SPACE = 'space',
+    AI_AGENT = 'ai_agent',
     SCHEDULED_DELIVERY = 'scheduled_delivery',
     ALERT = 'alert',
     GOOGLE_SHEETS_SYNC = 'google_sheets_sync',


### PR DESCRIPTION
### Description

Adds project-scoped AI agent configuration to the content-as-code workflow.

- Defines a versioned `ai_agent` YAML schema for agent metadata, instructions, semantic tags, capability flags, model configuration, and runtime `agentVersion`.
- Keeps YAML schema `version: 1` independent from runtime agent versions and preserves both runtime v1 and v2 agents across environments.
- Adds permission-gated, paginated API endpoints for deterministic download and idempotent create/update by slug.
- Adds CLI support for `lightdash download --include-agents`, filtered `--agents` downloads/uploads, and automatic upload from `lightdash/ai-agents/`.
- Preserves target-specific access, integrations, MCP servers, documents, conversations, and uploaded-avatar provenance.
- Validates duplicate or invalid configurations and returns a non-zero CLI exit code for invalid agent files.

### Validation

- Common, backend, and CLI typechecks.
- Affected common, backend, and CLI lint checks.
- Backend AI agent coder tests: 11 passed.
- CLI download/upload tests: 17 passed.
- Live CLI verification: default opt-out, filtered and UUID downloads, no-op upload, update, create via slug change, force, pagination, project isolation, invalid configuration cases, and runtime v1/v2 round trips.

Closes: PROD-8818
Relates: #16763