### PR TITLE
feat(frontend): homepage preset gallery

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -24,6 +24,7 @@ import {
     IconCircleCheck,
     IconCopy,
     IconEye,
+    IconLayoutGrid,
     IconPencil,
     IconPlus,
     IconSend,
@@ -51,6 +52,7 @@ import {
     usePublishHomepage,
     useUpdateHomepageDraft,
 } from './hooks/useProjectHomepage';
+import { PresetsModal } from './PresetsModal';
 import { PublishedHomepage } from './PublishedHomepage';
 
 type Props = {
@@ -81,6 +83,7 @@ export const HomepageEditor: FC<Props> = ({
     );
     const deleteMutation = useDeleteHomepage(projectUuid);
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const [isPresetsModalOpen, setIsPresetsModalOpen] = useState(false);
 
     const isAiEnabled = useAiAgentButtonVisibility();
     const availableBlocks = blockLibrary.filter(
@@ -173,6 +176,13 @@ export const HomepageEditor: FC<Props> = ({
                             </Menu.Item>
                         </Menu.Dropdown>
                     </Menu>
+                    <Button
+                        variant="default"
+                        leftSection={<MantineIcon icon={IconLayoutGrid} />}
+                        onClick={() => setIsPresetsModalOpen(true)}
+                    >
+                        Presets
+                    </Button>
                 </Group>
                 <Group gap="sm">
                     {isDirty ? (
@@ -405,6 +415,11 @@ export const HomepageEditor: FC<Props> = ({
                     </Stack>
                 </Group>
             )}
+            <PresetsModal
+                opened={isPresetsModalOpen}
+                onClose={() => setIsPresetsModalOpen(false)}
+                onApply={setDraft}
+            />
             <MantineModal
                 opened={isDeleteModalOpen}
                 onClose={() =>

--- a/packages/frontend/src/ee/features/homepageBuilder/PresetsModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PresetsModal.tsx
@@ -1,0 +1,103 @@
+import { type HomepageConfig } from '@lightdash/common';
+import { Badge, Card, Group, SimpleGrid, Stack, Text } from '@mantine-8/core';
+import { useState, type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
+import { useAiAgentButtonVisibility } from '../aiCopilot/hooks/useAiAgentsButtonVisibility';
+import { homepagePresets, type HomepagePreset } from './presets';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    onApply: (config: HomepageConfig) => void;
+};
+
+export const PresetsModal: FC<Props> = ({ opened, onClose, onApply }) => {
+    const isAiEnabled = useAiAgentButtonVisibility();
+    const [presetToConfirm, setPresetToConfirm] =
+        useState<HomepagePreset | null>(null);
+
+    const applyPreset = (preset: HomepagePreset) => {
+        const config = preset.create();
+        const rows = config.rows
+            .map((configRow) => ({
+                ...configRow,
+                blocks: configRow.blocks.filter(
+                    (block) => block.type !== 'ai' || isAiEnabled,
+                ),
+            }))
+            .filter((configRow) => configRow.blocks.length > 0);
+        onApply({ ...config, rows });
+        setPresetToConfirm(null);
+        onClose();
+    };
+
+    return (
+        <>
+            <MantineModal
+                opened={opened && presetToConfirm === null}
+                onClose={onClose}
+                title="Start from a preset"
+                size="xl"
+            >
+                <Stack gap="sm">
+                    <Text size="sm" c="dimmed">
+                        Replaces the current draft. You can tweak every block
+                        after.
+                    </Text>
+                    <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="sm">
+                        {homepagePresets.map((preset) => (
+                            <Card
+                                key={preset.key}
+                                withBorder
+                                p="md"
+                                style={{ cursor: 'pointer' }}
+                                onClick={() => setPresetToConfirm(preset)}
+                            >
+                                <Stack gap="xs">
+                                    <Group gap="sm">
+                                        <MantineIcon
+                                            icon={preset.icon}
+                                            size="lg"
+                                        />
+                                        <Text fw={600} size="sm">
+                                            {preset.name}
+                                        </Text>
+                                    </Group>
+                                    <Text size="xs" c="dimmed">
+                                        {preset.description}
+                                    </Text>
+                                    <Group gap={4}>
+                                        {preset.blockChips.map((chip) => (
+                                            <Badge
+                                                key={chip}
+                                                variant="default"
+                                                size="xs"
+                                                tt="none"
+                                            >
+                                                {chip}
+                                            </Badge>
+                                        ))}
+                                    </Group>
+                                </Stack>
+                            </Card>
+                        ))}
+                    </SimpleGrid>
+                </Stack>
+            </MantineModal>
+            <MantineModal
+                opened={presetToConfirm !== null}
+                onClose={() => setPresetToConfirm(null)}
+                title={`Apply “${presetToConfirm?.name}”?`}
+                onConfirm={() =>
+                    presetToConfirm && applyPreset(presetToConfirm)
+                }
+            >
+                <Text size="sm">
+                    This replaces the current draft for this homepage. The
+                    published version stays live until you publish again.
+                </Text>
+            </MantineModal>
+        </>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/presets.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/presets.ts
@@ -1,0 +1,173 @@
+import {
+    type HomepageBlock,
+    type HomepageConfig,
+    type HomepageRow,
+} from '@lightdash/common';
+import {
+    IconBriefcase,
+    IconChartHistogram,
+    IconFile,
+    IconLayoutDashboard,
+    IconUsersGroup,
+    IconUserStar,
+    type Icon,
+} from '@tabler/icons-react';
+import { v4 as uuidv4 } from 'uuid';
+
+export type HomepagePreset = {
+    key: string;
+    name: string;
+    description: string;
+    icon: Icon;
+    blockChips: string[];
+    create: () => HomepageConfig;
+};
+
+const row = (...blocks: HomepageBlock[]): HomepageRow => ({
+    id: uuidv4(),
+    blocks,
+});
+
+const hero = (title: string, subtitle: string): HomepageBlock => ({
+    id: uuidv4(),
+    type: 'hero',
+    config: { title, subtitle },
+});
+
+const ai = (chips: string[]): HomepageBlock => ({
+    id: uuidv4(),
+    type: 'ai',
+    config: { chips },
+});
+
+const collection = (title: string): HomepageBlock => ({
+    id: uuidv4(),
+    type: 'collection',
+    config: { title, items: [] },
+});
+
+const markdown = (content: string): HomepageBlock => ({
+    id: uuidv4(),
+    type: 'markdown',
+    config: { content },
+});
+
+const resources = (title: string): HomepageBlock => ({
+    id: uuidv4(),
+    type: 'resources',
+    config: { title, items: [] },
+});
+
+const announcements = (title: string): HomepageBlock => ({
+    id: uuidv4(),
+    type: 'announcements',
+    config: { title, items: [] },
+});
+
+const config = (...rows: HomepageRow[]): HomepageConfig => ({
+    version: 1,
+    rows,
+});
+
+export const homepagePresets: HomepagePreset[] = [
+    {
+        key: 'exec-overview',
+        name: 'Exec overview',
+        description: 'Company KPIs and the board pack, front and center.',
+        icon: IconBriefcase,
+        blockChips: ['Greeting', 'Collection', 'Ask AI'],
+        create: () =>
+            config(
+                row(
+                    hero(
+                        'Good morning, {name}',
+                        'Company performance at a glance.',
+                    ),
+                ),
+                row(collection('Company KPIs')),
+                row(ai(['Summarize this month vs. plan'])),
+            ),
+    },
+    {
+        key: 'team-hub',
+        name: 'Team hub',
+        description: 'A landing page for one team: dashboards, links, news.',
+        icon: IconUsersGroup,
+        blockChips: [
+            'Greeting',
+            'Ask AI',
+            'Collection',
+            'Resources',
+            'Announcements',
+        ],
+        create: () =>
+            config(
+                row(
+                    hero(
+                        'Good morning, {name}',
+                        'Your team’s snapshot — ask anything, or jump back in.',
+                    ),
+                ),
+                row(ai(['What drove revenue last month?'])),
+                row(collection('Team dashboards')),
+                row(
+                    resources('Getting started'),
+                    announcements('From the data team'),
+                ),
+            ),
+    },
+    {
+        key: 'business-user-starter',
+        name: 'Business-user starter',
+        description: 'Curated essentials for people who just need answers.',
+        icon: IconUserStar,
+        blockChips: ['Greeting', 'Collection', 'Resources'],
+        create: () =>
+            config(
+                row(
+                    hero(
+                        'Welcome, {name}',
+                        'Everything you need, curated by the data team.',
+                    ),
+                ),
+                row(collection('Your dashboards')),
+                row(resources('How-to guides')),
+            ),
+    },
+    {
+        key: 'analyst-workspace',
+        name: 'Analyst workspace',
+        description: 'Power-user shortcuts and a scratchpad.',
+        icon: IconChartHistogram,
+        blockChips: ['Greeting', 'Ask AI', 'Text'],
+        create: () =>
+            config(
+                row(
+                    hero(
+                        'Welcome back, {name}',
+                        'Here’s what’s been happening.',
+                    ),
+                ),
+                row(ai(['Charts nobody has viewed in 90 days'])),
+                row(
+                    markdown('## Notes\n\nKeep links, TODOs and context here.'),
+                ),
+            ),
+    },
+    {
+        key: 'dashboard-as-homepage',
+        name: 'Dashboard as homepage',
+        description: 'One key dashboard is the whole page.',
+        icon: IconLayoutDashboard,
+        blockChips: ['Collection'],
+        create: () => config(row(collection('Your dashboard'))),
+    },
+    {
+        key: 'blank',
+        name: 'Blank',
+        description: 'Start from nothing.',
+        icon: IconFile,
+        blockChips: [],
+        create: () => config(),
+    },
+];


### PR DESCRIPTION
## Homepage Builder — presets gallery (10)

Part of [ZAP-623](https://linear.app/lightdash/issue/ZAP-623) · Stacked on #25542

The six presets from the requirements as static, typed config factories — no backend.

### What
- **Presets**: Exec overview, Team hub, Business-user starter, Analyst workspace, Dashboard as homepage, Blank — each a `create(): HomepageConfig` factory that typechecks against the block schema (fresh uuids per apply)
- **Gallery modal** ("Presets" in the builder toolbar): cards with icon, description, block-type chips → **confirm step** (applying replaces the draft; published stays live until republish) → applied config lands in the editor fully editable, autosaves like any edit
- Ask AI blocks are stripped from presets when AI copilot is unavailable (same gate as the library rail)
- Team hub showcases a **side-by-side row** (resources ‖ announcements) — the config supported it since ZAP-615; presets are the first UI to create one (drag & drop is ZAP-624)
- Content blocks (collections) start empty, prompting the builder to pick content

### Verified live (Playwright + psql)
Created a scratch homepage → Presets → Team hub → confirm → draft became `[hero, ai, collection, resources+announcements]` (4 rows, last row 2 blocks) and autosaved → scratch deleted, demo homepage untouched.

### Regression analysis
- Frontend-only; flag off unchanged; applying is opt-in and behind an explicit confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ