### PR TITLE
fix(ai-agents): stop runSql tool calls crashing the agent chat bubble

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getToolCallChipLabel.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getToolCallChipLabel.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { getToolCallChipLabel } from './getToolCallChipLabel';
+
+describe('getToolCallChipLabel', () => {
+    it('returns null for runSql args without crashing', () => {
+        // Regression: runSql used to fall through into the runContentQuery
+        // handler and read `args.source.type` off undefined
+        expect(
+            getToolCallChipLabel('runSql', { sql: 'select 1', limit: 500 }),
+        ).toBeNull();
+    });
+
+    it('returns null for runSavedChart args', () => {
+        expect(
+            getToolCallChipLabel('runSavedChart', { chartSlug: 'my-chart' }),
+        ).toBeNull();
+    });
+
+    it('returns the table name for runContentQuery metricQuery sources', () => {
+        expect(
+            getToolCallChipLabel('runContentQuery', {
+                source: { type: 'metricQuery', tableName: 'orders' },
+            }),
+        ).toBe('orders');
+    });
+
+    it('returns dashboard and chart slugs for runContentQuery dashboardChart sources', () => {
+        expect(
+            getToolCallChipLabel('runContentQuery', {
+                source: {
+                    type: 'dashboardChart',
+                    dashboardSlug: 'sales',
+                    chartSlug: 'revenue',
+                },
+            }),
+        ).toBe('sales: revenue');
+    });
+
+    it('returns null for runContentQuery args without a source', () => {
+        expect(getToolCallChipLabel('runContentQuery', {})).toBeNull();
+    });
+
+    it('returns null when toolArgs is undefined', () => {
+        expect(getToolCallChipLabel('runSql', undefined)).toBeNull();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getToolCallChipLabel.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/getToolCallChipLabel.ts
@@ -181,14 +181,15 @@ export const getToolCallChipLabel = (
         case 'runSavedChart':
         case 'generateHashes':
         case 'improveContext':
+            return null;
         case 'runContentQuery': {
             const args = toolArgs as ToolRunContentQueryArgs;
-            if (args.source.type === 'metricQuery')
+            if (args.source?.type === 'metricQuery')
                 return args.source.tableName;
-            if (args.source.type === 'dashboardChart') {
+            if (args.source?.type === 'dashboardChart') {
                 return `${args.source.dashboardSlug}: ${args.source.chartSlug}`;
             }
-            return args.source.chartSlug;
+            return args.source?.chartSlug ?? null;
         }
         case 'loadProjectContext': {
             const args = toolArgs as { search?: string | null };


### PR DESCRIPTION
Fixes #25508

### Description:
Removing the proposeChange case in #25361 left runSql, runSavedChart, generateHashes, and improveContext falling through into the runContentQuery chip-label handler, which reads args.source.type — undefined for those tools' args. Approving any custom SQL run then crashed the whole assistant bubble with 'Cannot read properties of undefined (reading type)'.

Restore their own case returning null and make the runContentQuery handler tolerate a missing source.
