### PR TITLE
fix(ux): redesign semantic layer connection UI with token generation modal

### DIFF
--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -73,6 +73,11 @@ services:
             S3_BUCKET: ${S3_BUCKET}
             MCP_ENABLED: true
             CUSTOM_ROLES_ENABLED: true
+            # Enable service accounts in preview envs so the semantic-layer
+            # connection page can generate project-scoped tokens. Sets the
+            # health flag and (via LEGACY_ENABLE_ENV_VARS in parseConfig.ts)
+            # the unified `service-accounts` feature flag.
+            SERVICE_ACCOUNT_ENABLED: true
 
             # Enterprise Postgres wire protocol server for the semantic layer.
             # Setting the port starts the listener and lights up the "Semantic

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/GenerateTokenModal.tsx
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/GenerateTokenModal.tsx
@@ -1,0 +1,201 @@
+import {
+    ProjectMemberRole,
+    ProjectMemberRoleLabels,
+    ServiceAccountScope,
+} from '@lightdash/common';
+import { Button, Group, Select, Stack, Text, TextInput } from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { IconKey } from '@tabler/icons-react';
+import { addDays } from 'date-fns';
+import { useMemo, type FC } from 'react';
+import Callout from '../../common/Callout';
+import MantineModal from '../../common/MantineModal';
+import { useServiceAccounts } from '../../../ee/features/serviceAccounts/useServiceAccounts';
+import useToaster from '../../../hooks/toaster/useToaster';
+
+export type GeneratedToken = {
+    token: string;
+    description: string;
+    expiresLabel: string;
+};
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    projectName: string;
+    onGenerated: (token: GeneratedToken) => void;
+};
+
+const EXPIRE_OPTIONS = [
+    { label: '7 days', value: '7' },
+    { label: '30 days', value: '30' },
+    { label: '60 days', value: '60' },
+    { label: '90 days', value: '90' },
+    { label: '6 months', value: '180' },
+    { label: '1 year', value: '365' },
+    { label: 'No expiration', value: '' },
+];
+
+// Interactive Viewer is the minimum role that can run semantic-layer queries.
+// Lower roles (Viewer) can't, so they're intentionally omitted here.
+const ROLE_OPTIONS = [
+    {
+        value: ProjectMemberRole.INTERACTIVE_VIEWER,
+        label: `${
+            ProjectMemberRoleLabels[ProjectMemberRole.INTERACTIVE_VIEWER]
+        } (recommended)`,
+    },
+    {
+        value: ProjectMemberRole.EDITOR,
+        label: ProjectMemberRoleLabels[ProjectMemberRole.EDITOR],
+    },
+    {
+        value: ProjectMemberRole.DEVELOPER,
+        label: ProjectMemberRoleLabels[ProjectMemberRole.DEVELOPER],
+    },
+    {
+        value: ProjectMemberRole.ADMIN,
+        label: ProjectMemberRoleLabels[ProjectMemberRole.ADMIN],
+    },
+];
+
+export const GenerateTokenModal: FC<Props> = ({
+    opened,
+    onClose,
+    projectUuid,
+    projectName,
+    onGenerated,
+}) => {
+    const { createAccount } = useServiceAccounts();
+    const { showToastError } = useToaster();
+
+    const form = useForm({
+        initialValues: {
+            description: 'Semantic layer connection',
+            expiresAt: '90',
+            role: ProjectMemberRole.INTERACTIVE_VIEWER as ProjectMemberRole,
+        },
+    });
+
+    const expiresLabel = useMemo(
+        () =>
+            EXPIRE_OPTIONS.find((o) => o.value === form.values.expiresAt)
+                ?.label ?? '',
+        [form.values.expiresAt],
+    );
+
+    const handleClose = () => {
+        form.reset();
+        onClose();
+    };
+
+    const handleSubmit = form.onSubmit(({ description, expiresAt, role }) => {
+        const expiresAtValue = expiresAt
+            ? addDays(new Date(), Number(expiresAt))
+            : null;
+
+        createAccount.mutate(
+            {
+                description,
+                expiresAt: expiresAtValue,
+                // Project-scoped SA: `system:member` + a single project grant.
+                scopes: [ServiceAccountScope.SYSTEM_MEMBER],
+                projectAccess: [{ projectUuid, role }],
+            },
+            {
+                onSuccess: async (account) => {
+                    try {
+                        await navigator.clipboard.writeText(account.token);
+                    } catch {
+                        showToastError({
+                            title: "Couldn't copy token to clipboard",
+                            subtitle:
+                                'Copy it from the connection form before leaving the page.',
+                        });
+                    }
+                    onGenerated({
+                        token: account.token,
+                        description,
+                        expiresLabel: expiresAt
+                            ? `expires in ${expiresLabel.toLowerCase()}`
+                            : 'never expires',
+                    });
+                    form.reset();
+                },
+            },
+        );
+    });
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={handleClose}
+            title="Create service account token"
+            icon={IconKey}
+            size="md"
+            cancelLabel="Cancel"
+            cancelDisabled={createAccount.isLoading}
+            actions={
+                <Button
+                    type="submit"
+                    form="generate-pgwire-token-form"
+                    loading={createAccount.isLoading}
+                >
+                    Generate & copy
+                </Button>
+            }
+        >
+            <Text c="ldGray.6" fz="sm" mt={-4}>
+                A project-level token, scoped to this project. Shown only once.
+            </Text>
+            <form id="generate-pgwire-token-form" onSubmit={handleSubmit}>
+                <Stack gap="md">
+                    <TextInput
+                        label="Description"
+                        placeholder="What's this token for?"
+                        required
+                        disabled={createAccount.isLoading}
+                        {...form.getInputProps('description')}
+                    />
+                    <Select
+                        label="Expires"
+                        data={EXPIRE_OPTIONS}
+                        allowDeselect={false}
+                        disabled={createAccount.isLoading}
+                        {...form.getInputProps('expiresAt')}
+                    />
+                    <Stack gap="xs">
+                        <Text fz="sm" fw={500}>
+                            Project · role
+                        </Text>
+                        <Group grow align="flex-start" wrap="nowrap">
+                            <TextInput
+                                readOnly
+                                value={projectName}
+                                disabled
+                            />
+                            <Select
+                                data={ROLE_OPTIONS}
+                                allowDeselect={false}
+                                disabled={createAccount.isLoading}
+                                {...form.getInputProps('role')}
+                            />
+                        </Group>
+                    </Stack>
+                    <Callout variant="info" hideIcon>
+                        <Text fz="sm">
+                            <Text span fw={600}>
+                                Interactive Viewer
+                            </Text>{' '}
+                            is the minimum for the semantic layer — it can read
+                            this project&apos;s explores and run queries against
+                            them. Pick a higher role only if the same token is
+                            reused elsewhere.
+                        </Text>
+                    </Callout>
+                </Stack>
+            </form>
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/GenerateTokenModal.tsx
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/GenerateTokenModal.tsx
@@ -7,11 +7,13 @@ import { Button, Group, Select, Stack, Text, TextInput } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import { IconKey } from '@tabler/icons-react';
 import { addDays } from 'date-fns';
+import { zodResolver } from 'mantine-form-zod-resolver';
 import { useMemo, type FC } from 'react';
-import Callout from '../../common/Callout';
-import MantineModal from '../../common/MantineModal';
+import { z } from 'zod';
 import { useServiceAccounts } from '../../../ee/features/serviceAccounts/useServiceAccounts';
 import useToaster from '../../../hooks/toaster/useToaster';
+import Callout from '../../common/Callout';
+import MantineModal from '../../common/MantineModal';
 
 export type GeneratedToken = {
     token: string;
@@ -70,12 +72,19 @@ export const GenerateTokenModal: FC<Props> = ({
     const { createAccount } = useServiceAccounts();
     const { showToastError } = useToaster();
 
+    const validationSchema = z.object({
+        description: z.string().min(1, { message: 'Description is required' }),
+        expiresAt: z.string(),
+        role: z.nativeEnum(ProjectMemberRole),
+    });
+
     const form = useForm({
         initialValues: {
             description: 'Semantic layer connection',
             expiresAt: '90',
             role: ProjectMemberRole.INTERACTIVE_VIEWER as ProjectMemberRole,
         },
+        validate: zodResolver(validationSchema),
     });
 
     const expiresLabel = useMemo(
@@ -170,11 +179,7 @@ export const GenerateTokenModal: FC<Props> = ({
                             Project · role
                         </Text>
                         <Group grow align="flex-start" wrap="nowrap">
-                            <TextInput
-                                readOnly
-                                value={projectName}
-                                disabled
-                            />
+                            <TextInput readOnly value={projectName} disabled />
                             <Select
                                 data={ROLE_OPTIONS}
                                 allowDeselect={false}

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/GenerateTokenModal.tsx
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/GenerateTokenModal.tsx
@@ -80,7 +80,7 @@ export const GenerateTokenModal: FC<Props> = ({
 
     const form = useForm({
         initialValues: {
-            description: 'Semantic layer connection',
+            description: 'Metric SQL API',
             expiresAt: '90',
             role: ProjectMemberRole.INTERACTIVE_VIEWER as ProjectMemberRole,
         },
@@ -193,7 +193,7 @@ export const GenerateTokenModal: FC<Props> = ({
                             <Text span fw={600}>
                                 Interactive Viewer
                             </Text>{' '}
-                            is the minimum for the semantic layer — it can read
+                            is the minimum for the Metric SQL API — it can read
                             this project&apos;s explores and run queries against
                             them. Pick a higher role only if the same token is
                             reused elsewhere.

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/GenerateTokenModal.tsx
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/GenerateTokenModal.tsx
@@ -8,7 +8,7 @@ import { useForm } from '@mantine/form';
 import { IconKey } from '@tabler/icons-react';
 import { addDays } from 'date-fns';
 import { zodResolver } from 'mantine-form-zod-resolver';
-import { useMemo, type FC } from 'react';
+import { useCallback, useMemo, type FC } from 'react';
 import { z } from 'zod';
 import { useServiceAccounts } from '../../../ee/features/serviceAccounts/useServiceAccounts';
 import useToaster from '../../../hooks/toaster/useToaster';
@@ -94,10 +94,10 @@ export const GenerateTokenModal: FC<Props> = ({
         [form.values.expiresAt],
     );
 
-    const handleClose = () => {
+    const handleClose = useCallback(() => {
         form.reset();
         onClose();
-    };
+    }, [form, onClose]);
 
     const handleSubmit = form.onSubmit(({ description, expiresAt, role }) => {
         const expiresAtValue = expiresAt

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/SemanticLayerConnectionPanel.module.css
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/SemanticLayerConnectionPanel.module.css
@@ -116,3 +116,67 @@
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+/* Generated-token success card: header, field, copy button and hint all live
+   inside one green-tinted surface so they read as a single connected unit. */
+.tokenCard {
+    background-color: var(--mantine-color-green-light);
+    border: 1px solid var(--mantine-color-green-light-hover);
+    border-radius: var(--mantine-radius-md);
+    padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
+}
+
+.tokenCardTitle {
+    font-size: var(--mantine-font-size-sm);
+    font-weight: 600;
+    color: var(--mantine-color-green-light-color);
+}
+
+.tokenCardMeta {
+    font-size: var(--mantine-font-size-xs);
+    color: var(--mantine-color-green-light-color);
+    opacity: 0.85;
+}
+
+.tokenCardHint {
+    font-size: var(--mantine-font-size-xs);
+    color: var(--mantine-color-green-light-color);
+    opacity: 0.85;
+}
+
+.tokenField {
+    flex: 1;
+    min-width: 0;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    padding: 0 var(--mantine-spacing-sm);
+    border: 1px solid var(--mantine-color-green-light-hover);
+    border-radius: var(--mantine-radius-sm);
+    background-color: var(--mantine-color-body);
+    color: var(--mantine-color-green-light-color);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: var(--mantine-font-size-sm);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.tokenCopyBtn {
+    flex: none;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0 var(--mantine-spacing-sm);
+    border: 1px solid var(--mantine-color-green-light-hover);
+    border-radius: var(--mantine-radius-sm);
+    background-color: var(--mantine-color-body);
+    color: var(--mantine-color-green-light-color);
+    font-size: var(--mantine-font-size-sm);
+    font-weight: 600;
+}
+
+.tokenCopyBtn:hover {
+    background-color: var(--mantine-color-green-light);
+}

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/SemanticLayerConnectionPanel.module.css
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/SemanticLayerConnectionPanel.module.css
@@ -5,15 +5,15 @@
 }
 
 .step:not(:last-child) .content {
-    padding-bottom: var(--mantine-spacing-xl);
+    padding-bottom: var(--mantine-spacing-lg);
 }
 
 /* Connecting line runs down the centre of the bullet column, behind bullets. */
 .step:not(:last-child)::before {
     content: '';
     position: absolute;
-    top: 28px;
-    bottom: 0;
+    top: 34px;
+    bottom: 6px;
     left: 14px;
     width: 2px;
     transform: translateX(-50%);
@@ -71,4 +71,48 @@
 .codeMask {
     opacity: 0.55;
     letter-spacing: 1px;
+}
+
+/* Compact read-only info chips for the connection details step. */
+.chipGrid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--mantine-spacing-xs);
+}
+
+.chipSpan2 {
+    grid-column: 1 / -1;
+}
+
+.chip {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--mantine-spacing-xs);
+    min-width: 0;
+    border: 1px solid var(--mantine-color-default-border);
+    border-radius: var(--mantine-radius-md);
+    padding: 8px 10px;
+}
+
+.chipText {
+    min-width: 0;
+}
+
+.chipLabel {
+    font-size: 10.5px;
+    font-weight: 600;
+    line-height: 1.4;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--mantine-color-dimmed);
+}
+
+.chipValue {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 12.5px;
+    color: var(--mantine-color-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/SemanticLayerConnectionPanel.module.css
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/SemanticLayerConnectionPanel.module.css
@@ -1,0 +1,74 @@
+.step {
+    display: flex;
+    gap: var(--mantine-spacing-md);
+    position: relative;
+}
+
+.step:not(:last-child) .content {
+    padding-bottom: var(--mantine-spacing-xl);
+}
+
+/* Connecting line runs down the centre of the bullet column, behind bullets. */
+.step:not(:last-child)::before {
+    content: '';
+    position: absolute;
+    top: 28px;
+    bottom: 0;
+    left: 14px;
+    width: 2px;
+    transform: translateX(-50%);
+    background-color: var(--mantine-color-default-border);
+}
+
+.bullet {
+    flex-shrink: 0;
+    width: 28px;
+    height: 28px;
+    border-radius: var(--mantine-radius-xl);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--mantine-font-size-sm);
+    font-weight: 600;
+    z-index: 1;
+}
+
+.bulletActive {
+    background-color: var(--mantine-color-blue-filled);
+    color: var(--mantine-color-white);
+}
+
+.bulletInactive {
+    background-color: var(--mantine-color-blue-light);
+    color: var(--mantine-color-blue-light-color);
+}
+
+.content {
+    flex: 1;
+    min-width: 0;
+}
+
+.codeBlock {
+    position: relative;
+    background-color: var(--mantine-color-dark-8);
+    color: var(--mantine-color-gray-1);
+    border-radius: var(--mantine-radius-md);
+    padding: var(--mantine-spacing-md);
+    padding-right: 48px;
+    font-family: var(--mantine-font-family-monospace);
+    font-size: var(--mantine-font-size-sm);
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
+.codeBlockCopy {
+    position: absolute;
+    top: var(--mantine-spacing-xs);
+    right: var(--mantine-spacing-xs);
+}
+
+.codeMask {
+    opacity: 0.55;
+    letter-spacing: 1px;
+}

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
@@ -7,7 +7,7 @@ import {
     Button,
     CopyButton,
     Group,
-    Select,
+    PasswordInput,
     Stack,
     Switch,
     Tabs,
@@ -54,39 +54,39 @@ const maskToken = (token: string) => {
     return `${token.slice(0, 6)}${'•'.repeat(12)}${token.slice(-4)}`;
 };
 
-const CopyIconButton: FC<{ value: string }> = ({ value }) => (
-    <CopyButton value={value} timeout={2000}>
-        {({ copied, copy }) => (
-            <Tooltip
-                label={copied ? 'Copied' : 'Copy'}
-                withArrow
-                position="left"
-            >
-                <ActionIcon
-                    color={copied ? 'teal' : 'gray'}
-                    variant="subtle"
-                    onClick={copy}
+const ConnectionChip: FC<{ label: string; value: string; span?: boolean }> = ({
+    label,
+    value,
+    span = false,
+}) => (
+    <Box
+        className={`${classes.chip}${
+            span ? ` ${classes.chipSpan2}` : ''
+        } sentry-block ph-no-capture`}
+    >
+        <Box className={classes.chipText}>
+            <Text className={classes.chipLabel}>{label}</Text>
+            <Text className={classes.chipValue} title={value}>
+                {value}
+            </Text>
+        </Box>
+        <CopyButton value={value} timeout={2000}>
+            {({ copied, copy }) => (
+                <Tooltip
+                    label={copied ? 'Copied' : 'Copy'}
+                    withArrow
+                    position="left"
                 >
-                    <MantineIcon icon={copied ? IconCheck : IconCopy} />
-                </ActionIcon>
-            </Tooltip>
-        )}
-    </CopyButton>
-);
-
-const CopyableField: FC<{
-    label: string;
-    value: string;
-    description?: string;
-}> = ({ label, value, description }) => (
-    <TextInput
-        label={label}
-        description={description}
-        readOnly
-        value={value}
-        className="sentry-block ph-no-capture"
-        rightSection={<CopyIconButton value={value} />}
-    />
+                    <ActionIcon variant="default" size="sm" onClick={copy}>
+                        <MantineIcon
+                            icon={copied ? IconCheck : IconCopy}
+                            size="sm"
+                        />
+                    </ActionIcon>
+                </Tooltip>
+            )}
+        </CopyButton>
+    </Box>
 );
 
 const Step: FC<{
@@ -260,7 +260,7 @@ const SemanticLayerConnectionPanel: FC<Props> = ({ projectUuid }) => {
             )}
 
             {isEnabled && isOrgAdmin && (
-                <SettingsCard>
+                <SettingsCard p="lg">
                     <Stack gap="lg">
                         <Callout variant="info" title="Before you connect">
                             Only simple <code>SELECT</code> queries against a
@@ -269,192 +269,197 @@ const SemanticLayerConnectionPanel: FC<Props> = ({ projectUuid }) => {
                             so clients must use <code>sslmode=disable</code>.
                         </Callout>
 
-                        <Step
-                            index={1}
-                            active
-                            title="Token"
-                            description="Paste an existing Lightdash token or generate a new one for this integration. You can use a service account or personal access token."
-                        >
-                            {generated ? (
-                                <Stack gap="xs">
-                                    <Callout variant="success" hideIcon>
-                                        <Group
-                                            justify="space-between"
-                                            wrap="nowrap"
-                                            align="flex-start"
-                                        >
-                                            <Group gap="xs" wrap="nowrap">
-                                                <MantineIcon
-                                                    icon={IconCheck}
-                                                    color="green"
-                                                />
-                                                <Stack gap={0}>
-                                                    <Text fz="sm" fw={600}>
-                                                        Token added as your
-                                                        password
-                                                    </Text>
-                                                    <Text c="ldGray.6" fz="xs">
-                                                        Generated for{' '}
-                                                        {generated.description}{' '}
-                                                        ·{' '}
-                                                        {generated.expiresLabel}
-                                                    </Text>
-                                                </Stack>
-                                            </Group>
-                                            <Anchor
-                                                component="button"
-                                                type="button"
-                                                fz="sm"
-                                                fw={500}
-                                                onClick={handleReplace}
-                                                style={{ flexShrink: 0 }}
+                        <Box>
+                            <Step
+                                index={1}
+                                active
+                                title="Token"
+                                description="Paste an existing Lightdash token or generate a new one for this integration. You can use a service account or personal access token."
+                            >
+                                {generated ? (
+                                    <Stack gap="xs">
+                                        <Callout variant="success" hideIcon>
+                                            <Group
+                                                justify="space-between"
+                                                wrap="nowrap"
+                                                align="flex-start"
                                             >
-                                                Replace
-                                            </Anchor>
-                                        </Group>
-                                    </Callout>
-                                    <Group gap="xs" wrap="nowrap">
-                                        <TextInput
-                                            readOnly
-                                            style={{ flex: 1 }}
-                                            className="sentry-block ph-no-capture"
-                                            value={maskToken(generated.token)}
-                                        />
-                                        <CopyButton
-                                            value={generated.token}
-                                            timeout={2000}
-                                        >
-                                            {({ copied, copy }) => (
-                                                <Button
-                                                    variant="default"
-                                                    leftSection={
-                                                        <MantineIcon
-                                                            icon={
-                                                                copied
-                                                                    ? IconCheck
-                                                                    : IconCopy
+                                                <Group gap="xs" wrap="nowrap">
+                                                    <MantineIcon
+                                                        icon={IconCheck}
+                                                        color="green"
+                                                    />
+                                                    <Stack gap={0}>
+                                                        <Text fz="sm" fw={600}>
+                                                            Token added as your
+                                                            password
+                                                        </Text>
+                                                        <Text
+                                                            c="ldGray.6"
+                                                            fz="xs"
+                                                        >
+                                                            Generated for{' '}
+                                                            {
+                                                                generated.description
+                                                            }{' '}
+                                                            ·{' '}
+                                                            {
+                                                                generated.expiresLabel
                                                             }
-                                                        />
-                                                    }
-                                                    onClick={copy}
+                                                        </Text>
+                                                    </Stack>
+                                                </Group>
+                                                <Anchor
+                                                    component="button"
+                                                    type="button"
+                                                    fz="sm"
+                                                    fw={500}
+                                                    onClick={handleReplace}
+                                                    style={{ flexShrink: 0 }}
                                                 >
-                                                    {copied ? 'Copied' : 'Copy'}
-                                                </Button>
-                                            )}
-                                        </CopyButton>
-                                    </Group>
-                                    <Text c="ldGray.6" fz="xs">
-                                        Remember to save your token — you
-                                        can&apos;t access it again.
-                                    </Text>
-                                </Stack>
-                            ) : (
-                                <Stack gap="xs">
-                                    <TextInput
-                                        placeholder="ldsvc_… or ldpat_…"
-                                        className="sentry-block ph-no-capture"
-                                        value={manualToken}
-                                        onChange={(event) =>
-                                            setManualToken(
-                                                event.currentTarget.value.trim(),
-                                            )
-                                        }
-                                        rightSection={
-                                            manualToken ? (
-                                                <CopyIconButton
-                                                    value={manualToken}
-                                                />
-                                            ) : undefined
-                                        }
-                                    />
-                                    {isServiceAccountsEnabled ? (
-                                        <Text c="ldGray.6" fz="sm">
-                                            Don&apos;t have a token?{' '}
-                                            <Anchor
-                                                component="button"
-                                                type="button"
-                                                fw={500}
-                                                onClick={() =>
-                                                    setModalOpen(true)
-                                                }
+                                                    Replace
+                                                </Anchor>
+                                            </Group>
+                                        </Callout>
+                                        <Group gap="xs" wrap="nowrap">
+                                            <TextInput
+                                                readOnly
+                                                style={{ flex: 1 }}
+                                                className="sentry-block ph-no-capture"
+                                                value={maskToken(
+                                                    generated.token,
+                                                )}
+                                            />
+                                            <CopyButton
+                                                value={generated.token}
+                                                timeout={2000}
                                             >
-                                                Generate a new one
-                                            </Anchor>
+                                                {({ copied, copy }) => (
+                                                    <Button
+                                                        variant="default"
+                                                        leftSection={
+                                                            <MantineIcon
+                                                                icon={
+                                                                    copied
+                                                                        ? IconCheck
+                                                                        : IconCopy
+                                                                }
+                                                            />
+                                                        }
+                                                        onClick={copy}
+                                                    >
+                                                        {copied
+                                                            ? 'Copied'
+                                                            : 'Copy'}
+                                                    </Button>
+                                                )}
+                                            </CopyButton>
+                                        </Group>
+                                        <Text c="ldGray.6" fz="xs">
+                                            Remember to save your token — you
+                                            can&apos;t access it again.
                                         </Text>
-                                    ) : (
-                                        <Text c="ldGray.6" fz="sm">
-                                            Paste a personal access token from
-                                            your account settings.
-                                        </Text>
-                                    )}
-                                </Stack>
-                            )}
-                        </Step>
+                                    </Stack>
+                                ) : (
+                                    <Stack gap="xs">
+                                        <PasswordInput
+                                            placeholder="ldsvc_… or ldpat_…"
+                                            className="sentry-block ph-no-capture"
+                                            value={manualToken}
+                                            onChange={(event) =>
+                                                setManualToken(
+                                                    event.currentTarget.value.trim(),
+                                                )
+                                            }
+                                        />
+                                        {isServiceAccountsEnabled ? (
+                                            <Text c="ldGray.6" fz="sm">
+                                                Don&apos;t have a token?{' '}
+                                                <Anchor
+                                                    component="button"
+                                                    type="button"
+                                                    fw={500}
+                                                    onClick={() =>
+                                                        setModalOpen(true)
+                                                    }
+                                                >
+                                                    Generate a new one
+                                                </Anchor>
+                                            </Text>
+                                        ) : (
+                                            <Text c="ldGray.6" fz="sm">
+                                                Paste a personal access token
+                                                from your account settings.
+                                            </Text>
+                                        )}
+                                    </Stack>
+                                )}
+                            </Step>
 
-                        <Step
-                            index={2}
-                            active={false}
-                            title="Connection details"
-                        >
-                            <Stack gap="sm">
-                                <CopyableField label="Host" value={host} />
-                                <Group grow align="flex-start" wrap="nowrap">
-                                    <CopyableField
+                            <Step
+                                index={2}
+                                active={false}
+                                title="Connection details"
+                            >
+                                <Box className={classes.chipGrid}>
+                                    <ConnectionChip
+                                        label="Host"
+                                        value={host}
+                                        span
+                                    />
+                                    <ConnectionChip
                                         label="Port"
                                         value={portString}
                                     />
-                                    <CopyableField
+                                    <ConnectionChip
                                         label="User"
                                         value={DEFAULT_USER}
                                     />
-                                </Group>
-                                <CopyableField
-                                    label="Database"
-                                    description="Use the project UUID (unambiguous)."
-                                    value={projectUuid}
-                                />
-                                <Select
-                                    label="SSL mode"
-                                    description="SSL support is coming soon."
-                                    data={[
-                                        { value: 'disable', label: 'disable' },
-                                    ]}
-                                    value="disable"
-                                    disabled
-                                />
-                            </Stack>
-                        </Step>
+                                    <ConnectionChip
+                                        label="Database"
+                                        value={projectUuid}
+                                        span
+                                    />
+                                    <ConnectionChip
+                                        label="SSL mode"
+                                        value="disable"
+                                    />
+                                </Box>
+                            </Step>
 
-                        <Step
-                            index={3}
-                            active={false}
-                            title="Connect your client"
-                            description="Pick your tool and copy the ready-made string."
-                        >
-                            <Stack gap="sm">
-                                <Tabs
-                                    value={activeSnippet}
-                                    onChange={(value) =>
-                                        setActiveSnippet(value as SnippetKey)
-                                    }
-                                >
-                                    <Tabs.List>
-                                        {SNIPPET_TABS.map((tab) => (
-                                            <Tabs.Tab
-                                                key={tab.value}
-                                                value={tab.value}
-                                            >
-                                                {tab.label}
-                                            </Tabs.Tab>
-                                        ))}
-                                    </Tabs.List>
-                                </Tabs>
-                                <CodeBlock
-                                    displayValue={displaySnippet}
-                                    copyValue={snippets[activeSnippet]}
-                                />
-                            </Stack>
-                        </Step>
+                            <Step
+                                index={3}
+                                active={false}
+                                title="Connect your client"
+                                description="Pick your tool and copy the ready-made string."
+                            >
+                                <Stack gap="sm">
+                                    <Tabs
+                                        value={activeSnippet}
+                                        onChange={(value) =>
+                                            setActiveSnippet(
+                                                value as SnippetKey,
+                                            )
+                                        }
+                                    >
+                                        <Tabs.List>
+                                            {SNIPPET_TABS.map((tab) => (
+                                                <Tabs.Tab
+                                                    key={tab.value}
+                                                    value={tab.value}
+                                                >
+                                                    {tab.label}
+                                                </Tabs.Tab>
+                                            ))}
+                                        </Tabs.List>
+                                    </Tabs>
+                                    <CodeBlock
+                                        displayValue={displaySnippet}
+                                        copyValue={snippets[activeSnippet]}
+                                    />
+                                </Stack>
+                            </Step>
+                        </Box>
                     </Stack>
                 </SettingsCard>
             )}

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
@@ -295,7 +295,8 @@ const SemanticLayerConnectionPanel: FC<Props> = ({ projectUuid }) => {
                                                     </Text>
                                                     <Text c="ldGray.6" fz="xs">
                                                         Generated for{' '}
-                                                        {generated.description} ·{' '}
+                                                        {generated.description}{' '}
+                                                        ·{' '}
                                                         {generated.expiresLabel}
                                                     </Text>
                                                 </Stack>
@@ -416,7 +417,9 @@ const SemanticLayerConnectionPanel: FC<Props> = ({ projectUuid }) => {
                                 <Select
                                     label="SSL mode"
                                     description="SSL support is coming soon."
-                                    data={[{ value: 'disable', label: 'disable' }]}
+                                    data={[
+                                        { value: 'disable', label: 'disable' },
+                                    ]}
                                     value="disable"
                                     disabled
                                 />

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
@@ -405,7 +405,6 @@ const SemanticLayerConnectionPanel: FC<Props> = ({ projectUuid }) => {
                                     />
                                     <CopyableField
                                         label="User"
-                                        description="Not enforced — any value works."
                                         value={DEFAULT_USER}
                                     />
                                 </Group>

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
@@ -7,10 +7,10 @@ import {
     Button,
     CopyButton,
     Group,
-    SegmentedControl,
     Select,
     Stack,
     Switch,
+    Tabs,
     Text,
     TextInput,
     Title,
@@ -433,13 +433,23 @@ const SemanticLayerConnectionPanel: FC<Props> = ({ projectUuid }) => {
                             description="Pick your tool and copy the ready-made string."
                         >
                             <Stack gap="sm">
-                                <SegmentedControl
-                                    data={SNIPPET_TABS}
+                                <Tabs
                                     value={activeSnippet}
                                     onChange={(value) =>
                                         setActiveSnippet(value as SnippetKey)
                                     }
-                                />
+                                >
+                                    <Tabs.List>
+                                        {SNIPPET_TABS.map((tab) => (
+                                            <Tabs.Tab
+                                                key={tab.value}
+                                                value={tab.value}
+                                            >
+                                                {tab.label}
+                                            </Tabs.Tab>
+                                        ))}
+                                    </Tabs.List>
+                                </Tabs>
                                 <CodeBlock
                                     displayValue={displaySnippet}
                                     copyValue={snippets[activeSnippet]}

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
@@ -4,7 +4,6 @@ import {
     ActionIcon,
     Anchor,
     Box,
-    Button,
     CopyButton,
     Group,
     PasswordInput,
@@ -12,11 +11,15 @@ import {
     Switch,
     Tabs,
     Text,
-    TextInput,
     Title,
     Tooltip,
+    UnstyledButton,
 } from '@mantine-8/core';
-import { IconCheck, IconCopy } from '@tabler/icons-react';
+import {
+    IconCheck,
+    IconCircleCheckFilled,
+    IconCopy,
+} from '@tabler/icons-react';
 import { useMemo, useState, type FC, type ReactNode } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import {
@@ -148,6 +151,73 @@ const CodeBlock: FC<{ displayValue: ReactNode; copyValue: string }> = ({
     </Box>
 );
 
+// One connected green card: header, the masked token, its copy button, and the
+// reminder all live inside the same success-tinted surface so they read as a
+// single unit.
+const TokenAddedCard: FC<{
+    generated: GeneratedToken;
+    onReplace: () => void;
+}> = ({ generated, onReplace }) => {
+    const masked = maskToken(generated.token);
+    return (
+        <Box className={classes.tokenCard}>
+            <Group justify="space-between" wrap="nowrap" align="flex-start">
+                <Group gap="xs" wrap="nowrap" align="flex-start">
+                    <MantineIcon
+                        icon={IconCircleCheckFilled}
+                        color="green"
+                        size="lg"
+                    />
+                    <Box>
+                        <Text className={classes.tokenCardTitle}>
+                            Token added as your password
+                        </Text>
+                        <Text className={classes.tokenCardMeta}>
+                            Generated for {generated.description} ·{' '}
+                            {generated.expiresLabel}
+                        </Text>
+                    </Box>
+                </Group>
+                <Anchor
+                    component="button"
+                    type="button"
+                    fz="sm"
+                    fw={500}
+                    onClick={onReplace}
+                    style={{ flexShrink: 0 }}
+                >
+                    Replace
+                </Anchor>
+            </Group>
+            <Group gap="xs" wrap="nowrap" align="stretch" mt="sm">
+                <Box
+                    className={`${classes.tokenField} sentry-block ph-no-capture`}
+                    title={masked}
+                >
+                    {masked}
+                </Box>
+                <CopyButton value={generated.token} timeout={2000}>
+                    {({ copied, copy }) => (
+                        <UnstyledButton
+                            className={classes.tokenCopyBtn}
+                            onClick={copy}
+                        >
+                            <MantineIcon
+                                icon={copied ? IconCheck : IconCopy}
+                                size="sm"
+                            />
+                            {copied ? 'Copied' : 'Copy'}
+                        </UnstyledButton>
+                    )}
+                </CopyButton>
+            </Group>
+            <Text className={classes.tokenCardHint} mt="xs">
+                Remember to save your token — you can&apos;t access it again.
+            </Text>
+        </Box>
+    );
+};
+
 const SemanticLayerConnectionPanel: FC<Props> = ({ projectUuid }) => {
     const { health, user } = useApp();
     const { data: organization } = useOrganization();
@@ -229,7 +299,7 @@ const SemanticLayerConnectionPanel: FC<Props> = ({ projectUuid }) => {
             <SettingsCard>
                 <Group justify="space-between" wrap="nowrap" align="flex-start">
                     <Stack gap="xxs">
-                        <Title order={5}>Semantic layer connection</Title>
+                        <Title order={5}>Metric SQL API</Title>
                         <Text c="ldGray.6" size="sm">
                             Connect BI tools and SQL clients over the Postgres
                             wire protocol. Follow the three steps below.
@@ -277,89 +347,10 @@ const SemanticLayerConnectionPanel: FC<Props> = ({ projectUuid }) => {
                                 description="Paste an existing Lightdash token or generate a new one for this integration. You can use a service account or personal access token."
                             >
                                 {generated ? (
-                                    <Stack gap="xs">
-                                        <Callout variant="success" hideIcon>
-                                            <Group
-                                                justify="space-between"
-                                                wrap="nowrap"
-                                                align="flex-start"
-                                            >
-                                                <Group gap="xs" wrap="nowrap">
-                                                    <MantineIcon
-                                                        icon={IconCheck}
-                                                        color="green"
-                                                    />
-                                                    <Stack gap={0}>
-                                                        <Text fz="sm" fw={600}>
-                                                            Token added as your
-                                                            password
-                                                        </Text>
-                                                        <Text
-                                                            c="ldGray.6"
-                                                            fz="xs"
-                                                        >
-                                                            Generated for{' '}
-                                                            {
-                                                                generated.description
-                                                            }{' '}
-                                                            ·{' '}
-                                                            {
-                                                                generated.expiresLabel
-                                                            }
-                                                        </Text>
-                                                    </Stack>
-                                                </Group>
-                                                <Anchor
-                                                    component="button"
-                                                    type="button"
-                                                    fz="sm"
-                                                    fw={500}
-                                                    onClick={handleReplace}
-                                                    style={{ flexShrink: 0 }}
-                                                >
-                                                    Replace
-                                                </Anchor>
-                                            </Group>
-                                        </Callout>
-                                        <Group gap="xs" wrap="nowrap">
-                                            <TextInput
-                                                readOnly
-                                                style={{ flex: 1 }}
-                                                className="sentry-block ph-no-capture"
-                                                value={maskToken(
-                                                    generated.token,
-                                                )}
-                                            />
-                                            <CopyButton
-                                                value={generated.token}
-                                                timeout={2000}
-                                            >
-                                                {({ copied, copy }) => (
-                                                    <Button
-                                                        variant="default"
-                                                        leftSection={
-                                                            <MantineIcon
-                                                                icon={
-                                                                    copied
-                                                                        ? IconCheck
-                                                                        : IconCopy
-                                                                }
-                                                            />
-                                                        }
-                                                        onClick={copy}
-                                                    >
-                                                        {copied
-                                                            ? 'Copied'
-                                                            : 'Copy'}
-                                                    </Button>
-                                                )}
-                                            </CopyButton>
-                                        </Group>
-                                        <Text c="ldGray.6" fz="xs">
-                                            Remember to save your token — you
-                                            can&apos;t access it again.
-                                        </Text>
-                                    </Stack>
+                                    <TokenAddedCard
+                                        generated={generated}
+                                        onReplace={handleReplace}
+                                    />
                                 ) : (
                                     <Stack gap="xs">
                                         <PasswordInput

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
@@ -1,10 +1,13 @@
 import { subject } from '@casl/ability';
-import { CommercialFeatureFlags, ServiceAccountScope } from '@lightdash/common';
+import { CommercialFeatureFlags } from '@lightdash/common';
 import {
     ActionIcon,
+    Anchor,
+    Box,
     Button,
     CopyButton,
     Group,
+    SegmentedControl,
     Select,
     Stack,
     Switch,
@@ -13,19 +16,21 @@ import {
     Title,
     Tooltip,
 } from '@mantine-8/core';
-import { IconCheck, IconCopy, IconKey } from '@tabler/icons-react';
-import { useMemo, useState, type FC } from 'react';
-import { useServiceAccounts } from '../../../ee/features/serviceAccounts/useServiceAccounts';
+import { IconCheck, IconCopy } from '@tabler/icons-react';
+import { useMemo, useState, type FC, type ReactNode } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import {
     useOrganizationSettings,
     useUpdateOrganizationSettings,
 } from '../../../hooks/organization/useOrganizationSettings';
+import { useProject } from '../../../hooks/useProject';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import Callout from '../../common/Callout';
 import MantineIcon from '../../common/MantineIcon';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
+import { GenerateTokenModal, type GeneratedToken } from './GenerateTokenModal';
+import classes from './SemanticLayerConnectionPanel.module.css';
 
 type Props = {
     projectUuid: string;
@@ -33,6 +38,41 @@ type Props = {
 
 const DEFAULT_USER = 'lightdash';
 const TOKEN_PLACEHOLDER = '<token>';
+
+type SnippetKey = 'libpqUrl' | 'psql' | 'jdbc';
+
+const SNIPPET_TABS: { value: SnippetKey; label: string }[] = [
+    { value: 'libpqUrl', label: 'Connection URL' },
+    { value: 'psql', label: 'psql' },
+    { value: 'jdbc', label: 'JDBC' },
+];
+
+// Keep the token recognisable (prefix + last 4) while hiding the secret body,
+// so it's safe to show on screen shares yet still identifiable.
+const maskToken = (token: string) => {
+    if (token.length <= 10) return '•'.repeat(token.length);
+    return `${token.slice(0, 6)}${'•'.repeat(12)}${token.slice(-4)}`;
+};
+
+const CopyIconButton: FC<{ value: string }> = ({ value }) => (
+    <CopyButton value={value} timeout={2000}>
+        {({ copied, copy }) => (
+            <Tooltip
+                label={copied ? 'Copied' : 'Copy'}
+                withArrow
+                position="left"
+            >
+                <ActionIcon
+                    color={copied ? 'teal' : 'gray'}
+                    variant="subtle"
+                    onClick={copy}
+                >
+                    <MantineIcon icon={copied ? IconCheck : IconCopy} />
+                </ActionIcon>
+            </Tooltip>
+        )}
+    </CopyButton>
+);
 
 const CopyableField: FC<{
     label: string;
@@ -45,8 +85,49 @@ const CopyableField: FC<{
         readOnly
         value={value}
         className="sentry-block ph-no-capture"
-        rightSection={
-            <CopyButton value={value} timeout={2000}>
+        rightSection={<CopyIconButton value={value} />}
+    />
+);
+
+const Step: FC<{
+    index: number;
+    active: boolean;
+    title: string;
+    description?: ReactNode;
+    children: ReactNode;
+}> = ({ index, active, title, description, children }) => (
+    <Box className={classes.step}>
+        <Box
+            className={`${classes.bullet} ${
+                active ? classes.bulletActive : classes.bulletInactive
+            }`}
+        >
+            {index}
+        </Box>
+        <Box className={classes.content}>
+            <Stack gap="xs">
+                <Stack gap={2}>
+                    <Title order={6}>{title}</Title>
+                    {description && (
+                        <Text c="ldGray.6" fz="sm">
+                            {description}
+                        </Text>
+                    )}
+                </Stack>
+                {children}
+            </Stack>
+        </Box>
+    </Box>
+);
+
+const CodeBlock: FC<{ displayValue: ReactNode; copyValue: string }> = ({
+    displayValue,
+    copyValue,
+}) => (
+    <Box className={`${classes.codeBlock} sentry-block ph-no-capture`}>
+        {displayValue}
+        <Box className={classes.codeBlockCopy}>
+            <CopyButton value={copyValue} timeout={2000}>
                 {({ copied, copy }) => (
                     <Tooltip
                         label={copied ? 'Copied' : 'Copy'}
@@ -63,75 +144,14 @@ const CopyableField: FC<{
                     </Tooltip>
                 )}
             </CopyButton>
-        }
-    />
+        </Box>
+    </Box>
 );
-
-/**
- * Token step for the connection page. The pgwire password is a Lightdash token;
- * a token's plaintext is only ever returned once, at creation. So rather than
- * let the user pick an existing service account (whose token we can't recover),
- * we generate a fresh minimum-scope service account on the spot and reveal its
- * token once. It's lifted to the parent so the snippets can render a
- * ready-to-use password; a page reload clears it.
- */
-const GenerateTokenField: FC<{
-    generatedToken: string | null;
-    onTokenGenerated: (token: string) => void;
-}> = ({ generatedToken, onTokenGenerated }) => {
-    const { createAccount } = useServiceAccounts();
-
-    const handleGenerateToken = () => {
-        createAccount.mutate(
-            {
-                description: 'Semantic layer Postgres connection',
-                expiresAt: null,
-                // Minimum permissions needed to run semantic-layer queries.
-                scopes: [ServiceAccountScope.SYSTEM_INTERACTIVE_VIEWER],
-            },
-            {
-                onSuccess: (account) => onTokenGenerated(account.token),
-            },
-        );
-    };
-
-    if (generatedToken) {
-        return (
-            <Stack gap="xs">
-                <CopyableField
-                    label="Password (token)"
-                    value={generatedToken}
-                />
-                <Callout variant="info">
-                    Copy this token now — you won&apos;t be able to see it
-                    again. It&apos;s the password for every example below.
-                </Callout>
-            </Stack>
-        );
-    }
-
-    return (
-        <Group justify="space-between" wrap="nowrap" align="center">
-            <Text c="ldGray.6" fz="xs">
-                Generate a service account token (created with the minimum scope
-                needed to run queries) to use as the password.
-            </Text>
-            <Button
-                variant="default"
-                leftSection={<MantineIcon icon={IconKey} />}
-                loading={createAccount.isLoading}
-                onClick={handleGenerateToken}
-                style={{ flexShrink: 0 }}
-            >
-                Generate token
-            </Button>
-        </Group>
-    );
-};
 
 const SemanticLayerConnectionPanel: FC<Props> = ({ projectUuid }) => {
     const { health, user } = useApp();
     const { data: organization } = useOrganization();
+    const { data: project } = useProject(projectUuid);
     const { data: settings, isLoading: isSettingsLoading } =
         useOrganizationSettings();
     const update = useUpdateOrganizationSettings();
@@ -159,32 +179,60 @@ const SemanticLayerConnectionPanel: FC<Props> = ({ projectUuid }) => {
         (serviceAccountsFlag?.enabled ?? false);
 
     // The plaintext token is only returned once, when a service account is
-    // generated on the spot. We hold it in memory so the snippets can render a
-    // ready-to-use password; a page reload clears it.
-    const [generatedToken, setGeneratedToken] = useState<string | null>(null);
+    // generated on the spot. `manualToken` holds a token the user pasted;
+    // `generated` holds one we minted (which we mask and can't recover). Either
+    // feeds the snippets; a page reload clears both.
+    const [manualToken, setManualToken] = useState('');
+    const [generated, setGenerated] = useState<GeneratedToken | null>(null);
+    const [isModalOpen, setModalOpen] = useState(false);
+    const [activeSnippet, setActiveSnippet] = useState<SnippetKey>('libpqUrl');
+
+    const activeToken = generated?.token ?? manualToken;
+    const hasToken = activeToken.length > 0;
+    const tokenForSnippet = activeToken || TOKEN_PLACEHOLDER;
 
     const host = organization?.pgWire?.host ?? '';
     const port = organization?.pgWire?.port ?? null;
     const portString = port !== null ? String(port) : '';
-    const token = generatedToken ?? TOKEN_PLACEHOLDER;
 
-    const snippets = useMemo(() => {
-        const libpqUrl = `postgresql://${DEFAULT_USER}:${token}@${host}:${portString}/${projectUuid}?sslmode=disable`;
-        const psql = `PGPASSWORD=${token} psql -h ${host} -p ${portString} -U ${DEFAULT_USER} -d ${projectUuid} "sslmode=disable"`;
+    const snippets = useMemo<Record<SnippetKey, string>>(() => {
+        const libpqUrl = `postgresql://${DEFAULT_USER}:${tokenForSnippet}@${host}:${portString}/${projectUuid}?sslmode=disable`;
+        const psql = `PGPASSWORD=${tokenForSnippet} psql -h ${host} -p ${portString} -U ${DEFAULT_USER} -d ${projectUuid} "sslmode=disable"`;
         const jdbc = `jdbc:postgresql://${host}:${portString}/${projectUuid}?sslmode=disable`;
         return { libpqUrl, psql, jdbc };
-    }, [host, portString, projectUuid, token]);
+    }, [host, portString, projectUuid, tokenForSnippet]);
+
+    // The visible snippet blots out the token so it's safe on screen, while the
+    // copy button still yields the exact, ready-to-paste string.
+    const displaySnippet = useMemo<ReactNode>(() => {
+        const snippet = snippets[activeSnippet];
+        if (!hasToken || !snippet.includes(activeToken)) return snippet;
+        const [before, after] = snippet.split(activeToken);
+        return (
+            <>
+                {before}
+                <Text span className={classes.codeMask}>
+                    {maskToken(activeToken)}
+                </Text>
+                {after}
+            </>
+        );
+    }, [snippets, activeSnippet, hasToken, activeToken]);
+
+    const handleReplace = () => {
+        setGenerated(null);
+        setManualToken('');
+    };
 
     return (
         <Stack gap="sm">
-            <SettingsCard mb="lg">
+            <SettingsCard>
                 <Group justify="space-between" wrap="nowrap" align="flex-start">
                     <Stack gap="xxs">
                         <Title order={5}>Semantic layer connection</Title>
                         <Text c="ldGray.6" size="sm">
-                            Connect BI tools and SQL clients to this
-                            project&apos;s semantic layer over the Postgres wire
-                            protocol.
+                            Connect BI tools and SQL clients over the Postgres
+                            wire protocol. Follow the three steps below.
                         </Text>
                     </Stack>
                     <Switch
@@ -203,7 +251,7 @@ const SemanticLayerConnectionPanel: FC<Props> = ({ projectUuid }) => {
             </SettingsCard>
 
             {isEnabled && !isOrgAdmin && (
-                <SettingsCard mb="lg">
+                <SettingsCard>
                     <Callout variant="info">
                         Connection details are only visible to organization
                         admins.
@@ -212,91 +260,204 @@ const SemanticLayerConnectionPanel: FC<Props> = ({ projectUuid }) => {
             )}
 
             {isEnabled && isOrgAdmin && (
-                <>
-                    <SettingsCard mb="lg">
-                        <Stack gap="md">
-                            <Callout variant="info" title="Before you connect">
-                                Only simple <code>SELECT</code> queries against
-                                a single explore are supported (no SQL joins),
-                                with a default limit of 500 rows. TLS is not yet
-                                available, so clients must use{' '}
-                                <code>sslmode=disable</code>.
-                            </Callout>
+                <SettingsCard>
+                    <Stack gap="lg">
+                        <Callout variant="info" title="Before you connect">
+                            Only simple <code>SELECT</code> queries against a
+                            single explore are supported (no SQL joins), with a
+                            default limit of 500 rows. TLS is not yet available,
+                            so clients must use <code>sslmode=disable</code>.
+                        </Callout>
 
-                            <Title order={6}>Connection details</Title>
-                            <Group grow align="flex-start" wrap="nowrap">
+                        <Step
+                            index={1}
+                            active
+                            title="Token"
+                            description="Paste an existing Lightdash token or generate a new one for this integration. You can use a service account or personal access token."
+                        >
+                            {generated ? (
+                                <Stack gap="xs">
+                                    <Callout variant="success" hideIcon>
+                                        <Group
+                                            justify="space-between"
+                                            wrap="nowrap"
+                                            align="flex-start"
+                                        >
+                                            <Group gap="xs" wrap="nowrap">
+                                                <MantineIcon
+                                                    icon={IconCheck}
+                                                    color="green"
+                                                />
+                                                <Stack gap={0}>
+                                                    <Text fz="sm" fw={600}>
+                                                        Token added as your
+                                                        password
+                                                    </Text>
+                                                    <Text c="ldGray.6" fz="xs">
+                                                        Generated for{' '}
+                                                        {generated.description} ·{' '}
+                                                        {generated.expiresLabel}
+                                                    </Text>
+                                                </Stack>
+                                            </Group>
+                                            <Anchor
+                                                component="button"
+                                                type="button"
+                                                fz="sm"
+                                                fw={500}
+                                                onClick={handleReplace}
+                                                style={{ flexShrink: 0 }}
+                                            >
+                                                Replace
+                                            </Anchor>
+                                        </Group>
+                                    </Callout>
+                                    <Group gap="xs" wrap="nowrap">
+                                        <TextInput
+                                            readOnly
+                                            style={{ flex: 1 }}
+                                            className="sentry-block ph-no-capture"
+                                            value={maskToken(generated.token)}
+                                        />
+                                        <CopyButton
+                                            value={generated.token}
+                                            timeout={2000}
+                                        >
+                                            {({ copied, copy }) => (
+                                                <Button
+                                                    variant="default"
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={
+                                                                copied
+                                                                    ? IconCheck
+                                                                    : IconCopy
+                                                            }
+                                                        />
+                                                    }
+                                                    onClick={copy}
+                                                >
+                                                    {copied ? 'Copied' : 'Copy'}
+                                                </Button>
+                                            )}
+                                        </CopyButton>
+                                    </Group>
+                                    <Text c="ldGray.6" fz="xs">
+                                        Remember to save your token — you
+                                        can&apos;t access it again.
+                                    </Text>
+                                </Stack>
+                            ) : (
+                                <Stack gap="xs">
+                                    <TextInput
+                                        placeholder="ldsvc_… or ldpat_…"
+                                        className="sentry-block ph-no-capture"
+                                        value={manualToken}
+                                        onChange={(event) =>
+                                            setManualToken(
+                                                event.currentTarget.value.trim(),
+                                            )
+                                        }
+                                        rightSection={
+                                            manualToken ? (
+                                                <CopyIconButton
+                                                    value={manualToken}
+                                                />
+                                            ) : undefined
+                                        }
+                                    />
+                                    {isServiceAccountsEnabled ? (
+                                        <Text c="ldGray.6" fz="sm">
+                                            Don&apos;t have a token?{' '}
+                                            <Anchor
+                                                component="button"
+                                                type="button"
+                                                fw={500}
+                                                onClick={() =>
+                                                    setModalOpen(true)
+                                                }
+                                            >
+                                                Generate a new one
+                                            </Anchor>
+                                        </Text>
+                                    ) : (
+                                        <Text c="ldGray.6" fz="sm">
+                                            Paste a personal access token from
+                                            your account settings.
+                                        </Text>
+                                    )}
+                                </Stack>
+                            )}
+                        </Step>
+
+                        <Step
+                            index={2}
+                            active={false}
+                            title="Connection details"
+                        >
+                            <Stack gap="sm">
                                 <CopyableField label="Host" value={host} />
+                                <Group grow align="flex-start" wrap="nowrap">
+                                    <CopyableField
+                                        label="Port"
+                                        value={portString}
+                                    />
+                                    <CopyableField
+                                        label="User"
+                                        description="Not enforced — any value works."
+                                        value={DEFAULT_USER}
+                                    />
+                                </Group>
                                 <CopyableField
-                                    label="Port"
-                                    value={portString}
-                                />
-                            </Group>
-                            <CopyableField
-                                label="Database"
-                                description="Use the project UUID (unambiguous)."
-                                value={projectUuid}
-                            />
-                            <Group grow align="flex-start" wrap="nowrap">
-                                <CopyableField
-                                    label="User"
-                                    description="Not enforced — any value works."
-                                    value={DEFAULT_USER}
+                                    label="Database"
+                                    description="Use the project UUID (unambiguous)."
+                                    value={projectUuid}
                                 />
                                 <Select
                                     label="SSL mode"
                                     description="SSL support is coming soon."
-                                    data={[
-                                        { value: 'disable', label: 'disable' },
-                                    ]}
+                                    data={[{ value: 'disable', label: 'disable' }]}
                                     value="disable"
                                     disabled
                                 />
-                            </Group>
-                        </Stack>
-                    </SettingsCard>
-
-                    <SettingsCard mb="lg">
-                        <Stack gap="md">
-                            <Stack gap="xxs">
-                                <Title order={6}>Authentication</Title>
-                                <Text c="ldGray.6" fz="sm">
-                                    Use a service account token (
-                                    <code>ldsvc_...</code>) or a personal access
-                                    token (<code>ldpat_...</code>) as the
-                                    password.
-                                </Text>
                             </Stack>
-                            {isServiceAccountsEnabled ? (
-                                <GenerateTokenField
-                                    generatedToken={generatedToken}
-                                    onTokenGenerated={setGeneratedToken}
-                                />
-                            ) : (
-                                <Text c="ldGray.6" fz="xs">
-                                    Paste a personal access token from your
-                                    account settings to use as the password in
-                                    the examples below.
-                                </Text>
-                            )}
-                        </Stack>
-                    </SettingsCard>
+                        </Step>
 
-                    <SettingsCard mb="lg">
-                        <Stack gap="md">
-                            <Title order={6}>Ready-to-copy examples</Title>
-                            <CopyableField
-                                label="Connection URL"
-                                value={snippets.libpqUrl}
-                            />
-                            <CopyableField label="psql" value={snippets.psql} />
-                            <CopyableField
-                                label="JDBC (DBeaver / DataGrip)"
-                                value={snippets.jdbc}
-                            />
-                        </Stack>
-                    </SettingsCard>
-                </>
+                        <Step
+                            index={3}
+                            active={false}
+                            title="Connect your client"
+                            description="Pick your tool and copy the ready-made string."
+                        >
+                            <Stack gap="sm">
+                                <SegmentedControl
+                                    data={SNIPPET_TABS}
+                                    value={activeSnippet}
+                                    onChange={(value) =>
+                                        setActiveSnippet(value as SnippetKey)
+                                    }
+                                />
+                                <CodeBlock
+                                    displayValue={displaySnippet}
+                                    copyValue={snippets[activeSnippet]}
+                                />
+                            </Stack>
+                        </Step>
+                    </Stack>
+                </SettingsCard>
             )}
+
+            <GenerateTokenModal
+                opened={isModalOpen}
+                onClose={() => setModalOpen(false)}
+                projectUuid={projectUuid}
+                projectName={project?.name ?? ''}
+                onGenerated={(token) => {
+                    setManualToken('');
+                    setGenerated(token);
+                    setModalOpen(false);
+                }}
+            />
         </Stack>
     );
 };

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
@@ -436,11 +436,12 @@ const SemanticLayerConnectionPanel: FC<Props> = ({ projectUuid }) => {
                                 <Stack gap="sm">
                                     <Tabs
                                         value={activeSnippet}
-                                        onChange={(value) =>
-                                            setActiveSnippet(
-                                                value as SnippetKey,
-                                            )
-                                        }
+                                        onChange={(value) => {
+                                            if (value)
+                                                setActiveSnippet(
+                                                    value as SnippetKey,
+                                                );
+                                        }}
                                     >
                                         <Tabs.List>
                                             {SNIPPET_TABS.map((tab) => (

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
@@ -456,17 +456,19 @@ const SemanticLayerConnectionPanel: FC<Props> = ({ projectUuid }) => {
                 </SettingsCard>
             )}
 
-            <GenerateTokenModal
-                opened={isModalOpen}
-                onClose={() => setModalOpen(false)}
-                projectUuid={projectUuid}
-                projectName={project?.name ?? ''}
-                onGenerated={(token) => {
-                    setManualToken('');
-                    setGenerated(token);
-                    setModalOpen(false);
-                }}
-            />
+            {isEnabled && isOrgAdmin && isServiceAccountsEnabled && (
+                <GenerateTokenModal
+                    opened={isModalOpen}
+                    onClose={() => setModalOpen(false)}
+                    projectUuid={projectUuid}
+                    projectName={project?.name ?? ''}
+                    onGenerated={(token) => {
+                        setManualToken('');
+                        setGenerated(token);
+                        setModalOpen(false);
+                    }}
+                />
+            )}
         </Stack>
     );
 };

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -664,10 +664,18 @@ export const useSettingsNavigation = (
 
             if (organization?.pgWire?.enabled) {
                 projectItems.push({
-                    label: 'Semantic layer',
+                    label: 'Metric SQL API',
                     to: `${base}/semanticLayer`,
                     icon: IconPlug,
-                    keywords: ['postgres', 'pgwire', 'connection', 'sql', 'bi'],
+                    keywords: [
+                        'postgres',
+                        'pgwire',
+                        'connection',
+                        'sql',
+                        'bi',
+                        'metric',
+                        'semantic layer',
+                    ],
                     children: [],
                     exact: true,
                 });


### PR DESCRIPTION
Closes PROD-8878

https://linear.app/lightdash/issue/PROD-8878/improve-design-of-postgreswire-connection-panel

### Description:

Redesigns the semantic layer connection panel with a clearer, step-by-step workflow:

**Key Changes:**

1. **New Token Generation Modal** (`GenerateTokenModal.tsx`)
   - Allows users to create project-scoped service account tokens directly from the connection panel
   - Configurable expiration (7 days to 1 year, or no expiration)
   - Selectable project role (Interactive Viewer recommended, up to Admin)
   - Auto-copies token to clipboard on generation
   - Shows token once with masking for safe screen sharing
   - Form validated with a Zod schema via `zodResolver`

2. **Improved Connection Flow**
   - Reorganized into 3 clear steps: Token → Connection Details → Connect Your Client
   - Step indicators with visual progress (numbered bullets with connecting line)
   - Token input accepts manual paste or triggers modal for generation
   - Shows success state with token metadata (description, expiration) after generation

3. **Better Code Snippet Display**
   - Segmented control to switch between Connection URL, psql, and JDBC examples
   - Token masking in displayed snippets (prefix + last 4 chars) for safe screen sharing
   - Copy button still provides full, ready-to-paste string
   - Dedicated `CodeBlock` component with improved styling

4. **UX Improvements**
   - Generate flow now mints a project-scoped service account (Interactive Viewer by default) instead of an org-wide one
   - Added `useProject` hook to display project name in modal
   - Token state management: `manualToken` for pasted tokens, `generated` for created ones
   - "Replace" button to switch between manual and generated tokens
   - Clearer descriptions and help text throughout

5. **Styling**
   - New CSS module (`SemanticLayerConnectionPanel.module.css`) for step layout, code blocks, and token masking
   - Consistent spacing and visual hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWCJJT8wR97aPJ688zbtci