### PR TITLE
feat: multiple project homepages with create flow and switcher

### DIFF
--- a/packages/backend/src/ee/controllers/projectHomepageController.ts
+++ b/packages/backend/src/ee/controllers/projectHomepageController.ts
@@ -3,19 +3,23 @@ import {
     type ApiErrorPayload,
     type ApiProjectHomepageOrNullResponse,
     type ApiProjectHomepageResponse,
+    type ApiProjectHomepagesResponse,
     type ApiPublishedHomepageResponse,
+    type ApiSuccessEmpty,
     type CreateProjectHomepageRequest,
     type UpdateProjectHomepageDraftRequest,
     type UUID,
 } from '@lightdash/common';
 import {
     Body,
+    Delete,
     Get,
     Middlewares,
     OperationId,
     Patch,
     Path,
     Post,
+    Query,
     Request,
     Response,
     Route,
@@ -67,12 +71,33 @@ export class ProjectHomepageController extends BaseController {
     async getForBuilder(
         @Request() req: express.Request,
         @Path() projectUuid: UUID,
+        @Query() homepageUuid?: UUID,
     ): Promise<ApiProjectHomepageOrNullResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
             results: await this.getHomepageService().getHomepageForBuilder(
+                toSessionUser(req.account),
+                projectUuid,
+                homepageUuid,
+            ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/list')
+    @OperationId('listProjectHomepages')
+    async listHomepages(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+    ): Promise<ApiProjectHomepagesResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().listHomepages(
                 toSessionUser(req.account),
                 projectUuid,
             ),
@@ -128,6 +153,32 @@ export class ProjectHomepageController extends BaseController {
                 homepageUuid,
                 body,
             ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Delete('/{homepageUuid}')
+    @OperationId('deleteProjectHomepage')
+    async delete(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() homepageUuid: UUID,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.getHomepageService().deleteHomepage(
+            toSessionUser(req.account),
+            projectUuid,
+            homepageUuid,
+        );
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: undefined,
         };
     }
 

--- a/packages/backend/src/ee/database/entities/projectHomepages.ts
+++ b/packages/backend/src/ee/database/entities/projectHomepages.ts
@@ -27,7 +27,11 @@ export type DbProjectHomepageIn = Pick<
 export type DbProjectHomepageUpdate = Partial<
     Pick<
         DbProjectHomepage,
-        'name' | 'draft_config' | 'published_config' | 'updated_at'
+        | 'name'
+        | 'draft_config'
+        | 'published_config'
+        | 'is_default'
+        | 'updated_at'
     >
 >;
 

--- a/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
@@ -69,10 +69,12 @@ describe('ProjectHomepageModel', () => {
             );
         });
 
-        it('copies the draft config into published_config', async () => {
+        it('copies the draft config into published_config and promotes to default', async () => {
             tracker.on
                 .select(HomepagesTableName)
                 .responseOnce([makeDbHomepage()]);
+            // first update unsets the previous default, second publishes
+            tracker.on.update(HomepagesTableName).responseOnce(1);
             tracker.on
                 .update(HomepagesTableName)
                 .responseOnce([
@@ -81,8 +83,11 @@ describe('ProjectHomepageModel', () => {
 
             const result = await model.publish(HOMEPAGE_UUID);
 
-            const updateQuery = tracker.history.update[0];
-            expect(updateQuery.bindings).toContainEqual(draftConfig);
+            expect(tracker.history.update).toHaveLength(2);
+            const unsetQuery = tracker.history.update[0];
+            expect(unsetQuery.sql).toContain('is_default');
+            const publishQuery = tracker.history.update[1];
+            expect(publishQuery.bindings).toContainEqual(draftConfig);
             expect(result.publishedConfig).toEqual(draftConfig);
         });
     });

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -40,6 +40,31 @@ export class ProjectHomepageModel {
         return row ? ProjectHomepageModel.mapDbHomepage(row) : undefined;
     }
 
+    async getByUuid(
+        homepageUuid: string,
+    ): Promise<ProjectHomepage | undefined> {
+        const row = await this.database(HomepagesTableName)
+            .where({ homepage_uuid: homepageUuid })
+            .first();
+        return row ? ProjectHomepageModel.mapDbHomepage(row) : undefined;
+    }
+
+    async list(projectUuid: string): Promise<ProjectHomepage[]> {
+        const rows = await this.database(HomepagesTableName)
+            .where({ project_uuid: projectUuid })
+            .orderBy('created_at', 'asc');
+        return rows.map(ProjectHomepageModel.mapDbHomepage);
+    }
+
+    async delete(homepageUuid: string): Promise<void> {
+        const deletedCount = await this.database(HomepagesTableName)
+            .where({ homepage_uuid: homepageUuid })
+            .delete();
+        if (deletedCount === 0) {
+            throw new NotFoundError('Homepage not found');
+        }
+    }
+
     async getPublishedDefault(
         projectUuid: string,
     ): Promise<PublishedProjectHomepage | undefined> {
@@ -61,16 +86,21 @@ export class ProjectHomepageModel {
         draftConfig: HomepageConfig;
         createdByUserUuid: string;
     }): Promise<ProjectHomepage> {
-        const [row] = await this.database(HomepagesTableName)
-            .insert({
-                project_uuid: data.projectUuid,
-                name: data.name,
-                draft_config: data.draftConfig,
-                is_default: true,
-                created_by_user_uuid: data.createdByUserUuid,
-            })
-            .returning('*');
-        return ProjectHomepageModel.mapDbHomepage(row);
+        return this.database.transaction(async (trx) => {
+            const existingDefault = await trx(HomepagesTableName)
+                .where({ project_uuid: data.projectUuid, is_default: true })
+                .first();
+            const [row] = await trx(HomepagesTableName)
+                .insert({
+                    project_uuid: data.projectUuid,
+                    name: data.name,
+                    draft_config: data.draftConfig,
+                    is_default: existingDefault === undefined,
+                    created_by_user_uuid: data.createdByUserUuid,
+                })
+                .returning('*');
+            return ProjectHomepageModel.mapDbHomepage(row);
+        });
     }
 
     async updateDraft(
@@ -91,6 +121,7 @@ export class ProjectHomepageModel {
         return ProjectHomepageModel.mapDbHomepage(row);
     }
 
+    // Publishing promotes the homepage to the project default viewers land on
     async publish(homepageUuid: string): Promise<ProjectHomepage> {
         return this.database.transaction(async (trx) => {
             const existing = await trx(HomepagesTableName)
@@ -99,10 +130,18 @@ export class ProjectHomepageModel {
             if (!existing) {
                 throw new NotFoundError('Homepage not found');
             }
+            await trx(HomepagesTableName)
+                .where({
+                    project_uuid: existing.project_uuid,
+                    is_default: true,
+                })
+                .whereNot({ homepage_uuid: homepageUuid })
+                .update({ is_default: false });
             const [row] = await trx(HomepagesTableName)
                 .where({ homepage_uuid: homepageUuid })
                 .update({
                     published_config: existing.draft_config,
+                    is_default: true,
                     updated_at: new Date(),
                 })
                 .returning('*');

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -1,6 +1,5 @@
 import { Ability } from '@casl/ability';
 import {
-    AlreadyExistsError,
     ForbiddenError,
     NotFoundError,
     OrganizationMemberRole,
@@ -116,10 +115,13 @@ const makeService = ({
         },
         projectHomepageModel: {
             getDefault: vi.fn().mockResolvedValue(undefined),
+            getByUuid: vi.fn().mockResolvedValue(makeHomepage()),
             getPublishedDefault: vi.fn().mockResolvedValue(undefined),
+            list: vi.fn().mockResolvedValue([]),
             create: vi.fn().mockResolvedValue(makeHomepage()),
             updateDraft: vi.fn().mockResolvedValue(makeHomepage()),
             publish: vi.fn().mockResolvedValue(makeHomepage()),
+            delete: vi.fn().mockResolvedValue(undefined),
             ...projectHomepageModel,
         },
     });
@@ -151,18 +153,50 @@ describe('ProjectHomepageService', () => {
         ).rejects.toThrow(ForbiddenError);
     });
 
-    it('createHomepage throws AlreadyExistsError when a default homepage exists', async () => {
+    it('createHomepage copies the draft config when duplicating', async () => {
+        const create = vi.fn().mockResolvedValue(makeHomepage());
         const service = makeService({
             projectHomepageModel: {
-                getDefault: vi.fn().mockResolvedValue(makeHomepage()),
+                getByUuid: vi
+                    .fn()
+                    .mockResolvedValue(
+                        makeHomepage({ draftConfig: validConfig }),
+                    ),
+                create,
+            },
+        });
+
+        await service.createHomepage(makeAdminUser(), PROJECT_UUID, {
+            name: 'Copy',
+            duplicateFrom: HOMEPAGE_UUID,
+        });
+
+        expect(create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                name: 'Copy',
+                draftConfig: validConfig,
+            }),
+        );
+    });
+
+    it('deleteHomepage rejects a homepage from another project', async () => {
+        const service = makeService({
+            projectHomepageModel: {
+                getByUuid: vi
+                    .fn()
+                    .mockResolvedValue(
+                        makeHomepage({ projectUuid: 'other-project-uuid' }),
+                    ),
             },
         });
 
         await expect(
-            service.createHomepage(makeAdminUser(), PROJECT_UUID, {
-                name: 'Another',
-            }),
-        ).rejects.toThrow(AlreadyExistsError);
+            service.deleteHomepage(
+                makeAdminUser(),
+                PROJECT_UUID,
+                HOMEPAGE_UUID,
+            ),
+        ).rejects.toThrow(NotFoundError);
     });
 
     it('updateDraft rejects a row with more than 3 blocks', async () => {
@@ -195,10 +229,10 @@ describe('ProjectHomepageService', () => {
     it('updateDraft throws NotFoundError when the homepage belongs to another project', async () => {
         const service = makeService({
             projectHomepageModel: {
-                getDefault: vi
+                getByUuid: vi
                     .fn()
                     .mockResolvedValue(
-                        makeHomepage({ homepageUuid: 'other-homepage-uuid' }),
+                        makeHomepage({ projectUuid: 'other-project-uuid' }),
                     ),
             },
         });

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -1,6 +1,5 @@
 import { subject } from '@casl/ability';
 import {
-    AlreadyExistsError,
     CommercialFeatureFlags,
     defaultHomepageConfig,
     ForbiddenError,
@@ -22,10 +21,13 @@ export type ProjectHomepageServiceArguments = {
     projectHomepageModel: Pick<
         ProjectHomepageModel,
         | 'getDefault'
+        | 'getByUuid'
         | 'getPublishedDefault'
+        | 'list'
         | 'create'
         | 'updateDraft'
         | 'publish'
+        | 'delete'
     >;
     featureFlagService: Pick<FeatureFlagService, 'get'>;
 };
@@ -108,8 +110,8 @@ export class ProjectHomepageService extends BaseService {
         homepageUuid: string,
     ): Promise<ProjectHomepage> {
         const homepage =
-            await this.projectHomepageModel.getDefault(projectUuid);
-        if (!homepage || homepage.homepageUuid !== homepageUuid) {
+            await this.projectHomepageModel.getByUuid(homepageUuid);
+        if (!homepage || homepage.projectUuid !== projectUuid) {
             throw new NotFoundError('Homepage not found');
         }
         return homepage;
@@ -129,12 +131,27 @@ export class ProjectHomepageService extends BaseService {
     async getHomepageForBuilder(
         user: SessionUser,
         projectUuid: string,
+        homepageUuid?: string,
     ): Promise<ProjectHomepage | null> {
         await this.assertFlagEnabled(user);
         this.assertCanManage(user, projectUuid);
+        if (homepageUuid) {
+            return this.getOwnedHomepage(projectUuid, homepageUuid);
+        }
         const homepage =
             await this.projectHomepageModel.getDefault(projectUuid);
-        return homepage ?? null;
+        if (homepage) return homepage;
+        const [first] = await this.projectHomepageModel.list(projectUuid);
+        return first ?? null;
+    }
+
+    async listHomepages(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<ProjectHomepage[]> {
+        await this.assertFlagEnabled(user);
+        this.assertCanManage(user, projectUuid);
+        return this.projectHomepageModel.list(projectUuid);
     }
 
     async createHomepage(
@@ -144,17 +161,27 @@ export class ProjectHomepageService extends BaseService {
     ): Promise<ProjectHomepage> {
         await this.assertFlagEnabled(user);
         this.assertCanManage(user, projectUuid);
-        const existing =
-            await this.projectHomepageModel.getDefault(projectUuid);
-        if (existing) {
-            throw new AlreadyExistsError('This project already has a homepage');
-        }
+        const draftConfig = data.duplicateFrom
+            ? (await this.getOwnedHomepage(projectUuid, data.duplicateFrom))
+                  .draftConfig
+            : defaultHomepageConfig();
         return this.projectHomepageModel.create({
             projectUuid,
             name: data.name,
-            draftConfig: defaultHomepageConfig(),
+            draftConfig,
             createdByUserUuid: user.userUuid,
         });
+    }
+
+    async deleteHomepage(
+        user: SessionUser,
+        projectUuid: string,
+        homepageUuid: string,
+    ): Promise<void> {
+        await this.assertFlagEnabled(user);
+        this.assertCanManage(user, projectUuid);
+        await this.getOwnedHomepage(projectUuid, homepageUuid);
+        await this.projectHomepageModel.delete(homepageUuid);
     }
 
     async updateDraft(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1689,6 +1689,27 @@ const models: TsoaRoute.Models = {
         type: { ref: 'ApiSuccess_ProjectHomepage-or-null_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_ProjectHomepage-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'ProjectHomepage' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiProjectHomepagesResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_ProjectHomepage-Array_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiSuccess_ProjectHomepage_: {
         dataType: 'refAlias',
         type: {
@@ -1710,7 +1731,10 @@ const models: TsoaRoute.Models = {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
-            nestedProperties: { name: { dataType: 'string', required: true } },
+            nestedProperties: {
+                duplicateFrom: { dataType: 'string' },
+                name: { dataType: 'string', required: true },
+            },
             validators: {},
         },
     },
@@ -49291,6 +49315,7 @@ export function RegisterRoutes(app: Router) {
             required: true,
             ref: 'UUID',
         },
+        homepageUuid: { in: 'query', name: 'homepageUuid', ref: 'UUID' },
     };
     app.get(
         '/api/v1/projects/:projectUuid/homepage/builder',
@@ -49329,6 +49354,67 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getForBuilder',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectHomepageController_listHomepages: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/homepage/list',
+        ...fetchMiddlewares<RequestHandler>(ProjectHomepageController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectHomepageController.prototype.listHomepages,
+        ),
+
+        async function ProjectHomepageController_listHomepages(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectHomepageController_listHomepages,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectHomepageController>(
+                        ProjectHomepageController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listHomepages',
                     controller,
                     response,
                     next,
@@ -49469,6 +49555,73 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'updateDraft',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectHomepageController_delete: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        homepageUuid: {
+            in: 'path',
+            name: 'homepageUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.delete(
+        '/api/v1/projects/:projectUuid/homepage/:homepageUuid',
+        ...fetchMiddlewares<RequestHandler>(ProjectHomepageController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectHomepageController.prototype.delete,
+        ),
+
+        async function ProjectHomepageController_delete(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectHomepageController_delete,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectHomepageController>(
+                        ProjectHomepageController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'delete',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1700,6 +1700,26 @@
             "ApiProjectHomepageOrNullResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_ProjectHomepage-or-null_"
             },
+            "ApiSuccess_ProjectHomepage-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/ProjectHomepage"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiProjectHomepagesResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_ProjectHomepage-Array_"
+            },
             "ApiSuccess_ProjectHomepage_": {
                 "properties": {
                     "results": {
@@ -1719,6 +1739,9 @@
             },
             "CreateProjectHomepageRequest": {
                 "properties": {
+                    "duplicateFrom": {
+                        "type": "string"
+                    },
                     "name": {
                         "type": "string"
                     }
@@ -48914,6 +48937,53 @@
                         "schema": {
                             "$ref": "#/components/schemas/UUID"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "homepageUuid",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/homepage/list": {
+            "get": {
+                "operationId": "listProjectHomepages",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiProjectHomepagesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
                     }
                 ]
             }
@@ -48973,6 +49043,51 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "operationId": "deleteProjectHomepage",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "homepageUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/projects/{projectUuid}/homepage/{homepageUuid}/publish": {

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -86,6 +86,7 @@ export type PublishedProjectHomepage = {
 
 export type CreateProjectHomepageRequest = {
     name: string;
+    duplicateFrom?: string;
 };
 
 export type UpdateProjectHomepageDraftRequest = {
@@ -94,6 +95,7 @@ export type UpdateProjectHomepageDraftRequest = {
 };
 
 export type ApiProjectHomepageResponse = ApiSuccess<ProjectHomepage>;
+export type ApiProjectHomepagesResponse = ApiSuccess<ProjectHomepage[]>;
 export type ApiProjectHomepageOrNullResponse =
     ApiSuccess<ProjectHomepage | null>;
 export type ApiPublishedHomepageResponse =

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
@@ -1,7 +1,18 @@
 import { subject } from '@casl/ability';
-import { Button, Stack, Text, TextInput, Title } from '@mantine-8/core';
+import { type ProjectHomepage } from '@lightdash/common';
+import {
+    Button,
+    Card,
+    Radio,
+    Stack,
+    Text,
+    TextInput,
+    Title,
+} from '@mantine-8/core';
+import { IconArrowLeft } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
-import { useParams } from 'react-router';
+import { useParams, useSearchParams } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
 import Page from '../../../components/common/Page/Page';
 import ForbiddenPanel from '../../../components/ForbiddenPanel';
 import PageSpinner from '../../../components/PageSpinner';
@@ -11,19 +22,99 @@ import {
     useCreateHomepage,
     useHomepageBuilderFlag,
     useHomepageForBuilder,
+    useProjectHomepages,
 } from './hooks/useProjectHomepage';
+
+const CreateHomepageForm: FC<{
+    projectUuid: string;
+    homepages: ProjectHomepage[];
+    onCreated: (homepage: ProjectHomepage) => void;
+    onCancel: (() => void) | null;
+}> = ({ projectUuid, homepages, onCreated, onCancel }) => {
+    const createMutation = useCreateHomepage(projectUuid);
+    const [name, setName] = useState('');
+    const [startFrom, setStartFrom] = useState('blank');
+
+    return (
+        <Stack gap="sm" maw={560}>
+            {onCancel && (
+                <Button
+                    variant="subtle"
+                    size="xs"
+                    w="fit-content"
+                    leftSection={<MantineIcon icon={IconArrowLeft} />}
+                    onClick={onCancel}
+                >
+                    Back
+                </Button>
+            )}
+            <Title order={3}>Create a homepage</Title>
+            <Text c="dimmed" size="sm">
+                Curate a landing page for this project. Publishing makes it what
+                everyone sees when they land in Lightdash.
+            </Text>
+            <TextInput
+                label="Name"
+                placeholder="e.g. Team homepage"
+                value={name}
+                onChange={(e) => setName(e.currentTarget.value)}
+            />
+            <Radio.Group
+                label="Start from"
+                value={startFrom}
+                onChange={setStartFrom}
+            >
+                <Stack gap="xs" mt="xs">
+                    <Card withBorder p="sm">
+                        <Radio value="blank" label="Blank" />
+                    </Card>
+                    {homepages.map((homepage) => (
+                        <Card key={homepage.homepageUuid} withBorder p="sm">
+                            <Radio
+                                value={homepage.homepageUuid}
+                                label={`Duplicate “${homepage.name}”`}
+                            />
+                        </Card>
+                    ))}
+                </Stack>
+            </Radio.Group>
+            <Button
+                w="fit-content"
+                disabled={name.trim().length === 0}
+                loading={createMutation.isLoading}
+                onClick={() =>
+                    createMutation.mutate(
+                        {
+                            name: name.trim(),
+                            duplicateFrom:
+                                startFrom === 'blank' ? undefined : startFrom,
+                        },
+                        { onSuccess: onCreated },
+                    )
+                }
+            >
+                Create homepage
+            </Button>
+        </Stack>
+    );
+};
 
 // ts-unused-exports:disable-next-line
 export const HomepageBuilderPage: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
+    const [searchParams, setSearchParams] = useSearchParams();
+    const selectedHomepageUuid = searchParams.get('homepage') ?? undefined;
+    const isCreating = searchParams.get('create') === '1';
     const { user } = useApp();
     const { isEnabled: isFlagEnabled, isLoading: isFlagLoading } =
         useHomepageBuilderFlag();
     const homepage = useHomepageForBuilder(projectUuid, {
+        enabled: isFlagEnabled && !isCreating,
+        homepageUuid: selectedHomepageUuid,
+    });
+    const homepages = useProjectHomepages(projectUuid, {
         enabled: isFlagEnabled,
     });
-    const createMutation = useCreateHomepage(projectUuid!);
-    const [newName, setNewName] = useState('');
 
     const canManage =
         user.data?.ability?.can(
@@ -36,7 +127,10 @@ export const HomepageBuilderPage: FC = () => {
 
     // Wait for a fresh fetch: the editor snapshots the draft on mount, so
     // seeding it from a stale cache would autosave old state over the server
-    if (isFlagLoading || (isFlagEnabled && !homepage.isFetchedAfterMount)) {
+    if (
+        isFlagLoading ||
+        (isFlagEnabled && !isCreating && !homepage.isFetchedAfterMount)
+    ) {
         return <PageSpinner />;
     }
 
@@ -44,36 +138,33 @@ export const HomepageBuilderPage: FC = () => {
         return <ForbiddenPanel />;
     }
 
+    const openHomepage = (created: ProjectHomepage) =>
+        setSearchParams({ homepage: created.homepageUuid });
+
     return (
         <Page withFixedContent withPaddedContent>
-            {!homepage.data ? (
-                <Stack gap="sm" maw={480}>
-                    <Title order={3}>Create a homepage</Title>
-                    <Text c="dimmed" size="sm">
-                        Curate what everyone in this project sees when they land
-                        in Lightdash.
-                    </Text>
-                    <TextInput
-                        label="Name"
-                        placeholder="e.g. Team homepage"
-                        value={newName}
-                        onChange={(e) => setNewName(e.currentTarget.value)}
-                    />
-                    <Button
-                        disabled={newName.trim().length === 0}
-                        loading={createMutation.isLoading}
-                        onClick={() =>
-                            createMutation.mutate({ name: newName.trim() })
-                        }
-                    >
-                        Create homepage
-                    </Button>
-                </Stack>
+            {isCreating || !homepage.data ? (
+                <CreateHomepageForm
+                    projectUuid={projectUuid}
+                    homepages={homepages.data ?? []}
+                    onCreated={openHomepage}
+                    onCancel={
+                        isCreating && (homepages.data ?? []).length > 0
+                            ? () => setSearchParams({})
+                            : null
+                    }
+                />
             ) : (
                 <HomepageEditor
                     key={homepage.data.homepageUuid}
                     homepage={homepage.data}
                     projectUuid={projectUuid}
+                    homepages={homepages.data ?? []}
+                    onSwitchHomepage={(homepageUuid) =>
+                        setSearchParams({ homepage: homepageUuid })
+                    }
+                    onCreateNew={() => setSearchParams({ create: '1' })}
+                    onDeleted={() => setSearchParams({})}
                 />
             )}
         </Page>

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -8,6 +8,7 @@ import {
     Button,
     Card,
     Group,
+    Menu,
     Paper,
     Stack,
     Text,
@@ -18,16 +19,21 @@ import {
     IconArrowDown,
     IconArrowLeft,
     IconArrowUp,
+    IconCheck,
+    IconChevronDown,
     IconCircleCheck,
     IconCopy,
     IconEye,
     IconPencil,
+    IconPlus,
     IconSend,
     IconTrash,
+    IconUsers,
 } from '@tabler/icons-react';
 import { useEffect, useRef, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
 import { useAiAgentButtonVisibility } from '../aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { blockLibrary, getBlockDefinition } from './blocks/registry';
 import {
@@ -41,6 +47,7 @@ import {
     replaceBlock,
 } from './configOps';
 import {
+    useDeleteHomepage,
     usePublishHomepage,
     useUpdateHomepageDraft,
 } from './hooks/useProjectHomepage';
@@ -49,9 +56,20 @@ import { PublishedHomepage } from './PublishedHomepage';
 type Props = {
     homepage: ProjectHomepageType;
     projectUuid: string;
+    homepages: ProjectHomepageType[];
+    onSwitchHomepage: (homepageUuid: string) => void;
+    onCreateNew: () => void;
+    onDeleted: () => void;
 };
 
-export const HomepageEditor: FC<Props> = ({ homepage, projectUuid }) => {
+export const HomepageEditor: FC<Props> = ({
+    homepage,
+    projectUuid,
+    homepages,
+    onSwitchHomepage,
+    onCreateNew,
+    onDeleted,
+}) => {
     const navigate = useNavigate();
     const updateMutation = useUpdateHomepageDraft(
         projectUuid,
@@ -61,6 +79,8 @@ export const HomepageEditor: FC<Props> = ({ homepage, projectUuid }) => {
         projectUuid,
         homepage.homepageUuid,
     );
+    const deleteMutation = useDeleteHomepage(projectUuid);
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
     const isAiEnabled = useAiAgentButtonVisibility();
     const availableBlocks = blockLibrary.filter(
@@ -92,13 +112,68 @@ export const HomepageEditor: FC<Props> = ({ homepage, projectUuid }) => {
     return (
         <Stack gap="lg" w="100%">
             <Group justify="space-between">
-                <Button
-                    variant="default"
-                    leftSection={<MantineIcon icon={IconArrowLeft} />}
-                    onClick={() => navigate(`/projects/${projectUuid}/home`)}
-                >
-                    Exit
-                </Button>
+                <Group gap="sm">
+                    <Button
+                        variant="default"
+                        leftSection={<MantineIcon icon={IconArrowLeft} />}
+                        onClick={() =>
+                            navigate(`/projects/${projectUuid}/home`)
+                        }
+                    >
+                        Exit
+                    </Button>
+                    <Menu position="bottom-start" width={280}>
+                        <Menu.Target>
+                            <Button
+                                variant="default"
+                                leftSection={<MantineIcon icon={IconUsers} />}
+                                rightSection={
+                                    <MantineIcon icon={IconChevronDown} />
+                                }
+                            >
+                                Editing: {homepage.name}
+                                {homepage.isDefault ? ' (live)' : ' (draft)'}
+                            </Button>
+                        </Menu.Target>
+                        <Menu.Dropdown>
+                            <Menu.Label>Project homepages</Menu.Label>
+                            {homepages.map((item) => (
+                                <Menu.Item
+                                    key={item.homepageUuid}
+                                    leftSection={
+                                        item.homepageUuid ===
+                                        homepage.homepageUuid ? (
+                                            <MantineIcon
+                                                icon={IconCheck}
+                                                color="blue"
+                                            />
+                                        ) : undefined
+                                    }
+                                    onClick={() =>
+                                        onSwitchHomepage(item.homepageUuid)
+                                    }
+                                >
+                                    {item.name}
+                                    {item.isDefault ? ' · live' : ''}
+                                </Menu.Item>
+                            ))}
+                            <Menu.Divider />
+                            <Menu.Item
+                                leftSection={<MantineIcon icon={IconPlus} />}
+                                onClick={onCreateNew}
+                            >
+                                New homepage…
+                            </Menu.Item>
+                            <Menu.Item
+                                color="red"
+                                leftSection={<MantineIcon icon={IconTrash} />}
+                                onClick={() => setIsDeleteModalOpen(true)}
+                            >
+                                Delete this homepage
+                            </Menu.Item>
+                        </Menu.Dropdown>
+                    </Menu>
+                </Group>
                 <Group gap="sm">
                     {isDirty ? (
                         <Text size="xs" c="dimmed">
@@ -330,6 +405,23 @@ export const HomepageEditor: FC<Props> = ({ homepage, projectUuid }) => {
                     </Stack>
                 </Group>
             )}
+            <MantineModal
+                opened={isDeleteModalOpen}
+                onClose={() =>
+                    !deleteMutation.isLoading && setIsDeleteModalOpen(false)
+                }
+                title="Delete homepage"
+                variant="delete"
+                resourceType="homepage"
+                resourceLabel={homepage.name}
+                cancelDisabled={deleteMutation.isLoading}
+                onConfirm={() =>
+                    deleteMutation.mutate(homepage.homepageUuid, {
+                        onSuccess: onDeleted,
+                    })
+                }
+                confirmLoading={deleteMutation.isLoading}
+            />
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
@@ -20,10 +20,29 @@ const getPublishedHomepage = async (projectUuid: string) =>
         body: undefined,
     });
 
-const getHomepageForBuilder = async (projectUuid: string) =>
+const getHomepageForBuilder = async (
+    projectUuid: string,
+    homepageUuid?: string,
+) =>
     lightdashApi<ProjectHomepage | null>({
-        url: `/projects/${projectUuid}/homepage/builder`,
+        url: `/projects/${projectUuid}/homepage/builder${
+            homepageUuid ? `?homepageUuid=${homepageUuid}` : ''
+        }`,
         method: 'GET',
+        body: undefined,
+    });
+
+const listHomepagesApi = async (projectUuid: string) =>
+    lightdashApi<ProjectHomepage[]>({
+        url: `/projects/${projectUuid}/homepage/list`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const deleteHomepageApi = async (projectUuid: string, homepageUuid: string) =>
+    lightdashApi<undefined>({
+        url: `/projects/${projectUuid}/homepage/${homepageUuid}`,
+        method: 'DELETE',
         body: undefined,
     });
 
@@ -74,13 +93,55 @@ export const usePublishedHomepage = (
 
 export const useHomepageForBuilder = (
     projectUuid: string | undefined,
-    { enabled = true }: { enabled?: boolean } = {},
+    {
+        enabled = true,
+        homepageUuid,
+    }: { enabled?: boolean; homepageUuid?: string } = {},
 ) =>
     useQuery<ProjectHomepage | null, ApiError>({
         enabled: !!projectUuid && enabled,
-        queryKey: [PROJECT_HOMEPAGE_QUERY_KEY, projectUuid, 'builder'],
-        queryFn: () => getHomepageForBuilder(projectUuid!),
+        queryKey: [
+            PROJECT_HOMEPAGE_QUERY_KEY,
+            projectUuid,
+            'builder',
+            homepageUuid ?? 'default',
+        ],
+        queryFn: () => getHomepageForBuilder(projectUuid!, homepageUuid),
     });
+
+export const useProjectHomepages = (
+    projectUuid: string | undefined,
+    { enabled = true }: { enabled?: boolean } = {},
+) =>
+    useQuery<ProjectHomepage[], ApiError>({
+        enabled: !!projectUuid && enabled,
+        queryKey: [PROJECT_HOMEPAGE_QUERY_KEY, projectUuid, 'list'],
+        queryFn: () => listHomepagesApi(projectUuid!),
+    });
+
+export const useDeleteHomepage = (projectUuid: string) => {
+    const { showToastSuccess, showToastApiError } = useToaster();
+    const queryClient = useQueryClient();
+    return useMutation<undefined, ApiError, string>(
+        (homepageUuid) => deleteHomepageApi(projectUuid, homepageUuid),
+        {
+            mutationKey: ['delete_project_homepage'],
+            onSuccess: async () => {
+                await queryClient.invalidateQueries([
+                    PROJECT_HOMEPAGE_QUERY_KEY,
+                    projectUuid,
+                ]);
+                showToastSuccess({ title: 'Homepage deleted' });
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to delete homepage',
+                    apiError: error,
+                });
+            },
+        },
+    );
+};
 
 export const useCreateHomepage = (projectUuid: string) => {
     const { showToastApiError } = useToaster();


### PR DESCRIPTION
## Homepage Builder — multiple homepages (8)

Part of [ZAP-622](https://linear.app/lightdash/issue/ZAP-622) · Stacked on #25535

A project can now have many homepages. Publishing one **promotes it to the project default** (what viewers land on), demoting the previous default in the same transaction.

### Backend
- Model: `list` / `getByUuid` / `delete`; `create` only claims `is_default` when the project has none (first homepage); `publish` transactionally unsets the previous default and sets the target — the partial unique index (one default per project) is never violated
- Service: `listHomepages`, `deleteHomepage`, `createHomepage` accepts `duplicateFrom` (deep-copies the source draft); ownership checks now resolve by uuid + project match (multi-homepage safe)
- Controller: `GET /homepage/list`, `DELETE /homepage/:homepageUuid`, `GET /homepage/builder?homepageUuid=` (falls back default → first)

### Frontend
- Builder toolbar gains the **"Editing: {name} (live|draft)"** switcher menu: all homepages, New homepage…, Delete (confirm modal, `variant="delete"`)
- **Create flow**: name + Start from (Blank / Duplicate an existing homepage), per the design; selected homepage tracked in `?homepage=` so the editor remounts per homepage
- Deleting the live homepage falls back to the day-1 default for viewers until another publish (full audience assignment is ZAP-625)

### Verified live (Playwright + psql)
Created "Exec homepage" duplicated from "Team homepage" (config copied, non-default) → published it → DB shows Exec `is_default=true`, Team demoted → deleted Exec via switcher+confirm → viewers fall back to day-one (`GET /homepage` → null) → republished Team → restored.

### Regression analysis
- Flag off: unchanged. Single-homepage projects behave exactly as before (create claims default; publish republishes it).
- New endpoints additive; `publish` semantic change (promote-to-default) only observable with >1 homepage, which was previously impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ