### PR TITLE
feat(common): homepage builder types and commercial feature flag

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -482,6 +482,10 @@ import {
     ProjectCiStatusTableName,
 } from '../ee/database/entities/projectCiStatus';
 import {
+    HomepagesTableName,
+    ProjectHomepagesTable,
+} from '../ee/database/entities/projectHomepages';
+import {
     SchedulerAiAugmentationTable,
     SchedulerAiAugmentationTableName,
 } from '../ee/database/entities/schedulerAiAugmentation';
@@ -614,6 +618,7 @@ declare module 'knex/types/tables' {
         [AiMcpServerCredentialTableName]: AiMcpServerCredentialTable;
         [AiAgentMcpServerTableName]: AiAgentMcpServerTable;
         [AiAgentUserPreferencesTableName]: AiAgentUserPreferencesTable;
+        [HomepagesTableName]: ProjectHomepagesTable;
         [AiAgentReasoningTableName]: AiAgentReasoningTable;
         [AiAgentToolCallTableName]: AiAgentToolCallTable;
         [AiAgentToolResultTableName]: AiAgentToolResultTable;

--- a/packages/backend/src/ee/controllers/projectHomepageController.ts
+++ b/packages/backend/src/ee/controllers/projectHomepageController.ts
@@ -1,0 +1,158 @@
+import {
+    assertRegisteredAccount,
+    type ApiErrorPayload,
+    type ApiProjectHomepageOrNullResponse,
+    type ApiProjectHomepageResponse,
+    type ApiPublishedHomepageResponse,
+    type CreateProjectHomepageRequest,
+    type UpdateProjectHomepageDraftRequest,
+    type UUID,
+} from '@lightdash/common';
+import {
+    Body,
+    Get,
+    Middlewares,
+    OperationId,
+    Patch,
+    Path,
+    Post,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import { toSessionUser } from '../../auth/account/account';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { type ProjectHomepageService } from '../services/ProjectHomepageService';
+
+@Route('/api/v1/projects/{projectUuid}/homepage')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('Homepage')
+export class ProjectHomepageController extends BaseController {
+    private getHomepageService(): ProjectHomepageService {
+        return this.services.getProjectHomepageService<ProjectHomepageService>();
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('getPublishedProjectHomepage')
+    async getPublished(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+    ): Promise<ApiPublishedHomepageResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().getPublishedHomepage(
+                toSessionUser(req.account),
+                projectUuid,
+            ),
+        };
+    }
+
+    // Literal route must be declared before '/{homepageUuid}' param routes
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/builder')
+    @OperationId('getProjectHomepageForBuilder')
+    async getForBuilder(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+    ): Promise<ApiProjectHomepageOrNullResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().getHomepageForBuilder(
+                toSessionUser(req.account),
+                projectUuid,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('201', 'Created')
+    @Post('/')
+    @OperationId('createProjectHomepage')
+    async create(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Body() body: CreateProjectHomepageRequest,
+    ): Promise<ApiProjectHomepageResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(201);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().createHomepage(
+                toSessionUser(req.account),
+                projectUuid,
+                body,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/{homepageUuid}')
+    @OperationId('updateProjectHomepageDraft')
+    async updateDraft(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() homepageUuid: UUID,
+        @Body() body: UpdateProjectHomepageDraftRequest,
+    ): Promise<ApiProjectHomepageResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().updateDraft(
+                toSessionUser(req.account),
+                projectUuid,
+                homepageUuid,
+                body,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/{homepageUuid}/publish')
+    @OperationId('publishProjectHomepage')
+    async publish(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() homepageUuid: UUID,
+    ): Promise<ApiProjectHomepageResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().publishHomepage(
+                toSessionUser(req.account),
+                projectUuid,
+                homepageUuid,
+            ),
+        };
+    }
+}

--- a/packages/backend/src/ee/database/entities/projectHomepages.ts
+++ b/packages/backend/src/ee/database/entities/projectHomepages.ts
@@ -1,0 +1,38 @@
+import { type HomepageConfig } from '@lightdash/common';
+import { type Knex } from 'knex';
+
+export const HomepagesTableName = 'homepages';
+
+export type DbProjectHomepage = {
+    homepage_uuid: string;
+    project_uuid: string;
+    name: string;
+    draft_config: HomepageConfig;
+    published_config: HomepageConfig | null;
+    is_default: boolean;
+    created_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type DbProjectHomepageIn = Pick<
+    DbProjectHomepage,
+    | 'project_uuid'
+    | 'name'
+    | 'draft_config'
+    | 'is_default'
+    | 'created_by_user_uuid'
+>;
+
+export type DbProjectHomepageUpdate = Partial<
+    Pick<
+        DbProjectHomepage,
+        'name' | 'draft_config' | 'published_config' | 'updated_at'
+    >
+>;
+
+export type ProjectHomepagesTable = Knex.CompositeTableType<
+    DbProjectHomepage,
+    DbProjectHomepageIn,
+    DbProjectHomepageUpdate
+>;

--- a/packages/backend/src/ee/database/migrations/20260714150000_create_homepages_table.ts
+++ b/packages/backend/src/ee/database/migrations/20260714150000_create_homepages_table.ts
@@ -1,0 +1,46 @@
+import { Knex } from 'knex';
+
+const HOMEPAGES_TABLE = 'homepages';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(HOMEPAGES_TABLE, (table) => {
+        table
+            .uuid('homepage_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE')
+            .index();
+        table.text('name').notNullable();
+        table.jsonb('draft_config').notNullable();
+        table.jsonb('published_config').nullable();
+        table.boolean('is_default').notNullable().defaultTo(false);
+        table
+            .uuid('created_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL')
+            .index();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+    await knex.raw(`
+        CREATE UNIQUE INDEX homepages_one_default_per_project
+        ON homepages (project_uuid) WHERE is_default = true
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(HOMEPAGES_TABLE);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -46,6 +46,7 @@ import { ManagedAgentModel } from './models/ManagedAgentModel';
 import { McpToolCallModel } from './models/McpToolCallModel';
 import { ProjectCiStatusModel } from './models/ProjectCiStatusModel';
 import { ProjectContextModel } from './models/ProjectContextModel';
+import { ProjectHomepageModel } from './models/ProjectHomepageModel';
 import { SandboxRegistryModel } from './models/SandboxRegistryModel';
 import { SchedulerAiAugmentationModel } from './models/SchedulerAiAugmentationModel';
 import { ServiceAccountModel } from './models/ServiceAccountModel';
@@ -85,6 +86,7 @@ import { McpService } from './services/McpService/McpService';
 import { OrganizationWarehouseCredentialsService } from './services/OrganizationWarehouseCredentialsService';
 import { PreviewDeploySetupService } from './services/PreviewDeploySetupService/PreviewDeploySetupService';
 import { ProjectContextService } from './services/ProjectContextService/ProjectContextService';
+import { ProjectHomepageService } from './services/ProjectHomepageService';
 import { SchedulerAiAugmentationService } from './services/SchedulerAiAugmentationService/SchedulerAiAugmentationService';
 import { ScimService } from './services/ScimService/ScimService';
 import { ServiceAccountService } from './services/ServiceAccountService/ServiceAccountService';
@@ -127,6 +129,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
 
     return {
         serviceProviders: {
+            projectHomepageService: ({ models, repository }) =>
+                new ProjectHomepageService({
+                    projectHomepageModel:
+                        models.getProjectHomepageModel<ProjectHomepageModel>(),
+                    featureFlagService: repository.getFeatureFlagService(),
+                }),
             aiDeepResearchService: ({
                 models,
                 clients,
@@ -875,6 +883,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 }),
         },
         modelProviders: {
+            projectHomepageModel: ({ database }) =>
+                new ProjectHomepageModel({ database }),
             aiAgentModel: ({ database, utils }) =>
                 new AiAgentModel({
                     database,

--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -14,7 +14,21 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
             // Add new commercial handlers
             [CommercialFeatureFlags.AiCopilot]:
                 this.getAiCopilotFlag.bind(this),
+            [CommercialFeatureFlags.HomepageBuilder]:
+                this.getHomepageBuilderFlag.bind(this),
         };
+    }
+
+    // Default-off; enabled per-org via DB-backed overrides.
+    private async getHomepageBuilderFlag({
+        featureFlagId,
+        user,
+    }: FeatureFlagLogicArgs) {
+        if (!user) {
+            return { id: featureFlagId, enabled: false };
+        }
+        const dbResult = await this.tryGetFromDatabase({ user, featureFlagId });
+        return dbResult ?? { id: featureFlagId, enabled: false };
     }
 
     private async getAiCopilotFlag({

--- a/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
@@ -1,0 +1,99 @@
+import { NotFoundError, type HomepageConfig } from '@lightdash/common';
+import knex, { Knex } from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { HomepagesTableName } from '../database/entities/projectHomepages';
+import { ProjectHomepageModel } from './ProjectHomepageModel';
+
+// Covers only behavior beyond a thin Knex wrapper: NotFoundError
+// contracts and the publish draft→published copy the service depends on.
+
+const PROJECT_UUID = '00000000-0000-0000-0000-000000000001';
+const HOMEPAGE_UUID = '00000000-0000-0000-0000-000000000010';
+
+const draftConfig: HomepageConfig = {
+    version: 1,
+    rows: [
+        {
+            id: 'row-1',
+            blocks: [
+                { id: 'block-1', type: 'markdown', config: { content: 'hi' } },
+            ],
+        },
+    ],
+};
+
+const makeDbHomepage = (overrides: Partial<Record<string, unknown>> = {}) => ({
+    homepage_uuid: HOMEPAGE_UUID,
+    project_uuid: PROJECT_UUID,
+    name: 'Team homepage',
+    draft_config: draftConfig,
+    published_config: null,
+    is_default: true,
+    created_by_user_uuid: null,
+    created_at: new Date('2026-01-01T00:00:00Z'),
+    updated_at: new Date('2026-01-02T00:00:00Z'),
+    ...overrides,
+});
+
+describe('ProjectHomepageModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new ProjectHomepageModel({
+        database: database as unknown as Knex,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    describe('updateDraft', () => {
+        it('throws NotFoundError when no row is updated', async () => {
+            tracker.on.update(HomepagesTableName).responseOnce([]);
+
+            await expect(
+                model.updateDraft(HOMEPAGE_UUID, { draftConfig }),
+            ).rejects.toThrow(NotFoundError);
+        });
+    });
+
+    describe('publish', () => {
+        it('throws NotFoundError when homepage does not exist', async () => {
+            tracker.on.select(HomepagesTableName).responseOnce([]);
+
+            await expect(model.publish(HOMEPAGE_UUID)).rejects.toThrow(
+                NotFoundError,
+            );
+        });
+
+        it('copies the draft config into published_config', async () => {
+            tracker.on
+                .select(HomepagesTableName)
+                .responseOnce([makeDbHomepage()]);
+            tracker.on
+                .update(HomepagesTableName)
+                .responseOnce([
+                    makeDbHomepage({ published_config: draftConfig }),
+                ]);
+
+            const result = await model.publish(HOMEPAGE_UUID);
+
+            const updateQuery = tracker.history.update[0];
+            expect(updateQuery.bindings).toContainEqual(draftConfig);
+            expect(result.publishedConfig).toEqual(draftConfig);
+        });
+    });
+
+    describe('getPublishedDefault', () => {
+        it('returns undefined when nothing is published', async () => {
+            tracker.on.select(HomepagesTableName).responseOnce([]);
+
+            await expect(
+                model.getPublishedDefault(PROJECT_UUID),
+            ).resolves.toBeUndefined();
+        });
+    });
+});

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -1,0 +1,112 @@
+import {
+    NotFoundError,
+    type HomepageConfig,
+    type ProjectHomepage,
+    type PublishedProjectHomepage,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import {
+    HomepagesTableName,
+    type DbProjectHomepage,
+} from '../database/entities/projectHomepages';
+
+export class ProjectHomepageModel {
+    private readonly database: Knex;
+
+    constructor({ database }: { database: Knex }) {
+        this.database = database;
+    }
+
+    private static mapDbHomepage(row: DbProjectHomepage): ProjectHomepage {
+        return {
+            homepageUuid: row.homepage_uuid,
+            projectUuid: row.project_uuid,
+            name: row.name,
+            draftConfig: row.draft_config,
+            publishedConfig: row.published_config,
+            isDefault: row.is_default,
+            createdByUserUuid: row.created_by_user_uuid,
+            createdAt: row.created_at,
+            updatedAt: row.updated_at,
+        };
+    }
+
+    async getDefault(
+        projectUuid: string,
+    ): Promise<ProjectHomepage | undefined> {
+        const row = await this.database(HomepagesTableName)
+            .where({ project_uuid: projectUuid, is_default: true })
+            .first();
+        return row ? ProjectHomepageModel.mapDbHomepage(row) : undefined;
+    }
+
+    async getPublishedDefault(
+        projectUuid: string,
+    ): Promise<PublishedProjectHomepage | undefined> {
+        const row = await this.database(HomepagesTableName)
+            .where({ project_uuid: projectUuid, is_default: true })
+            .whereNotNull('published_config')
+            .first();
+        if (!row || row.published_config === null) return undefined;
+        return {
+            homepageUuid: row.homepage_uuid,
+            name: row.name,
+            config: row.published_config,
+        };
+    }
+
+    async create(data: {
+        projectUuid: string;
+        name: string;
+        draftConfig: HomepageConfig;
+        createdByUserUuid: string;
+    }): Promise<ProjectHomepage> {
+        const [row] = await this.database(HomepagesTableName)
+            .insert({
+                project_uuid: data.projectUuid,
+                name: data.name,
+                draft_config: data.draftConfig,
+                is_default: true,
+                created_by_user_uuid: data.createdByUserUuid,
+            })
+            .returning('*');
+        return ProjectHomepageModel.mapDbHomepage(row);
+    }
+
+    async updateDraft(
+        homepageUuid: string,
+        update: { name?: string; draftConfig: HomepageConfig },
+    ): Promise<ProjectHomepage> {
+        const [row] = await this.database(HomepagesTableName)
+            .where({ homepage_uuid: homepageUuid })
+            .update({
+                ...(update.name !== undefined ? { name: update.name } : {}),
+                draft_config: update.draftConfig,
+                updated_at: new Date(),
+            })
+            .returning('*');
+        if (!row) {
+            throw new NotFoundError('Homepage not found');
+        }
+        return ProjectHomepageModel.mapDbHomepage(row);
+    }
+
+    async publish(homepageUuid: string): Promise<ProjectHomepage> {
+        return this.database.transaction(async (trx) => {
+            const existing = await trx(HomepagesTableName)
+                .where({ homepage_uuid: homepageUuid })
+                .first();
+            if (!existing) {
+                throw new NotFoundError('Homepage not found');
+            }
+            const [row] = await trx(HomepagesTableName)
+                .where({ homepage_uuid: homepageUuid })
+                .update({
+                    published_config: existing.draft_config,
+                    updated_at: new Date(),
+                })
+                .returning('*');
+            return ProjectHomepageModel.mapDbHomepage(row);
+        });
+    }
+}

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -1,0 +1,233 @@
+import { Ability } from '@casl/ability';
+import {
+    AlreadyExistsError,
+    ForbiddenError,
+    NotFoundError,
+    OrganizationMemberRole,
+    ParameterError,
+    type HomepageConfig,
+    type PossibleAbilities,
+    type ProjectHomepage,
+    type SessionUser,
+} from '@lightdash/common';
+import {
+    ProjectHomepageService,
+    type ProjectHomepageServiceArguments,
+} from './ProjectHomepageService';
+
+const NOW = new Date('2026-07-14T10:00:00.000Z');
+const ORGANIZATION_UUID = '00000000-0000-0000-0000-000000000001';
+const PROJECT_UUID = '00000000-0000-0000-0000-000000000002';
+const USER_UUID = '00000000-0000-0000-0000-000000000004';
+const HOMEPAGE_UUID = '00000000-0000-0000-0000-000000000010';
+
+const validConfig: HomepageConfig = {
+    version: 1,
+    rows: [
+        {
+            id: 'row-1',
+            blocks: [
+                { id: 'b1', type: 'markdown', config: { content: 'hello' } },
+            ],
+        },
+    ],
+};
+
+const makeHomepage = (
+    overrides: Partial<ProjectHomepage> = {},
+): ProjectHomepage => ({
+    homepageUuid: HOMEPAGE_UUID,
+    projectUuid: PROJECT_UUID,
+    name: 'Team homepage',
+    draftConfig: validConfig,
+    publishedConfig: null,
+    isDefault: true,
+    createdByUserUuid: USER_UUID,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+});
+
+const baseUser = (): Omit<SessionUser, 'ability'> => ({
+    userUuid: USER_UUID,
+    email: 'admin@example.com',
+    firstName: 'Admin',
+    lastName: 'User',
+    organizationUuid: ORGANIZATION_UUID,
+    organizationName: 'Acme',
+    organizationCreatedAt: NOW,
+    userId: 1,
+    role: OrganizationMemberRole.ADMIN,
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    avatarUrl: null,
+    avatarGradient: null,
+    isSetupComplete: true,
+    isActive: true,
+    createdAt: NOW,
+    updatedAt: NOW,
+    timezone: null,
+    abilityRules: [],
+});
+
+const makeAdminUser = (): SessionUser => ({
+    ...baseUser(),
+    ability: new Ability<PossibleAbilities>([
+        {
+            action: 'view',
+            subject: 'Project',
+            conditions: { projectUuid: PROJECT_UUID },
+        },
+        {
+            action: 'manage',
+            subject: 'ProjectHomepage',
+            conditions: { projectUuid: PROJECT_UUID },
+        },
+    ]),
+});
+
+const makeViewerUser = (): SessionUser => ({
+    ...baseUser(),
+    role: OrganizationMemberRole.VIEWER,
+    ability: new Ability<PossibleAbilities>([
+        {
+            action: 'view',
+            subject: 'Project',
+            conditions: { projectUuid: PROJECT_UUID },
+        },
+    ]),
+});
+
+const makeService = ({
+    flagEnabled = true,
+    projectHomepageModel = {},
+}: {
+    flagEnabled?: boolean;
+    projectHomepageModel?: Partial<
+        ProjectHomepageServiceArguments['projectHomepageModel']
+    >;
+} = {}) =>
+    new ProjectHomepageService({
+        featureFlagService: {
+            get: vi.fn().mockResolvedValue({
+                id: 'homepage-builder',
+                enabled: flagEnabled,
+            }),
+        },
+        projectHomepageModel: {
+            getDefault: vi.fn().mockResolvedValue(undefined),
+            getPublishedDefault: vi.fn().mockResolvedValue(undefined),
+            create: vi.fn().mockResolvedValue(makeHomepage()),
+            updateDraft: vi.fn().mockResolvedValue(makeHomepage()),
+            publish: vi.fn().mockResolvedValue(makeHomepage()),
+            ...projectHomepageModel,
+        },
+    });
+
+describe('ProjectHomepageService', () => {
+    it('getPublishedHomepage throws ForbiddenError when flag is disabled', async () => {
+        const service = makeService({ flagEnabled: false });
+
+        await expect(
+            service.getPublishedHomepage(makeAdminUser(), PROJECT_UUID),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('getPublishedHomepage returns null when nothing is published', async () => {
+        const service = makeService();
+
+        await expect(
+            service.getPublishedHomepage(makeViewerUser(), PROJECT_UUID),
+        ).resolves.toBeNull();
+    });
+
+    it('createHomepage throws ForbiddenError for a viewer', async () => {
+        const service = makeService();
+
+        await expect(
+            service.createHomepage(makeViewerUser(), PROJECT_UUID, {
+                name: 'Nope',
+            }),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('createHomepage throws AlreadyExistsError when a default homepage exists', async () => {
+        const service = makeService({
+            projectHomepageModel: {
+                getDefault: vi.fn().mockResolvedValue(makeHomepage()),
+            },
+        });
+
+        await expect(
+            service.createHomepage(makeAdminUser(), PROJECT_UUID, {
+                name: 'Another',
+            }),
+        ).rejects.toThrow(AlreadyExistsError);
+    });
+
+    it('updateDraft rejects a row with more than 3 blocks', async () => {
+        const service = makeService({
+            projectHomepageModel: {
+                getDefault: vi.fn().mockResolvedValue(makeHomepage()),
+            },
+        });
+        const block = {
+            id: 'b',
+            type: 'markdown' as const,
+            config: { content: 'x' },
+        };
+
+        await expect(
+            service.updateDraft(makeAdminUser(), PROJECT_UUID, HOMEPAGE_UUID, {
+                draftConfig: {
+                    version: 1,
+                    rows: [
+                        {
+                            id: 'row-1',
+                            blocks: [block, block, block, block],
+                        },
+                    ],
+                },
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    it('updateDraft throws NotFoundError when the homepage belongs to another project', async () => {
+        const service = makeService({
+            projectHomepageModel: {
+                getDefault: vi
+                    .fn()
+                    .mockResolvedValue(
+                        makeHomepage({ homepageUuid: 'other-homepage-uuid' }),
+                    ),
+            },
+        });
+
+        await expect(
+            service.updateDraft(makeAdminUser(), PROJECT_UUID, HOMEPAGE_UUID, {
+                draftConfig: validConfig,
+            }),
+        ).rejects.toThrow(NotFoundError);
+    });
+
+    it('publishHomepage publishes for an admin when the flag is on', async () => {
+        const publish = vi
+            .fn()
+            .mockResolvedValue(makeHomepage({ publishedConfig: validConfig }));
+        const service = makeService({
+            projectHomepageModel: {
+                getDefault: vi.fn().mockResolvedValue(makeHomepage()),
+                publish,
+            },
+        });
+
+        const result = await service.publishHomepage(
+            makeAdminUser(),
+            PROJECT_UUID,
+            HOMEPAGE_UUID,
+        );
+
+        expect(publish).toHaveBeenCalledWith(HOMEPAGE_UUID);
+        expect(result.publishedConfig).toEqual(validConfig);
+    });
+});

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -52,6 +52,9 @@ export class ProjectHomepageService extends BaseService {
     }
 
     private assertCanView(user: SessionUser, projectUuid: string): void {
+        if (!user.organizationUuid) {
+            throw new ForbiddenError();
+        }
         const ability = this.createAuditedAbility(user);
         if (
             ability.cannot(
@@ -67,6 +70,9 @@ export class ProjectHomepageService extends BaseService {
     }
 
     private assertCanManage(user: SessionUser, projectUuid: string): void {
+        if (!user.organizationUuid) {
+            throw new ForbiddenError();
+        }
         const ability = this.createAuditedAbility(user);
         if (
             ability.cannot(

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -1,0 +1,180 @@
+import { subject } from '@casl/ability';
+import {
+    AlreadyExistsError,
+    CommercialFeatureFlags,
+    defaultHomepageConfig,
+    ForbiddenError,
+    HOMEPAGE_MAX_BLOCKS_PER_ROW,
+    NotFoundError,
+    ParameterError,
+    type CreateProjectHomepageRequest,
+    type HomepageConfig,
+    type ProjectHomepage,
+    type PublishedProjectHomepage,
+    type SessionUser,
+    type UpdateProjectHomepageDraftRequest,
+} from '@lightdash/common';
+import { BaseService } from '../../services/BaseService';
+import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
+import { type ProjectHomepageModel } from '../models/ProjectHomepageModel';
+
+export type ProjectHomepageServiceArguments = {
+    projectHomepageModel: Pick<
+        ProjectHomepageModel,
+        | 'getDefault'
+        | 'getPublishedDefault'
+        | 'create'
+        | 'updateDraft'
+        | 'publish'
+    >;
+    featureFlagService: Pick<FeatureFlagService, 'get'>;
+};
+
+export class ProjectHomepageService extends BaseService {
+    private readonly projectHomepageModel: ProjectHomepageServiceArguments['projectHomepageModel'];
+
+    private readonly featureFlagService: ProjectHomepageServiceArguments['featureFlagService'];
+
+    constructor(args: ProjectHomepageServiceArguments) {
+        super();
+        this.projectHomepageModel = args.projectHomepageModel;
+        this.featureFlagService = args.featureFlagService;
+    }
+
+    private async assertFlagEnabled(user: SessionUser): Promise<void> {
+        const flag = await this.featureFlagService.get({
+            user,
+            featureFlagId: CommercialFeatureFlags.HomepageBuilder,
+        });
+        if (!flag.enabled) {
+            throw new ForbiddenError('Homepage builder is not enabled');
+        }
+    }
+
+    private assertCanView(user: SessionUser, projectUuid: string): void {
+        const ability = this.createAuditedAbility(user);
+        if (
+            ability.cannot(
+                'view',
+                subject('Project', {
+                    organizationUuid: user.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+    }
+
+    private assertCanManage(user: SessionUser, projectUuid: string): void {
+        const ability = this.createAuditedAbility(user);
+        if (
+            ability.cannot(
+                'manage',
+                subject('ProjectHomepage', {
+                    organizationUuid: user.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to manage the project homepage',
+            );
+        }
+    }
+
+    private static validateConfig(config: HomepageConfig): void {
+        if (config.version !== 1) {
+            throw new ParameterError('Unsupported homepage config version');
+        }
+        const oversizedRow = config.rows.find(
+            (row) => row.blocks.length > HOMEPAGE_MAX_BLOCKS_PER_ROW,
+        );
+        if (oversizedRow) {
+            throw new ParameterError(
+                `Rows support at most ${HOMEPAGE_MAX_BLOCKS_PER_ROW} blocks`,
+            );
+        }
+    }
+
+    private async getOwnedHomepage(
+        projectUuid: string,
+        homepageUuid: string,
+    ): Promise<ProjectHomepage> {
+        const homepage =
+            await this.projectHomepageModel.getDefault(projectUuid);
+        if (!homepage || homepage.homepageUuid !== homepageUuid) {
+            throw new NotFoundError('Homepage not found');
+        }
+        return homepage;
+    }
+
+    async getPublishedHomepage(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<PublishedProjectHomepage | null> {
+        await this.assertFlagEnabled(user);
+        this.assertCanView(user, projectUuid);
+        const published =
+            await this.projectHomepageModel.getPublishedDefault(projectUuid);
+        return published ?? null;
+    }
+
+    async getHomepageForBuilder(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<ProjectHomepage | null> {
+        await this.assertFlagEnabled(user);
+        this.assertCanManage(user, projectUuid);
+        const homepage =
+            await this.projectHomepageModel.getDefault(projectUuid);
+        return homepage ?? null;
+    }
+
+    async createHomepage(
+        user: SessionUser,
+        projectUuid: string,
+        data: CreateProjectHomepageRequest,
+    ): Promise<ProjectHomepage> {
+        await this.assertFlagEnabled(user);
+        this.assertCanManage(user, projectUuid);
+        const existing =
+            await this.projectHomepageModel.getDefault(projectUuid);
+        if (existing) {
+            throw new AlreadyExistsError('This project already has a homepage');
+        }
+        return this.projectHomepageModel.create({
+            projectUuid,
+            name: data.name,
+            draftConfig: defaultHomepageConfig(),
+            createdByUserUuid: user.userUuid,
+        });
+    }
+
+    async updateDraft(
+        user: SessionUser,
+        projectUuid: string,
+        homepageUuid: string,
+        data: UpdateProjectHomepageDraftRequest,
+    ): Promise<ProjectHomepage> {
+        await this.assertFlagEnabled(user);
+        this.assertCanManage(user, projectUuid);
+        ProjectHomepageService.validateConfig(data.draftConfig);
+        await this.getOwnedHomepage(projectUuid, homepageUuid);
+        return this.projectHomepageModel.updateDraft(homepageUuid, {
+            name: data.name,
+            draftConfig: data.draftConfig,
+        });
+    }
+
+    async publishHomepage(
+        user: SessionUser,
+        projectUuid: string,
+        homepageUuid: string,
+    ): Promise<ProjectHomepage> {
+        await this.assertFlagEnabled(user);
+        this.assertCanManage(user, projectUuid);
+        await this.getOwnedHomepage(projectUuid, homepageUuid);
+        return this.projectHomepageModel.publish(homepageUuid);
+    }
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -175,6 +175,8 @@ import { OrganizationWarehouseCredentialsController } from './../ee/controllers/
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { PreAggregateController } from './../ee/controllers/PreAggregateController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { ProjectHomepageController } from './../ee/controllers/projectHomepageController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { SchedulerAiAugmentationController } from './../ee/controllers/schedulerAiAugmentationController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ScimGroupController } from './../ee/controllers/scimGroupController';
@@ -1429,6 +1431,197 @@ const models: TsoaRoute.Models = {
                     value: '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}',
                 },
             },
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageMarkdownBlock: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                config: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        content: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                type: { dataType: 'enum', enums: ['markdown'], required: true },
+                id: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageBlock: {
+        dataType: 'refAlias',
+        type: { ref: 'HomepageMarkdownBlock', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageRow: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                blocks: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'HomepageBlock' },
+                    required: true,
+                },
+                id: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                rows: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'HomepageRow' },
+                    required: true,
+                },
+                version: { dataType: 'enum', enums: [1], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PublishedProjectHomepage: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                config: { ref: 'HomepageConfig', required: true },
+                name: { dataType: 'string', required: true },
+                homepageUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_PublishedProjectHomepage-or-null_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'PublishedProjectHomepage' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiPublishedHomepageResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess_PublishedProjectHomepage-or-null_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ProjectHomepage: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                createdByUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                isDefault: { dataType: 'boolean', required: true },
+                publishedConfig: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'HomepageConfig' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                draftConfig: { ref: 'HomepageConfig', required: true },
+                name: { dataType: 'string', required: true },
+                projectUuid: { dataType: 'string', required: true },
+                homepageUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_ProjectHomepage-or-null_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'ProjectHomepage' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiProjectHomepageOrNullResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_ProjectHomepage-or-null_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_ProjectHomepage_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'ProjectHomepage', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiProjectHomepageResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_ProjectHomepage_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateProjectHomepageRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { name: { dataType: 'string', required: true } },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateProjectHomepageDraftRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                draftConfig: { ref: 'HomepageConfig', required: true },
+                name: { dataType: 'string' },
+            },
+            validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -15506,17 +15699,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -15545,29 +15738,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 requiredFilters:
                                                                                                     {
                                                                                                         dataType:
@@ -15606,6 +15776,18 @@ const models: TsoaRoute.Models = {
                                                                                                                                             },
                                                                                                                                         ],
                                                                                                                                 },
+                                                                                                                                required:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'boolean',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                tableName:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
                                                                                                                                 fieldRef:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -15618,26 +15800,37 @@ const models: TsoaRoute.Models = {
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                tableName:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
                                                                                                                                 operator:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                required:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'boolean',
-                                                                                                                                        required: true,
-                                                                                                                                    },
                                                                                                                             },
                                                                                                                     },
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -15738,6 +15931,21 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                error: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'string',
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
                                                                                 pagination:
                                                                                     {
                                                                                         dataType:
@@ -15798,21 +16006,6 @@ const models: TsoaRoute.Models = {
                                                                                                 enums: [
                                                                                                     'success',
                                                                                                 ],
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
-                                                                                error: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'string',
                                                                                             },
                                                                                             {
                                                                                                 dataType:
@@ -15904,17 +16097,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -16002,13 +16195,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
-                                                    required: true,
-                                                },
-                                                name: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -16035,13 +16228,13 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: [
                                                                 'not_found',
                                                             ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16074,6 +16267,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -16118,16 +16330,39 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
                                                                                 fieldValueType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                fieldFilterType:
+                                                                                fieldType:
                                                                                     {
                                                                                         dataType:
-                                                                                            'string',
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
                                                                                         required: true,
                                                                                     },
                                                                                 description:
@@ -16150,30 +16385,7 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
+                                                                                label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -16184,37 +16396,18 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
+                                                                                name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                name: {
+                                                                                table: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
                                                                             },
                                                                     },
-                                                                    required: true,
-                                                                },
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 explore: {
@@ -16260,6 +16453,18 @@ const models: TsoaRoute.Models = {
                                                                                                                         },
                                                                                                                     ],
                                                                                                             },
+                                                                                                            required:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'boolean',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            tableName:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
                                                                                                             fieldRef:
                                                                                                                 {
                                                                                                                     dataType:
@@ -16272,22 +16477,10 @@ const models: TsoaRoute.Models = {
                                                                                                                         'string',
                                                                                                                     required: true,
                                                                                                                 },
-                                                                                                            tableName:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
                                                                                                             operator:
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'string',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            required:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'boolean',
                                                                                                                     required: true,
                                                                                                                 },
                                                                                                         },
@@ -16356,17 +16549,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -16491,21 +16684,21 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
-                                                    required: true,
-                                                },
-                                                slug: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 uuid: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
                                                     dataType: 'string',
+                                                    required: true,
+                                                },
+                                                slug: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                             },
@@ -16652,18 +16845,6 @@ const models: TsoaRoute.Models = {
                                                                                 ],
                                                                             required: true,
                                                                         },
-                                                                        isPrimary:
-                                                                            {
-                                                                                dataType:
-                                                                                    'boolean',
-                                                                                required: true,
-                                                                            },
-                                                                        projectDbtSourceUuid:
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
                                                                         repository:
                                                                             {
                                                                                 dataType:
@@ -16682,6 +16863,18 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         },
                                                                                     ],
+                                                                                required: true,
+                                                                            },
+                                                                        isPrimary:
+                                                                            {
+                                                                                dataType:
+                                                                                    'boolean',
+                                                                                required: true,
+                                                                            },
+                                                                        projectDbtSourceUuid:
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
                                                                                 required: true,
                                                                             },
                                                                         name: {
@@ -16706,6 +16899,77 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'union',
                                                     subSchemas: [
                                                         { dataType: 'boolean' },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
+                                                steps: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'array',
+                                                            array: {
+                                                                dataType:
+                                                                    'nestedObjectLiteral',
+                                                                nestedProperties:
+                                                                    {
+                                                                        kind: {
+                                                                            dataType:
+                                                                                'union',
+                                                                            subSchemas:
+                                                                                [
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'read',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'edit',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'compile',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'stage',
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
+                                                                    },
+                                                            },
+                                                        },
                                                         {
                                                             dataType: 'enum',
                                                             enums: [null],
@@ -16793,77 +17057,6 @@ const models: TsoaRoute.Models = {
                                                         },
                                                     ],
                                                 },
-                                                steps: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'array',
-                                                            array: {
-                                                                dataType:
-                                                                    'nestedObjectLiteral',
-                                                                nestedProperties:
-                                                                    {
-                                                                        kind: {
-                                                                            dataType:
-                                                                                'union',
-                                                                            subSchemas:
-                                                                                [
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'read',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'compile',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'stage',
-                                                                                        ],
-                                                                                    },
-                                                                                ],
-                                                                            required: true,
-                                                                        },
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
-                                                                    },
-                                                            },
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
-                                                        },
-                                                    ],
-                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -16895,12 +17088,6 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
-                                                                'unsupported_source_control',
-                                                            ],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [
                                                                 'github_not_installed',
                                                             ],
                                                         },
@@ -16908,6 +17095,12 @@ const models: TsoaRoute.Models = {
                                                             dataType: 'enum',
                                                             enums: [
                                                                 'gitlab_not_installed',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
+                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -16975,17 +17168,17 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                             },
@@ -17050,6 +17243,10 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['timeout'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
                                                         {
@@ -17059,10 +17256,6 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['timeout'],
                                                         },
                                                     ],
                                                     required: true,
@@ -17098,25 +17291,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -17177,17 +17351,17 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 tableName:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -17195,6 +17369,25 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
+                                                                    required: true,
+                                                                },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 type: {
@@ -17206,14 +17399,14 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'metric',
+                                                                                    'dimension',
                                                                                 ],
                                                                             },
                                                                             {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    'metric',
                                                                                 ],
                                                                             },
                                                                             {
@@ -35968,7 +36161,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -35978,7 +36171,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -35988,7 +36181,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -36001,7 +36194,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -48904,6 +49097,335 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'deleteAugmentation',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectHomepageController_getPublished: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/homepage',
+        ...fetchMiddlewares<RequestHandler>(ProjectHomepageController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectHomepageController.prototype.getPublished,
+        ),
+
+        async function ProjectHomepageController_getPublished(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectHomepageController_getPublished,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectHomepageController>(
+                        ProjectHomepageController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getPublished',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectHomepageController_getForBuilder: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/homepage/builder',
+        ...fetchMiddlewares<RequestHandler>(ProjectHomepageController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectHomepageController.prototype.getForBuilder,
+        ),
+
+        async function ProjectHomepageController_getForBuilder(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectHomepageController_getForBuilder,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectHomepageController>(
+                        ProjectHomepageController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getForBuilder',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectHomepageController_create: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'CreateProjectHomepageRequest',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/homepage',
+        ...fetchMiddlewares<RequestHandler>(ProjectHomepageController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectHomepageController.prototype.create,
+        ),
+
+        async function ProjectHomepageController_create(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectHomepageController_create,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectHomepageController>(
+                        ProjectHomepageController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'create',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 201,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectHomepageController_updateDraft: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        homepageUuid: {
+            in: 'path',
+            name: 'homepageUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpdateProjectHomepageDraftRequest',
+        },
+    };
+    app.patch(
+        '/api/v1/projects/:projectUuid/homepage/:homepageUuid',
+        ...fetchMiddlewares<RequestHandler>(ProjectHomepageController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectHomepageController.prototype.updateDraft,
+        ),
+
+        async function ProjectHomepageController_updateDraft(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectHomepageController_updateDraft,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectHomepageController>(
+                        ProjectHomepageController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateDraft',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectHomepageController_publish: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        homepageUuid: {
+            in: 'path',
+            name: 'homepageUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/homepage/:homepageUuid/publish',
+        ...fetchMiddlewares<RequestHandler>(ProjectHomepageController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectHomepageController.prototype.publish,
+        ),
+
+        async function ProjectHomepageController_publish(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectHomepageController_publish,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectHomepageController>(
+                        ProjectHomepageController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'publish',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1425,6 +1425,212 @@
                 "description": "Stringified UUIDv4.\nSee [RFC 4112](https://tools.ietf.org/html/rfc4122)",
                 "pattern": "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}"
             },
+            "HomepageMarkdownBlock": {
+                "properties": {
+                    "config": {
+                        "properties": {
+                            "content": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["content"],
+                        "type": "object"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["markdown"],
+                        "nullable": false
+                    },
+                    "id": {
+                        "type": "string"
+                    }
+                },
+                "required": ["config", "type", "id"],
+                "type": "object"
+            },
+            "HomepageBlock": {
+                "$ref": "#/components/schemas/HomepageMarkdownBlock"
+            },
+            "HomepageRow": {
+                "properties": {
+                    "blocks": {
+                        "items": {
+                            "$ref": "#/components/schemas/HomepageBlock"
+                        },
+                        "type": "array"
+                    },
+                    "id": {
+                        "type": "string"
+                    }
+                },
+                "required": ["blocks", "id"],
+                "type": "object"
+            },
+            "HomepageConfig": {
+                "properties": {
+                    "rows": {
+                        "items": {
+                            "$ref": "#/components/schemas/HomepageRow"
+                        },
+                        "type": "array"
+                    },
+                    "version": {
+                        "type": "number",
+                        "enum": [1],
+                        "nullable": false
+                    }
+                },
+                "required": ["rows", "version"],
+                "type": "object"
+            },
+            "PublishedProjectHomepage": {
+                "properties": {
+                    "config": {
+                        "$ref": "#/components/schemas/HomepageConfig"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "homepageUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["config", "name", "homepageUuid"],
+                "type": "object"
+            },
+            "ApiSuccess_PublishedProjectHomepage-or-null_": {
+                "properties": {
+                    "results": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/PublishedProjectHomepage"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiPublishedHomepageResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_PublishedProjectHomepage-or-null_"
+            },
+            "ProjectHomepage": {
+                "properties": {
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdByUserUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "isDefault": {
+                        "type": "boolean"
+                    },
+                    "publishedConfig": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/HomepageConfig"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "draftConfig": {
+                        "$ref": "#/components/schemas/HomepageConfig"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "homepageUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "updatedAt",
+                    "createdAt",
+                    "createdByUserUuid",
+                    "isDefault",
+                    "publishedConfig",
+                    "draftConfig",
+                    "name",
+                    "projectUuid",
+                    "homepageUuid"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_ProjectHomepage-or-null_": {
+                "properties": {
+                    "results": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ProjectHomepage"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiProjectHomepageOrNullResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_ProjectHomepage-or-null_"
+            },
+            "ApiSuccess_ProjectHomepage_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/ProjectHomepage"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiProjectHomepageResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_ProjectHomepage_"
+            },
+            "CreateProjectHomepageRequest": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name"],
+                "type": "object"
+            },
+            "UpdateProjectHomepageDraftRequest": {
+                "properties": {
+                    "draftConfig": {
+                        "$ref": "#/components/schemas/HomepageConfig"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["draftConfig"],
+                "type": "object"
+            },
             "ManagedAgentScheduleOption": {
                 "enum": [
                     "every_6_hours",
@@ -17037,10 +17243,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -17049,8 +17255,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -17060,11 +17266,6 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "requiredFilters": {
                                                                             "items": {
                                                                                 "properties": {
@@ -17073,32 +17274,37 @@
                                                                                         "items": {},
                                                                                         "type": "array"
                                                                                     },
+                                                                                    "required": {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    "tableName": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "fieldRef": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "fieldId": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "operator": {
                                                                                         "type": "string"
-                                                                                    },
-                                                                                    "required": {
-                                                                                        "type": "boolean"
                                                                                     }
                                                                                 },
                                                                                 "required": [
+                                                                                    "required",
+                                                                                    "tableName",
                                                                                     "fieldRef",
                                                                                     "fieldId",
-                                                                                    "tableName",
-                                                                                    "operator",
-                                                                                    "required"
+                                                                                    "operator"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
                                                                             "type": "array"
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
                                                                         },
                                                                         "joinedTables": {
                                                                             "items": {
@@ -17149,6 +17355,9 @@
                                                             "searchQueries": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "error": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "pagination": {
                                                                             "properties": {
                                                                                 "totalPageCount": {
@@ -17183,9 +17392,6 @@
                                                                                 "success"
                                                                             ]
                                                                         },
-                                                                        "error": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
@@ -17207,10 +17413,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -17219,8 +17425,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "tableName",
                                                                                     "label",
+                                                                                    "tableName",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -17262,19 +17468,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "status",
-                                                    "name"
+                                                    "name",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -17295,8 +17501,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "success",
-                                                            "not_found"
+                                                            "not_found",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -17322,6 +17528,10 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
@@ -17336,55 +17546,51 @@
                                                                                         "not_applicable"
                                                                                     ]
                                                                                 },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
                                                                                 "fieldValueType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
                                                                                 },
                                                                                 "description": {
                                                                                     "type": "string",
                                                                                     "nullable": true
                                                                                 },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "metric",
-                                                                                        "dimension"
-                                                                                    ]
-                                                                                },
-                                                                                "table": {
+                                                                                "label": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldId": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "label": {
+                                                                                "name": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "name": {
+                                                                                "table": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
                                                                             "required": [
                                                                                 "isFromJoinedTable",
                                                                                 "caseSensitiveFilters",
-                                                                                "fieldValueType",
                                                                                 "fieldFilterType",
-                                                                                "description",
+                                                                                "fieldValueType",
                                                                                 "fieldType",
-                                                                                "table",
-                                                                                "fieldId",
+                                                                                "description",
                                                                                 "label",
-                                                                                "name"
+                                                                                "fieldId",
+                                                                                "name",
+                                                                                "table"
                                                                             ],
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
-                                                                    },
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
                                                                     },
                                                                     "explore": {
                                                                         "properties": {
@@ -17396,28 +17602,28 @@
                                                                                             "items": {},
                                                                                             "type": "array"
                                                                                         },
+                                                                                        "required": {
+                                                                                            "type": "boolean"
+                                                                                        },
+                                                                                        "tableName": {
+                                                                                            "type": "string"
+                                                                                        },
                                                                                         "fieldRef": {
                                                                                             "type": "string"
                                                                                         },
                                                                                         "fieldId": {
                                                                                             "type": "string"
                                                                                         },
-                                                                                        "tableName": {
-                                                                                            "type": "string"
-                                                                                        },
                                                                                         "operator": {
                                                                                             "type": "string"
-                                                                                        },
-                                                                                        "required": {
-                                                                                            "type": "boolean"
                                                                                         }
                                                                                     },
                                                                                     "required": [
+                                                                                        "required",
+                                                                                        "tableName",
                                                                                         "fieldRef",
                                                                                         "fieldId",
-                                                                                        "tableName",
-                                                                                        "operator",
-                                                                                        "required"
+                                                                                        "operator"
                                                                                     ],
                                                                                     "type": "object"
                                                                                 },
@@ -17456,8 +17662,8 @@
                                                                     }
                                                                 },
                                                                 "required": [
-                                                                    "fields",
                                                                     "rationale",
+                                                                    "fields",
                                                                     "explore",
                                                                     "status"
                                                                 ],
@@ -17471,10 +17677,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -17482,8 +17688,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "exploreLabel",
                                                                                 "reason",
+                                                                                "exploreLabel",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -17566,29 +17772,29 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": ["success"],
-                                                        "nullable": false
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
                                                     "uuid": {
                                                         "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
+                                                    },
+                                                    "slug": {
+                                                        "type": "string"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["success"],
+                                                        "nullable": false
                                                     }
                                                 },
                                                 "required": [
                                                     "versionUuids",
                                                     "warnings",
                                                     "href",
-                                                    "status",
-                                                    "slug",
                                                     "uuid",
-                                                    "name"
+                                                    "name",
+                                                    "slug",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -17622,15 +17828,15 @@
                                                                     "type": "string",
                                                                     "nullable": true
                                                                 },
+                                                                "repository": {
+                                                                    "type": "string",
+                                                                    "nullable": true
+                                                                },
                                                                 "isPrimary": {
                                                                     "type": "boolean"
                                                                 },
                                                                 "projectDbtSourceUuid": {
                                                                     "type": "string"
-                                                                },
-                                                                "repository": {
-                                                                    "type": "string",
-                                                                    "nullable": true
                                                                 },
                                                                 "name": {
                                                                     "type": "string"
@@ -17639,9 +17845,9 @@
                                                             "required": [
                                                                 "projectSubPath",
                                                                 "branch",
+                                                                "repository",
                                                                 "isPrimary",
                                                                 "projectDbtSourceUuid",
-                                                                "repository",
                                                                 "name"
                                                             ],
                                                             "type": "object"
@@ -17651,6 +17857,32 @@
                                                     },
                                                     "needsDbtSourceSelection": {
                                                         "type": "boolean",
+                                                        "nullable": true
+                                                    },
+                                                    "steps": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "kind": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "read",
+                                                                        "edit",
+                                                                        "search",
+                                                                        "compile",
+                                                                        "stage"
+                                                                    ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kind",
+                                                                "label"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
                                                         "nullable": true
                                                     },
                                                     "previewUrl": {
@@ -17680,32 +17912,6 @@
                                                         ],
                                                         "nullable": true
                                                     },
-                                                    "steps": {
-                                                        "items": {
-                                                            "properties": {
-                                                                "kind": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "search",
-                                                                        "read",
-                                                                        "edit",
-                                                                        "compile",
-                                                                        "stage"
-                                                                    ]
-                                                                },
-                                                                "label": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "kind",
-                                                                "label"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array",
-                                                        "nullable": true
-                                                    },
                                                     "prUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -17725,9 +17931,9 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "unknown",
-                                                            "unsupported_source_control",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
+                                                            "unsupported_source_control",
                                                             "pull_request_not_open",
                                                             "git_write_permission",
                                                             null
@@ -17748,23 +17954,23 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": ["success"],
-                                                        "nullable": false
+                                                    "name": {
+                                                        "type": "string"
                                                     },
                                                     "slug": {
                                                         "type": "string"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["success"],
+                                                        "nullable": false
                                                     }
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "status",
+                                                    "name",
                                                     "slug",
-                                                    "name"
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -17790,10 +17996,10 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "timeout",
                                                             "error",
                                                             "rejected",
-                                                            "success",
-                                                            "timeout"
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -17804,10 +18010,6 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -17824,10 +18026,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -17836,27 +18038,31 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
                                                                 },
                                                                 "type": "array"
                                                             },
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "metric",
                                                                     "dimension",
+                                                                    "metric",
                                                                     null
                                                                 ],
                                                                 "nullable": true
                                                             }
                                                         },
                                                         "required": [
-                                                            "searchQuery",
                                                             "fields",
+                                                            "searchQuery",
                                                             "type"
                                                         ],
                                                         "type": "object"
@@ -36206,22 +36412,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -46964,7 +47170,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3390.0",
+        "version": "0.3389.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -48453,6 +48659,235 @@
                     {
                         "in": "path",
                         "name": "schedulerUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/homepage": {
+            "get": {
+                "operationId": "getPublishedProjectHomepage",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiPublishedHomepageResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "createProjectHomepage",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiProjectHomepageResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateProjectHomepageRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/homepage/builder": {
+            "get": {
+                "operationId": "getProjectHomepageForBuilder",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiProjectHomepageOrNullResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/homepage/{homepageUuid}": {
+            "patch": {
+                "operationId": "updateProjectHomepageDraft",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiProjectHomepageResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "homepageUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateProjectHomepageDraftRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/homepage/{homepageUuid}/publish": {
+            "post": {
+                "operationId": "publishProjectHomepage",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiProjectHomepageResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "homepageUuid",
                         "required": true,
                         "schema": {
                             "$ref": "#/components/schemas/UUID"

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -147,6 +147,7 @@ export type ModelManifest = {
     projectParametersModel: ProjectParametersModel;
     /** An implementation signature for these models are not available at this stage */
     aiAgentModel: unknown;
+    projectHomepageModel: unknown;
     aiAgentDocumentModel: unknown;
     aiWritebackThreadModel: unknown;
     aiWritebackRunModel: unknown;
@@ -794,6 +795,10 @@ export class ModelRepository
 
     public getAiAgentModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiAgentModel');
+    }
+
+    public getProjectHomepageModel<ModelImplT>(): ModelImplT {
+        return this.getModel('projectHomepageModel');
     }
 
     public getMcpToolCallModel<ModelImplT>(): ModelImplT {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -160,6 +160,7 @@ interface ServiceManifest {
     embedService: unknown;
     aiService: unknown;
     aiAgentCoderService: unknown;
+    projectHomepageService: unknown;
     aiAgentService: unknown;
     aiAgentToolsService: unknown;
     aiAgentAdminService: unknown;
@@ -1410,6 +1411,12 @@ export class ServiceRepository
 
     public getAiService<AiServiceImplT>(): AiServiceImplT {
         return this.getService('aiService');
+    }
+
+    public getProjectHomepageService<
+        ProjectHomepageServiceImplT,
+    >(): ProjectHomepageServiceImplT {
+        return this.getService('projectHomepageService');
     }
 
     public getAiAgentCoderService<

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -463,6 +463,9 @@ export const applyOrganizationMemberStaticAbilities: Record<
         can('manage', 'PinnedItems', {
             organizationUuid: member.organizationUuid,
         });
+        can('manage', 'ProjectHomepage', {
+            organizationUuid: member.organizationUuid,
+        });
         can('manage', 'Group', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -389,5 +389,9 @@ export const projectMemberAbilities: Record<
         can('manage', 'DeletedContent', {
             projectUuid: member.projectUuid,
         });
+
+        can('manage', 'ProjectHomepage', {
+            projectUuid: member.projectUuid,
+        });
     },
 };

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -168,6 +168,7 @@ const BASE_ROLE_SCOPES = {
         'manage:Project', // Required for managing non-private spaces
         'manage:SavedChart', // All saved charts
         'manage:DeletedContent', // Soft-deleted content management
+        'manage:ProjectHomepage', // Curated project homepages (EE)
         'view:AiAgentThread', // All threads in project
         'manage:AiAgentThread', // All threads in project
         'manage:ScheduledDeliveries',

--- a/packages/common/src/authorization/roleToScopeParity.test.ts
+++ b/packages/common/src/authorization/roleToScopeParity.test.ts
@@ -82,6 +82,7 @@ const ENTERPRISE_SUBJECTS = new Set([
     'ContentAsCode',
     'PreAggregation',
     'ExternalConnection',
+    'ProjectHomepage',
     // The matching scopes (`view:` + `manage:OrganizationWarehouseCredentials`)
     // are `isEnterprise: true` in scopes.ts, so the scope-build path
     // strips them in non-enterprise mode. Mirror that filter on the

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -399,6 +399,14 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
     {
+        name: 'manage:ProjectHomepage',
+        description: 'Create, edit and publish project homepages',
+        isEnterprise: true,
+        group: ScopeGroup.CONTENT,
+        dependencies: [{ name: 'view:Project' }],
+        getConditions: addDefaultUuidCondition,
+    },
+    {
         name: 'manage:DeletedContent',
         description:
             'Manage soft-deleted content (restore, permanently delete)',

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -373,6 +373,9 @@ const applyServiceAccountStaticAbilities: Record<
         can('manage', 'PinnedItems', {
             organizationUuid,
         });
+        can('manage', 'ProjectHomepage', {
+            organizationUuid,
+        });
         can('manage', 'Group', {
             organizationUuid,
         });

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -58,6 +58,7 @@ export type CaslSubjectNames =
     | 'PreAggregation'
     | 'PinnedItems'
     | 'Project'
+    | 'ProjectHomepage'
     | 'SavedChart'
     | 'ScheduledDeliveries'
     | 'SemanticViewer'

--- a/packages/common/src/ee/commercialFeatureFlags.ts
+++ b/packages/common/src/ee/commercialFeatureFlags.ts
@@ -5,4 +5,5 @@ export enum CommercialFeatureFlags {
     ServiceAccounts = 'service-accounts',
     OrganizationWarehouseCredentials = 'organization-warehouse-credentials',
     CustomRoles = 'custom-roles',
+    HomepageBuilder = 'homepage-builder',
 }

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -1,0 +1,73 @@
+import { type ApiSuccess } from '../../types/api/success';
+
+export type HomepageMarkdownBlock = {
+    id: string;
+    type: 'markdown';
+    config: { content: string };
+};
+
+export type HomepageBlock = HomepageMarkdownBlock;
+
+export type HomepageRow = {
+    id: string;
+    blocks: HomepageBlock[];
+};
+
+export type HomepageConfig = {
+    version: 1;
+    rows: HomepageRow[];
+};
+
+export const HOMEPAGE_MAX_BLOCKS_PER_ROW = 3;
+
+export const defaultHomepageConfig = (): HomepageConfig => ({
+    version: 1,
+    rows: [
+        {
+            id: 'row-1',
+            blocks: [
+                {
+                    id: 'block-1',
+                    type: 'markdown',
+                    config: {
+                        content:
+                            '## Welcome\n\nEdit this homepage to get started.',
+                    },
+                },
+            ],
+        },
+    ],
+});
+
+export type ProjectHomepage = {
+    homepageUuid: string;
+    projectUuid: string;
+    name: string;
+    draftConfig: HomepageConfig;
+    publishedConfig: HomepageConfig | null;
+    isDefault: boolean;
+    createdByUserUuid: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+};
+
+export type PublishedProjectHomepage = {
+    homepageUuid: string;
+    name: string;
+    config: HomepageConfig;
+};
+
+export type CreateProjectHomepageRequest = {
+    name: string;
+};
+
+export type UpdateProjectHomepageDraftRequest = {
+    name?: string;
+    draftConfig: HomepageConfig;
+};
+
+export type ApiProjectHomepageResponse = ApiSuccess<ProjectHomepage>;
+export type ApiProjectHomepageOrNullResponse =
+    ApiSuccess<ProjectHomepage | null>;
+export type ApiPublishedHomepageResponse =
+    ApiSuccess<PublishedProjectHomepage | null>;

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -9,6 +9,7 @@ export * from './ambientAi';
 export * from './commercialFeatureFlags';
 export * from './designs/types';
 export * from './embed';
+export * from './homepage/types';
 export * from './preAggregates';
 export * from './preAggregates/types';
 export * as preAggregateUtils from './preAggregates/utils';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -64,8 +64,11 @@ import type {
     ApiOrganizationDesignResponse,
     ApiOrganizationDesignsResponse,
     ApiPreviewTokenResponse,
+    ApiProjectHomepageOrNullResponse,
+    ApiProjectHomepageResponse,
     ApiPromoteAppDiffResponse,
     ApiPromoteAppResponse,
+    ApiPublishedHomepageResponse,
     ApiUpdateAiOrganizationSettingsResponse,
     ApiUpdateUserAgentPreferencesResponse,
     AppExternalConnectionLink,
@@ -1277,6 +1280,9 @@ type ApiResults =
     | ApiOrganizationDesignResponse['results']
     | ApiOrganizationDesignsResponse['results']
     | ApiOrganizationDesignFileResponse['results']
+    | ApiProjectHomepageResponse['results']
+    | ApiProjectHomepageOrNullResponse['results']
+    | ApiPublishedHomepageResponse['results']
     | ApiProjectColorPaletteResponse['results']
     | ApiOrganizationBrandResponse['results']
     | ApiManagedAgentRunResponse['results']


### PR DESCRIPTION
## Homepage Builder foundation — backend (1/3)

Part of [ZAP-614](https://linear.app/lightdash/issue/ZAP-614) · Project: [Homepage Builder](https://linear.app/lightdash/project/homepage-builder-9b6282e2143c)

First slice of the Homepage Builder: an EE-only, admin-curated homepage per project, stored as a versioned block config (draft + published), published "to everyone" for now (audience assignment lands in ZAP-625).

### What
- `homepages` table (EE migration): draft/published JSONB configs, `is_default` + partial unique index (one default per project — prefigures multi-homepage in ZAP-622)
- `@lightdash/common`: `HomepageConfig` v1 block schema (markdown block only; max 3 blocks/row), API types, `CommercialFeatureFlags.HomepageBuilder`
- New CASL subject `ProjectHomepage` with `manage:ProjectHomepage` (EE scope) for project/org admins + service-account ORG_ADMIN; published-homepage reads ride on `view:Project`
- `ProjectHomepageModel` / `ProjectHomepageService` / TSOA controller under `packages/backend/src/ee/`, wired via EE providers (`getEnterpriseAppArguments`) — OSS builds get only inert repository slots
- Commercial flag handler: default OFF, per-org DB override

### API
- `GET /api/v1/projects/:projectUuid/homepage` — published config for viewers (null if none)
- `GET .../homepage/builder` — admin: full homepage (draft+published)
- `POST .../homepage` / `PATCH .../homepage/:homepageUuid` / `POST .../homepage/:homepageUuid/publish`

### How to test
```sql
INSERT INTO feature_flags (flag_id) VALUES ('homepage-builder') ON CONFLICT DO NOTHING;
INSERT INTO feature_flag_overrides (flag_id, organization_uuid, enabled) VALUES ('homepage-builder', <org_uuid>, true);
```
Then exercise the lifecycle with curl (create → patch draft → publish → get). Verified locally: flag off → 403; draft edits don’t change published; 4-blocks-in-a-row → 400; viewer ability cannot hit manage endpoints (service tests).

### Regression analysis
- **Flag default OFF** and EE-license-gated: no behavior change for any existing org (OSS or EE) unless an operator explicitly enables the flag.
- New endpoints only; no existing endpoint or table touched. `generated/` diff is additive routes.
- New scope `manage:ProjectHomepage` is additive — system roles gain it (admins only); custom roles are unaffected until they opt in (scope vocabulary addition, no migration needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ