### PR TITLE
feat: favorites and recently-viewed homepage blocks

### DIFF
--- a/packages/backend/src/ee/controllers/projectHomepageController.ts
+++ b/packages/backend/src/ee/controllers/projectHomepageController.ts
@@ -5,6 +5,7 @@ import {
     type ApiProjectHomepageResponse,
     type ApiProjectHomepagesResponse,
     type ApiPublishedHomepageResponse,
+    type ApiRecentlyViewedResponse,
     type ApiSuccessEmpty,
     type CreateProjectHomepageRequest,
     type UpdateProjectHomepageDraftRequest,
@@ -81,6 +82,25 @@ export class ProjectHomepageController extends BaseController {
                 toSessionUser(req.account),
                 projectUuid,
                 homepageUuid,
+            ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/recently-viewed')
+    @OperationId('getHomepageRecentlyViewed')
+    async getRecentlyViewed(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+    ): Promise<ApiRecentlyViewedResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().getRecentlyViewed(
+                toSessionUser(req.account),
+                projectUuid,
             ),
         };
     }

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -1,6 +1,7 @@
 import {
     NotFoundError,
     type HomepageConfig,
+    type HomepageRecentlyViewedItem,
     type ProjectHomepage,
     type PublishedProjectHomepage,
 } from '@lightdash/common';
@@ -119,6 +120,55 @@ export class ProjectHomepageModel {
             throw new NotFoundError('Homepage not found');
         }
         return ProjectHomepageModel.mapDbHomepage(row);
+    }
+
+    // Derived from the existing analytics view events — no separate tracking
+    async getRecentlyViewed(
+        projectUuid: string,
+        userUuid: string,
+        limit: number = 8,
+    ): Promise<HomepageRecentlyViewedItem[]> {
+        const { rows } = await this.database.raw<{
+            rows: Array<{
+                content_type: 'chart' | 'dashboard';
+                content_uuid: string;
+                viewed_at: Date;
+            }>;
+        }>(
+            `
+            SELECT content_type, content_uuid, max(viewed_at) AS viewed_at
+            FROM (
+                SELECT 'chart' AS content_type,
+                       acv.chart_uuid AS content_uuid,
+                       acv.timestamp AS viewed_at
+                FROM analytics_chart_views acv
+                JOIN saved_queries sq ON sq.saved_query_uuid = acv.chart_uuid
+                JOIN spaces s ON s.space_id = sq.space_id
+                JOIN projects p ON p.project_id = s.project_id
+                WHERE acv.user_uuid = :userUuid
+                  AND p.project_uuid = :projectUuid
+                UNION ALL
+                SELECT 'dashboard' AS content_type,
+                       adv.dashboard_uuid AS content_uuid,
+                       adv.timestamp AS viewed_at
+                FROM analytics_dashboard_views adv
+                JOIN dashboards d ON d.dashboard_uuid = adv.dashboard_uuid
+                JOIN spaces s ON s.space_id = d.space_id
+                JOIN projects p ON p.project_id = s.project_id
+                WHERE adv.user_uuid = :userUuid
+                  AND p.project_uuid = :projectUuid
+            ) views
+            GROUP BY content_type, content_uuid
+            ORDER BY viewed_at DESC
+            LIMIT :limit
+            `,
+            { userUuid, projectUuid, limit },
+        );
+        return rows.map((row) => ({
+            contentType: row.content_type,
+            uuid: row.content_uuid,
+            viewedAt: row.viewed_at,
+        }));
     }
 
     // Publishing promotes the homepage to the project default viewers land on

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -117,6 +117,7 @@ const makeService = ({
             getDefault: vi.fn().mockResolvedValue(undefined),
             getByUuid: vi.fn().mockResolvedValue(makeHomepage()),
             getPublishedDefault: vi.fn().mockResolvedValue(undefined),
+            getRecentlyViewed: vi.fn().mockResolvedValue([]),
             list: vi.fn().mockResolvedValue([]),
             create: vi.fn().mockResolvedValue(makeHomepage()),
             updateDraft: vi.fn().mockResolvedValue(makeHomepage()),

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -8,6 +8,7 @@ import {
     ParameterError,
     type CreateProjectHomepageRequest,
     type HomepageConfig,
+    type HomepageRecentlyViewedItem,
     type ProjectHomepage,
     type PublishedProjectHomepage,
     type SessionUser,
@@ -23,6 +24,7 @@ export type ProjectHomepageServiceArguments = {
         | 'getDefault'
         | 'getByUuid'
         | 'getPublishedDefault'
+        | 'getRecentlyViewed'
         | 'list'
         | 'create'
         | 'updateDraft'
@@ -126,6 +128,18 @@ export class ProjectHomepageService extends BaseService {
         const published =
             await this.projectHomepageModel.getPublishedDefault(projectUuid);
         return published ?? null;
+    }
+
+    async getRecentlyViewed(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<HomepageRecentlyViewedItem[]> {
+        await this.assertFlagEnabled(user);
+        this.assertCanView(user, projectUuid);
+        return this.projectHomepageModel.getRecentlyViewed(
+            projectUuid,
+            user.userUuid,
+        );
     }
 
     async getHomepageForBuilder(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1647,6 +1647,48 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageFavoritesBlock: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                config: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        title: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                type: {
+                    dataType: 'enum',
+                    enums: ['favorites'],
+                    required: true,
+                },
+                id: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageRecentBlock: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                config: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        title: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                type: { dataType: 'enum', enums: ['recent'], required: true },
+                id: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     HomepageBlock: {
         dataType: 'refAlias',
         type: {
@@ -1658,6 +1700,8 @@ const models: TsoaRoute.Models = {
                 { ref: 'HomepageCollectionBlock' },
                 { ref: 'HomepageResourcesBlock' },
                 { ref: 'HomepageAnnouncementsBlock' },
+                { ref: 'HomepageFavoritesBlock' },
+                { ref: 'HomepageRecentBlock' },
             ],
             validators: {},
         },
@@ -1790,6 +1834,53 @@ const models: TsoaRoute.Models = {
     ApiProjectHomepageOrNullResponse: {
         dataType: 'refAlias',
         type: { ref: 'ApiSuccess_ProjectHomepage-or-null_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageRecentlyViewedItem: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                viewedAt: { dataType: 'datetime', required: true },
+                uuid: { dataType: 'string', required: true },
+                contentType: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['chart'] },
+                        { dataType: 'enum', enums: ['dashboard'] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_HomepageRecentlyViewedItem-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'HomepageRecentlyViewedItem',
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiRecentlyViewedResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess_HomepageRecentlyViewedItem-Array_',
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'ApiSuccess_ProjectHomepage-Array_': {
@@ -49457,6 +49548,67 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getForBuilder',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectHomepageController_getRecentlyViewed: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/homepage/recently-viewed',
+        ...fetchMiddlewares<RequestHandler>(ProjectHomepageController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectHomepageController.prototype.getRecentlyViewed,
+        ),
+
+        async function ProjectHomepageController_getRecentlyViewed(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectHomepageController_getRecentlyViewed,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectHomepageController>(
+                        ProjectHomepageController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getRecentlyViewed',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1634,6 +1634,52 @@
                 "required": ["config", "type", "id"],
                 "type": "object"
             },
+            "HomepageFavoritesBlock": {
+                "properties": {
+                    "config": {
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["title"],
+                        "type": "object"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["favorites"],
+                        "nullable": false
+                    },
+                    "id": {
+                        "type": "string"
+                    }
+                },
+                "required": ["config", "type", "id"],
+                "type": "object"
+            },
+            "HomepageRecentBlock": {
+                "properties": {
+                    "config": {
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["title"],
+                        "type": "object"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["recent"],
+                        "nullable": false
+                    },
+                    "id": {
+                        "type": "string"
+                    }
+                },
+                "required": ["config", "type", "id"],
+                "type": "object"
+            },
             "HomepageBlock": {
                 "anyOf": [
                     {
@@ -1653,6 +1699,12 @@
                     },
                     {
                         "$ref": "#/components/schemas/HomepageAnnouncementsBlock"
+                    },
+                    {
+                        "$ref": "#/components/schemas/HomepageFavoritesBlock"
+                    },
+                    {
+                        "$ref": "#/components/schemas/HomepageRecentBlock"
                     }
                 ]
             },
@@ -1797,6 +1849,43 @@
             },
             "ApiProjectHomepageOrNullResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_ProjectHomepage-or-null_"
+            },
+            "HomepageRecentlyViewedItem": {
+                "properties": {
+                    "viewedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "contentType": {
+                        "type": "string",
+                        "enum": ["chart", "dashboard"]
+                    }
+                },
+                "required": ["viewedAt", "uuid", "contentType"],
+                "type": "object"
+            },
+            "ApiSuccess_HomepageRecentlyViewedItem-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/HomepageRecentlyViewedItem"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiRecentlyViewedResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_HomepageRecentlyViewedItem-Array_"
             },
             "ApiSuccess_ProjectHomepage-Array_": {
                 "properties": {
@@ -49040,6 +49129,45 @@
                         "in": "query",
                         "name": "homepageUuid",
                         "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/homepage/recently-viewed": {
+            "get": {
+                "operationId": "getHomepageRecentlyViewed",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiRecentlyViewedResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
                         "schema": {
                             "$ref": "#/components/schemas/UUID"
                         }

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -55,13 +55,37 @@ export type HomepageAnnouncementsBlock = {
     config: { title: string; items: HomepageAnnouncementItem[] };
 };
 
+export type HomepageFavoritesBlock = {
+    id: string;
+    type: 'favorites';
+    config: { title: string };
+};
+
+export type HomepageRecentBlock = {
+    id: string;
+    type: 'recent';
+    config: { title: string };
+};
+
 export type HomepageBlock =
     | HomepageMarkdownBlock
     | HomepageHeroBlock
     | HomepageAiBlock
     | HomepageCollectionBlock
     | HomepageResourcesBlock
-    | HomepageAnnouncementsBlock;
+    | HomepageAnnouncementsBlock
+    | HomepageFavoritesBlock
+    | HomepageRecentBlock;
+
+export type HomepageRecentlyViewedItem = {
+    contentType: 'chart' | 'dashboard';
+    uuid: string;
+    viewedAt: Date;
+};
+
+export type ApiRecentlyViewedResponse = ApiSuccess<
+    HomepageRecentlyViewedItem[]
+>;
 
 export type HomepageRow = {
     id: string;

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
@@ -1,0 +1,161 @@
+import { ResourceViewItemType, type ResourceViewItem } from '@lightdash/common';
+import { ActionIcon, Anchor, Badge, Group, Stack, Text } from '@mantine-8/core';
+import {
+    IconChartBar,
+    IconFolder,
+    IconLayoutDashboard,
+    IconStarFilled,
+    IconTerminal2,
+    type Icon,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import { useFavoriteMutation } from '../../../../hooks/favorites/useFavoriteMutation';
+import { useFavorites } from '../../../../hooks/favorites/useFavorites';
+import { type BlockComponentProps, type BuildComponentProps } from './types';
+
+const FAVORITE_ICONS: Partial<Record<ResourceViewItemType, Icon>> = {
+    [ResourceViewItemType.CHART]: IconChartBar,
+    [ResourceViewItemType.DASHBOARD]: IconLayoutDashboard,
+    [ResourceViewItemType.SPACE]: IconFolder,
+    [ResourceViewItemType.DATA_APP]: IconTerminal2,
+};
+
+const favoriteUrl = (projectUuid: string, item: ResourceViewItem): string => {
+    switch (item.type) {
+        case ResourceViewItemType.DASHBOARD:
+            return `/projects/${projectUuid}/dashboards/${item.data.uuid}/view`;
+        case ResourceViewItemType.SPACE:
+            return `/projects/${projectUuid}/spaces/${item.data.uuid}`;
+        case ResourceViewItemType.DATA_APP:
+            return `/projects/${projectUuid}/apps/${item.data.uuid}`;
+        default:
+            return `/projects/${projectUuid}/saved/${item.data.uuid}`;
+    }
+};
+
+const FavoritePills: FC<{
+    projectUuid: string;
+    isInteractive: boolean;
+}> = ({ projectUuid, isInteractive }) => {
+    const { data: favorites } = useFavorites(projectUuid);
+    const { mutate: toggleFavorite } = useFavoriteMutation(projectUuid);
+
+    if (!favorites || favorites.length === 0) {
+        return (
+            <Text
+                size="xs"
+                c="dimmed"
+                p="sm"
+                style={{
+                    border: '1px dashed var(--mantine-color-gray-4)',
+                    borderRadius: 8,
+                }}
+            >
+                Star any dashboard or chart to keep it here — each person sees
+                their own favorites.
+            </Text>
+        );
+    }
+
+    return (
+        <Group gap="xs">
+            {favorites.map((item) => (
+                <Anchor
+                    key={item.data.uuid}
+                    component={Link}
+                    to={favoriteUrl(projectUuid, item)}
+                    underline="never"
+                    c="inherit"
+                >
+                    <Group
+                        gap={6}
+                        px="sm"
+                        py={6}
+                        style={{
+                            border: '1px solid var(--mantine-color-gray-3)',
+                            borderRadius: 8,
+                        }}
+                        wrap="nowrap"
+                    >
+                        <MantineIcon
+                            icon={FAVORITE_ICONS[item.type] ?? IconChartBar}
+                            color="gray"
+                        />
+                        <Text size="sm" fw={500}>
+                            {item.data.name}
+                        </Text>
+                        {isInteractive ? (
+                            <ActionIcon
+                                variant="transparent"
+                                color="yellow"
+                                size="xs"
+                                aria-label={`Remove ${item.data.name} from favorites`}
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    toggleFavorite({
+                                        contentType: item.type,
+                                        contentUuid: item.data.uuid,
+                                    });
+                                }}
+                            >
+                                <MantineIcon icon={IconStarFilled} />
+                            </ActionIcon>
+                        ) : (
+                            <MantineIcon
+                                icon={IconStarFilled}
+                                color="yellow"
+                                size="sm"
+                            />
+                        )}
+                    </Group>
+                </Anchor>
+            ))}
+        </Group>
+    );
+};
+
+export const FavoritesBlockView: FC<BlockComponentProps> = ({
+    block,
+    projectUuid,
+}) => {
+    if (block.type !== 'favorites') return null;
+    return (
+        <Stack gap="xs">
+            <Group gap="xs">
+                <Text size="xs" fw={600} tt="uppercase" c="dimmed">
+                    {block.config.title}
+                </Text>
+                <Badge variant="default" size="xs" tt="none">
+                    Only you see this
+                </Badge>
+            </Group>
+            <FavoritePills projectUuid={projectUuid} isInteractive />
+        </Stack>
+    );
+};
+
+export const FavoritesBlockBuild: FC<BuildComponentProps> = ({
+    block,
+    projectUuid,
+}) => {
+    if (block.type !== 'favorites') return null;
+    return (
+        <Stack gap="xs">
+            <Group gap="xs">
+                <Text size="xs" fw={600} tt="uppercase" c="dimmed">
+                    {block.config.title}
+                </Text>
+                <Badge variant="default" size="xs" tt="none">
+                    Personal per viewer
+                </Badge>
+            </Group>
+            <FavoritePills projectUuid={projectUuid} isInteractive={false} />
+            <Text size="xs" c="dimmed">
+                Showing your favorites as a sample — every viewer sees their
+                own.
+            </Text>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
@@ -1,0 +1,138 @@
+import {
+    type ApiError,
+    type HomepageRecentlyViewedItem,
+} from '@lightdash/common';
+import { Badge, Card, Group, Skeleton, Stack, Text } from '@mantine-8/core';
+import { useQuery } from '@tanstack/react-query';
+import { type FC } from 'react';
+import { lightdashApi } from '../../../../api';
+import { useTimeAgo } from '../../../../hooks/useTimeAgo';
+import { useCollectionContent } from '../hooks/useCollectionContent';
+import { ContentCard } from './ContentCard';
+import { type BlockComponentProps, type BuildComponentProps } from './types';
+
+const getRecentlyViewed = async (projectUuid: string) =>
+    lightdashApi<HomepageRecentlyViewedItem[]>({
+        url: `/projects/${projectUuid}/homepage/recently-viewed`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const useRecentlyViewed = (projectUuid: string) =>
+    useQuery<HomepageRecentlyViewedItem[], ApiError>({
+        queryKey: ['homepage_recently_viewed', projectUuid],
+        queryFn: () => getRecentlyViewed(projectUuid),
+    });
+
+const ViewedAt: FC<{ date: Date }> = ({ date }) => {
+    const timeAgo = useTimeAgo(date);
+    return (
+        <Text size="xs" c="dimmed" style={{ whiteSpace: 'nowrap' }}>
+            {timeAgo}
+        </Text>
+    );
+};
+
+const RecentList: FC<{ projectUuid: string }> = ({ projectUuid }) => {
+    const { data: recents, isInitialLoading } = useRecentlyViewed(projectUuid);
+    const uuids = (recents ?? []).map((item) => item.uuid);
+    const { data: contents, isInitialLoading: isResolving } =
+        useCollectionContent(projectUuid, uuids);
+
+    if (isInitialLoading || isResolving) {
+        return (
+            <Stack gap="xs">
+                {[0, 1, 2].map((i) => (
+                    <Skeleton key={i} h={56} radius="md" />
+                ))}
+            </Stack>
+        );
+    }
+    if (!contents || contents.length === 0) {
+        return (
+            <Text
+                size="xs"
+                c="dimmed"
+                p="sm"
+                style={{
+                    border: '1px dashed var(--mantine-color-gray-4)',
+                    borderRadius: 8,
+                }}
+            >
+                Charts and dashboards you open will show up here.
+            </Text>
+        );
+    }
+    const viewedAtByUuid = new Map(
+        (recents ?? []).map((item) => [item.uuid, item.viewedAt]),
+    );
+    return (
+        <Card withBorder p="sm">
+            <Stack gap="xs">
+                {contents.map((content) => {
+                    const viewedAt = viewedAtByUuid.get(content.uuid);
+                    return (
+                        <Group
+                            key={content.uuid}
+                            gap="sm"
+                            wrap="nowrap"
+                            align="center"
+                        >
+                            <div style={{ flex: 1, minWidth: 0 }}>
+                                <ContentCard
+                                    content={content}
+                                    projectUuid={projectUuid}
+                                />
+                            </div>
+                            {viewedAt && <ViewedAt date={viewedAt} />}
+                        </Group>
+                    );
+                })}
+            </Stack>
+        </Card>
+    );
+};
+
+export const RecentBlockView: FC<BlockComponentProps> = ({
+    block,
+    projectUuid,
+}) => {
+    if (block.type !== 'recent') return null;
+    return (
+        <Stack gap="xs">
+            <Group gap="xs">
+                <Text size="xs" fw={600} tt="uppercase" c="dimmed">
+                    {block.config.title}
+                </Text>
+                <Badge variant="default" size="xs" tt="none">
+                    Personal per viewer
+                </Badge>
+            </Group>
+            <RecentList projectUuid={projectUuid} />
+        </Stack>
+    );
+};
+
+export const RecentBlockBuild: FC<BuildComponentProps> = ({
+    block,
+    projectUuid,
+}) => {
+    if (block.type !== 'recent') return null;
+    return (
+        <Stack gap="xs">
+            <Group gap="xs">
+                <Text size="xs" fw={600} tt="uppercase" c="dimmed">
+                    {block.config.title}
+                </Text>
+                <Badge variant="default" size="xs" tt="none">
+                    Personal per viewer
+                </Badge>
+            </Group>
+            <RecentList projectUuid={projectUuid} />
+            <Text size="xs" c="dimmed">
+                Showing your recent activity as a sample — every viewer sees
+                their own.
+            </Text>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
@@ -1,10 +1,12 @@
 import { type HomepageBlock } from '@lightdash/common';
 import {
     IconBook,
+    IconClock,
     IconLayoutGrid,
     IconMarkdown,
     IconSparkles,
     IconSpeakerphone,
+    IconStar,
     IconTypography,
     type Icon,
 } from '@tabler/icons-react';
@@ -16,8 +18,10 @@ import {
     AnnouncementsBlockView,
 } from './AnnouncementsBlock';
 import { CollectionBlockBuild, CollectionBlockView } from './CollectionBlock';
+import { FavoritesBlockBuild, FavoritesBlockView } from './FavoritesBlock';
 import { HeroBlockBuild, HeroBlockView } from './HeroBlock';
 import { MarkdownBlockBuild, MarkdownBlockView } from './MarkdownBlock';
+import { RecentBlockBuild, RecentBlockView } from './RecentBlock';
 import { ResourcesBlockBuild, ResourcesBlockView } from './ResourcesBlock';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
@@ -102,6 +106,32 @@ export const blockLibrary: BlockDefinition[] = [
         }),
         View: AnnouncementsBlockView,
         Build: AnnouncementsBlockBuild,
+    },
+    {
+        type: 'favorites',
+        label: 'Favorites',
+        description: 'Each viewer’s starred content, only visible to them.',
+        icon: IconStar,
+        create: () => ({
+            id: uuidv4(),
+            type: 'favorites',
+            config: { title: 'My favorites' },
+        }),
+        View: FavoritesBlockView,
+        Build: FavoritesBlockBuild,
+    },
+    {
+        type: 'recent',
+        label: 'Recently viewed',
+        description: 'Each viewer’s recently opened charts and dashboards.',
+        icon: IconClock,
+        create: () => ({
+            id: uuidv4(),
+            type: 'recent',
+            config: { title: 'Recently viewed' },
+        }),
+        View: RecentBlockView,
+        Build: RecentBlockBuild,
     },
     {
         type: 'markdown',


### PR DESCRIPTION
## Homepage Builder — favorites + recently-viewed blocks (11)

Part of [ZAP-621](https://linear.app/lightdash/issue/ZAP-621) · Stacked on #25548

Two per-viewer blocks: the curated page is shared, but these render each viewer’s own content.

### Favorites
- Pill cards from the existing `user_favorites` (`useFavorites`), with click-through and unfavorite in view mode; empty state explains starring
- Build mode shows the builder’s favorites as a read-only sample, labelled "Personal per viewer"

### Recently viewed — no new table needed
The ticket proposed a `user_recently_viewed` table + tracking hooks, but `analytics_chart_views` / `analytics_dashboard_views` **already record per-user view events**. Recently-viewed is a read model over them:
- `ProjectHomepageModel.getRecentlyViewed` — UNION over both analytics tables, scoped to project + user, latest-distinct per content, limit 8
- `GET /projects/:uuid/homepage/recently-viewed` (flag + `view Project` gate — personal data, any member)
- The block resolves refs through the access-checked content API (`useCollectionContent`), so deleted/inaccessible content is omitted; rows show relative view time

### Verified live (Playwright + psql + curl)
Endpoint returns the session user’s real recents from analytics; both blocks added via the rail, published, and `/home` renders "My favorites · Only you see this" with the chart starred earlier today + unfavorite buttons, and the recently-viewed list with timestamps.

### Also
Filed [ZAP-631](https://linear.app/lightdash/issue/ZAP-631) during verification: draft PATCH is last-write-wins; a stale writer (second tab) can clobber newer state — needs optimistic locking (compare-and-set on `updatedAt`).

### Regression analysis
- New read-only endpoint; no writes, no new tables. Flag off unchanged; config union widening backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ