### PR TITLE
fix: include content slugs and failing resources in content as code error messages

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -12,6 +12,21 @@ import { CoderService } from './CoderService';
 
 describe('CoderService', () => {
     describe('transformChart', () => {
+        it('identifies the chart when its space is missing', () => {
+            expect(() =>
+                (
+                    CoderService as unknown as {
+                        transformChart: (...args: AnyType[]) => AnyType;
+                    }
+                ).transformChart(
+                    { slug: 'missing-chart', spaceUuid: 'space-uuid' },
+                    [],
+                    {},
+                    new Map(),
+                ),
+            ).toThrow('Space space-uuid not found');
+        });
+
         it('preserves per-value pivot series customizations for chart-as-code download', () => {
             const chartConfig = {
                 type: ChartType.CARTESIAN,
@@ -715,6 +730,22 @@ describe('CoderService', () => {
             ]);
             expect(result[0].uuid).toEqual(expect.any(String));
             expect(result[1].uuid).toEqual(expect.any(String));
+        });
+    });
+
+    describe('transformDashboard', () => {
+        it('identifies the dashboard when its space is missing', () => {
+            expect(() =>
+                (
+                    CoderService as unknown as {
+                        transformDashboard: (...args: AnyType[]) => AnyType;
+                    }
+                ).transformDashboard(
+                    { slug: 'missing-dashboard', spaceUuid: 'space-uuid' },
+                    [],
+                    new Map(),
+                ),
+            ).toThrow('Space space-uuid not found');
         });
     });
 });

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -288,20 +288,22 @@ export class CoderService extends BaseService {
                 .filter(isCustomSqlDimension)
                 .map((dimension) => [dimension.id, dimension]),
         );
-        const hasNewOrChangedSqlDimension = (
+        const newOrChangedSqlDimensionIds = (
             nextChart.metricQuery.customDimensions ?? []
         )
             .filter(isCustomSqlDimension)
-            .some((dimension) => {
+            .filter((dimension) => {
                 const current = currentSqlDimensionsById.get(dimension.id);
                 return !current || current.sql !== dimension.sql;
-            });
+            })
+            .map((dimension) => dimension.id);
 
-        if (hasNewOrChangedSqlDimension) {
+        if (newOrChangedSqlDimensionIds.length > 0) {
             checks.push({
                 check: 'customSqlDimension',
-                message:
-                    'User cannot upload content with new or modified custom SQL dimensions',
+                message: `User cannot upload content with new or modified custom SQL dimensions: ${newOrChangedSqlDimensionIds.join(
+                    ', ',
+                )} (chart slug "${nextChart.slug}")`,
             });
         }
 
@@ -310,22 +312,24 @@ export class CoderService extends BaseService {
                 .filter(isSqlTableCalculation)
                 .map((calculation) => [calculation.name, calculation]),
         );
-        const hasNewOrChangedSqlTableCalculation = (
+        const newOrChangedSqlTableCalculationNames = (
             nextChart.metricQuery.tableCalculations ?? []
         )
             .filter(isSqlTableCalculation)
-            .some((calculation) => {
+            .filter((calculation) => {
                 const current = currentSqlTableCalculationsByName.get(
                     calculation.name,
                 );
                 return !current || current.sql !== calculation.sql;
-            });
+            })
+            .map((calculation) => calculation.name);
 
-        if (hasNewOrChangedSqlTableCalculation) {
+        if (newOrChangedSqlTableCalculationNames.length > 0) {
             checks.push({
                 check: 'sqlTableCalculation',
-                message:
-                    'User cannot upload content with new or modified SQL table calculations',
+                message: `User cannot upload content with new or modified SQL table calculations: ${newOrChangedSqlTableCalculationNames.join(
+                    ', ',
+                )} (chart slug "${nextChart.slug}")`,
             });
         }
 
@@ -685,7 +689,9 @@ export class CoderService extends BaseService {
         });
 
         if (missingChecks.length === 0) return;
-        throw new ForbiddenError(missingChecks[0].message);
+        throw new ForbiddenError(
+            missingChecks.map(({ message }) => message).join('; '),
+        );
     }
 
     private static transformSpaces(
@@ -2725,8 +2731,7 @@ export class CoderService extends BaseService {
                     projectUuid,
                     spaceSlug: chartWithDefaults.spaceSlug,
                     subjectType: 'SavedChart',
-                    errorMessage:
-                        "You don't have access to create charts in this space",
+                    errorMessage: `You don't have access to create charts in space "${chartWithDefaults.spaceSlug}"`,
                 });
             }
 
@@ -2754,8 +2759,7 @@ export class CoderService extends BaseService {
                     action: 'create',
                     subjectType: 'SavedChart',
                     spaceUuids: [space.uuid],
-                    errorMessage:
-                        "You don't have access to create charts in this space",
+                    errorMessage: `You don't have access to create charts in space "${chartWithDefaults.spaceSlug}"`,
                     accessContexts: spaceAccessContexts,
                 });
             }
@@ -2785,8 +2789,7 @@ export class CoderService extends BaseService {
                             action: 'create',
                             subjectType: 'Dashboard',
                             spaceUuids: [space.uuid],
-                            errorMessage:
-                                "You don't have access to create dashboards in this space",
+                            errorMessage: `You don't have access to create dashboards in space "${chartWithDefaults.spaceSlug}"`,
                             accessContexts: spaceAccessContexts,
                         });
                     }
@@ -2817,7 +2820,7 @@ export class CoderService extends BaseService {
                     // the dashboard's space is required.
                     if (!dashboard.spaceUuid) {
                         throw new ForbiddenError(
-                            "You don't have access to create charts in this space",
+                            `You don't have access to create charts in dashboard "${chartWithDefaults.dashboardSlug}"`,
                         );
                     }
                     await this.assertSpaceContentAccess({
@@ -2826,8 +2829,7 @@ export class CoderService extends BaseService {
                         action: 'create',
                         subjectType: 'SavedChart',
                         spaceUuids: [dashboard.spaceUuid],
-                        errorMessage:
-                            "You don't have access to create charts in this space",
+                        errorMessage: `You don't have access to create charts in dashboard "${chartWithDefaults.dashboardSlug}"`,
                     });
                 }
                 createChart = {
@@ -2903,7 +2905,7 @@ export class CoderService extends BaseService {
                 !allowSpaceCreate
             ) {
                 throw new ForbiddenError(
-                    "You don't have access to create spaces",
+                    `You don't have access to create space "${chartWithDefaults.spaceSlug}"`,
                 );
             }
 
@@ -2911,7 +2913,7 @@ export class CoderService extends BaseService {
             // dashboard-contained charts, so this covers both kinds
             if (!chart.spaceUuid) {
                 throw new ForbiddenError(
-                    "You don't have access to update this chart",
+                    `You don't have access to update chart "${slug}"`,
                 );
             }
 
@@ -2925,7 +2927,7 @@ export class CoderService extends BaseService {
                     ...(chart.spaceUuid ? [chart.spaceUuid] : []),
                 ],
                 metadata: { savedChartUuid: chart.uuid },
-                errorMessage: "You don't have access to update this chart",
+                errorMessage: `You don't have access to update chart "${slug}"`,
             });
 
             const currentChart = await this.savedChartModel.get(chart.uuid);
@@ -2957,7 +2959,7 @@ export class CoderService extends BaseService {
                 subjectType: 'SavedChart',
                 spaceUuids: [space.uuid],
                 metadata: { savedChartUuid: chart.uuid },
-                errorMessage: "You don't have access to update this chart",
+                errorMessage: `You don't have access to update chart "${slug}"`,
             });
         }
 
@@ -3076,8 +3078,7 @@ export class CoderService extends BaseService {
                 spaceSlug: sqlChartWithDefaults.spaceSlug,
                 subjectType: 'SavedChart',
                 metadata: { savedSqlUuid: null },
-                errorMessage:
-                    "You don't have access to create this Saved SQL chart",
+                errorMessage: `You don't have access to create Saved SQL chart "${slug}"`,
             });
         }
 
@@ -3091,7 +3092,6 @@ export class CoderService extends BaseService {
             allowSpaceCreate,
         );
 
-        // Moves require SavedChart access in both current and target spaces.
         const savedChartAction = isUpdate ? 'update' : 'create';
         await this.assertSpaceContentAccess({
             userUuid: user.userUuid,
@@ -3105,7 +3105,7 @@ export class CoderService extends BaseService {
             metadata: {
                 savedSqlUuid: existingSqlChart?.saved_sql_uuid ?? null,
             },
-            errorMessage: `You don't have access to ${savedChartAction} this Saved SQL chart`,
+            errorMessage: `You don't have access to ${savedChartAction} Saved SQL chart "${slug}"`,
         });
 
         if (existingSqlChart === undefined) {
@@ -3215,7 +3215,7 @@ export class CoderService extends BaseService {
             !(await this.spacePermissionService.can('view', user, space.uuid))
         ) {
             throw new ForbiddenError(
-                "You don't have access to a private space",
+                `You don't have access to the private space "${spaceSlug}"`,
             );
         }
 
@@ -3272,7 +3272,9 @@ export class CoderService extends BaseService {
             contentAsCodeSubject,
         );
         if (auditedAbility.cannot('create', contentAsCodeSubject)) {
-            throw new ForbiddenError();
+            throw new ForbiddenError(
+                `You don't have permission to upload content as code to this project (content slug "${slug}")`,
+            );
         }
         const allowSpaceCreate =
             canUploadAnyContent ||
@@ -3410,10 +3412,12 @@ export class CoderService extends BaseService {
         ]);
         const referencedCharts = [
             ...charts.map((chart) => ({
+                slug: chart.slug,
                 spaceUuid: chart.spaceUuid,
                 metadata: { savedChartUuid: chart.uuid },
             })),
             ...sqlChartRows.map((row) => ({
+                slug: row.slug,
                 spaceUuid: row.space_uuid,
                 metadata: { savedSqlUuid: row.saved_sql_uuid },
             })),
@@ -3424,18 +3428,22 @@ export class CoderService extends BaseService {
             await this.spacePermissionService.getSpacesAccessContext(userUuid, [
                 ...new Set(referencedCharts.map((chart) => chart.spaceUuid)),
             ]);
-        const lacksAccess = referencedCharts.some((chart) =>
-            auditedAbility.cannot(
-                'view',
-                subject('SavedChart', {
-                    ...spaceAccessContexts[chart.spaceUuid],
-                    metadata: chart.metadata,
-                }),
-            ),
-        );
-        if (lacksAccess) {
+        const inaccessibleChartSlugs = referencedCharts
+            .filter((chart) =>
+                auditedAbility.cannot(
+                    'view',
+                    subject('SavedChart', {
+                        ...spaceAccessContexts[chart.spaceUuid],
+                        metadata: chart.metadata,
+                    }),
+                ),
+            )
+            .map((chart) => chart.slug);
+        if (inaccessibleChartSlugs.length > 0) {
             throw new ForbiddenError(
-                "You don't have access to a chart referenced by this dashboard",
+                `You don't have access to chart(s) referenced by this dashboard: ${inaccessibleChartSlugs.join(
+                    ', ',
+                )}`,
             );
         }
     }
@@ -3448,12 +3456,12 @@ export class CoderService extends BaseService {
     }: {
         userUuid: string;
         auditedAbility: ReturnType<CoderService['createAuditedAbility']>;
-        dashboard: { uuid: string; spaceUuid: string | null };
+        dashboard: { uuid: string; slug: string; spaceUuid: string | null };
         additionalSpaceUuids?: string[];
     }): Promise<void> {
         if (!dashboard.spaceUuid) {
             throw new ForbiddenError(
-                "You don't have access to update this dashboard",
+                `You don't have access to update dashboard "${dashboard.slug}"`,
             );
         }
         await this.assertSpaceContentAccess({
@@ -3463,7 +3471,7 @@ export class CoderService extends BaseService {
             subjectType: 'Dashboard',
             spaceUuids: [dashboard.spaceUuid, ...additionalSpaceUuids],
             metadata: { dashboardUuid: dashboard.uuid },
-            errorMessage: "You don't have access to update this dashboard",
+            errorMessage: `You don't have access to update dashboard "${dashboard.slug}"`,
         });
     }
 
@@ -3491,7 +3499,9 @@ export class CoderService extends BaseService {
             );
         }
         if (!allowSpaceCreate) {
-            throw new ForbiddenError("You don't have access to create spaces");
+            throw new ForbiddenError(
+                `You don't have access to create space "${spaceSlug}"`,
+            );
         }
         const path = getLtreePathFromContentAsCodePath(spaceSlug);
 
@@ -3690,8 +3700,7 @@ export class CoderService extends BaseService {
                     projectUuid,
                     spaceSlug: dashboardWithDefaults.spaceSlug,
                     subjectType: 'Dashboard',
-                    errorMessage:
-                        "You don't have access to create dashboards in this space",
+                    errorMessage: `You don't have access to create dashboards in space "${dashboardWithDefaults.spaceSlug}"`,
                 });
             }
 
@@ -3712,8 +3721,7 @@ export class CoderService extends BaseService {
                     action: 'create',
                     subjectType: 'Dashboard',
                     spaceUuids: [space.uuid],
-                    errorMessage:
-                        "You don't have access to create dashboards in this space",
+                    errorMessage: `You don't have access to create dashboards in space "${dashboardWithDefaults.spaceSlug}"`,
                 });
             }
 
@@ -3782,7 +3790,7 @@ export class CoderService extends BaseService {
                 !allowSpaceCreate
             ) {
                 throw new ForbiddenError(
-                    "You don't have access to create spaces",
+                    `You don't have access to create space "${dashboardWithDefaults.spaceSlug}"`,
                 );
             }
             await this.assertDashboardUpdateAccess({
@@ -3835,7 +3843,7 @@ export class CoderService extends BaseService {
                 subjectType: 'Dashboard',
                 spaceUuids: [space.uuid],
                 metadata: { dashboardUuid: dashboard.uuid },
-                errorMessage: "You don't have access to update this dashboard",
+                errorMessage: `You don't have access to update dashboard "${slug}"`,
             });
         }
 

--- a/packages/backend/src/services/CoderService/CoderService.upsertContentAccess.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.upsertContentAccess.test.ts
@@ -162,6 +162,21 @@ describe('CoderService content-as-code space permissions', () => {
         } as AnyType);
     };
 
+    it('identifies content denied at the project upload gate', async () => {
+        const service = buildService();
+
+        await expect(
+            service.upsertChart(
+                makeUser([]),
+                PROJECT_UUID,
+                chartAsCode.slug,
+                chartAsCode,
+            ),
+        ).rejects.toThrow(
+            'You don\'t have permission to upload content as code to this project (content slug "chart")',
+        );
+    });
+
     it('allows write-only callers to create basic charts', async () => {
         const service = buildService();
         prepareChartCreate(service);
@@ -228,7 +243,9 @@ describe('CoderService content-as-code space permissions', () => {
                     },
                 },
             ),
-        ).rejects.toThrow(ForbiddenError);
+        ).rejects.toThrow(
+            'User cannot upload content with new or modified custom SQL dimensions: sql_dim (chart slug "chart")',
+        );
         expect(service.savedChartModel.create).not.toHaveBeenCalled();
     });
 
@@ -255,8 +272,48 @@ describe('CoderService content-as-code space permissions', () => {
                     },
                 },
             ),
-        ).rejects.toThrow(ForbiddenError);
+        ).rejects.toThrow(
+            'User cannot upload content with new or modified SQL table calculations: sql_calc (chart slug "chart")',
+        );
         expect(service.savedChartModel.create).not.toHaveBeenCalled();
+    });
+
+    it('reports all missing SQL permissions together', async () => {
+        const service = buildService();
+        prepareChartCreate(service);
+
+        await expect(
+            service.upsertChart(
+                makeUser(chartCreateRules),
+                PROJECT_UUID,
+                chartAsCode.slug,
+                {
+                    ...chartAsCode,
+                    metricQuery: {
+                        ...chartAsCode.metricQuery,
+                        customDimensions: [
+                            {
+                                id: 'sql_dim',
+                                name: 'sql_dim',
+                                table: 'orders',
+                                type: CustomDimensionType.SQL,
+                                sql: '${TABLE}.status',
+                                dimensionType: DimensionType.STRING,
+                            },
+                        ],
+                        tableCalculations: [
+                            {
+                                name: 'sql_calc',
+                                displayName: 'SQL calc',
+                                sql: '${orders.count} + 1',
+                            },
+                        ],
+                    },
+                },
+            ),
+        ).rejects.toThrow(
+            'User cannot upload content with new or modified custom SQL dimensions: sql_dim (chart slug "chart"); User cannot upload content with new or modified SQL table calculations: sql_calc (chart slug "chart")',
+        );
     });
 
     it('lets manage upload any content without SQL and space checks', async () => {
@@ -307,7 +364,9 @@ describe('CoderService content-as-code space permissions', () => {
                 chartAsCode.slug,
                 chartAsCode,
             ),
-        ).rejects.toThrow(ForbiddenError);
+        ).rejects.toThrow(
+            'You don\'t have access to create charts in space "space"',
+        );
         expect(service.savedChartModel.create).not.toHaveBeenCalled();
     });
 
@@ -323,7 +382,7 @@ describe('CoderService content-as-code space permissions', () => {
                 chartAsCode.slug,
                 chartAsCode,
             ),
-        ).rejects.toThrow(ForbiddenError);
+        ).rejects.toThrow('You don\'t have access to create space "space"');
         expect(service.spaceModel.createSpace).not.toHaveBeenCalled();
     });
 
@@ -370,7 +429,9 @@ describe('CoderService content-as-code space permissions', () => {
                 ...chartAsCode,
                 spaceSlug: 'restricted/new-space',
             }),
-        ).rejects.toThrow(ForbiddenError);
+        ).rejects.toThrow(
+            'You don\'t have access to create charts in space "restricted/new-space"',
+        );
         expect(service.spaceModel.createSpace).not.toHaveBeenCalled();
     });
 
@@ -462,7 +523,7 @@ describe('CoderService content-as-code space permissions', () => {
                 ...chartAsCode,
                 spaceSlug: 'restricted/new-space',
             }),
-        ).rejects.toThrow(ForbiddenError);
+        ).rejects.toThrow('You don\'t have access to update chart "chart"');
         expect(service.spaceModel.createSpace).toHaveBeenCalledOnce();
         expect(service.promoteService.getPromoteCharts).not.toHaveBeenCalled();
     });
@@ -482,7 +543,9 @@ describe('CoderService content-as-code space permissions', () => {
                 dashboardAsCode.slug,
                 dashboardAsCode,
             ),
-        ).rejects.toThrow(ForbiddenError);
+        ).rejects.toThrow(
+            'You don\'t have access to create dashboards in space "space"',
+        );
         expect(service.dashboardModel.create).not.toHaveBeenCalled();
     });
 
@@ -592,6 +655,7 @@ describe('CoderService content-as-code space permissions', () => {
         ]);
         vi.mocked(service.dashboardModel.getByIdOrSlug).mockResolvedValue({
             uuid: 'dashboard-uuid',
+            slug: 'dashboard',
             name: 'Dashboard',
             filters: { dimensions: [], metrics: [], tableCalculations: [] },
         } as AnyType);
@@ -621,6 +685,7 @@ describe('CoderService content-as-code space permissions', () => {
         ]);
         vi.mocked(service.dashboardModel.getByIdOrSlug).mockResolvedValue({
             uuid: 'dashboard-uuid',
+            slug: 'dashboard',
             name: 'Dashboard',
             spaceUuid: SPACE_UUID,
             filters: { dimensions: [], metrics: [], tableCalculations: [] },
@@ -697,6 +762,7 @@ describe('CoderService content-as-code space permissions', () => {
         ]);
         vi.mocked(service.dashboardModel.getByIdOrSlug).mockResolvedValue({
             uuid: 'dashboard-uuid',
+            slug: 'dashboard',
             name: 'Dashboard',
             spaceUuid: OTHER_SPACE_UUID,
             filters: { dimensions: [], metrics: [], tableCalculations: [] },
@@ -741,11 +807,83 @@ describe('CoderService content-as-code space permissions', () => {
                 dashboardAsCode.slug,
                 dashboardAsCode,
             ),
-        ).rejects.toThrow(ForbiddenError);
+        ).rejects.toThrow(
+            'You don\'t have access to update dashboard "dashboard"',
+        );
         expect(
             service.promoteService.getPromotedDashboard,
         ).not.toHaveBeenCalled();
         expect(service.spaceModel.createSpace).not.toHaveBeenCalled();
+    });
+
+    it('identifies a restricted dashboard destination space', async () => {
+        const service = buildService();
+        vi.mocked(service.dashboardModel.find).mockResolvedValue([
+            { uuid: 'dashboard-uuid' } as AnyType,
+        ]);
+        vi.mocked(service.dashboardModel.getByIdOrSlug).mockResolvedValue({
+            uuid: 'dashboard-uuid',
+            slug: 'dashboard',
+            name: 'Dashboard',
+            spaceUuid: OTHER_SPACE_UUID,
+            filters: { dimensions: [], metrics: [], tableCalculations: [] },
+        } as AnyType);
+        vi.mocked(
+            service.spacePermissionService.getSpacesAccessContext,
+        ).mockImplementation(async (_userUuid, spaceUuids) =>
+            Object.fromEntries(
+                spaceUuids.map((spaceUuid) => [
+                    spaceUuid,
+                    {
+                        organizationUuid: ORG_UUID,
+                        projectUuid:
+                            spaceUuid === SPACE_UUID
+                                ? 'restricted-project'
+                                : PROJECT_UUID,
+                        inheritsFromOrgOrProject: true,
+                        access: [],
+                        admins: [],
+                    },
+                ]),
+            ),
+        );
+        const user = makeUser([
+            { subject: 'ContentAsCode', action: 'create' },
+            {
+                subject: 'Dashboard',
+                action: 'update',
+                conditions: { projectUuid: PROJECT_UUID },
+            },
+        ]);
+
+        await expect(
+            service.upsertDashboard(
+                user,
+                PROJECT_UUID,
+                dashboardAsCode.slug,
+                dashboardAsCode,
+            ),
+        ).rejects.toThrow(
+            'You don\'t have access to update dashboard "dashboard"',
+        );
+        expect(
+            service.promoteService.getPromotedDashboard,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('identifies inaccessible private spaces', async () => {
+        const service = buildService();
+        vi.mocked(service.spacePermissionService.can).mockResolvedValue(false);
+
+        await expect(
+            service.getOrCreateSpace(
+                PROJECT_UUID,
+                'private/space',
+                makeUser([{ subject: 'ContentAsCode', action: 'create' }]),
+            ),
+        ).rejects.toThrow(
+            'You don\'t have access to the private space "private/space"',
+        );
     });
 
     it('gates dashboard-contained chart update on SavedChart update in the dashboard space', async () => {
@@ -944,6 +1082,13 @@ describe('CoderService content-as-code space permissions', () => {
                 spaceUuid: OTHER_SPACE_UUID,
             } as AnyType,
         ]);
+        vi.mocked(service.savedSqlModel.find).mockResolvedValue([
+            {
+                saved_sql_uuid: 'private-sql-chart-uuid',
+                slug: 'private-sql-chart',
+                space_uuid: OTHER_SPACE_UUID,
+            } as AnyType,
+        ]);
         vi.mocked(
             service.spacePermissionService.getSpacesAccessContext,
         ).mockImplementation(async (_userUuid, spaceUuids) =>
@@ -1005,9 +1150,19 @@ describe('CoderService content-as-code space permissions', () => {
                         w: 3,
                         properties: { chartSlug: 'private-chart' },
                     },
+                    {
+                        type: DashboardTileTypes.SQL_CHART,
+                        x: 3,
+                        y: 0,
+                        h: 3,
+                        w: 3,
+                        properties: { chartSlug: 'private-sql-chart' },
+                    },
                 ],
             } as DashboardAsCode),
-        ).rejects.toThrow(ForbiddenError);
+        ).rejects.toThrow(
+            "You don't have access to chart(s) referenced by this dashboard: private-chart, private-sql-chart",
+        );
         expect(service.dashboardModel.create).not.toHaveBeenCalled();
     });
 
@@ -1018,6 +1173,7 @@ describe('CoderService content-as-code space permissions', () => {
         ]);
         vi.mocked(service.dashboardModel.getByIdOrSlug).mockResolvedValue({
             uuid: 'dashboard-uuid',
+            slug: 'dashboard',
             name: 'Dashboard',
             spaceUuid: SPACE_UUID,
             filters: { dimensions: [], metrics: [], tableCalculations: [] },

--- a/packages/backend/src/services/CoderService/CoderService.upsertSqlChart.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.upsertSqlChart.test.ts
@@ -154,7 +154,9 @@ describe('CoderService.upsertSqlChart - permissions', () => {
                 { subject: 'CustomSql', action: 'manage' },
             ]);
 
-            await expect(upsert(service, user)).rejects.toThrow(ForbiddenError);
+            await expect(upsert(service, user)).rejects.toThrow(
+                'You don\'t have access to create Saved SQL chart "my-sql-chart"',
+            );
             expect(savedSqlModel.create).not.toHaveBeenCalled();
         });
 
@@ -309,7 +311,9 @@ describe('CoderService.upsertSqlChart - permissions', () => {
                 },
             ]);
 
-            await expect(upsert(service, user)).rejects.toThrow(ForbiddenError);
+            await expect(upsert(service, user)).rejects.toThrow(
+                'You don\'t have access to update Saved SQL chart "my-sql-chart"',
+            );
             expect(savedSqlModel.update).not.toHaveBeenCalled();
             // both the target and the current space were checked
             expect(getSpacesAccessContext).toHaveBeenCalledWith('user-uuid', [

--- a/packages/backend/src/services/CoderService/contentAsCodePermissions.test.ts
+++ b/packages/backend/src/services/CoderService/contentAsCodePermissions.test.ts
@@ -94,6 +94,14 @@ describe('content-as-code SQL permission detector', () => {
                         sql: '${TABLE}.new_status',
                         dimensionType: DimensionType.STRING,
                     },
+                    {
+                        id: 'new_dim',
+                        name: 'new_dim',
+                        table: 'orders',
+                        type: CustomDimensionType.SQL,
+                        sql: '${TABLE}.category',
+                        dimensionType: DimensionType.STRING,
+                    },
                 ],
                 tableCalculations: [
                     {
@@ -106,15 +114,28 @@ describe('content-as-code SQL permission detector', () => {
                         displayName: 'Formula',
                         formula: '=A1',
                     },
+                    {
+                        name: 'new_calc',
+                        displayName: 'New calc',
+                        sql: '${orders.count} + 3',
+                    },
                 ],
             },
         } as ChartAsCode;
 
         expect(
             CoderService.getChartContentAsCodePermissionChecks(next, current),
-        ).toMatchObject([
-            { check: 'customSqlDimension' },
-            { check: 'sqlTableCalculation' },
+        ).toEqual([
+            {
+                check: 'customSqlDimension',
+                message:
+                    'User cannot upload content with new or modified custom SQL dimensions: dim, new_dim (chart slug "chart")',
+            },
+            {
+                check: 'sqlTableCalculation',
+                message:
+                    'User cannot upload content with new or modified SQL table calculations: calc, new_calc (chart slug "chart")',
+            },
         ]);
     });
 });


### PR DESCRIPTION
Content-as-code upload errors were hard to debug: the CLI attributes failures per file, but the inner messages were generic — bare `ForbiddenError` ("Insufficient permissions"), "You don't have access to a private space", "…a chart referenced by this dashboard" — with no hint of *which* resource tripped the check. Follow-up to #25219/#25518, message-only changes: every value interpolated is a slug/id the caller already supplied in their YAML (or a DB slug resolved by exact match on one), so nothing new is disclosed. Permission-check behavior is byte-equivalent to the parent branch.

## Changes (all `CoderService`)

- Project upload gate: bare `ForbiddenError()` → names the content slug being uploaded
- SQL authoring checks: report **all** missing checks joined with `; ` (previously only the first), and list the offending custom SQL dimension ids / table calculation names + chart slug
- Dashboard tile check: lists the inaccessible referenced chart slug(s) instead of "a chart"
- Space create/update denials: include the space slug from the YAML (`create charts in space "x"`, `create space "x"`, `private space "x"`, `create charts in dashboard "x"`)
- Chart/dashboard/SQL-chart update denials: include the content slug

## Tests

Existing assertions strengthened from `toThrow(ForbiddenError)` to exact messages; new tests for the joined multi-failure message, tile SQL-chart slugs, private-space and project-gate messages. Backend suite green (4,197 tests), typecheck + lint clean.

Relates: ZAP-551

🤖 Generated with [Claude Code](https://claude.com/claude-code)
