### PR TITLE
feat(frontend): homepage builder page with autosave and publish

### DIFF
--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -593,6 +593,14 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
         },
     },
     {
+        path: 'homepage-builder',
+        lazy: async () => {
+            const { HomepageBuilderPage } =
+                await import('./ee/features/homepageBuilder/HomepageBuilderPage');
+            return { Component: HomepageBuilderPage };
+        },
+    },
+    {
         path: 'improve',
         element: <Navigate to="../autopilot" replace />,
     },

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
@@ -1,0 +1,188 @@
+import { subject } from '@casl/ability';
+import { type HomepageConfig } from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Group,
+    Stack,
+    Text,
+    TextInput,
+    Title,
+} from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import { IconArrowLeft, IconCircleCheck, IconSend } from '@tabler/icons-react';
+import MDEditor from '@uiw/react-md-editor';
+import { useEffect, useState, type FC } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import Page from '../../../components/common/Page/Page';
+import ForbiddenPanel from '../../../components/ForbiddenPanel';
+import PageSpinner from '../../../components/PageSpinner';
+import useApp from '../../../providers/App/useApp';
+import {
+    useCreateHomepage,
+    useHomepageBuilderFlag,
+    useHomepageForBuilder,
+    usePublishHomepage,
+    useUpdateHomepageDraft,
+} from './hooks/useProjectHomepage';
+
+// ts-unused-exports:disable-next-line
+export const HomepageBuilderPage: FC = () => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const navigate = useNavigate();
+    const { user } = useApp();
+    const { isEnabled: isFlagEnabled, isLoading: isFlagLoading } =
+        useHomepageBuilderFlag();
+    const homepage = useHomepageForBuilder(projectUuid, {
+        enabled: isFlagEnabled,
+    });
+    const createMutation = useCreateHomepage(projectUuid!);
+    const updateMutation = useUpdateHomepageDraft(
+        projectUuid!,
+        homepage.data?.homepageUuid,
+    );
+    const publishMutation = usePublishHomepage(
+        projectUuid!,
+        homepage.data?.homepageUuid,
+    );
+
+    const [newName, setNewName] = useState('');
+    const [content, setContent] = useState<string | null>(null);
+    const [debouncedContent] = useDebouncedValue(content, 800);
+
+    const serverContent =
+        homepage.data?.draftConfig.rows[0]?.blocks[0]?.config.content;
+
+    useEffect(() => {
+        if (content === null && serverContent !== undefined) {
+            setContent(serverContent);
+        }
+    }, [content, serverContent]);
+
+    const homepageData = homepage.data;
+    useEffect(() => {
+        if (
+            debouncedContent === null ||
+            !homepageData ||
+            debouncedContent === serverContent
+        ) {
+            return;
+        }
+        const firstRow = homepageData.draftConfig.rows[0];
+        const draftConfig: HomepageConfig = {
+            version: 1,
+            rows: [
+                {
+                    id: firstRow?.id ?? 'row-1',
+                    blocks: [
+                        {
+                            id: firstRow?.blocks[0]?.id ?? 'block-1',
+                            type: 'markdown',
+                            config: { content: debouncedContent },
+                        },
+                    ],
+                },
+            ],
+        };
+        updateMutation.mutate({ draftConfig });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [debouncedContent]);
+
+    const canManage =
+        user.data?.ability?.can(
+            'manage',
+            subject('ProjectHomepage', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+            }),
+        ) ?? false;
+
+    if (isFlagLoading || homepage.isInitialLoading) {
+        return <PageSpinner />;
+    }
+
+    if (!isFlagEnabled || !canManage) {
+        return <ForbiddenPanel />;
+    }
+
+    return (
+        <Page withFixedContent withPaddedContent>
+            <Stack gap="lg" maw={920} mx="auto" w="100%">
+                <Group justify="space-between">
+                    <Button
+                        variant="default"
+                        leftSection={<MantineIcon icon={IconArrowLeft} />}
+                        onClick={() =>
+                            navigate(`/projects/${projectUuid}/home`)
+                        }
+                    >
+                        Exit
+                    </Button>
+                    {homepage.data && (
+                        <Group gap="sm">
+                            {updateMutation.isLoading ? (
+                                <Text size="xs" c="dimmed">
+                                    Saving…
+                                </Text>
+                            ) : (
+                                <Group gap={4}>
+                                    <MantineIcon
+                                        icon={IconCircleCheck}
+                                        color="green"
+                                    />
+                                    <Text size="xs" c="dimmed">
+                                        Draft saved
+                                    </Text>
+                                </Group>
+                            )}
+                            <Button
+                                leftSection={<MantineIcon icon={IconSend} />}
+                                loading={publishMutation.isLoading}
+                                onClick={() => publishMutation.mutate()}
+                            >
+                                Publish
+                            </Button>
+                        </Group>
+                    )}
+                </Group>
+
+                {!homepage.data ? (
+                    <Stack gap="sm" maw={480}>
+                        <Title order={3}>Create a homepage</Title>
+                        <Text c="dimmed" size="sm">
+                            Curate what everyone in this project sees when they
+                            land in Lightdash.
+                        </Text>
+                        <TextInput
+                            label="Name"
+                            placeholder="e.g. Team homepage"
+                            value={newName}
+                            onChange={(e) => setNewName(e.currentTarget.value)}
+                        />
+                        <Button
+                            disabled={newName.trim().length === 0}
+                            loading={createMutation.isLoading}
+                            onClick={() =>
+                                createMutation.mutate({ name: newName.trim() })
+                            }
+                        >
+                            Create homepage
+                        </Button>
+                    </Stack>
+                ) : (
+                    <Box data-color-mode="light">
+                        <MDEditor
+                            value={content ?? ''}
+                            onChange={(value) => setContent(value ?? '')}
+                            preview="edit"
+                            minHeight={220}
+                            height={420}
+                            visibleDragbar
+                        />
+                    </Box>
+                )}
+            </Stack>
+        </Page>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
@@ -1,16 +1,57 @@
 import {
     CommercialFeatureFlags,
     type ApiError,
+    type CreateProjectHomepageRequest,
+    type ProjectHomepage,
     type PublishedProjectHomepage,
+    type UpdateProjectHomepageDraftRequest,
 } from '@lightdash/common';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../../../api';
+import useToaster from '../../../../hooks/toaster/useToaster';
 import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
+
+const PROJECT_HOMEPAGE_QUERY_KEY = 'project_homepage';
 
 const getPublishedHomepage = async (projectUuid: string) =>
     lightdashApi<PublishedProjectHomepage | null>({
         url: `/projects/${projectUuid}/homepage`,
         method: 'GET',
+        body: undefined,
+    });
+
+const getHomepageForBuilder = async (projectUuid: string) =>
+    lightdashApi<ProjectHomepage | null>({
+        url: `/projects/${projectUuid}/homepage/builder`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const createHomepageApi = async (
+    projectUuid: string,
+    data: CreateProjectHomepageRequest,
+) =>
+    lightdashApi<ProjectHomepage>({
+        url: `/projects/${projectUuid}/homepage`,
+        method: 'POST',
+        body: JSON.stringify(data),
+    });
+
+const updateHomepageDraftApi = async (
+    projectUuid: string,
+    homepageUuid: string,
+    data: UpdateProjectHomepageDraftRequest,
+) =>
+    lightdashApi<ProjectHomepage>({
+        url: `/projects/${projectUuid}/homepage/${homepageUuid}`,
+        method: 'PATCH',
+        body: JSON.stringify(data),
+    });
+
+const publishHomepageApi = async (projectUuid: string, homepageUuid: string) =>
+    lightdashApi<ProjectHomepage>({
+        url: `/projects/${projectUuid}/homepage/${homepageUuid}/publish`,
+        method: 'POST',
         body: undefined,
     });
 
@@ -27,6 +68,94 @@ export const usePublishedHomepage = (
 ) =>
     useQuery<PublishedProjectHomepage | null, ApiError>({
         enabled: !!projectUuid && enabled,
-        queryKey: ['project_homepage', projectUuid, 'published'],
+        queryKey: [PROJECT_HOMEPAGE_QUERY_KEY, projectUuid, 'published'],
         queryFn: () => getPublishedHomepage(projectUuid!),
     });
+
+export const useHomepageForBuilder = (
+    projectUuid: string | undefined,
+    { enabled = true }: { enabled?: boolean } = {},
+) =>
+    useQuery<ProjectHomepage | null, ApiError>({
+        enabled: !!projectUuid && enabled,
+        queryKey: [PROJECT_HOMEPAGE_QUERY_KEY, projectUuid, 'builder'],
+        queryFn: () => getHomepageForBuilder(projectUuid!),
+    });
+
+export const useCreateHomepage = (projectUuid: string) => {
+    const { showToastApiError } = useToaster();
+    const queryClient = useQueryClient();
+    return useMutation<ProjectHomepage, ApiError, CreateProjectHomepageRequest>(
+        (data) => createHomepageApi(projectUuid, data),
+        {
+            mutationKey: ['create_project_homepage'],
+            onSuccess: async () => {
+                await queryClient.invalidateQueries([
+                    PROJECT_HOMEPAGE_QUERY_KEY,
+                    projectUuid,
+                ]);
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to create homepage',
+                    apiError: error,
+                });
+            },
+        },
+    );
+};
+
+export const useUpdateHomepageDraft = (
+    projectUuid: string,
+    homepageUuid: string | undefined,
+) => {
+    const { showToastApiError } = useToaster();
+    const queryClient = useQueryClient();
+    return useMutation<
+        ProjectHomepage,
+        ApiError,
+        UpdateProjectHomepageDraftRequest
+    >((data) => updateHomepageDraftApi(projectUuid, homepageUuid!, data), {
+        mutationKey: ['update_project_homepage_draft'],
+        onSettled: async () => {
+            await queryClient.invalidateQueries([
+                PROJECT_HOMEPAGE_QUERY_KEY,
+                projectUuid,
+                'builder',
+            ]);
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to save draft',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const usePublishHomepage = (
+    projectUuid: string,
+    homepageUuid: string | undefined,
+) => {
+    const { showToastSuccess, showToastApiError } = useToaster();
+    const queryClient = useQueryClient();
+    return useMutation<ProjectHomepage, ApiError, void>(
+        () => publishHomepageApi(projectUuid, homepageUuid!),
+        {
+            mutationKey: ['publish_project_homepage'],
+            onSuccess: async () => {
+                await queryClient.invalidateQueries([
+                    PROJECT_HOMEPAGE_QUERY_KEY,
+                    projectUuid,
+                ]);
+                showToastSuccess({ title: 'Homepage published' });
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to publish homepage',
+                    apiError: error,
+                });
+            },
+        },
+    );
+};

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -1,10 +1,12 @@
 import { subject } from '@casl/ability';
 import { DbtProjectType, ProjectType } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
+import { Button, Group, Stack } from '@mantine-8/core';
+import { IconEdit } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 import { useUnmount } from 'react-use';
 import ErrorState from '../components/common/ErrorState';
+import MantineIcon from '../components/common/MantineIcon';
 import Page from '../components/common/Page/Page';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import { HomepageContentPanel } from '../components/Home/HomepageContentPanel';
@@ -27,12 +29,14 @@ import {
     useMostPopularAndRecentlyUpdated,
     useProject,
 } from '../hooks/useProject';
+import { Can } from '../providers/Ability';
 import useApp from '../providers/App/useApp';
 import { FavoritesProvider } from '../providers/Favorites/FavoritesProvider';
 import { PinnedItemsProvider } from '../providers/PinnedItems/PinnedItemsProvider';
 
 const Home: FC = () => {
     const params = useParams<{ projectUuid: string }>();
+    const navigate = useNavigate();
     const selectedProjectUuid = params.projectUuid;
     const project = useProject(selectedProjectUuid);
     const onboarding = useOnboardingStatus();
@@ -87,10 +91,34 @@ const Home: FC = () => {
     if (isHomepageBuilderEnabled && publishedHomepage.data) {
         return (
             <Page withFixedContent withPaddedContent withFooter>
-                <PublishedHomepage
-                    config={publishedHomepage.data.config}
-                    projectUuid={project.data.projectUuid}
-                />
+                <Stack gap="md">
+                    <Can
+                        I="manage"
+                        this={subject('ProjectHomepage', {
+                            organizationUuid: project.data.organizationUuid,
+                            projectUuid: project.data.projectUuid,
+                        })}
+                    >
+                        <Group justify="flex-end">
+                            <Button
+                                variant="default"
+                                size="xs"
+                                leftSection={<MantineIcon icon={IconEdit} />}
+                                onClick={() =>
+                                    navigate(
+                                        `/projects/${project.data.projectUuid}/homepage-builder`,
+                                    )
+                                }
+                            >
+                                Customize homepage
+                            </Button>
+                        </Group>
+                    </Can>
+                    <PublishedHomepage
+                        config={publishedHomepage.data.config}
+                        projectUuid={project.data.projectUuid}
+                    />
+                </Stack>
             </Page>
         );
     }


### PR DESCRIPTION
## Homepage Builder foundation — builder page (3/3)

Part of [ZAP-614](https://linear.app/lightdash/issue/ZAP-614) · Stacked on #25522

Minimal admin builder at `/projects/:uuid/homepage-builder`: create the project homepage, edit its markdown block with debounced autosave ("Draft saved" indicator), and publish. A flag+CASL-gated "Customize homepage" button appears on the published homepage.

### What
- `HomepageBuilderPage`: flag + `manage:ProjectHomepage` gates (ForbiddenPanel otherwise), create-form empty state, `MDEditor` with 800ms debounced autosave, Publish with success toast, Exit back home
- Builder query + create/update-draft/publish mutations in `useProjectHomepage.ts`
- Route registered next to `autopilot` in `Routes.tsx` (lazy)

### Verified end-to-end (local, Playwright)
- Admin: home → Customize → edit → "Draft saved" → home still shows old published content → Publish → home shows new content
- Flag off: classic home fully restored; builder route → ForbiddenPanel; API 403
- Draft/published independence confirmed at DB level

### Regression analysis
- Flag off: new route renders ForbiddenPanel only; no other surface changes.
- Non-admins (flag on): no Customize button (CASL `Can`), builder page ForbiddenPanel, mutations rejected server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ