### PR TITLE
fix: pivot row totals missing for rows beyond the first 500 index values

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -3954,4 +3954,87 @@ describe('AsyncQueryService', () => {
             expect(mergedJson).not.toContain('customers_segment');
         });
     });
+
+    describe('runQueryAndTransformRows', () => {
+        const buildWarehouseClientStreaming = (
+            batches: Record<string, unknown>[][],
+        ) =>
+            ({
+                executeAsyncQuery: vi.fn(
+                    async (
+                        _args: unknown,
+                        streamCallback?: (
+                            rows: Record<string, unknown>[],
+                            fields: Record<string, { type: DimensionType }>,
+                        ) => void | Promise<void>,
+                    ) => {
+                        for (const batch of batches) {
+                            // eslint-disable-next-line no-await-in-loop
+                            await streamCallback?.(batch, {
+                                dim_a: { type: DimensionType.STRING },
+                                metric_x_any: { type: DimensionType.NUMBER },
+                            });
+                        }
+                        return {
+                            queryId: 'query-id',
+                            queryMetadata: null,
+                            totalRows: batches.flat().length,
+                            durationMs: 1,
+                            phaseTimings: {},
+                        };
+                    },
+                ),
+            }) as unknown as WarehouseClient;
+
+        test('counts total rows when the pivot has no groupBy columns (collapsed totals query)', async () => {
+            const batches = [
+                [
+                    { dim_a: 'a', metric_x_any: 1 },
+                    { dim_a: 'b', metric_x_any: 2 },
+                    { dim_a: 'c', metric_x_any: 3 },
+                ],
+                [
+                    { dim_a: 'd', metric_x_any: 4 },
+                    { dim_a: 'e', metric_x_any: 5 },
+                ],
+            ];
+            const write = vi.fn();
+
+            const { pivotDetails } =
+                await AsyncQueryService.runQueryAndTransformRows({
+                    warehouseClient: buildWarehouseClientStreaming(batches),
+                    query: 'SELECT 1',
+                    queryTags: {
+                        query_context: QueryExecutionContext.EXPLORE,
+                    },
+                    write,
+                    pivotConfiguration: {
+                        indexColumn: {
+                            reference: 'dim_a',
+                            type: VizIndexType.CATEGORY,
+                        },
+                        valuesColumns: [
+                            {
+                                reference: 'metric_x',
+                                aggregation: VizAggregationOptions.ANY,
+                            },
+                        ],
+                        groupByColumns: [],
+                        sortBy: undefined,
+                    },
+                    itemsMap: {},
+                    displayTimezone: null,
+                });
+
+            // Rows pass through untransformed…
+            expect(write).toHaveBeenCalledTimes(2);
+            expect(write).toHaveBeenNthCalledWith(1, batches[0]);
+            expect(write).toHaveBeenNthCalledWith(2, batches[1]);
+            // …and totalRows must reflect every streamed row, otherwise the
+            // query history records total_row_count=0 and paginated reads of
+            // the totals result stop after the first page.
+            expect(pivotDetails).not.toBeNull();
+            expect(pivotDetails?.totalRows).toBe(5);
+        });
+    });
 });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1996,6 +1996,7 @@ export class AsyncQueryService extends ProjectService {
                               // columnIndex is omitted when no groupBy columns
                           });
                       });
+                      pivotTotalRows += rows.length;
                       await write?.(rows);
                       return;
                   }


### PR DESCRIPTION
## Problem

In a pivot table with row totals enabled, every row beyond the first 500 distinct index-value combinations renders `-` in the "Total" column. Since the row-totals query drops the source query's metric sort, which rows fall inside the first 500 is warehouse-dependent, so missing totals can also appear scattered throughout the table.

The row-totals query (`calculate-total`, `kind: 'rowTotal'`) computes correct values for every row, but its paginated results endpoint reported `totalResults: 0` / `totalPageCount: 0`, so the frontend stopped reading after page 1 (500 rows) and every unmatched rendered row got no total. Column subtotals read results through the same paginated loop, so subtotal levels with more than 500 groups were affected the same way.

## Root cause

`AsyncQueryService.runQueryAndTransformRows` has an early-return branch for pivot configurations with no `groupByColumns` (exactly what `TotalQueryBuilder` produces for collapsed totals queries). That branch streams rows through without incrementing `pivotTotalRows`, so `pivotDetails.totalRows` stays `0`. When the query completes, `total_row_count: pivotDetails?.totalRows ?? totalRows` keeps the `0` (it's not nullish), the query history records 0 rows, and the results endpoint derives `totalPageCount: 0` from it — which stops the frontend's `while (page <= totalPageCount)` loop after one page.

## Fix

Count streamed rows in the no-`groupByColumns` branch so `total_row_count` (and therefore `totalResults` / `totalPageCount` / `nextPage`) is correct for collapsed totals queries. One line; no frontend changes.

Note for rollout: results cached before this fix still carry `total_row_count: 0` in the results cache, so affected charts recover once their cache entry expires or is invalidated.

## Tests

Regression test for `runQueryAndTransformRows` asserting `pivotDetails.totalRows` counts every streamed row when the pivot has no groupBy columns (failed with `0` before the fix).

Verified manually end to end with the unmodified frontend: a pivot table over 2007 index rows previously showed `-` totals from row 501 onwards; with only this backend line changed, the totals query reports `totalResults: 2007 / totalPageCount: 5`, the existing frontend loop fetches all 5 pages, and every row renders its total.

Closes: #25506
