### PR TITLE
fix: align content as code dashboard-attach checks with UI SavedChart permissions

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -2812,20 +2812,20 @@ export class CoderService extends BaseService {
 
                     dashboardUuid = newDashboard.uuid;
                 } else if (!canUploadAnyContent) {
-                    await this.assertDashboardUpdateAccess({
-                        userUuid: user.userUuid,
-                        auditedAbility,
-                        dashboard,
-                    });
-                    // Chart lives in the dashboard, not the YAML space
+                    // Chart lives in the dashboard, not the YAML space.
+                    // Mirrors SavedChartService: only SavedChart create in
+                    // the dashboard's space is required.
+                    if (!dashboard.spaceUuid) {
+                        throw new ForbiddenError(
+                            "You don't have access to create charts in this space",
+                        );
+                    }
                     await this.assertSpaceContentAccess({
                         userUuid: user.userUuid,
                         auditedAbility,
                         action: 'create',
                         subjectType: 'SavedChart',
-                        spaceUuids: dashboard.spaceUuid
-                            ? [dashboard.spaceUuid]
-                            : [],
+                        spaceUuids: [dashboard.spaceUuid],
                         errorMessage:
                             "You don't have access to create charts in this space",
                     });
@@ -2907,7 +2907,9 @@ export class CoderService extends BaseService {
                 );
             }
 
-            if (!chart.spaceUuid && !chart.dashboardUuid) {
+            // find() coalesces spaceUuid to the dashboard's space for
+            // dashboard-contained charts, so this covers both kinds
+            if (!chart.spaceUuid) {
                 throw new ForbiddenError(
                     "You don't have access to update this chart",
                 );
@@ -2925,17 +2927,6 @@ export class CoderService extends BaseService {
                 metadata: { savedChartUuid: chart.uuid },
                 errorMessage: "You don't have access to update this chart",
             });
-
-            if (chart.dashboardUuid) {
-                const dashboard = await this.dashboardModel.getByIdOrSlug(
-                    chart.dashboardUuid,
-                );
-                await this.assertDashboardUpdateAccess({
-                    userUuid: user.userUuid,
-                    auditedAbility,
-                    dashboard,
-                });
-            }
 
             const currentChart = await this.savedChartModel.get(chart.uuid);
             CoderService.handleContentAsCodeSqlPermissionChecks({

--- a/packages/backend/src/services/CoderService/CoderService.upsertContentAccess.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.upsertContentAccess.test.ts
@@ -552,7 +552,7 @@ describe('CoderService content-as-code space permissions', () => {
         expect(service.getOrCreateSpace).not.toHaveBeenCalled();
     });
 
-    it('does not let chart create attach to a dashboard without dashboard update access', async () => {
+    it('lets chart create attach to a dashboard with chart create access but no dashboard ability (UI parity)', async () => {
         const service = buildService();
         vi.spyOn(service, 'getOrCreateSpace').mockResolvedValue({
             space: { uuid: SPACE_UUID } as AnyType,
@@ -564,6 +564,9 @@ describe('CoderService content-as-code space permissions', () => {
                 spaceUuid: OTHER_SPACE_UUID,
             } as AnyType,
         ]);
+        vi.mocked(service.savedChartModel.create).mockResolvedValue({
+            uuid: 'chart-uuid',
+        } as AnyType);
         const user = makeUser([
             { subject: 'ContentAsCode', action: 'create' },
             {
@@ -578,8 +581,8 @@ describe('CoderService content-as-code space permissions', () => {
                 ...chartAsCode,
                 dashboardSlug: 'dashboard',
             }),
-        ).rejects.toThrow(ForbiddenError);
-        expect(service.savedChartModel.create).not.toHaveBeenCalled();
+        ).resolves.toMatchObject({ charts: [{ action: 'create' }] });
+        expect(service.savedChartModel.create).toHaveBeenCalled();
     });
 
     it('does not let ContentAsCode alone update dashboards into target spaces', async () => {
@@ -745,12 +748,13 @@ describe('CoderService content-as-code space permissions', () => {
         expect(service.spaceModel.createSpace).not.toHaveBeenCalled();
     });
 
-    it('does not let chart update bypass dashboard access for dashboard-contained charts', async () => {
+    it('gates dashboard-contained chart update on SavedChart update in the dashboard space', async () => {
         const service = buildService();
+        // Model coalesces spaceUuid to the dashboard's space
         vi.mocked(service.savedChartModel.find).mockResolvedValue([
             {
                 uuid: 'chart-uuid',
-                spaceUuid: null,
+                spaceUuid: OTHER_SPACE_UUID,
                 dashboardUuid: 'dashboard-uuid',
                 metricQuery: {
                     tableCalculations: [],
@@ -758,10 +762,6 @@ describe('CoderService content-as-code space permissions', () => {
                 },
             } as AnyType,
         ]);
-        vi.mocked(service.dashboardModel.getByIdOrSlug).mockResolvedValue({
-            uuid: 'dashboard-uuid',
-            spaceUuid: OTHER_SPACE_UUID,
-        } as AnyType);
         vi.spyOn(service, 'getOrCreateSpace').mockResolvedValue({
             space: { uuid: SPACE_UUID } as AnyType,
             created: false,
@@ -771,7 +771,14 @@ describe('CoderService content-as-code space permissions', () => {
             {
                 subject: 'SavedChart',
                 action: 'update',
-                conditions: { projectUuid: PROJECT_UUID },
+                conditions: {
+                    access: {
+                        $elemMatch: {
+                            userUuid: 'user-uuid',
+                            role: SpaceMemberRole.EDITOR,
+                        },
+                    },
+                },
             },
         ]);
 
@@ -784,6 +791,7 @@ describe('CoderService content-as-code space permissions', () => {
             ),
         ).rejects.toThrow(ForbiddenError);
         expect(service.promoteService.getPromoteCharts).not.toHaveBeenCalled();
+        expect(service.dashboardModel.getByIdOrSlug).not.toHaveBeenCalled();
     });
 
     it('does not let chart create attach to a dashboard without SavedChart create access in the dashboard space', async () => {


### PR DESCRIPTION
Stacked on #25219.

Content-as-code chart writes into dashboards required `update:Dashboard` on the dashboard's space — stricter than the UI path (`SavedChartService`), which only checks `create`/`update` on `SavedChart` against that space. A custom role with space-scoped SavedChart access but no Dashboard ability could edit dashboard-contained charts in the UI but got 403 via `lightdash upload`.

This aligns both upload paths with the UI:

- **Create/attach**: dropped the `assertDashboardUpdateAccess` gate; kept `SavedChart create` against the dashboard's space (with a fail-closed guard for a null space).
- **Update**: dropped the dashboard fetch + gate entirely — `savedChartModel.find` already coalesces `spaceUuid` to the dashboard's space, so the existing `SavedChart update` check covers dashboard-contained charts. Tightened the null-space guard accordingly.

Legacy `manage:ContentAsCode` behavior unchanged. The dashboard upsert path keeps its own `Dashboard` gate.

Tests: rewrote the two tests pinning the stricter behavior — attach with SavedChart-create but no Dashboard ability now asserts success (UI parity); dashboard-contained chart update asserts the gate is SavedChart update in the coalesced space.

Linear: ZAP-551

🤖 Generated with [Claude Code](https://claude.com/claude-code)