### PR TITLE
feat(frontend): day-one default homepage with discovery grid

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
@@ -1,0 +1,301 @@
+import {
+    ContentSortByColumns,
+    ContentType,
+    type SummaryContent,
+} from '@lightdash/common';
+import {
+    Anchor,
+    Box,
+    Button,
+    Card,
+    Group,
+    SimpleGrid,
+    Skeleton,
+    Stack,
+    Text,
+    Title,
+} from '@mantine-8/core';
+import {
+    IconChartBar,
+    IconFolder,
+    IconLayoutDashboard,
+    IconTable,
+    type Icon,
+} from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useFavoriteMutation } from '../../../hooks/favorites/useFavoriteMutation';
+import { useFavorites } from '../../../hooks/favorites/useFavorites';
+import { useInfiniteContent } from '../../../hooks/useContent';
+import useApp from '../../../providers/App/useApp';
+import AiSearchBox from '../../components/Home/AiSearchBox';
+import { useAiAgentButtonVisibility } from '../aiCopilot/hooks/useAiAgentsButtonVisibility';
+import { ContentCard } from './blocks/ContentCard';
+
+type DiscoverGroupDefinition = {
+    key: string;
+    label: string;
+    contentType: ContentType;
+    browseUrl: (projectUuid: string) => string;
+};
+
+const DISCOVER_GROUPS: DiscoverGroupDefinition[] = [
+    {
+        key: 'dashboards',
+        label: 'Dashboards',
+        contentType: ContentType.DASHBOARD,
+        browseUrl: (projectUuid) => `/projects/${projectUuid}/dashboards`,
+    },
+    {
+        key: 'charts',
+        label: 'Charts',
+        contentType: ContentType.CHART,
+        browseUrl: (projectUuid) => `/projects/${projectUuid}/saved`,
+    },
+    {
+        key: 'spaces',
+        label: 'Spaces',
+        contentType: ContentType.SPACE,
+        browseUrl: (projectUuid) => `/projects/${projectUuid}/spaces`,
+    },
+];
+
+const useDiscoverContent = (projectUuid: string, contentType: ContentType) =>
+    useInfiniteContent({
+        projectUuids: [projectUuid],
+        contentTypes: [contentType],
+        pageSize: 6,
+        sortBy: ContentSortByColumns.VIEWS,
+        sortDirection: 'desc',
+    });
+
+const GroupSection: FC<{
+    definition: DiscoverGroupDefinition;
+    projectUuid: string;
+    favoriteUuids: Set<string>;
+    onToggleFavorite: (content: SummaryContent) => void;
+}> = ({ definition, projectUuid, favoriteUuids, onToggleFavorite }) => {
+    const { data, isInitialLoading } = useDiscoverContent(
+        projectUuid,
+        definition.contentType,
+    );
+    const items = (data?.pages ?? []).flatMap((page) => page.data);
+    const total = data?.pages[0]?.pagination?.totalResults ?? 0;
+    if (!isInitialLoading && total === 0) return null;
+    return (
+        <Stack gap="xs">
+            <Group gap="xs">
+                <Text size="xs" fw={600} tt="uppercase" c="dimmed">
+                    {definition.label}
+                </Text>
+                <Text size="xs" c="dimmed">
+                    {total}
+                </Text>
+                <Box style={{ flex: 1 }} />
+                <Anchor
+                    component={Link}
+                    to={definition.browseUrl(projectUuid)}
+                    size="xs"
+                    fw={500}
+                >
+                    Browse all
+                </Anchor>
+            </Group>
+            {isInitialLoading ? (
+                <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+                    {[0, 1, 2].map((i) => (
+                        <Skeleton key={i} h={72} radius="md" />
+                    ))}
+                </SimpleGrid>
+            ) : (
+                <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+                    {items.map((content) => (
+                        <ContentCard
+                            key={content.uuid}
+                            content={content}
+                            projectUuid={projectUuid}
+                            star={{
+                                isFavorite: favoriteUuids.has(content.uuid),
+                                onToggle: () => onToggleFavorite(content),
+                            }}
+                        />
+                    ))}
+                </SimpleGrid>
+            )}
+        </Stack>
+    );
+};
+
+const GET_STARTED_CARDS: Array<{
+    icon: Icon;
+    title: string;
+    description: string;
+    url: (projectUuid: string) => string;
+}> = [
+    {
+        icon: IconTable,
+        title: 'Run a query',
+        description: 'Explore your data and answer a business question.',
+        url: (projectUuid) => `/projects/${projectUuid}/tables`,
+    },
+    {
+        icon: IconLayoutDashboard,
+        title: 'Browse dashboards',
+        description: 'See what your team has already built.',
+        url: (projectUuid) => `/projects/${projectUuid}/dashboards`,
+    },
+    {
+        icon: IconFolder,
+        title: 'Browse spaces',
+        description: 'Content organized by team and topic.',
+        url: (projectUuid) => `/projects/${projectUuid}/spaces`,
+    },
+];
+
+type Props = {
+    projectUuid: string;
+    projectName: string;
+};
+
+export const DayOneHomepage: FC<Props> = ({ projectUuid, projectName }) => {
+    const { user } = useApp();
+    const isAiEnabled = useAiAgentButtonVisibility();
+    const { data: favorites } = useFavorites(projectUuid);
+    const { mutate: toggleFavorite } = useFavoriteMutation(projectUuid);
+    const [typeFilter, setTypeFilter] = useState<string | null>(null);
+
+    const favoriteUuids = new Set(
+        (favorites ?? []).map((item) => item.data.uuid),
+    );
+
+    const handleToggleFavorite = (content: SummaryContent) => {
+        toggleFavorite({
+            contentType: content.contentType,
+            contentUuid: content.uuid,
+        });
+    };
+
+    return (
+        <Stack gap="xl">
+            {isAiEnabled ? (
+                <Stack gap="md" align="center" py="lg">
+                    <Title order={1} fw={600} ta="center">
+                        What do you want to know, {user.data?.firstName}?
+                    </Title>
+                    <Text c="dimmed" ta="center">
+                        Ask in plain English — the agent queries your governed
+                        metrics and builds the chart.
+                    </Text>
+                    <Box w="100%" maw={720}>
+                        <AiSearchBox projectUuid={projectUuid} />
+                    </Box>
+                </Stack>
+            ) : (
+                <Stack gap="md">
+                    <Box>
+                        <Title order={2} fw={600}>
+                            Welcome to {projectName}, {user.data?.firstName}
+                        </Title>
+                        <Text c="dimmed" size="sm">
+                            Nothing’s curated here yet — start exploring, or
+                            your data team can build this page.
+                        </Text>
+                    </Box>
+                    <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+                        {GET_STARTED_CARDS.map((card) => (
+                            <Anchor
+                                key={card.title}
+                                component={Link}
+                                to={card.url(projectUuid)}
+                                underline="never"
+                                c="inherit"
+                            >
+                                <Card withBorder p="md" h="100%">
+                                    <Stack gap="xs">
+                                        <MantineIcon
+                                            icon={card.icon}
+                                            size="xl"
+                                        />
+                                        <Text fw={600} size="sm">
+                                            {card.title}
+                                        </Text>
+                                        <Text size="xs" c="dimmed">
+                                            {card.description}
+                                        </Text>
+                                    </Stack>
+                                </Card>
+                            </Anchor>
+                        ))}
+                    </SimpleGrid>
+                </Stack>
+            )}
+
+            <Stack gap="md">
+                <Box>
+                    <Title order={4} fw={600}>
+                        Explore your workspace
+                    </Title>
+                    <Text size="xs" c="dimmed">
+                        Everything the data team has published, grouped by type.
+                        Star anything to keep it handy.
+                    </Text>
+                </Box>
+                <Group gap="xs">
+                    <Button
+                        variant={typeFilter === null ? 'filled' : 'default'}
+                        size="compact-xs"
+                        onClick={() => setTypeFilter(null)}
+                    >
+                        All
+                    </Button>
+                    {DISCOVER_GROUPS.map((definition) => (
+                        <Button
+                            key={definition.key}
+                            variant={
+                                typeFilter === definition.key
+                                    ? 'filled'
+                                    : 'default'
+                            }
+                            size="compact-xs"
+                            leftSection={
+                                <MantineIcon
+                                    icon={
+                                        definition.contentType ===
+                                        ContentType.DASHBOARD
+                                            ? IconLayoutDashboard
+                                            : definition.contentType ===
+                                                ContentType.CHART
+                                              ? IconChartBar
+                                              : IconFolder
+                                    }
+                                />
+                            }
+                            onClick={() =>
+                                setTypeFilter((current) =>
+                                    current === definition.key
+                                        ? null
+                                        : definition.key,
+                                )
+                            }
+                        >
+                            {definition.label}
+                        </Button>
+                    ))}
+                </Group>
+                {DISCOVER_GROUPS.filter(
+                    (definition) =>
+                        typeFilter === null || typeFilter === definition.key,
+                ).map((definition) => (
+                    <GroupSection
+                        key={definition.key}
+                        definition={definition}
+                        projectUuid={projectUuid}
+                        favoriteUuids={favoriteUuids}
+                        onToggleFavorite={handleToggleFavorite}
+                    />
+                ))}
+            </Stack>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -5,11 +5,8 @@ import {
     type SummaryContent,
 } from '@lightdash/common';
 import {
-    ActionIcon,
-    Anchor,
     Box,
     Button,
-    Card,
     Group,
     Loader,
     SimpleGrid,
@@ -17,18 +14,10 @@ import {
     Stack,
     Text,
     TextInput,
-    Tooltip,
 } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine/hooks';
-import {
-    IconCircleCheckFilled,
-    IconEye,
-    IconPin,
-    IconPlus,
-    IconX,
-} from '@tabler/icons-react';
+import { IconPin, IconPlus } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
-import { Link } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
 import { ResourceIcon } from '../../../../components/common/ResourceIcon';
@@ -36,84 +25,14 @@ import { usePinnedItems } from '../../../../hooks/pinning/usePinnedItems';
 import { useInfiniteContent } from '../../../../hooks/useContent';
 import { useProject } from '../../../../hooks/useProject';
 import { useCollectionContent } from '../hooks/useCollectionContent';
+import { ContentCard } from './ContentCard';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
-
-const contentUrl = (projectUuid: string, content: SummaryContent): string =>
-    content.contentType === ContentType.DASHBOARD
-        ? `/projects/${projectUuid}/dashboards/${content.uuid}/view`
-        : `/projects/${projectUuid}/saved/${content.uuid}`;
 
 const toItemRef = (content: SummaryContent): HomepageCollectionItemRef => ({
     contentType:
         content.contentType === ContentType.DASHBOARD ? 'dashboard' : 'chart',
     uuid: content.uuid,
 });
-
-const ContentCard: FC<{
-    content: SummaryContent;
-    projectUuid: string;
-    onRemove?: () => void;
-}> = ({ content, projectUuid, onRemove }) => {
-    const card = (
-        <Card withBorder p="sm" h="100%">
-            <Group gap="sm" wrap="nowrap" align="flex-start">
-                <ResourceIcon item={contentToResourceViewItem(content)} />
-                <Box style={{ flex: 1, minWidth: 0 }}>
-                    <Group gap={4} wrap="nowrap">
-                        <Text size="sm" fw={600} truncate>
-                            {content.name}
-                        </Text>
-                        {content.verification && (
-                            <Tooltip label="Verified by the data team">
-                                <MantineIcon
-                                    icon={IconCircleCheckFilled}
-                                    color="green"
-                                />
-                            </Tooltip>
-                        )}
-                    </Group>
-                    <Group gap={4}>
-                        <Text size="xs" c="dimmed" tt="capitalize">
-                            {content.contentType}
-                        </Text>
-                        <Text size="xs" c="dimmed">
-                            ·
-                        </Text>
-                        <MantineIcon icon={IconEye} color="gray" size="sm" />
-                        <Text size="xs" c="dimmed">
-                            {content.views}
-                        </Text>
-                    </Group>
-                </Box>
-                {onRemove && (
-                    <ActionIcon
-                        variant="subtle"
-                        color="gray"
-                        size="sm"
-                        aria-label={`Remove ${content.name} from collection`}
-                        onClick={(e) => {
-                            e.preventDefault();
-                            onRemove();
-                        }}
-                    >
-                        <MantineIcon icon={IconX} />
-                    </ActionIcon>
-                )}
-            </Group>
-        </Card>
-    );
-    if (onRemove) return card;
-    return (
-        <Anchor
-            component={Link}
-            to={contentUrl(projectUuid, content)}
-            underline="never"
-            c="inherit"
-        >
-            {card}
-        </Anchor>
-    );
-};
 
 const CollectionPickerModal: FC<{
     opened: boolean;

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
@@ -1,0 +1,130 @@
+import {
+    ContentType,
+    contentToResourceViewItem,
+    type SummaryContent,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Anchor,
+    Box,
+    Card,
+    Group,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import {
+    IconCircleCheckFilled,
+    IconEye,
+    IconStar,
+    IconStarFilled,
+    IconX,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import { ResourceIcon } from '../../../../components/common/ResourceIcon';
+
+const contentUrl = (projectUuid: string, content: SummaryContent): string => {
+    switch (content.contentType) {
+        case ContentType.DASHBOARD:
+            return `/projects/${projectUuid}/dashboards/${content.uuid}/view`;
+        case ContentType.SPACE:
+            return `/projects/${projectUuid}/spaces/${content.uuid}`;
+        default:
+            return `/projects/${projectUuid}/saved/${content.uuid}`;
+    }
+};
+
+type Props = {
+    content: SummaryContent;
+    projectUuid: string;
+    onRemove?: () => void;
+    star?: { isFavorite: boolean; onToggle: () => void };
+};
+
+export const ContentCard: FC<Props> = ({
+    content,
+    projectUuid,
+    onRemove,
+    star,
+}) => {
+    const card = (
+        <Card withBorder p="sm" h="100%">
+            <Group gap="sm" wrap="nowrap" align="flex-start">
+                <ResourceIcon item={contentToResourceViewItem(content)} />
+                <Box style={{ flex: 1, minWidth: 0 }}>
+                    <Group gap={4} wrap="nowrap">
+                        <Text size="sm" fw={600} truncate>
+                            {content.name}
+                        </Text>
+                        {content.verification && (
+                            <Tooltip label="Verified by the data team">
+                                <MantineIcon
+                                    icon={IconCircleCheckFilled}
+                                    color="green"
+                                />
+                            </Tooltip>
+                        )}
+                    </Group>
+                    <Group gap={4}>
+                        <Text size="xs" c="dimmed" tt="capitalize">
+                            {content.contentType}
+                        </Text>
+                        <Text size="xs" c="dimmed">
+                            ·
+                        </Text>
+                        <MantineIcon icon={IconEye} color="gray" size="sm" />
+                        <Text size="xs" c="dimmed">
+                            {content.views}
+                        </Text>
+                    </Group>
+                </Box>
+                {star && (
+                    <ActionIcon
+                        variant="subtle"
+                        color={star.isFavorite ? 'yellow' : 'gray'}
+                        size="sm"
+                        aria-label={
+                            star.isFavorite
+                                ? `Remove ${content.name} from favorites`
+                                : `Add ${content.name} to favorites`
+                        }
+                        onClick={(e) => {
+                            e.preventDefault();
+                            star.onToggle();
+                        }}
+                    >
+                        <MantineIcon
+                            icon={star.isFavorite ? IconStarFilled : IconStar}
+                        />
+                    </ActionIcon>
+                )}
+                {onRemove && (
+                    <ActionIcon
+                        variant="subtle"
+                        color="gray"
+                        size="sm"
+                        aria-label={`Remove ${content.name} from collection`}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            onRemove();
+                        }}
+                    >
+                        <MantineIcon icon={IconX} />
+                    </ActionIcon>
+                )}
+            </Group>
+        </Card>
+    );
+    if (onRemove) return card;
+    return (
+        <Anchor
+            component={Link}
+            to={contentUrl(projectUuid, content)}
+            underline="never"
+            c="inherit"
+        >
+            {card}
+        </Anchor>
+    );
+};

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -16,6 +16,7 @@ import PageSpinner from '../components/PageSpinner';
 import PinnedAndFavoritesSection from '../components/PinnedAndFavoritesSection';
 import AiSearchBox from '../ee/components/Home/AiSearchBox';
 import { useAiAgentButtonVisibility } from '../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
+import { DayOneHomepage } from '../ee/features/homepageBuilder/DayOneHomepage';
 import {
     useHomepageBuilderFlag,
     usePublishedHomepage,
@@ -117,6 +118,45 @@ const Home: FC = () => {
                     <PublishedHomepage
                         config={publishedHomepage.data.config}
                         projectUuid={project.data.projectUuid}
+                    />
+                </Stack>
+            </Page>
+        );
+    }
+
+    if (
+        isHomepageBuilderEnabled &&
+        publishedHomepage.data === null &&
+        onboarding.data.ranQuery
+    ) {
+        return (
+            <Page withFixedContent withPaddedContent withFooter>
+                <Stack gap="md">
+                    <Can
+                        I="manage"
+                        this={subject('ProjectHomepage', {
+                            organizationUuid: project.data.organizationUuid,
+                            projectUuid: project.data.projectUuid,
+                        })}
+                    >
+                        <Group justify="flex-end">
+                            <Button
+                                variant="default"
+                                size="xs"
+                                leftSection={<MantineIcon icon={IconEdit} />}
+                                onClick={() =>
+                                    navigate(
+                                        `/projects/${project.data.projectUuid}/homepage-builder`,
+                                    )
+                                }
+                            >
+                                Customize homepage
+                            </Button>
+                        </Group>
+                    </Can>
+                    <DayOneHomepage
+                        projectUuid={project.data.projectUuid}
+                        projectName={project.data.name}
                     />
                 </Stack>
             </Page>


### PR DESCRIPTION
## Homepage Builder — day-1 default homepage (7)

Part of [ZAP-626](https://linear.app/lightdash/issue/ZAP-626) · Stacked on #25533

The built-in default every flag-on workspace sees before anything is curated — per the requirements, this is the feature’s starting point.

### What
- **AI available:** centered "What do you want to know, {name}?" hero with the real `AiSearchBox`
- **AI unavailable:** classic greeting + three get-started cards (Run a query / Browse dashboards / Browse spaces)
- **Both:** "Explore your workspace" — published content grouped by Dashboards / Charts / Spaces (top 6 by views via the v2 content API), per-group counts, type-filter chips, "Browse all" links into existing browse pages, and **star-to-favorite** on every card (existing `user_favorites`)
- `ContentCard` extracted to a shared component (collection block + day-one both use it); gains optional star support and space URLs
- `Home.tsx`: renders when flag on + published homepage resolves to `null` + project has run a query; the never-ran-a-query `OnboardingPanel` is untouched

### Verified live (Playwright)
Unpublished the homepage → `/home` shows the ask-hero + grouped discovery (30 dashboards / 102 charts / 9 spaces, counts from the API); starred a chart → row landed in `user_favorites` + filled star; type-filter chip narrows to one group; republished → curated homepage returns.

### Regression analysis
- Flag off: today’s home untouched (branch never reached).
- Flag on + published homepage: unchanged (published branch takes precedence).
- Content queries are the existing access-filtered v2 content API — no new data exposure.
- Non-AI variant is a structural fork of the same component; exercised via the `isAiEnabled` flag (not driveable in this dev env where AI is on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ