### PR TITLE
feat(frontend): render published homepage on project home

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.test.tsx
@@ -1,0 +1,29 @@
+import { type HomepageConfig } from '@lightdash/common';
+import { MantineProvider } from '@mantine-8/core';
+import { render, screen } from '@testing-library/react';
+import { PublishedHomepage } from './PublishedHomepage';
+
+const config: HomepageConfig = {
+    version: 1,
+    rows: [
+        {
+            id: 'r1',
+            blocks: [
+                {
+                    id: 'b1',
+                    type: 'markdown',
+                    config: { content: '# Hello team' },
+                },
+            ],
+        },
+    ],
+};
+
+it('renders markdown blocks', () => {
+    render(
+        <MantineProvider>
+            <PublishedHomepage config={config} projectUuid="p1" />
+        </MantineProvider>,
+    );
+    expect(screen.getByText(/Hello team/)).toBeInTheDocument();
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -1,0 +1,47 @@
+import {
+    assertUnreachable,
+    type HomepageBlock,
+    type HomepageConfig,
+} from '@lightdash/common';
+import { Box, Group, Stack, useMantineColorScheme } from '@mantine-8/core';
+import MarkdownPreview from '@uiw/react-markdown-preview';
+import { type FC } from 'react';
+import rehypeExternalLinks from 'rehype-external-links';
+
+const BlockRenderer: FC<{ block: HomepageBlock }> = ({ block }) => {
+    const { colorScheme } = useMantineColorScheme();
+    switch (block.type) {
+        case 'markdown':
+            return (
+                <Box data-color-mode={colorScheme} w="100%">
+                    <MarkdownPreview
+                        source={block.config.content}
+                        rehypePlugins={[
+                            [rehypeExternalLinks, { target: '_blank' }],
+                        ]}
+                    />
+                </Box>
+            );
+        default:
+            return assertUnreachable(block.type, 'Unknown homepage block');
+    }
+};
+
+type Props = {
+    config: HomepageConfig;
+    projectUuid: string;
+};
+
+export const PublishedHomepage: FC<Props> = ({ config }) => (
+    <Stack gap="lg" maw={920} mx="auto" w="100%">
+        {config.rows.map((row) => (
+            <Group key={row.id} gap="md" align="stretch" wrap="nowrap">
+                {row.blocks.map((block) => (
+                    <Box key={block.id} style={{ flex: 1, minWidth: 0 }}>
+                        <BlockRenderer block={block} />
+                    </Box>
+                ))}
+            </Group>
+        ))}
+    </Stack>
+);

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
@@ -1,0 +1,32 @@
+import {
+    CommercialFeatureFlags,
+    type ApiError,
+    type PublishedProjectHomepage,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
+
+const getPublishedHomepage = async (projectUuid: string) =>
+    lightdashApi<PublishedProjectHomepage | null>({
+        url: `/projects/${projectUuid}/homepage`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useHomepageBuilderFlag = () => {
+    const { data: flag, isLoading } = useServerFeatureFlag(
+        CommercialFeatureFlags.HomepageBuilder,
+    );
+    return { isEnabled: !!flag?.enabled, isLoading };
+};
+
+export const usePublishedHomepage = (
+    projectUuid: string | undefined,
+    { enabled = true }: { enabled?: boolean } = {},
+) =>
+    useQuery<PublishedProjectHomepage | null, ApiError>({
+        enabled: !!projectUuid && enabled,
+        queryKey: ['project_homepage', projectUuid, 'published'],
+        queryFn: () => getPublishedHomepage(projectUuid!),
+    });

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -14,6 +14,11 @@ import PageSpinner from '../components/PageSpinner';
 import PinnedAndFavoritesSection from '../components/PinnedAndFavoritesSection';
 import AiSearchBox from '../ee/components/Home/AiSearchBox';
 import { useAiAgentButtonVisibility } from '../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
+import {
+    useHomepageBuilderFlag,
+    usePublishedHomepage,
+} from '../ee/features/homepageBuilder/hooks/useProjectHomepage';
+import { PublishedHomepage } from '../ee/features/homepageBuilder/PublishedHomepage';
 import { ManagedAgentHomeCard } from '../ee/features/managedAgent/ManagedAgentHomeCard';
 import { useFavorites } from '../hooks/favorites/useFavorites';
 import { usePinnedItems } from '../hooks/pinning/usePinnedItems';
@@ -43,6 +48,10 @@ const Home: FC = () => {
 
     const { user } = useApp();
     const isAiAgentsEnabled = useAiAgentButtonVisibility();
+    const { isEnabled: isHomepageBuilderEnabled } = useHomepageBuilderFlag();
+    const publishedHomepage = usePublishedHomepage(selectedProjectUuid, {
+        enabled: isHomepageBuilderEnabled,
+    });
 
     const isLoading =
         onboarding.isInitialLoading ||
@@ -74,6 +83,17 @@ const Home: FC = () => {
     const isGitHubProject =
         project.data.type !== ProjectType.PREVIEW &&
         project.data.dbtConnection.type === DbtProjectType.GITHUB;
+
+    if (isHomepageBuilderEnabled && publishedHomepage.data) {
+        return (
+            <Page withFixedContent withPaddedContent withFooter>
+                <PublishedHomepage
+                    config={publishedHomepage.data.config}
+                    projectUuid={project.data.projectUuid}
+                />
+            </Page>
+        );
+    }
 
     return (
         <Page withFixedContent withPaddedContent withFooter>


### PR DESCRIPTION
## Homepage Builder foundation — published homepage rendering (2/3)

Part of [ZAP-614](https://linear.app/lightdash/issue/ZAP-614) · Stacked on #25521

When the `homepage-builder` commercial flag is on and the project has a published homepage, `/projects/:uuid/home` renders it (markdown blocks via `MarkdownPreview`, row layout) instead of the default home. Everything else falls through to today’s home unchanged.

### What
- `ee/features/homepageBuilder/`: `usePublishedHomepage` + `useHomepageBuilderFlag` hooks, `PublishedHomepage` renderer (block-renderer switch, `assertUnreachable` for forward compat)
- `Home.tsx`: flag-gated early return **after** the existing loading/error/forbidden guards
- RTL test for the renderer

### Regression analysis
- Flag off (all orgs today): `usePublishedHomepage` never fires (query disabled) and Home renders exactly as before.
- Flag on without a published homepage: unchanged home too — only a published config switches the branch.
- Known tradeoff (noted for review): with flag on + published homepage, first paint may briefly show the default home while the published query resolves; foundation accepts this rather than blocking home on a new query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ