### PR TITLE
refactor: derive project system-role abilities from role scope mapping

### DIFF
--- a/packages/backend/src/models/UserModel.test.ts
+++ b/packages/backend/src/models/UserModel.test.ts
@@ -141,7 +141,7 @@ const expectCollapsedDashboardProjectRule = (
         );
     }
 
-    expect(rules.length).toBeLessThan(100);
+    expect(rules.length).toBeLessThan(150);
     expect(
         (dashboardRule.conditions as Record<string, { $in: string[] }>)
             .projectUuid.$in,

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -900,6 +900,8 @@ export class UserModel {
                         projectUuid: row.project_uuid,
                         userUuid,
                         role: row.role,
+                        projectType: row.project_type,
+                        projectCreatedByUserUuid: row.created_by_user_uuid,
                     },
                     builder,
                 );

--- a/packages/common/src/authorization/__snapshots__/projectMemberAbility.snapshot.test.ts.snap
+++ b/packages/common/src/authorization/__snapshots__/projectMemberAbility.snapshot.test.ts.snap
@@ -1,0 +1,5231 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`project system-role rules snapshot > admin rules in own preview project match snapshot 1`] = `
+[
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgent",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgent",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentDocument",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentDocument",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiDeepResearch",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Analytics",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ChangeCsvResults",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "CompileProject",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+      "type": "PREVIEW",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentVerification",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentVerification",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "CustomFields",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "CustomSql",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "CustomSqlTableCalculations",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataAppDependency",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DeletedContent",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DeployProject",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+      "type": "PREVIEW",
+    },
+    "subject": "DeployProject",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "DeployProject",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Explore",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Explore",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExportCsv",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExternalConnection",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExternalConnection",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "GoogleSheets",
+  },
+  {
+    "action": "create",
+    "subject": "Job",
+  },
+  {
+    "action": "manage",
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "userUuid": "user-uuid",
+    },
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+    },
+    "subject": "JobStatus",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "JobStatus",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "MetricsTree",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "MetricsTree",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PinnedItems",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PinnedItems",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PreAggregation",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "delete",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+      "type": "PREVIEW",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "delete",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "delete",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "update",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "update",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+      "type": "PREVIEW",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "update",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "isProtectedBranch": false,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SourceCode",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SourceCode",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$exists": false,
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SpotlightTableConfig",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SpotlightTableConfig",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SqlRunner",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Tags",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Tags",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "UnderlyingData",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Validation",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "VirtualView",
+  },
+  {
+    "action": "delete",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "VirtualView",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "VirtualView",
+  },
+]
+`;
+
+exports[`project system-role rules snapshot > admin rules match snapshot 1`] = `
+[
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgent",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgent",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentDocument",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentDocument",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiDeepResearch",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Analytics",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ChangeCsvResults",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "CompileProject",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+      "type": "PREVIEW",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentVerification",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentVerification",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "CustomFields",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "CustomSql",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "CustomSqlTableCalculations",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataAppDependency",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DeletedContent",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DeployProject",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+      "type": "PREVIEW",
+    },
+    "subject": "DeployProject",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "DeployProject",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Explore",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExportCsv",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExternalConnection",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExternalConnection",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "GoogleSheets",
+  },
+  {
+    "action": "create",
+    "subject": "Job",
+  },
+  {
+    "action": "manage",
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "userUuid": "user-uuid",
+    },
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+    },
+    "subject": "JobStatus",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "JobStatus",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "MetricsTree",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "MetricsTree",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PinnedItems",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PinnedItems",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PreAggregation",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "delete",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+      "type": "PREVIEW",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "delete",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "delete",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "update",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "update",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+      "type": "PREVIEW",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "update",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "isProtectedBranch": false,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SourceCode",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SourceCode",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SpotlightTableConfig",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SpotlightTableConfig",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SqlRunner",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Tags",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Tags",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "UnderlyingData",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Validation",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "VirtualView",
+  },
+  {
+    "action": "delete",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "VirtualView",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "VirtualView",
+  },
+]
+`;
+
+exports[`project system-role rules snapshot > developer rules in own preview project match snapshot 1`] = `
+[
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgent",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgent",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentDocument",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentDocument",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiDeepResearch",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ChangeCsvResults",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "CompileProject",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+      "type": "PREVIEW",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentVerification",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentVerification",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "CustomFields",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "CustomSql",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "CustomSqlTableCalculations",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DeployProject",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+      "type": "PREVIEW",
+    },
+    "subject": "DeployProject",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "DeployProject",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Explore",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Explore",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExportCsv",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExternalConnection",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "GoogleSheets",
+  },
+  {
+    "action": "create",
+    "subject": "Job",
+  },
+  {
+    "action": "manage",
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "userUuid": "user-uuid",
+    },
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+    },
+    "subject": "JobStatus",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "JobStatus",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "MetricsTree",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "MetricsTree",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PinnedItems",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PinnedItems",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PreAggregation",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "delete",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+      "type": "PREVIEW",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "delete",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "update",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "update",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+      "type": "PREVIEW",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "update",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "isProtectedBranch": false,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SourceCode",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SourceCode",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$exists": false,
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SpotlightTableConfig",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SpotlightTableConfig",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SqlRunner",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Tags",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Tags",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "UnderlyingData",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Validation",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "VirtualView",
+  },
+  {
+    "action": "delete",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "VirtualView",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "VirtualView",
+  },
+]
+`;
+
+exports[`project system-role rules snapshot > developer rules match snapshot 1`] = `
+[
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgent",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgent",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentDocument",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentDocument",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiDeepResearch",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ChangeCsvResults",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "CompileProject",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+      "type": "PREVIEW",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentVerification",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentVerification",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "CustomFields",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "CustomSql",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "CustomSqlTableCalculations",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DeployProject",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+      "type": "PREVIEW",
+    },
+    "subject": "DeployProject",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "DeployProject",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Explore",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExportCsv",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExternalConnection",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "GoogleSheets",
+  },
+  {
+    "action": "create",
+    "subject": "Job",
+  },
+  {
+    "action": "manage",
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "userUuid": "user-uuid",
+    },
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+    },
+    "subject": "JobStatus",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "JobStatus",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "MetricsTree",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "MetricsTree",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PinnedItems",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PinnedItems",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PreAggregation",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "delete",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+      "type": "PREVIEW",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "delete",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "update",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "update",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+      "type": "PREVIEW",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "update",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "type": "PREVIEW",
+      "upstreamProjectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "promote",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "isProtectedBranch": false,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SourceCode",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SourceCode",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SpotlightTableConfig",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SpotlightTableConfig",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SqlRunner",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Tags",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Tags",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "UnderlyingData",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Validation",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "VirtualView",
+  },
+  {
+    "action": "delete",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "VirtualView",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "VirtualView",
+  },
+]
+`;
+
+exports[`project system-role rules snapshot > editor rules in own preview project match snapshot 1`] = `
+[
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgent",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentDocument",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ChangeCsvResults",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentVerification",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Explore",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExportCsv",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExternalConnection",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "GoogleSheets",
+  },
+  {
+    "action": "create",
+    "subject": "Job",
+  },
+  {
+    "action": "manage",
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "userUuid": "user-uuid",
+    },
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+    },
+    "subject": "JobStatus",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "MetricsTree",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "MetricsTree",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PinnedItems",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PinnedItems",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SpotlightTableConfig",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Tags",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Tags",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "UnderlyingData",
+  },
+]
+`;
+
+exports[`project system-role rules snapshot > editor rules match snapshot 1`] = `
+[
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgent",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentDocument",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ChangeCsvResults",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentAsCode",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentVerification",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Explore",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExportCsv",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExternalConnection",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "GoogleSheets",
+  },
+  {
+    "action": "create",
+    "subject": "Job",
+  },
+  {
+    "action": "manage",
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "userUuid": "user-uuid",
+    },
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+    },
+    "subject": "JobStatus",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "MetricsTree",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "MetricsTree",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PinnedItems",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PinnedItems",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SpotlightTableConfig",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Tags",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Tags",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "UnderlyingData",
+  },
+]
+`;
+
+exports[`project system-role rules snapshot > interactive_viewer rules in own preview project match snapshot 1`] = `
+[
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgent",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentDocument",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ChangeCsvResults",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentVerification",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Explore",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExportCsv",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExternalConnection",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "GoogleSheets",
+  },
+  {
+    "action": "create",
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "userUuid": "user-uuid",
+    },
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+    },
+    "subject": "JobStatus",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "MetricsTree",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PinnedItems",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SpotlightTableConfig",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Tags",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "UnderlyingData",
+  },
+]
+`;
+
+exports[`project system-role rules snapshot > interactive_viewer rules match snapshot 1`] = `
+[
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgent",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentDocument",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ChangeCsvResults",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ContentVerification",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DataApp",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Explore",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExportCsv",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExternalConnection",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "GoogleSheets",
+  },
+  {
+    "action": "create",
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "userUuid": "user-uuid",
+    },
+    "subject": "Job",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+    },
+    "subject": "JobStatus",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "MetricsTree",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PinnedItems",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "create",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "ScheduledDeliveries",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "editor",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SemanticViewer",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "role": "admin",
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SpotlightTableConfig",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Tags",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "UnderlyingData",
+  },
+]
+`;
+
+exports[`project system-role rules snapshot > viewer rules in own preview project match snapshot 1`] = `
+[
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExportCsv",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+    },
+    "subject": "JobStatus",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "MetricsTree",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PinnedItems",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SpotlightTableConfig",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Tags",
+  },
+]
+`;
+
+exports[`project system-role rules snapshot > viewer rules match snapshot 1`] = `
+[
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+      "userUuid": "user-uuid",
+    },
+    "subject": "AiAgentThread",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Dashboard",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "DashboardComments",
+  },
+  {
+    "action": "manage",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "ExportCsv",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "createdByUserUuid": "user-uuid",
+    },
+    "subject": "JobStatus",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "MetricsTree",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "PinnedItems",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Project",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SavedChart",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "inheritsFromOrgOrProject": true,
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "access": {
+        "$elemMatch": {
+          "userUuid": "user-uuid",
+        },
+      },
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Space",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "SpotlightTableConfig",
+  },
+  {
+    "action": "view",
+    "conditions": {
+      "projectUuid": "project-uuid",
+    },
+    "subject": "Tags",
+  },
+]
+`;

--- a/packages/common/src/authorization/collapseAbilityRules.test.ts
+++ b/packages/common/src/authorization/collapseAbilityRules.test.ts
@@ -43,7 +43,7 @@ describe('collapseAbilityRules', () => {
 
         const collapsed = collapseAbilityRules(raw);
         // 125 projects of identical shape collapse to one project's worth of rules
-        expect(collapsed.length).toBeLessThan(100);
+        expect(collapsed.length).toBeLessThan(150);
     });
 
     it('merges non-projectUuid scalar ids too (e.g. upstreamProjectUuid)', () => {

--- a/packages/common/src/authorization/getUserAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/getUserAbilityBuilder.test.ts
@@ -253,7 +253,7 @@ describe('getUserAbilityBuilder — org-level role resolution', () => {
                     >
                 ).projectUuid.$in,
             ).toEqual([...projectUuids].sort());
-            expect(ability.rules.length).toBeLessThan(100);
+            expect(ability.rules.length).toBeLessThan(150);
             expect(
                 ability.can(
                     'manage',

--- a/packages/common/src/authorization/projectMemberAbility.snapshot.test.ts
+++ b/packages/common/src/authorization/projectMemberAbility.snapshot.test.ts
@@ -1,0 +1,67 @@
+import { Ability, AbilityBuilder } from '@casl/ability';
+import { ProjectMemberRole } from '../types/projectMemberRole';
+import { ProjectType } from '../types/projects';
+import {
+    projectMemberAbilities,
+    type ProjectAbilityMember,
+} from './projectMemberAbility';
+import { type MemberAbility } from './types';
+
+/**
+ * Escalation guard: system-role project abilities are derived from
+ * `roleToScopeMapping.ts` + `scopes.ts`, so any edit to either file changes
+ * the rules every system-role user gets. This snapshot makes that blast
+ * radius visible in review — an unexpected diff here means a scope change
+ * leaked into system roles.
+ */
+const PROJECT_UUID = 'project-uuid';
+const USER_UUID = 'user-uuid';
+
+const buildRules = (
+    role: ProjectMemberRole,
+    metadata?: Pick<
+        ProjectAbilityMember,
+        'projectType' | 'projectCreatedByUserUuid'
+    >,
+) => {
+    const builder = new AbilityBuilder<MemberAbility>(Ability);
+    projectMemberAbilities[role](
+        { projectUuid: PROJECT_UUID, userUuid: USER_UUID, role, ...metadata },
+        builder,
+    );
+    return builder.rules
+        .map((rule) => ({
+            action: rule.action,
+            subject: rule.subject,
+            ...(rule.conditions ? { conditions: rule.conditions } : {}),
+        }))
+        .sort((a, b) =>
+            `${a.subject}:${a.action}`.localeCompare(
+                `${b.subject}:${b.action}`,
+            ),
+        );
+};
+
+describe('project system-role rules snapshot', () => {
+    it.each(Object.values(ProjectMemberRole))(
+        '%s rules match snapshot',
+        (role) => {
+            expect(buildRules(role)).toMatchSnapshot();
+        },
+    );
+
+    // Second leg in own-preview context: the `@self` scopes only emit rules
+    // when `isSelfPreview` holds, so without this the guard would miss any
+    // change to what system-role users get inside previews they created.
+    it.each(Object.values(ProjectMemberRole))(
+        '%s rules in own preview project match snapshot',
+        (role) => {
+            expect(
+                buildRules(role, {
+                    projectType: ProjectType.PREVIEW,
+                    projectCreatedByUserUuid: USER_UUID,
+                }),
+            ).toMatchSnapshot();
+        },
+    );
+});

--- a/packages/common/src/authorization/projectMemberAbility.test.ts
+++ b/packages/common/src/authorization/projectMemberAbility.test.ts
@@ -2238,3 +2238,143 @@ describe('Project member permissions', () => {
         },
     );
 });
+
+describe('org-only scopes do not leak into project-scoped roles', () => {
+    // CASL ignores conditions on bare subject-type checks, so a
+    // project-scoped rule for an org-keyed subject would still turn
+    // `can('manage', 'Organization')` true. Project builds must not emit
+    // org-only scopes at all.
+    const admin = defineAbilityForProjectMember(PROJECT_ADMIN);
+
+    it('project admin has no org-management abilities (bare checks)', () => {
+        expect(admin.can('manage', 'Organization')).toEqual(false);
+        expect(admin.can('manage', 'OrganizationMemberProfile')).toEqual(false);
+        expect(admin.can('manage', 'Group')).toEqual(false);
+        expect(admin.can('manage', 'InviteLink')).toEqual(false);
+        expect(admin.can('manage', 'GitIntegration')).toEqual(false);
+        expect(admin.can('impersonate', 'User')).toEqual(false);
+        expect(admin.can('manage', 'OrganizationWarehouseCredentials')).toEqual(
+            false,
+        );
+        expect(admin.can('manage', 'OrganizationDesign')).toEqual(false);
+    });
+
+    it('project admin has no PAT ability (deployment gate stays intact)', () => {
+        expect(admin.can('manage', 'PersonalAccessToken')).toEqual(false);
+    });
+
+    it('project viewer gets no org view abilities from the project layer', () => {
+        const viewer = defineAbilityForProjectMember(PROJECT_VIEWER);
+        expect(viewer.can('view', 'Organization')).toEqual(false);
+        expect(viewer.can('view', 'OrganizationMemberProfile')).toEqual(false);
+        expect(viewer.can('view', 'OrganizationDesign')).toEqual(false);
+    });
+
+    it('project-scoped abilities are unaffected', () => {
+        expect(
+            admin.can('manage', subject('Project', { projectUuid })),
+        ).toEqual(true);
+        expect(
+            admin.can(
+                'manage',
+                subject('Dashboard', {
+                    projectUuid,
+                    inheritsFromOrgOrProject: true,
+                }),
+            ),
+        ).toEqual(true);
+    });
+});
+
+describe('promote permissions', () => {
+    const developer = defineAbilityForProjectMember(PROJECT_DEVELOPER);
+    const admin = defineAbilityForProjectMember(PROJECT_ADMIN);
+    const editor = defineAbilityForProjectMember(PROJECT_EDITOR);
+
+    it('developer cannot promote content in spaces they have no access to', () => {
+        expect(
+            developer.can(
+                'promote',
+                subject('SavedChart', { projectUuid, access: [] }),
+            ),
+        ).toEqual(false);
+        expect(
+            developer.can(
+                'promote',
+                subject('Dashboard', { projectUuid, access: [] }),
+            ),
+        ).toEqual(false);
+    });
+
+    it('developer can promote content in spaces where they are editor', () => {
+        const access = [
+            {
+                userUuid: PROJECT_DEVELOPER.userUuid,
+                role: SpaceMemberRole.EDITOR,
+            },
+        ];
+        expect(
+            developer.can(
+                'promote',
+                subject('SavedChart', { projectUuid, access }),
+            ),
+        ).toEqual(true);
+        expect(
+            developer.can(
+                'promote',
+                subject('Dashboard', { projectUuid, access }),
+            ),
+        ).toEqual(true);
+    });
+
+    it('developer cannot promote with only space viewer access', () => {
+        const access = [
+            {
+                userUuid: PROJECT_DEVELOPER.userUuid,
+                role: SpaceMemberRole.VIEWER,
+            },
+        ];
+        expect(
+            developer.can(
+                'promote',
+                subject('SavedChart', { projectUuid, access }),
+            ),
+        ).toEqual(false);
+    });
+
+    it('admin can promote content project-wide', () => {
+        expect(
+            admin.can(
+                'promote',
+                subject('SavedChart', { projectUuid, access: [] }),
+            ),
+        ).toEqual(true);
+        expect(
+            admin.can(
+                'promote',
+                subject('Dashboard', { projectUuid, access: [] }),
+            ),
+        ).toEqual(true);
+    });
+
+    it('editor promote follows space access (manage wildcard), never project-wide', () => {
+        const access = [
+            {
+                userUuid: PROJECT_EDITOR.userUuid,
+                role: SpaceMemberRole.EDITOR,
+            },
+        ];
+        expect(
+            editor.can(
+                'promote',
+                subject('SavedChart', { projectUuid, access }),
+            ),
+        ).toEqual(true);
+        expect(
+            editor.can(
+                'promote',
+                subject('SavedChart', { projectUuid, access: [] }),
+            ),
+        ).toEqual(false);
+    });
+});

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -1,392 +1,63 @@
 import { type AbilityBuilder } from '@casl/ability';
 import { type ProjectMemberProfile } from '../types/projectMemberProfile';
-import { type ProjectMemberRole } from '../types/projectMemberRole';
-import { ProjectType } from '../types/projects';
-import { SpaceMemberRole } from '../types/space';
+import { ProjectMemberRole } from '../types/projectMemberRole';
+import { type ProjectType } from '../types/projects';
+import { getAllScopesForRole } from './roleToScopeMapping';
+import { buildAbilityFromScopes } from './scopeAbilityBuilder';
 import { type MemberAbility } from './types';
+
+/**
+ * Project membership plus the project metadata needed by `@self` scope
+ * conditions (e.g. `manage:ContentAsCode@self` on own preview projects).
+ */
+export type ProjectAbilityMember = Pick<
+    ProjectMemberProfile,
+    'role' | 'projectUuid' | 'userUuid'
+> & {
+    projectType?: ProjectType;
+    projectCreatedByUserUuid?: string | null;
+};
+
+/**
+ * System-role abilities are derived from the same scope vocabulary that
+ * powers custom roles (`BASE_ROLE_SCOPES` → `buildAbilityFromScopes`), so
+ * `scopes.ts` is the single source of truth for what each role can do.
+ * `isEnterprise: true` matches the previous hand-written rules, which always
+ * emitted enterprise subjects — enterprise features are license-gated at
+ * runtime, not at ability-build time.
+ */
+const buildProjectRoleAbility =
+    (role: ProjectMemberRole) =>
+    (
+        member: ProjectAbilityMember,
+        builder: AbilityBuilder<MemberAbility>,
+    ): void => {
+        buildAbilityFromScopes(
+            {
+                projectUuid: member.projectUuid,
+                projectType: member.projectType,
+                projectCreatedByUserUuid: member.projectCreatedByUserUuid,
+                userUuid: member.userUuid,
+                scopes: getAllScopesForRole(role),
+                isEnterprise: true,
+            },
+            builder,
+        );
+    };
 
 // eslint-disable-next-line import/prefer-default-export
 export const projectMemberAbilities: Record<
     ProjectMemberRole,
     (
-        member: Pick<ProjectMemberProfile, 'role' | 'projectUuid' | 'userUuid'>,
-        builder: Pick<AbilityBuilder<MemberAbility>, 'can'>,
+        member: ProjectAbilityMember,
+        builder: AbilityBuilder<MemberAbility>,
     ) => void
 > = {
-    viewer(member, { can }) {
-        can('view', 'Dashboard', {
-            projectUuid: member.projectUuid,
-            inheritsFromOrgOrProject: true,
-        });
-        can('view', 'JobStatus', {
-            createdByUserUuid: member.userUuid,
-        });
-        can('view', 'SavedChart', {
-            projectUuid: member.projectUuid,
-            inheritsFromOrgOrProject: true,
-        });
-        can('view', 'Dashboard', {
-            projectUuid: member.projectUuid,
-            access: {
-                $elemMatch: { userUuid: member.userUuid },
-            },
-        });
-        can('view', 'SavedChart', {
-            projectUuid: member.projectUuid,
-            access: {
-                $elemMatch: { userUuid: member.userUuid },
-            },
-        });
-        can('view', 'Space', {
-            projectUuid: member.projectUuid,
-            inheritsFromOrgOrProject: true,
-        });
-        can('view', 'Space', {
-            projectUuid: member.projectUuid,
-            access: {
-                $elemMatch: { userUuid: member.userUuid },
-            },
-        });
-        can('view', 'Project', {
-            projectUuid: member.projectUuid,
-        });
-        can('view', 'PinnedItems', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'ExportCsv', {
-            projectUuid: member.projectUuid,
-        });
-        can('view', 'DashboardComments', {
-            projectUuid: member.projectUuid,
-        });
-        can('view', 'Tags', {
-            projectUuid: member.projectUuid,
-        });
-        can('view', 'MetricsTree', {
-            projectUuid: member.projectUuid,
-        });
-        can('view', 'SpotlightTableConfig', {
-            projectUuid: member.projectUuid,
-        });
-        can('view', 'AiAgentThread', {
-            projectUuid: member.projectUuid,
-            userUuid: member.userUuid,
-        });
-    },
-    interactive_viewer(member, { can }) {
-        projectMemberAbilities.viewer(member, { can });
-        can('view', 'UnderlyingData', {
-            projectUuid: member.projectUuid,
-        });
-        can('view', 'SemanticViewer', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'Explore', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'ChangeCsvResults', {
-            projectUuid: member.projectUuid,
-        });
-        can('create', 'ScheduledDeliveries', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'ScheduledDeliveries', {
-            projectUuid: member.projectUuid,
-            userUuid: member.userUuid,
-        });
-        can('manage', 'GoogleSheets', {
-            projectUuid: member.projectUuid,
-        });
-        can('create', 'DashboardComments', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'Dashboard', {
-            projectUuid: member.projectUuid,
-            access: {
-                $elemMatch: {
-                    userUuid: member.userUuid,
-                    role: SpaceMemberRole.EDITOR,
-                },
-            },
-        });
-        can('manage', 'SavedChart', {
-            projectUuid: member.projectUuid,
-            access: {
-                $elemMatch: {
-                    userUuid: member.userUuid,
-                    role: SpaceMemberRole.EDITOR,
-                },
-            },
-        });
-        can('manage', 'Dashboard', {
-            projectUuid: member.projectUuid,
-            access: {
-                $elemMatch: {
-                    userUuid: member.userUuid,
-                    role: SpaceMemberRole.ADMIN,
-                },
-            },
-        });
-        can('manage', 'SavedChart', {
-            projectUuid: member.projectUuid,
-            access: {
-                $elemMatch: {
-                    userUuid: member.userUuid,
-                    role: SpaceMemberRole.ADMIN,
-                },
-            },
-        });
-        can('manage', 'DataApp', {
-            projectUuid: member.projectUuid,
-            access: {
-                $elemMatch: {
-                    userUuid: member.userUuid,
-                    role: SpaceMemberRole.EDITOR,
-                },
-            },
-        });
-        can('manage', 'DataApp', {
-            projectUuid: member.projectUuid,
-            access: {
-                $elemMatch: {
-                    userUuid: member.userUuid,
-                    role: SpaceMemberRole.ADMIN,
-                },
-            },
-        });
-        // View data apps shared project-wide or in spaces the user can
-        // access. Gated at interactive-viewer (not viewer) for parity with
-        // manage:Explore — plain viewers don't get data app access.
-        can('view', 'DataApp', {
-            projectUuid: member.projectUuid,
-            inheritsFromOrgOrProject: true,
-        });
-        can('view', 'DataApp', {
-            projectUuid: member.projectUuid,
-            access: {
-                $elemMatch: { userUuid: member.userUuid },
-            },
-        });
-        can('view', 'DataApp', {
-            projectUuid: member.projectUuid,
-            createdByUserUuid: member.userUuid,
-        });
-        can('manage', 'DataApp', {
-            projectUuid: member.projectUuid,
-            createdByUserUuid: member.userUuid,
-        });
-        // View external connections to select and link them when building a
-        // data app. Managing (create/edit/delete) stays admin-only.
-        can('view', 'ExternalConnection', {
-            projectUuid: member.projectUuid,
-        });
-
-        can('manage', 'Space', {
-            projectUuid: member.projectUuid,
-
-            access: {
-                $elemMatch: {
-                    userUuid: member.userUuid,
-                    role: SpaceMemberRole.ADMIN,
-                },
-            },
-        });
-        can('view', 'AiAgent', {
-            projectUuid: member.projectUuid,
-        });
-        can('view', 'AiAgentDocument', {
-            projectUuid: member.projectUuid,
-        });
-        can('create', 'AiAgentThread', {
-            projectUuid: member.projectUuid,
-        });
-        can('view', 'ContentVerification', {
-            projectUuid: member.projectUuid,
-        });
-    },
-    editor(member, { can }) {
-        projectMemberAbilities.interactive_viewer(member, { can });
-        can('create', 'DataApp', {
-            projectUuid: member.projectUuid,
-        });
-        can('create', 'Space', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'Space', {
-            projectUuid: member.projectUuid,
-            inheritsFromOrgOrProject: true,
-        });
-        can('manage', 'Job');
-        can('manage', 'PinnedItems', {
-            projectUuid: member.projectUuid,
-        });
-
-        can('manage', 'DashboardComments', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'Tags', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'MetricsTree', {
-            projectUuid: member.projectUuid,
-        });
-
-        can('manage', 'AiAgentThread', {
-            projectUuid: member.projectUuid,
-            userUuid: member.userUuid,
-        });
-        // Editors can download content as code but not upload it. Upload
-        // stays gated behind `manage:ContentAsCode` (developer+).
-        can('view', 'ContentAsCode', {
-            projectUuid: member.projectUuid,
-        });
-    },
-    developer(member, { can }) {
-        projectMemberAbilities.editor(member, { can });
-        can('manage', 'PreAggregation', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'VirtualView', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'CustomSql', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'CustomFields', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'CustomSqlTableCalculations', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'SqlRunner', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'Validation', {
-            projectUuid: member.projectUuid,
-        });
-        can('view', 'SourceCode', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'SourceCode', {
-            projectUuid: member.projectUuid,
-            isProtectedBranch: false, // Only allow writes when NOT writing to protected branch
-        });
-
-        can('manage', 'CompileProject', {
-            projectUuid: member.projectUuid,
-        });
-
-        can('manage', 'DeployProject', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'DeployProject', {
-            projectUuid: member.projectUuid,
-            type: ProjectType.PREVIEW,
-            createdByUserUuid: member.userUuid,
-        });
-
-        can('delete', 'Project', {
-            projectUuid: member.projectUuid,
-            type: ProjectType.PREVIEW,
-            createdByUserUuid: member.userUuid,
-        });
-
-        can('create', 'Project', {
-            upstreamProjectUuid: member.projectUuid,
-            type: ProjectType.PREVIEW,
-        });
-
-        can('update', 'Project', {
-            projectUuid: member.projectUuid,
-        });
-        can('update', 'Project', {
-            projectUuid: member.projectUuid,
-            type: ProjectType.PREVIEW,
-            createdByUserUuid: member.userUuid,
-        });
-        can('manage', 'SpotlightTableConfig', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'ContentAsCode', {
-            projectUuid: member.projectUuid,
-        });
-        // Redundant with the broad grant above, but kept so the system
-        // role mirrors the `manage:ContentAsCode@self` scope a custom role
-        // would carry without full `manage:ContentAsCode`.
-        can('manage', 'ContentAsCode', {
-            projectUuid: member.projectUuid,
-            type: ProjectType.PREVIEW,
-            createdByUserUuid: member.userUuid,
-        });
-        can('view', 'JobStatus', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'AiAgent', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'AiAgentDocument', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'ContentVerification', {
-            projectUuid: member.projectUuid,
-        });
-        can('create', 'AiDeepResearch', {
-            projectUuid: member.projectUuid,
-        });
-    },
-    admin(member, { can }) {
-        projectMemberAbilities.developer(member, { can });
-
-        can('manage', 'DataApp', {
-            projectUuid: member.projectUuid,
-        });
-
-        // Adding custom npm dependencies is a supply-chain capability gated
-        // above ordinary data-app management — admins only by default.
-        can('manage', 'DataAppDependency', {
-            projectUuid: member.projectUuid,
-        });
-
-        can('manage', 'ExternalConnection', {
-            projectUuid: member.projectUuid,
-        });
-
-        can('delete', 'Project', {
-            projectUuid: member.projectUuid,
-        });
-
-        can('view', 'Analytics', {
-            projectUuid: member.projectUuid,
-        });
-
-        can('manage', 'Project', {
-            projectUuid: member.projectUuid,
-        });
-
-        can('manage', 'Space', {
-            projectUuid: member.projectUuid,
-        });
-
-        can('manage', 'Dashboard', {
-            projectUuid: member.projectUuid,
-        });
-
-        can('manage', 'SavedChart', {
-            projectUuid: member.projectUuid,
-        });
-        can('view', 'AiAgentThread', {
-            projectUuid: member.projectUuid,
-        });
-        can('manage', 'AiAgentThread', {
-            projectUuid: member.projectUuid,
-        });
-
-        can('manage', 'ScheduledDeliveries', {
-            projectUuid: member.projectUuid,
-        });
-
-        can('manage', 'DeletedContent', {
-            projectUuid: member.projectUuid,
-        });
-    },
+    viewer: buildProjectRoleAbility(ProjectMemberRole.VIEWER),
+    interactive_viewer: buildProjectRoleAbility(
+        ProjectMemberRole.INTERACTIVE_VIEWER,
+    ),
+    editor: buildProjectRoleAbility(ProjectMemberRole.EDITOR),
+    developer: buildProjectRoleAbility(ProjectMemberRole.DEVELOPER),
+    admin: buildProjectRoleAbility(ProjectMemberRole.ADMIN),
 };

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -28,6 +28,8 @@ const BASE_ROLE_SCOPES = {
         // Org-context view scopes — every member-or-above can see the
         // org's own metadata + the list of fellow members. Granted by
         // `applyOrganizationMemberStaticAbilities.member` / `viewer`.
+        // Org-only, so filtered out of project-context builds; they only
+        // fire when the role is assigned at org level.
         'view:Organization',
         'view:OrganizationMemberProfile',
 
@@ -132,11 +134,11 @@ const BASE_ROLE_SCOPES = {
         'view:SourceCode',
         'manage:SourceCode',
 
-        // Promote to upstream project. Both broad + @space variants
-        // surface in `applyOrganizationMemberStaticAbilities.developer`.
-        'promote:Dashboard',
+        // Promote to upstream project, gated on space editor/admin access —
+        // mirrors the pre-scopes behavior where promote came from the CASL
+        // `manage` wildcard on space-conditioned content rules. The broad
+        // (project-wide) promote scopes live in the ADMIN tier.
         'promote:Dashboard@space',
-        'promote:SavedChart',
         'promote:SavedChart@space',
 
         // Enterprise scopes
@@ -170,12 +172,17 @@ const BASE_ROLE_SCOPES = {
         'view:AiAgentThread', // All threads in project
         'manage:AiAgentThread', // All threads in project
         'manage:ScheduledDeliveries',
+        // Project-wide promote regardless of space access. Below admin,
+        // promote is gated on space access via the @space variants.
+        'promote:Dashboard',
+        'promote:SavedChart',
 
-        // Organization-management scopes. These are no-ops at project
-        // assignment (CASL conditions match `organizationUuid`-keyed
-        // subjects only) but are necessary at the role's intended ORG
-        // assignment — service accounts with `roleUuid`, or any future
-        // org-level human assignment. See `docs/authentication-and-roles.md`
+        // Organization-management scopes. Filtered out entirely in
+        // project-context builds (`applyScopeAbilities` skips org-only
+        // scopes when `projectUuid` is set) but active at the role's
+        // intended ORG assignment — service accounts with `roleUuid`, or
+        // any future org-level human assignment. See
+        // `docs/authentication-and-roles.md`
         // → "Project vs organization assignment of custom roles".
         // Granted at `applyOrganizationMemberStaticAbilities.admin`.
         'manage:OrganizationMemberProfile',
@@ -191,12 +198,13 @@ const BASE_ROLE_SCOPES = {
         // deployment-wide `PAT_ALLOWED_ORG_ROLES` env var — that path
         // remains the source of truth for system roles. Listing it
         // here lets admin-clone custom roles surface the toggle in the
-        // role builder. **Caveat:** toggling it in a custom role
-        // *bypasses* the dynamic gate, since CASL is additive (the
+        // role builder. **Caveat:** toggling it in an ORG-level custom
+        // role *bypasses* the dynamic gate, since CASL is additive (the
         // static scope-built rule wins regardless of deployment
-        // config). Operators who clone admin into a lower-privilege
-        // role should untick it manually if their deployment intends
-        // to restrict PAT to specific tiers.
+        // config). Project-context builds filter it out with the other
+        // org-only scopes. Operators who clone admin into a
+        // lower-privilege org role should untick it manually if their
+        // deployment intends to restrict PAT to specific tiers.
         'manage:PersonalAccessToken',
     ],
 } as const;

--- a/packages/common/src/authorization/roleToScopeParity.test.ts
+++ b/packages/common/src/authorization/roleToScopeParity.test.ts
@@ -10,14 +10,6 @@ import {
     ORGANIZATION_INTERACTIVE_VIEWER,
     ORGANIZATION_VIEWER,
 } from './organizationMemberAbility.mock';
-import { projectMemberAbilities } from './projectMemberAbility';
-import {
-    PROJECT_ADMIN,
-    PROJECT_DEVELOPER,
-    PROJECT_EDITOR,
-    PROJECT_INTERACTIVE_VIEWER,
-    PROJECT_VIEWER,
-} from './projectMemberAbility.mock';
 import { getAllScopesForRole } from './roleToScopeMapping';
 import { buildAbilityFromScopes } from './scopeAbilityBuilder';
 import { getScopes } from './scopes';
@@ -105,121 +97,14 @@ const filterEnterpriseRules = (
 };
 
 /**
- * `${action}:${subject}` pairs that we expect on the **scope-built** side
- * but NOT on the **project-role-built** side, when comparing project
- * parity. Two reasons something lands here:
- *
- * 1. **Org-only subject** — the subject never appears in any project
- *    ability (e.g. `manage:OrganizationMemberProfile`,
- *    `manage:Group`, `impersonate:User`). The scope-built rule for
- *    these in project context is dead-on-arrival (`{ projectUuid }`
- *    conditions never match `{ organizationUuid }`-keyed subjects),
- *    but we keep the toggle in `BASE_ROLE_SCOPES` so admin custom
- *    roles surface it at org-level assignment. See
- *    `docs/authentication-and-roles.md`.
- *
- * 2. **Granular action of a subject covered by `manage:X` at project
- *    level** — e.g. project ability grants `manage:Job` (which CASL
- *    expands to cover `create`/`view`/`update`/`delete`), while the
- *    scope vocabulary lists `create:Job` and `view:Job@self` as
- *    separate scopes. The scope-built rules are benign extras — at
- *    runtime they're subsumed by the broader `manage:Job` already
- *    in role-based.
- *
- * Subjects with `*` mean "all actions on this subject," used for
- * org-only subjects (case 1).
- */
-const PROJECT_PARITY_IGNORE = new Set([
-    // Case 1: org-only subjects.
-    '*:OrganizationMemberProfile',
-    '*:Organization',
-    '*:OrganizationDesign',
-    '*:Group',
-    '*:InviteLink',
-    '*:GitIntegration',
-    '*:OrganizationWarehouseCredentials',
-    '*:User', // impersonate:User
-
-    // Case 2: granular actions subsumed by project's broader `manage:X`.
-    'create:Job',
-    'view:Job',
-    'manage:SemanticViewer', // broad org-only; @space variant is project
-    'create:VirtualView',
-    'delete:VirtualView',
-    'promote:Dashboard',
-    'promote:SavedChart',
-    'promote:Dashboard@space',
-    'promote:SavedChart@space',
-]);
-
-const isProjectParityIgnored = (rule: CASLRule): boolean => {
-    const key = `${rule.action}:${rule.subject}`;
-    return (
-        PROJECT_PARITY_IGNORE.has(key) ||
-        PROJECT_PARITY_IGNORE.has(`*:${rule.subject}`)
-    );
-};
-
-/**
- * Test project-context parity for a role.
- *
- * Compares `projectMemberAbilities[role]` against
- * `buildAbilityFromScopes(scopes, { projectUuid })`. Org-only subjects
- * are filtered out of the scope-built side because their rules at
- * project context are dead-on-arrival (`{ projectUuid }` conditions
- * never match `{ organizationUuid }`-keyed subjects) — the role-builder
- * UI still surfaces them for org-level assignment, but project parity
- * shouldn't fail on them.
- */
-const testProjectRoleScopeParity = (
-    role: ProjectMemberRole,
-    isEnterprise: boolean = false,
-): { isEqual: boolean; mismatches: string[] } => {
-    const member = {
-        [ProjectMemberRole.VIEWER]: PROJECT_VIEWER,
-        [ProjectMemberRole.INTERACTIVE_VIEWER]: PROJECT_INTERACTIVE_VIEWER,
-        [ProjectMemberRole.EDITOR]: PROJECT_EDITOR,
-        [ProjectMemberRole.DEVELOPER]: PROJECT_DEVELOPER,
-        [ProjectMemberRole.ADMIN]: PROJECT_ADMIN,
-    }[role];
-
-    const roleBuilder = new AbilityBuilder<MemberAbility>(Ability);
-    projectMemberAbilities[role](member, roleBuilder);
-    const filteredRoleRules = filterEnterpriseRules(
-        roleBuilder.build().rules as CASLRule[],
-        isEnterprise,
-    );
-
-    const scopeBuilder = new AbilityBuilder<MemberAbility>(Ability);
-    buildAbilityFromScopes(
-        {
-            userUuid: member.userUuid,
-            projectUuid: member.projectUuid,
-            scopes: getAllScopesForRole(role),
-            isEnterprise,
-        },
-        scopeBuilder,
-    );
-    const scopeRules = (scopeBuilder.build().rules as CASLRule[]).filter(
-        (r) => !isProjectParityIgnored(r),
-    );
-
-    return checkRoleCoveredByScopes(
-        filteredRoleRules,
-        scopeRules,
-        `${role} (project)`,
-    );
-};
-
-/**
  * Test org-context parity for a role.
  *
  * Compares `applyOrganizationMemberStaticAbilities[role]` against
- * `buildAbilityFromScopes(scopes, { organizationUuid })`. This is the
- * second leg the project-only test never had — it catches drift on
- * org-management scopes (which is what let `manage:Group`,
- * `manage:InviteLink`, etc. silently fall out of the scope vocabulary
- * before this PR).
+ * `buildAbilityFromScopes(scopes, { organizationUuid })`. Project-role
+ * parity no longer needs a test: `projectMemberAbilities` is built FROM
+ * the scope mapping, so it can't drift. Org static abilities are still
+ * hand-written, so this leg remains — it catches drift on
+ * org-management scopes (`manage:Group`, `manage:InviteLink`, etc.).
  */
 const testOrgRoleScopeParity = (
     role: ProjectMemberRole,
@@ -281,28 +166,6 @@ describe('Role to Scope Parity', () => {
         expect(comparison.isEqual).toBe(true);
     };
 
-    describe('Project parity (Non-Enterprise)', () => {
-        it.each(systemProjectRoles)(
-            'project ability ≡ scope build (project context) for %s',
-            (role) =>
-                reportAndAssert(
-                    `PROJECT PARITY MISMATCH FOR ${role.toUpperCase()}`,
-                    testProjectRoleScopeParity(role, false),
-                ),
-        );
-    });
-
-    describe('Project parity (Enterprise)', () => {
-        it.each(systemProjectRoles)(
-            'project ability ≡ scope build (project context) for %s [EE]',
-            (role) =>
-                reportAndAssert(
-                    `ENTERPRISE PROJECT PARITY MISMATCH FOR ${role.toUpperCase()}`,
-                    testProjectRoleScopeParity(role, true),
-                ),
-        );
-    });
-
     describe('Org parity (Non-Enterprise)', () => {
         it.each(systemProjectRoles)(
             'org ability ≡ scope build (org context) for %s',
@@ -358,55 +221,6 @@ describe('Role to Scope Parity', () => {
             }
 
             expect(missing).toEqual([]);
-        });
-    });
-
-    // This is helpful for debugging, but it's not a test
-    describe.skip('Rule Count Analysis', () => {
-        it('should report rule counts for documentation', () => {
-            console.log('\n=== ROLE PERMISSION RULE COUNTS ===');
-
-            systemProjectRoles.forEach((role) => {
-                const member = {
-                    [ProjectMemberRole.VIEWER]: PROJECT_VIEWER,
-                    [ProjectMemberRole.INTERACTIVE_VIEWER]:
-                        PROJECT_INTERACTIVE_VIEWER,
-                    [ProjectMemberRole.EDITOR]: PROJECT_EDITOR,
-                    [ProjectMemberRole.DEVELOPER]: PROJECT_DEVELOPER,
-                    [ProjectMemberRole.ADMIN]: PROJECT_ADMIN,
-                }[role];
-
-                // Count role-based rules
-                const roleBuilder = new AbilityBuilder<MemberAbility>(Ability);
-                projectMemberAbilities[role](member, roleBuilder);
-                const roleRuleCount = roleBuilder.build().rules.length;
-
-                // Count scope-based rules
-                const scopeBuilder = new AbilityBuilder<MemberAbility>(Ability);
-                const scopes = getAllScopesForRole(role);
-                buildAbilityFromScopes(
-                    {
-                        userUuid: member.userUuid,
-                        projectUuid: member.projectUuid,
-                        scopes,
-                        isEnterprise: false,
-                    },
-                    scopeBuilder,
-                );
-                const scopeRuleCount = scopeBuilder.build().rules.length;
-
-                console.log(
-                    `${role.padEnd(20)}: Role-based: ${roleRuleCount
-                        .toString()
-                        .padStart(3)}, Scope-based: ${scopeRuleCount
-                        .toString()
-                        .padStart(3)}, Scopes: ${scopes.length
-                        .toString()
-                        .padStart(3)}`,
-                );
-            });
-
-            console.log('=== END RULE COUNT ANALYSIS ===\n');
         });
     });
 });

--- a/packages/common/src/authorization/scopeAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.test.ts
@@ -2195,11 +2195,11 @@ describe('scopeAbilityBuilder', () => {
             ).toBe(false);
         });
 
-        it('should handle manage:organization_member_profile permissions', () => {
+        it('should handle manage:organization_member_profile permissions at org level', () => {
             const builder = new AbilityBuilder<MemberAbility>(Ability);
             buildAbilityFromScopes(
                 {
-                    ...baseContext,
+                    ...baseContextWithOrg,
                     scopes: ['manage:OrganizationMemberProfile'],
                 },
                 builder,
@@ -2211,10 +2211,38 @@ describe('scopeAbilityBuilder', () => {
                     'manage',
                     subject('OrganizationMemberProfile', {
                         organizationUuid: 'org-123',
-                        projectUuid: 'project-123',
                     }),
                 ),
             ).toBe(true);
+        });
+
+        it('skips org-only scopes in project-context builds', () => {
+            // CASL ignores conditions on bare subject-type checks, so
+            // emitting an org-only rule from a project build would leak
+            // org UI surfaces (and the PAT deployment gate) to
+            // project-scoped roles.
+            const builder = new AbilityBuilder<MemberAbility>(Ability);
+            buildAbilityFromScopes(
+                {
+                    ...baseContext,
+                    scopes: [
+                        'manage:OrganizationMemberProfile',
+                        'manage:Organization',
+                        'impersonate:User',
+                        'manage:PersonalAccessToken',
+                    ],
+                },
+                builder,
+            );
+            const ability = builder.build();
+
+            expect(builder.rules).toHaveLength(0);
+            expect(ability.can('manage', 'Organization')).toBe(false);
+            expect(ability.can('manage', 'OrganizationMemberProfile')).toBe(
+                false,
+            );
+            expect(ability.can('impersonate', 'User')).toBe(false);
+            expect(ability.can('manage', 'PersonalAccessToken')).toBe(false);
         });
     });
 

--- a/packages/common/src/authorization/scopeAbilityBuilder.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.ts
@@ -2,7 +2,7 @@ import { type AbilityBuilder } from '@casl/ability';
 import { type ProjectType } from '../types/projects';
 import { type ScopeContext } from '../types/scopes';
 import { parseScope, parseScopes } from './parseScopes';
-import { getAllScopeMap } from './scopes';
+import { getAllScopeMap, isOrganizationOnlyScope } from './scopes';
 import { type MemberAbility } from './types';
 
 const handlePatConfigApplication = (
@@ -41,6 +41,12 @@ const applyScopeAbilities = (
         const scope = scopeMap[scopeName];
 
         if (!scope) return;
+
+        // Org-only scopes never apply in a project-context build. Their
+        // conditions can't match org-keyed subject instances, but CASL
+        // ignores conditions on bare subject-type checks, so emitting the
+        // rule would still flip e.g. `can('manage', 'Organization')` true.
+        if (context.projectUuid && isOrganizationOnlyScope(scopeName)) return;
 
         const [action, subject] = parseScope(scopeName);
         const conditionsList = scope.getConditions(context);

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -1146,7 +1146,11 @@ const scopes: Scope[] = [
         isEnterprise: false,
         group: ScopeGroup.DATA,
         dependencies: [{ name: 'view:Project' }],
-        getConditions: addDefaultUuidCondition,
+        // Writes are only allowed when NOT targeting a protected branch,
+        // matching the system developer role.
+        getConditions: (context) => [
+            { ...addUuidCondition(context), isProtectedBranch: false },
+        ],
     },
 
     // AI Agent

--- a/packages/common/src/authorization/serviceAccountAbility.test.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.test.ts
@@ -1,6 +1,7 @@
 import { Ability, AbilityBuilder, subject } from '@casl/ability';
 import { ServiceAccountScope } from '../ee/serviceAccounts/types';
 import { ProjectMemberRole } from '../types/projectMemberRole';
+import { ProjectType } from '../types/projects';
 import { projectMemberAbilities } from './projectMemberAbility';
 import { buildAbilityFromScopes } from './scopeAbilityBuilder';
 import { applyServiceAccountAbilities } from './serviceAccountAbility';
@@ -27,7 +28,12 @@ const buildAbility = (scopes: ServiceAccountScope[]) => {
 const buildAbilityWithGrants = (
     scopes: ServiceAccountScope[],
     grants: Array<
-        | { projectUuid: string; role: ProjectMemberRole }
+        | {
+              projectUuid: string;
+              role: ProjectMemberRole;
+              projectType?: ProjectType;
+              projectCreatedByUserUuid?: string | null;
+          }
         | { projectUuid: string; customRoleScopes: string[] }
     >,
 ) => {
@@ -45,6 +51,8 @@ const buildAbilityWithGrants = (
                     projectUuid: grant.projectUuid,
                     userUuid: SA_USER,
                     role: grant.role,
+                    projectType: grant.projectType,
+                    projectCreatedByUserUuid: grant.projectCreatedByUserUuid,
                 },
                 builder,
             );
@@ -269,6 +277,55 @@ describe('SYSTEM_MEMBER + project_memberships (custom roles)', () => {
                 }),
             ),
         ).toBe(true);
+    });
+
+    it('honors @self preview scopes when project metadata is passed (mirrors UserModel system-role branch)', () => {
+        // Developer's manage:Dashboard@self only fires inside a preview the
+        // principal created — requires projectType + projectCreatedByUserUuid
+        // in the builder context, exactly what UserModel passes per row.
+        const ownPreview = buildAbilityWithGrants(
+            [ServiceAccountScope.SYSTEM_MEMBER],
+            [
+                {
+                    projectUuid: PROJ_A,
+                    role: ProjectMemberRole.DEVELOPER,
+                    projectType: ProjectType.PREVIEW,
+                    projectCreatedByUserUuid: SA_USER,
+                },
+            ],
+        );
+        expect(
+            ownPreview.can(
+                'manage',
+                subject('Dashboard', {
+                    organizationUuid: ORG,
+                    projectUuid: PROJ_A,
+                    inheritsFromOrgOrProject: true,
+                }),
+            ),
+        ).toBe(true);
+
+        const othersPreview = buildAbilityWithGrants(
+            [ServiceAccountScope.SYSTEM_MEMBER],
+            [
+                {
+                    projectUuid: PROJ_A,
+                    role: ProjectMemberRole.DEVELOPER,
+                    projectType: ProjectType.PREVIEW,
+                    projectCreatedByUserUuid: 'someone-else',
+                },
+            ],
+        );
+        expect(
+            othersPreview.can(
+                'manage',
+                subject('Dashboard', {
+                    organizationUuid: ORG,
+                    projectUuid: PROJ_A,
+                    inheritsFromOrgOrProject: true,
+                }),
+            ),
+        ).toBe(false);
     });
 
     it('grants are additive — SYSTEM_MEMBER org abilities still apply', () => {


### PR DESCRIPTION
## What

Project system-role abilities are now derived from the custom-role scope vocabulary instead of a hand-written CASL rule list. `projectMemberAbilities[role]` runs `getAllScopesForRole(role)` (`BASE_ROLE_SCOPES`, tiers accumulated) through `buildAbilityFromScopes` — the exact path custom roles use.

## Why

Until now the same permission lived in three hand-synced places (`projectMemberAbility.ts`, `roleToScopeMapping.ts`, plus org file), kept honest only by a coverage-level parity test that compares `action:subject` keys, not conditions. Every permission change had to touch all of them. After this PR, a project role *is* its scopes: adding a permission = `scopes.ts` entry + one mapping line, and system/custom roles cannot drift.

## Notable details

- **Latent custom-role hole found and fixed — behavior change for persisted custom roles**: `manage:SourceCode` as a scope was missing the `isProtectedBranch: false` condition the project developer system role has, so a custom role with that scope could write to protected branches. The scope now carries the condition. ⚠️ This tightens **existing persisted custom roles** on deploy: any custom role holding `manage:SourceCode` loses protected-branch write, with no scope in the vocabulary granting it back (the org-level *system* developer keeps its unconditioned hand-written grant — pre-existing divergence). If protected-branch write should stay grantable to custom roles, that needs a follow-up `@protected` scope variant + `scoped_roles` migration.
- **Org-only scopes are filtered from project-context builds** (`applyScopeAbilities` skips `isOrganizationOnlyScope` when `projectUuid` is set). CASL ignores conditions on bare subject-type checks (`can('manage', 'Organization')`), so emitting org-only rules from a project build would leak org settings/invites/groups/impersonation UI surfaces — and the `PAT_ALLOWED_ORG_ROLES` deployment gate — to project-scoped roles. This also closes the same latent hole for project-level custom roles whose persisted scopes include org-only entries.
- **Broad `promote:*` moved to the admin tier**: developer keeps the `@space` promote variants (promote where space editor/admin — matches main, where promote came from the CASL `manage` wildcard on space-conditioned content rules); project-wide promote regardless of space access is admin-only, matching main's `manage:SavedChart`/`manage:Dashboard` admin grants. Note for custom roles cloned from developer *after* this change: service accounts never appear in space `access` arrays, so an SA holding such a clone can't promote at all — grant the broad promote scopes (or admin clone) for CI/CD promote workflows.
- **Service-account system-role grants now honor `@self` preview scopes**: `UserModel.applyServiceAccountProjectMemberships` passes `projectType`/`projectCreatedByUserUuid` like the human and SA custom-role paths already did.
- The project-parity legs of `roleToScopeParity.test.ts` are deleted — they'd be tautological now. In their place, a per-role **rules snapshot test** (`projectMemberAbility.snapshot.test.ts`) makes the system-role blast radius of any `scopes.ts`/`roleToScopeMapping.ts` edit visible in review. Org-parity legs and the scope-vocabulary coverage test remain (org static abilities are still hand-written — follow-up candidate).
- Rule-count payload guards bumped `<100` → `<150`: scope-built rules are more granular (a rule per toggle vs broad `manage:X` CASL expansion). Per-project rules by role, hand-written → derived: viewer 15 → 15, interactive_viewer 39 → 43, editor 49 → 54, developer 72 → 87, admin 85 → 102. `collapseAbilityRules` still collapses 125 projects to one project's worth, so payload scales with role tiers, not project count, same as before.
- `isEnterprise: true` at build time matches the old hand-written behavior (enterprise subjects were always emitted; licensing gates at runtime).

## Verification

The condition-level parity harness is the existing behavior suites, run against the swapped implementation:

- `projectMemberAbility.test.ts` (126 behaviors): 1 divergence found = the SourceCode bug above; all pass after the scope fix
- New regression tests: org-only scopes absent from project builds (bare checks), promote tiering per role, SA `@self` preview grants, per-role rules snapshot (default + own-preview context)
- full `common` suite 2799/2799, `backend` modified-file suites 3907/3907
- `common`/`backend` typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
