### PR TITLE
fix(e2e): repair app e2e specs broken by Mantine 8 Select/Checkbox migration

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -261,8 +261,7 @@ describe('Dashboard', () => {
         cy.get('[data-testid="DashboardFilterConfiguration/ChartTiles"]')
             .findAllByRole('checkbox')
             .eq(1)
-            .focus()
-            .type(' ');
+            .uncheck({ force: true });
         cy.contains('button', 'Apply').click({ force: true });
 
         // Saved chart should have no filter applied
@@ -315,8 +314,7 @@ describe('Dashboard', () => {
             .contains('Stg Payments (payment method x amount)?')
             .closest('[data-testid="tile-filter-item"]')
             .findByRole('checkbox')
-            .focus()
-            .type(' ');
+            .check({ force: true });
         cy.get(
             '[data-testid="DashboardFilterConfiguration/ChartTiles"] [data-testid="tile-filter-item"]',
         )

--- a/packages/e2e/cypress/support/commands.ts
+++ b/packages/e2e/cypress/support/commands.ts
@@ -145,10 +145,7 @@ Cypress.Commands.add(
     'selectMantine',
     (inputName: string, optionLabel: string) => {
         // Mantine 8 Select puts `name` on a hidden input right after the Select root
-        cy.get(`input[name="${inputName}"]`)
-            .prev()
-            .find('input')
-            .click(); // open dropdown
+        cy.get(`input[name="${inputName}"]`).prev().find('input').click(); // open dropdown
         cy.findByRole('option', { name: optionLabel }).click();
     },
 );

--- a/packages/e2e/cypress/support/commands.ts
+++ b/packages/e2e/cypress/support/commands.ts
@@ -144,12 +144,12 @@ Cypress.on('uncaught:exception', (err) => {
 Cypress.Commands.add(
     'selectMantine',
     (inputName: string, optionLabel: string) => {
+        // Mantine 8 Select puts `name` on a hidden input right after the Select root
         cy.get(`input[name="${inputName}"]`)
-            .parent()
-            .click() // open dropdown
-            .parent('.mantine-Select-root')
-            .contains(optionLabel)
-            .click(); // click option
+            .prev()
+            .find('input')
+            .click(); // open dropdown
+        cy.findByRole('option', { name: optionLabel }).click();
     },
 );
 


### PR DESCRIPTION
### Description:

`E2E: App (1/5)` is red on every current PR (e.g. #25505, and unrelated PRs like the ai-agents fix) since the Mantine 8 migration wave merged on Jul 13. Two separate breakages, both test-side — the product behaviour is fine:

**1. `createProjects.cy.ts` — 3 failures (`.mantine-Select-root` not found)**

#25479 migrated `Select` to Mantine 8, which renders with the `mantine-8-` class prefix and moves the `name` attribute onto a **hidden input placed after** the `.mantine-8-Select-root` element (options render portaled with `role="option"`). The `selectMantine` support command still walked up to the v6-only `.mantine-Select-root` class. Rewritten to open the dropdown via the Select root preceding the hidden name input and pick the option by role.

**2. `dashboard.cy.ts` — tile-target test failure (`expected ... to contain bank_transfer`)**

#25482 replaced the v6 `.mantine-Checkbox-body ... .click()` selectors with `findAllByRole('checkbox').focus().type(' ')`. Cypress `.type(' ')` does **not** perform the native space-toggle default action on a checkbox input, so the command passes while toggling nothing — Apply then applies unchanged tile targets and the assertion times out. (The CI attempt-3 failure at the chart-name toast is downstream retry noise from the same root cause.) Replaced with semantic `.check()`/`.uncheck({ force: true })` (`force` because Mantine's checkbox input is visually covered by the styled icon), which also asserts the resulting state.

Verified locally against the dev server: `dashboard.cy.ts` goes from 2 failing to **3 passing / 0 failing**, and `createProjects.cy.ts` now gets past all `selectMantine` steps (remaining local failure is only the CI-docker-specific `/dbt` project directory). Also verified in-browser that the product path works: real checkbox toggle + Apply correctly unfilters the tile.

### Follow-up risk (not fixed here):

Other specs still use v6 class selectors that will break as their components migrate to Mantine 8 — `dates.cy.ts` (DateInput/DatePicker), `explore.cy.ts` (`.mantine-Select-item`, `.mantine-Badge-inner`), `tableCalculation.cy.ts`, `customDimensions.cy.ts`, `sqlRunner.cy.ts`, and `.mantine-MultiSelect-input` in `dashboard.cy.ts`. They pass today because those components are still on v6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNjo5KfcV9zeNnNStStrW8