### PR TITLE
feat: optimistic locking for homepage draft saves

### DIFF
--- a/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
@@ -1,4 +1,8 @@
-import { NotFoundError, type HomepageConfig } from '@lightdash/common';
+import {
+    ConflictError,
+    NotFoundError,
+    type HomepageConfig,
+} from '@lightdash/common';
 import knex, { Knex } from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { HomepagesTableName } from '../database/entities/projectHomepages';
@@ -51,12 +55,47 @@ describe('ProjectHomepageModel', () => {
     });
 
     describe('updateDraft', () => {
-        it('throws NotFoundError when no row is updated', async () => {
+        const baseUpdatedAt = new Date('2026-01-02T00:00:00Z');
+
+        it('throws NotFoundError when the homepage does not exist', async () => {
             tracker.on.update(HomepagesTableName).responseOnce([]);
+            tracker.on.select(HomepagesTableName).responseOnce([]);
 
             await expect(
-                model.updateDraft(HOMEPAGE_UUID, { draftConfig }),
+                model.updateDraft(HOMEPAGE_UUID, {
+                    draftConfig,
+                    baseUpdatedAt,
+                }),
             ).rejects.toThrow(NotFoundError);
+        });
+
+        it('throws ConflictError when the base timestamp is stale', async () => {
+            tracker.on.update(HomepagesTableName).responseOnce([]);
+            tracker.on
+                .select(HomepagesTableName)
+                .responseOnce([makeDbHomepage()]);
+
+            await expect(
+                model.updateDraft(HOMEPAGE_UUID, {
+                    draftConfig,
+                    baseUpdatedAt,
+                }),
+            ).rejects.toThrow(ConflictError);
+        });
+
+        it('includes the compare-and-set condition in the update', async () => {
+            tracker.on
+                .update(HomepagesTableName)
+                .responseOnce([makeDbHomepage()]);
+
+            await model.updateDraft(HOMEPAGE_UUID, {
+                draftConfig,
+                baseUpdatedAt,
+            });
+
+            const updateQuery = tracker.history.update[0];
+            expect(updateQuery.sql).toContain('updated_at');
+            expect(updateQuery.bindings).toContainEqual(baseUpdatedAt);
         });
     });
 

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -1,4 +1,5 @@
 import {
+    ConflictError,
     NotFoundError,
     type HomepageConfig,
     type HomepageRecentlyViewedItem,
@@ -106,10 +107,19 @@ export class ProjectHomepageModel {
 
     async updateDraft(
         homepageUuid: string,
-        update: { name?: string; draftConfig: HomepageConfig },
+        update: {
+            name?: string;
+            draftConfig: HomepageConfig;
+            baseUpdatedAt: Date;
+        },
     ): Promise<ProjectHomepage> {
         const [row] = await this.database(HomepagesTableName)
             .where({ homepage_uuid: homepageUuid })
+            // JS dates are ms-precision; Postgres stores µs — compare at ms
+            .whereRaw(
+                "date_trunc('milliseconds', updated_at) = date_trunc('milliseconds', ?::timestamp)",
+                [update.baseUpdatedAt],
+            )
             .update({
                 ...(update.name !== undefined ? { name: update.name } : {}),
                 draft_config: update.draftConfig,
@@ -117,6 +127,14 @@ export class ProjectHomepageModel {
             })
             .returning('*');
         if (!row) {
+            const exists = await this.database(HomepagesTableName)
+                .where({ homepage_uuid: homepageUuid })
+                .first();
+            if (exists) {
+                throw new ConflictError(
+                    'This homepage was changed somewhere else',
+                );
+            }
             throw new NotFoundError('Homepage not found');
         }
         return ProjectHomepageModel.mapDbHomepage(row);

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -223,6 +223,7 @@ describe('ProjectHomepageService', () => {
                         },
                     ],
                 },
+                baseUpdatedAt: NOW,
             }),
         ).rejects.toThrow(ParameterError);
     });
@@ -241,6 +242,7 @@ describe('ProjectHomepageService', () => {
         await expect(
             service.updateDraft(makeAdminUser(), PROJECT_UUID, HOMEPAGE_UUID, {
                 draftConfig: validConfig,
+                baseUpdatedAt: NOW,
             }),
         ).rejects.toThrow(NotFoundError);
     });

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -211,6 +211,7 @@ export class ProjectHomepageService extends BaseService {
         return this.projectHomepageModel.updateDraft(homepageUuid, {
             name: data.name,
             draftConfig: data.draftConfig,
+            baseUpdatedAt: data.baseUpdatedAt,
         });
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1938,6 +1938,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                baseUpdatedAt: { dataType: 'datetime', required: true },
                 draftConfig: { ref: 'HomepageConfig', required: true },
                 name: { dataType: 'string' },
             },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1938,6 +1938,11 @@
             },
             "UpdateProjectHomepageDraftRequest": {
                 "properties": {
+                    "baseUpdatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Compare-and-set token: the updatedAt the client based its edit on"
+                    },
                     "draftConfig": {
                         "$ref": "#/components/schemas/HomepageConfig"
                     },
@@ -1945,7 +1950,7 @@
                         "type": "string"
                     }
                 },
-                "required": ["draftConfig"],
+                "required": ["baseUpdatedAt", "draftConfig"],
                 "type": "object"
             },
             "ManagedAgentScheduleOption": {

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -144,6 +144,8 @@ export type CreateProjectHomepageRequest = {
 export type UpdateProjectHomepageDraftRequest = {
     name?: string;
     draftConfig: HomepageConfig;
+    /** Compare-and-set token: the updatedAt the client based its edit on */
+    baseUpdatedAt: Date;
 };
 
 export type ApiProjectHomepageResponse = ApiSuccess<ProjectHomepage>;

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -389,6 +389,17 @@ export class AlreadyExistsError extends LightdashError {
     }
 }
 
+export class ConflictError extends LightdashError {
+    constructor(message: string) {
+        super({
+            message,
+            name: 'ConflictError',
+            statusCode: 409,
+            data: {},
+        });
+    }
+}
+
 export class MissingConfigError extends LightdashError {
     constructor(message: string) {
         super({

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
@@ -10,6 +10,7 @@ import {
     Title,
 } from '@mantine-8/core';
 import { IconArrowLeft } from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useState, type FC } from 'react';
 import { useParams, useSearchParams } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -103,6 +104,8 @@ const CreateHomepageForm: FC<{
 export const HomepageBuilderPage: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const [searchParams, setSearchParams] = useSearchParams();
+    const queryClient = useQueryClient();
+    const [editorEpoch, setEditorEpoch] = useState(0);
     const selectedHomepageUuid = searchParams.get('homepage') ?? undefined;
     const isCreating = searchParams.get('create') === '1';
     const { user } = useApp();
@@ -156,7 +159,7 @@ export const HomepageBuilderPage: FC = () => {
                 />
             ) : (
                 <HomepageEditor
-                    key={homepage.data.homepageUuid}
+                    key={`${homepage.data.homepageUuid}-${editorEpoch}`}
                     homepage={homepage.data}
                     projectUuid={projectUuid}
                     homepages={homepages.data ?? []}
@@ -165,6 +168,14 @@ export const HomepageBuilderPage: FC = () => {
                     }
                     onCreateNew={() => setSearchParams({ create: '1' })}
                     onDeleted={() => setSearchParams({})}
+                    onConflictReload={async () => {
+                        await queryClient.refetchQueries([
+                            'project_homepage',
+                            projectUuid,
+                            'builder',
+                        ]);
+                        setEditorEpoch((epoch) => epoch + 1);
+                    }}
                 />
             )}
         </Page>

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -62,6 +62,7 @@ type Props = {
     onSwitchHomepage: (homepageUuid: string) => void;
     onCreateNew: () => void;
     onDeleted: () => void;
+    onConflictReload: () => void;
 };
 
 export const HomepageEditor: FC<Props> = ({
@@ -71,6 +72,7 @@ export const HomepageEditor: FC<Props> = ({
     onSwitchHomepage,
     onCreateNew,
     onDeleted,
+    onConflictReload,
 }) => {
     const navigate = useNavigate();
     const updateMutation = useUpdateHomepageDraft(
@@ -93,19 +95,53 @@ export const HomepageEditor: FC<Props> = ({
     const [draft, setDraft] = useState<HomepageConfig>(homepage.draftConfig);
     const [isPreviewing, setIsPreviewing] = useState(false);
     const [debouncedDraft] = useDebouncedValue(draft, 800);
+    const [hasConflict, setHasConflict] = useState(false);
     const lastSavedRef = useRef<HomepageConfig>(homepage.draftConfig);
+    // Compare-and-set token so a stale editor can never clobber newer state
+    const baseUpdatedAtRef = useRef<Date>(homepage.updatedAt);
 
     const { mutate: saveDraft } = updateMutation;
     useEffect(() => {
-        if (debouncedDraft === lastSavedRef.current) return;
+        if (hasConflict || debouncedDraft === lastSavedRef.current) return;
         lastSavedRef.current = debouncedDraft;
-        saveDraft({ draftConfig: debouncedDraft });
-    }, [debouncedDraft, saveDraft]);
+        saveDraft(
+            {
+                draftConfig: debouncedDraft,
+                baseUpdatedAt: baseUpdatedAtRef.current,
+            },
+            {
+                onSuccess: (saved) => {
+                    baseUpdatedAtRef.current = saved.updatedAt;
+                },
+                onError: (error) => {
+                    if (error.error.statusCode === 409) setHasConflict(true);
+                },
+            },
+        );
+    }, [debouncedDraft, hasConflict, saveDraft]);
 
     const handlePublish = async () => {
+        if (hasConflict) return;
         if (draft !== lastSavedRef.current) {
             lastSavedRef.current = draft;
-            await updateMutation.mutateAsync({ draftConfig: draft });
+            try {
+                const saved = await updateMutation.mutateAsync(
+                    {
+                        draftConfig: draft,
+                        baseUpdatedAt: baseUpdatedAtRef.current,
+                    },
+                    {
+                        onError: (error) => {
+                            if (error.error.statusCode === 409) {
+                                setHasConflict(true);
+                            }
+                        },
+                    },
+                );
+                baseUpdatedAtRef.current = saved.updatedAt;
+            } catch {
+                return;
+            }
         }
         publishMutation.mutate();
     };
@@ -114,6 +150,25 @@ export const HomepageEditor: FC<Props> = ({
 
     return (
         <Stack gap="lg" w="100%">
+            {hasConflict && (
+                <Group
+                    justify="space-between"
+                    p="sm"
+                    style={{
+                        border: '1px solid var(--mantine-color-orange-4)',
+                        borderRadius: 8,
+                        background: 'var(--mantine-color-orange-0)',
+                    }}
+                >
+                    <Text size="sm" fw={500}>
+                        This homepage was changed somewhere else — your latest
+                        edits here can’t be saved.
+                    </Text>
+                    <Button size="xs" onClick={onConflictReload}>
+                        Reload homepage
+                    </Button>
+                </Group>
+            )}
             <Group justify="space-between">
                 <Group gap="sm">
                     <Button


### PR DESCRIPTION
## Homepage Builder — optimistic locking for draft saves (12)

Part of [ZAP-631](https://linear.app/lightdash/issue/ZAP-631) · Stacked on #25550

`PATCH /homepage/:uuid` was last-write-wins: a stale writer (second tab, editor holding an old snapshot) silently overwrote newer drafts — hit twice during development.

### What
- `UpdateProjectHomepageDraftRequest.baseUpdatedAt` (required): the `updatedAt` the client based its edit on
- Model update becomes compare-and-set; zero rows → existence check → **409 `ConflictError`** (new common error class) vs 404
- **Precision gotcha found by live probing**: JS `Date` is ms-precision, Postgres `timestamp` stores µs — naive equality never matches SQL-written rows. Comparison runs on `date_trunc(milliseconds, …)` both sides.
- Editor: tracks the base token per save chain (updates from each save response), flushes with it before publish; on 409 it stops autosaving and shows a banner — *"This homepage was changed somewhere else"* — with **Reload homepage** (refetches + remounts the editor via an epoch key)

### Verified live (curl)
Round-tripped `updatedAt` from `GET /builder` → PATCH succeeds; immediate replay of the same token → 409. Fabricated stale token → 409.

### Regression analysis
- The builder in this stack is the only client of the endpoint, so requiring `baseUpdatedAt` breaks no external callers.
- Worst-case regression is a false conflict (banner + reload), never data loss — strictly safer than the previous silent clobber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ