### PR TITLE
feat(cli): rename the selected project

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -51,6 +51,7 @@ import {
     SqlChartAsCode,
     UpdateDefaultUserSpaces,
     UpdateMetadata,
+    UpdateProjectDetails,
     UpdateProjectMember,
     UserWarehouseCredentials,
     VirtualViewAsCode,
@@ -71,6 +72,7 @@ import {
     type CreateDashboardWithCharts,
     type DataTimezonePreviewRequest,
     type DuplicateDashboardParams,
+    type ProjectSummary,
     type Tag,
     type UpdateMultipleDashboards,
     type UpdatePreviewExpirationProjectSettings,
@@ -134,6 +136,32 @@ export class ProjectController extends BaseController {
             results: await this.services
                 .getProjectService()
                 .getProject(projectUuid, req.account!),
+        };
+    }
+
+    /**
+     * Update simple project details without changing its connection configuration
+     * @summary Update project details
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('{projectUuid}/details')
+    @OperationId('UpdateProjectDetails')
+    async updateProjectDetails(
+        @Path() projectUuid: string,
+        @Body() body: UpdateProjectDetails,
+        @Request() req: express.Request,
+    ): Promise<ApiSuccess<ProjectSummary>> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getProjectService()
+                .updateProjectDetails(projectUuid, req.account!, body),
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -32752,6 +32752,52 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ProjectSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                createdByUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                upstreamProjectUuid: { dataType: 'string' },
+                type: { ref: 'ProjectType', required: true },
+                name: { dataType: 'string', required: true },
+                projectUuid: { dataType: 'string', required: true },
+                organizationUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_ProjectSummary_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'ProjectSummary', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateProjectDetails: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiChartListResponse: {
         dataType: 'refAlias',
         type: {
@@ -70919,6 +70965,71 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getProject',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectController_updateProjectDetails: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpdateProjectDetails',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.patch(
+        '/api/v1/projects/:projectUuid/details',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.updateProjectDetails,
+        ),
+
+        async function ProjectController_updateProjectDetails(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectController_updateProjectDetails,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectController>(ProjectController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateProjectDetails',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -33242,6 +33242,59 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "ProjectSummary": {
+                "properties": {
+                    "createdByUserUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "upstreamProjectUuid": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ProjectType"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "createdByUserUuid",
+                    "type",
+                    "name",
+                    "projectUuid",
+                    "organizationUuid"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_ProjectSummary_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/ProjectSummary"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "UpdateProjectDetails": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "ApiChartListResponse": {
                 "properties": {
                     "results": {
@@ -61174,6 +61227,57 @@
                         }
                     }
                 ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/details": {
+            "patch": {
+                "operationId": "UpdateProjectDetails",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccess_ProjectSummary_"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update simple project details without changing its connection configuration",
+                "summary": "Update project details",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateProjectDetails"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/projects/{projectUuid}/charts": {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -45,6 +45,7 @@ import {
     UnexpectedServerError,
     UpdateMetadata,
     UpdateProject,
+    UpdateProjectDetails,
     UpdateQueryTimezoneSettings,
     UpdateSchedulerSettings,
     UpdateVirtualViewPayload,
@@ -766,6 +767,20 @@ export class ProjectModel {
                 data.warehouseConnection,
             );
         });
+    }
+
+    async updateDetails(
+        projectUuid: string,
+        details: UpdateProjectDetails,
+    ): Promise<void> {
+        const updatedProjects = await this.database(ProjectTableName)
+            .where('project_uuid', projectUuid)
+            .update(details)
+            .returning('project_uuid');
+
+        if (updatedProjects.length === 0) {
+            throw new NotFoundError('Project not found');
+        }
     }
 
     async getExpiredPreviewProjects(): Promise<

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -141,6 +141,7 @@ import {
     ProjectGroupAccess,
     ProjectMemberProfile,
     ProjectMemberRole,
+    ProjectSummary,
     ProjectType,
     QueryExecutionContext,
     RegisteredAccount,
@@ -169,6 +170,7 @@ import {
     UpdateDefaultUserSpaces,
     UpdateMetadata,
     UpdateProject,
+    UpdateProjectDetails,
     UpdateProjectMember,
     UpdateQueryTimezoneSettings,
     UpdateSchedulerSettings,
@@ -2998,6 +3000,35 @@ export class ProjectService extends BaseService {
         return {
             jobUuid: job.jobUuid,
         };
+    }
+
+    async updateProjectDetails(
+        projectUuid: string,
+        account: Account,
+        details: UpdateProjectDetails,
+    ): Promise<ProjectSummary> {
+        assertIsAccountWithOrg(account);
+        const updatedDetails = { ...details };
+        if (details.name !== undefined) {
+            const trimmedName = details.name.trim();
+            if (trimmedName.length === 0) {
+                throw new ParameterError('Project name cannot be empty');
+            }
+            updatedDetails.name = trimmedName;
+        }
+        if (Object.keys(updatedDetails).length === 0) {
+            throw new ParameterError('No project details to update');
+        }
+
+        const project = await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(account);
+        if (auditedAbility.cannot('update', subject('Project', project))) {
+            throw new ForbiddenError();
+        }
+
+        await this.projectModel.updateDetails(projectUuid, updatedDetails);
+
+        return { ...project, ...updatedDetails };
     }
 
     /*

--- a/packages/cli/src/handlers/renameProject.ts
+++ b/packages/cli/src/handlers/renameProject.ts
@@ -1,0 +1,57 @@
+import { ParameterError, ProjectSummary } from '@lightdash/common';
+import { LightdashAnalytics } from '../analytics/analytics';
+import { getConfig, setProject } from '../config';
+import GlobalState from '../globalState';
+import { lightdashApi } from './dbt/apiClient';
+
+type RenameProjectOptions = {
+    name: string;
+    verbose: boolean;
+};
+
+export const renameProjectCommand = async (name: string) => {
+    const trimmedName = name.trim();
+    if (trimmedName.length === 0) {
+        throw new ParameterError('Project name cannot be empty');
+    }
+
+    const config = await getConfig();
+    const projectUuid = config.context?.project;
+
+    if (!projectUuid) {
+        throw new Error(
+            'No project set. Use `lightdash config set-project` to select a project.',
+        );
+    }
+
+    const project = await lightdashApi<ProjectSummary>({
+        method: 'PATCH',
+        url: `/api/v1/projects/${projectUuid}/details`,
+        body: JSON.stringify({ name: trimmedName }),
+    });
+
+    await setProject(project.projectUuid, project.name);
+    console.error(`\n  ✅️ Renamed project to: ${project.name}\n`);
+};
+
+export const renameProjectHandler = async (options: RenameProjectOptions) => {
+    const startTime = Date.now();
+    let success = true;
+    GlobalState.setVerbose(options.verbose);
+
+    try {
+        await renameProjectCommand(options.name);
+    } catch (e) {
+        success = false;
+        throw e;
+    } finally {
+        await LightdashAnalytics.track({
+            event: 'command.executed',
+            properties: {
+                command: 'rename-project',
+                durationMs: Date.now() - startTime,
+                success,
+            },
+        });
+    }
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -40,6 +40,7 @@ import {
     stopPreviewHandler,
 } from './handlers/preview';
 import { renameHandler } from './handlers/renameHandler';
+import { renameProjectHandler } from './handlers/renameProject';
 import { runChartHandler } from './handlers/runChart';
 import { setProjectHandler, unsetProjectHandler } from './handlers/setProject';
 import { setWarehouseHandler } from './handlers/setWarehouse';
@@ -281,6 +282,12 @@ configProgram
     .description('Show the currently selected project')
     .option('--verbose', undefined, false)
     .action(getProjectHandler);
+configProgram
+    .command('rename-project')
+    .description('Rename the currently selected project')
+    .requiredOption('--name <name>', 'New project name')
+    .option('--verbose', undefined, false)
+    .action(renameProjectHandler);
 configProgram
     .command('unset-project')
     .description('Clear the currently selected project')

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -271,6 +271,7 @@ export type {
     SslConfiguration,
     TrinoCredentials,
     UpdateProjectDbtSource,
+    UpdateProjectDetails,
     UpdateQueryTimezoneSettings,
     UpdateSchedulerSettings,
     WarehouseCredentials,

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -1110,6 +1110,8 @@ export type ApiProjectResponse = {
     results: Project;
 };
 
+export type UpdateProjectDetails = Partial<Pick<Project, 'name'>>;
+
 export type ApiGetProjectGroupAccesses = {
     status: 'ok';
     results: ProjectGroupAccess[];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-8867

### Description:
Adds `lightdash config rename-project --name "<name>"` to rename the selected project and immediately update local CLI context.
Introduces an authenticated and authorized project details endpoint with a narrow service/model update that validates names without mutating connection settings or triggering compilation.
Updates the generated API routes and OpenAPI specification.

### Example:
```console
$ lightdash config rename-project --name "Analytics"

  ✅️ Renamed project to: Analytics

$ lightdash config get-project

Current project:

  Name: Analytics
  UUID: 00000000-0000-0000-0000-000000000001
```