### PR TITLE
fix(frontend): pin per-tile SQL column select to filter panel

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
@@ -556,6 +556,14 @@ const TileFilterConfiguration: FC<Props> = ({
                                             withScrollArea={false}
                                             leftSection={undefined}
                                             allowDeselect={false}
+                                            comboboxProps={{
+                                                withinPortal:
+                                                    popoverProps?.withinPortal,
+                                            }}
+                                            onDropdownOpen={popoverProps?.onOpen}
+                                            onDropdownClose={
+                                                popoverProps?.onClose
+                                            }
                                             value={value.selectedField ?? null}
                                             data={value.sortedFilters}
                                             onChange={(newField) => {

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
@@ -560,7 +560,9 @@ const TileFilterConfiguration: FC<Props> = ({
                                                 withinPortal:
                                                     popoverProps?.withinPortal,
                                             }}
-                                            onDropdownOpen={popoverProps?.onOpen}
+                                            onDropdownOpen={
+                                                popoverProps?.onOpen
+                                            }
                                             onDropdownClose={
                                                 popoverProps?.onClose
                                             }


### PR DESCRIPTION
Follow-up to #25504. That PR fixed the field/column/value/date dropdowns, but a sweep found one more: the **per-tile SQL column `Select`** in the filter popover's *Chart tiles* tab (`TileFilterConfiguration`) still rendered portaled, so mapping a filter to a SQL tile's column registered as an outside click and closed the whole popover.

Adds `withinPortal:false` + `onDropdownOpen`/`onDropdownClose` wiring, matching the sibling `FieldSelect` right above it.

Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)