### PR TITLE
feat(ai): expose the Deep Research API

### DIFF
--- a/packages/backend/src/ee/controllers/AiDeepResearchController.ts
+++ b/packages/backend/src/ee/controllers/AiDeepResearchController.ts
@@ -1,13 +1,14 @@
 import {
     assertRegisteredAccount,
+    type AiDeepResearchRequestBody,
     type ApiAiDeepResearchEventsResponse,
     type ApiAiDeepResearchRunResponse,
     type ApiErrorPayload,
     type UUID,
 } from '@lightdash/common';
 import {
+    Body,
     Get,
-    Hidden,
     Middlewares,
     OperationId,
     Path,
@@ -23,14 +24,44 @@ import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
+    unauthorisedInDemo,
 } from '../../controllers/authentication';
 import { BaseController } from '../../controllers/baseController';
 import { AiDeepResearchService } from '../services/AiDeepResearchService/AiDeepResearchService';
 
 @Route('/api/v1/ee/projects/{projectUuid}/ai-deep-research')
-@Hidden()
 @Response<ApiErrorPayload>('default', 'Error')
 export class AiDeepResearchController extends BaseController {
+    /**
+     * Start a durable Deep Research investigation.
+     * @summary Start Deep Research run
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('202', 'Accepted')
+    @Post('/')
+    @OperationId('createAiDeepResearchRun')
+    async createRun(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Body() body: AiDeepResearchRequestBody,
+    ): Promise<ApiAiDeepResearchRunResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(202);
+        return {
+            status: 'ok',
+            results: await this.getAiDeepResearchService().createRun({
+                user: toSessionUser(req.account),
+                projectUuid,
+                prompt: body.prompt,
+                effort: body.effort,
+            }),
+        };
+    }
+
     /**
      * Get the durable state and result of a Deep Research run.
      * @summary Get Deep Research run
@@ -58,6 +89,8 @@ export class AiDeepResearchController extends BaseController {
 
     /**
      * List persisted progress for a Deep Research run in chronological order.
+     * Pass the returned cursor unchanged to receive only newer events. The
+     * cursor remains usable when no new events are available.
      * @summary List Deep Research events
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.integration.test.ts
@@ -97,6 +97,27 @@ describe('AiDeepResearchRunModel integration', () => {
         ]);
     });
 
+    it('does not replay the cursor event when Postgres stores microseconds', async () => {
+        const run = await createRun();
+        const [event] = await model.listEvents({
+            aiDeepResearchRunUuid: run.ai_deep_research_run_uuid,
+            cursor: null,
+            limit: 10,
+        });
+
+        expect(event.cursor_created_at).toMatch(/\.\d{6}$/);
+        expect(
+            await model.listEvents({
+                aiDeepResearchRunUuid: run.ai_deep_research_run_uuid,
+                cursor: {
+                    createdAt: event.cursor_created_at,
+                    eventUuid: event.ai_deep_research_event_uuid,
+                },
+                limit: 10,
+            }),
+        ).toEqual([]);
+    });
+
     it('settles a claim and cancellation race without losing cancellation', async () => {
         const run = await createRun();
 

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.test.ts
@@ -136,7 +136,7 @@ describe('AiDeepResearchRunModel', () => {
 
     it('uses a stable created-at and uuid keyset for event pagination', async () => {
         tracker.on.select(AiDeepResearchEventsTableName).responseOnce([]);
-        const createdAt = new Date('2026-07-13T12:00:00.000Z');
+        const createdAt = '2026-07-13 12:00:00.000001';
 
         await model.listEvents({
             aiDeepResearchRunUuid: RUN_UUID,
@@ -146,7 +146,7 @@ describe('AiDeepResearchRunModel', () => {
 
         const [select] = tracker.history.select;
         expect(select.sql).toContain(
-            '(created_at, ai_deep_research_event_uuid) > ($2, $3)',
+            '(created_at, ai_deep_research_event_uuid) > ($2::timestamp, $3::uuid)',
         );
         expect(select.sql).toContain('order by "created_at" asc');
         expect(select.sql).toContain(

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -33,8 +33,12 @@ type CreateAiDeepResearchRun = {
 };
 
 type EventCursor = {
-    createdAt: Date;
+    createdAt: string;
     eventUuid: string;
+};
+
+export type DbAiDeepResearchEventWithCursor = DbAiDeepResearchEvent & {
+    cursor_created_at: string;
 };
 
 type Queryable = Knex | Knex.Transaction;
@@ -382,15 +386,22 @@ export class AiDeepResearchRunModel {
         aiDeepResearchRunUuid: string;
         cursor: EventCursor | null;
         limit: number;
-    }): Promise<DbAiDeepResearchEvent[]> {
+    }): Promise<DbAiDeepResearchEventWithCursor[]> {
         const query = this.database<AiDeepResearchEventsTable>(
             AiDeepResearchEventsTableName,
-        ).where('ai_deep_research_run_uuid', args.aiDeepResearchRunUuid);
+        )
+            .select(
+                '*',
+                this.database.raw(
+                    `to_char(created_at, 'YYYY-MM-DD HH24:MI:SS.US') as cursor_created_at`,
+                ),
+            )
+            .where('ai_deep_research_run_uuid', args.aiDeepResearchRunUuid);
 
         const pageQuery = args.cursor
             ? query.andWhere(
                   this.database.raw(
-                      '(created_at, ai_deep_research_event_uuid) > (?, ?)',
+                      '(created_at, ai_deep_research_event_uuid) > (?::timestamp, ?::uuid)',
                       [args.cursor.createdAt, args.cursor.eventUuid],
                   ),
               )

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -20,6 +20,49 @@ const budget: AiDeepResearchBudget = {
     maxResultRows: 1_000,
 };
 
+const effortBudgets = [
+    {
+        effort: 'low',
+        budget: {
+            maxRuntimeMs: 15 * 60 * 1_000,
+            maxTokens: 150_000,
+            maxToolCalls: 50,
+            maxWarehouseQueries: 10,
+            maxResultRows: 5_000,
+        },
+    },
+    {
+        effort: 'medium',
+        budget: {
+            maxRuntimeMs: 30 * 60 * 1_000,
+            maxTokens: 500_000,
+            maxToolCalls: 125,
+            maxWarehouseQueries: 25,
+            maxResultRows: 10_000,
+        },
+    },
+    {
+        effort: 'high',
+        budget: {
+            maxRuntimeMs: 45 * 60 * 1_000,
+            maxTokens: 1_000_000,
+            maxToolCalls: 250,
+            maxWarehouseQueries: 50,
+            maxResultRows: 25_000,
+        },
+    },
+    {
+        effort: 'xhigh',
+        budget: {
+            maxRuntimeMs: 55 * 60 * 1_000,
+            maxTokens: 2_000_000,
+            maxToolCalls: 500,
+            maxWarehouseQueries: 100,
+            maxResultRows: 50_000,
+        },
+    },
+] as const;
+
 const report: AiDeepResearchReport = {
     summary: 'Summary',
     findings: [],
@@ -173,6 +216,75 @@ describe('AiDeepResearchService', () => {
                 featureFlagId: FeatureFlags.AiDeepResearch,
             });
             expect(run.status).toBe('queued');
+        });
+
+        it('uses the server-owned default budget when none is provided', async () => {
+            const { service, model } = buildService();
+
+            await service.createRun({
+                user: userWithProjectAccess(),
+                projectUuid: 'project-1',
+                prompt: 'Investigate revenue',
+            });
+
+            expect(model.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    budget: effortBudgets[1].budget,
+                }),
+            );
+        });
+
+        it.each(effortBudgets)(
+            'maps $effort effort to its server-owned budget',
+            async ({ effort, budget: expectedBudget }) => {
+                const { service, model } = buildService();
+
+                await service.createRun({
+                    user: userWithProjectAccess(),
+                    projectUuid: 'project-1',
+                    prompt: 'Investigate revenue',
+                    effort,
+                });
+
+                expect(model.create).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        budget: expectedBudget,
+                    }),
+                );
+            },
+        );
+
+        it('rejects a blank prompt before persistence', async () => {
+            const { service, model } = buildService();
+
+            await expect(
+                service.createRun({
+                    user: userWithProjectAccess(),
+                    projectUuid: 'project-1',
+                    prompt: '   ',
+                }),
+            ).rejects.toBeInstanceOf(ParameterError);
+            expect(model.create).not.toHaveBeenCalled();
+        });
+
+        it('rejects run creation when Deep Research is disabled', async () => {
+            const { service, model } = buildService({
+                featureFlagModel: {
+                    get: vi.fn().mockResolvedValue({
+                        id: FeatureFlags.AiDeepResearch,
+                        enabled: false,
+                    }),
+                },
+            });
+
+            await expect(
+                service.createRun({
+                    user: userWithProjectAccess(),
+                    projectUuid: 'project-1',
+                    prompt: 'Investigate revenue',
+                }),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+            expect(model.create).not.toHaveBeenCalled();
         });
 
         it('marks the durable run failed when enqueueing fails', async () => {
@@ -389,6 +501,7 @@ describe('AiDeepResearchService', () => {
                             event_type: 'status_changed',
                             payload: { status: 'queued' },
                             created_at: new Date('2026-07-13T12:00:00.000Z'),
+                            cursor_created_at: '2026-07-13 12:00:00.000001',
                         },
                         {
                             ai_deep_research_event_uuid: 'event-2',
@@ -396,6 +509,7 @@ describe('AiDeepResearchService', () => {
                             event_type: 'status_changed',
                             payload: { status: 'running' },
                             created_at: new Date('2026-07-13T12:01:00.000Z'),
+                            cursor_created_at: '2026-07-13 12:01:00.000001',
                         },
                     ]),
                 },
@@ -417,6 +531,51 @@ describe('AiDeepResearchService', () => {
             });
         });
 
+        it('returns a cursor for the final event so clients can keep polling', async () => {
+            const { service } = buildService({
+                model: {
+                    listEvents: vi.fn().mockResolvedValue([
+                        {
+                            ai_deep_research_event_uuid:
+                                '9323399d-2329-4fd1-aa22-840c014f36f1',
+                            ai_deep_research_run_uuid: 'run-1',
+                            event_type: 'status_changed',
+                            payload: { status: 'queued' },
+                            created_at: new Date('2026-07-13T12:00:00.000Z'),
+                            cursor_created_at: '2026-07-13 12:00:00.000001',
+                        },
+                    ]),
+                },
+            });
+
+            const page = await service.listEvents({
+                user: userWithProjectAccess(),
+                projectUuid: 'project-1',
+                aiDeepResearchRunUuid: 'run-1',
+            });
+
+            expect(page.nextCursor).not.toBeNull();
+        });
+
+        it('keeps the current cursor when no new events are available', async () => {
+            const { service } = buildService();
+            const cursor = Buffer.from(
+                JSON.stringify({
+                    createdAt: '2026-07-13 12:00:00.000001',
+                    eventUuid: '9323399d-2329-4fd1-aa22-840c014f36f1',
+                }),
+            ).toString('base64url');
+
+            const page = await service.listEvents({
+                user: userWithProjectAccess(),
+                projectUuid: 'project-1',
+                aiDeepResearchRunUuid: 'run-1',
+                cursor,
+            });
+
+            expect(page).toEqual({ events: [], nextCursor: cursor });
+        });
+
         it('rejects malformed cursors', async () => {
             const { service } = buildService();
 
@@ -434,7 +593,7 @@ describe('AiDeepResearchService', () => {
             const { service, model } = buildService();
             const cursor = Buffer.from(
                 JSON.stringify({
-                    createdAt: '2026-07-13T12:00:00.000Z',
+                    createdAt: '2026-07-13 12:00:00.000001',
                     eventUuid: 'not-a-uuid',
                 }),
             ).toString('base64url');

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -8,6 +8,7 @@ import {
     NotFoundError,
     ParameterError,
     type AiDeepResearchBudget,
+    type AiDeepResearchEffort,
     type AiDeepResearchEvent,
     type AiDeepResearchEventPayloadMap,
     type AiDeepResearchEventsPage,
@@ -25,7 +26,10 @@ import {
     type DbAiDeepResearchEvent,
     type DbAiDeepResearchRun,
 } from '../../database/entities/aiDeepResearch';
-import { type AiDeepResearchRunModel } from '../../models/AiDeepResearchRunModel';
+import {
+    type AiDeepResearchRunModel,
+    type DbAiDeepResearchEventWithCursor,
+} from '../../models/AiDeepResearchRunModel';
 import { type CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 
 const MAX_EVENT_PAGE_SIZE = 100;
@@ -111,17 +115,17 @@ const toEvent = (row: DbAiDeepResearchEvent): AiDeepResearchEvent => {
     }
 };
 
-const encodeEventCursor = (event: AiDeepResearchEvent): string =>
+const encodeEventCursor = (event: DbAiDeepResearchEventWithCursor): string =>
     Buffer.from(
         JSON.stringify({
-            createdAt: event.createdAt,
-            eventUuid: event.aiDeepResearchEventUuid,
+            createdAt: event.cursor_created_at,
+            eventUuid: event.ai_deep_research_event_uuid,
         } satisfies EventCursorPayload),
     ).toString('base64url');
 
 const decodeEventCursor = (
     cursor: string | undefined,
-): { createdAt: Date; eventUuid: string } | null => {
+): EventCursorPayload | null => {
     if (!cursor) {
         return null;
     }
@@ -141,26 +145,63 @@ const decodeEventCursor = (
             throw new Error('Invalid cursor payload');
         }
 
-        const createdAt = new Date(parsed.createdAt);
+        const createdAt = new Date(`${parsed.createdAt.replace(' ', 'T')}Z`);
         if (
+            !/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6}$/.test(
+                parsed.createdAt,
+            ) ||
             Number.isNaN(createdAt.getTime()) ||
             !isValidUuid(parsed.eventUuid)
         ) {
             throw new Error('Invalid cursor values');
         }
-        return { createdAt, eventUuid: parsed.eventUuid };
+        return { createdAt: parsed.createdAt, eventUuid: parsed.eventUuid };
     } catch {
         throw new ParameterError('Invalid Deep Research event cursor');
     }
 };
 
-export const AI_DEEP_RESEARCH_MAX_BUDGET: AiDeepResearchBudget = {
-    maxRuntimeMs: 60 * 60 * 1_000,
-    maxTokens: 500_000,
-    maxToolCalls: 500,
-    maxWarehouseQueries: 200,
-    maxResultRows: 10_000,
+export const AI_DEEP_RESEARCH_BUDGETS_BY_EFFORT: Record<
+    AiDeepResearchEffort,
+    AiDeepResearchBudget
+> = {
+    low: {
+        maxRuntimeMs: 15 * 60 * 1_000,
+        maxTokens: 150_000,
+        maxToolCalls: 50,
+        maxWarehouseQueries: 10,
+        maxResultRows: 5_000,
+    },
+    medium: {
+        maxRuntimeMs: 30 * 60 * 1_000,
+        maxTokens: 500_000,
+        maxToolCalls: 125,
+        maxWarehouseQueries: 25,
+        maxResultRows: 10_000,
+    },
+    high: {
+        maxRuntimeMs: 45 * 60 * 1_000,
+        maxTokens: 1_000_000,
+        maxToolCalls: 250,
+        maxWarehouseQueries: 50,
+        maxResultRows: 25_000,
+    },
+    xhigh: {
+        maxRuntimeMs: 55 * 60 * 1_000,
+        maxTokens: 2_000_000,
+        maxToolCalls: 500,
+        maxWarehouseQueries: 100,
+        maxResultRows: 50_000,
+    },
 };
+
+export const AI_DEEP_RESEARCH_DEFAULT_EFFORT: AiDeepResearchEffort = 'medium';
+
+export const AI_DEEP_RESEARCH_DEFAULT_BUDGET =
+    AI_DEEP_RESEARCH_BUDGETS_BY_EFFORT[AI_DEEP_RESEARCH_DEFAULT_EFFORT];
+
+export const AI_DEEP_RESEARCH_MAX_BUDGET =
+    AI_DEEP_RESEARCH_BUDGETS_BY_EFFORT.xhigh;
 
 const assertValidBudget = (budget: AiDeepResearchBudget): void => {
     if (
@@ -255,7 +296,8 @@ export class AiDeepResearchService extends BaseService {
         user: SessionUser;
         projectUuid: string;
         prompt: string;
-        budget: AiDeepResearchBudget;
+        effort?: AiDeepResearchEffort;
+        budget?: AiDeepResearchBudget;
         aiThreadUuid?: string;
         promptUuid?: string;
         toolCallId?: string;
@@ -266,7 +308,12 @@ export class AiDeepResearchService extends BaseService {
         if (args.prompt.trim().length === 0) {
             throw new ParameterError('Deep Research prompt is required');
         }
-        assertValidBudget(args.budget);
+        const budget =
+            args.budget ??
+            AI_DEEP_RESEARCH_BUDGETS_BY_EFFORT[
+                args.effort ?? AI_DEEP_RESEARCH_DEFAULT_EFFORT
+            ];
+        assertValidBudget(budget);
 
         await this.assertCanViewProject(args.user, args.projectUuid);
         const featureFlag = await this.featureFlagModel.get({
@@ -285,7 +332,7 @@ export class AiDeepResearchService extends BaseService {
             promptUuid: args.promptUuid ?? null,
             toolCallId: args.toolCallId ?? null,
             prompt: args.prompt.trim(),
-            budget: args.budget,
+            budget,
         });
 
         try {
@@ -352,13 +399,14 @@ export class AiDeepResearchService extends BaseService {
             cursor: decodeEventCursor(args.cursor),
             limit,
         });
-        const events = rows.slice(0, limit).map(toEvent);
+        const pageRows = rows.slice(0, limit);
+        const events = pageRows.map(toEvent);
         return {
             events,
             nextCursor:
-                rows.length > limit && events.length > 0
-                    ? encodeEventCursor(events[events.length - 1])
-                    : null,
+                pageRows.length > 0
+                    ? encodeEventCursor(pageRows[pageRows.length - 1])
+                    : (args.cursor ?? null),
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -23601,6 +23601,32 @@ const models: TsoaRoute.Models = {
         type: { ref: 'ApiSuccess_AiDeepResearchRun_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDeepResearchEffort: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['high'] },
+                { dataType: 'enum', enums: ['medium'] },
+                { dataType: 'enum', enums: ['low'] },
+                { dataType: 'enum', enums: ['xhigh'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDeepResearchRequestBody: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                effort: { ref: 'AiDeepResearchEffort' },
+                prompt: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiDeepResearchPhase: {
         dataType: 'refAlias',
         type: {
@@ -61094,6 +61120,73 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiDeepResearchController_createRun: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'AiDeepResearchRequestBody',
+        },
+    };
+    app.post(
+        '/api/v1/ee/projects/:projectUuid/ai-deep-research',
+        ...fetchMiddlewares<RequestHandler>(AiDeepResearchController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiDeepResearchController.prototype.createRun,
+        ),
+
+        async function AiDeepResearchController_createRun(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiDeepResearchController_createRun,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiDeepResearchController>(
+                        AiDeepResearchController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'createRun',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 202,
                 });
             } catch (err) {
                 return next(err);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -23959,6 +23959,23 @@
             "ApiAiDeepResearchRunResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiDeepResearchRun_"
             },
+            "AiDeepResearchEffort": {
+                "type": "string",
+                "enum": ["high", "medium", "low", "xhigh"]
+            },
+            "AiDeepResearchRequestBody": {
+                "properties": {
+                    "effort": {
+                        "$ref": "#/components/schemas/AiDeepResearchEffort",
+                        "description": "Server-owned execution budget tier. Defaults to medium."
+                    },
+                    "prompt": {
+                        "type": "string"
+                    }
+                },
+                "required": ["prompt"],
+                "type": "object"
+            },
             "AiDeepResearchPhase": {
                 "type": "string",
                 "enum": [
@@ -53491,6 +53508,217 @@
                         "required": true,
                         "schema": {
                             "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/ee/projects/{projectUuid}/ai-deep-research": {
+            "post": {
+                "operationId": "createAiDeepResearchRun",
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiDeepResearchRunResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Start a durable Deep Research investigation.",
+                "summary": "Start Deep Research run",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AiDeepResearchRequestBody"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/ee/projects/{projectUuid}/ai-deep-research/{aiDeepResearchRunUuid}": {
+            "get": {
+                "operationId": "getAiDeepResearchRun",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiDeepResearchRunResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the durable state and result of a Deep Research run.",
+                "summary": "Get Deep Research run",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "aiDeepResearchRunUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/ee/projects/{projectUuid}/ai-deep-research/{aiDeepResearchRunUuid}/events": {
+            "get": {
+                "operationId": "listAiDeepResearchEvents",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiDeepResearchEventsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "List persisted progress for a Deep Research run in chronological order.\nPass the returned cursor unchanged to receive only newer events. The\ncursor remains usable when no new events are available.",
+                "summary": "List Deep Research events",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "aiDeepResearchRunUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "cursor",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "limit",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/ee/projects/{projectUuid}/ai-deep-research/{aiDeepResearchRunUuid}/cancel": {
+            "post": {
+                "operationId": "cancelAiDeepResearchRun",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiDeepResearchRunResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Cancel a queued run immediately or request cancellation for a running run.",
+                "summary": "Cancel Deep Research run",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "aiDeepResearchRunUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
                         }
                     }
                 ]

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -37,6 +37,21 @@ export type AiDeepResearchBudget = {
     maxResultRows: number;
 };
 
+export const AI_DEEP_RESEARCH_EFFORTS = [
+    'low',
+    'medium',
+    'high',
+    'xhigh',
+] as const;
+
+export type AiDeepResearchEffort = (typeof AI_DEEP_RESEARCH_EFFORTS)[number];
+
+export type AiDeepResearchRequestBody = {
+    prompt: string;
+    /** Server-owned execution budget tier. Defaults to medium. */
+    effort?: AiDeepResearchEffort;
+};
+
 export type AiDeepResearchConfidence = 'low' | 'medium' | 'high';
 
 export type AiDeepResearchEvidence = {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8827/expose-the-deep-research-run-and-polling-api

## Summary

PR 4 of 6 for [Deep Research](https://linear.app/lightdash/issue/PROD-8821/deep-research). Exposes the complete API lifecycle so clients can start a managed investigation, poll durable progress, retrieve its report, and cancel it before the AI-chat UI is added.

Stacks on PR3 ([#25514](https://github.com/lightdash/lightdash/pull/25514), merged), which connected durable Deep Research runs to the read-only Claude managed-agent executor.

## API flow

```
POST prompt + effort ──► queued run ──► Graphile ──► managed investigation
       │                     │                              │
       ├── GET run ◄─────────┴──────── durable result ◄────┤
       ├── GET events?cursor=… ◄────── progress events ◄───┤
       └── POST cancel ───────────────► cancellation signal ┘
```

## Changes

**API**

- Adds `POST /api/v1/ee/projects/{projectUuid}/ai-deep-research`, returning `202 Accepted` after persistence and enqueueing.
- Publishes create, get status/result, poll events, and cancel in generated OpenAPI.
- Accepts a required `prompt` and optional `effort`; demo mode cannot create managed-agent jobs.

**Effort budgets**

- `low` → 15m, 150k tokens, 50 tool calls, 10 warehouse queries, 5k result rows.
- `medium` (default) → 30m, 500k tokens, 125 tool calls, 25 warehouse queries, 10k rows.
- `high` → 45m, 1M tokens, 250 tool calls, 50 warehouse queries, 25k rows.
- `xhigh` → 55m, 2M tokens, 500 tool calls, 100 warehouse queries, 50k rows.
- Raw budgets remain server-owned; the 55-minute ceiling leaves cleanup grace under the existing 60-minute worker timeout.

**Polling**

- Returns a cursor for the last delivered event and preserves it when the caller reaches the current tail.
- Preserves PostgreSQL microsecond precision in the opaque cursor so polling does not replay its final event after a JavaScript `Date` round-trip.

## Test plan

- [x] Focused model/service suites: 32 tests passed.
- [x] Full backend suite: 4,148 tests passed, 1 skipped.
- [x] Backend and common fast typechecks passed.
- [x] Changed-file backend/common lint and `git diff --check` passed.
- [x] `pnpm generate-api`; Swagger contains exactly the four Deep Research lifecycle paths and two new request/effort schemas.
- [x] London API: 400 empty prompt, 422 invalid effort, default/low budget snapshots, durable GET, and cancellation request.
- [x] London PostgreSQL/API: repeated cursor polling returned no duplicate event UUIDs; empty-tail polling preserved the cursor.

🤖 Generated with Codex