### PR TITLE
feat: expose warehouse catalog through the CLI

### DIFF
--- a/packages/cli/src/handlers/warehouseCatalog.ts
+++ b/packages/cli/src/handlers/warehouseCatalog.ts
@@ -1,0 +1,200 @@
+import {
+    type DimensionType,
+    type PartitionColumn,
+    type WarehouseTablesCatalog,
+    type WarehouseTableSchema,
+} from '@lightdash/common';
+import columnify from 'columnify';
+import { getConfig } from '../config';
+import GlobalState from '../globalState';
+import * as styles from '../styles';
+import { lightdashApi } from './dbt/apiClient';
+
+type WarehouseCatalogOptions = {
+    database?: string;
+    schema?: string;
+    table?: string;
+    includeFields: boolean;
+    refresh: boolean;
+    json: boolean;
+    verbose: boolean;
+};
+
+type WarehouseCatalogField = {
+    name: string;
+    type: DimensionType;
+};
+
+type WarehouseCatalogTable = {
+    database: string;
+    schema: string;
+    table: string;
+    partitionColumn?: PartitionColumn;
+    fields?: WarehouseCatalogField[];
+};
+
+type WarehouseCatalogOutput = {
+    tables: WarehouseCatalogTable[];
+};
+
+const compareStrings = (left: string, right: string): number => {
+    if (left < right) return -1;
+    if (left > right) return 1;
+    return 0;
+};
+
+const compareTables = (
+    left: WarehouseCatalogTable,
+    right: WarehouseCatalogTable,
+): number =>
+    compareStrings(left.database, right.database) ||
+    compareStrings(left.schema, right.schema) ||
+    compareStrings(left.table, right.table);
+
+const flattenCatalog = (
+    catalog: WarehouseTablesCatalog,
+): WarehouseCatalogTable[] =>
+    Object.entries(catalog)
+        .flatMap(([database, schemas]) =>
+            Object.entries(schemas).flatMap(([schema, tables]) =>
+                Object.entries(tables).map(([table, metadata]) => ({
+                    database,
+                    schema,
+                    table,
+                    ...(metadata.partitionColumn
+                        ? {
+                              partitionColumn: {
+                                  field: metadata.partitionColumn.field,
+                                  partitionType:
+                                      metadata.partitionColumn.partitionType,
+                              },
+                          }
+                        : {}),
+                })),
+            ),
+        )
+        .sort(compareTables);
+
+const filterTables = (
+    tables: WarehouseCatalogTable[],
+    options: Pick<WarehouseCatalogOptions, 'database' | 'schema' | 'table'>,
+): WarehouseCatalogTable[] =>
+    tables.filter(
+        (table) =>
+            (!options.database || table.database === options.database) &&
+            (!options.schema || table.schema === options.schema) &&
+            (!options.table || table.table === options.table),
+    );
+
+const validateFieldLookup = (
+    options: Pick<
+        WarehouseCatalogOptions,
+        'database' | 'schema' | 'table' | 'includeFields'
+    >,
+): void => {
+    if (
+        options.includeFields &&
+        (!options.database || !options.schema || !options.table)
+    ) {
+        throw new Error(
+            '--include-fields requires --database, --schema, and --table to identify exactly one warehouse table.',
+        );
+    }
+};
+
+const fieldsToList = (fields: WarehouseTableSchema): WarehouseCatalogField[] =>
+    Object.entries(fields)
+        .map(([name, type]) => ({ name, type }))
+        .sort((left, right) => compareStrings(left.name, right.name));
+
+const renderHumanOutput = ({ tables }: WarehouseCatalogOutput): void => {
+    if (tables.length === 0) {
+        process.stdout.write(
+            `${styles.warning('No warehouse tables found.')}\n`,
+        );
+        return;
+    }
+
+    process.stdout.write(
+        `${styles.bold(
+            `Warehouse catalog (${tables.length} ${
+                tables.length === 1 ? 'table' : 'tables'
+            })`,
+        )}\n\n`,
+    );
+    process.stdout.write(
+        `${columnify(tables, {
+            columns: ['database', 'schema', 'table'],
+        })}\n`,
+    );
+
+    const tableWithFields = tables.find((table) => table.fields);
+    if (tableWithFields?.fields) {
+        process.stdout.write(
+            `\n${styles.bold(
+                `Fields for ${tableWithFields.database}.${tableWithFields.schema}.${tableWithFields.table} (${tableWithFields.fields.length})`,
+            )}\n\n`,
+        );
+        process.stdout.write(
+            `${columnify(tableWithFields.fields, {
+                columns: ['name', 'type'],
+            })}\n`,
+        );
+    }
+};
+
+export const warehouseCatalogHandler = async (
+    options: WarehouseCatalogOptions,
+): Promise<void> => {
+    GlobalState.setVerbose(options.verbose);
+    validateFieldLookup(options);
+
+    const config = await getConfig();
+    const projectUuid = config.context?.project;
+    if (!projectUuid) {
+        throw new Error(
+            "No project selected. Run 'lightdash config set-project' first.",
+        );
+    }
+
+    if (options.refresh) {
+        await lightdashApi<undefined>({
+            method: 'POST',
+            url: `/api/v1/projects/${projectUuid}/sqlRunner/refresh-catalog`,
+            body: undefined,
+        });
+    }
+
+    const catalog = await lightdashApi<WarehouseTablesCatalog>({
+        method: 'GET',
+        url: `/api/v1/projects/${projectUuid}/sqlRunner/tables`,
+        body: undefined,
+    });
+    const tables = filterTables(flattenCatalog(catalog), options);
+
+    if (options.includeFields) {
+        if (tables.length !== 1) {
+            throw new Error(
+                `Could not find the exact warehouse table ${options.database}.${options.schema}.${options.table}.`,
+            );
+        }
+        const query = new URLSearchParams({
+            databaseName: options.database!,
+            schemaName: options.schema!,
+            tableName: options.table!,
+        });
+        const fields = await lightdashApi<WarehouseTableSchema>({
+            method: 'GET',
+            url: `/api/v1/projects/${projectUuid}/sqlRunner/fields?${query.toString()}`,
+            body: undefined,
+        });
+        tables[0].fields = fieldsToList(fields);
+    }
+
+    const output = { tables };
+    if (options.json) {
+        process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+    } else {
+        renderHumanOutput(output);
+    }
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -45,6 +45,7 @@ import { setProjectHandler, unsetProjectHandler } from './handlers/setProject';
 import { setWarehouseHandler } from './handlers/setWarehouse';
 import { sqlHandler } from './handlers/sql';
 import { validateHandler } from './handlers/validate';
+import { warehouseCatalogHandler } from './handlers/warehouseCatalog';
 import * as styles from './styles';
 // Trigger CLI tests
 // Suppress AWS SDK V2 warning, imported by snowflake SDK
@@ -1367,6 +1368,41 @@ ${styles.bold('Examples:')}
         'cli',
     )
     .action(lintHandler);
+
+program
+    .command('warehouse-catalog')
+    .description(
+        "Explore the selected project's raw warehouse databases, schemas, tables, and fields",
+    )
+    .option('--database <name>', 'Filter by exact database name')
+    .option('--schema <name>', 'Filter by exact schema name')
+    .option('--table <name>', 'Filter by exact table name')
+    .option(
+        '--include-fields',
+        'Include field names and Lightdash types for one fully qualified table',
+        false,
+    )
+    .option(
+        '--refresh',
+        'Refetch warehouse metadata and refresh the server catalog cache first',
+        false,
+    )
+    .option('--json', 'Emit machine-readable JSON instead of a table', false)
+    .option('--verbose', 'Show detailed output', false)
+    .addHelpText(
+        'after',
+        `
+${styles.bold('Examples:')}
+  ${styles.title('⚡')} lightdash ${styles.bold('warehouse-catalog')}
+  ${styles.title('⚡')} lightdash ${styles.bold(
+      'warehouse-catalog',
+  )} --database analytics --schema public
+  ${styles.title('⚡')} lightdash ${styles.bold(
+      'warehouse-catalog',
+  )} --database analytics --schema public --table orders --include-fields --json
+`,
+    )
+    .action(warehouseCatalogHandler);
 
 program
     .command('pre-aggregate-audit')

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -303,7 +303,10 @@ import {
     type ApiSingleValidationResponse,
     type ValidationResponse,
 } from './validation';
-import { type ApiWarehouseTableFields } from './warehouse';
+import {
+    type ApiWarehouseTableFields,
+    type ApiWarehouseTablesCatalog,
+} from './warehouse';
 
 export type ApiGetDashboardPreAggregateAuditResponse = {
     status: 'ok';
@@ -1103,6 +1106,7 @@ type ApiResults =
     | ApiCatalogAnalyticsResults
     | ApiPromotionChangesResponse['results']
     | ApiWarehouseTableFields['results']
+    | ApiWarehouseTablesCatalog['results']
     | ApiTogglePinnedItem['results']
     | ApiOrganizationMemberProfiles['results']
     | ApiSqlChart['results']

--- a/skills/developing-in-lightdash/SKILL.md
+++ b/skills/developing-in-lightdash/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: developing-in-lightdash
-description: Use when working with Lightdash YAML files, dbt models with Lightdash metadata, the lightdash CLI (deploy, upload, download, preview, lint, sql, set-warehouse), or creating/editing charts, dashboards, metrics, and dimensions as code
+description: Use when working with Lightdash YAML files, dbt models with Lightdash metadata, the lightdash CLI (deploy, upload, download, preview, lint, warehouse-catalog, sql, set-warehouse), or creating/editing charts, dashboards, metrics, and dimensions as code
 ---
 
 # Developing in Lightdash
@@ -10,7 +10,7 @@ Build and deploy Lightdash analytics projects. This skill covers the **semantic 
 ## When to Use
 
 - Working with Lightdash YAML files (charts, dashboards, models as code)
-- Using the `lightdash` CLI (`deploy`, `upload`, `download`, `preview`, `lint`, `sql`)
+- Using the `lightdash` CLI (`deploy`, `upload`, `download`, `preview`, `lint`, `warehouse-catalog`, `sql`)
 - Defining metrics, dimensions, joins, or tables in dbt or pure Lightdash projects
 - Creating or editing charts and dashboards as code
 
@@ -20,7 +20,8 @@ Build and deploy Lightdash analytics projects. This skill covers the **semantic 
 
 | Task | Commands | References |
 |------|----------|------------|
-| Explore data warehouse | `lightdash sql` to execute raw sql, read .csv results | [CLI Reference](./resources/cli-reference.md) |
+| Discover warehouse tables and fields | `lightdash warehouse-catalog --json` | [CLI Reference](./resources/cli-reference.md) |
+| Explore data warehouse values | `lightdash sql` to execute raw sql, read .csv results | [CLI Reference](./resources/cli-reference.md) |
 | Define metrics & dimensions | Edit dbt YAML or Lightdash YAML | [Metrics](./resources/metrics-reference.md), [Dimensions](./resources/dimensions-reference.md) |
 | Create charts | `lightdash download`, edit YAML, `lightdash upload` | [Chart Types](#chart-types) |
 | Add period comparisons | Add PoP additional metrics to chart YAML | [Period over Period](./resources/period-over-period-reference.md) |
@@ -218,6 +219,7 @@ lightdash stop-preview --name "my-feature"
 | `lightdash download` | Download charts/dashboards as YAML |
 | `lightdash lint` | Validate YAML locally |
 | `lightdash preview` | Create temporary test project |
+| `lightdash warehouse-catalog --json` | Discover raw warehouse tables |
 | `lightdash sql "..." -o file.csv` | Run SQL queries against warehouse |
 | `lightdash run-chart -p chart.yml` | Execute chart YAML query against warehouse |
 

--- a/skills/developing-in-lightdash/resources/cli-reference.md
+++ b/skills/developing-in-lightdash/resources/cli-reference.md
@@ -110,6 +110,41 @@ lightdash upload --dashboards my-dashboard --include-charts
 
 ## SQL Runner
 
+### Warehouse catalog
+
+Discover databases, schemas, and tables using the currently selected project's server-side warehouse credentials. The default output is a terminal table; use `--json` for deterministic machine-readable output.
+
+```bash
+# List all warehouse tables
+lightdash warehouse-catalog
+
+# Filter by exact database and schema names
+lightdash warehouse-catalog --database analytics --schema public
+
+# Return deterministic JSON for an agent or script
+lightdash warehouse-catalog --schema public --json
+
+# Include fields and Lightdash types for one fully qualified table
+lightdash warehouse-catalog --database analytics --schema public --table orders --include-fields --json
+
+# Refetch warehouse metadata and refresh the server cache before listing
+lightdash warehouse-catalog --refresh
+```
+
+**Options:**
+
+- `--database <name>` - Filter by exact database name
+- `--schema <name>` - Filter by exact schema name
+- `--table <name>` - Filter by exact table name
+- `--include-fields` - Include fields and Lightdash types; requires all three filters
+- `--refresh` - Refetch warehouse metadata and refresh the server catalog cache before listing
+- `--json` - Output deterministic JSON instead of a terminal table
+- `--verbose` - Show detailed API request output
+
+The command requires a project selected with `lightdash config set-project` and never returns warehouse credentials or secret connection metadata.
+
+### Run SQL
+
 Execute raw SQL queries against the warehouse using the current project's credentials.
 
 ```bash
@@ -216,6 +251,7 @@ lightdash set-warehouse --project-dir ./dbt --profiles-dir ./profiles --assume-y
 | `lightdash validate`  | Validate against server          |
 | `lightdash lint`      | Validate YAML locally            |
 | `lightdash generate`  | Generate YAML from dbt models    |
+| `lightdash warehouse-catalog` | Discover warehouse tables and fields |
 | `lightdash sql`       | Run SQL queries                  |
 | `lightdash run-chart` | Execute chart YAML query         |
 | `lightdash set-warehouse` | Update project warehouse connection |


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-8866

### Description:
Adds `lightdash warehouse-catalog` with human-readable default output, deterministic JSON, exact filters, typed field discovery, and cache refresh while using server-side credentials. Updates the installed skill documentation and shared API result typing.

### Option examples

```bash
# Full catalog: all databases, schemas, and tables
lightdash warehouse-catalog

# Just the database names
lightdash warehouse-catalog --json | jq -r '.tables[].database' | sort -u

# Just the schemas in one database
lightdash warehouse-catalog --database staging_postgres_trino --json | jq -r '.tables[].schema' | sort -u

# Just the table names in one schema
lightdash warehouse-catalog --database staging_postgres_trino --schema jaffle --json | jq -r '.tables[].table'

# One exact table
lightdash warehouse-catalog --database staging_postgres_trino --schema jaffle --table orders

# One exact table with fields and Lightdash types
lightdash warehouse-catalog --database staging_postgres_trino --schema jaffle --table orders --include-fields

# Refetch warehouse metadata before listing
lightdash warehouse-catalog --refresh

# Return the filtered catalog as JSON
lightdash warehouse-catalog --database staging_postgres_trino --schema jaffle --table orders --include-fields --json
```

### Local CLI output

Human output:

```console
$ lightdash warehouse-catalog --database staging_postgres_trino --schema jaffle --table orders --include-fields
Warehouse catalog (1 table)

DATABASE               SCHEMA TABLE
staging_postgres_trino jaffle orders

Fields for staging_postgres_trino.jaffle.orders (10)

NAME                 TYPE
amount               number
bank_transfer_amount number
coupon_amount        number
credit_card_amount   number
customer_id          number
gift_card_amount     number
is_completed         boolean
order_date           date
order_id             number
status               string
```

JSON output:

```json
{
  "tables": [
    {
      "database": "staging_postgres_trino",
      "schema": "jaffle",
      "table": "orders",
      "fields": [
        {
          "name": "amount",
          "type": "number"
        },
        {
          "name": "bank_transfer_amount",
          "type": "number"
        },
        {
          "name": "coupon_amount",
          "type": "number"
        },
        {
          "name": "credit_card_amount",
          "type": "number"
        },
        {
          "name": "customer_id",
          "type": "number"
        },
        {
          "name": "gift_card_amount",
          "type": "number"
        },
        {
          "name": "is_completed",
          "type": "boolean"
        },
        {
          "name": "order_date",
          "type": "date"
        },
        {
          "name": "order_id",
          "type": "number"
        },
        {
          "name": "status",
          "type": "string"
        }
      ]
    }
  ]
}
```

Validation: `pnpm --filter @lightdash/cli test` (21 files, 196 tests), CLI typecheck, and focused lint.
