### PR TITLE
feat: render each dashboard tab as its own page in PDF exports (opt-in)

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -173,6 +173,7 @@
         "passport-openidconnect": "0.1.1",
         "passport-slack-oauth2": "1.2.0",
         "passport-strategy": "1.0.0",
+        "pdf-lib": "1.17.1",
         "pg": "8.13.1",
         "pg-connection-string": "2.7.0",
         "pgsql-ast-parser": "12.0.2",

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1242,6 +1242,7 @@ export type SchedulerNotificationJobEvent = BaseTrack & {
         type: 'slack' | 'email' | 'gsheets' | 'msteams' | 'googlechat';
         format?: SchedulerFormat;
         withPdf?: boolean;
+        pdfPageCount?: number;
         sendNow: boolean;
         isThresholdAlert?: boolean;
         targetCount?: number;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10763,7 +10763,10 @@ const models: TsoaRoute.Models = {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
-            nestedProperties: { withPdf: { dataType: 'boolean' } },
+            nestedProperties: {
+                pagePerTab: { dataType: 'boolean' },
+                withPdf: { dataType: 'boolean' },
+            },
             validators: {},
         },
     },
@@ -10783,18 +10786,13 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Record_string.never_': {
+    SchedulerPdfOptions: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
-            nestedProperties: {},
+            nestedProperties: { pagePerTab: { dataType: 'boolean' } },
             validators: {},
         },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerPdfOptions: {
-        dataType: 'refAlias',
-        type: { ref: 'Record_string.never_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SchedulerOptions: {
@@ -15069,6 +15067,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['resolveUrl'] },
                 { dataType: 'enum', enums: ['editContent'] },
                 { dataType: 'enum', enums: ['createContent'] },
+                { dataType: 'enum', enums: ['createScheduledDelivery'] },
                 { dataType: 'enum', enums: ['runContentQuery'] },
                 { dataType: 'enum', enums: ['improveContext'] },
                 { dataType: 'enum', enums: ['listProjects'] },
@@ -15326,6 +15325,33 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
+                                                                                                joinedTables:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
                                                                                                 searchRank:
                                                                                                     {
                                                                                                         dataType:
@@ -15426,33 +15452,6 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 label: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -15519,6 +15518,21 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                error: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'string',
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
                                                                                 pagination:
                                                                                     {
                                                                                         dataType:
@@ -15561,21 +15575,6 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                error: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'string',
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
                                                                                 status: {
                                                                                     dataType:
                                                                                         'union',
@@ -15855,6 +15854,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -15863,10 +15881,10 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                isFromJoinedTable:
+                                                                                fieldValueType:
                                                                                     {
                                                                                         dataType:
-                                                                                            'boolean',
+                                                                                            'string',
                                                                                         required: true,
                                                                                     },
                                                                                 caseSensitiveFilters:
@@ -15899,10 +15917,10 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldValueType:
+                                                                                isFromJoinedTable:
                                                                                     {
                                                                                         dataType:
-                                                                                            'string',
+                                                                                            'boolean',
                                                                                         required: true,
                                                                                     },
                                                                                 fieldFilterType:
@@ -15965,37 +15983,18 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                table: {
+                                                                                name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                name: {
+                                                                                table: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
                                                                             },
                                                                     },
-                                                                    required: true,
-                                                                },
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 explore: {
@@ -16080,6 +16079,12 @@ const models: TsoaRoute.Models = {
                                                                                             },
                                                                                         ],
                                                                                 },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                             joinedTables:
                                                                                 {
                                                                                     dataType:
@@ -16088,12 +16093,6 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'string',
                                                                                     },
-                                                                                    required: true,
-                                                                                },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
                                                                                     required: true,
                                                                                 },
                                                                             label: {
@@ -16137,17 +16136,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -16433,18 +16432,6 @@ const models: TsoaRoute.Models = {
                                                                                 ],
                                                                             required: true,
                                                                         },
-                                                                        isPrimary:
-                                                                            {
-                                                                                dataType:
-                                                                                    'boolean',
-                                                                                required: true,
-                                                                            },
-                                                                        projectDbtSourceUuid:
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
                                                                         repository:
                                                                             {
                                                                                 dataType:
@@ -16463,6 +16450,18 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         },
                                                                                     ],
+                                                                                required: true,
+                                                                            },
+                                                                        isPrimary:
+                                                                            {
+                                                                                dataType:
+                                                                                    'boolean',
+                                                                                required: true,
+                                                                            },
+                                                                        projectDbtSourceUuid:
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
                                                                                 required: true,
                                                                             },
                                                                         name: {
@@ -16487,6 +16486,77 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'union',
                                                     subSchemas: [
                                                         { dataType: 'boolean' },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
+                                                steps: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'array',
+                                                            array: {
+                                                                dataType:
+                                                                    'nestedObjectLiteral',
+                                                                nestedProperties:
+                                                                    {
+                                                                        kind: {
+                                                                            dataType:
+                                                                                'union',
+                                                                            subSchemas:
+                                                                                [
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'read',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'edit',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'compile',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'stage',
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
+                                                                    },
+                                                            },
+                                                        },
                                                         {
                                                             dataType: 'enum',
                                                             enums: [null],
@@ -16574,77 +16644,6 @@ const models: TsoaRoute.Models = {
                                                         },
                                                     ],
                                                 },
-                                                steps: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'array',
-                                                            array: {
-                                                                dataType:
-                                                                    'nestedObjectLiteral',
-                                                                nestedProperties:
-                                                                    {
-                                                                        kind: {
-                                                                            dataType:
-                                                                                'union',
-                                                                            subSchemas:
-                                                                                [
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'read',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'compile',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'stage',
-                                                                                        ],
-                                                                                    },
-                                                                                ],
-                                                                            required: true,
-                                                                        },
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
-                                                                    },
-                                                            },
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
-                                                        },
-                                                    ],
-                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -16676,12 +16675,6 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
-                                                                'unsupported_source_control',
-                                                            ],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [
                                                                 'github_not_installed',
                                                             ],
                                                         },
@@ -16689,6 +16682,12 @@ const models: TsoaRoute.Models = {
                                                             dataType: 'enum',
                                                             enums: [
                                                                 'gitlab_not_installed',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
+                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -16835,11 +16834,11 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -23451,6 +23450,15 @@ const models: TsoaRoute.Models = {
     ApiAiDeepResearchRunResponse: {
         dataType: 'refAlias',
         type: { ref: 'ApiSuccess_AiDeepResearchRun_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.never_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiDeepResearchPhase: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -12161,6 +12161,9 @@
             },
             "SchedulerImageOptions": {
                 "properties": {
+                    "pagePerTab": {
+                        "type": "boolean"
+                    },
                     "withPdf": {
                         "type": "boolean"
                     }
@@ -12193,13 +12196,13 @@
                 ],
                 "type": "object"
             },
-            "Record_string.never_": {
-                "properties": {},
-                "type": "object",
-                "description": "Construct a type with a set of properties K of type T"
-            },
             "SchedulerPdfOptions": {
-                "$ref": "#/components/schemas/Record_string.never_"
+                "properties": {
+                    "pagePerTab": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
             },
             "SchedulerOptions": {
                 "anyOf": [
@@ -16722,6 +16725,7 @@
                     "resolveUrl",
                     "editContent",
                     "createContent",
+                    "createScheduledDelivery",
                     "runContentQuery",
                     "improveContext",
                     "listProjects",
@@ -16820,6 +16824,13 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "joinedTables": {
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array",
+                                                                            "nullable": true
+                                                                        },
                                                                         "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
@@ -16859,13 +16870,6 @@
                                                                                 "type": "object"
                                                                             },
                                                                             "type": "array"
-                                                                        },
-                                                                        "joinedTables": {
-                                                                            "items": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "type": "array",
-                                                                            "nullable": true
                                                                         },
                                                                         "label": {
                                                                             "type": "string"
@@ -16909,6 +16913,9 @@
                                                             "searchQueries": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "error": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "pagination": {
                                                                             "properties": {
                                                                                 "totalPageCount": {
@@ -16935,9 +16942,6 @@
                                                                                 "page"
                                                                             ],
                                                                             "type": "object"
-                                                                        },
-                                                                        "error": {
-                                                                            "type": "string"
                                                                         },
                                                                         "status": {
                                                                             "type": "string",
@@ -17082,11 +17086,15 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
                                                                                 },
                                                                                 "caseSensitiveFilters": {
                                                                                     "type": "string",
@@ -17096,8 +17104,8 @@
                                                                                         "not_applicable"
                                                                                     ]
                                                                                 },
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
                                                                                 },
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
@@ -17119,32 +17127,28 @@
                                                                                 "fieldId": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "table": {
+                                                                                "name": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "name": {
+                                                                                "table": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "isFromJoinedTable",
-                                                                                "caseSensitiveFilters",
                                                                                 "fieldValueType",
+                                                                                "caseSensitiveFilters",
+                                                                                "isFromJoinedTable",
                                                                                 "fieldFilterType",
                                                                                 "fieldType",
                                                                                 "description",
                                                                                 "label",
                                                                                 "fieldId",
-                                                                                "table",
-                                                                                "name"
+                                                                                "name",
+                                                                                "table"
                                                                             ],
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
-                                                                    },
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
                                                                     },
                                                                     "explore": {
                                                                         "properties": {
@@ -17183,14 +17187,14 @@
                                                                                 },
                                                                                 "type": "array"
                                                                             },
+                                                                            "baseTable": {
+                                                                                "type": "string"
+                                                                            },
                                                                             "joinedTables": {
                                                                                 "items": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "type": "array"
-                                                                            },
-                                                                            "baseTable": {
-                                                                                "type": "string"
                                                                             },
                                                                             "label": {
                                                                                 "type": "string"
@@ -17200,8 +17204,8 @@
                                                                             }
                                                                         },
                                                                         "required": [
-                                                                            "joinedTables",
                                                                             "baseTable",
+                                                                            "joinedTables",
                                                                             "label",
                                                                             "name"
                                                                         ],
@@ -17216,8 +17220,8 @@
                                                                     }
                                                                 },
                                                                 "required": [
-                                                                    "fields",
                                                                     "rationale",
+                                                                    "fields",
                                                                     "explore",
                                                                     "status"
                                                                 ],
@@ -17231,10 +17235,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -17242,8 +17246,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "exploreLabel",
                                                                                 "reason",
+                                                                                "exploreLabel",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -17382,15 +17386,15 @@
                                                                     "type": "string",
                                                                     "nullable": true
                                                                 },
+                                                                "repository": {
+                                                                    "type": "string",
+                                                                    "nullable": true
+                                                                },
                                                                 "isPrimary": {
                                                                     "type": "boolean"
                                                                 },
                                                                 "projectDbtSourceUuid": {
                                                                     "type": "string"
-                                                                },
-                                                                "repository": {
-                                                                    "type": "string",
-                                                                    "nullable": true
                                                                 },
                                                                 "name": {
                                                                     "type": "string"
@@ -17399,9 +17403,9 @@
                                                             "required": [
                                                                 "projectSubPath",
                                                                 "branch",
+                                                                "repository",
                                                                 "isPrimary",
                                                                 "projectDbtSourceUuid",
-                                                                "repository",
                                                                 "name"
                                                             ],
                                                             "type": "object"
@@ -17411,6 +17415,32 @@
                                                     },
                                                     "needsDbtSourceSelection": {
                                                         "type": "boolean",
+                                                        "nullable": true
+                                                    },
+                                                    "steps": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "kind": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "search",
+                                                                        "read",
+                                                                        "edit",
+                                                                        "compile",
+                                                                        "stage"
+                                                                    ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kind",
+                                                                "label"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
                                                         "nullable": true
                                                     },
                                                     "previewUrl": {
@@ -17440,32 +17470,6 @@
                                                         ],
                                                         "nullable": true
                                                     },
-                                                    "steps": {
-                                                        "items": {
-                                                            "properties": {
-                                                                "kind": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "search",
-                                                                        "read",
-                                                                        "edit",
-                                                                        "compile",
-                                                                        "stage"
-                                                                    ]
-                                                                },
-                                                                "label": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "kind",
-                                                                "label"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array",
-                                                        "nullable": true
-                                                    },
                                                     "prUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -17485,9 +17489,9 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "unknown",
-                                                            "unsupported_source_control",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
+                                                            "unsupported_source_control",
                                                             "pull_request_not_open",
                                                             "git_write_permission",
                                                             null
@@ -17551,8 +17555,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "rejected",
                                                             "success",
+                                                            "rejected",
                                                             "timeout"
                                                         ]
                                                     }
@@ -23787,6 +23791,11 @@
             },
             "ApiAiDeepResearchRunResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiDeepResearchRun_"
+            },
+            "Record_string.never_": {
+                "properties": {},
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
             },
             "AiDeepResearchPhase": {
                 "type": "string",
@@ -45905,7 +45914,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3371.3",
+        "version": "0.3375.3",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -601,6 +601,7 @@ export default class SchedulerTask {
         let csvUrl;
         let csvUrls;
         let pdfFile;
+        let pdfPageCount: number | undefined;
         let failures: PartialFailure[] | undefined;
         let deliveryQueries: SchedulerDeliveryQuery[] | undefined;
 
@@ -675,12 +676,18 @@ export default class SchedulerTask {
                     )
                         ? scheduler.options
                         : undefined;
+                    const imagePagePerTabPdf =
+                        dashboardUuid !== null &&
+                        imageOptions?.withPdf === true &&
+                        imageOptions?.pagePerTab === true;
                     const unfurlImage = await this.unfurlService.unfurlImage({
                         url: minimalRenderUrl.href,
                         lightdashPage: pageType,
                         imageId,
                         authUserUuid: userUuid,
-                        withPdf: imageOptions?.withPdf,
+                        withPdf: imagePagePerTabPdf
+                            ? false
+                            : imageOptions?.withPdf,
                         gridWidth:
                             isDashboardScheduler(scheduler) &&
                             scheduler.customViewportWidth
@@ -700,6 +707,30 @@ export default class SchedulerTask {
                     pdfFile = unfurlImage.pdfFile;
                     imageUrl = unfurlImage.imageUrl;
                     imageS3Key = `${imageId}.png`;
+
+                    if (imagePagePerTabPdf && dashboardUuid) {
+                        const perTabResult =
+                            await this.unfurlService.unfurlPdfPerTab({
+                                minimalUrl: minimalRenderUrl.href,
+                                dashboardUuid,
+                                imageId,
+                                authUserUuid: userUuid,
+                                gridWidth:
+                                    isDashboardScheduler(scheduler) &&
+                                    scheduler.customViewportWidth
+                                        ? scheduler.customViewportWidth
+                                        : undefined,
+                                context: ScreenshotContext.SCHEDULED_DELIVERY,
+                                contextId: jobId,
+                                selectedTabs,
+                                sendNowSchedulerDashboardFilters:
+                                    exportOptions?.dashboardFilters,
+                                sendNowSchedulerFilters,
+                                sendNowSchedulerParameters,
+                            });
+                        pdfFile = perTabResult.pdfFile;
+                        pdfPageCount = perTabResult.pdfPageCount;
+                    }
 
                     if (this.fileStorageClient.isEnabled() && imageUrl) {
                         imageUrl =
@@ -736,29 +767,58 @@ export default class SchedulerTask {
             case SchedulerFormat.PDF:
                 try {
                     const pdfId = `pdf-notification-${nanoid()}`;
-                    const unfurlPdf = await this.unfurlService.unfurlImage({
-                        url: minimalRenderUrl.href,
-                        lightdashPage: pageType,
-                        imageId: pdfId,
-                        authUserUuid: userUuid,
-                        outputFormat: 'pdf',
-                        gridWidth:
-                            isDashboardScheduler(scheduler) &&
-                            scheduler.customViewportWidth
-                                ? scheduler.customViewportWidth
-                                : undefined,
-                        context: ScreenshotContext.SCHEDULED_DELIVERY,
-                        contextId: jobId,
-                        selectedTabs,
-                        sendNowSchedulerDashboardFilters:
-                            exportOptions?.dashboardFilters,
-                        sendNowSchedulerFilters,
-                        sendNowSchedulerParameters,
-                    });
-                    if (!unfurlPdf.pdfFile) {
-                        throw new Error('Unable to generate PDF');
+                    const pagePerTab =
+                        dashboardUuid !== null &&
+                        'pagePerTab' in options &&
+                        options.pagePerTab === true;
+
+                    if (pagePerTab && dashboardUuid) {
+                        const perTabResult =
+                            await this.unfurlService.unfurlPdfPerTab({
+                                minimalUrl: minimalRenderUrl.href,
+                                dashboardUuid,
+                                imageId: pdfId,
+                                authUserUuid: userUuid,
+                                gridWidth:
+                                    isDashboardScheduler(scheduler) &&
+                                    scheduler.customViewportWidth
+                                        ? scheduler.customViewportWidth
+                                        : undefined,
+                                context: ScreenshotContext.SCHEDULED_DELIVERY,
+                                contextId: jobId,
+                                selectedTabs,
+                                sendNowSchedulerDashboardFilters:
+                                    exportOptions?.dashboardFilters,
+                                sendNowSchedulerFilters,
+                                sendNowSchedulerParameters,
+                            });
+                        pdfFile = perTabResult.pdfFile;
+                        pdfPageCount = perTabResult.pdfPageCount;
+                    } else {
+                        const unfurlPdf = await this.unfurlService.unfurlImage({
+                            url: minimalRenderUrl.href,
+                            lightdashPage: pageType,
+                            imageId: pdfId,
+                            authUserUuid: userUuid,
+                            outputFormat: 'pdf',
+                            gridWidth:
+                                isDashboardScheduler(scheduler) &&
+                                scheduler.customViewportWidth
+                                    ? scheduler.customViewportWidth
+                                    : undefined,
+                            context: ScreenshotContext.SCHEDULED_DELIVERY,
+                            contextId: jobId,
+                            selectedTabs,
+                            sendNowSchedulerDashboardFilters:
+                                exportOptions?.dashboardFilters,
+                            sendNowSchedulerFilters,
+                            sendNowSchedulerParameters,
+                        });
+                        if (!unfurlPdf.pdfFile) {
+                            throw new Error('Unable to generate PDF');
+                        }
+                        pdfFile = unfurlPdf.pdfFile;
                     }
-                    pdfFile = unfurlPdf.pdfFile;
                 } catch (error) {
                     if (this.slackClient.isEnabled && isFinalAttempt) {
                         await this.slackClient.postMessageToNotificationChannel(
@@ -1292,6 +1352,7 @@ export default class SchedulerTask {
             csvUrl,
             csvUrls,
             pdfFile,
+            pdfPageCount,
             failures,
             deliveryQueries,
         };
@@ -1386,6 +1447,7 @@ export default class SchedulerTask {
                 csvUrl,
                 csvUrls,
                 pdfFile,
+                pdfPageCount,
                 failures,
             } = notificationPageData;
 
@@ -1594,6 +1656,7 @@ export default class SchedulerTask {
                     groupId: notification.jobGroup,
                     type: 'slack',
                     format,
+                    pdfPageCount: pdfFile ? pdfPageCount : undefined,
                     ...getSchedulerResourceTypeAndId(scheduler),
                     sendNow: schedulerUuid === undefined,
                     isThresholdAlert: scheduler.thresholds !== undefined,
@@ -1765,6 +1828,7 @@ export default class SchedulerTask {
                 csvUrl,
                 csvUrls,
                 pdfFile,
+                pdfPageCount,
                 failures,
             } = notificationPageData;
 
@@ -1856,6 +1920,7 @@ export default class SchedulerTask {
                     groupId: notification.jobGroup,
                     type: 'msteams',
                     format,
+                    pdfPageCount: pdfFile ? pdfPageCount : undefined,
                     ...getSchedulerResourceTypeAndId(scheduler),
                     sendNow: schedulerUuid === undefined,
                     isThresholdAlert: scheduler.thresholds !== undefined,
@@ -2907,6 +2972,7 @@ export default class SchedulerTask {
                 csvUrl,
                 csvUrls,
                 pdfFile,
+                pdfPageCount,
                 failures,
             } = notificationPageData;
 
@@ -3099,6 +3165,7 @@ export default class SchedulerTask {
                     type: 'email',
                     format,
                     withPdf: pdfFile !== undefined,
+                    pdfPageCount: pdfFile ? pdfPageCount : undefined,
                     ...getSchedulerResourceTypeAndId(scheduler),
                     sendNow: schedulerUuid === undefined,
                     isThresholdAlert: scheduler.thresholds !== undefined,

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -6354,6 +6354,7 @@ export default class SchedulerTask {
                 csvUrl,
                 csvUrls,
                 pdfFile,
+                pdfPageCount,
                 failures,
             } = notificationPageData;
 
@@ -6445,6 +6446,7 @@ export default class SchedulerTask {
                     groupId: notification.jobGroup,
                     type: 'googlechat',
                     format,
+                    pdfPageCount: pdfFile ? pdfPageCount : undefined,
                     ...getSchedulerResourceTypeAndId(scheduler),
                     sendNow: schedulerUuid === undefined,
                     isThresholdAlert: scheduler.thresholds !== undefined,

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -19,6 +19,7 @@ import {
     ParameterError,
     QueryHistoryStatus,
     RequestMethod,
+    resolveExportTabs,
     SCREENSHOT_SELECTORS,
     ScreenshotError,
     SessionStorageKeys,
@@ -29,6 +30,7 @@ import {
     validateSelectedTabs,
     type DashboardFilterRule,
     type DashboardFilters,
+    type DashboardTab,
     type ParametersValuesMap,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
@@ -68,6 +70,7 @@ import { getAuthenticationToken } from '../../routers/headlessBrowser';
 import { traceSpan } from '../../tracing/tracing';
 import { BaseService } from '../BaseService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import { mergePdfBuffers } from './pdfMerge';
 
 const uuid = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
 const uuidRegex = new RegExp(uuid, 'g');
@@ -712,6 +715,136 @@ export class UnfurlService extends BaseService {
             imageUrl,
             pdfFile,
         };
+    }
+
+    async unfurlPdfPerTab({
+        minimalUrl,
+        dashboardUuid,
+        imageId,
+        authUserUuid,
+        gridWidth,
+        context,
+        contextId,
+        selectedTabs,
+        sendNowSchedulerDashboardFilters,
+        sendNowSchedulerFilters,
+        sendNowSchedulerParameters,
+    }: {
+        minimalUrl: string;
+        dashboardUuid: string;
+        imageId: string;
+        authUserUuid: string;
+        gridWidth: number | undefined;
+        context: ScreenshotContext;
+        contextId?: unknown;
+        selectedTabs: string[] | null;
+        sendNowSchedulerDashboardFilters?: DashboardFilters;
+        sendNowSchedulerFilters?: DashboardFilterRule[];
+        sendNowSchedulerParameters?: ParametersValuesMap;
+    }): Promise<{
+        pdfFile: { source: string; fileName: string };
+        pdfPageCount: number;
+    }> {
+        return Sentry.startSpan(
+            {
+                op: 'unfurl.pdf_per_tab',
+                name: 'UnfurlService.unfurlPdfPerTab',
+            },
+            async (span) => {
+                const dashboard =
+                    await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+                const tabs = resolveExportTabs(dashboard.tabs, selectedTabs);
+                // Stale flag on an untabbed dashboard: behave exactly like today
+                // (single stacked render, no header).
+                const tabRenders: { tab: DashboardTab | null }[] =
+                    dashboard.tabs.length === 0
+                        ? [{ tab: null }]
+                        : tabs.map((tab) => ({ tab }));
+                if (tabRenders.length === 0) {
+                    throw new Error(
+                        `Page-per-tab PDF requested for dashboard ${dashboardUuid} but none of the selected tabs exist`,
+                    );
+                }
+
+                const cookie = await this.getUserCookie(authUserUuid);
+                const pdfBuffers: Buffer[] = [];
+
+                for (const [index, { tab }] of tabRenders.entries()) {
+                    const tabUrl = new URL(minimalUrl);
+                    if (tab) {
+                        // Orphan tiles (tabUuid null) always render on the first page
+                        const tabSelection: (string | null)[] =
+                            index === 0 ? [tab.uuid, null] : [tab.uuid];
+                        tabUrl.searchParams.set(
+                            'selectedTabs',
+                            JSON.stringify(tabSelection),
+                        );
+                        tabUrl.searchParams.set('exportHeader', 'true');
+                    }
+                    const tabSelectedTabs = tab ? [tab.uuid] : selectedTabs;
+
+                    // eslint-disable-next-line no-await-in-loop
+                    const details = await this.unfurlDetails(
+                        tabUrl.href,
+                        tabSelectedTabs,
+                    );
+
+                    // eslint-disable-next-line no-await-in-loop
+                    const result = await this.saveScreenshot({
+                        authUserUuid,
+                        imageId: `${imageId}-tab-${index}`,
+                        cookie,
+                        url: tabUrl.href,
+                        lightdashPage: LightdashPage.DASHBOARD,
+                        chartType: details?.chartType,
+                        organizationUuid: details?.organizationUuid,
+                        gridWidth,
+                        resourceUuid: details?.resourceUuid,
+                        resourceName: details?.title,
+                        chartTileUuids: details?.chartTileUuids,
+                        sqlChartTileUuids: details?.sqlChartTileUuids,
+                        loomTileUuids: details?.loomTileUuids,
+                        context,
+                        contextId,
+                        selectedTabs: tabSelectedTabs,
+                        sendNowSchedulerDashboardFilters,
+                        sendNowSchedulerFilters,
+                        sendNowSchedulerParameters,
+                        outputFormat: 'pdf',
+                        withPdf: false,
+                    });
+                    if (!result?.pdfBuffer) {
+                        throw new Error(
+                            `Unable to render PDF page for ${
+                                tab ? `tab "${tab.name}" of ` : ''
+                            }dashboard "${dashboard.name}"`,
+                        );
+                    }
+                    pdfBuffers.push(result.pdfBuffer);
+                }
+
+                const merged = await mergePdfBuffers(
+                    pdfBuffers,
+                    dashboard.name,
+                );
+                const pdfFile = await this.uploadPdf(
+                    imageId,
+                    merged,
+                    dashboard.name,
+                );
+
+                span.setAttributes({
+                    tabsCount: tabs.length,
+                    pdfPageCount: pdfBuffers.length,
+                    pagePerTab: true,
+                });
+                this.logger.info(
+                    `UnfurlService unfurlPdfPerTab rendered ${pdfBuffers.length} pages for dashboard ${dashboardUuid} - unfurlId: ${imageId}`,
+                );
+
+                return { pdfFile, pdfPageCount: pdfBuffers.length };
+            },
+        );
     }
 
     async exportDashboard(

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -12,6 +12,7 @@ import {
     isDashboardChartTileType,
     isDashboardSqlChartTile,
     isTileInSelectedTabs,
+    isTileInSelectedTabsStrict,
     LightdashMode,
     LightdashPage,
     LightdashRequestMethodHeader,
@@ -745,7 +746,7 @@ export class UnfurlService extends BaseService {
         pdfFile: { source: string; fileName: string };
         pdfPageCount: number;
     }> {
-        return Sentry.startSpan(
+        return traceSpan(
             {
                 op: 'unfurl.pdf_per_tab',
                 name: 'UnfurlService.unfurlPdfPerTab',
@@ -761,7 +762,7 @@ export class UnfurlService extends BaseService {
                         ? [{ tab: null }]
                         : tabs.map((tab) => ({ tab }));
                 if (tabRenders.length === 0) {
-                    throw new Error(
+                    throw new ParameterError(
                         `Page-per-tab PDF requested for dashboard ${dashboardUuid} but none of the selected tabs exist`,
                     );
                 }
@@ -771,6 +772,14 @@ export class UnfurlService extends BaseService {
 
                 for (const [index, { tab }] of tabRenders.entries()) {
                     const tabUrl = new URL(minimalUrl);
+                    // Tile sets the screenshot waits on (e.g. Loom tiles) must
+                    // match what the page actually renders, so non-first pages
+                    // don't block on orphan tiles that only appear on page one.
+                    let strictTileUuids: {
+                        chartTileUuids: (string | null)[];
+                        sqlChartTileUuids: (string | null)[];
+                        loomTileUuids: (string | null)[];
+                    } | null = null;
                     if (tab) {
                         // Orphan tiles (tabUuid null) always render on the first page
                         const tabSelection: (string | null)[] =
@@ -780,6 +789,23 @@ export class UnfurlService extends BaseService {
                             JSON.stringify(tabSelection),
                         );
                         tabUrl.searchParams.set('exportHeader', 'true');
+
+                        const renderedTiles = dashboard.tiles.filter((tile) =>
+                            isTileInSelectedTabsStrict(tile, tabSelection),
+                        );
+                        strictTileUuids = {
+                            chartTileUuids: renderedTiles
+                                .filter(isDashboardChartTileType)
+                                .map((t) => t.properties.savedChartUuid),
+                            sqlChartTileUuids: renderedTiles
+                                .filter(isDashboardSqlChartTile)
+                                .map((t) => t.properties.savedSqlUuid),
+                            loomTileUuids: renderedTiles
+                                .filter(
+                                    (t) => t.type === DashboardTileTypes.LOOM,
+                                )
+                                .map((t) => t.uuid),
+                        };
                     }
                     const tabSelectedTabs = tab ? [tab.uuid] : selectedTabs;
 
@@ -801,9 +827,15 @@ export class UnfurlService extends BaseService {
                         gridWidth,
                         resourceUuid: details?.resourceUuid,
                         resourceName: details?.title,
-                        chartTileUuids: details?.chartTileUuids,
-                        sqlChartTileUuids: details?.sqlChartTileUuids,
-                        loomTileUuids: details?.loomTileUuids,
+                        chartTileUuids:
+                            strictTileUuids?.chartTileUuids ??
+                            details?.chartTileUuids,
+                        sqlChartTileUuids:
+                            strictTileUuids?.sqlChartTileUuids ??
+                            details?.sqlChartTileUuids,
+                        loomTileUuids:
+                            strictTileUuids?.loomTileUuids ??
+                            details?.loomTileUuids,
                         context,
                         contextId,
                         selectedTabs: tabSelectedTabs,

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -763,7 +763,7 @@ export class UnfurlService extends BaseService {
                         : tabs.map((tab) => ({ tab }));
                 if (tabRenders.length === 0) {
                     throw new ParameterError(
-                        `Page-per-tab PDF requested for dashboard ${dashboardUuid} but none of the selected tabs exist`,
+                        `Page-per-tab PDF requested for dashboard ${dashboardUuid} but it has no visible or selected tabs to export`,
                     );
                 }
 

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -770,6 +770,14 @@ export class UnfurlService extends BaseService {
                 const cookie = await this.getUserCookie(authUserUuid);
                 const pdfBuffers: Buffer[] = [];
 
+                // Tab-invariant details resolved once against the original
+                // selection, so an empty tab's per-tab tile set never hits
+                // validateSelectedTabs and kills the whole export.
+                const details = await this.unfurlDetails(
+                    minimalUrl,
+                    selectedTabs,
+                );
+
                 for (const [index, { tab }] of tabRenders.entries()) {
                     const tabUrl = new URL(minimalUrl);
                     // Tile sets the screenshot waits on (e.g. Loom tiles) must
@@ -808,12 +816,6 @@ export class UnfurlService extends BaseService {
                         };
                     }
                     const tabSelectedTabs = tab ? [tab.uuid] : selectedTabs;
-
-                    // eslint-disable-next-line no-await-in-loop
-                    const details = await this.unfurlDetails(
-                        tabUrl.href,
-                        tabSelectedTabs,
-                    );
 
                     // eslint-disable-next-line no-await-in-loop
                     const result = await this.saveScreenshot({

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -185,7 +185,7 @@ function cropPdfToClipInternal(
     return Buffer.from(pdfStr + appendix, 'binary');
 }
 
-function cropPdfToClip(
+export function cropPdfToClip(
     buffer: Buffer,
     clip: { x: number; y: number; width: number; height: number },
 ): Buffer {

--- a/packages/backend/src/services/UnfurlService/pdfMerge.test.ts
+++ b/packages/backend/src/services/UnfurlService/pdfMerge.test.ts
@@ -29,10 +29,13 @@ describe('mergePdfBuffers', () => {
         expect(doc.getTitle()).toBe('My dashboard');
     });
 
-    it('returns the single buffer untouched for one page', async () => {
+    it('sets the title on a single-buffer merge', async () => {
         const only = await createPdf(1050, 600);
         const merged = await mergePdfBuffers([only], 'Solo');
-        expect(merged.equals(only)).toBe(true);
+        const doc = await PDFDocument.load(new Uint8Array(merged));
+        expect(doc.getPageCount()).toBe(1);
+        expect(doc.getPage(0).getSize()).toEqual({ width: 1050, height: 600 });
+        expect(doc.getTitle()).toBe('Solo');
     });
 
     it('merges buffers mutated by cropPdfToClip incremental updates', async () => {

--- a/packages/backend/src/services/UnfurlService/pdfMerge.test.ts
+++ b/packages/backend/src/services/UnfurlService/pdfMerge.test.ts
@@ -1,0 +1,58 @@
+import { PDFDocument } from 'pdf-lib';
+import { mergePdfBuffers } from './pdfMerge';
+import { cropPdfToClip } from './UnfurlService';
+
+// Classic xref table (no object streams) — matches Chromium page.pdf output,
+// which is what cropPdfToClip's hand-rolled parser expects.
+const createPdf = async (
+    widthPt: number,
+    heightPt: number,
+): Promise<Buffer> => {
+    const doc = await PDFDocument.create();
+    const page = doc.addPage([widthPt, heightPt]);
+    page.drawText('content', { x: 20, y: heightPt - 40 });
+    return Buffer.from(await doc.save({ useObjectStreams: false }));
+};
+
+describe('mergePdfBuffers', () => {
+    it('merges pages preserving unequal page sizes and sets title', async () => {
+        const short = await createPdf(1050, 600);
+        const tall = await createPdf(1050, 2250);
+        const merged = await mergePdfBuffers([short, tall], 'My dashboard');
+        const doc = await PDFDocument.load(new Uint8Array(merged));
+        expect(doc.getPageCount()).toBe(2);
+        expect(doc.getPage(0).getSize()).toEqual({ width: 1050, height: 600 });
+        expect(doc.getPage(1).getSize()).toEqual({
+            width: 1050,
+            height: 2250,
+        });
+        expect(doc.getTitle()).toBe('My dashboard');
+    });
+
+    it('returns the single buffer untouched for one page', async () => {
+        const only = await createPdf(1050, 600);
+        const merged = await mergePdfBuffers([only], 'Solo');
+        expect(merged.equals(only)).toBe(true);
+    });
+
+    it('merges buffers mutated by cropPdfToClip incremental updates', async () => {
+        // 1050pt x 2250pt == Chromium page.pdf at 1400px x 3000px (px * 0.75)
+        const raw = await createPdf(1050, 2250);
+        const cropped = cropPdfToClip(raw, {
+            x: 0,
+            y: 0,
+            width: 1400,
+            height: 2500,
+        });
+        // Guard: the crop must have actually appended an incremental update —
+        // otherwise this test silently stops covering the integration.
+        expect(cropped.length).toBeGreaterThan(raw.length);
+
+        const merged = await mergePdfBuffers([cropped, cropped], 'Cropped');
+        const doc = await PDFDocument.load(new Uint8Array(merged));
+        expect(doc.getPageCount()).toBe(2);
+        // Cropped MediaBox: 2500px * 0.75 = 1875pt tall
+        expect(doc.getPage(0).getSize().height).toBeCloseTo(1875, 0);
+        expect(doc.getPage(0).getSize().width).toBeCloseTo(1050, 0);
+    });
+});

--- a/packages/backend/src/services/UnfurlService/pdfMerge.test.ts
+++ b/packages/backend/src/services/UnfurlService/pdfMerge.test.ts
@@ -55,4 +55,10 @@ describe('mergePdfBuffers', () => {
         expect(doc.getPage(0).getSize().height).toBeCloseTo(1875, 0);
         expect(doc.getPage(0).getSize().width).toBeCloseTo(1050, 0);
     });
+
+    it('throws on an empty list of buffers', async () => {
+        await expect(mergePdfBuffers([], 'Empty')).rejects.toThrow(
+            'Cannot merge an empty list of PDF buffers',
+        );
+    });
 });

--- a/packages/backend/src/services/UnfurlService/pdfMerge.ts
+++ b/packages/backend/src/services/UnfurlService/pdfMerge.ts
@@ -11,7 +11,6 @@ export const mergePdfBuffers = async (
     if (buffers.length === 0) {
         throw new Error('Cannot merge an empty list of PDF buffers');
     }
-    if (buffers.length === 1) return buffers[0];
 
     const merged = await PDFDocument.create();
     merged.setTitle(title);

--- a/packages/backend/src/services/UnfurlService/pdfMerge.ts
+++ b/packages/backend/src/services/UnfurlService/pdfMerge.ts
@@ -1,0 +1,27 @@
+import { PDFDocument } from 'pdf-lib';
+
+/**
+ * Merges single-page per-tab PDFs into one document, preserving each page's
+ * own size (per-tab auto height). Input buffers may carry cropPdfToClip's
+ * incremental updates; pdf-lib re-serializes them cleanly.
+ */
+export const mergePdfBuffers = async (
+    buffers: Buffer[],
+    title: string,
+): Promise<Buffer> => {
+    if (buffers.length === 0) {
+        throw new Error('Cannot merge an empty list of PDF buffers');
+    }
+    if (buffers.length === 1) return buffers[0];
+
+    const merged = await PDFDocument.create();
+    merged.setTitle(title);
+    for (const buffer of buffers) {
+        // eslint-disable-next-line no-await-in-loop
+        const doc = await PDFDocument.load(new Uint8Array(buffer));
+        // eslint-disable-next-line no-await-in-loop
+        const pages = await merged.copyPages(doc, doc.getPageIndices());
+        pages.forEach((p) => merged.addPage(p));
+    }
+    return Buffer.from(await merged.save());
+};

--- a/packages/backend/src/services/UnfurlService/pdfMerge.ts
+++ b/packages/backend/src/services/UnfurlService/pdfMerge.ts
@@ -1,9 +1,8 @@
 import { PDFDocument } from 'pdf-lib';
 
 /**
- * Merges single-page per-tab PDFs into one document, preserving each page's
- * own size (per-tab auto height). Input buffers may carry cropPdfToClip's
- * incremental updates; pdf-lib re-serializes them cleanly.
+ * Merges single-page per-tab PDFs into one document, preserving each
+ * page's own size (per-tab auto height).
  */
 export const mergePdfBuffers = async (
     buffers: Buffer[],

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -324,6 +324,7 @@ export * from './utils/dashboard';
 export * from './utils/dbt';
 export * from './utils/dependencyGraph';
 export * from './utils/email';
+export * from './utils/exportTabs';
 export * from './utils/fields';
 export * from './utils/filters';
 export * from './utils/formatting';

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -199,6 +199,142 @@
                 "idempotentHint": false,
                 "readOnlyHint": false
             },
+            "description": "Create a LIVE scheduled delivery that sends a saved chart or dashboard to Slack channels and/or email recipients on a cron schedule. IMPORTANT: before calling this tool, propose the full configuration to the user (name, schedule in plain words, timezone, destinations, format, AI augmentation prompt if any) and wait for their explicit confirmation in the conversation. Requires an existing saved chart or dashboard — if the content only exists in this conversation, create it with createContent first, then schedule the created uuid. On success, share the returned href with the user — the delivery is managed (paused, edited, deleted) from that page.",
+            "inputSchema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                    "aiAugmentationPrompt": {
+                        "description": "Instructions for the AI-written delivery message, regenerated from the delivered data on every send. null = plain delivery without AI augmentation., ",
+                        "type": "string"
+                    },
+                    "cron": {
+                        "description": "5-part cron expression, e.g. \"0 9 * * 1\". Minimum frequency is hourly — sub-hourly minute patterns (e.g. \"*/15\") are rejected.",
+                        "type": "string"
+                    },
+                    "csvOptions": {
+                        "additionalProperties": false,
+                        "description": "Only used when format is \"csv\". null = defaults (formatted, table limit)., ",
+                        "properties": {
+                            "formatted": {
+                                "description": "Apply Lightdash value formatting.",
+                                "type": "boolean"
+                            },
+                            "limit": {
+                                "anyOf": [
+                                    {
+                                        "const": "table",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": "all",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "exclusiveMinimum": 0,
+                                        "type": "integer"
+                                    }
+                                ],
+                                "description": "\"table\" = the chart's own limit, \"all\" = all results, or an explicit row count."
+                            }
+                        },
+                        "required": ["formatted", "limit"],
+                        "type": "object"
+                    },
+                    "enabled": {
+                        "description": "Whether the delivery starts firing immediately. Use true only when the user explicitly confirmed it should go live; when in doubt, create it paused (false) — the user can enable it from the UI.",
+                        "type": "boolean"
+                    },
+                    "format": {
+                        "description": "\"image\" sends a rendered image of the chart/dashboard; \"csv\" sends the results as CSV.",
+                        "enum": ["csv", "image"],
+                        "type": "string"
+                    },
+                    "message": {
+                        "description": "Optional static message included with every delivery. Ignored when aiAugmentationPrompt is set (the AI writes the message instead)., ",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Human-readable delivery name.",
+                        "minLength": 1,
+                        "type": "string"
+                    },
+                    "resourceType": {
+                        "description": "Type of saved content to deliver.",
+                        "enum": ["chart", "dashboard"],
+                        "type": "string"
+                    },
+                    "resourceUuidOrSlug": {
+                        "description": "UUID (preferred) or slug of the saved chart or dashboard to deliver. Use the uuid from createContent/findContent results — slugs are not guaranteed unique.",
+                        "type": "string"
+                    },
+                    "targets": {
+                        "description": "At least one Slack channel or email recipient.",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "channel": {
+                                            "description": "Slack channel ID (preferred, e.g. \"C0123ABCDEF\") or channel name. The Lightdash Slack app must be able to join it.",
+                                            "minLength": 1,
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "const": "slack",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": ["type", "channel"],
+                                    "type": "object"
+                                },
+                                {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "recipient": {
+                                            "description": "Email address of the recipient.",
+                                            "minLength": 3,
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "const": "email",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": ["type", "recipient"],
+                                    "type": "object"
+                                }
+                            ]
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                    },
+                    "timezone": {
+                        "description": "IANA timezone the cron runs in (e.g. \"Europe/London\"). null = project default., ",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "resourceType",
+                    "resourceUuidOrSlug",
+                    "name",
+                    "cron",
+                    "format",
+                    "targets",
+                    "enabled"
+                ],
+                "type": "object"
+            },
+            "name": "create_scheduled_delivery",
+            "outputSchema": null,
+            "title": "Create scheduled delivery"
+        },
+        {
+            "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": false,
+                "readOnlyHint": false
+            },
             "description": "Edit a dashboard or chart by applying a patch to its JSON, then validate before persisting",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -29,6 +29,7 @@ export type SchedulerCsvOptions = {
 
 export type SchedulerImageOptions = {
     withPdf?: boolean;
+    pagePerTab?: boolean;
 };
 
 export type SchedulerGsheetsOptions = {
@@ -38,7 +39,9 @@ export type SchedulerGsheetsOptions = {
     url: string;
     tabName?: string;
 };
-export type SchedulerPdfOptions = Record<string, never>;
+export type SchedulerPdfOptions = {
+    pagePerTab?: boolean;
+};
 export type SchedulerOptions =
     | SchedulerCsvOptions
     | SchedulerImageOptions

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -656,6 +656,7 @@ export type NotificationPayloadBase = {
             source: string;
             fileName: string;
         };
+        pdfPageCount?: number;
         failures?: PartialFailure[];
     };
     scheduler: CreateSchedulerAndTargets;

--- a/packages/common/src/utils/dashboard.test.ts
+++ b/packages/common/src/utils/dashboard.test.ts
@@ -1,6 +1,10 @@
 import { type DashboardTile } from '../types/dashboard';
 import { ParameterError } from '../types/errors';
-import { isTileInSelectedTabs, validateSelectedTabs } from './dashboard';
+import {
+    isTileInSelectedTabs,
+    isTileInSelectedTabsStrict,
+    validateSelectedTabs,
+} from './dashboard';
 
 describe('validateSelectedTabs', () => {
     // Simple mock that focuses on just the tabUuid property
@@ -81,5 +85,43 @@ describe('isTileInSelectedTabs', () => {
     it('excludes non-orphan tiles when selectedTabs is empty', () => {
         expect(isTileInSelectedTabs({ tabUuid: 'tab1' }, [])).toBe(false);
         expect(isTileInSelectedTabs({ tabUuid: null }, [])).toBe(true);
+    });
+});
+
+describe('isTileInSelectedTabsStrict', () => {
+    it('includes a tabbed tile whose tab is in selectedTabs', () => {
+        expect(isTileInSelectedTabsStrict({ tabUuid: 'tab1' }, ['tab1'])).toBe(
+            true,
+        );
+        expect(
+            isTileInSelectedTabsStrict({ tabUuid: 'tab2' }, ['tab1', 'tab2']),
+        ).toBe(true);
+    });
+
+    it('excludes a tabbed tile whose tab is not in selectedTabs', () => {
+        expect(isTileInSelectedTabsStrict({ tabUuid: 'tab3' }, ['tab1'])).toBe(
+            false,
+        );
+        expect(isTileInSelectedTabsStrict({ tabUuid: 'tab1' }, [null])).toBe(
+            false,
+        );
+    });
+
+    it('includes orphan tiles only when selectedTabs contains null', () => {
+        expect(
+            isTileInSelectedTabsStrict({ tabUuid: null }, ['tab1', null]),
+        ).toBe(true);
+        expect(
+            isTileInSelectedTabsStrict({ tabUuid: undefined }, ['tab1', null]),
+        ).toBe(true);
+    });
+
+    it('excludes orphan tiles when selectedTabs does not contain null', () => {
+        expect(isTileInSelectedTabsStrict({ tabUuid: null }, ['tab1'])).toBe(
+            false,
+        );
+        expect(
+            isTileInSelectedTabsStrict({ tabUuid: undefined }, ['tab1']),
+        ).toBe(false);
     });
 });

--- a/packages/common/src/utils/dashboard.ts
+++ b/packages/common/src/utils/dashboard.ts
@@ -34,6 +34,19 @@ export const isTileInSelectedTabs = (
     !selectedTabs || !tile.tabUuid || selectedTabs.includes(tile.tabUuid);
 
 /**
+ * Strict variant used by the per-tab PDF export-header mode: orphan tiles (no
+ * `tabUuid`) render only when `selectedTabs` explicitly contains the `null`
+ * sentinel, not on every page. Tabbed tiles still match by uuid membership.
+ */
+export const isTileInSelectedTabsStrict = (
+    tile: { tabUuid?: string | null },
+    selectedTabs: (string | null)[],
+): boolean =>
+    tile.tabUuid
+        ? selectedTabs.includes(tile.tabUuid)
+        : selectedTabs.includes(null);
+
+/**
  * Validates that selected tabs exist in the dashboard tiles.
  * If selectedTabs is provided and not empty, ensures at least one selected tab exists in dashboard tabs.
  * @param selectedTabs - Array of selected tab UUIDs or null

--- a/packages/common/src/utils/exportTabs.test.ts
+++ b/packages/common/src/utils/exportTabs.test.ts
@@ -34,4 +34,11 @@ describe('resolveExportTabs', () => {
     it('returns empty array for untabbed dashboards', () => {
         expect(resolveExportTabs([], null)).toEqual([]);
     });
+
+    it('does not mutate the input array', () => {
+        const input = [tab('c', 2), tab('a', 0)];
+        const snapshot = [...input];
+        resolveExportTabs(input, null);
+        expect(input).toEqual(snapshot);
+    });
 });

--- a/packages/common/src/utils/exportTabs.test.ts
+++ b/packages/common/src/utils/exportTabs.test.ts
@@ -1,0 +1,37 @@
+import { type DashboardTab } from '../types/dashboard';
+import { resolveExportTabs } from './exportTabs';
+
+const tab = (uuid: string, order: number, hidden?: boolean): DashboardTab => ({
+    uuid,
+    name: `Tab ${uuid}`,
+    order,
+    hidden,
+});
+
+describe('resolveExportTabs', () => {
+    const tabs = [tab('c', 2), tab('a', 0), tab('b', 1, true)];
+
+    it('returns all non-hidden tabs in order when selectedTabs is null', () => {
+        expect(resolveExportTabs(tabs, null).map((t) => t.uuid)).toEqual([
+            'a',
+            'c',
+        ]);
+    });
+
+    it('returns explicitly selected tabs in dashboard order, including hidden', () => {
+        expect(resolveExportTabs(tabs, ['c', 'b']).map((t) => t.uuid)).toEqual([
+            'b',
+            'c',
+        ]);
+    });
+
+    it('ignores selected uuids that no longer exist', () => {
+        expect(
+            resolveExportTabs(tabs, ['a', 'deleted']).map((t) => t.uuid),
+        ).toEqual(['a']);
+    });
+
+    it('returns empty array for untabbed dashboards', () => {
+        expect(resolveExportTabs([], null)).toEqual([]);
+    });
+});

--- a/packages/common/src/utils/exportTabs.ts
+++ b/packages/common/src/utils/exportTabs.ts
@@ -1,0 +1,14 @@
+import { type DashboardTab } from '../types/dashboard';
+
+/**
+ * Resolves which dashboard tabs a per-tab export renders, in dashboard order.
+ * null = "all tabs" → non-hidden only; explicit selection honors hidden tabs.
+ */
+export const resolveExportTabs = (
+    tabs: DashboardTab[],
+    selectedTabs: string[] | null,
+): DashboardTab[] => {
+    const ordered = [...tabs].sort((a, b) => a.order - b.order);
+    if (selectedTabs === null) return ordered.filter((t) => !t.hidden);
+    return ordered.filter((t) => selectedTabs.includes(t.uuid));
+};

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDataFormatSection.tsx
@@ -155,6 +155,18 @@ export const SchedulerDataFormatSection: FC<Props> = ({
                         })}
                     />
                 )}
+                {isDashboardTabsAvailable &&
+                    (format === SchedulerFormat.PDF ||
+                        (format === SchedulerFormat.IMAGE &&
+                            form.values.options.withPdf)) && (
+                        <Checkbox
+                            size="xs"
+                            label="Each tab on its own page (with dashboard and tab title)"
+                            {...form.getInputProps('options.pagePerTab', {
+                                type: 'checkbox',
+                            })}
+                        />
+                    )}
                 {format === SchedulerFormat.CSV && (
                     <Tooltip
                         label="You must have at least one email recipient to attach a file to emails"

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -19,6 +19,7 @@ import {
     type SchedulerAndTargets,
     type SchedulerCsvOptions,
     type SchedulerImageOptions,
+    type SchedulerPdfOptions,
 } from '@lightdash/common';
 import { createFormContext } from '@mantine/form';
 import intersection from 'lodash/intersection';
@@ -35,6 +36,7 @@ export interface SchedulerFormValues {
         limit: Limit;
         customLimit: number;
         withPdf: boolean;
+        pagePerTab: boolean;
         asAttachment: boolean;
         exportPivotedData: boolean;
         xlsxFileLayout: NonNullable<SchedulerCsvOptions['xlsxFileLayout']>;
@@ -75,6 +77,7 @@ export const DEFAULT_VALUES: SchedulerFormValues = {
         limit: Limit.TABLE,
         customLimit: 1,
         withPdf: false,
+        pagePerTab: false,
         asAttachment: false,
         exportPivotedData: true,
         xlsxFileLayout: 'zip',
@@ -152,6 +155,13 @@ export const getFormValuesFromScheduler = (
         formOptions.xlsxFileLayout = options.xlsxFileLayout ?? 'zip';
     } else if (isSchedulerImageOptions(options)) {
         formOptions.withPdf = options.withPdf || false;
+        formOptions.pagePerTab = options.pagePerTab || false;
+    }
+    if (
+        schedulerData.format === SchedulerFormat.PDF &&
+        'pagePerTab' in options
+    ) {
+        formOptions.pagePerTab = options.pagePerTab || false;
     }
 
     const emailTargets: string[] = [];
@@ -227,9 +237,14 @@ export const transformFormValues = (
     } else if (values.format === SchedulerFormat.IMAGE) {
         options = {
             withPdf: values.options.withPdf,
+            pagePerTab: values.options.withPdf
+                ? values.options.pagePerTab
+                : undefined,
         } satisfies SchedulerImageOptions;
     } else if (values.format === SchedulerFormat.PDF) {
-        options = {};
+        options = {
+            pagePerTab: values.options.pagePerTab,
+        } satisfies SchedulerPdfOptions;
     }
 
     const emailTargets = (values.emailTargets || []).map((email: string) => ({

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -11,6 +11,7 @@ import {
     DashboardTileTypes,
     isDashboardScheduler,
     isTileInSelectedTabs,
+    isTileInSelectedTabsStrict,
     SessionStorageKeys,
 } from '@lightdash/common';
 import { Stack, Text, Title } from '@mantine-8/core';
@@ -408,6 +409,15 @@ const MinimalDashboard: FC = () => {
                 // exports surface legacy tiles on the first tab, matching the backend rule in
                 // isTileInSelectedTabs (PROD-2505).
                 if (schedulerTabsSelected) {
+                    // Per-tab PDF export: orphan tiles render only on the page
+                    // whose selection carries the `null` sentinel (the first
+                    // tab), not on every page.
+                    if (showExportHeader) {
+                        return isTileInSelectedTabsStrict(
+                            tile,
+                            schedulerTabsSelected,
+                        );
+                    }
                     return isTileInSelectedTabs(tile, schedulerTabsSelected);
                 }
 
@@ -436,7 +446,13 @@ const MinimalDashboard: FC = () => {
             );
             return tabAIndex - tabBIndex;
         });
-    }, [dashboard?.tiles, schedulerTabsSelected, activeTab, sortedTabs]);
+    }, [
+        dashboard?.tiles,
+        schedulerTabsSelected,
+        showExportHeader,
+        activeTab,
+        sortedTabs,
+    ]);
 
     const layouts = useMemo(() => {
         return {

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -13,6 +13,7 @@ import {
     isTileInSelectedTabs,
     SessionStorageKeys,
 } from '@lightdash/common';
+import { Stack, Text, Title } from '@mantine-8/core';
 import { useSessionStorage } from '@mantine/hooks';
 import { IconLayoutDashboard } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
@@ -64,6 +65,7 @@ type MinimalDashboardContentProps = {
     canNavigateBetweenTabs: boolean;
     tabsWithUrls: TabWithUrls[];
     activeTab: DashboardTab | null;
+    exportHeaderTab: DashboardTab | null;
 };
 
 const renderDashboardTile = (tile: Dashboard['tiles'][number]) => {
@@ -146,6 +148,7 @@ const MinimalDashboardContent: FC<MinimalDashboardContentProps> = ({
     canNavigateBetweenTabs,
     tabsWithUrls,
     activeTab,
+    exportHeaderTab,
 }) => {
     const dashboard = useDashboardContext((c) => c.dashboard);
     const isDashboardLoading = useDashboardContext((c) => c.isDashboardLoading);
@@ -206,46 +209,52 @@ const MinimalDashboardContent: FC<MinimalDashboardContentProps> = ({
                 />
             )}
 
-            {isTabEmpty ? (
-                <SuboptimalState
-                    icon={IconLayoutDashboard}
-                    title="Tab is empty"
-                    mt="40px"
-                />
-            ) : (
-                // Wrapper is the deterministic screenshot/PDF target used by
-                // UnfurlService — it must encompass all grids so multi-tab
-                // exports are captured fully.
-                <div className={DASHBOARD_GRID_CLASS}>
-                    {tabGroups ? (
-                        // Multi-tab export: one grid per tab so each tab
-                        // keeps its own y=0 origin and react-grid-layout's
-                        // vertical compact cannot flow tiles from one tab
-                        // into another tab's empty cells.
-                        tabGroups.map((group) => (
-                            <ResponsiveGridLayout
-                                key={group.key}
-                                {...gridProps}
-                                layouts={group.layouts}
-                            >
-                                {group.tiles.map((tile) => (
-                                    <div key={tile.uuid}>
-                                        {renderDashboardTile(tile)}
-                                    </div>
-                                ))}
-                            </ResponsiveGridLayout>
-                        ))
-                    ) : (
-                        <ResponsiveGridLayout {...gridProps} layouts={layouts}>
-                            {filteredAndSortedDashboardTiles.map((tile) => (
+            {/* Wrapper is the deterministic screenshot/PDF target used by
+                UnfurlService — it must encompass all grids (and the empty
+                state) so multi-tab exports are captured fully. */}
+            <div className={DASHBOARD_GRID_CLASS}>
+                {exportHeaderTab && dashboard && (
+                    <Stack gap={0} p="md">
+                        <Title order={3}>{dashboard.name}</Title>
+                        <Text size="sm" c="ldGray.6">
+                            {exportHeaderTab.name}
+                        </Text>
+                    </Stack>
+                )}
+                {isTabEmpty ? (
+                    <SuboptimalState
+                        icon={IconLayoutDashboard}
+                        title="Tab is empty"
+                        mt="40px"
+                    />
+                ) : tabGroups ? (
+                    // Multi-tab export: one grid per tab so each tab
+                    // keeps its own y=0 origin and react-grid-layout's
+                    // vertical compact cannot flow tiles from one tab
+                    // into another tab's empty cells.
+                    tabGroups.map((group) => (
+                        <ResponsiveGridLayout
+                            key={group.key}
+                            {...gridProps}
+                            layouts={group.layouts}
+                        >
+                            {group.tiles.map((tile) => (
                                 <div key={tile.uuid}>
                                     {renderDashboardTile(tile)}
                                 </div>
                             ))}
                         </ResponsiveGridLayout>
-                    )}
-                </div>
-            )}
+                    ))
+                ) : (
+                    <ResponsiveGridLayout {...gridProps} layouts={layouts}>
+                        {filteredAndSortedDashboardTiles.map((tile) => (
+                            <div key={tile.uuid}>
+                                {renderDashboardTile(tile)}
+                            </div>
+                        ))}
+                    </ResponsiveGridLayout>
+                )}
+            </div>
 
             <ScreenshotProgressIndicator
                 expectedTileUuids={expectedScreenshotTileUuids}
@@ -347,6 +356,20 @@ const MinimalDashboard: FC = () => {
         }
         return undefined;
     }, [schedulerTabs]);
+
+    const showExportHeader = useSearchParams('exportHeader') === 'true';
+
+    // Header renders only for single-tab export renders (per-tab PDF pages).
+    // The orphan-tile marker `null` may accompany the first tab's uuid.
+    const exportHeaderTab = useMemo(() => {
+        if (!showExportHeader || !schedulerTabsSelected || !dashboard)
+            return null;
+        const tabUuids = (schedulerTabsSelected as (string | null)[]).filter(
+            (t): t is string => t !== null,
+        );
+        if (tabUuids.length !== 1) return null;
+        return dashboard.tabs.find((tab) => tab.uuid === tabUuids[0]) ?? null;
+    }, [showExportHeader, schedulerTabsSelected, dashboard]);
 
     const generateTabUrl = useCallback(
         (tabId: string) =>
@@ -542,6 +565,7 @@ const MinimalDashboard: FC = () => {
                 canNavigateBetweenTabs={canNavigateBetweenTabs}
                 tabsWithUrls={tabsWithUrls}
                 activeTab={activeTab}
+                exportHeaderTab={exportHeaderTab}
             />
         </DashboardProvider>
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,6 +525,9 @@ importers:
       passport-strategy:
         specifier: 1.0.0
         version: 1.0.0
+      pdf-lib:
+        specifier: 1.17.1
+        version: 1.17.1
       pg:
         specifier: 8.13.1
         version: 8.13.1
@@ -5714,6 +5717,12 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+
+  '@pdf-lib/upng@1.0.1':
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
   '@peggyjs/from-mem@1.3.5':
     resolution: {integrity: sha512-oRyzXE7nirAn+5yYjCdWQHg3EG2XXcYRoYNOK8Quqnmm+9FyK/2YWVunwudlYl++M3xY+gIAdf0vAYS+p0nKfQ==}
@@ -14116,6 +14125,9 @@ packages:
   pcg@1.0.0:
     resolution: {integrity: sha512-6wjoSJZ4TEJhI0rLDOKd5mOu6TwS4svn9oBaRsD1PCrhlDNLWAaTimWJgBABmIGJxzkI+RbaHJYRLGVf9QFE5Q==}
 
+  pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
+
   peggy@4.2.0:
     resolution: {integrity: sha512-ZjzyJYY8NqW8JOZr2PbS/J0UH/hnfGALxSDsBUVQg5Y/I+ZaPuGeBJ7EclUX2RvWjhlsi4pnuL1C/K/3u+cDeg==}
     engines: {node: '>=18'}
@@ -17711,7 +17723,7 @@ snapshots:
   '@apm-js-collab/tracing-hooks@0.3.1':
     dependencies:
       '@apm-js-collab/code-transformer': 0.8.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -19061,7 +19073,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -19133,7 +19145,7 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -19894,7 +19906,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.27.2
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19918,7 +19930,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -20460,7 +20472,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.15.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -20822,7 +20834,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -21323,7 +21335,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22801,6 +22813,14 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.57.0':
     optional: true
 
+  '@pdf-lib/standard-fonts@1.0.0':
+    dependencies:
+      pako: 1.0.11
+
+  '@pdf-lib/upng@1.0.1':
+    dependencies:
+      pako: 1.0.11
+
   '@peggyjs/from-mem@1.3.5':
     dependencies:
       semver: 7.6.3
@@ -22837,7 +22857,7 @@ snapshots:
 
   '@pm2/pm2-version-check@1.0.4':
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -24651,7 +24671,7 @@ snapshots:
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
@@ -25424,7 +25444,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.1'
@@ -25437,7 +25457,7 @@ snapshots:
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/typescript-estree': 8.43.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/visitor-keys': 8.43.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
       typescript: '@typescript/typescript6@6.0.1'
     transitivePeerDependencies:
@@ -25447,7 +25467,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(@typescript/typescript6@6.0.1)
       '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: '@typescript/typescript6@6.0.1'
     transitivePeerDependencies:
       - supports-color
@@ -25456,7 +25476,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(@typescript/typescript6@6.0.1)
       '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: '@typescript/typescript6@6.0.1'
     transitivePeerDependencies:
       - supports-color
@@ -25465,7 +25485,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -25506,7 +25526,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/utils': 7.18.0(@typescript/typescript6@6.0.1)(eslint@8.57.1)
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
       ts-api-utils: 1.4.3(@typescript/typescript6@6.0.1)
     optionalDependencies:
@@ -25519,7 +25539,7 @@ snapshots:
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/typescript-estree': 8.43.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/utils': 8.43.0(@typescript/typescript6@6.0.1)(eslint@8.57.1)
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
       ts-api-utils: 2.4.0(@typescript/typescript6@6.0.1)
       typescript: '@typescript/typescript6@6.0.1'
@@ -25538,7 +25558,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.3
@@ -25552,7 +25572,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -25569,7 +25589,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.43.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/visitor-keys': 8.43.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -25585,7 +25605,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.56.1(@typescript/typescript6@6.0.1)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.7.3
       tinyglobby: 0.2.15
@@ -25600,7 +25620,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.7.3
       tinyglobby: 0.2.15
@@ -26042,7 +26062,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -26667,7 +26687,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.0
       iconv-lite: 0.7.0
       on-finished: 2.4.1
@@ -27518,7 +27538,7 @@ snapshots:
       '@actions/core': 2.0.3
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       fast-shuffle: 6.1.0
       find-cypress-specs: 1.54.11(@babel/core@7.28.4)
       globby: 11.1.0
@@ -28039,7 +28059,7 @@ snapshots:
 
   docker-modem@5.0.7:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       readable-stream: 3.6.2
       split-ca: 1.0.1
       ssh2: 1.17.0
@@ -28560,7 +28580,7 @@ snapshots:
       '@es-joy/resolve.exports': 1.2.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.5
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint: 8.57.1
       espree: 11.1.0
@@ -28678,7 +28698,7 @@ snapshots:
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -28916,7 +28936,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -29138,7 +29158,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -29152,7 +29172,7 @@ snapshots:
       '@actions/core': 2.0.3
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       find-test-names: 1.29.19(@babel/core@7.28.4)
       minimatch: 10.2.5
       pluralize: 8.0.0
@@ -29176,7 +29196,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.4)
       acorn-walk: 8.2.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       simple-bin-help: 1.8.0
       tinyglobby: 0.2.15
     transitivePeerDependencies:
@@ -29481,7 +29501,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 11.3.2
     transitivePeerDependencies:
       - supports-color
@@ -30023,14 +30043,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -30043,14 +30063,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -30230,7 +30250,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -30525,7 +30545,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.0:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -32141,7 +32161,7 @@ snapshots:
 
   micromark@2.11.4:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -32149,7 +32169,7 @@ snapshots:
   micromark@4.0.1:
     dependencies:
       '@types/debug': 4.1.7
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.2
@@ -32494,7 +32514,7 @@ snapshots:
 
   nock@13.5.1:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -32956,7 +32976,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -32969,7 +32989,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -33141,6 +33161,13 @@ snapshots:
       long: 5.2.3
       ramda: 0.29.0
 
+  pdf-lib@1.17.1:
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
+
   peggy@4.2.0:
     dependencies:
       '@peggyjs/from-mem': 1.3.5
@@ -33275,7 +33302,7 @@ snapshots:
   pm2-sysmonit@1.2.8:
     dependencies:
       async: 3.2.6
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       pidusage: 2.0.21
       systeminformation: 5.31.6
       tx2: 1.0.5
@@ -33297,7 +33324,7 @@ snapshots:
       commander: 2.15.1
       croner: 4.1.97
       dayjs: 1.11.15
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eventemitter2: 6.4.9
       fast-json-patch: 3.1.1
       js-yaml: 4.1.1
@@ -33838,7 +33865,7 @@ snapshots:
   proxy-agent@6.4.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -33851,7 +33878,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -34563,7 +34590,7 @@ snapshots:
 
   require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -34571,7 +34598,7 @@ snapshots:
 
   require-in-the-middle@8.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -34697,7 +34724,7 @@ snapshots:
 
   rollup-plugin-esbuild@6.2.1(esbuild@0.27.7)(rollup@4.60.2):
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       esbuild: 0.27.7
       get-tsconfig: 4.10.1
@@ -34776,7 +34803,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -34925,7 +34952,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -35135,7 +35162,7 @@ snapshots:
       '@kwsites/promise-deferred': 1.1.1
       '@simple-git/args-pathspec': 1.0.3
       '@simple-git/argv-parser': 1.1.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -35247,7 +35274,7 @@ snapshots:
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.7.3
     transitivePeerDependencies:
       - supports-color
@@ -35255,7 +35282,7 @@ snapshots:
   socks-proxy-agent@8.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.7.3
     transitivePeerDependencies:
       - supports-color
@@ -35263,7 +35290,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
@@ -35314,7 +35341,7 @@ snapshots:
   spec-change@1.11.21:
     dependencies:
       arg: 5.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       deep-equal: 2.2.3
       dependency-tree: 11.4.0
       lazy-ass: 2.0.3
@@ -36807,7 +36834,7 @@ snapshots:
       '@volar/typescript': 2.4.23
       '@vue/language-core': 2.2.0(@typescript/typescript6@6.0.1)
       compare-versions: 6.1.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21


### PR DESCRIPTION
## Summary

Adds an opt-in **"Each tab on its own page (with dashboard and tab title)"** option to scheduled-delivery PDF exports. When enabled on a multi-tab dashboard, the delivered PDF renders one native page per tab — each page auto-sized to its tab's content and headed by the dashboard name + tab name — instead of today's single very long page with every tab stacked and no titles.

Applies to both PDF outputs: the native **PDF format** and the **Image + "PDF attachment"** (`withPdf`) variant. Off by default; existing schedulers are untouched (no migration — absent option = current behavior).

## How it works

- **`UnfurlService.unfurlPdfPerTab`** resolves the ordered tab list server-side (`resolveExportTabs`: dashboard `order`, hidden tabs excluded on "all tabs", honored when explicitly selected), renders each tab through the existing single-tab minimal-dashboard pipeline (`page.pdf()` + crop, isolated browser per capture), merges with **pdf-lib** (new backend dep, pure JS, no install scripts), and uploads once.
- **Header** is DOM-rendered by `MinimalDashboard` when `exportHeader=true` — selectable text in the native PDF. Empty tabs render as a header + "Tab is empty" page (the empty state now lives inside the screenshot target so the export can't hang).
- **Orphan tiles** (in no tab) render on page 1 only, via a new strict tile predicate (`isTileInSelectedTabsStrict`) applied only in export-header mode; backend-computed tile sets mirror it so readiness waits can't stall on tiles that never render.
- **Failure semantics**: any tab render failure fails the job (scheduler retry/alerting) — no silent fallback to the stacked layout.
- **Observability**: `traceSpan` around render + merge + upload with `tabsCount` / `pdfPageCount` / `pagePerTab`; `pdfPageCount` added to `scheduler_notification_job.completed` analytics (Slack/Teams/Email/Google Chat).

## Performance

Measured on a 3-tab dashboard (medians of 4 warm runs, local dev):

| Variant | Median wall-clock |
|---|---|
| Stacked (flag off) | 4.45 s |
| Per-tab (flag on) | 9.94 s |

≈ 2.2× for 3 tabs — the per-tab cost is browser connect/navigate/ready-wait repeated per tab (chart query work is equivalent). This is an opt-in async background job, so we ship as-is; browser-context reuse across tabs is the known follow-up optimization if needed. Ops note: a dashboard with N tabs = N sequential isolated browser renders in one worker job (per-render timeouts still apply).

## Verification

- Unit/integration: `resolveExportTabs` (5), `isTileInSelectedTabsStrict` (15), `mergePdfBuffers` incl. merging real `cropPdfToClip` incremental-update buffers with unequal page sizes (4).
- E2E on local dev: 4-tab dashboard → 4-page merged PDF (unequal heights, dashboard-name doc title, headers on every page, empty tab renders); Image+withPdf → exactly one stacked image + one merged PDF; flag-off output unchanged; single-tab + flag → 1-page PDF with header; header-in-crop invariant confirmed (+63 pt page height, unclipped); delivered attachment verified via mailpit + MinIO.

Requested by multiple customers (5 orgs across community/support threads), including enterprise customers sending client-facing filtered dashboard reports.

Closes: PROD-484
Closes: #15726

🤖 Generated with [Claude Code](https://claude.com/claude-code)
