### PR TITLE
fix(frontend): filter dropdowns close the whole popover on select

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -427,6 +427,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                     disabled={disabled}
                     unitOfTime={rule.settings?.unitOfTime}
                     field={field}
+                    popoverProps={popoverProps}
                     onChange={(unitOfTime) =>
                         onChange({
                             ...rule,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterPeriodToDateSelect.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterPeriodToDateSelect.tsx
@@ -38,6 +38,11 @@ interface Props {
     unitOfTime?: UnitOfTime;
     field?: FilterableField;
     onChange: (unitOfTime: UnitOfTime) => void;
+    popoverProps?: {
+        withinPortal?: boolean;
+        onOpen?: () => void;
+        onClose?: () => void;
+    };
 }
 
 const FilterPeriodToDateSelect: FC<Props> = ({
@@ -45,6 +50,7 @@ const FilterPeriodToDateSelect: FC<Props> = ({
     unitOfTime,
     field,
     onChange,
+    popoverProps,
 }) => {
     const options = useMemo(() => {
         if (!field || !isDimension(field) || !field.timeInterval) {
@@ -66,6 +72,9 @@ const FilterPeriodToDateSelect: FC<Props> = ({
             size="xs"
             disabled={disabled}
             placeholder="Select period"
+            comboboxProps={{ withinPortal: popoverProps?.withinPortal }}
+            onDropdownOpen={popoverProps?.onOpen}
+            onDropdownClose={popoverProps?.onClose}
             data={options}
             value={unitOfTime ?? null}
             data-autofocus={!unitOfTime || undefined}

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -382,6 +382,13 @@ const FilterConfiguration: FC<Props> = ({
         ? 'A locked, required filter must have a value'
         : 'Filter field and value required';
 
+    // Render nested dropdowns inside the popover (not portaled) so selecting an
+    // option doesn't register as an outside click and close the whole popover.
+    const inlinePopoverProps = {
+        ...popoverProps,
+        withinPortal: false,
+    };
+
     return (
         // Make inline dropdowns flow in the panel (instead of absolute), so the
         // panel grows with them and Apply stays visible — PROD-2395 sketch.
@@ -435,7 +442,7 @@ const FilterConfiguration: FC<Props> = ({
                                     activeTabUuid={activeTabUuid}
                                     selectedField={selectedField}
                                     onChange={handleChangeField}
-                                    popoverProps={popoverProps}
+                                    popoverProps={inlinePopoverProps}
                                 />
                             ) : (
                                 <Select
@@ -450,6 +457,12 @@ const FilterConfiguration: FC<Props> = ({
                                         </Text>
                                     }
                                     placeholder="Search column..."
+                                    comboboxProps={{
+                                        withinPortal:
+                                            inlinePopoverProps.withinPortal,
+                                    }}
+                                    onDropdownOpen={inlinePopoverProps.onOpen}
+                                    onDropdownClose={inlinePopoverProps.onClose}
                                     value={draftFilterRule?.target.fieldId}
                                     data={columnsOptions.map(
                                         ({ reference }) => reference,
@@ -506,7 +519,7 @@ const FilterConfiguration: FC<Props> = ({
                                 field={selectedField}
                                 filterRule={draftFilterRule}
                                 onChangeFilterRule={handleChangeFilterRule}
-                                popoverProps={popoverProps}
+                                popoverProps={inlinePopoverProps}
                             />
                         )}
 
@@ -537,7 +550,7 @@ const FilterConfiguration: FC<Props> = ({
                             field={selectedField}
                             tabs={tabs}
                             filterRule={draftFilterRule}
-                            popoverProps={popoverProps}
+                            popoverProps={inlinePopoverProps}
                             tiles={tiles}
                             availableTileFilters={availableTileFilters}
                             onChange={handleChangeTileConfiguration}


### PR DESCRIPTION
## Problem

Adding a dashboard filter and selecting from a dropdown (the field/column picker, or a value dropdown) closes the entire filter popover and adds nothing — in both edit and view mode. Reported on a dashboard with SQL-column filters; also reproduces in-house on regular value dropdowns.

## Root cause

A later refactor dropped the `inlinePopoverProps` wrapper in `FilterConfiguration`. It now passed `popoverProps` straight through, so nested `Select`s rendered with `withinPortal` **undefined** → portaled out of the popover. Selecting an option then counts as an outside click, so the popover's `closeOnClickOutside`/`onDismiss` fires and closes it. This was previously prevented by pinning the dropdowns inside the panel (`withinPortal: false`, PROD-2395).

## Fix

- Reintroduce `inlinePopoverProps = { ...popoverProps, withinPortal: false }` and thread it to `FilterFieldSelect`, `FilterSettings`, and `TileFilterConfiguration` — so every operator/value dropdown pins to the panel again.
- Add the missing portal wiring (`withinPortal: false` + `onDropdownOpen/onDropdownClose`) to the two dropdowns that never had it: the SQL-column `Select` and `FilterPeriodToDateSelect`.

## Testing

- Typecheck + lint clean.
- Manual: add filter → pick a field/SQL column → set a value; popover stays open through each selection, in edit and view mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)