### PR TITLE
feat(deep-research): increase effort token budgets

### DIFF
--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -25,7 +25,7 @@ const effortBudgets = [
         effort: 'low',
         budget: {
             maxRuntimeMs: 15 * 60 * 1_000,
-            maxTokens: 150_000,
+            maxTokens: 500_000,
             maxToolCalls: 50,
             maxWarehouseQueries: 10,
             maxResultRows: 5_000,
@@ -35,7 +35,7 @@ const effortBudgets = [
         effort: 'medium',
         budget: {
             maxRuntimeMs: 30 * 60 * 1_000,
-            maxTokens: 500_000,
+            maxTokens: 1_000_000,
             maxToolCalls: 125,
             maxWarehouseQueries: 25,
             maxResultRows: 10_000,
@@ -45,7 +45,7 @@ const effortBudgets = [
         effort: 'high',
         budget: {
             maxRuntimeMs: 45 * 60 * 1_000,
-            maxTokens: 1_000_000,
+            maxTokens: 2_000_000,
             maxToolCalls: 250,
             maxWarehouseQueries: 50,
             maxResultRows: 25_000,
@@ -55,7 +55,7 @@ const effortBudgets = [
         effort: 'xhigh',
         budget: {
             maxRuntimeMs: 55 * 60 * 1_000,
-            maxTokens: 2_000_000,
+            maxTokens: 4_000_000,
             maxToolCalls: 500,
             maxWarehouseQueries: 100,
             maxResultRows: 50_000,

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -167,28 +167,28 @@ export const AI_DEEP_RESEARCH_BUDGETS_BY_EFFORT: Record<
 > = {
     low: {
         maxRuntimeMs: 15 * 60 * 1_000,
-        maxTokens: 150_000,
+        maxTokens: 500_000,
         maxToolCalls: 50,
         maxWarehouseQueries: 10,
         maxResultRows: 5_000,
     },
     medium: {
         maxRuntimeMs: 30 * 60 * 1_000,
-        maxTokens: 500_000,
+        maxTokens: 1_000_000,
         maxToolCalls: 125,
         maxWarehouseQueries: 25,
         maxResultRows: 10_000,
     },
     high: {
         maxRuntimeMs: 45 * 60 * 1_000,
-        maxTokens: 1_000_000,
+        maxTokens: 2_000_000,
         maxToolCalls: 250,
         maxWarehouseQueries: 50,
         maxResultRows: 25_000,
     },
     xhigh: {
         maxRuntimeMs: 55 * 60 * 1_000,
-        maxTokens: 2_000_000,
+        maxTokens: 4_000_000,
         maxToolCalls: 500,
         maxWarehouseQueries: 100,
         maxResultRows: 50_000,


### PR DESCRIPTION
## Description:

Increases Deep Research token budgets so investigations have enough room to produce useful reports. The four effort tiers now start at 500k tokens and double at each level, while runtime, tool-call, warehouse-query, and result-row limits remain unchanged.

```text
low      150k -> 500k
medium   500k -> 1M
high       1M -> 2M
xhigh      2M -> 4M
```

Test plan:

- Run the focused `AiDeepResearchService` suite.
- Run backend fast typechecking and full backend lint.
- Verify only token limits and matching test expectations changed.