### PR TITLE
fix(cli): replace ts-node with tsx

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -230,7 +230,6 @@
         "eslint-plugin-jsdoc": "62.5.0",
         "knex-mock-client": "1.11.0",
         "nodemon": "3.1.9",
-        "ts-node": "10.9.2",
         "typescript": "npm:@typescript/typescript6@6.0.1",
         "typescript-7": "npm:typescript@7.0.1-rc",
         "zod-to-json-schema": "3.25.1"

--- a/packages/backend/src/@types/express-account.d.ts
+++ b/packages/backend/src/@types/express-account.d.ts
@@ -1,6 +1,6 @@
 // Express.Request.account is set by accountMiddleware and consumed by
 // other middlewares like winston.ts. The full augmentation lives in App.ts,
-// but `ts-node` invocations that don't transitively import App.ts (e.g. the
+// but sucrase invocations that don't transitively import App.ts (e.g. the
 // knex seed runner) won't see it. This ambient file mirrors the relevant
 // slice so type checks pass in all entry points.
 import type { Account } from '@lightdash/common';

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -92,7 +92,7 @@ import { VERSION } from './version';
 
 // Express Request/User type augmentations live in src/@types/express.d.ts
 // so they're picked up as ambient declarations regardless of which file is
-// the compilation entry point (e.g. knex seed/migrate via ts-node).
+// the compilation entry point (e.g. knex seed/migrate via sucrase).
 
 initOtelTracing();
 

--- a/packages/backend/src/ee/services/AiWritebackService/skills.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/skills.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import type { WarehouseSkillKey } from './types';
 
 // Directory holding the committed skill markdown. Resolved relative to this
-// module so it works in dev (ts-node/tsx → src/) and prod (the backend
+// module so it works in dev (tsx → src/) and prod (the backend
 // `postbuild` copies `src/**/*.md` into dist/, so the files sit next to the
 // compiled JS).
 export const SKILLS_SOURCE_DIR = path.join(__dirname, 'skills', 'warehouses');

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "test": "vitest run --config vitest.config.ts",
     "test:dev": "vitest watch --config vitest.config.ts --changed",
-    "dev": "ts-node src/index.ts",
+    "dev": "tsx src/index.ts",
     "build": "tsc6 --build tsconfig.json",
     "postbuild": "copyfiles --all -u 5 \"../../sandboxes/data-apps/template/**/*\" dist/vendor/template && copyfiles --all -u 4 \"src/handlers/apps/authoring/**/*\" dist/vendor/authoring",
     "build:fast": "tsc --build tsconfig.fast.json",
@@ -76,7 +76,7 @@
     "@vercel/ncc": "0.38.4",
     "@yao-pkg/pkg": "6.7.0",
     "copyfiles": "2.4.1",
-    "ts-node": "10.9.2",
+    "tsx": "4.19.4",
     "typescript": "npm:@typescript/typescript6@6.0.1",
     "typescript-7": "npm:typescript@7.0.1-rc",
     "vitest": "4.1.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -694,9 +694,6 @@ importers:
       nodemon:
         specifier: 3.1.9
         version: 3.1.9
-      ts-node:
-        specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.13.5)(@types/node@24.3.1)(@typescript/typescript6@6.0.1)
       typescript:
         specifier: npm:@typescript/typescript6@6.0.1
         version: '@typescript/typescript6@6.0.1'
@@ -846,9 +843,9 @@ importers:
       copyfiles:
         specifier: 2.4.1
         version: 2.4.1
-      ts-node:
-        specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.13.5)(@types/node@24.3.1)(@typescript/typescript6@6.0.1)
+      tsx:
+        specifier: 4.19.4
+        version: 4.19.4
       typescript:
         specifier: npm:@typescript/typescript6@6.0.1
         version: '@typescript/typescript6@6.0.1'
@@ -19524,6 +19521,7 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+    optional: true
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -20648,6 +20646,7 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+    optional: true
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
@@ -23963,13 +23962,17 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
-  '@tsconfig/node10@1.0.9': {}
+  '@tsconfig/node10@1.0.9':
+    optional: true
 
-  '@tsconfig/node12@1.0.11': {}
+  '@tsconfig/node12@1.0.11':
+    optional: true
 
-  '@tsconfig/node14@1.0.3': {}
+  '@tsconfig/node14@1.0.3':
+    optional: true
 
-  '@tsconfig/node16@1.0.3': {}
+  '@tsconfig/node16@1.0.3':
+    optional: true
 
   '@tsoa/cli@6.6.0':
     dependencies:
@@ -24436,6 +24439,7 @@ snapshots:
   '@types/node@24.3.1':
     dependencies:
       undici-types: 7.10.0
+    optional: true
 
   '@types/nodemailer@7.0.9':
     dependencies:
@@ -25602,7 +25606,8 @@ snapshots:
       delegates: 1.0.0
       readable-stream: 3.6.2
 
-  arg@4.1.3: {}
+  arg@4.1.3:
+    optional: true
 
   arg@5.0.2: {}
 
@@ -26617,7 +26622,8 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 4.5.2
 
-  create-require@1.1.1: {}
+  create-require@1.1.1:
+    optional: true
 
   crelt@1.0.6: {}
 
@@ -27286,7 +27292,8 @@ snapshots:
 
   diff-match-patch@1.0.5: {}
 
-  diff@4.0.2: {}
+  diff@4.0.2:
+    optional: true
 
   diff@8.0.3: {}
 
@@ -30390,7 +30397,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  make-error@1.3.6: {}
+  make-error@1.3.6:
+    optional: true
 
   make-fetch-happen@10.2.1:
     dependencies:
@@ -34777,6 +34785,7 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.13.5
+    optional: true
 
   ts-unused-exports@9.0.4(@typescript/typescript6@6.0.1):
     dependencies:
@@ -34983,7 +34992,8 @@ snapshots:
 
   undici-types@6.20.0: {}
 
-  undici-types@7.10.0: {}
+  undici-types@7.10.0:
+    optional: true
 
   undici@6.27.0: {}
 
@@ -35238,7 +35248,8 @@ snapshots:
 
   uuidv7@1.1.0: {}
 
-  v8-compile-cache-lib@3.0.1: {}
+  v8-compile-cache-lib@3.0.1:
+    optional: true
 
   validate.io-array@1.0.6: {}
 
@@ -36063,7 +36074,8 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
-  yn@3.1.1: {}
+  yn@3.1.1:
+    optional: true
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
Run the CLI development entrypoint with tsx because ts-node cannot load TypeScript 7.

Remove direct ts-node declarations; Knex continues loading TypeScript through its existing sucrase integration.