### PR TITLE
fix(cli): friendly errors for missing metrics key and unreadable manifest

### DIFF
--- a/packages/cli/src/dbt/manifest.ts
+++ b/packages/cli/src/dbt/manifest.ts
@@ -1,4 +1,4 @@
-import { DbtManifest, getErrorMessage } from '@lightdash/common';
+import { DbtManifest, getErrorMessage, ParseError } from '@lightdash/common';
 import { promises as fs } from 'fs';
 import fetch from 'node-fetch';
 import * as path from 'path';
@@ -29,7 +29,11 @@ export const loadManifestFromFile = async (
         return manifest;
     } catch (err: unknown) {
         const msg = getErrorMessage(err);
-        throw new Error(`Could not load manifest from ${filename}:\n  ${msg}`);
+        // ParseError is a LightdashError: an unreadable manifest is user
+        // input, so the CLI reports it without a stack trace / bug-report link
+        throw new ParseError(
+            `Could not load manifest from ${filename}:\n  ${msg}`,
+        );
     }
 };
 
@@ -62,7 +66,7 @@ export const loadManifestFromUrl = async (
         return manifest;
     } catch (err: unknown) {
         const msg = getErrorMessage(err);
-        throw new Error(`Could not load manifest from ${url}:\n  ${msg}`);
+        throw new ParseError(`Could not load manifest from ${url}:\n  ${msg}`);
     }
 };
 

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -431,8 +431,7 @@ export const compile = async (options: CompileHandlerOptions) => {
         );
     }
 
-    const metricsCount =
-        dbtMetrics === null ? 0 : Object.values(dbtMetrics).length;
+    const metricsCount = dbtMetrics ? Object.values(dbtMetrics).length : 0;
     await LightdashAnalytics.track({
         event: 'compile.completed',
         properties: {


### PR DESCRIPTION
## What & why

Two pre-existing CLI error-handling bugs, found by fault-injection testing of the compile path:

1. **Missing `metrics` key crashed after a successful compile.** If `target/manifest.json` has no `metrics` key, `lightdash compile` printed `Compiled N explores, SUCCESS=N` and then crashed with `TypeError: Cannot convert undefined or null to object` from the analytics `metricsCount` line — `dbtMetrics === null` missed `undefined`. Now guarded.

2. **Unreadable manifest was treated as an internal error.** A corrupt/truncated `manifest.json` threw a plain `Error`, so the CLI error handler dumped the stack trace (twice) plus the GitHub bug-report link for what is user input. Now throws `ParseError` (a `LightdashError`), so the CLI reports the friendly message only.

## Testing

- `pnpm -F cli typecheck` and manifest unit tests pass (message unchanged, so existing assertions hold).
- Verified manually: manifest without `metrics` key → compile completes, exit 0; truncated manifest → two-line `Could not load manifest …: Unexpected end of JSON input` message, exit 1, no stack trace.

Closes: PROD-8858