### PR TITLE
feat(frontend): drag and drop in the homepage builder

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -24,6 +24,7 @@ import {
     IconCircleCheck,
     IconCopy,
     IconEye,
+    IconGripVertical,
     IconLayoutGrid,
     IconPencil,
     IconPlus,
@@ -36,16 +37,24 @@ import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import { useAiAgentButtonVisibility } from '../aiCopilot/hooks/useAiAgentsButtonVisibility';
-import { blockLibrary, getBlockDefinition } from './blocks/registry';
+import {
+    blockLibrary,
+    getBlockDefinition,
+    type BlockDefinition,
+} from './blocks/registry';
 import {
     addBlock,
+    canDropInRow,
     canMoveDown,
     canMoveUp,
+    dropExistingBlock,
+    dropNewBlock,
     duplicateBlock,
     moveBlockDown,
     moveBlockUp,
     removeBlock,
     replaceBlock,
+    type DropTarget,
 } from './configOps';
 import {
     useDeleteHomepage,
@@ -147,6 +156,57 @@ export const HomepageEditor: FC<Props> = ({
     };
 
     const isDirty = draft !== lastSavedRef.current || updateMutation.isLoading;
+
+    type DragSource =
+        | { kind: 'new'; definition: BlockDefinition }
+        | { kind: 'existing'; blockId: string };
+    const [drag, setDrag] = useState<DragSource | null>(null);
+    const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
+
+    const clearDrag = () => {
+        setDrag(null);
+        setDropTarget(null);
+    };
+
+    const handleDrop = (target: DropTarget) => {
+        if (!drag) return;
+        setDraft((prev) =>
+            drag.kind === 'new'
+                ? dropNewBlock(prev, drag.definition.create(), target)
+                : dropExistingBlock(prev, drag.blockId, target),
+        );
+        clearDrag();
+    };
+
+    const dropZoneProps = (target: DropTarget) => ({
+        onDragOver: (e: React.DragEvent) => {
+            if (!drag) return;
+            e.preventDefault();
+            setDropTarget(target);
+        },
+        onDrop: (e: React.DragEvent) => {
+            if (!drag) return;
+            e.preventDefault();
+            handleDrop(target);
+        },
+    });
+
+    const isDropTarget = (target: DropTarget): boolean => {
+        if (!dropTarget) return false;
+        if (dropTarget.kind !== target.kind) return false;
+        if (dropTarget.kind === 'end') return true;
+        if (dropTarget.kind === 'row' && target.kind === 'row') {
+            return dropTarget.rowIndex === target.rowIndex;
+        }
+        return (
+            dropTarget.kind === 'cell' &&
+            target.kind === 'cell' &&
+            dropTarget.rowIndex === target.rowIndex &&
+            dropTarget.blockIndex === target.blockIndex
+        );
+    };
+
+    const draggedBlockId = drag?.kind === 'existing' ? drag.blockId : undefined;
 
     return (
         <Stack gap="lg" w="100%">
@@ -287,7 +347,12 @@ export const HomepageEditor: FC<Props> = ({
                                     key={definition.type}
                                     withBorder
                                     p="sm"
-                                    style={{ cursor: 'pointer' }}
+                                    style={{ cursor: 'grab' }}
+                                    draggable
+                                    onDragStart={() =>
+                                        setDrag({ kind: 'new', definition })
+                                    }
+                                    onDragEnd={clearDrag}
                                     onClick={() =>
                                         setDraft((prev) =>
                                             addBlock(prev, definition.create()),
@@ -311,162 +376,321 @@ export const HomepageEditor: FC<Props> = ({
                                 </Paper>
                             ))}
                             <Text size="xs" c="dimmed">
-                                Click a block to add it to the page.
+                                Click to add, or drag a block onto the page.
                             </Text>
                         </Stack>
                     </Card>
 
-                    <Stack gap="md" style={{ flex: 1, minWidth: 0 }}>
-                        {draft.rows.map((row) => (
-                            <Group
-                                key={row.id}
-                                gap="md"
-                                align="stretch"
-                                wrap="nowrap"
-                            >
-                                {row.blocks.map((block) => {
-                                    const definition = getBlockDefinition(
-                                        block.type,
-                                    );
-                                    if (!definition) return null;
-                                    const { Build } = definition;
-                                    return (
-                                        <Card
-                                            key={block.id}
-                                            withBorder
-                                            p="sm"
-                                            style={{ flex: 1, minWidth: 0 }}
-                                        >
-                                            <Group
-                                                gap={4}
-                                                mb="xs"
-                                                justify="space-between"
+                    <Stack gap={0} style={{ flex: 1, minWidth: 0 }}>
+                        {draft.rows.map((row, rowIndex) => (
+                            <Box key={row.id}>
+                                <Box
+                                    h={drag ? 18 : 12}
+                                    {...dropZoneProps({
+                                        kind: 'row',
+                                        rowIndex,
+                                    })}
+                                >
+                                    <Box
+                                        h={3}
+                                        style={{
+                                            borderRadius: 2,
+                                            marginTop: drag ? 7 : 4,
+                                            background: isDropTarget({
+                                                kind: 'row',
+                                                rowIndex,
+                                            })
+                                                ? 'var(--mantine-color-blue-5)'
+                                                : 'transparent',
+                                        }}
+                                    />
+                                </Box>
+                                <Group gap="md" align="stretch" wrap="nowrap">
+                                    {row.blocks.map((block, blockIndex) => {
+                                        const definition = getBlockDefinition(
+                                            block.type,
+                                        );
+                                        if (!definition) return null;
+                                        const { Build } = definition;
+                                        const showSideZones =
+                                            drag !== null &&
+                                            canDropInRow(
+                                                draft,
+                                                rowIndex,
+                                                draggedBlockId,
+                                            );
+                                        return (
+                                            <Card
+                                                key={block.id}
+                                                withBorder
+                                                p="sm"
+                                                style={{
+                                                    flex: 1,
+                                                    minWidth: 0,
+                                                    position: 'relative',
+                                                }}
                                             >
-                                                <Text
-                                                    size="xs"
-                                                    fw={600}
-                                                    tt="uppercase"
-                                                    c="dimmed"
+                                                {showSideZones && (
+                                                    <>
+                                                        <Box
+                                                            style={{
+                                                                position:
+                                                                    'absolute',
+                                                                left: -14,
+                                                                top: 0,
+                                                                bottom: 0,
+                                                                width: 24,
+                                                                zIndex: 20,
+                                                                display: 'flex',
+                                                                justifyContent:
+                                                                    'center',
+                                                            }}
+                                                            {...dropZoneProps({
+                                                                kind: 'cell',
+                                                                rowIndex,
+                                                                blockIndex,
+                                                            })}
+                                                        >
+                                                            <Box
+                                                                w={3}
+                                                                style={{
+                                                                    borderRadius: 2,
+                                                                    background:
+                                                                        isDropTarget(
+                                                                            {
+                                                                                kind: 'cell',
+                                                                                rowIndex,
+                                                                                blockIndex,
+                                                                            },
+                                                                        )
+                                                                            ? 'var(--mantine-color-blue-5)'
+                                                                            : 'transparent',
+                                                                }}
+                                                            />
+                                                        </Box>
+                                                        <Box
+                                                            style={{
+                                                                position:
+                                                                    'absolute',
+                                                                right: -14,
+                                                                top: 0,
+                                                                bottom: 0,
+                                                                width: 24,
+                                                                zIndex: 20,
+                                                                display: 'flex',
+                                                                justifyContent:
+                                                                    'center',
+                                                            }}
+                                                            {...dropZoneProps({
+                                                                kind: 'cell',
+                                                                rowIndex,
+                                                                blockIndex:
+                                                                    blockIndex +
+                                                                    1,
+                                                            })}
+                                                        >
+                                                            <Box
+                                                                w={3}
+                                                                style={{
+                                                                    borderRadius: 2,
+                                                                    background:
+                                                                        isDropTarget(
+                                                                            {
+                                                                                kind: 'cell',
+                                                                                rowIndex,
+                                                                                blockIndex:
+                                                                                    blockIndex +
+                                                                                    1,
+                                                                            },
+                                                                        )
+                                                                            ? 'var(--mantine-color-blue-5)'
+                                                                            : 'transparent',
+                                                                }}
+                                                            />
+                                                        </Box>
+                                                    </>
+                                                )}
+                                                <Group
+                                                    gap={4}
+                                                    mb="xs"
+                                                    justify="space-between"
                                                 >
-                                                    {definition.label}
-                                                </Text>
-                                                <Group gap={2}>
-                                                    <Tooltip label="Move up">
-                                                        <ActionIcon
-                                                            variant="subtle"
-                                                            color="gray"
-                                                            disabled={
-                                                                !canMoveUp(
-                                                                    draft,
+                                                    <Group
+                                                        gap={6}
+                                                        style={{
+                                                            cursor: 'grab',
+                                                        }}
+                                                        draggable
+                                                        onDragStart={(e) => {
+                                                            e.stopPropagation();
+                                                            setDrag({
+                                                                kind: 'existing',
+                                                                blockId:
                                                                     block.id,
-                                                                )
+                                                            });
+                                                        }}
+                                                        onDragEnd={clearDrag}
+                                                    >
+                                                        <MantineIcon
+                                                            icon={
+                                                                IconGripVertical
                                                             }
-                                                            onClick={() =>
-                                                                setDraft(
-                                                                    (prev) =>
-                                                                        moveBlockUp(
-                                                                            prev,
-                                                                            block.id,
-                                                                        ),
-                                                                )
-                                                            }
-                                                        >
-                                                            <MantineIcon
-                                                                icon={
-                                                                    IconArrowUp
-                                                                }
-                                                            />
-                                                        </ActionIcon>
-                                                    </Tooltip>
-                                                    <Tooltip label="Move down">
-                                                        <ActionIcon
-                                                            variant="subtle"
                                                             color="gray"
-                                                            disabled={
-                                                                !canMoveDown(
-                                                                    draft,
-                                                                    block.id,
-                                                                )
-                                                            }
-                                                            onClick={() =>
-                                                                setDraft(
-                                                                    (prev) =>
-                                                                        moveBlockDown(
-                                                                            prev,
-                                                                            block.id,
-                                                                        ),
-                                                                )
-                                                            }
+                                                        />
+                                                        <Text
+                                                            size="xs"
+                                                            fw={600}
+                                                            tt="uppercase"
+                                                            c="dimmed"
                                                         >
-                                                            <MantineIcon
-                                                                icon={
-                                                                    IconArrowDown
+                                                            {definition.label}
+                                                        </Text>
+                                                    </Group>
+                                                    <Group gap={2}>
+                                                        <Tooltip label="Move up">
+                                                            <ActionIcon
+                                                                variant="subtle"
+                                                                color="gray"
+                                                                disabled={
+                                                                    !canMoveUp(
+                                                                        draft,
+                                                                        block.id,
+                                                                    )
                                                                 }
-                                                            />
-                                                        </ActionIcon>
-                                                    </Tooltip>
-                                                    <Tooltip label="Duplicate">
-                                                        <ActionIcon
-                                                            variant="subtle"
-                                                            color="gray"
-                                                            onClick={() =>
-                                                                setDraft(
-                                                                    (prev) =>
-                                                                        duplicateBlock(
+                                                                onClick={() =>
+                                                                    setDraft(
+                                                                        (
                                                                             prev,
-                                                                            block.id,
-                                                                        ),
-                                                                )
-                                                            }
-                                                        >
-                                                            <MantineIcon
-                                                                icon={IconCopy}
-                                                            />
-                                                        </ActionIcon>
-                                                    </Tooltip>
-                                                    <Tooltip label="Remove">
-                                                        <ActionIcon
-                                                            variant="subtle"
-                                                            color="red"
-                                                            onClick={() =>
-                                                                setDraft(
-                                                                    (prev) =>
-                                                                        removeBlock(
+                                                                        ) =>
+                                                                            moveBlockUp(
+                                                                                prev,
+                                                                                block.id,
+                                                                            ),
+                                                                    )
+                                                                }
+                                                            >
+                                                                <MantineIcon
+                                                                    icon={
+                                                                        IconArrowUp
+                                                                    }
+                                                                />
+                                                            </ActionIcon>
+                                                        </Tooltip>
+                                                        <Tooltip label="Move down">
+                                                            <ActionIcon
+                                                                variant="subtle"
+                                                                color="gray"
+                                                                disabled={
+                                                                    !canMoveDown(
+                                                                        draft,
+                                                                        block.id,
+                                                                    )
+                                                                }
+                                                                onClick={() =>
+                                                                    setDraft(
+                                                                        (
                                                                             prev,
-                                                                            block.id,
-                                                                        ),
-                                                                )
-                                                            }
-                                                        >
-                                                            <MantineIcon
-                                                                icon={IconTrash}
-                                                            />
-                                                        </ActionIcon>
-                                                    </Tooltip>
+                                                                        ) =>
+                                                                            moveBlockDown(
+                                                                                prev,
+                                                                                block.id,
+                                                                            ),
+                                                                    )
+                                                                }
+                                                            >
+                                                                <MantineIcon
+                                                                    icon={
+                                                                        IconArrowDown
+                                                                    }
+                                                                />
+                                                            </ActionIcon>
+                                                        </Tooltip>
+                                                        <Tooltip label="Duplicate">
+                                                            <ActionIcon
+                                                                variant="subtle"
+                                                                color="gray"
+                                                                onClick={() =>
+                                                                    setDraft(
+                                                                        (
+                                                                            prev,
+                                                                        ) =>
+                                                                            duplicateBlock(
+                                                                                prev,
+                                                                                block.id,
+                                                                            ),
+                                                                    )
+                                                                }
+                                                            >
+                                                                <MantineIcon
+                                                                    icon={
+                                                                        IconCopy
+                                                                    }
+                                                                />
+                                                            </ActionIcon>
+                                                        </Tooltip>
+                                                        <Tooltip label="Remove">
+                                                            <ActionIcon
+                                                                variant="subtle"
+                                                                color="red"
+                                                                onClick={() =>
+                                                                    setDraft(
+                                                                        (
+                                                                            prev,
+                                                                        ) =>
+                                                                            removeBlock(
+                                                                                prev,
+                                                                                block.id,
+                                                                            ),
+                                                                    )
+                                                                }
+                                                            >
+                                                                <MantineIcon
+                                                                    icon={
+                                                                        IconTrash
+                                                                    }
+                                                                />
+                                                            </ActionIcon>
+                                                        </Tooltip>
+                                                    </Group>
                                                 </Group>
-                                            </Group>
-                                            <Build
-                                                block={block}
-                                                projectUuid={projectUuid}
-                                                onChange={(updated) =>
-                                                    setDraft((prev) =>
-                                                        replaceBlock(
-                                                            prev,
-                                                            updated,
-                                                        ),
-                                                    )
-                                                }
-                                            />
-                                        </Card>
-                                    );
-                                })}
-                            </Group>
+                                                <Build
+                                                    block={block}
+                                                    projectUuid={projectUuid}
+                                                    onChange={(updated) =>
+                                                        setDraft((prev) =>
+                                                            replaceBlock(
+                                                                prev,
+                                                                updated,
+                                                            ),
+                                                        )
+                                                    }
+                                                />
+                                            </Card>
+                                        );
+                                    })}
+                                </Group>
+                            </Box>
                         ))}
-                        {draft.rows.length === 0 && (
-                            <Text size="sm" c="dimmed">
-                                No blocks yet — add one from the library.
+                        <Box
+                            mt="md"
+                            p="lg"
+                            style={{
+                                border: `2px dashed ${
+                                    isDropTarget({ kind: 'end' })
+                                        ? 'var(--mantine-color-blue-5)'
+                                        : 'var(--mantine-color-gray-4)'
+                                }`,
+                                borderRadius: 12,
+                                textAlign: 'center',
+                            }}
+                            {...dropZoneProps({ kind: 'end' })}
+                        >
+                            <Text size="sm" c="dimmed" fw={500}>
+                                {draft.rows.length === 0
+                                    ? 'No blocks yet — click or drag one from the library.'
+                                    : 'Drag a block here, or click one in the library.'}
                             </Text>
-                        )}
+                        </Box>
                     </Stack>
                 </Group>
             )}

--- a/packages/frontend/src/ee/features/homepageBuilder/configOps.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/configOps.test.ts
@@ -1,8 +1,11 @@
 import { type HomepageBlock, type HomepageConfig } from '@lightdash/common';
 import {
     addBlock,
+    canDropInRow,
     canMoveDown,
     canMoveUp,
+    dropExistingBlock,
+    dropNewBlock,
     duplicateBlock,
     moveBlockDown,
     moveBlockUp,
@@ -94,6 +97,100 @@ describe('configOps', () => {
         const result = replaceBlock(config, block('a', 'edited'));
         expect(result.rows[0].blocks[0].config).toEqual({ content: 'edited' });
         expect(result.rows[0].blocks[1].config).toEqual({ content: 'b' });
+    });
+
+    describe('drag & drop', () => {
+        it('dropNewBlock into a cell places it side-by-side', () => {
+            const config = makeConfig([[block('a')]]);
+            const result = dropNewBlock(config, block('x'), {
+                kind: 'cell',
+                rowIndex: 0,
+                blockIndex: 1,
+            });
+            expect(result.rows[0].blocks.map((b) => b.id)).toEqual(['a', 'x']);
+        });
+
+        it('dropNewBlock into a full row is a no-op', () => {
+            const config = makeConfig([[block('a'), block('b'), block('c')]]);
+            const result = dropNewBlock(config, block('x'), {
+                kind: 'cell',
+                rowIndex: 0,
+                blockIndex: 1,
+            });
+            expect(result.rows[0].blocks).toHaveLength(3);
+        });
+
+        it('dropNewBlock between rows inserts a new row', () => {
+            const config = makeConfig([[block('a')], [block('b')]]);
+            const result = dropNewBlock(config, block('x'), {
+                kind: 'row',
+                rowIndex: 1,
+            });
+            expect(result.rows.map((r) => r.blocks[0].id)).toEqual([
+                'a',
+                'x',
+                'b',
+            ]);
+        });
+
+        it('dropExistingBlock re-nests into another row', () => {
+            const config = makeConfig([[block('a')], [block('b')]]);
+            const result = dropExistingBlock(config, 'a', {
+                kind: 'cell',
+                rowIndex: 1,
+                blockIndex: 1,
+            });
+            expect(result.rows).toHaveLength(1);
+            expect(result.rows[0].blocks.map((b) => b.id)).toEqual(['b', 'a']);
+        });
+
+        it('dropExistingBlock adjusts indices when the source row empties', () => {
+            const config = makeConfig([
+                [block('a')],
+                [block('b')],
+                [block('c')],
+            ]);
+            const result = dropExistingBlock(config, 'a', {
+                kind: 'row',
+                rowIndex: 3,
+            });
+            expect(result.rows.map((r) => r.blocks[0].id)).toEqual([
+                'b',
+                'c',
+                'a',
+            ]);
+        });
+
+        it('dropExistingBlock beside itself is a no-op', () => {
+            const config = makeConfig([[block('a'), block('b')]]);
+            expect(
+                dropExistingBlock(config, 'a', {
+                    kind: 'cell',
+                    rowIndex: 0,
+                    blockIndex: 1,
+                }),
+            ).toBe(config);
+        });
+
+        it('dropExistingBlock reorders within the same row', () => {
+            const config = makeConfig([[block('a'), block('b'), block('c')]]);
+            const result = dropExistingBlock(config, 'a', {
+                kind: 'cell',
+                rowIndex: 0,
+                blockIndex: 3,
+            });
+            expect(result.rows[0].blocks.map((b) => b.id)).toEqual([
+                'b',
+                'c',
+                'a',
+            ]);
+        });
+
+        it('canDropInRow respects the 3-block cap but allows same-row moves', () => {
+            const config = makeConfig([[block('a'), block('b'), block('c')]]);
+            expect(canDropInRow(config, 0)).toBe(false);
+            expect(canDropInRow(config, 0, 'a')).toBe(true);
+        });
     });
 
     it('operations never mutate the input config', () => {

--- a/packages/frontend/src/ee/features/homepageBuilder/configOps.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/configOps.ts
@@ -128,6 +128,96 @@ export const canMoveDown = (
     return row.blocks.length > 1 || location.rowIndex < config.rows.length - 1;
 };
 
+export type DropTarget =
+    | { kind: 'row'; rowIndex: number }
+    | { kind: 'cell'; rowIndex: number; blockIndex: number }
+    | { kind: 'end' };
+
+const insertAt = (
+    rows: HomepageRow[],
+    block: HomepageBlock,
+    target: DropTarget,
+): HomepageRow[] => {
+    switch (target.kind) {
+        case 'end':
+            rows.push(newRowOf([block]));
+            return rows;
+        case 'row':
+            rows.splice(target.rowIndex, 0, newRowOf([block]));
+            return rows;
+        case 'cell': {
+            const row = rows[target.rowIndex];
+            if (!row || row.blocks.length >= HOMEPAGE_MAX_BLOCKS_PER_ROW) {
+                return rows;
+            }
+            row.blocks.splice(target.blockIndex, 0, block);
+            return rows;
+        }
+        default:
+            return rows;
+    }
+};
+
+export const dropNewBlock = (
+    config: HomepageConfig,
+    block: HomepageBlock,
+    target: DropTarget,
+): HomepageConfig =>
+    withRows(config, insertAt(cloneRows(config), block, target));
+
+export const dropExistingBlock = (
+    config: HomepageConfig,
+    blockId: string,
+    target: DropTarget,
+): HomepageConfig => {
+    const location = findBlock(config, blockId);
+    if (!location) return config;
+    if (
+        target.kind === 'cell' &&
+        target.rowIndex === location.rowIndex &&
+        (target.blockIndex === location.blockIndex ||
+            target.blockIndex === location.blockIndex + 1)
+    ) {
+        return config; // dropping beside itself is a no-op
+    }
+    const rows = cloneRows(config);
+    const sourceRow = rows[location.rowIndex];
+    const [block] = sourceRow.blocks.splice(location.blockIndex, 1);
+    const sourceRowEmptied = sourceRow.blocks.length === 0;
+
+    const adjusted: DropTarget = (() => {
+        if (target.kind === 'end') return target;
+        let { rowIndex } = target;
+        if (sourceRowEmptied && rowIndex > location.rowIndex) rowIndex -= 1;
+        if (target.kind === 'row') return { kind: 'row', rowIndex };
+        let { blockIndex } = target;
+        if (
+            rowIndex === location.rowIndex &&
+            !sourceRowEmptied &&
+            blockIndex > location.blockIndex
+        ) {
+            blockIndex -= 1;
+        }
+        return { kind: 'cell', rowIndex, blockIndex };
+    })();
+
+    if (sourceRowEmptied) rows.splice(location.rowIndex, 1);
+    return withRows(config, insertAt(rows, block, adjusted));
+};
+
+export const canDropInRow = (
+    config: HomepageConfig,
+    rowIndex: number,
+    draggedBlockId?: string,
+): boolean => {
+    const row = config.rows[rowIndex];
+    if (!row) return false;
+    const isSameRow =
+        draggedBlockId !== undefined &&
+        row.blocks.some((block) => block.id === draggedBlockId);
+    return isSameRow || row.blocks.length < HOMEPAGE_MAX_BLOCKS_PER_ROW;
+};
+
 export const replaceBlock = (
     config: HomepageConfig,
     updated: HomepageBlock,


### PR DESCRIPTION
## Homepage Builder — drag & drop (13)

Part of [ZAP-624](https://linear.app/lightdash/issue/ZAP-624) · Stacked on #25552

Full drag & drop for the builder canvas — HTML5 DnD, no new dependencies, mirroring the prototype interaction model.

### What
- **Drag from the library** onto the page: between-row strips (insert full-width row), left/right side zones on each block (side-by-side, up to 3 per row), and the end drop zone
- **Drag existing blocks** by the grip (⠿ in the block header) to reorder or re-nest
- Drop indicators: blue lines on row strips and side zones, highlighted dashed end zone
- **≤3 per row enforced**: side zones don’t appear on full rows (unless the drag originates in that row — same-row reorder stays allowed)
- Pure drop logic in `configOps` (`dropNewBlock` / `dropExistingBlock` / `canDropInRow` with a `DropTarget` union): immutable, index-adjusted for emptied source rows and same-row moves — **8 new unit tests (19 total)**
- Keyboard fallback (move up/down buttons) unchanged
- Drop handlers are internally guarded on drag state, so stray HTML5 drops (text selections, files) are ignored

### Verification
- 19/19 configOps unit tests; typecheck + oxlint clean
- Live: library→end-zone drag verified in the browser (block landed + autosaved)
- Reorder/side-zone drags: covered by unit tests; **manual QA pending** — verification paused because the author was actively using the shared dev environment 🙂

### Regression analysis
- Frontend-only, flag-gated builder page only. Click-to-add and arrow reordering unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ