### PR TITLE
docs: clarify MetricFlow example setup and remove docker-dev references

### DIFF
--- a/examples/metricflow-demo/README.md
+++ b/examples/metricflow-demo/README.md
@@ -1,43 +1,49 @@
-# MetricFlow → Lightdash demo (PROD-2191)
+# MetricFlow → Lightdash example
 
-Two complete dbt projects demonstrating native MetricFlow support in the
-Lightdash CLI deploy/compile flow (PR
-[#25478](https://github.com/lightdash/lightdash/pull/25478)) — **no dbt Cloud
-required**. Both projects define the *same* metrics over the same tiny orders
-dataset, one in each YAML spec:
+Two complete dbt projects showing how to bring your dbt **MetricFlow** metrics
+into Lightdash using the Lightdash CLI (`compile` / `deploy`) — **no dbt Cloud
+required**. If you already define metrics with MetricFlow in your dbt project,
+Lightdash can read them straight from the dbt manifest and turn them into
+Lightdash metrics.
+
+Both projects define the *same* metrics over the same tiny orders dataset, one
+in each of the two MetricFlow YAML specs:
 
 | Project | Metrics spec | dbt engine | Warehouse |
 |---|---|---|---|
-| `legacy-spec/` | Legacy: top-level `semantic_models:` + `metrics:` with `type_params` ([docs](https://docs.getdbt.com/docs/build/sl-getting-started)) | dbt Core ≥ 1.6 (python) | Postgres (Lightdash docker-dev, `localhost:5532`) |
+| `legacy-spec/` | Legacy: top-level `semantic_models:` + `metrics:` with `type_params` ([docs](https://docs.getdbt.com/docs/build/sl-getting-started)) | dbt Core ≥ 1.6 (python) | Postgres |
 | `latest-spec/` | Latest: inline `semantic_model:` on the model, metrics with top-level `agg`/`expr` ([docs](https://docs.getdbt.com/docs/build/latest-metrics-spec)) | dbt Fusion 2.0 (≥ preview.199) | DuckDB (local file, zero infra) |
 
 Both author layers compile to the same manifest sections (`semantic_models` +
-`metrics`), which is what Lightdash reads. One wrinkle: Fusion writes simple
-metrics with `type_params.measure: null` and the aggregation inlined as
-`type_params.metric_aggregation_params` — the translator handles both shapes.
+`metrics`), which is what Lightdash reads — so whichever spec your project uses,
+the result in Lightdash is identical. One thing worth knowing: Fusion writes
+simple metrics with `type_params.measure: null` and the aggregation inlined as
+`type_params.metric_aggregation_params`, while dbt Core writes the older shape.
+Lightdash handles both.
 
-## Quick start (reproducible test)
+## Quick start
 
 ```bash
 # from the repo root: build the CLI once
 pnpm -F @lightdash/common build && pnpm -F @lightdash/warehouses build && pnpm -F @lightdash/cli build
 
-# run both projects end-to-end and assert the translation
+# run both projects end-to-end
 ./examples/metricflow-demo/test.sh
 ```
 
 `test.sh` seeds/runs/parses each dbt project, runs `lightdash compile` on the
-manifest, and asserts (via `assert-translation.cjs`) that exactly the expected
-metrics translate — names, metric types, SQL, percentile value — and that the
-unsupported ones are skipped **with warnings**.
+manifest, and verifies which metrics translate — names, metric types, SQL,
+percentile value — and that unsupported ones are skipped **with warnings**. It's
+a convenience for trying the example out; the two dbt projects below are the part
+worth studying for your own setup.
 
 ## Environment setup
 
 ### legacy-spec — python / dbt Core
 
-Requires [uv](https://docs.astral.sh/uv/) and a Postgres to build against
-(the Lightdash docker-dev database on `localhost:5532` works out of the box;
-override with `PGHOST`/`PGPORT`/`PGUSER`/`PGPASSWORD`/`PGDATABASE`).
+Requires [uv](https://docs.astral.sh/uv/) and a Postgres to build against.
+The profile defaults to a local Postgres on `localhost:5432`; override any of
+`PGHOST`/`PGPORT`/`PGUSER`/`PGPASSWORD`/`PGDATABASE` to point at your own.
 
 ```bash
 cd legacy-spec
@@ -49,8 +55,7 @@ uv pip install --python .venv/bin/python 'dbt-core>=1.9,<2.0' dbt-postgres
 ```
 
 Any dbt Core ≥ 1.6 emits the semantic layer into the manifest (v10+). dbt
-Core ≥ 1.9 needs Python ≥ 3.9; 3.12 is a safe choice. The repo-root `venv/`
-(python 3.9 / dbt 1.7) also works for this project.
+Core ≥ 1.9 needs Python ≥ 3.9; 3.12 is a safe choice.
 
 ### latest-spec — dbt Fusion
 
@@ -74,31 +79,36 @@ cd latest-spec && mkdir -p warehouse
 Why DuckDB here: Fusion's postgres adapter is experimental
 (`DBT_ALLOW_EXPERIMENTAL_ADAPTERS=true`) and currently **segfaults on
 execution** (parse works). DuckDB is officially supported by Fusion and by
-Lightdash.
+Lightdash, and keeps this example fully self-contained.
 
 ### Lightdash compile / deploy
 
 ```bash
-# compile only (no Lightdash server needed)
+# compile only (no Lightdash server needed) — good for checking the translation
 node ../../packages/cli/dist/index.js compile \
     --project-dir . --profiles-dir profiles --skip-dbt-compile --verbose
 
-# deploy legacy-spec into a local Lightdash as a new project
-LIGHTDASH_URL=http://localhost:8090 LIGHTDASH_API_KEY=<your PAT> \
+# deploy legacy-spec into Lightdash as a new project
+LIGHTDASH_URL=<your Lightdash URL> LIGHTDASH_API_KEY=<your PAT> \
 node ../../packages/cli/dist/index.js deploy --create "MetricFlow demo (legacy)" \
     --project-dir . --profiles-dir profiles --skip-dbt-compile
 ```
 
+If you've installed the published CLI (`npm install -g @lightdash/cli`), use
+`lightdash compile` / `lightdash deploy` in place of the `node ...` invocations
+above.
+
 `--skip-dbt-compile` makes the CLI read the manifest your chosen dbt engine
 already wrote (so the CLI doesn't need dbt on PATH). For `latest-spec` add
 `--no-warehouse-credentials`: the CLI's duckdb profile support only covers
-MotherDuck/DuckLake targets, so local-file duckdb can't provide credentials —
-compile works, `deploy` does not (deploy the legacy project to play in the UI).
+MotherDuck/DuckLake targets, so a local-file duckdb can't provide credentials —
+compile works, `deploy` does not (deploy the legacy project if you want to
+explore the result in the Lightdash UI).
 
 ## What translates (and what doesn't)
 
-Verified by `test.sh` — both specs produce the identical result:
-**8 translated, 5 skipped (with warnings)**.
+Both specs produce the identical result: **8 translated, 5 skipped (with
+warnings)**.
 
 ### Supported → Lightdash metrics
 
@@ -116,14 +126,14 @@ Verified by `test.sh` — both specs produce the identical result:
 | metric/measure `label` + `description` | carried over (metric-level wins) |
 
 YAML-defined `meta.metrics` win over translated MetricFlow metrics on name
-collision.
+collision — so you can always override a translated metric by hand.
 
-### Not supported (skipped, warning on deploy; details under `--verbose`)
+### Not currently supported (skipped, warning on deploy; details under `--verbose`)
 
 | MetricFlow feature | Why |
 |---|---|
-| `ratio` metrics | Lightdash has no native multi-metric division; follow-up |
-| `derived` metrics | expression over other metrics; follow-up |
+| `ratio` metrics | Lightdash has no native multi-metric division |
+| `derived` metrics | expression over other metrics |
 | `cumulative` metrics | needs time-spine semantics Lightdash doesn't have |
 | `conversion` metrics | needs entity-journey semantics |
 | metric `filter:` / measure-level filters | MetricFlow where-filter templates (`{{ Dimension('order__status') }}`) don't map to Lightdash metric filters |
@@ -134,16 +144,20 @@ collision.
 | `join_to_timespine`, `fill_nulls_with`, `non_additive_dimension`, `percentile_type: discrete` | no equivalents (percentiles always compile to `PERCENTILE_CONT`) |
 | saved queries / exports | out of scope |
 
+For unsupported metrics, define the equivalent as a Lightdash metric in your
+model's `meta` (the columns and dimensions are already there) — the two layers
+coexist.
+
 ## Layout
 
 ```
 metricflow-demo/
 ├── README.md                  ← you are here
-├── test.sh                    ← reproducible end-to-end test (both specs)
-├── assert-translation.cjs     ← asserts manifest → Lightdash metric translation
+├── test.sh                    ← runs both specs end-to-end
+├── assert-translation.cjs     ← checks manifest → Lightdash metric translation
 ├── legacy-spec/
 │   ├── dbt_project.yml
-│   ├── profiles/profiles.yml  ← postgres (docker-dev defaults)
+│   ├── profiles/profiles.yml  ← postgres
 │   ├── seeds/raw_orders.csv
 │   └── models/
 │       ├── orders.sql

--- a/examples/metricflow-demo/legacy-spec/profiles/profiles.yml
+++ b/examples/metricflow-demo/legacy-spec/profiles/profiles.yml
@@ -7,7 +7,7 @@ metricflow_demo_legacy:
     dev:
       type: postgres
       host: "{{ env_var('PGHOST', 'localhost') }}"
-      port: "{{ env_var('PGPORT', '5532') | as_number }}"
+      port: "{{ env_var('PGPORT', '5432') | as_number }}"
       user: "{{ env_var('PGUSER', 'postgres') }}"
       pass: "{{ env_var('PGPASSWORD', 'password') }}"
       dbname: "{{ env_var('PGDATABASE', 'postgres') }}"

--- a/examples/metricflow-demo/test.sh
+++ b/examples/metricflow-demo/test.sh
@@ -3,8 +3,8 @@
 # → dbt manifest → Lightdash metrics via the CLI compile pipeline.
 #
 # Requirements: uv (https://docs.astral.sh/uv/), node, and for the legacy
-# project a running postgres (Lightdash docker-dev, localhost:5532).
-# See README.md for details.
+# project a running postgres (defaults to localhost:5432; override with
+# PGHOST/PGPORT/PGUSER/PGPASSWORD/PGDATABASE). See README.md for details.
 set -euo pipefail
 cd "$(dirname "$0")"
 REPO_ROOT="$(cd ../.. && pwd)"


### PR DESCRIPTION
### Description

Updates the MetricFlow → Lightdash example documentation and configuration to:

1. **Clarify the example's purpose**: Reframes the README from a test-focused demo to a practical guide for bringing MetricFlow metrics into Lightdash using the CLI
2. **Remove docker-dev dependencies**: Changes default Postgres port from 5532 (Lightdash docker-dev) to standard 5432, making the example work with any local Postgres instance
3. **Improve setup instructions**: 
   - Simplifies environment setup sections with clearer defaults and override instructions
   - Removes references to repo-root venv and docker-dev specifics
   - Clarifies that `test.sh` is a convenience script, not the main focus
4. **Enhance documentation clarity**:
   - Better explains how both MetricFlow specs compile to identical Lightdash metrics
   - Clarifies which metrics are supported vs. unsupported and why
   - Improves CLI usage examples with better context
   - Adds guidance on handling unsupported metrics with manual Lightdash definitions

The changes make the example more accessible to users with their own Postgres/dbt setups while maintaining the reproducible test capability for contributors.

**Files changed:**
- `examples/metricflow-demo/README.md` — documentation improvements and clarifications
- `examples/metricflow-demo/test.sh` — updated comments to reflect new defaults
- `examples/metricflow-demo/legacy-spec/profiles/profiles.yml` — changed default port to 5432

No functional changes to the dbt projects or test logic.

https://claude.ai/code/session_01QrVeak54g3mmqzBENSHcMd