### PR TITLE
fix(frontend): tolerate partial create_saved_chart_version url state

### DIFF
--- a/packages/frontend/src/hooks/useExplorerRoute.test.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.test.ts
@@ -1,0 +1,94 @@
+import { ChartType } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { parseChartFromExplorerSearchParams } from './useExplorerRoute';
+
+const searchFromPayload = (payload: unknown) =>
+    `?create_saved_chart_version=${encodeURIComponent(
+        JSON.stringify(payload),
+    )}`;
+
+describe('parseChartFromExplorerSearchParams', () => {
+    it('returns undefined when the param is absent', () => {
+        expect(parseChartFromExplorerSearchParams('')).toBeUndefined();
+    });
+
+    it('defaults missing state keys instead of crashing', () => {
+        // Regression: agent-generated share links carried payloads with only
+        // a metricQuery — no chartConfig/tableConfig/tableCalculations — and
+        // the explorer crashed reading `chartConfig.type` on load
+        const parsed = parseChartFromExplorerSearchParams(
+            searchFromPayload({
+                tableName: 'orders',
+                metricQuery: {
+                    exploreName: 'orders',
+                    dimensions: ['orders_status'],
+                    metrics: ['orders_total'],
+                    sorts: [{ fieldId: 'orders_total', descending: true }],
+                    limit: 500,
+                },
+            }),
+        );
+
+        expect(parsed).toBeDefined();
+        expect(parsed!.chartConfig).toEqual({
+            type: ChartType.CARTESIAN,
+            config: { layout: {}, eChartsConfig: {} },
+        });
+        expect(parsed!.tableConfig).toEqual({ columnOrder: [] });
+        expect(parsed!.metricQuery.filters).toEqual({});
+        expect(parsed!.metricQuery.tableCalculations).toEqual([]);
+    });
+
+    it('defaults missing metricQuery arrays', () => {
+        const parsed = parseChartFromExplorerSearchParams(
+            searchFromPayload({
+                tableName: 'orders',
+                metricQuery: { exploreName: 'orders', limit: 500 },
+            }),
+        );
+
+        expect(parsed!.metricQuery.dimensions).toEqual([]);
+        expect(parsed!.metricQuery.metrics).toEqual([]);
+        expect(parsed!.metricQuery.sorts).toEqual([]);
+    });
+
+    it('falls back to tableName when exploreName is missing', () => {
+        const parsed = parseChartFromExplorerSearchParams(
+            searchFromPayload({
+                tableName: 'orders',
+                metricQuery: { dimensions: [], metrics: [], limit: 500 },
+            }),
+        );
+
+        expect(parsed!.metricQuery.exploreName).toBe('orders');
+    });
+
+    it('keeps provided state untouched', () => {
+        const chartConfig = {
+            type: ChartType.TABLE,
+            config: { showColumnCalculation: false },
+        };
+        const parsed = parseChartFromExplorerSearchParams(
+            searchFromPayload({
+                tableName: 'orders',
+                metricQuery: {
+                    exploreName: 'orders',
+                    dimensions: ['orders_status'],
+                    metrics: [],
+                    filters: {},
+                    sorts: [],
+                    limit: 100,
+                    tableCalculations: [],
+                },
+                chartConfig,
+                tableConfig: { columnOrder: ['orders_status'] },
+            }),
+        );
+
+        expect(parsed!.chartConfig).toEqual(chartConfig);
+        expect(parsed!.tableConfig).toEqual({
+            columnOrder: ['orders_status'],
+        });
+        expect(parsed!.metricQuery.limit).toBe(100);
+    });
+});

--- a/packages/frontend/src/hooks/useExplorerRoute.ts
+++ b/packages/frontend/src/hooks/useExplorerRoute.ts
@@ -131,12 +131,32 @@ export const useDateZoomGranularitySearch = ():
     return standardMatch ?? dateZoomParam;
 };
 
-// To handle older url params where exploreName wasn't required
+// Url params come from outside the app (old agent share links, hand-crafted
+// urls), so any key can be missing: older urls lack exploreName, and links
+// generated from AI answers can omit chartConfig, tableConfig, or metricQuery
+// sub-fields entirely.
 type BackwardsCompatibleCreateSavedChartVersionUrlParam = Omit<
     CreateSavedChartVersion,
-    'metricQuery'
+    'metricQuery' | 'chartConfig' | 'tableConfig'
 > & {
-    metricQuery: Omit<MetricQuery, 'exploreName'> & { exploreName?: string };
+    chartConfig?: CreateSavedChartVersion['chartConfig'];
+    tableConfig?: CreateSavedChartVersion['tableConfig'];
+    metricQuery: Omit<
+        MetricQuery,
+        | 'exploreName'
+        | 'dimensions'
+        | 'metrics'
+        | 'filters'
+        | 'sorts'
+        | 'tableCalculations'
+    > & {
+        exploreName?: string;
+        dimensions?: MetricQuery['dimensions'];
+        metrics?: MetricQuery['metrics'];
+        filters?: MetricQuery['filters'];
+        sorts?: MetricQuery['sorts'];
+        tableCalculations?: MetricQuery['tableCalculations'];
+    };
 };
 
 export const parseChartFromExplorerSearchParams = (
@@ -151,12 +171,21 @@ export const parseChartFromExplorerSearchParams = (
             JSON.parse(chartConfigSearchParam);
         return {
             ...parsedValue,
+            chartConfig:
+                parsedValue.chartConfig ??
+                DEFAULT_EMPTY_EXPLORE_CONFIG.chartConfig,
             tableConfig: parsedValue.tableConfig ?? { columnOrder: [] },
             metricQuery: {
                 ...parsedValue.metricQuery,
                 exploreName:
                     parsedValue.metricQuery.exploreName ||
                     parsedValue.tableName,
+                dimensions: parsedValue.metricQuery.dimensions ?? [],
+                metrics: parsedValue.metricQuery.metrics ?? [],
+                filters: parsedValue.metricQuery.filters ?? {},
+                sorts: parsedValue.metricQuery.sorts ?? [],
+                tableCalculations:
+                    parsedValue.metricQuery.tableCalculations ?? [],
                 customDimensions:
                     parsedValue.metricQuery.customDimensions?.map<CustomDimension>(
                         (customDimension) => {


### PR DESCRIPTION
Fixes #25510


### Description:
Explore urls are external input (old AI-agent share links, hand-crafted links), but parseChartFromExplorerSearchParams trusted the payload to be a complete CreateSavedChartVersion and only defaulted tableConfig. A payload without chartConfig crashed the explorer on load with 'Cannot read properties of undefined (reading type)' while seeding cachedChartConfigs, and one without tableCalculations crashed further down the hydration path.

Default every missing state key at the parse boundary: chartConfig falls back to the empty cartesian config, and the metricQuery dimensions/metrics/filters/sorts/tableCalculations fall back to empty.

