### PR TITLE
fix(frontend): use dark filter pill remove icon

### DIFF
--- a/packages/frontend/src/components/common/TagInput/DefaultValue/DefaultValue.tsx
+++ b/packages/frontend/src/components/common/TagInput/DefaultValue/DefaultValue.tsx
@@ -60,7 +60,7 @@ export function DefaultValue({
                     onMouseDown={onRemove}
                     size={buttonSizes[size]}
                     radius={2}
-                    c="blue"
+                    c="ldDark.5"
                     variant="transparent"
                     iconSize="70%"
                     className={classes.defaultValueRemove}


### PR DESCRIPTION
## Summary

- change the legacy numeric-filter tag remove icon from blue to `ldDark.5`
- keep the change separate from the MultiSelect migration

## Root cause

The `DefaultValue` close button explicitly set `c="blue"`, overriding its neutral remove styling.

## Validation

- visually verified in dashboard filter configuration
- frontend typecheck
- targeted lint and format checks
- `FilterMultiNumberInput.test.tsx` (11 tests)