### PR TITLE
feat(frontend): resources and announcements homepage blocks

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1546,6 +1546,107 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageResourceKind: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['video'] },
+                { dataType: 'enum', enums: ['doc'] },
+                { dataType: 'enum', enums: ['link'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageResourceItem: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                kind: { ref: 'HomepageResourceKind', required: true },
+                url: { dataType: 'string', required: true },
+                title: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageResourcesBlock: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                config: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        items: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'HomepageResourceItem',
+                            },
+                            required: true,
+                        },
+                        title: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                type: {
+                    dataType: 'enum',
+                    enums: ['resources'],
+                    required: true,
+                },
+                id: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageAnnouncementItem: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                author: { dataType: 'string', required: true },
+                date: { dataType: 'string', required: true },
+                text: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageAnnouncementsBlock: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                config: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        items: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'HomepageAnnouncementItem',
+                            },
+                            required: true,
+                        },
+                        title: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                type: {
+                    dataType: 'enum',
+                    enums: ['announcements'],
+                    required: true,
+                },
+                id: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     HomepageBlock: {
         dataType: 'refAlias',
         type: {
@@ -1555,6 +1656,8 @@ const models: TsoaRoute.Models = {
                 { ref: 'HomepageHeroBlock' },
                 { ref: 'HomepageAiBlock' },
                 { ref: 'HomepageCollectionBlock' },
+                { ref: 'HomepageResourcesBlock' },
+                { ref: 'HomepageAnnouncementsBlock' },
             ],
             validators: {},
         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1542,6 +1542,98 @@
                 "required": ["config", "type", "id"],
                 "type": "object"
             },
+            "HomepageResourceKind": {
+                "type": "string",
+                "enum": ["video", "doc", "link"]
+            },
+            "HomepageResourceItem": {
+                "properties": {
+                    "kind": {
+                        "$ref": "#/components/schemas/HomepageResourceKind"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                },
+                "required": ["kind", "url", "title"],
+                "type": "object"
+            },
+            "HomepageResourcesBlock": {
+                "properties": {
+                    "config": {
+                        "properties": {
+                            "items": {
+                                "items": {
+                                    "$ref": "#/components/schemas/HomepageResourceItem"
+                                },
+                                "type": "array"
+                            },
+                            "title": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["items", "title"],
+                        "type": "object"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["resources"],
+                        "nullable": false
+                    },
+                    "id": {
+                        "type": "string"
+                    }
+                },
+                "required": ["config", "type", "id"],
+                "type": "object"
+            },
+            "HomepageAnnouncementItem": {
+                "properties": {
+                    "author": {
+                        "type": "string"
+                    },
+                    "date": {
+                        "type": "string"
+                    },
+                    "text": {
+                        "type": "string"
+                    }
+                },
+                "required": ["author", "date", "text"],
+                "type": "object"
+            },
+            "HomepageAnnouncementsBlock": {
+                "properties": {
+                    "config": {
+                        "properties": {
+                            "items": {
+                                "items": {
+                                    "$ref": "#/components/schemas/HomepageAnnouncementItem"
+                                },
+                                "type": "array"
+                            },
+                            "title": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["items", "title"],
+                        "type": "object"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["announcements"],
+                        "nullable": false
+                    },
+                    "id": {
+                        "type": "string"
+                    }
+                },
+                "required": ["config", "type", "id"],
+                "type": "object"
+            },
             "HomepageBlock": {
                 "anyOf": [
                     {
@@ -1555,6 +1647,12 @@
                     },
                     {
                         "$ref": "#/components/schemas/HomepageCollectionBlock"
+                    },
+                    {
+                        "$ref": "#/components/schemas/HomepageResourcesBlock"
+                    },
+                    {
+                        "$ref": "#/components/schemas/HomepageAnnouncementsBlock"
                     }
                 ]
             },

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -29,11 +29,39 @@ export type HomepageCollectionBlock = {
     config: { title: string; items: HomepageCollectionItemRef[] };
 };
 
+export type HomepageResourceKind = 'video' | 'doc' | 'link';
+
+export type HomepageResourceItem = {
+    title: string;
+    url: string;
+    kind: HomepageResourceKind;
+};
+
+export type HomepageResourcesBlock = {
+    id: string;
+    type: 'resources';
+    config: { title: string; items: HomepageResourceItem[] };
+};
+
+export type HomepageAnnouncementItem = {
+    text: string;
+    date: string;
+    author: string;
+};
+
+export type HomepageAnnouncementsBlock = {
+    id: string;
+    type: 'announcements';
+    config: { title: string; items: HomepageAnnouncementItem[] };
+};
+
 export type HomepageBlock =
     | HomepageMarkdownBlock
     | HomepageHeroBlock
     | HomepageAiBlock
-    | HomepageCollectionBlock;
+    | HomepageCollectionBlock
+    | HomepageResourcesBlock
+    | HomepageAnnouncementsBlock;
 
 export type HomepageRow = {
     id: string;

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
@@ -1,0 +1,156 @@
+import { type HomepageAnnouncementItem } from '@lightdash/common';
+import {
+    ActionIcon,
+    Box,
+    Card,
+    Group,
+    Stack,
+    Text,
+    Textarea,
+} from '@mantine-8/core';
+import { IconSend, IconX } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import { useTimeAgo } from '../../../../hooks/useTimeAgo';
+import useApp from '../../../../providers/App/useApp';
+import { type BlockComponentProps, type BuildComponentProps } from './types';
+
+const AnnouncementRow: FC<{
+    item: HomepageAnnouncementItem;
+    onRemove?: () => void;
+}> = ({ item, onRemove }) => {
+    const timeAgo = useTimeAgo(item.date);
+    return (
+        <Group gap="sm" wrap="nowrap" p="sm" align="flex-start">
+            <Box
+                w={7}
+                h={7}
+                mt={6}
+                bg="violet"
+                style={{ borderRadius: '50%', flexShrink: 0 }}
+            />
+            <Box style={{ flex: 1, minWidth: 0 }}>
+                <Text size="sm">{item.text}</Text>
+                <Text size="xs" c="dimmed" mt={2}>
+                    {timeAgo} · {item.author}
+                </Text>
+            </Box>
+            {onRemove && (
+                <ActionIcon
+                    variant="subtle"
+                    color="gray"
+                    size="sm"
+                    aria-label="Remove announcement"
+                    onClick={onRemove}
+                >
+                    <MantineIcon icon={IconX} />
+                </ActionIcon>
+            )}
+        </Group>
+    );
+};
+
+export const AnnouncementsBlockView: FC<BlockComponentProps> = ({ block }) => {
+    if (block.type !== 'announcements' || block.config.items.length === 0) {
+        return null;
+    }
+    return (
+        <Stack gap="xs">
+            <Text size="xs" fw={600} tt="uppercase" c="dimmed">
+                {block.config.title}
+            </Text>
+            <Card withBorder p={0}>
+                <Stack gap={0}>
+                    {block.config.items.map((item) => (
+                        <AnnouncementRow
+                            key={`${item.date}-${item.author}`}
+                            item={item}
+                        />
+                    ))}
+                </Stack>
+            </Card>
+        </Stack>
+    );
+};
+
+export const AnnouncementsBlockBuild: FC<BuildComponentProps> = ({
+    block,
+    onChange,
+}) => {
+    const { user } = useApp();
+    const [text, setText] = useState('');
+    if (block.type !== 'announcements') return null;
+
+    const postAnnouncement = () => {
+        const trimmed = text.trim();
+        if (!trimmed) return;
+        const author = [user.data?.firstName, user.data?.lastName]
+            .filter(Boolean)
+            .join(' ');
+        onChange({
+            ...block,
+            config: {
+                ...block.config,
+                items: [
+                    {
+                        text: trimmed,
+                        date: new Date().toISOString(),
+                        author,
+                    },
+                    ...block.config.items,
+                ],
+            },
+        });
+        setText('');
+    };
+
+    return (
+        <Stack gap="xs">
+            <Text size="xs" fw={600} tt="uppercase" c="dimmed">
+                {block.config.title}
+            </Text>
+            <Card withBorder p={0}>
+                <Stack gap={0}>
+                    {block.config.items.map((item, index) => (
+                        <AnnouncementRow
+                            key={`${item.date}-${item.author}`}
+                            item={item}
+                            onRemove={() =>
+                                onChange({
+                                    ...block,
+                                    config: {
+                                        ...block.config,
+                                        items: block.config.items.filter(
+                                            (_, i) => i !== index,
+                                        ),
+                                    },
+                                })
+                            }
+                        />
+                    ))}
+                </Stack>
+            </Card>
+            <Group gap="xs" align="flex-end">
+                <Textarea
+                    aria-label="New announcement"
+                    size="xs"
+                    style={{ flex: 1 }}
+                    autosize
+                    minRows={1}
+                    maxRows={4}
+                    placeholder="Post an announcement to this audience…"
+                    value={text}
+                    onChange={(e) => setText(e.currentTarget.value)}
+                />
+                <ActionIcon
+                    variant="default"
+                    size="lg"
+                    aria-label="Post announcement"
+                    onClick={postAnnouncement}
+                >
+                    <MantineIcon icon={IconSend} />
+                </ActionIcon>
+            </Group>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -1,0 +1,212 @@
+import {
+    type HomepageResourceItem,
+    type HomepageResourceKind,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Anchor,
+    Badge,
+    Box,
+    Card,
+    Group,
+    Select,
+    Stack,
+    Text,
+    TextInput,
+} from '@mantine-8/core';
+import {
+    IconBook,
+    IconExternalLink,
+    IconLink,
+    IconPlus,
+    IconVideo,
+    IconX,
+    type Icon,
+} from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import { type BlockComponentProps, type BuildComponentProps } from './types';
+
+const KIND_ICONS: Record<HomepageResourceKind, Icon> = {
+    video: IconVideo,
+    doc: IconBook,
+    link: IconLink,
+};
+
+const ResourceRow: FC<{
+    item: HomepageResourceItem;
+    onRemove?: () => void;
+}> = ({ item, onRemove }) => {
+    const row = (
+        <Group gap="sm" wrap="nowrap" p="xs">
+            <MantineIcon icon={KIND_ICONS[item.kind] ?? IconLink} size="lg" />
+            <Box style={{ flex: 1, minWidth: 0 }}>
+                <Text size="sm" fw={500} truncate>
+                    {item.title}
+                </Text>
+                <Text size="xs" c="dimmed" truncate>
+                    {item.url}
+                </Text>
+            </Box>
+            <Badge variant="default" size="sm" tt="capitalize">
+                {item.kind}
+            </Badge>
+            {onRemove ? (
+                <ActionIcon
+                    variant="subtle"
+                    color="gray"
+                    size="sm"
+                    aria-label={`Remove resource ${item.title}`}
+                    onClick={onRemove}
+                >
+                    <MantineIcon icon={IconX} />
+                </ActionIcon>
+            ) : (
+                <MantineIcon icon={IconExternalLink} color="gray" />
+            )}
+        </Group>
+    );
+    if (onRemove) return row;
+    return (
+        <Anchor
+            href={item.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            underline="never"
+            c="inherit"
+        >
+            {row}
+        </Anchor>
+    );
+};
+
+export const ResourcesBlockView: FC<BlockComponentProps> = ({ block }) => {
+    if (block.type !== 'resources' || block.config.items.length === 0) {
+        return null;
+    }
+    return (
+        <Stack gap="xs">
+            <Text size="xs" fw={600} tt="uppercase" c="dimmed">
+                {block.config.title}
+            </Text>
+            <Card withBorder p={0}>
+                <Stack gap={0}>
+                    {block.config.items.map((item) => (
+                        <ResourceRow key={item.url} item={item} />
+                    ))}
+                </Stack>
+            </Card>
+        </Stack>
+    );
+};
+
+export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
+    block,
+    onChange,
+}) => {
+    const [title, setTitle] = useState('');
+    const [url, setUrl] = useState('');
+    const [kind, setKind] = useState<string | null>('link');
+    if (block.type !== 'resources') return null;
+
+    const addResource = () => {
+        const trimmedTitle = title.trim();
+        const trimmedUrl = url.trim();
+        if (!trimmedTitle || !trimmedUrl) return;
+        onChange({
+            ...block,
+            config: {
+                ...block.config,
+                items: [
+                    ...block.config.items,
+                    {
+                        title: trimmedTitle,
+                        url: trimmedUrl,
+                        kind: (kind ?? 'link') as HomepageResourceKind,
+                    },
+                ],
+            },
+        });
+        setTitle('');
+        setUrl('');
+    };
+
+    return (
+        <Stack gap="xs">
+            <TextInput
+                aria-label="Resources title"
+                size="xs"
+                fw={600}
+                value={block.config.title}
+                onChange={(e) =>
+                    onChange({
+                        ...block,
+                        config: {
+                            ...block.config,
+                            title: e.currentTarget.value,
+                        },
+                    })
+                }
+            />
+            <Card withBorder p={0}>
+                <Stack gap={0}>
+                    {block.config.items.map((item) => (
+                        <ResourceRow
+                            key={item.url}
+                            item={item}
+                            onRemove={() =>
+                                onChange({
+                                    ...block,
+                                    config: {
+                                        ...block.config,
+                                        items: block.config.items.filter(
+                                            (i) => i.url !== item.url,
+                                        ),
+                                    },
+                                })
+                            }
+                        />
+                    ))}
+                </Stack>
+            </Card>
+            <Group gap="xs" align="flex-end">
+                <TextInput
+                    label="Title"
+                    size="xs"
+                    style={{ flex: 1 }}
+                    placeholder="e.g. Intro to Lightdash (3 min)"
+                    value={title}
+                    onChange={(e) => setTitle(e.currentTarget.value)}
+                />
+                <TextInput
+                    label="URL"
+                    size="xs"
+                    style={{ flex: 1 }}
+                    placeholder="https://…"
+                    value={url}
+                    onChange={(e) => setUrl(e.currentTarget.value)}
+                />
+                <Select
+                    label="Kind"
+                    size="xs"
+                    w={90}
+                    data={[
+                        { value: 'link', label: 'Link' },
+                        { value: 'doc', label: 'Doc' },
+                        { value: 'video', label: 'Video' },
+                    ]}
+                    value={kind}
+                    onChange={setKind}
+                />
+                <ActionIcon
+                    variant="default"
+                    size="lg"
+                    aria-label="Add resource"
+                    onClick={addResource}
+                >
+                    <MantineIcon icon={IconPlus} />
+                </ActionIcon>
+            </Group>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
@@ -1,17 +1,24 @@
 import { type HomepageBlock } from '@lightdash/common';
 import {
+    IconBook,
     IconLayoutGrid,
     IconMarkdown,
     IconSparkles,
+    IconSpeakerphone,
     IconTypography,
     type Icon,
 } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { AiBlockBuild, AiBlockView } from './AiBlock';
+import {
+    AnnouncementsBlockBuild,
+    AnnouncementsBlockView,
+} from './AnnouncementsBlock';
 import { CollectionBlockBuild, CollectionBlockView } from './CollectionBlock';
 import { HeroBlockBuild, HeroBlockView } from './HeroBlock';
 import { MarkdownBlockBuild, MarkdownBlockView } from './MarkdownBlock';
+import { ResourcesBlockBuild, ResourcesBlockView } from './ResourcesBlock';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 export type BlockDefinition = {
@@ -69,6 +76,32 @@ export const blockLibrary: BlockDefinition[] = [
         }),
         View: CollectionBlockView,
         Build: CollectionBlockBuild,
+    },
+    {
+        type: 'resources',
+        label: 'Resources',
+        description: 'Curated links — docs, videos, request forms.',
+        icon: IconBook,
+        create: () => ({
+            id: uuidv4(),
+            type: 'resources',
+            config: { title: 'Getting started', items: [] },
+        }),
+        View: ResourcesBlockView,
+        Build: ResourcesBlockBuild,
+    },
+    {
+        type: 'announcements',
+        label: 'Announcements',
+        description: 'Updates from the data team, newest first.',
+        icon: IconSpeakerphone,
+        create: () => ({
+            id: uuidv4(),
+            type: 'announcements',
+            config: { title: 'From the data team', items: [] },
+        }),
+        View: AnnouncementsBlockView,
+        Build: AnnouncementsBlockBuild,
     },
     {
         type: 'markdown',


### PR DESCRIPTION
## Homepage Builder — resources + announcements blocks (9)

Part of [ZAP-619](https://linear.app/lightdash/issue/ZAP-619) · Stacked on #25541

Two curated-content blocks stored entirely in block config — no new tables, pure registry entries.

### Resources
- Build: editable section title, add link (title + URL + kind Video/Doc/Link), remove per row
- View: list rows with kind icon + badge; external links open in a new tab with `rel="noopener noreferrer"`

### Announcements
- Build: "Post an announcement" composer — prepends with author auto-filled from the current user and an ISO timestamp; delete per row
- View: feed with relative time ("1 minute ago · David Attenborough") via the existing `useTimeAgo`

Both render nothing when empty and pair side-by-side in one row like the design (multi-block rows land with DnD in ZAP-624).

### Verified live (Playwright + psql)
Added both from the rail → added a doc link → posted an announcement (author/date auto-filled in `draft_config`) → published → `/home` shows the "Getting started" list and the "From the data team" feed with relative time.

### Regression analysis
- Config-only union widening; existing configs unaffected. Flag off: unchanged.
- No backend changes beyond the regenerated OpenAPI union.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ