### PR TITLE
feat(settings): make in-page sub-sections searchable

### DIFF
--- a/packages/frontend/src/hooks/settings/CLAUDE.md
+++ b/packages/frontend/src/hooks/settings/CLAUDE.md
@@ -5,11 +5,12 @@ Single source for the settings sidebar navigation. `useSettingsContext` gathers 
 <howToUse>
 The sidebar nav is data, not JSX. To add or edit a sidebar entry, edit the builder in `useSettingsNavigation.ts` — do NOT hand-write `RouterNavLink`s.
 
-- Entry shape is `SettingsNavigationItem` (`types.ts`): `label`, `to`, `icon`, `keywords`, `children`, optional `exact`, optional `onClick`.
+- Entry shape is `SettingsNavigationItem` (`types.ts`): `label`, `to`, `icon`, `keywords`, `children`, optional `pageSections`, optional `exact`, optional `onClick`.
 - Entries are pushed into one of three sections (`your-settings`, `organization`, `current-project`) in display order — position your `push` where you want it to appear.
 - Gating is the `if` guarding each `push`: combine `ability?.can(...)` (CASL, with `subject(...)` for scoped checks) and the resolved feature-flag booleans destructured from `useSettingsContext()`. Only permitted entries are added, so rendering stays a dumb map.
 - Leaf entries set `exact: true`. A parent with `children` omits `exact` (partial match) so it stays active on its child routes; nested children render expanded when the path matches (`defaultOpened` in `SettingsNavigation`).
 - `keywords` are hidden search aliases that feed the sidebar search (`filterSettingsNavigation`, Fuse.js fuzzy match on label + keywords) — add the synonyms a user might type (e.g. `Single Sign-On` → `['sso','saml','okta']`). Matched label text is highlighted in results; keyword-only matches surface without a highlight.
+- `pageSections` makes **in-page content** searchable. The search index is the nav model, not the rendered pages, so a sub-section heading (e.g. "User impersonation" inside the org "General" page) is invisible to search unless listed here. Add `{ title, keywords }` for each notable heading a page renders; a match promotes the parent entry so the page surfaces in the sidebar (it does not deep-link/scroll to the section). Keep these titles in step with the page component (e.g. the `Settings.tsx` / `ProjectSettings.tsx` route element), since nothing enforces the link. Omit for pages with no notable sub-sections.
 
 If your entry needs a new feature flag, resolve it in `useSettingsContext.ts` and add it to the `SettingsContext` type, then destructure it in `useSettingsNavigation`. `SettingsNavigation.tsx` renders whatever sections it's given; you rarely need to touch it.
 </howToUse>

--- a/packages/frontend/src/hooks/settings/filterSettingsNavigation.test.ts
+++ b/packages/frontend/src/hooks/settings/filterSettingsNavigation.test.ts
@@ -6,6 +6,7 @@ import {
 } from './filterSettingsNavigation';
 import {
     type SettingsNavigationItem,
+    type SettingsPageSection,
     type SettingsNavigationSection,
 } from './types';
 
@@ -13,12 +14,14 @@ const item = (
     label: string,
     keywords: string[] = [],
     children: SettingsNavigationItem[] = [],
+    pageSections: SettingsPageSection[] = [],
 ): SettingsNavigationItem => ({
     label,
     to: `/${label.toLowerCase().replace(/\s+/g, '-')}`,
     icon: IconSearch,
     keywords,
     children,
+    pageSections,
 });
 
 const sections: SettingsNavigationSection[] = [
@@ -38,6 +41,15 @@ const sections: SettingsNavigationSection[] = [
         items: [
             item('Single Sign-On', ['sso', 'saml', 'okta']),
             item('User attributes', ['groups']),
+            item(
+                'General',
+                ['organization'],
+                [],
+                [
+                    { title: 'User impersonation', keywords: ['impersonate'] },
+                    { title: 'Danger zone', keywords: ['delete organization'] },
+                ],
+            ),
             item(
                 'Ask AI',
                 ['copilot'],
@@ -111,6 +123,20 @@ describe('filterSettingsNavigation', () => {
         ]);
     });
 
+    it('matches by an in-page sub-section title', () => {
+        const result = filterSettingsNavigation(sections, 'impersonation');
+        expect(result.flatMap((s) => s.items.map((i) => i.label))).toContain(
+            'General',
+        );
+    });
+
+    it('matches by an in-page sub-section keyword', () => {
+        const result = filterSettingsNavigation(sections, 'impersonate');
+        expect(result.flatMap((s) => s.items.map((i) => i.label))).toContain(
+            'General',
+        );
+    });
+
     it('tolerates fuzzy typos', () => {
         const result = filterSettingsNavigation(sections, 'attributs');
         expect(result.flatMap((s) => s.items.map((i) => i.label))).toContain(
@@ -178,6 +204,16 @@ describe('searchSettingsNavigationItemsWithPath', () => {
         const general = result.find((r) => r.item.label === 'General');
         expect(general).toBeDefined();
         expect(general?.path).toEqual(['Organization settings', 'Ask AI']);
+    });
+
+    it('surfaces a page via its in-page sub-section', () => {
+        const result = searchSettingsNavigationItemsWithPath(
+            sections,
+            'impersonation',
+        );
+        const general = result.find((r) => r.item.label === 'General');
+        expect(general).toBeDefined();
+        expect(general?.path).toEqual(['Organization settings']);
     });
 
     it('matches every item in a section by its title', () => {

--- a/packages/frontend/src/hooks/settings/filterSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/filterSettingsNavigation.ts
@@ -13,7 +13,9 @@ const flattenItems = (
 
 /**
  * Filters the settings nav model by a free-text query using fuzzy matching
- * (Fuse.js, mirroring the explores search). A matching parent keeps all its
+ * (Fuse.js, mirroring the explores search). Matches the label, hidden keywords,
+ * and each entry's in-page sub-section titles/keywords — so page content (e.g.
+ * "impersonation") surfaces the parent page. A matching parent keeps all its
  * children; an unmatched parent is kept only for its matching descendants.
  * Sections with no surviving items are dropped. An empty query returns the
  * model unchanged.
@@ -31,6 +33,8 @@ export const filterSettingsNavigation = (
         keys: [
             { name: 'label', weight: 2 },
             { name: 'keywords', weight: 1 },
+            { name: 'pageSections.title', weight: 1 },
+            { name: 'pageSections.keywords', weight: 1 },
         ],
         ignoreLocation: true,
         threshold: FUSE_THRESHOLD,
@@ -94,8 +98,9 @@ const flattenWithAncestors = (
 
 /**
  * Flat fuzzy match across every nav destination, each carrying its breadcrumb.
- * Matches label, keywords, ancestor labels, and section title — so "ask ai" or
- * "current project" surface the relevant pages.
+ * Matches label, keywords, in-page sub-sections, ancestor labels, and section
+ * title — so "ask ai", "current project", or "impersonation" surface the
+ * relevant pages.
  */
 export const searchSettingsNavigationItemsWithPath = (
     sections: SettingsNavigationSection[],
@@ -113,6 +118,8 @@ export const searchSettingsNavigationItemsWithPath = (
         keys: [
             { name: 'item.label', weight: 2 },
             { name: 'item.keywords', weight: 1 },
+            { name: 'item.pageSections.title', weight: 1 },
+            { name: 'item.pageSections.keywords', weight: 1 },
             { name: 'ancestors', weight: 1 },
             { name: 'sectionTitle', weight: 1 },
         ],

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -8,6 +8,19 @@ import {
 import { type Icon as TablerIcon } from '@tabler/icons-react';
 import { type UserWithAbility } from '../user/useUser';
 
+/**
+ * An in-page sub-section heading (e.g. "User impersonation" inside the org
+ * "General" page). Indexed by the settings search so page content — not just
+ * the sidebar label — surfaces the parent nav entry. This is search metadata
+ * only; the page component owns the actual rendering.
+ */
+export type SettingsPageSection = {
+    /** The heading shown on the page. */
+    title: string;
+    /** Search aliases for this sub-section, e.g. "impersonate". */
+    keywords: string[];
+};
+
 export type SettingsNavigationItem = {
     label: string;
     to: string;
@@ -16,6 +29,12 @@ export type SettingsNavigationItem = {
     aiAgentIcon?: boolean;
     /** Hidden search aliases so e.g. "sso" finds "Single Sign-On". */
     keywords: string[];
+    /**
+     * In-page sub-sections indexed by the settings search so a match on page
+     * content surfaces this entry (e.g. "impersonation" finds the "General"
+     * page). Omit when the page has no notable sub-sections.
+     */
+    pageSections?: SettingsPageSection[];
     children: SettingsNavigationItem[];
     exact?: boolean;
     onClick?: () => void;

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -169,6 +169,28 @@ export const useSettingsNavigation = (
                     'default project',
                     'danger zone',
                 ],
+                pageSections: [
+                    {
+                        title: 'Allowed email domains',
+                        keywords: ['email', 'domain', 'auto join'],
+                    },
+                    {
+                        title: 'Default project',
+                        keywords: ['landing project', 'home project'],
+                    },
+                    {
+                        title: 'User impersonation',
+                        keywords: ['impersonate', 'impersonation'],
+                    },
+                    {
+                        title: 'Lightdash support access',
+                        keywords: ['support', 'impersonate', 'impersonation'],
+                    },
+                    {
+                        title: 'Danger zone',
+                        keywords: ['delete organization', 'leave organization'],
+                    },
+                ],
                 children: [],
                 exact: true,
             });


### PR DESCRIPTION
### Description:
The settings search only indexed the sidebar nav model (menu labels + keyword aliases), so sub-section headings rendered inside a page were invisible — e.g. searching "impersonation" found nothing even though the org "General" page has a "User impersonation" section.

Add an optional `pageSections` field to `SettingsNavigationItem` describing a page's notable headings; Fuse now indexes their titles/keywords so a match promotes the parent nav entry. Populate it for the org General page.

Before:
<img width="305" height="240" alt="Screenshot 2026-07-14 at 17 00 23" src="https://github.com/user-attachments/assets/6076de3c-016c-4cfe-bf37-c696596a31f9" />
<img width="305" height="240" alt="Screenshot 2026-07-14 at 17 00 37" src="https://github.com/user-attachments/assets/f47c984a-7150-43fc-80e4-a5fc9c628181" />

After:
<img width="305" height="240" alt="Screenshot 2026-07-14 at 17 01 43" src="https://github.com/user-attachments/assets/fc8c321d-c032-4149-a3fa-71e5176f5fcc" />
<img width="305" height="240" alt="Screenshot 2026-07-14 at 17 01 46" src="https://github.com/user-attachments/assets/38ef4fbd-e560-459b-a930-9547d42dfd7b" />


