### PR TITLE
feat: homepage audience assignment with group and role resolution

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -482,6 +482,8 @@ import {
     ProjectCiStatusTableName,
 } from '../ee/database/entities/projectCiStatus';
 import {
+    HomepageAssignmentsTable,
+    HomepageAssignmentsTableName,
     HomepagesTableName,
     ProjectHomepagesTable,
 } from '../ee/database/entities/projectHomepages';
@@ -619,6 +621,7 @@ declare module 'knex/types/tables' {
         [AiAgentMcpServerTableName]: AiAgentMcpServerTable;
         [AiAgentUserPreferencesTableName]: AiAgentUserPreferencesTable;
         [HomepagesTableName]: ProjectHomepagesTable;
+        [HomepageAssignmentsTableName]: HomepageAssignmentsTable;
         [AiAgentReasoningTableName]: AiAgentReasoningTable;
         [AiAgentToolCallTableName]: AiAgentToolCallTable;
         [AiAgentToolResultTableName]: AiAgentToolResultTable;

--- a/packages/backend/src/ee/controllers/projectHomepageController.ts
+++ b/packages/backend/src/ee/controllers/projectHomepageController.ts
@@ -1,6 +1,7 @@
 import {
     assertRegisteredAccount,
     type ApiErrorPayload,
+    type ApiHomepageAssignmentsResponse,
     type ApiProjectHomepageOrNullResponse,
     type ApiProjectHomepageResponse,
     type ApiProjectHomepagesResponse,
@@ -8,6 +9,8 @@ import {
     type ApiRecentlyViewedResponse,
     type ApiSuccessEmpty,
     type CreateProjectHomepageRequest,
+    type PublishProjectHomepageRequest,
+    type UpdateHomepageGroupPrioritiesRequest,
     type UpdateProjectHomepageDraftRequest,
     type UUID,
 } from '@lightdash/common';
@@ -102,6 +105,51 @@ export class ProjectHomepageController extends BaseController {
                 toSessionUser(req.account),
                 projectUuid,
             ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/assignments')
+    @OperationId('getHomepageAssignments')
+    async getAssignments(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+    ): Promise<ApiHomepageAssignmentsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().getAssignments(
+                toSessionUser(req.account),
+                projectUuid,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/group-priorities')
+    @OperationId('updateHomepageGroupPriorities')
+    async updateGroupPriorities(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Body() body: UpdateHomepageGroupPrioritiesRequest,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.getHomepageService().updateGroupPriorities(
+            toSessionUser(req.account),
+            projectUuid,
+            body.groupUuids,
+        );
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: undefined,
         };
     }
 
@@ -214,6 +262,7 @@ export class ProjectHomepageController extends BaseController {
         @Request() req: express.Request,
         @Path() projectUuid: UUID,
         @Path() homepageUuid: UUID,
+        @Body() body: PublishProjectHomepageRequest,
     ): Promise<ApiProjectHomepageResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
@@ -223,6 +272,7 @@ export class ProjectHomepageController extends BaseController {
                 toSessionUser(req.account),
                 projectUuid,
                 homepageUuid,
+                body.audience,
             ),
         };
     }

--- a/packages/backend/src/ee/database/entities/projectHomepages.ts
+++ b/packages/backend/src/ee/database/entities/projectHomepages.ts
@@ -40,3 +40,31 @@ export type ProjectHomepagesTable = Knex.CompositeTableType<
     DbProjectHomepageIn,
     DbProjectHomepageUpdate
 >;
+
+export const HomepageAssignmentsTableName = 'homepage_assignments';
+
+export type DbHomepageAssignment = {
+    assignment_uuid: string;
+    project_uuid: string;
+    homepage_uuid: string;
+    target_type: 'group' | 'role';
+    group_uuid: string | null;
+    role: string | null;
+    priority: number;
+    created_at: Date;
+};
+
+export type DbHomepageAssignmentIn = Pick<
+    DbHomepageAssignment,
+    'project_uuid' | 'homepage_uuid' | 'target_type' | 'group_uuid' | 'role' | 'priority'
+>;
+
+export type DbHomepageAssignmentUpdate = Partial<
+    Pick<DbHomepageAssignment, 'priority'>
+>;
+
+export type HomepageAssignmentsTable = Knex.CompositeTableType<
+    DbHomepageAssignment,
+    DbHomepageAssignmentIn,
+    DbHomepageAssignmentUpdate
+>;

--- a/packages/backend/src/ee/database/migrations/20260714180000_create_homepage_assignments_table.ts
+++ b/packages/backend/src/ee/database/migrations/20260714180000_create_homepage_assignments_table.ts
@@ -1,0 +1,54 @@
+import { Knex } from 'knex';
+
+const ASSIGNMENTS_TABLE = 'homepage_assignments';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(ASSIGNMENTS_TABLE, (table) => {
+        table
+            .uuid('assignment_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE')
+            .index();
+        table
+            .uuid('homepage_uuid')
+            .notNullable()
+            .references('homepage_uuid')
+            .inTable('homepages')
+            .onDelete('CASCADE')
+            .index();
+        table.text('target_type').notNullable();
+        table
+            .uuid('group_uuid')
+            .nullable()
+            .references('group_uuid')
+            .inTable('groups')
+            .onDelete('CASCADE');
+        table.text('role').nullable();
+        table.integer('priority').notNullable().defaultTo(0);
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+    // A group/role lands on exactly one homepage per project
+    await knex.raw(`
+        CREATE UNIQUE INDEX homepage_assignments_one_group_per_project
+        ON homepage_assignments (project_uuid, group_uuid)
+        WHERE target_type = 'group'
+    `);
+    await knex.raw(`
+        CREATE UNIQUE INDEX homepage_assignments_one_role_per_project
+        ON homepage_assignments (project_uuid, role)
+        WHERE target_type = 'role'
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(ASSIGNMENTS_TABLE);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -134,6 +134,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectHomepageModel:
                         models.getProjectHomepageModel<ProjectHomepageModel>(),
                     featureFlagService: repository.getFeatureFlagService(),
+                    groupsModel: models.getGroupsModel(),
+                    projectModel: models.getProjectModel(),
                 }),
             aiDeepResearchService: ({
                 models,

--- a/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
@@ -103,12 +103,12 @@ describe('ProjectHomepageModel', () => {
         it('throws NotFoundError when homepage does not exist', async () => {
             tracker.on.select(HomepagesTableName).responseOnce([]);
 
-            await expect(model.publish(HOMEPAGE_UUID)).rejects.toThrow(
-                NotFoundError,
-            );
+            await expect(
+                model.publish(HOMEPAGE_UUID, { type: 'everyone' }),
+            ).rejects.toThrow(NotFoundError);
         });
 
-        it('copies the draft config into published_config and promotes to default', async () => {
+        it('publishing to everyone copies the draft and promotes to default', async () => {
             tracker.on
                 .select(HomepagesTableName)
                 .responseOnce([makeDbHomepage()]);
@@ -120,7 +120,9 @@ describe('ProjectHomepageModel', () => {
                     makeDbHomepage({ published_config: draftConfig }),
                 ]);
 
-            const result = await model.publish(HOMEPAGE_UUID);
+            const result = await model.publish(HOMEPAGE_UUID, {
+                type: 'everyone',
+            });
 
             expect(tracker.history.update).toHaveLength(2);
             const unsetQuery = tracker.history.update[0];
@@ -128,6 +130,38 @@ describe('ProjectHomepageModel', () => {
             const publishQuery = tracker.history.update[1];
             expect(publishQuery.bindings).toContainEqual(draftConfig);
             expect(result.publishedConfig).toEqual(draftConfig);
+        });
+
+        it('publishing to groups replaces assignments without touching the default', async () => {
+            tracker.on
+                .select(HomepagesTableName)
+                .responseOnce([makeDbHomepage({ is_default: false })]);
+            tracker.on
+                .update(HomepagesTableName)
+                .responseOnce([
+                    makeDbHomepage({
+                        is_default: false,
+                        published_config: draftConfig,
+                    }),
+                ]);
+            tracker.on.delete('homepage_assignments').responseOnce(1);
+            tracker.on
+                .select('homepage_assignments')
+                .responseOnce([{ max: 1 }]);
+            tracker.on.insert('homepage_assignments').responseOnce([]);
+
+            const result = await model.publish(HOMEPAGE_UUID, {
+                type: 'groups',
+                groupUuids: ['group-a', 'group-b'],
+            });
+
+            // publish update must not set is_default for group audiences
+            const publishQuery = tracker.history.update[0];
+            expect(publishQuery.sql).not.toContain('is_default');
+            const insertQuery = tracker.history.insert[0];
+            expect(insertQuery.bindings).toContainEqual('group-a');
+            expect(insertQuery.bindings).toContainEqual('group-b');
+            expect(result.isDefault).toBe(false);
         });
     });
 

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -1,13 +1,17 @@
 import {
     ConflictError,
     NotFoundError,
+    type HomepageAssignment,
+    type HomepageAudience,
     type HomepageConfig,
     type HomepageRecentlyViewedItem,
     type ProjectHomepage,
+    type ProjectMemberRole,
     type PublishedProjectHomepage,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
 import {
+    HomepageAssignmentsTableName,
     HomepagesTableName,
     type DbProjectHomepage,
 } from '../database/entities/projectHomepages';
@@ -189,8 +193,11 @@ export class ProjectHomepageModel {
         }));
     }
 
-    // Publishing promotes the homepage to the project default viewers land on
-    async publish(homepageUuid: string): Promise<ProjectHomepage> {
+    // Publishing to "everyone" promotes the homepage to the project default
+    async publish(
+        homepageUuid: string,
+        audience: HomepageAudience,
+    ): Promise<ProjectHomepage> {
         return this.database.transaction(async (trx) => {
             const existing = await trx(HomepagesTableName)
                 .where({ homepage_uuid: homepageUuid })
@@ -198,22 +205,196 @@ export class ProjectHomepageModel {
             if (!existing) {
                 throw new NotFoundError('Homepage not found');
             }
-            await trx(HomepagesTableName)
-                .where({
-                    project_uuid: existing.project_uuid,
-                    is_default: true,
-                })
-                .whereNot({ homepage_uuid: homepageUuid })
-                .update({ is_default: false });
+            const makeDefault = audience.type === 'everyone';
+            if (makeDefault) {
+                await trx(HomepagesTableName)
+                    .where({
+                        project_uuid: existing.project_uuid,
+                        is_default: true,
+                    })
+                    .whereNot({ homepage_uuid: homepageUuid })
+                    .update({ is_default: false });
+            }
             const [row] = await trx(HomepagesTableName)
                 .where({ homepage_uuid: homepageUuid })
                 .update({
                     published_config: existing.draft_config,
-                    is_default: true,
+                    ...(makeDefault ? { is_default: true } : {}),
                     updated_at: new Date(),
                 })
                 .returning('*');
+
+            if (audience.type === 'groups') {
+                // Reassigning a group moves it off its previous homepage
+                await trx(HomepageAssignmentsTableName)
+                    .where({
+                        project_uuid: existing.project_uuid,
+                        target_type: 'group',
+                    })
+                    .where((builder) =>
+                        builder
+                            .whereIn('group_uuid', audience.groupUuids)
+                            .orWhere({ homepage_uuid: homepageUuid }),
+                    )
+                    .delete();
+                const maxPriorityRow = await trx(HomepageAssignmentsTableName)
+                    .where({
+                        project_uuid: existing.project_uuid,
+                        target_type: 'group',
+                    })
+                    .max<{ max: number | null }>('priority as max')
+                    .first();
+                const basePriority = (maxPriorityRow?.max ?? -1) + 1;
+                if (audience.groupUuids.length > 0) {
+                    await trx(HomepageAssignmentsTableName).insert(
+                        audience.groupUuids.map((groupUuid, index) => ({
+                            project_uuid: existing.project_uuid,
+                            homepage_uuid: homepageUuid,
+                            target_type: 'group' as const,
+                            group_uuid: groupUuid,
+                            role: null,
+                            priority: basePriority + index,
+                        })),
+                    );
+                }
+            } else if (audience.type === 'roles') {
+                await trx(HomepageAssignmentsTableName)
+                    .where({
+                        project_uuid: existing.project_uuid,
+                        target_type: 'role',
+                    })
+                    .where((builder) =>
+                        builder
+                            .whereIn('role', audience.roles)
+                            .orWhere({ homepage_uuid: homepageUuid }),
+                    )
+                    .delete();
+                if (audience.roles.length > 0) {
+                    await trx(HomepageAssignmentsTableName).insert(
+                        audience.roles.map((role) => ({
+                            project_uuid: existing.project_uuid,
+                            homepage_uuid: homepageUuid,
+                            target_type: 'role' as const,
+                            group_uuid: null,
+                            role,
+                            priority: 0,
+                        })),
+                    );
+                }
+            }
             return ProjectHomepageModel.mapDbHomepage(row);
         });
+    }
+
+    async getAssignments(projectUuid: string): Promise<HomepageAssignment[]> {
+        const rows = await this.database(HomepageAssignmentsTableName)
+            .leftJoin(
+                HomepagesTableName,
+                `${HomepagesTableName}.homepage_uuid`,
+                `${HomepageAssignmentsTableName}.homepage_uuid`,
+            )
+            .leftJoin(
+                'groups',
+                'groups.group_uuid',
+                `${HomepageAssignmentsTableName}.group_uuid`,
+            )
+            .where(`${HomepageAssignmentsTableName}.project_uuid`, projectUuid)
+            .orderBy(`${HomepageAssignmentsTableName}.priority`, 'asc')
+            .select(
+                `${HomepageAssignmentsTableName}.assignment_uuid`,
+                `${HomepageAssignmentsTableName}.homepage_uuid`,
+                `${HomepagesTableName}.name as homepage_name`,
+                `${HomepageAssignmentsTableName}.target_type`,
+                `${HomepageAssignmentsTableName}.group_uuid`,
+                'groups.name as group_name',
+                `${HomepageAssignmentsTableName}.role`,
+                `${HomepageAssignmentsTableName}.priority`,
+            );
+        return rows.map((row) => ({
+            assignmentUuid: row.assignment_uuid,
+            homepageUuid: row.homepage_uuid,
+            homepageName: row.homepage_name,
+            targetType: row.target_type,
+            groupUuid: row.group_uuid,
+            groupName: row.group_name ?? null,
+            role: row.role,
+            priority: row.priority,
+        }));
+    }
+
+    async updateGroupPriorities(
+        projectUuid: string,
+        groupUuids: string[],
+    ): Promise<void> {
+        await this.database.transaction(async (trx) => {
+            await Promise.all(
+                groupUuids.map((groupUuid, index) =>
+                    trx(HomepageAssignmentsTableName)
+                        .where({
+                            project_uuid: projectUuid,
+                            target_type: 'group',
+                            group_uuid: groupUuid,
+                        })
+                        .update({ priority: index }),
+                ),
+            );
+        });
+    }
+
+    // Resolution: group (by admin-ranked priority) → role → project default
+    async resolvePublished(
+        projectUuid: string,
+        viewer: { groupUuids: string[]; role: ProjectMemberRole | undefined },
+    ): Promise<PublishedProjectHomepage | undefined> {
+        const publishedAssigned = async (
+            builderFilter: (builder: Knex.QueryBuilder) => void,
+        ) => {
+            const query = this.database(HomepageAssignmentsTableName)
+                .join(
+                    HomepagesTableName,
+                    `${HomepagesTableName}.homepage_uuid`,
+                    `${HomepageAssignmentsTableName}.homepage_uuid`,
+                )
+                .where(
+                    `${HomepageAssignmentsTableName}.project_uuid`,
+                    projectUuid,
+                )
+                .whereNotNull(`${HomepagesTableName}.published_config`)
+                .orderBy(`${HomepageAssignmentsTableName}.priority`, 'asc')
+                .select(`${HomepagesTableName}.*`)
+                .first();
+            builderFilter(query);
+            return query;
+        };
+
+        if (viewer.groupUuids.length > 0) {
+            const byGroup = await publishedAssigned((builder) => {
+                void builder
+                    .where('target_type', 'group')
+                    .whereIn('group_uuid', viewer.groupUuids);
+            });
+            if (byGroup && byGroup.published_config) {
+                return {
+                    homepageUuid: byGroup.homepage_uuid,
+                    name: byGroup.name,
+                    config: byGroup.published_config,
+                };
+            }
+        }
+        if (viewer.role) {
+            const byRole = await publishedAssigned((builder) => {
+                void builder
+                    .where('target_type', 'role')
+                    .where('role', viewer.role);
+            });
+            if (byRole && byRole.published_config) {
+                return {
+                    homepageUuid: byRole.homepage_uuid,
+                    name: byRole.name,
+                    config: byRole.published_config,
+                };
+            }
+        }
+        return this.getPublishedDefault(projectUuid);
     }
 }

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -100,11 +100,15 @@ const makeViewerUser = (): SessionUser => ({
 const makeService = ({
     flagEnabled = true,
     projectHomepageModel = {},
+    groupsModel = {},
+    projectModel = {},
 }: {
     flagEnabled?: boolean;
     projectHomepageModel?: Partial<
         ProjectHomepageServiceArguments['projectHomepageModel']
     >;
+    groupsModel?: Partial<ProjectHomepageServiceArguments['groupsModel']>;
+    projectModel?: Partial<ProjectHomepageServiceArguments['projectModel']>;
 } = {}) =>
     new ProjectHomepageService({
         featureFlagService: {
@@ -118,12 +122,23 @@ const makeService = ({
             getByUuid: vi.fn().mockResolvedValue(makeHomepage()),
             getPublishedDefault: vi.fn().mockResolvedValue(undefined),
             getRecentlyViewed: vi.fn().mockResolvedValue([]),
+            getAssignments: vi.fn().mockResolvedValue([]),
+            updateGroupPriorities: vi.fn().mockResolvedValue(undefined),
+            resolvePublished: vi.fn().mockResolvedValue(undefined),
             list: vi.fn().mockResolvedValue([]),
             create: vi.fn().mockResolvedValue(makeHomepage()),
             updateDraft: vi.fn().mockResolvedValue(makeHomepage()),
             publish: vi.fn().mockResolvedValue(makeHomepage()),
             delete: vi.fn().mockResolvedValue(undefined),
             ...projectHomepageModel,
+        },
+        groupsModel: {
+            findUserGroups: vi.fn().mockResolvedValue([]),
+            ...groupsModel,
+        },
+        projectModel: {
+            getProjectMemberAccess: vi.fn().mockResolvedValue(undefined),
+            ...projectModel,
         },
     });
 
@@ -262,9 +277,49 @@ describe('ProjectHomepageService', () => {
             makeAdminUser(),
             PROJECT_UUID,
             HOMEPAGE_UUID,
+            { type: 'everyone' },
         );
 
-        expect(publish).toHaveBeenCalledWith(HOMEPAGE_UUID);
+        expect(publish).toHaveBeenCalledWith(HOMEPAGE_UUID, {
+            type: 'everyone',
+        });
         expect(result.publishedConfig).toEqual(validConfig);
+    });
+
+    it('getPublishedHomepage resolves with the viewer’s groups and role', async () => {
+        const resolvePublished = vi.fn().mockResolvedValue({
+            homepageUuid: HOMEPAGE_UUID,
+            name: 'Sales homepage',
+            config: validConfig,
+        });
+        const service = makeService({
+            projectHomepageModel: { resolvePublished },
+            groupsModel: {
+                findUserGroups: vi
+                    .fn()
+                    .mockResolvedValue([{ uuid: 'group-1', name: 'Sales' }]),
+            },
+            projectModel: {
+                getProjectMemberAccess: vi.fn().mockResolvedValue({
+                    userUuid: USER_UUID,
+                    projectUuid: PROJECT_UUID,
+                    role: 'editor',
+                    email: 'x@y.z',
+                    firstName: 'A',
+                    lastName: 'B',
+                }),
+            },
+        });
+
+        const result = await service.getPublishedHomepage(
+            makeViewerUser(),
+            PROJECT_UUID,
+        );
+
+        expect(resolvePublished).toHaveBeenCalledWith(PROJECT_UUID, {
+            groupUuids: ['group-1'],
+            role: 'editor',
+        });
+        expect(result?.name).toBe('Sales homepage');
     });
 });

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -7,6 +7,8 @@ import {
     NotFoundError,
     ParameterError,
     type CreateProjectHomepageRequest,
+    type HomepageAssignment,
+    type HomepageAudience,
     type HomepageConfig,
     type HomepageRecentlyViewedItem,
     type ProjectHomepage,
@@ -14,6 +16,8 @@ import {
     type SessionUser,
     type UpdateProjectHomepageDraftRequest,
 } from '@lightdash/common';
+import { type GroupsModel } from '../../models/GroupsModel';
+import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { BaseService } from '../../services/BaseService';
 import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
 import { type ProjectHomepageModel } from '../models/ProjectHomepageModel';
@@ -25,6 +29,9 @@ export type ProjectHomepageServiceArguments = {
         | 'getByUuid'
         | 'getPublishedDefault'
         | 'getRecentlyViewed'
+        | 'getAssignments'
+        | 'updateGroupPriorities'
+        | 'resolvePublished'
         | 'list'
         | 'create'
         | 'updateDraft'
@@ -32,6 +39,8 @@ export type ProjectHomepageServiceArguments = {
         | 'delete'
     >;
     featureFlagService: Pick<FeatureFlagService, 'get'>;
+    groupsModel: Pick<GroupsModel, 'findUserGroups'>;
+    projectModel: Pick<ProjectModel, 'getProjectMemberAccess'>;
 };
 
 export class ProjectHomepageService extends BaseService {
@@ -39,10 +48,16 @@ export class ProjectHomepageService extends BaseService {
 
     private readonly featureFlagService: ProjectHomepageServiceArguments['featureFlagService'];
 
+    private readonly groupsModel: ProjectHomepageServiceArguments['groupsModel'];
+
+    private readonly projectModel: ProjectHomepageServiceArguments['projectModel'];
+
     constructor(args: ProjectHomepageServiceArguments) {
         super();
         this.projectHomepageModel = args.projectHomepageModel;
         this.featureFlagService = args.featureFlagService;
+        this.groupsModel = args.groupsModel;
+        this.projectModel = args.projectModel;
     }
 
     private async assertFlagEnabled(user: SessionUser): Promise<void> {
@@ -119,15 +134,55 @@ export class ProjectHomepageService extends BaseService {
         return homepage;
     }
 
+    // Resolution: group priority → role → project default (personal = ZAP-628)
     async getPublishedHomepage(
         user: SessionUser,
         projectUuid: string,
     ): Promise<PublishedProjectHomepage | null> {
         await this.assertFlagEnabled(user);
         this.assertCanView(user, projectUuid);
-        const published =
-            await this.projectHomepageModel.getPublishedDefault(projectUuid);
+        const [groups, membership] = await Promise.all([
+            user.organizationUuid
+                ? this.groupsModel.findUserGroups({
+                      userUuid: user.userUuid,
+                      organizationUuid: user.organizationUuid,
+                  })
+                : Promise.resolve([]),
+            this.projectModel.getProjectMemberAccess(
+                projectUuid,
+                user.userUuid,
+            ),
+        ]);
+        const published = await this.projectHomepageModel.resolvePublished(
+            projectUuid,
+            {
+                groupUuids: groups.map((group) => group.uuid),
+                role: membership?.role,
+            },
+        );
         return published ?? null;
+    }
+
+    async getAssignments(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<HomepageAssignment[]> {
+        await this.assertFlagEnabled(user);
+        this.assertCanManage(user, projectUuid);
+        return this.projectHomepageModel.getAssignments(projectUuid);
+    }
+
+    async updateGroupPriorities(
+        user: SessionUser,
+        projectUuid: string,
+        groupUuids: string[],
+    ): Promise<void> {
+        await this.assertFlagEnabled(user);
+        this.assertCanManage(user, projectUuid);
+        await this.projectHomepageModel.updateGroupPriorities(
+            projectUuid,
+            groupUuids,
+        );
     }
 
     async getRecentlyViewed(
@@ -219,10 +274,11 @@ export class ProjectHomepageService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         homepageUuid: string,
+        audience: HomepageAudience,
     ): Promise<ProjectHomepage> {
         await this.assertFlagEnabled(user);
         this.assertCanManage(user, projectUuid);
         await this.getOwnedHomepage(projectUuid, homepageUuid);
-        return this.projectHomepageModel.publish(homepageUuid);
+        return this.projectHomepageModel.publish(homepageUuid, audience);
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1883,6 +1883,88 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageAssignment: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                priority: { dataType: 'double', required: true },
+                role: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'ProjectMemberRole' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                groupName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                groupUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                targetType: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['group'] },
+                        { dataType: 'enum', enums: ['role'] },
+                    ],
+                    required: true,
+                },
+                homepageName: { dataType: 'string', required: true },
+                homepageUuid: { dataType: 'string', required: true },
+                assignmentUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_HomepageAssignment-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'HomepageAssignment' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiHomepageAssignmentsResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_HomepageAssignment-Array_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateHomepageGroupPrioritiesRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                groupUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'ApiSuccess_ProjectHomepage-Array_': {
         dataType: 'refAlias',
         type: {
@@ -1941,6 +2023,70 @@ const models: TsoaRoute.Models = {
                 baseUpdatedAt: { dataType: 'datetime', required: true },
                 draftConfig: { ref: 'HomepageConfig', required: true },
                 name: { dataType: 'string' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageAudience: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        type: {
+                            dataType: 'enum',
+                            enums: ['everyone'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        groupUuids: {
+                            dataType: 'array',
+                            array: { dataType: 'string' },
+                            required: true,
+                        },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['groups'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        roles: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refEnum',
+                                ref: 'ProjectMemberRole',
+                            },
+                            required: true,
+                        },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['roles'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PublishProjectHomepageRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                audience: { ref: 'HomepageAudience', required: true },
             },
             validators: {},
         },
@@ -49622,6 +49768,134 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectHomepageController_getAssignments: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/homepage/assignments',
+        ...fetchMiddlewares<RequestHandler>(ProjectHomepageController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectHomepageController.prototype.getAssignments,
+        ),
+
+        async function ProjectHomepageController_getAssignments(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectHomepageController_getAssignments,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectHomepageController>(
+                        ProjectHomepageController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getAssignments',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectHomepageController_updateGroupPriorities: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpdateHomepageGroupPrioritiesRequest',
+        },
+    };
+    app.patch(
+        '/api/v1/projects/:projectUuid/homepage/group-priorities',
+        ...fetchMiddlewares<RequestHandler>(ProjectHomepageController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectHomepageController.prototype.updateGroupPriorities,
+        ),
+
+        async function ProjectHomepageController_updateGroupPriorities(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectHomepageController_updateGroupPriorities,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectHomepageController>(
+                        ProjectHomepageController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateGroupPriorities',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsProjectHomepageController_listHomepages: Record<
         string,
         TsoaRoute.ParameterSchema
@@ -49906,6 +50180,12 @@ export function RegisterRoutes(app: Router) {
             name: 'homepageUuid',
             required: true,
             ref: 'UUID',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'PublishProjectHomepageRequest',
         },
     };
     app.post(

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1887,6 +1887,87 @@
             "ApiRecentlyViewedResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_HomepageRecentlyViewedItem-Array_"
             },
+            "HomepageAssignment": {
+                "properties": {
+                    "priority": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "role": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ProjectMemberRole"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "groupName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "groupUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "targetType": {
+                        "type": "string",
+                        "enum": ["group", "role"]
+                    },
+                    "homepageName": {
+                        "type": "string"
+                    },
+                    "homepageUuid": {
+                        "type": "string"
+                    },
+                    "assignmentUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "priority",
+                    "role",
+                    "groupName",
+                    "groupUuid",
+                    "targetType",
+                    "homepageName",
+                    "homepageUuid",
+                    "assignmentUuid"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_HomepageAssignment-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/HomepageAssignment"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiHomepageAssignmentsResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_HomepageAssignment-Array_"
+            },
+            "UpdateHomepageGroupPrioritiesRequest": {
+                "properties": {
+                    "groupUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "description": "Group uuids in priority order — first wins for multi-group users"
+                    }
+                },
+                "required": ["groupUuids"],
+                "type": "object"
+            },
             "ApiSuccess_ProjectHomepage-Array_": {
                 "properties": {
                     "results": {
@@ -1951,6 +2032,64 @@
                     }
                 },
                 "required": ["baseUpdatedAt", "draftConfig"],
+                "type": "object"
+            },
+            "HomepageAudience": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["everyone"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "groupUuids": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["groups"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["groupUuids", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "roles": {
+                                "items": {
+                                    "$ref": "#/components/schemas/ProjectMemberRole"
+                                },
+                                "type": "array"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["roles"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["roles", "type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "PublishProjectHomepageRequest": {
+                "properties": {
+                    "audience": {
+                        "$ref": "#/components/schemas/HomepageAudience"
+                    }
+                },
+                "required": ["audience"],
                 "type": "object"
             },
             "ManagedAgentScheduleOption": {
@@ -49180,6 +49319,94 @@
                 ]
             }
         },
+        "/api/v1/projects/{projectUuid}/homepage/assignments": {
+            "get": {
+                "operationId": "getHomepageAssignments",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiHomepageAssignmentsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/homepage/group-priorities": {
+            "patch": {
+                "operationId": "updateHomepageGroupPriorities",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateHomepageGroupPrioritiesRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/projects/{projectUuid}/homepage/list": {
             "get": {
                 "operationId": "listProjectHomepages",
@@ -49365,7 +49592,17 @@
                             "$ref": "#/components/schemas/UUID"
                         }
                     }
-                ]
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PublishProjectHomepageRequest"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/databricks/sso/is-authenticated": {

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -1,4 +1,5 @@
 import { type ApiSuccess } from '../../types/api/success';
+import { type ProjectMemberRole } from '../../types/projectMemberRole';
 
 export type HomepageMarkdownBlock = {
     id: string;
@@ -76,6 +77,33 @@ export type HomepageBlock =
     | HomepageAnnouncementsBlock
     | HomepageFavoritesBlock
     | HomepageRecentBlock;
+
+export type HomepageAudience =
+    | { type: 'everyone' }
+    | { type: 'groups'; groupUuids: string[] }
+    | { type: 'roles'; roles: ProjectMemberRole[] };
+
+export type PublishProjectHomepageRequest = {
+    audience: HomepageAudience;
+};
+
+export type HomepageAssignment = {
+    assignmentUuid: string;
+    homepageUuid: string;
+    homepageName: string;
+    targetType: 'group' | 'role';
+    groupUuid: string | null;
+    groupName: string | null;
+    role: ProjectMemberRole | null;
+    priority: number;
+};
+
+export type UpdateHomepageGroupPrioritiesRequest = {
+    /** Group uuids in priority order — first wins for multi-group users */
+    groupUuids: string[];
+};
+
+export type ApiHomepageAssignmentsResponse = ApiSuccess<HomepageAssignment[]>;
 
 export type HomepageRecentlyViewedItem = {
     contentType: 'chart' | 'dashboard';

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -63,6 +63,7 @@ import {
 } from './hooks/useProjectHomepage';
 import { PresetsModal } from './PresetsModal';
 import { PublishedHomepage } from './PublishedHomepage';
+import { PublishModal } from './PublishModal';
 
 type Props = {
     homepage: ProjectHomepageType;
@@ -95,6 +96,7 @@ export const HomepageEditor: FC<Props> = ({
     const deleteMutation = useDeleteHomepage(projectUuid);
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const [isPresetsModalOpen, setIsPresetsModalOpen] = useState(false);
+    const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
 
     const isAiEnabled = useAiAgentButtonVisibility();
     const availableBlocks = blockLibrary.filter(
@@ -129,7 +131,7 @@ export const HomepageEditor: FC<Props> = ({
         );
     }, [debouncedDraft, hasConflict, saveDraft]);
 
-    const handlePublish = async () => {
+    const handleOpenPublish = async () => {
         if (hasConflict) return;
         if (draft !== lastSavedRef.current) {
             lastSavedRef.current = draft;
@@ -152,7 +154,7 @@ export const HomepageEditor: FC<Props> = ({
                 return;
             }
         }
-        publishMutation.mutate();
+        setIsPublishModalOpen(true);
     };
 
     const isDirty = draft !== lastSavedRef.current || updateMutation.isLoading;
@@ -326,7 +328,7 @@ export const HomepageEditor: FC<Props> = ({
                     <Button
                         leftSection={<MantineIcon icon={IconSend} />}
                         loading={publishMutation.isLoading}
-                        onClick={handlePublish}
+                        onClick={handleOpenPublish}
                     >
                         Publish
                     </Button>
@@ -698,6 +700,19 @@ export const HomepageEditor: FC<Props> = ({
                 opened={isPresetsModalOpen}
                 onClose={() => setIsPresetsModalOpen(false)}
                 onApply={setDraft}
+            />
+            <PublishModal
+                opened={isPublishModalOpen}
+                onClose={() => setIsPublishModalOpen(false)}
+                projectUuid={projectUuid}
+                homepageUuid={homepage.homepageUuid}
+                homepageName={homepage.name}
+                isPublishing={publishMutation.isLoading}
+                onPublish={(audience) =>
+                    publishMutation.mutate(audience, {
+                        onSuccess: () => setIsPublishModalOpen(false),
+                    })
+                }
             />
             <MantineModal
                 opened={isDeleteModalOpen}

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
@@ -1,0 +1,313 @@
+import {
+    ProjectMemberRole,
+    ProjectMemberRoleLabels,
+    type HomepageAssignment,
+    type HomepageAudience,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Badge,
+    Card,
+    Checkbox,
+    Group,
+    SegmentedControl,
+    Stack,
+    Text,
+} from '@mantine-8/core';
+import {
+    IconArrowDown,
+    IconArrowUp,
+    IconChevronRight,
+} from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
+import { useOrganizationGroups } from '../../../hooks/useOrganizationGroups';
+import {
+    useHomepageAssignments,
+    useUpdateGroupPriorities,
+} from './hooks/useProjectHomepage';
+
+const RESOLUTION_STEPS = ['Personal', 'Group priority', 'Role', 'Org default'];
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    homepageUuid: string;
+    homepageName: string;
+    isPublishing: boolean;
+    onPublish: (audience: HomepageAudience) => void;
+};
+
+export const PublishModal: FC<Props> = ({
+    opened,
+    onClose,
+    projectUuid,
+    homepageUuid,
+    homepageName,
+    isPublishing,
+    onPublish,
+}) => {
+    const [mode, setMode] = useState<string>('everyone');
+    const [selectedGroups, setSelectedGroups] = useState<string[]>([]);
+    const [selectedRoles, setSelectedRoles] = useState<ProjectMemberRole[]>([]);
+    const { data: groups } = useOrganizationGroups({}, { enabled: opened });
+    const { data: assignments } = useHomepageAssignments(projectUuid, {
+        enabled: opened,
+    });
+    const { mutate: reorderGroups } = useUpdateGroupPriorities(projectUuid);
+
+    const groupAssignments = (assignments ?? []).filter(
+        (assignment) => assignment.targetType === 'group',
+    );
+    const assignmentByGroup = new Map(
+        groupAssignments.map((assignment) => [
+            assignment.groupUuid,
+            assignment,
+        ]),
+    );
+    const assignmentByRole = new Map(
+        (assignments ?? [])
+            .filter((assignment) => assignment.targetType === 'role')
+            .map((assignment) => [assignment.role, assignment]),
+    );
+
+    const elsewhereBadge = (assignment: HomepageAssignment | undefined) =>
+        assignment && assignment.homepageUuid !== homepageUuid ? (
+            <Badge variant="default" size="xs" tt="none">
+                now on {assignment.homepageName}
+            </Badge>
+        ) : null;
+
+    const movePriority = (groupUuid: string, direction: -1 | 1) => {
+        const order = groupAssignments.map(
+            (assignment) => assignment.groupUuid,
+        );
+        const index = order.indexOf(groupUuid);
+        const target = index + direction;
+        if (index < 0 || target < 0 || target >= order.length) return;
+        [order[index], order[target]] = [order[target], order[index]];
+        reorderGroups(order.flatMap((uuid) => (uuid ? [uuid] : [])));
+    };
+
+    const handlePublish = () => {
+        if (mode === 'groups') {
+            onPublish({ type: 'groups', groupUuids: selectedGroups });
+        } else if (mode === 'roles') {
+            onPublish({ type: 'roles', roles: selectedRoles });
+        } else {
+            onPublish({ type: 'everyone' });
+        }
+    };
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Publish homepage"
+            size="lg"
+            onConfirm={handlePublish}
+            confirmLoading={isPublishing}
+            confirmDisabled={
+                (mode === 'groups' && selectedGroups.length === 0) ||
+                (mode === 'roles' && selectedRoles.length === 0)
+            }
+        >
+            <Stack gap="sm">
+                <Text size="sm" c="dimmed">
+                    Choose who lands on{' '}
+                    <Text span fw={600} c="inherit">
+                        {homepageName}
+                    </Text>{' '}
+                    when they open this project.
+                </Text>
+                <SegmentedControl
+                    fullWidth
+                    value={mode}
+                    onChange={setMode}
+                    data={[
+                        { value: 'everyone', label: 'Everyone' },
+                        { value: 'groups', label: 'By group' },
+                        { value: 'roles', label: 'By role' },
+                    ]}
+                />
+
+                {mode === 'everyone' && (
+                    <Card withBorder p="sm">
+                        <Text size="sm" c="dimmed">
+                            This becomes the starting point everyone lands on —
+                            unless a group they’re in has its own homepage.
+                        </Text>
+                    </Card>
+                )}
+
+                {mode === 'groups' && (
+                    <>
+                        <Card withBorder p="sm">
+                            <Stack gap="xs">
+                                {(groups ?? []).map((group) => (
+                                    <Group
+                                        key={group.uuid}
+                                        gap="sm"
+                                        wrap="nowrap"
+                                    >
+                                        <Checkbox
+                                            label={group.name}
+                                            checked={selectedGroups.includes(
+                                                group.uuid,
+                                            )}
+                                            onChange={(e) =>
+                                                setSelectedGroups(
+                                                    e.currentTarget.checked
+                                                        ? [
+                                                              ...selectedGroups,
+                                                              group.uuid,
+                                                          ]
+                                                        : selectedGroups.filter(
+                                                              (uuid) =>
+                                                                  uuid !==
+                                                                  group.uuid,
+                                                          ),
+                                                )
+                                            }
+                                        />
+                                        {elsewhereBadge(
+                                            assignmentByGroup.get(group.uuid),
+                                        )}
+                                    </Group>
+                                ))}
+                                {(groups ?? []).length === 0 && (
+                                    <Text size="sm" c="dimmed">
+                                        No groups in this organization yet.
+                                    </Text>
+                                )}
+                            </Stack>
+                        </Card>
+                        {groupAssignments.length > 1 && (
+                            <Card withBorder p="sm">
+                                <Stack gap="xs">
+                                    <Text size="xs" fw={600} c="dimmed">
+                                        If someone’s in more than one group, the
+                                        higher-ranked group wins
+                                    </Text>
+                                    {groupAssignments.map(
+                                        (assignment, index) => (
+                                            <Group
+                                                key={assignment.assignmentUuid}
+                                                gap="xs"
+                                                wrap="nowrap"
+                                            >
+                                                <Badge
+                                                    variant="filled"
+                                                    size="sm"
+                                                >
+                                                    {index + 1}
+                                                </Badge>
+                                                <Text
+                                                    size="sm"
+                                                    style={{ flex: 1 }}
+                                                >
+                                                    {assignment.groupName} →{' '}
+                                                    {assignment.homepageName}
+                                                </Text>
+                                                <ActionIcon
+                                                    variant="subtle"
+                                                    color="gray"
+                                                    size="sm"
+                                                    disabled={index === 0}
+                                                    aria-label={`Move ${assignment.groupName} up`}
+                                                    onClick={() =>
+                                                        assignment.groupUuid &&
+                                                        movePriority(
+                                                            assignment.groupUuid,
+                                                            -1,
+                                                        )
+                                                    }
+                                                >
+                                                    <MantineIcon
+                                                        icon={IconArrowUp}
+                                                    />
+                                                </ActionIcon>
+                                                <ActionIcon
+                                                    variant="subtle"
+                                                    color="gray"
+                                                    size="sm"
+                                                    disabled={
+                                                        index ===
+                                                        groupAssignments.length -
+                                                            1
+                                                    }
+                                                    aria-label={`Move ${assignment.groupName} down`}
+                                                    onClick={() =>
+                                                        assignment.groupUuid &&
+                                                        movePriority(
+                                                            assignment.groupUuid,
+                                                            1,
+                                                        )
+                                                    }
+                                                >
+                                                    <MantineIcon
+                                                        icon={IconArrowDown}
+                                                    />
+                                                </ActionIcon>
+                                            </Group>
+                                        ),
+                                    )}
+                                </Stack>
+                            </Card>
+                        )}
+                    </>
+                )}
+
+                {mode === 'roles' && (
+                    <Card withBorder p="sm">
+                        <Stack gap="xs">
+                            {Object.values(ProjectMemberRole).map((role) => (
+                                <Group key={role} gap="sm" wrap="nowrap">
+                                    <Checkbox
+                                        label={ProjectMemberRoleLabels[role]}
+                                        checked={selectedRoles.includes(role)}
+                                        onChange={(e) =>
+                                            setSelectedRoles(
+                                                e.currentTarget.checked
+                                                    ? [...selectedRoles, role]
+                                                    : selectedRoles.filter(
+                                                          (r) => r !== role,
+                                                      ),
+                                            )
+                                        }
+                                    />
+                                    {elsewhereBadge(assignmentByRole.get(role))}
+                                </Group>
+                            ))}
+                            <Text size="xs" c="dimmed">
+                                A group assignment always wins over a role.
+                            </Text>
+                        </Stack>
+                    </Card>
+                )}
+
+                <Group gap={4} wrap="nowrap">
+                    <Text size="xs" c="dimmed">
+                        Resolves:
+                    </Text>
+                    {RESOLUTION_STEPS.map((step, index) => (
+                        <Group key={step} gap={4} wrap="nowrap">
+                            <Badge variant="default" size="xs" tt="none">
+                                {step}
+                            </Badge>
+                            {index < RESOLUTION_STEPS.length - 1 && (
+                                <MantineIcon
+                                    icon={IconChevronRight}
+                                    size="sm"
+                                    color="gray"
+                                />
+                            )}
+                        </Group>
+                    ))}
+                </Group>
+            </Stack>
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
@@ -2,6 +2,8 @@ import {
     CommercialFeatureFlags,
     type ApiError,
     type CreateProjectHomepageRequest,
+    type HomepageAssignment,
+    type HomepageAudience,
     type ProjectHomepage,
     type PublishedProjectHomepage,
     type UpdateProjectHomepageDraftRequest,
@@ -67,11 +69,32 @@ const updateHomepageDraftApi = async (
         body: JSON.stringify(data),
     });
 
-const publishHomepageApi = async (projectUuid: string, homepageUuid: string) =>
+const publishHomepageApi = async (
+    projectUuid: string,
+    homepageUuid: string,
+    audience: HomepageAudience,
+) =>
     lightdashApi<ProjectHomepage>({
         url: `/projects/${projectUuid}/homepage/${homepageUuid}/publish`,
         method: 'POST',
+        body: JSON.stringify({ audience }),
+    });
+
+const getAssignmentsApi = async (projectUuid: string) =>
+    lightdashApi<HomepageAssignment[]>({
+        url: `/projects/${projectUuid}/homepage/assignments`,
+        method: 'GET',
         body: undefined,
+    });
+
+const updateGroupPrioritiesApi = async (
+    projectUuid: string,
+    groupUuids: string[],
+) =>
+    lightdashApi<undefined>({
+        url: `/projects/${projectUuid}/homepage/group-priorities`,
+        method: 'PATCH',
+        body: JSON.stringify({ groupUuids }),
     });
 
 export const useHomepageBuilderFlag = () => {
@@ -194,14 +217,48 @@ export const useUpdateHomepageDraft = (
     });
 };
 
+export const useHomepageAssignments = (
+    projectUuid: string,
+    { enabled = true }: { enabled?: boolean } = {},
+) =>
+    useQuery<HomepageAssignment[], ApiError>({
+        enabled,
+        queryKey: [PROJECT_HOMEPAGE_QUERY_KEY, projectUuid, 'assignments'],
+        queryFn: () => getAssignmentsApi(projectUuid),
+    });
+
+export const useUpdateGroupPriorities = (projectUuid: string) => {
+    const { showToastApiError } = useToaster();
+    const queryClient = useQueryClient();
+    return useMutation<undefined, ApiError, string[]>(
+        (groupUuids) => updateGroupPrioritiesApi(projectUuid, groupUuids),
+        {
+            mutationKey: ['update_homepage_group_priorities'],
+            onSuccess: async () => {
+                await queryClient.invalidateQueries([
+                    PROJECT_HOMEPAGE_QUERY_KEY,
+                    projectUuid,
+                    'assignments',
+                ]);
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to reorder group priority',
+                    apiError: error,
+                });
+            },
+        },
+    );
+};
+
 export const usePublishHomepage = (
     projectUuid: string,
     homepageUuid: string | undefined,
 ) => {
     const { showToastSuccess, showToastApiError } = useToaster();
     const queryClient = useQueryClient();
-    return useMutation<ProjectHomepage, ApiError, void>(
-        () => publishHomepageApi(projectUuid, homepageUuid!),
+    return useMutation<ProjectHomepage, ApiError, HomepageAudience>(
+        (audience) => publishHomepageApi(projectUuid, homepageUuid!, audience),
         {
             mutationKey: ['publish_project_homepage'],
             onSuccess: async () => {


### PR DESCRIPTION
## Homepage Builder — audience assignment (14)

Part of [ZAP-625](https://linear.app/lightdash/issue/ZAP-625) · Stacked on #25553

The publish modal and resolution engine: homepages can now target **Everyone**, **groups** (with an admin-ranked priority list), or **project roles**.

### Resolution (first match wins)
`group priority → role → org default` — the *personal* tier slots in front in ZAP-628; the resolver is written so it composes cleanly.
- Groups via `GroupsModel.findUserGroups`, project role via `ProjectModel.getProjectMemberAccess` — both resolved **server-side** inside `GET /homepage`, no extra client round-trips
- Known limitation (documented): role targeting matches explicit project members; org-role-only users fall through to the org default

### Storage & semantics
- New EE table `homepage_assignments` (group xor role target, priority, FKs cascade) with partial unique indexes: **a group/role lands on exactly one homepage per project** — reassigning moves it, atomically inside the publish transaction
- `publish(homepageUuid, audience)`: "everyone" keeps the promote-to-default semantics from #25541; group/role publishes content **without** touching the default
- Priorities are project-wide (`PATCH /homepage/group-priorities`, order = rank)

### Publish modal
Everyone / By group / By role segmented control; group checkboxes with "now on {homepage}" badges; the cross-homepage **priority list with reorder arrows**; role checkboxes; the resolution-order strip — per the prototype.

### Verified live (curl + psql, resolver matrix)
- Published a scratch homepage to a group → member of that group resolves it; non-member falls through ✓
- Role assignment resolves for a project admin ✓ · **group beats role** for a user matching both ✓
- Deleting a homepage cascade-deletes its assignments ✓
- Modal UI: unit-typechecked; **manual QA pending** (author was using the shared dev env)

### Regression analysis
- No assignments ⇒ resolver output identical to before (default-only path); publish "everyone" unchanged.
- New endpoints additive; `GET /homepage` gains two indexed lookups (groups, membership) per load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ