### PR TITLE
feat(frontend): homepage builder block engine

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
@@ -1,36 +1,21 @@
 import { subject } from '@casl/ability';
-import { type HomepageConfig } from '@lightdash/common';
-import {
-    Box,
-    Button,
-    Group,
-    Stack,
-    Text,
-    TextInput,
-    Title,
-} from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
-import { IconArrowLeft, IconCircleCheck, IconSend } from '@tabler/icons-react';
-import MDEditor from '@uiw/react-md-editor';
-import { useEffect, useState, type FC } from 'react';
-import { useNavigate, useParams } from 'react-router';
-import MantineIcon from '../../../components/common/MantineIcon';
+import { Button, Stack, Text, TextInput, Title } from '@mantine-8/core';
+import { useState, type FC } from 'react';
+import { useParams } from 'react-router';
 import Page from '../../../components/common/Page/Page';
 import ForbiddenPanel from '../../../components/ForbiddenPanel';
 import PageSpinner from '../../../components/PageSpinner';
 import useApp from '../../../providers/App/useApp';
+import { HomepageEditor } from './HomepageEditor';
 import {
     useCreateHomepage,
     useHomepageBuilderFlag,
     useHomepageForBuilder,
-    usePublishHomepage,
-    useUpdateHomepageDraft,
 } from './hooks/useProjectHomepage';
 
 // ts-unused-exports:disable-next-line
 export const HomepageBuilderPage: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
-    const navigate = useNavigate();
     const { user } = useApp();
     const { isEnabled: isFlagEnabled, isLoading: isFlagLoading } =
         useHomepageBuilderFlag();
@@ -38,56 +23,7 @@ export const HomepageBuilderPage: FC = () => {
         enabled: isFlagEnabled,
     });
     const createMutation = useCreateHomepage(projectUuid!);
-    const updateMutation = useUpdateHomepageDraft(
-        projectUuid!,
-        homepage.data?.homepageUuid,
-    );
-    const publishMutation = usePublishHomepage(
-        projectUuid!,
-        homepage.data?.homepageUuid,
-    );
-
     const [newName, setNewName] = useState('');
-    const [content, setContent] = useState<string | null>(null);
-    const [debouncedContent] = useDebouncedValue(content, 800);
-
-    const serverContent =
-        homepage.data?.draftConfig.rows[0]?.blocks[0]?.config.content;
-
-    useEffect(() => {
-        if (content === null && serverContent !== undefined) {
-            setContent(serverContent);
-        }
-    }, [content, serverContent]);
-
-    const homepageData = homepage.data;
-    useEffect(() => {
-        if (
-            debouncedContent === null ||
-            !homepageData ||
-            debouncedContent === serverContent
-        ) {
-            return;
-        }
-        const firstRow = homepageData.draftConfig.rows[0];
-        const draftConfig: HomepageConfig = {
-            version: 1,
-            rows: [
-                {
-                    id: firstRow?.id ?? 'row-1',
-                    blocks: [
-                        {
-                            id: firstRow?.blocks[0]?.id ?? 'block-1',
-                            type: 'markdown',
-                            config: { content: debouncedContent },
-                        },
-                    ],
-                },
-            ],
-        };
-        updateMutation.mutate({ draftConfig });
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [debouncedContent]);
 
     const canManage =
         user.data?.ability?.can(
@@ -102,87 +38,42 @@ export const HomepageBuilderPage: FC = () => {
         return <PageSpinner />;
     }
 
-    if (!isFlagEnabled || !canManage) {
+    if (!isFlagEnabled || !canManage || !projectUuid) {
         return <ForbiddenPanel />;
     }
 
     return (
         <Page withFixedContent withPaddedContent>
-            <Stack gap="lg" maw={920} mx="auto" w="100%">
-                <Group justify="space-between">
+            {!homepage.data ? (
+                <Stack gap="sm" maw={480}>
+                    <Title order={3}>Create a homepage</Title>
+                    <Text c="dimmed" size="sm">
+                        Curate what everyone in this project sees when they land
+                        in Lightdash.
+                    </Text>
+                    <TextInput
+                        label="Name"
+                        placeholder="e.g. Team homepage"
+                        value={newName}
+                        onChange={(e) => setNewName(e.currentTarget.value)}
+                    />
                     <Button
-                        variant="default"
-                        leftSection={<MantineIcon icon={IconArrowLeft} />}
+                        disabled={newName.trim().length === 0}
+                        loading={createMutation.isLoading}
                         onClick={() =>
-                            navigate(`/projects/${projectUuid}/home`)
+                            createMutation.mutate({ name: newName.trim() })
                         }
                     >
-                        Exit
+                        Create homepage
                     </Button>
-                    {homepage.data && (
-                        <Group gap="sm">
-                            {updateMutation.isLoading ? (
-                                <Text size="xs" c="dimmed">
-                                    Saving…
-                                </Text>
-                            ) : (
-                                <Group gap={4}>
-                                    <MantineIcon
-                                        icon={IconCircleCheck}
-                                        color="green"
-                                    />
-                                    <Text size="xs" c="dimmed">
-                                        Draft saved
-                                    </Text>
-                                </Group>
-                            )}
-                            <Button
-                                leftSection={<MantineIcon icon={IconSend} />}
-                                loading={publishMutation.isLoading}
-                                onClick={() => publishMutation.mutate()}
-                            >
-                                Publish
-                            </Button>
-                        </Group>
-                    )}
-                </Group>
-
-                {!homepage.data ? (
-                    <Stack gap="sm" maw={480}>
-                        <Title order={3}>Create a homepage</Title>
-                        <Text c="dimmed" size="sm">
-                            Curate what everyone in this project sees when they
-                            land in Lightdash.
-                        </Text>
-                        <TextInput
-                            label="Name"
-                            placeholder="e.g. Team homepage"
-                            value={newName}
-                            onChange={(e) => setNewName(e.currentTarget.value)}
-                        />
-                        <Button
-                            disabled={newName.trim().length === 0}
-                            loading={createMutation.isLoading}
-                            onClick={() =>
-                                createMutation.mutate({ name: newName.trim() })
-                            }
-                        >
-                            Create homepage
-                        </Button>
-                    </Stack>
-                ) : (
-                    <Box data-color-mode="light">
-                        <MDEditor
-                            value={content ?? ''}
-                            onChange={(value) => setContent(value ?? '')}
-                            preview="edit"
-                            minHeight={220}
-                            height={420}
-                            visibleDragbar
-                        />
-                    </Box>
-                )}
-            </Stack>
+                </Stack>
+            ) : (
+                <HomepageEditor
+                    key={homepage.data.homepageUuid}
+                    homepage={homepage.data}
+                    projectUuid={projectUuid}
+                />
+            )}
         </Page>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -1,0 +1,336 @@
+import {
+    type HomepageConfig,
+    type ProjectHomepage as ProjectHomepageType,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Box,
+    Button,
+    Card,
+    Group,
+    Paper,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import {
+    IconArrowDown,
+    IconArrowLeft,
+    IconArrowUp,
+    IconCircleCheck,
+    IconCopy,
+    IconEye,
+    IconPencil,
+    IconSend,
+    IconTrash,
+} from '@tabler/icons-react';
+import { useEffect, useRef, useState, type FC } from 'react';
+import { useNavigate } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import {
+    blockLibrary,
+    createBlock,
+    getBlockDefinition,
+} from './blocks/registry';
+import {
+    addBlock,
+    canMoveDown,
+    canMoveUp,
+    duplicateBlock,
+    moveBlockDown,
+    moveBlockUp,
+    removeBlock,
+    updateBlockConfig,
+} from './configOps';
+import {
+    usePublishHomepage,
+    useUpdateHomepageDraft,
+} from './hooks/useProjectHomepage';
+import { PublishedHomepage } from './PublishedHomepage';
+
+type Props = {
+    homepage: ProjectHomepageType;
+    projectUuid: string;
+};
+
+export const HomepageEditor: FC<Props> = ({ homepage, projectUuid }) => {
+    const navigate = useNavigate();
+    const updateMutation = useUpdateHomepageDraft(
+        projectUuid,
+        homepage.homepageUuid,
+    );
+    const publishMutation = usePublishHomepage(
+        projectUuid,
+        homepage.homepageUuid,
+    );
+
+    const [draft, setDraft] = useState<HomepageConfig>(homepage.draftConfig);
+    const [isPreviewing, setIsPreviewing] = useState(false);
+    const [debouncedDraft] = useDebouncedValue(draft, 800);
+    const lastSavedRef = useRef<HomepageConfig>(homepage.draftConfig);
+
+    const { mutate: saveDraft } = updateMutation;
+    useEffect(() => {
+        if (debouncedDraft === lastSavedRef.current) return;
+        lastSavedRef.current = debouncedDraft;
+        saveDraft({ draftConfig: debouncedDraft });
+    }, [debouncedDraft, saveDraft]);
+
+    const handlePublish = async () => {
+        if (draft !== lastSavedRef.current) {
+            lastSavedRef.current = draft;
+            await updateMutation.mutateAsync({ draftConfig: draft });
+        }
+        publishMutation.mutate();
+    };
+
+    const isDirty = draft !== lastSavedRef.current || updateMutation.isLoading;
+
+    return (
+        <Stack gap="lg" w="100%">
+            <Group justify="space-between">
+                <Button
+                    variant="default"
+                    leftSection={<MantineIcon icon={IconArrowLeft} />}
+                    onClick={() => navigate(`/projects/${projectUuid}/home`)}
+                >
+                    Exit
+                </Button>
+                <Group gap="sm">
+                    {isDirty ? (
+                        <Text size="xs" c="dimmed">
+                            Saving…
+                        </Text>
+                    ) : (
+                        <Group gap={4}>
+                            <MantineIcon icon={IconCircleCheck} color="green" />
+                            <Text size="xs" c="dimmed">
+                                Draft saved
+                            </Text>
+                        </Group>
+                    )}
+                    <Button
+                        variant="default"
+                        leftSection={
+                            <MantineIcon
+                                icon={isPreviewing ? IconPencil : IconEye}
+                            />
+                        }
+                        onClick={() => setIsPreviewing((prev) => !prev)}
+                    >
+                        {isPreviewing ? 'Back to editing' : 'Preview'}
+                    </Button>
+                    <Button
+                        leftSection={<MantineIcon icon={IconSend} />}
+                        loading={publishMutation.isLoading}
+                        onClick={handlePublish}
+                    >
+                        Publish
+                    </Button>
+                </Group>
+            </Group>
+
+            {isPreviewing ? (
+                <PublishedHomepage config={draft} projectUuid={projectUuid} />
+            ) : (
+                <Group align="flex-start" gap="lg" wrap="nowrap">
+                    <Card withBorder w={264} p="sm" style={{ flexShrink: 0 }}>
+                        <Stack gap="xs">
+                            <Text size="xs" fw={600} tt="uppercase" c="dimmed">
+                                Blocks
+                            </Text>
+                            {blockLibrary.map((definition) => (
+                                <Paper
+                                    key={definition.type}
+                                    withBorder
+                                    p="sm"
+                                    style={{ cursor: 'pointer' }}
+                                    onClick={() =>
+                                        setDraft((prev) =>
+                                            addBlock(
+                                                prev,
+                                                createBlock(definition),
+                                            ),
+                                        )
+                                    }
+                                >
+                                    <Group gap="sm" wrap="nowrap">
+                                        <MantineIcon
+                                            icon={definition.icon}
+                                            size="lg"
+                                        />
+                                        <Box>
+                                            <Text size="sm" fw={500}>
+                                                {definition.label}
+                                            </Text>
+                                            <Text size="xs" c="dimmed">
+                                                {definition.description}
+                                            </Text>
+                                        </Box>
+                                    </Group>
+                                </Paper>
+                            ))}
+                            <Text size="xs" c="dimmed">
+                                Click a block to add it to the page.
+                            </Text>
+                        </Stack>
+                    </Card>
+
+                    <Stack gap="md" style={{ flex: 1, minWidth: 0 }}>
+                        {draft.rows.map((row) => (
+                            <Group
+                                key={row.id}
+                                gap="md"
+                                align="stretch"
+                                wrap="nowrap"
+                            >
+                                {row.blocks.map((block) => {
+                                    const definition = getBlockDefinition(
+                                        block.type,
+                                    );
+                                    if (!definition) return null;
+                                    const { Build } = definition;
+                                    return (
+                                        <Card
+                                            key={block.id}
+                                            withBorder
+                                            p="sm"
+                                            style={{ flex: 1, minWidth: 0 }}
+                                        >
+                                            <Group
+                                                gap={4}
+                                                mb="xs"
+                                                justify="space-between"
+                                            >
+                                                <Text
+                                                    size="xs"
+                                                    fw={600}
+                                                    tt="uppercase"
+                                                    c="dimmed"
+                                                >
+                                                    {definition.label}
+                                                </Text>
+                                                <Group gap={2}>
+                                                    <Tooltip label="Move up">
+                                                        <ActionIcon
+                                                            variant="subtle"
+                                                            color="gray"
+                                                            disabled={
+                                                                !canMoveUp(
+                                                                    draft,
+                                                                    block.id,
+                                                                )
+                                                            }
+                                                            onClick={() =>
+                                                                setDraft(
+                                                                    (prev) =>
+                                                                        moveBlockUp(
+                                                                            prev,
+                                                                            block.id,
+                                                                        ),
+                                                                )
+                                                            }
+                                                        >
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconArrowUp
+                                                                }
+                                                            />
+                                                        </ActionIcon>
+                                                    </Tooltip>
+                                                    <Tooltip label="Move down">
+                                                        <ActionIcon
+                                                            variant="subtle"
+                                                            color="gray"
+                                                            disabled={
+                                                                !canMoveDown(
+                                                                    draft,
+                                                                    block.id,
+                                                                )
+                                                            }
+                                                            onClick={() =>
+                                                                setDraft(
+                                                                    (prev) =>
+                                                                        moveBlockDown(
+                                                                            prev,
+                                                                            block.id,
+                                                                        ),
+                                                                )
+                                                            }
+                                                        >
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconArrowDown
+                                                                }
+                                                            />
+                                                        </ActionIcon>
+                                                    </Tooltip>
+                                                    <Tooltip label="Duplicate">
+                                                        <ActionIcon
+                                                            variant="subtle"
+                                                            color="gray"
+                                                            onClick={() =>
+                                                                setDraft(
+                                                                    (prev) =>
+                                                                        duplicateBlock(
+                                                                            prev,
+                                                                            block.id,
+                                                                        ),
+                                                                )
+                                                            }
+                                                        >
+                                                            <MantineIcon
+                                                                icon={IconCopy}
+                                                            />
+                                                        </ActionIcon>
+                                                    </Tooltip>
+                                                    <Tooltip label="Remove">
+                                                        <ActionIcon
+                                                            variant="subtle"
+                                                            color="red"
+                                                            onClick={() =>
+                                                                setDraft(
+                                                                    (prev) =>
+                                                                        removeBlock(
+                                                                            prev,
+                                                                            block.id,
+                                                                        ),
+                                                                )
+                                                            }
+                                                        >
+                                                            <MantineIcon
+                                                                icon={IconTrash}
+                                                            />
+                                                        </ActionIcon>
+                                                    </Tooltip>
+                                                </Group>
+                                            </Group>
+                                            <Build
+                                                block={block}
+                                                onChange={(config) =>
+                                                    setDraft((prev) =>
+                                                        updateBlockConfig(
+                                                            prev,
+                                                            block.id,
+                                                            config,
+                                                        ),
+                                                    )
+                                                }
+                                            />
+                                        </Card>
+                                    );
+                                })}
+                            </Group>
+                        ))}
+                        {draft.rows.length === 0 && (
+                            <Text size="sm" c="dimmed">
+                                No blocks yet — add one from the library.
+                            </Text>
+                        )}
+                    </Stack>
+                </Group>
+            )}
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -1,30 +1,14 @@
-import {
-    assertUnreachable,
-    type HomepageBlock,
-    type HomepageConfig,
-} from '@lightdash/common';
-import { Box, Group, Stack, useMantineColorScheme } from '@mantine-8/core';
-import MarkdownPreview from '@uiw/react-markdown-preview';
+import { type HomepageBlock, type HomepageConfig } from '@lightdash/common';
+import { Box, Group, Stack } from '@mantine-8/core';
 import { type FC } from 'react';
-import rehypeExternalLinks from 'rehype-external-links';
+import { getBlockDefinition } from './blocks/registry';
 
+// Unknown block types render nothing so newer configs degrade gracefully
 const BlockRenderer: FC<{ block: HomepageBlock }> = ({ block }) => {
-    const { colorScheme } = useMantineColorScheme();
-    switch (block.type) {
-        case 'markdown':
-            return (
-                <Box data-color-mode={colorScheme} w="100%">
-                    <MarkdownPreview
-                        source={block.config.content}
-                        rehypePlugins={[
-                            [rehypeExternalLinks, { target: '_blank' }],
-                        ]}
-                    />
-                </Box>
-            );
-        default:
-            return assertUnreachable(block.type, 'Unknown homepage block');
-    }
+    const definition = getBlockDefinition(block.type);
+    if (!definition) return null;
+    const { View } = definition;
+    return <View block={block} />;
 };
 
 type Props = {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MarkdownBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MarkdownBlock.tsx
@@ -1,0 +1,39 @@
+import { type HomepageMarkdownBlock } from '@lightdash/common';
+import { Box, useMantineColorScheme } from '@mantine-8/core';
+import MarkdownPreview from '@uiw/react-markdown-preview';
+import MDEditor from '@uiw/react-md-editor';
+import { type FC } from 'react';
+import rehypeExternalLinks from 'rehype-external-links';
+
+export const MarkdownBlockView: FC<{ block: HomepageMarkdownBlock }> = ({
+    block,
+}) => {
+    const { colorScheme } = useMantineColorScheme();
+    return (
+        <Box data-color-mode={colorScheme} w="100%">
+            <MarkdownPreview
+                source={block.config.content}
+                rehypePlugins={[[rehypeExternalLinks, { target: '_blank' }]]}
+            />
+        </Box>
+    );
+};
+
+export const MarkdownBlockBuild: FC<{
+    block: HomepageMarkdownBlock;
+    onChange: (config: HomepageMarkdownBlock['config']) => void;
+}> = ({ block, onChange }) => {
+    const { colorScheme } = useMantineColorScheme();
+    return (
+        <Box data-color-mode={colorScheme} w="100%">
+            <MDEditor
+                value={block.config.content}
+                onChange={(value) => onChange({ content: value ?? '' })}
+                preview="edit"
+                minHeight={140}
+                height={220}
+                visibleDragbar
+            />
+        </Box>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
@@ -1,0 +1,39 @@
+import { type HomepageBlock } from '@lightdash/common';
+import { IconMarkdown, type Icon } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { MarkdownBlockBuild, MarkdownBlockView } from './MarkdownBlock';
+
+export type BlockDefinition = {
+    type: HomepageBlock['type'];
+    label: string;
+    description: string;
+    icon: Icon;
+    defaultConfig: () => HomepageBlock['config'];
+    View: FC<{ block: HomepageBlock }>;
+    Build: FC<{
+        block: HomepageBlock;
+        onChange: (config: HomepageBlock['config']) => void;
+    }>;
+};
+
+export const blockLibrary: BlockDefinition[] = [
+    {
+        type: 'markdown',
+        label: 'Text / banner',
+        description: 'Markdown text, notes or a welcome banner.',
+        icon: IconMarkdown,
+        defaultConfig: () => ({ content: '## New section\n\nEdit me.' }),
+        View: MarkdownBlockView,
+        Build: MarkdownBlockBuild,
+    },
+];
+
+export const getBlockDefinition = (type: string): BlockDefinition | undefined =>
+    blockLibrary.find((def) => def.type === type);
+
+export const createBlock = (definition: BlockDefinition): HomepageBlock => ({
+    id: uuidv4(),
+    type: definition.type,
+    config: definition.defaultConfig(),
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/configOps.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/configOps.test.ts
@@ -1,0 +1,109 @@
+import { type HomepageBlock, type HomepageConfig } from '@lightdash/common';
+import {
+    addBlock,
+    canMoveDown,
+    canMoveUp,
+    duplicateBlock,
+    moveBlockDown,
+    moveBlockUp,
+    removeBlock,
+    updateBlockConfig,
+} from './configOps';
+
+const block = (id: string, content = id): HomepageBlock => ({
+    id,
+    type: 'markdown',
+    config: { content },
+});
+
+const makeConfig = (rows: HomepageBlock[][]): HomepageConfig => ({
+    version: 1,
+    rows: rows.map((blocks, i) => ({ id: `row-${i}`, blocks })),
+});
+
+describe('configOps', () => {
+    it('addBlock appends a new single-block row', () => {
+        const config = makeConfig([[block('a')]]);
+        const result = addBlock(config, block('b'));
+        expect(result.rows).toHaveLength(2);
+        expect(result.rows[1].blocks.map((b) => b.id)).toEqual(['b']);
+    });
+
+    it('removeBlock drops the block and its emptied row', () => {
+        const config = makeConfig([[block('a')], [block('b')]]);
+        const result = removeBlock(config, 'a');
+        expect(result.rows).toHaveLength(1);
+        expect(result.rows[0].blocks[0].id).toBe('b');
+    });
+
+    it('removeBlock with unknown id returns config unchanged', () => {
+        const config = makeConfig([[block('a')]]);
+        expect(removeBlock(config, 'nope')).toBe(config);
+    });
+
+    it('duplicateBlock copies within the row when there is space', () => {
+        const config = makeConfig([[block('a'), block('b')]]);
+        const result = duplicateBlock(config, 'a');
+        expect(result.rows[0].blocks).toHaveLength(3);
+        expect(result.rows[0].blocks[1].config.content).toBe('a');
+        expect(result.rows[0].blocks[1].id).not.toBe('a');
+    });
+
+    it('duplicateBlock overflows a full row into a new row below', () => {
+        const config = makeConfig([
+            [block('a'), block('b'), block('c')],
+            [block('d')],
+        ]);
+        const result = duplicateBlock(config, 'b');
+        expect(result.rows).toHaveLength(3);
+        expect(result.rows[0].blocks).toHaveLength(3);
+        expect(result.rows[1].blocks[0].config.content).toBe('b');
+        expect(result.rows[2].blocks[0].id).toBe('d');
+    });
+
+    it('moveBlockDown swaps single-block rows', () => {
+        const config = makeConfig([[block('a')], [block('b')]]);
+        const result = moveBlockDown(config, 'a');
+        expect(result.rows.map((r) => r.blocks[0].id)).toEqual(['b', 'a']);
+    });
+
+    it('moveBlockUp extracts a block from a multi-block row', () => {
+        const config = makeConfig([[block('a'), block('b')]]);
+        const result = moveBlockUp(config, 'b');
+        expect(result.rows).toHaveLength(2);
+        expect(result.rows[0].blocks.map((b) => b.id)).toEqual(['b']);
+        expect(result.rows[1].blocks.map((b) => b.id)).toEqual(['a']);
+    });
+
+    it('move at the boundary is a no-op', () => {
+        const config = makeConfig([[block('a')], [block('b')]]);
+        expect(moveBlockUp(config, 'a')).toBe(config);
+        expect(moveBlockDown(config, 'b')).toBe(config);
+    });
+
+    it('canMoveUp/Down reflect boundaries and multi-block rows', () => {
+        const config = makeConfig([[block('a')], [block('b'), block('c')]]);
+        expect(canMoveUp(config, 'a')).toBe(false);
+        expect(canMoveDown(config, 'a')).toBe(true);
+        expect(canMoveUp(config, 'b')).toBe(true);
+        expect(canMoveDown(config, 'c')).toBe(true);
+    });
+
+    it('updateBlockConfig replaces only the target block config', () => {
+        const config = makeConfig([[block('a'), block('b')]]);
+        const result = updateBlockConfig(config, 'a', { content: 'edited' });
+        expect(result.rows[0].blocks[0].config.content).toBe('edited');
+        expect(result.rows[0].blocks[1].config.content).toBe('b');
+    });
+
+    it('operations never mutate the input config', () => {
+        const config = makeConfig([[block('a')], [block('b')]]);
+        const snapshot = JSON.parse(JSON.stringify(config));
+        addBlock(config, block('x'));
+        removeBlock(config, 'a');
+        duplicateBlock(config, 'a');
+        moveBlockDown(config, 'a');
+        updateBlockConfig(config, 'a', { content: 'x' });
+        expect(config).toEqual(snapshot);
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/configOps.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/configOps.ts
@@ -1,0 +1,145 @@
+import {
+    HOMEPAGE_MAX_BLOCKS_PER_ROW,
+    type HomepageBlock,
+    type HomepageConfig,
+    type HomepageRow,
+} from '@lightdash/common';
+import { v4 as uuidv4 } from 'uuid';
+
+type BlockLocation = { rowIndex: number; blockIndex: number };
+
+const findBlock = (
+    config: HomepageConfig,
+    blockId: string,
+): BlockLocation | undefined => {
+    for (let rowIndex = 0; rowIndex < config.rows.length; rowIndex += 1) {
+        const blockIndex = config.rows[rowIndex].blocks.findIndex(
+            (b) => b.id === blockId,
+        );
+        if (blockIndex >= 0) return { rowIndex, blockIndex };
+    }
+    return undefined;
+};
+
+const withRows = (
+    config: HomepageConfig,
+    rows: HomepageRow[],
+): HomepageConfig => ({
+    ...config,
+    rows: rows.filter((row) => row.blocks.length > 0),
+});
+
+const cloneRows = (config: HomepageConfig): HomepageRow[] =>
+    config.rows.map((row) => ({ ...row, blocks: [...row.blocks] }));
+
+const newRowOf = (blocks: HomepageBlock[]): HomepageRow => ({
+    id: uuidv4(),
+    blocks,
+});
+
+export const addBlock = (
+    config: HomepageConfig,
+    block: HomepageBlock,
+): HomepageConfig => withRows(config, [...config.rows, newRowOf([block])]);
+
+export const removeBlock = (
+    config: HomepageConfig,
+    blockId: string,
+): HomepageConfig => {
+    const location = findBlock(config, blockId);
+    if (!location) return config;
+    const rows = cloneRows(config);
+    rows[location.rowIndex].blocks.splice(location.blockIndex, 1);
+    return withRows(config, rows);
+};
+
+export const duplicateBlock = (
+    config: HomepageConfig,
+    blockId: string,
+): HomepageConfig => {
+    const location = findBlock(config, blockId);
+    if (!location) return config;
+    const rows = cloneRows(config);
+    const original = rows[location.rowIndex].blocks[location.blockIndex];
+    const copy: HomepageBlock = structuredClone(original);
+    copy.id = uuidv4();
+    if (rows[location.rowIndex].blocks.length < HOMEPAGE_MAX_BLOCKS_PER_ROW) {
+        rows[location.rowIndex].blocks.splice(location.blockIndex + 1, 0, copy);
+    } else {
+        rows.splice(location.rowIndex + 1, 0, newRowOf([copy]));
+    }
+    return withRows(config, rows);
+};
+
+const moveBlock = (
+    config: HomepageConfig,
+    blockId: string,
+    direction: -1 | 1,
+): HomepageConfig => {
+    const location = findBlock(config, blockId);
+    if (!location) return config;
+    const rows = cloneRows(config);
+    const row = rows[location.rowIndex];
+    const [block] = row.blocks.splice(location.blockIndex, 1);
+    if (row.blocks.length > 0) {
+        // extract from a multi-block row into its own adjacent row
+        const insertAt =
+            direction === -1 ? location.rowIndex : location.rowIndex + 1;
+        rows.splice(insertAt, 0, newRowOf([block]));
+        return withRows(config, rows);
+    }
+    // single-block row: swap with the adjacent row
+    const targetIndex = location.rowIndex + direction;
+    if (targetIndex < 0 || targetIndex >= rows.length) {
+        return config;
+    }
+    row.blocks.push(block);
+    [rows[location.rowIndex], rows[targetIndex]] = [
+        rows[targetIndex],
+        rows[location.rowIndex],
+    ];
+    return withRows(config, rows);
+};
+
+export const moveBlockUp = (
+    config: HomepageConfig,
+    blockId: string,
+): HomepageConfig => moveBlock(config, blockId, -1);
+
+export const moveBlockDown = (
+    config: HomepageConfig,
+    blockId: string,
+): HomepageConfig => moveBlock(config, blockId, 1);
+
+export const canMoveUp = (config: HomepageConfig, blockId: string): boolean => {
+    const location = findBlock(config, blockId);
+    if (!location) return false;
+    const row = config.rows[location.rowIndex];
+    return row.blocks.length > 1 || location.rowIndex > 0;
+};
+
+export const canMoveDown = (
+    config: HomepageConfig,
+    blockId: string,
+): boolean => {
+    const location = findBlock(config, blockId);
+    if (!location) return false;
+    const row = config.rows[location.rowIndex];
+    return row.blocks.length > 1 || location.rowIndex < config.rows.length - 1;
+};
+
+export const updateBlockConfig = (
+    config: HomepageConfig,
+    blockId: string,
+    blockConfig: HomepageBlock['config'],
+): HomepageConfig => {
+    const location = findBlock(config, blockId);
+    if (!location) return config;
+    const rows = cloneRows(config);
+    const block = rows[location.rowIndex].blocks[location.blockIndex];
+    rows[location.rowIndex].blocks[location.blockIndex] = {
+        ...block,
+        config: blockConfig,
+    };
+    return withRows(config, rows);
+};


### PR DESCRIPTION
## Homepage Builder — block engine (4)

Part of [ZAP-615](https://linear.app/lightdash/issue/ZAP-615) · Stacked on #25523

Turns the minimal single-markdown builder into a real block engine. Frontend-only — the ZAP-614 backend already validates configs (version + max 3 blocks/row).

### What
- **`configOps.ts`** — pure, immutable config operations: add / remove / duplicate (within row, overflow to new row at 3) / move up-down (row swap, or extract from multi-block rows) — 11 unit tests
- **`blocks/registry.tsx`** — `BlockDefinition` (label, icon, defaultConfig, `View` + `Build` renderers); adding a future block type touches only `blocks/`
- **`PublishedHomepage`** now renders through the registry; unknown block types render nothing (forward compat)
- **`HomepageEditor`** (inner component keyed by `homepageUuid`, per frontend state guidelines): library rail with click-to-add, per-block chrome (move/duplicate/remove with boundary-disabled buttons), **Preview toggle** rendering the exact viewer layout from the draft, whole-config debounced autosave, Publish flushes any pending draft save first

### Verified live (Playwright)
Add second block → move up → duplicate (side-by-side row) → preview shows viewer layout → remove → publish → `/home` renders the two-row homepage. Each op confirmed persisted in `draft_config` via psql.

### Regression analysis
- Flag off: unchanged (all surfaces gated in ZAP-614).
- Existing published configs from ZAP-614 render identically through the registry path.
- No backend/API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ