### PR TITLE
feat: homepage collection block with uuid content filter

### DIFF
--- a/packages/backend/src/controllers/v2/ContentController.test.ts
+++ b/packages/backend/src/controllers/v2/ContentController.test.ts
@@ -78,6 +78,7 @@ describe('ContentController', () => {
                 ['project-uuid'],
                 ['requested-space-uuid'],
                 undefined,
+                undefined,
                 [ContentType.CHART],
                 50,
                 1,

--- a/packages/backend/src/controllers/v2/ContentController.ts
+++ b/packages/backend/src/controllers/v2/ContentController.ts
@@ -50,6 +50,7 @@ export class ContentController extends BaseController {
         @Request() req: express.Request,
         @Query() projectUuids?: string[],
         @Query() spaceUuids?: string[],
+        @Query() uuids?: string[],
         @Query() parentSpaceUuid?: string,
         @Query() contentTypes?: ContentType[],
         @Query() pageSize?: number,
@@ -68,6 +69,7 @@ export class ContentController extends BaseController {
                 {
                     projectUuids,
                     spaceUuids,
+                    uuids,
                     contentTypes,
                     search,
                     includePersonalDataApps,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1496,6 +1496,56 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageCollectionItemRef: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                uuid: { dataType: 'string', required: true },
+                contentType: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['chart'] },
+                        { dataType: 'enum', enums: ['dashboard'] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageCollectionBlock: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                config: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        items: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'HomepageCollectionItemRef',
+                            },
+                            required: true,
+                        },
+                        title: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                type: {
+                    dataType: 'enum',
+                    enums: ['collection'],
+                    required: true,
+                },
+                id: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     HomepageBlock: {
         dataType: 'refAlias',
         type: {
@@ -1504,6 +1554,7 @@ const models: TsoaRoute.Models = {
                 { ref: 'HomepageMarkdownBlock' },
                 { ref: 'HomepageHeroBlock' },
                 { ref: 'HomepageAiBlock' },
+                { ref: 'HomepageCollectionBlock' },
             ],
             validators: {},
         },
@@ -90287,6 +90338,12 @@ export function RegisterRoutes(app: Router) {
         spaceUuids: {
             in: 'query',
             name: 'spaceUuids',
+            dataType: 'array',
+            array: { dataType: 'string' },
+        },
+        uuids: {
+            in: 'query',
+            name: 'uuids',
             dataType: 'array',
             array: { dataType: 'string' },
         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1500,6 +1500,48 @@
                 "required": ["config", "type", "id"],
                 "type": "object"
             },
+            "HomepageCollectionItemRef": {
+                "properties": {
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "contentType": {
+                        "type": "string",
+                        "enum": ["chart", "dashboard"]
+                    }
+                },
+                "required": ["uuid", "contentType"],
+                "type": "object"
+            },
+            "HomepageCollectionBlock": {
+                "properties": {
+                    "config": {
+                        "properties": {
+                            "items": {
+                                "items": {
+                                    "$ref": "#/components/schemas/HomepageCollectionItemRef"
+                                },
+                                "type": "array"
+                            },
+                            "title": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["items", "title"],
+                        "type": "object"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["collection"],
+                        "nullable": false
+                    },
+                    "id": {
+                        "type": "string"
+                    }
+                },
+                "required": ["config", "type", "id"],
+                "type": "object"
+            },
             "HomepageBlock": {
                 "anyOf": [
                     {
@@ -1510,6 +1552,9 @@
                     },
                     {
                         "$ref": "#/components/schemas/HomepageAiBlock"
+                    },
+                    {
+                        "$ref": "#/components/schemas/HomepageCollectionBlock"
                     }
                 ]
             },
@@ -76611,6 +76656,17 @@
                     {
                         "in": "query",
                         "name": "spaceUuids",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "uuids",
                         "required": false,
                         "schema": {
                             "type": "array",

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts
@@ -188,6 +188,13 @@ export const dashboardContentConfiguration: ContentConfiguration<SummaryContentR
                         );
                     }
 
+                    if (filters.uuids) {
+                        void builder.whereIn(
+                            `${DashboardsTableName}.dashboard_uuid`,
+                            filters.uuids,
+                        );
+                    }
+
                     if (filters.spaceUuids) {
                         void builder.whereIn(
                             `${SpaceTableName}.space_uuid`,

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
@@ -158,6 +158,13 @@ export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow
                         );
                     }
 
+                    if (filters.uuids) {
+                        void builder.whereIn(
+                            `${AppsTableName}.app_id`,
+                            filters.uuids,
+                        );
+                    }
+
                     const personal = filters.dataApps;
                     if (personal) {
                         // Surface space apps the caller can access OR personal

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
@@ -196,6 +196,13 @@ export const dbtExploreChartContentConfiguration: ContentConfiguration<SelectSav
                         );
                     }
 
+                    if (filters.uuids) {
+                        void builder.whereIn(
+                            `${SavedChartsTableName}.saved_query_uuid`,
+                            filters.uuids,
+                        );
+                    }
+
                     if (filters.spaceUuids) {
                         void builder.whereIn(
                             `${SpaceTableName}.space_uuid`,

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
@@ -197,6 +197,13 @@ export const spaceContentConfiguration: ContentConfiguration<SpaceContentRow> =
                         );
                     }
 
+                    if (filters.uuids) {
+                        void builder.whereIn(
+                            `${SpaceTableName}.space_uuid`,
+                            filters.uuids,
+                        );
+                    }
+
                     if (filters.search) {
                         applyContentNameSearch(
                             builder,

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
@@ -186,6 +186,13 @@ export const sqlChartContentConfiguration: ContentConfiguration<SelectSavedSql> 
                         );
                     }
 
+                    if (filters.uuids) {
+                        void builder.whereIn(
+                            `${SavedSqlTableName}.saved_sql_uuid`,
+                            filters.uuids,
+                        );
+                    }
+
                     if (filters.spaceUuids) {
                         void builder.whereIn(
                             `${SpaceTableName}.space_uuid`,

--- a/packages/backend/src/models/ContentModel/ContentModelTypes.ts
+++ b/packages/backend/src/models/ContentModel/ContentModelTypes.ts
@@ -19,6 +19,8 @@ export enum ContentTypePriority {
 export type ContentFilters = {
     projectUuids?: string[];
     spaceUuids?: string[];
+    /** Restrict to specific content uuids (e.g. resolving curated collections) */
+    uuids?: string[];
     contentTypes?: ContentType[];
     chart?: {
         sources?: ChartContent['source'][];

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -18,10 +18,22 @@ export type HomepageAiBlock = {
     config: { chips: string[] };
 };
 
+export type HomepageCollectionItemRef = {
+    contentType: 'chart' | 'dashboard';
+    uuid: string;
+};
+
+export type HomepageCollectionBlock = {
+    id: string;
+    type: 'collection';
+    config: { title: string; items: HomepageCollectionItemRef[] };
+};
+
 export type HomepageBlock =
     | HomepageMarkdownBlock
     | HomepageHeroBlock
-    | HomepageAiBlock;
+    | HomepageAiBlock
+    | HomepageCollectionBlock;
 
 export type HomepageRow = {
     id: string;

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
@@ -34,7 +34,9 @@ export const HomepageBuilderPage: FC = () => {
             }),
         ) ?? false;
 
-    if (isFlagLoading || homepage.isInitialLoading) {
+    // Wait for a fresh fetch: the editor snapshots the draft on mount, so
+    // seeding it from a stale cache would autosave old state over the server
+    if (isFlagLoading || (isFlagEnabled && !homepage.isFetchedAfterMount)) {
         return <PageSpinner />;
     }
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -1,0 +1,345 @@
+import {
+    ContentType,
+    contentToResourceViewItem,
+    type HomepageCollectionItemRef,
+    type SummaryContent,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Anchor,
+    Box,
+    Button,
+    Card,
+    Group,
+    Loader,
+    SimpleGrid,
+    Skeleton,
+    Stack,
+    Text,
+    TextInput,
+    Tooltip,
+} from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import {
+    IconCircleCheckFilled,
+    IconEye,
+    IconPin,
+    IconPlus,
+    IconX,
+} from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import MantineModal from '../../../../components/common/MantineModal';
+import { ResourceIcon } from '../../../../components/common/ResourceIcon';
+import { usePinnedItems } from '../../../../hooks/pinning/usePinnedItems';
+import { useInfiniteContent } from '../../../../hooks/useContent';
+import { useProject } from '../../../../hooks/useProject';
+import { useCollectionContent } from '../hooks/useCollectionContent';
+import { type BlockComponentProps, type BuildComponentProps } from './types';
+
+const contentUrl = (projectUuid: string, content: SummaryContent): string =>
+    content.contentType === ContentType.DASHBOARD
+        ? `/projects/${projectUuid}/dashboards/${content.uuid}/view`
+        : `/projects/${projectUuid}/saved/${content.uuid}`;
+
+const toItemRef = (content: SummaryContent): HomepageCollectionItemRef => ({
+    contentType:
+        content.contentType === ContentType.DASHBOARD ? 'dashboard' : 'chart',
+    uuid: content.uuid,
+});
+
+const ContentCard: FC<{
+    content: SummaryContent;
+    projectUuid: string;
+    onRemove?: () => void;
+}> = ({ content, projectUuid, onRemove }) => {
+    const card = (
+        <Card withBorder p="sm" h="100%">
+            <Group gap="sm" wrap="nowrap" align="flex-start">
+                <ResourceIcon item={contentToResourceViewItem(content)} />
+                <Box style={{ flex: 1, minWidth: 0 }}>
+                    <Group gap={4} wrap="nowrap">
+                        <Text size="sm" fw={600} truncate>
+                            {content.name}
+                        </Text>
+                        {content.verification && (
+                            <Tooltip label="Verified by the data team">
+                                <MantineIcon
+                                    icon={IconCircleCheckFilled}
+                                    color="green"
+                                />
+                            </Tooltip>
+                        )}
+                    </Group>
+                    <Group gap={4}>
+                        <Text size="xs" c="dimmed" tt="capitalize">
+                            {content.contentType}
+                        </Text>
+                        <Text size="xs" c="dimmed">
+                            ·
+                        </Text>
+                        <MantineIcon icon={IconEye} color="gray" size="sm" />
+                        <Text size="xs" c="dimmed">
+                            {content.views}
+                        </Text>
+                    </Group>
+                </Box>
+                {onRemove && (
+                    <ActionIcon
+                        variant="subtle"
+                        color="gray"
+                        size="sm"
+                        aria-label={`Remove ${content.name} from collection`}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            onRemove();
+                        }}
+                    >
+                        <MantineIcon icon={IconX} />
+                    </ActionIcon>
+                )}
+            </Group>
+        </Card>
+    );
+    if (onRemove) return card;
+    return (
+        <Anchor
+            component={Link}
+            to={contentUrl(projectUuid, content)}
+            underline="never"
+            c="inherit"
+        >
+            {card}
+        </Anchor>
+    );
+};
+
+const CollectionPickerModal: FC<{
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    selectedUuids: string[];
+    onAdd: (ref: HomepageCollectionItemRef) => void;
+}> = ({ opened, onClose, projectUuid, selectedUuids, onAdd }) => {
+    const [search, setSearch] = useState('');
+    const [debouncedSearch] = useDebouncedValue(search, 300);
+    const { data, isFetching } = useInfiniteContent(
+        {
+            projectUuids: [projectUuid],
+            contentTypes: [ContentType.CHART, ContentType.DASHBOARD],
+            search: debouncedSearch.length > 0 ? debouncedSearch : undefined,
+            pageSize: 25,
+        },
+        { enabled: opened, keepPreviousData: true },
+    );
+    const results = (data?.pages ?? [])
+        .flatMap((page) => page.data)
+        .filter((content) => !selectedUuids.includes(content.uuid));
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Add content"
+            size="lg"
+        >
+            <Stack gap="sm">
+                <TextInput
+                    placeholder="Search charts and dashboards…"
+                    value={search}
+                    onChange={(e) => setSearch(e.currentTarget.value)}
+                    rightSection={isFetching ? <Loader size="xs" /> : null}
+                />
+                <Stack gap={4} mah={360} style={{ overflowY: 'auto' }}>
+                    {results.map((content) => (
+                        <Group
+                            key={content.uuid}
+                            gap="sm"
+                            wrap="nowrap"
+                            p="xs"
+                            style={{ cursor: 'pointer', borderRadius: 8 }}
+                            onClick={() => onAdd(toItemRef(content))}
+                        >
+                            <ResourceIcon
+                                item={contentToResourceViewItem(content)}
+                            />
+                            <Box style={{ flex: 1, minWidth: 0 }}>
+                                <Text size="sm" fw={500} truncate>
+                                    {content.name}
+                                </Text>
+                                <Text size="xs" c="dimmed">
+                                    {content.space?.name}
+                                </Text>
+                            </Box>
+                            <MantineIcon icon={IconPlus} color="gray" />
+                        </Group>
+                    ))}
+                    {results.length === 0 && !isFetching && (
+                        <Text size="sm" c="dimmed" p="sm">
+                            No matching charts or dashboards.
+                        </Text>
+                    )}
+                </Stack>
+            </Stack>
+        </MantineModal>
+    );
+};
+
+export const CollectionBlockView: FC<BlockComponentProps> = ({
+    block,
+    projectUuid,
+}) => {
+    const uuids =
+        block.type === 'collection'
+            ? block.config.items.map((item) => item.uuid)
+            : [];
+    const { data: contents, isInitialLoading } = useCollectionContent(
+        projectUuid,
+        uuids,
+    );
+    if (block.type !== 'collection' || block.config.items.length === 0) {
+        return null;
+    }
+    return (
+        <Stack gap="xs">
+            <Text size="xs" fw={600} tt="uppercase" c="dimmed">
+                {block.config.title}
+            </Text>
+            {isInitialLoading ? (
+                <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+                    {uuids.slice(0, 3).map((uuid) => (
+                        <Skeleton key={uuid} h={72} radius="md" />
+                    ))}
+                </SimpleGrid>
+            ) : (
+                <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+                    {(contents ?? []).map((content) => (
+                        <ContentCard
+                            key={content.uuid}
+                            content={content}
+                            projectUuid={projectUuid}
+                        />
+                    ))}
+                </SimpleGrid>
+            )}
+        </Stack>
+    );
+};
+
+export const CollectionBlockBuild: FC<BuildComponentProps> = ({
+    block,
+    projectUuid,
+    onChange,
+}) => {
+    const [isPickerOpen, setIsPickerOpen] = useState(false);
+    const uuids =
+        block.type === 'collection'
+            ? block.config.items.map((item) => item.uuid)
+            : [];
+    const { data: contents } = useCollectionContent(projectUuid, uuids);
+    const { data: project } = useProject(projectUuid);
+    const { data: pinnedItems } = usePinnedItems(
+        projectUuid,
+        project?.pinnedListUuid,
+    );
+    if (block.type !== 'collection') return null;
+
+    const importablePins = (pinnedItems ?? []).flatMap(
+        (item): HomepageCollectionItemRef[] =>
+            item.type === ContentType.CHART ||
+            item.type === ContentType.DASHBOARD
+                ? [
+                      {
+                          contentType:
+                              item.type === ContentType.DASHBOARD
+                                  ? 'dashboard'
+                                  : 'chart',
+                          uuid: item.data.uuid,
+                      },
+                  ]
+                : [],
+    );
+
+    return (
+        <Stack gap="xs">
+            <TextInput
+                aria-label="Collection title"
+                size="xs"
+                fw={600}
+                value={block.config.title}
+                onChange={(e) =>
+                    onChange({
+                        ...block,
+                        config: {
+                            ...block.config,
+                            title: e.currentTarget.value,
+                        },
+                    })
+                }
+            />
+            <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+                {(contents ?? []).map((content) => (
+                    <ContentCard
+                        key={content.uuid}
+                        content={content}
+                        projectUuid={projectUuid}
+                        onRemove={() =>
+                            onChange({
+                                ...block,
+                                config: {
+                                    ...block.config,
+                                    items: block.config.items.filter(
+                                        (item) => item.uuid !== content.uuid,
+                                    ),
+                                },
+                            })
+                        }
+                    />
+                ))}
+                <Button
+                    variant="default"
+                    h={72}
+                    leftSection={<MantineIcon icon={IconPlus} />}
+                    onClick={() => setIsPickerOpen(true)}
+                >
+                    Add content
+                </Button>
+            </SimpleGrid>
+            {block.config.items.length === 0 && importablePins.length > 0 && (
+                <Button
+                    variant="subtle"
+                    size="xs"
+                    w="fit-content"
+                    leftSection={<MantineIcon icon={IconPin} />}
+                    onClick={() =>
+                        onChange({
+                            ...block,
+                            config: {
+                                ...block.config,
+                                items: importablePins,
+                            },
+                        })
+                    }
+                >
+                    Import pinned items
+                </Button>
+            )}
+            <CollectionPickerModal
+                opened={isPickerOpen}
+                onClose={() => setIsPickerOpen(false)}
+                projectUuid={projectUuid}
+                selectedUuids={uuids}
+                onAdd={(ref) =>
+                    onChange({
+                        ...block,
+                        config: {
+                            ...block.config,
+                            items: [...block.config.items, ref],
+                        },
+                    })
+                }
+            />
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
@@ -1,5 +1,6 @@
 import { type HomepageBlock } from '@lightdash/common';
 import {
+    IconLayoutGrid,
     IconMarkdown,
     IconSparkles,
     IconTypography,
@@ -8,6 +9,7 @@ import {
 import { type FC } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { AiBlockBuild, AiBlockView } from './AiBlock';
+import { CollectionBlockBuild, CollectionBlockView } from './CollectionBlock';
 import { HeroBlockBuild, HeroBlockView } from './HeroBlock';
 import { MarkdownBlockBuild, MarkdownBlockView } from './MarkdownBlock';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
@@ -54,6 +56,19 @@ export const blockLibrary: BlockDefinition[] = [
         }),
         View: AiBlockView,
         Build: AiBlockBuild,
+    },
+    {
+        type: 'collection',
+        label: 'Collection',
+        description: 'A curated set of dashboards and charts.',
+        icon: IconLayoutGrid,
+        create: () => ({
+            id: uuidv4(),
+            type: 'collection',
+            config: { title: 'Key dashboards', items: [] },
+        }),
+        View: CollectionBlockView,
+        Build: CollectionBlockBuild,
     },
     {
         type: 'markdown',

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useCollectionContent.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useCollectionContent.ts
@@ -1,0 +1,34 @@
+import {
+    type ApiContentResponse,
+    type ApiError,
+    type SummaryContent,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+
+const getContentByUuids = async (projectUuid: string, uuids: string[]) => {
+    const params = new URLSearchParams();
+    params.append('projectUuids', projectUuid);
+    uuids.forEach((uuid) => params.append('uuids', uuid));
+    params.append('pageSize', String(Math.max(uuids.length, 10)));
+    return lightdashApi<ApiContentResponse['results']>({
+        version: 'v2',
+        url: `/content?${params.toString()}`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+// Server-side access filtering: inaccessible or deleted refs are simply absent
+export const useCollectionContent = (projectUuid: string, uuids: string[]) =>
+    useQuery<SummaryContent[], ApiError>({
+        enabled: uuids.length > 0,
+        queryKey: ['homepage_collection_content', projectUuid, ...uuids],
+        queryFn: async () => {
+            const results = await getContentByUuids(projectUuid, uuids);
+            const byUuid = new Map(
+                results.data.map((content) => [content.uuid, content]),
+            );
+            return uuids.flatMap((uuid) => byUuid.get(uuid) ?? []);
+        },
+    });

--- a/packages/frontend/src/hooks/useContent.ts
+++ b/packages/frontend/src/hooks/useContent.ts
@@ -25,6 +25,7 @@ import useToaster from './toaster/useToaster';
 export type ContentArgs = {
     projectUuids: string[];
     spaceUuids?: string[];
+    uuids?: string[];
     contentTypes?: ContentType[];
     pageSize?: number;
     page?: number;


### PR DESCRIPTION
## Homepage Builder — collection block (6)

Part of [ZAP-617](https://linear.app/lightdash/issue/ZAP-617) · Stacked on #25529

A "collection" block: a titled, curated set of charts/dashboards, stored as UUID refs and resolved through the access-checked content API at render time.

### Backend: `uuids` filter on `GET /api/v2/content`
- `ContentFilters.uuids` + `whereIn` in all five content configurations (dashboards, dbt charts, SQL charts, spaces, data apps); new `uuids` query param on the controller
- Flows through `ContentService.find`, so results stay intersected with the caller’s accessible projects/spaces — **inaccessible or deleted refs are silently absent** (verified live: a chart uuid from another org returned an empty result)

### Frontend
- `useCollectionContent(projectUuid, uuids)` resolves refs and preserves the config’s order
- View: card grid (ResourceIcon, name, verified check, type · views) linking to `/saved/:uuid` and `/dashboards/:uuid/view`; skeletons while loading; empty collections render nothing
- Build: editable title, remove per card, **Add content** modal (search over `useInfiniteContent`, charts+dashboards, click-to-add, already-added filtered out), **Import pinned items** seeds an empty collection from the project’s pinned list
- Config stores `{contentType, uuid}` refs only — renames never stale the config

### 🐛 Also fixes a real editor bug found while verifying
The builder editor snapshots the draft on mount; it previously seeded from React Query’s **cached** builder response, and the next autosave wrote that stale config over the server draft (reproduced: draft lost blocks). The page now waits for `isFetchedAfterMount` before mounting the editor. (Concurrent-tab editing remains last-write-wins — future slice.)

### Verified live (Playwright)
Added Collection from rail → Import pinned items (3 items) → Add content picker search → added 4th item → publish → `/home` renders the titled card grid with working navigation; DB confirmed refs after each step.

### Regression analysis
- `uuids` param is additive; existing content API consumers unaffected (`ContentController` unit tests + 55 content tests pass).
- Flag off: unchanged. Existing homepage configs unaffected (union widening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ