### PR TITLE
feat(frontend): metrics KPI homepage block

### DIFF
--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -56,6 +56,18 @@ export type HomepageAnnouncementsBlock = {
     config: { title: string; items: HomepageAnnouncementItem[] };
 };
 
+export type HomepageMetricRef = {
+    tableName: string;
+    metricName: string;
+    label: string;
+};
+
+export type HomepageMetricsBlock = {
+    id: string;
+    type: 'metrics';
+    config: { title: string; items: HomepageMetricRef[] };
+};
+
 export type HomepageFavoritesBlock = {
     id: string;
     type: 'favorites';
@@ -75,6 +87,7 @@ export type HomepageBlock =
     | HomepageCollectionBlock
     | HomepageResourcesBlock
     | HomepageAnnouncementsBlock
+    | HomepageMetricsBlock
     | HomepageFavoritesBlock
     | HomepageRecentBlock;
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
@@ -1,0 +1,325 @@
+import {
+    applyCustomFormat,
+    ComparisonFormatTypes,
+    CustomFormatType,
+    formatItemValue,
+    getDefaultDateRangeFromInterval,
+    MetricTotalComparisonType,
+    TimeFrames,
+    type HomepageMetricRef,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Anchor,
+    Badge,
+    Box,
+    Button,
+    Card,
+    Group,
+    Loader,
+    SimpleGrid,
+    Skeleton,
+    Stack,
+    Text,
+    TextInput,
+} from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import { IconHash, IconPlus, IconX } from '@tabler/icons-react';
+import { useMemo, useState, type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import MantineModal from '../../../../components/common/MantineModal';
+import { useMetricsCatalog } from '../../../../features/metricsCatalog/hooks/useMetricsCatalog';
+import { useRunMetricTotal } from '../../../../features/metricsCatalog/hooks/useRunMetricExplorerQuery';
+import { calculateComparisonValue } from '../../../../hooks/useBigNumberConfig';
+import { type BlockComponentProps, type BuildComponentProps } from './types';
+
+const KPI_TIME_FRAME = TimeFrames.MONTH;
+
+const MetricKpiCard: FC<{
+    metricRef: HomepageMetricRef;
+    projectUuid: string;
+}> = ({ metricRef, projectUuid }) => {
+    const dateRange = useMemo(
+        () => getDefaultDateRangeFromInterval(KPI_TIME_FRAME),
+        [],
+    );
+    const totalQuery = useRunMetricTotal({
+        projectUuid,
+        exploreName: metricRef.tableName,
+        metricName: metricRef.metricName,
+        timeFrame: KPI_TIME_FRAME,
+        granularity: KPI_TIME_FRAME,
+        comparisonType: MetricTotalComparisonType.PREVIOUS_PERIOD,
+        dateRange,
+        options: { retry: false },
+    });
+
+    const change = useMemo(() => {
+        const value = totalQuery.data?.value;
+        const compareValue = totalQuery.data?.comparisonValue;
+        if (value && compareValue) {
+            return calculateComparisonValue(
+                Number(value),
+                Number(compareValue),
+                ComparisonFormatTypes.PERCENTAGE,
+            );
+        }
+        return undefined;
+    }, [totalQuery.data]);
+
+    if (totalQuery.isInitialLoading) {
+        return <Skeleton h={92} radius="md" />;
+    }
+
+    return (
+        <Anchor
+            component={Link}
+            to={`/projects/${projectUuid}/metrics/peek/${metricRef.tableName}/${metricRef.metricName}`}
+            underline="never"
+            c="inherit"
+        >
+            <Card withBorder p="sm" h="100%">
+                <Stack gap={4}>
+                    <Text size="xs" c="dimmed" fw={500} truncate>
+                        {totalQuery.data?.metric.label ?? metricRef.label}
+                    </Text>
+                    {totalQuery.isError ? (
+                        <Text size="sm" c="dimmed">
+                            Couldn’t load this metric
+                        </Text>
+                    ) : (
+                        <>
+                            <Text size="xl" fw={600}>
+                                {totalQuery.data
+                                    ? formatItemValue(
+                                          totalQuery.data.metric,
+                                          totalQuery.data.value,
+                                      )
+                                    : '-'}
+                            </Text>
+                            <Group gap={4}>
+                                {change !== undefined && (
+                                    <Badge
+                                        variant="light"
+                                        size="sm"
+                                        tt="none"
+                                        color={change >= 0 ? 'teal' : 'red'}
+                                    >
+                                        {change >= 0 ? '↑' : '↓'}{' '}
+                                        {applyCustomFormat(change, {
+                                            round: 2,
+                                            type: CustomFormatType.PERCENT,
+                                        })}
+                                    </Badge>
+                                )}
+                                <Text size="xs" c="dimmed">
+                                    vs previous period
+                                </Text>
+                            </Group>
+                        </>
+                    )}
+                </Stack>
+            </Card>
+        </Anchor>
+    );
+};
+
+const MetricsPickerModal: FC<{
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    selected: HomepageMetricRef[];
+    onAdd: (metricRef: HomepageMetricRef) => void;
+}> = ({ opened, onClose, projectUuid, selected, onAdd }) => {
+    const [search, setSearch] = useState('');
+    const [debouncedSearch] = useDebouncedValue(search, 300);
+    const { data, isFetching } = useMetricsCatalog({
+        projectUuid: opened ? projectUuid : undefined,
+        search: debouncedSearch.length >= 2 ? debouncedSearch : undefined,
+        pageSize: 25,
+    });
+    const results = (data?.pages ?? [])
+        .flatMap((page) => page.data)
+        .filter(
+            (metric) =>
+                !selected.some(
+                    (ref) =>
+                        ref.tableName === metric.tableName &&
+                        ref.metricName === metric.name,
+                ),
+        );
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Choose metrics"
+            size="lg"
+        >
+            <Stack gap="sm">
+                <TextInput
+                    placeholder="Search metrics…"
+                    value={search}
+                    onChange={(e) => setSearch(e.currentTarget.value)}
+                    rightSection={isFetching ? <Loader size="xs" /> : null}
+                />
+                <Stack gap={4} mah={360} style={{ overflowY: 'auto' }}>
+                    {results.map((metric) => (
+                        <Group
+                            key={metric.catalogSearchUuid}
+                            gap="sm"
+                            wrap="nowrap"
+                            p="xs"
+                            style={{ cursor: 'pointer', borderRadius: 8 }}
+                            onClick={() =>
+                                onAdd({
+                                    tableName: metric.tableName,
+                                    metricName: metric.name,
+                                    label: metric.label ?? metric.name,
+                                })
+                            }
+                        >
+                            <MantineIcon icon={IconHash} color="gray" />
+                            <Box style={{ flex: 1, minWidth: 0 }}>
+                                <Text size="sm" fw={500} truncate>
+                                    {metric.label ?? metric.name}
+                                </Text>
+                                <Text size="xs" c="dimmed">
+                                    {metric.tableLabel ?? metric.tableName}
+                                </Text>
+                            </Box>
+                            <MantineIcon icon={IconPlus} color="gray" />
+                        </Group>
+                    ))}
+                    {results.length === 0 && !isFetching && (
+                        <Text size="sm" c="dimmed" p="sm">
+                            No matching metrics.
+                        </Text>
+                    )}
+                </Stack>
+            </Stack>
+        </MantineModal>
+    );
+};
+
+export const MetricsBlockView: FC<BlockComponentProps> = ({
+    block,
+    projectUuid,
+}) => {
+    if (block.type !== 'metrics' || block.config.items.length === 0) {
+        return null;
+    }
+    return (
+        <Stack gap="xs">
+            <Text size="xs" fw={600} tt="uppercase" c="dimmed">
+                {block.config.title}
+            </Text>
+            <SimpleGrid cols={{ base: 1, sm: 2, md: 4 }} spacing="sm">
+                {block.config.items.map((metricRef) => (
+                    <MetricKpiCard
+                        key={`${metricRef.tableName}-${metricRef.metricName}`}
+                        metricRef={metricRef}
+                        projectUuid={projectUuid}
+                    />
+                ))}
+            </SimpleGrid>
+        </Stack>
+    );
+};
+
+export const MetricsBlockBuild: FC<BuildComponentProps> = ({
+    block,
+    projectUuid,
+    onChange,
+}) => {
+    const [isPickerOpen, setIsPickerOpen] = useState(false);
+    if (block.type !== 'metrics') return null;
+
+    return (
+        <Stack gap="xs">
+            <TextInput
+                aria-label="Metrics title"
+                size="xs"
+                fw={600}
+                value={block.config.title}
+                onChange={(e) =>
+                    onChange({
+                        ...block,
+                        config: {
+                            ...block.config,
+                            title: e.currentTarget.value,
+                        },
+                    })
+                }
+            />
+            <SimpleGrid cols={{ base: 1, sm: 2, md: 4 }} spacing="sm">
+                {block.config.items.map((metricRef) => (
+                    <Card
+                        key={`${metricRef.tableName}-${metricRef.metricName}`}
+                        withBorder
+                        p="sm"
+                    >
+                        <Group gap="xs" wrap="nowrap" justify="space-between">
+                            <Box style={{ minWidth: 0 }}>
+                                <Text size="sm" fw={500} truncate>
+                                    {metricRef.label}
+                                </Text>
+                                <Text size="xs" c="dimmed" truncate>
+                                    {metricRef.tableName}
+                                </Text>
+                            </Box>
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                size="sm"
+                                aria-label={`Remove metric ${metricRef.label}`}
+                                onClick={() =>
+                                    onChange({
+                                        ...block,
+                                        config: {
+                                            ...block.config,
+                                            items: block.config.items.filter(
+                                                (item) =>
+                                                    item.metricName !==
+                                                        metricRef.metricName ||
+                                                    item.tableName !==
+                                                        metricRef.tableName,
+                                            ),
+                                        },
+                                    })
+                                }
+                            >
+                                <MantineIcon icon={IconX} />
+                            </ActionIcon>
+                        </Group>
+                    </Card>
+                ))}
+            </SimpleGrid>
+            <Button
+                variant="default"
+                size="xs"
+                w="fit-content"
+                leftSection={<MantineIcon icon={IconHash} />}
+                onClick={() => setIsPickerOpen(true)}
+            >
+                Choose metrics from catalog…
+            </Button>
+            <MetricsPickerModal
+                opened={isPickerOpen}
+                onClose={() => setIsPickerOpen(false)}
+                projectUuid={projectUuid}
+                selected={block.config.items}
+                onAdd={(metricRef) =>
+                    onChange({
+                        ...block,
+                        config: {
+                            ...block.config,
+                            items: [...block.config.items, metricRef],
+                        },
+                    })
+                }
+            />
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
@@ -1,6 +1,7 @@
 import { type HomepageBlock } from '@lightdash/common';
 import {
     IconBook,
+    IconChartDots,
     IconClock,
     IconLayoutGrid,
     IconMarkdown,
@@ -21,6 +22,7 @@ import { CollectionBlockBuild, CollectionBlockView } from './CollectionBlock';
 import { FavoritesBlockBuild, FavoritesBlockView } from './FavoritesBlock';
 import { HeroBlockBuild, HeroBlockView } from './HeroBlock';
 import { MarkdownBlockBuild, MarkdownBlockView } from './MarkdownBlock';
+import { MetricsBlockBuild, MetricsBlockView } from './MetricsBlock';
 import { RecentBlockBuild, RecentBlockView } from './RecentBlock';
 import { ResourcesBlockBuild, ResourcesBlockView } from './ResourcesBlock';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
@@ -67,6 +69,19 @@ export const blockLibrary: BlockDefinition[] = [
         }),
         View: AiBlockView,
         Build: AiBlockBuild,
+    },
+    {
+        type: 'metrics',
+        label: 'Metrics',
+        description: 'KPI cards from the metrics catalog, with deltas.',
+        icon: IconChartDots,
+        create: () => ({
+            id: uuidv4(),
+            type: 'metrics',
+            config: { title: 'This month', items: [] },
+        }),
+        View: MetricsBlockView,
+        Build: MetricsBlockBuild,
     },
     {
         type: 'collection',


### PR DESCRIPTION
## Homepage Builder — metrics KPI block (15)

Part of [ZAP-618](https://linear.app/lightdash/issue/ZAP-618) · Stacked on #25563

KPI cards from the metrics catalog, per audience.

### What
- **Build**: "Choose metrics from catalog…" picker (search over `useMetricsCatalog`, ≥2-char search, click-to-add), editable section title, removable metric chips; config stores `{tableName, metricName, label}` refs
- **View**: one KPI card per metric via `useRunMetricTotal` (`comparisonType: PREVIOUS_PERIOD`, month window) — formatted value (`formatItemValue`, respects the metric’s own format e.g. `usd`), **delta badge vs previous period** (green ↑ / red ↓, same `calculateComparisonValue` + `applyCustomFormat` recipe as the metrics tree), click-through to `/metrics/peek/:table/:metric`
- Per-card skeletons and per-card error state ("Couldn’t load this metric") — one failing metric never takes down the page
- Queries respect viewer permissions (standard metricsExplorer endpoint)

### Deliberate scope cut: sparkline deferred
No sparkline component or lightweight time-series endpoint exists anywhere in the codebase (the metrics tree shows number+delta only; the peek modal uses full echarts through the query executor). Building that infra belongs in its own slice — the ticket’s value/delta/click-through land now.

### Verified (curl)
Catalog listing returns `{tableName, name, label}`; `runMetricTotal` for `orders.total_order_amount` returns `{value, comparisonValue, metric}` — dev seed’s current month is empty so the card renders "-" (handled) with prior-period comparison present.

### Regression analysis
- Frontend-only + config union widening. Flag off unchanged. No new endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ