### PR TITLE
feat(homepage): personal homepage layer — per-user dashboard override + allow-personal publish toggle

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -484,6 +484,8 @@ import {
 import {
     HomepageAssignmentsTable,
     HomepageAssignmentsTableName,
+    HomepagePersonalOverridesTable,
+    HomepagePersonalOverridesTableName,
     HomepagesTableName,
     ProjectHomepagesTable,
 } from '../ee/database/entities/projectHomepages';
@@ -622,6 +624,7 @@ declare module 'knex/types/tables' {
         [AiAgentUserPreferencesTableName]: AiAgentUserPreferencesTable;
         [HomepagesTableName]: ProjectHomepagesTable;
         [HomepageAssignmentsTableName]: HomepageAssignmentsTable;
+        [HomepagePersonalOverridesTableName]: HomepagePersonalOverridesTable;
         [AiAgentReasoningTableName]: AiAgentReasoningTable;
         [AiAgentToolCallTableName]: AiAgentToolCallTable;
         [AiAgentToolResultTableName]: AiAgentToolResultTable;

--- a/packages/backend/src/ee/controllers/projectHomepageController.ts
+++ b/packages/backend/src/ee/controllers/projectHomepageController.ts
@@ -5,11 +5,13 @@ import {
     type ApiProjectHomepageOrNullResponse,
     type ApiProjectHomepageResponse,
     type ApiProjectHomepagesResponse,
-    type ApiPublishedHomepageResponse,
     type ApiRecentlyViewedResponse,
+    type ApiResolvedHomepageResponse,
+    type ApiSuccess,
     type ApiSuccessEmpty,
     type CreateProjectHomepageRequest,
     type PublishProjectHomepageRequest,
+    type SetPersonalHomepageRequest,
     type UpdateHomepageGroupPrioritiesRequest,
     type UpdateProjectHomepageDraftRequest,
     type UUID,
@@ -51,20 +53,83 @@ export class ProjectHomepageController extends BaseController {
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Get('/')
-    @OperationId('getPublishedProjectHomepage')
-    async getPublished(
+    @OperationId('getResolvedProjectHomepage')
+    async getResolved(
         @Request() req: express.Request,
         @Path() projectUuid: UUID,
-    ): Promise<ApiPublishedHomepageResponse> {
+    ): Promise<ApiResolvedHomepageResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
         return {
             status: 'ok',
-            results: await this.getHomepageService().getPublishedHomepage(
+            results: await this.getHomepageService().getResolvedHomepage(
                 toSessionUser(req.account),
                 projectUuid,
             ),
         };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/personal-override')
+    @OperationId('getPersonalHomepage')
+    async getPersonalOverride(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+    ): Promise<ApiSuccess<string | null>> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().getPersonalHomepage(
+                toSessionUser(req.account),
+                projectUuid,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/personal-override')
+    @OperationId('setPersonalHomepage')
+    async setPersonalOverride(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Body() body: SetPersonalHomepageRequest,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.getHomepageService().setPersonalHomepage(
+            toSessionUser(req.account),
+            projectUuid,
+            body.dashboardUuid,
+        );
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Delete('/personal-override')
+    @OperationId('clearPersonalHomepage')
+    async clearPersonalOverride(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.getHomepageService().clearPersonalHomepage(
+            toSessionUser(req.account),
+            projectUuid,
+        );
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
     }
 
     // Literal route must be declared before '/{homepageUuid}' param routes
@@ -273,6 +338,7 @@ export class ProjectHomepageController extends BaseController {
                 projectUuid,
                 homepageUuid,
                 body.audience,
+                body.allowPersonal,
             ),
         };
     }

--- a/packages/backend/src/ee/database/entities/projectHomepages.ts
+++ b/packages/backend/src/ee/database/entities/projectHomepages.ts
@@ -10,6 +10,7 @@ export type DbProjectHomepage = {
     draft_config: HomepageConfig;
     published_config: HomepageConfig | null;
     is_default: boolean;
+    allow_personal: boolean;
     created_by_user_uuid: string | null;
     created_at: Date;
     updated_at: Date;
@@ -31,6 +32,7 @@ export type DbProjectHomepageUpdate = Partial<
         | 'draft_config'
         | 'published_config'
         | 'is_default'
+        | 'allow_personal'
         | 'updated_at'
     >
 >;
@@ -39,6 +41,24 @@ export type ProjectHomepagesTable = Knex.CompositeTableType<
     DbProjectHomepage,
     DbProjectHomepageIn,
     DbProjectHomepageUpdate
+>;
+
+export const HomepagePersonalOverridesTableName = 'homepage_personal_overrides';
+
+export type DbHomepagePersonalOverride = {
+    user_uuid: string;
+    project_uuid: string;
+    dashboard_uuid: string;
+    created_at: Date;
+};
+
+export type HomepagePersonalOverridesTable = Knex.CompositeTableType<
+    DbHomepagePersonalOverride,
+    Pick<
+        DbHomepagePersonalOverride,
+        'user_uuid' | 'project_uuid' | 'dashboard_uuid'
+    >,
+    Pick<DbHomepagePersonalOverride, 'dashboard_uuid'>
 >;
 
 export const HomepageAssignmentsTableName = 'homepage_assignments';
@@ -56,7 +76,12 @@ export type DbHomepageAssignment = {
 
 export type DbHomepageAssignmentIn = Pick<
     DbHomepageAssignment,
-    'project_uuid' | 'homepage_uuid' | 'target_type' | 'group_uuid' | 'role' | 'priority'
+    | 'project_uuid'
+    | 'homepage_uuid'
+    | 'target_type'
+    | 'group_uuid'
+    | 'role'
+    | 'priority'
 >;
 
 export type DbHomepageAssignmentUpdate = Partial<

--- a/packages/backend/src/ee/database/migrations/20260715090000_add_homepage_personal_overrides.ts
+++ b/packages/backend/src/ee/database/migrations/20260715090000_add_homepage_personal_overrides.ts
@@ -1,0 +1,42 @@
+import { Knex } from 'knex';
+
+const OVERRIDES_TABLE = 'homepage_personal_overrides';
+const HOMEPAGES_TABLE = 'homepages';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(HOMEPAGES_TABLE, (table) => {
+        table.boolean('allow_personal').notNullable().defaultTo(true);
+    });
+    await knex.schema.createTable(OVERRIDES_TABLE, (table) => {
+        table
+            .uuid('user_uuid')
+            .notNullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('CASCADE');
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE');
+        table
+            .uuid('dashboard_uuid')
+            .notNullable()
+            .references('dashboard_uuid')
+            .inTable('dashboards')
+            .onDelete('CASCADE');
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table.primary(['user_uuid', 'project_uuid']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(OVERRIDES_TABLE);
+    await knex.schema.alterTable(HOMEPAGES_TABLE, (table) => {
+        table.dropColumn('allow_personal');
+    });
+}

--- a/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
@@ -28,6 +28,7 @@ const draftConfig: HomepageConfig = {
 
 const makeDbHomepage = (overrides: Partial<Record<string, unknown>> = {}) => ({
     homepage_uuid: HOMEPAGE_UUID,
+    allow_personal: true,
     project_uuid: PROJECT_UUID,
     name: 'Team homepage',
     draft_config: draftConfig,
@@ -104,7 +105,7 @@ describe('ProjectHomepageModel', () => {
             tracker.on.select(HomepagesTableName).responseOnce([]);
 
             await expect(
-                model.publish(HOMEPAGE_UUID, { type: 'everyone' }),
+                model.publish(HOMEPAGE_UUID, { type: 'everyone' }, true),
             ).rejects.toThrow(NotFoundError);
         });
 
@@ -120,9 +121,11 @@ describe('ProjectHomepageModel', () => {
                     makeDbHomepage({ published_config: draftConfig }),
                 ]);
 
-            const result = await model.publish(HOMEPAGE_UUID, {
-                type: 'everyone',
-            });
+            const result = await model.publish(
+                HOMEPAGE_UUID,
+                { type: 'everyone' },
+                true,
+            );
 
             expect(tracker.history.update).toHaveLength(2);
             const unsetQuery = tracker.history.update[0];
@@ -136,24 +139,23 @@ describe('ProjectHomepageModel', () => {
             tracker.on
                 .select(HomepagesTableName)
                 .responseOnce([makeDbHomepage({ is_default: false })]);
-            tracker.on
-                .update(HomepagesTableName)
-                .responseOnce([
-                    makeDbHomepage({
-                        is_default: false,
-                        published_config: draftConfig,
-                    }),
-                ]);
+            tracker.on.update(HomepagesTableName).responseOnce([
+                makeDbHomepage({
+                    is_default: false,
+                    published_config: draftConfig,
+                }),
+            ]);
             tracker.on.delete('homepage_assignments').responseOnce(1);
             tracker.on
                 .select('homepage_assignments')
                 .responseOnce([{ max: 1 }]);
             tracker.on.insert('homepage_assignments').responseOnce([]);
 
-            const result = await model.publish(HOMEPAGE_UUID, {
-                type: 'groups',
-                groupUuids: ['group-a', 'group-b'],
-            });
+            const result = await model.publish(
+                HOMEPAGE_UUID,
+                { type: 'groups', groupUuids: ['group-a', 'group-b'] },
+                true,
+            );
 
             // publish update must not set is_default for group audiences
             const publishQuery = tracker.history.update[0];

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -12,6 +12,7 @@ import {
 import { type Knex } from 'knex';
 import {
     HomepageAssignmentsTableName,
+    HomepagePersonalOverridesTableName,
     HomepagesTableName,
     type DbProjectHomepage,
 } from '../database/entities/projectHomepages';
@@ -31,6 +32,7 @@ export class ProjectHomepageModel {
             draftConfig: row.draft_config,
             publishedConfig: row.published_config,
             isDefault: row.is_default,
+            allowPersonal: row.allow_personal,
             createdByUserUuid: row.created_by_user_uuid,
             createdAt: row.created_at,
             updatedAt: row.updated_at,
@@ -83,6 +85,7 @@ export class ProjectHomepageModel {
             homepageUuid: row.homepage_uuid,
             name: row.name,
             config: row.published_config,
+            allowPersonal: row.allow_personal,
         };
     }
 
@@ -169,6 +172,8 @@ export class ProjectHomepageModel {
                 JOIN projects p ON p.project_id = s.project_id
                 WHERE acv.user_uuid = :userUuid
                   AND p.project_uuid = :projectUuid
+                  AND sq.deleted_at IS NULL
+                  AND s.deleted_at IS NULL
                 UNION ALL
                 SELECT 'dashboard' AS content_type,
                        adv.dashboard_uuid AS content_uuid,
@@ -179,6 +184,8 @@ export class ProjectHomepageModel {
                 JOIN projects p ON p.project_id = s.project_id
                 WHERE adv.user_uuid = :userUuid
                   AND p.project_uuid = :projectUuid
+                  AND d.deleted_at IS NULL
+                  AND s.deleted_at IS NULL
             ) views
             GROUP BY content_type, content_uuid
             ORDER BY viewed_at DESC
@@ -193,10 +200,66 @@ export class ProjectHomepageModel {
         }));
     }
 
+    async getPersonalOverride(
+        userUuid: string,
+        projectUuid: string,
+    ): Promise<string | undefined> {
+        const row = await this.database(HomepagePersonalOverridesTableName)
+            .join(
+                'dashboards',
+                'dashboards.dashboard_uuid',
+                `${HomepagePersonalOverridesTableName}.dashboard_uuid`,
+            )
+            .where(`${HomepagePersonalOverridesTableName}.user_uuid`, userUuid)
+            .andWhere(
+                `${HomepagePersonalOverridesTableName}.project_uuid`,
+                projectUuid,
+            )
+            .whereNull('dashboards.deleted_at')
+            .select(`${HomepagePersonalOverridesTableName}.dashboard_uuid`)
+            .first();
+        return row?.dashboard_uuid;
+    }
+
+    async setPersonalOverride(
+        userUuid: string,
+        projectUuid: string,
+        dashboardUuid: string,
+    ): Promise<void> {
+        const dashboardInProject = await this.database('dashboards')
+            .join('spaces', 'spaces.space_id', 'dashboards.space_id')
+            .join('projects', 'projects.project_id', 'spaces.project_id')
+            .where('dashboards.dashboard_uuid', dashboardUuid)
+            .where('projects.project_uuid', projectUuid)
+            .whereNull('dashboards.deleted_at')
+            .first();
+        if (!dashboardInProject) {
+            throw new NotFoundError('Dashboard not found in this project');
+        }
+        await this.database(HomepagePersonalOverridesTableName)
+            .insert({
+                user_uuid: userUuid,
+                project_uuid: projectUuid,
+                dashboard_uuid: dashboardUuid,
+            })
+            .onConflict(['user_uuid', 'project_uuid'])
+            .merge({ dashboard_uuid: dashboardUuid });
+    }
+
+    async deletePersonalOverride(
+        userUuid: string,
+        projectUuid: string,
+    ): Promise<void> {
+        await this.database(HomepagePersonalOverridesTableName)
+            .where({ user_uuid: userUuid, project_uuid: projectUuid })
+            .delete();
+    }
+
     // Publishing to "everyone" promotes the homepage to the project default
     async publish(
         homepageUuid: string,
         audience: HomepageAudience,
+        allowPersonal: boolean,
     ): Promise<ProjectHomepage> {
         return this.database.transaction(async (trx) => {
             const existing = await trx(HomepagesTableName)
@@ -219,6 +282,7 @@ export class ProjectHomepageModel {
                 .where({ homepage_uuid: homepageUuid })
                 .update({
                     published_config: existing.draft_config,
+                    allow_personal: allowPersonal,
                     ...(makeDefault ? { is_default: true } : {}),
                     updated_at: new Date(),
                 })
@@ -378,6 +442,7 @@ export class ProjectHomepageModel {
                     homepageUuid: byGroup.homepage_uuid,
                     name: byGroup.name,
                     config: byGroup.published_config,
+                    allowPersonal: byGroup.allow_personal,
                 };
             }
         }
@@ -392,6 +457,7 @@ export class ProjectHomepageModel {
                     homepageUuid: byRole.homepage_uuid,
                     name: byRole.name,
                     config: byRole.published_config,
+                    allowPersonal: byRole.allow_personal,
                 };
             }
         }

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -41,6 +41,7 @@ const makeHomepage = (
     draftConfig: validConfig,
     publishedConfig: null,
     isDefault: true,
+    allowPersonal: true,
     createdByUserUuid: USER_UUID,
     createdAt: NOW,
     updatedAt: NOW,
@@ -123,6 +124,9 @@ const makeService = ({
             getPublishedDefault: vi.fn().mockResolvedValue(undefined),
             getRecentlyViewed: vi.fn().mockResolvedValue([]),
             getAssignments: vi.fn().mockResolvedValue([]),
+            getPersonalOverride: vi.fn().mockResolvedValue(undefined),
+            setPersonalOverride: vi.fn().mockResolvedValue(undefined),
+            deletePersonalOverride: vi.fn().mockResolvedValue(undefined),
             updateGroupPriorities: vi.fn().mockResolvedValue(undefined),
             resolvePublished: vi.fn().mockResolvedValue(undefined),
             list: vi.fn().mockResolvedValue([]),
@@ -147,7 +151,7 @@ describe('ProjectHomepageService', () => {
         const service = makeService({ flagEnabled: false });
 
         await expect(
-            service.getPublishedHomepage(makeAdminUser(), PROJECT_UUID),
+            service.getResolvedHomepage(makeAdminUser(), PROJECT_UUID),
         ).rejects.toThrow(ForbiddenError);
     });
 
@@ -155,7 +159,7 @@ describe('ProjectHomepageService', () => {
         const service = makeService();
 
         await expect(
-            service.getPublishedHomepage(makeViewerUser(), PROJECT_UUID),
+            service.getResolvedHomepage(makeViewerUser(), PROJECT_UUID),
         ).resolves.toBeNull();
     });
 
@@ -278,11 +282,14 @@ describe('ProjectHomepageService', () => {
             PROJECT_UUID,
             HOMEPAGE_UUID,
             { type: 'everyone' },
+            true,
         );
 
-        expect(publish).toHaveBeenCalledWith(HOMEPAGE_UUID, {
-            type: 'everyone',
-        });
+        expect(publish).toHaveBeenCalledWith(
+            HOMEPAGE_UUID,
+            { type: 'everyone' },
+            true,
+        );
         expect(result.publishedConfig).toEqual(validConfig);
     });
 
@@ -291,6 +298,7 @@ describe('ProjectHomepageService', () => {
             homepageUuid: HOMEPAGE_UUID,
             name: 'Sales homepage',
             config: validConfig,
+            allowPersonal: true,
         });
         const service = makeService({
             projectHomepageModel: { resolvePublished },
@@ -311,7 +319,7 @@ describe('ProjectHomepageService', () => {
             },
         });
 
-        const result = await service.getPublishedHomepage(
+        const result = await service.getResolvedHomepage(
             makeViewerUser(),
             PROJECT_UUID,
         );
@@ -320,6 +328,11 @@ describe('ProjectHomepageService', () => {
             groupUuids: ['group-1'],
             role: 'editor',
         });
-        expect(result?.name).toBe('Sales homepage');
+        expect(result).toEqual(
+            expect.objectContaining({
+                type: 'homepage',
+                homepage: expect.objectContaining({ name: 'Sales homepage' }),
+            }),
+        );
     });
 });

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -13,6 +13,7 @@ import {
     type HomepageRecentlyViewedItem,
     type ProjectHomepage,
     type PublishedProjectHomepage,
+    type ResolvedHomepage,
     type SessionUser,
     type UpdateProjectHomepageDraftRequest,
 } from '@lightdash/common';
@@ -30,6 +31,9 @@ export type ProjectHomepageServiceArguments = {
         | 'getPublishedDefault'
         | 'getRecentlyViewed'
         | 'getAssignments'
+        | 'getPersonalOverride'
+        | 'setPersonalOverride'
+        | 'deletePersonalOverride'
         | 'updateGroupPriorities'
         | 'resolvePublished'
         | 'list'
@@ -134,14 +138,18 @@ export class ProjectHomepageService extends BaseService {
         return homepage;
     }
 
-    // Resolution: group priority → role → project default (personal = ZAP-628)
-    async getPublishedHomepage(
+    // Resolution: personal → group priority → role → project default
+    async getResolvedHomepage(
         user: SessionUser,
         projectUuid: string,
-    ): Promise<PublishedProjectHomepage | null> {
+    ): Promise<ResolvedHomepage | null> {
         await this.assertFlagEnabled(user);
         this.assertCanView(user, projectUuid);
-        const [groups, membership] = await Promise.all([
+        const [override, groups, membership] = await Promise.all([
+            this.projectHomepageModel.getPersonalOverride(
+                user.userUuid,
+                projectUuid,
+            ),
             user.organizationUuid
                 ? this.groupsModel.findUserGroups({
                       userUuid: user.userUuid,
@@ -160,7 +168,53 @@ export class ProjectHomepageService extends BaseService {
                 role: membership?.role,
             },
         );
-        return published ?? null;
+        // Personal choice wins unless the audience homepage disallows it
+        if (override && (published?.allowPersonal ?? true)) {
+            return { type: 'dashboard', dashboardUuid: override };
+        }
+        if (published) {
+            return { type: 'homepage', homepage: published };
+        }
+        return null;
+    }
+
+    async setPersonalHomepage(
+        user: SessionUser,
+        projectUuid: string,
+        dashboardUuid: string,
+    ): Promise<void> {
+        await this.assertFlagEnabled(user);
+        this.assertCanView(user, projectUuid);
+        await this.projectHomepageModel.setPersonalOverride(
+            user.userUuid,
+            projectUuid,
+            dashboardUuid,
+        );
+    }
+
+    async clearPersonalHomepage(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<void> {
+        await this.assertFlagEnabled(user);
+        this.assertCanView(user, projectUuid);
+        await this.projectHomepageModel.deletePersonalOverride(
+            user.userUuid,
+            projectUuid,
+        );
+    }
+
+    async getPersonalHomepage(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<string | null> {
+        await this.assertFlagEnabled(user);
+        this.assertCanView(user, projectUuid);
+        const override = await this.projectHomepageModel.getPersonalOverride(
+            user.userUuid,
+            projectUuid,
+        );
+        return override ?? null;
     }
 
     async getAssignments(
@@ -275,10 +329,15 @@ export class ProjectHomepageService extends BaseService {
         projectUuid: string,
         homepageUuid: string,
         audience: HomepageAudience,
+        allowPersonal: boolean,
     ): Promise<ProjectHomepage> {
         await this.assertFlagEnabled(user);
         this.assertCanManage(user, projectUuid);
         await this.getOwnedHomepage(projectUuid, homepageUuid);
-        return this.projectHomepageModel.publish(homepageUuid, audience);
+        return this.projectHomepageModel.publish(
+            homepageUuid,
+            audience,
+            allowPersonal,
+        );
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1878,6 +1878,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                allowPersonal: { dataType: 'boolean', required: true },
                 config: { ref: 'HomepageConfig', required: true },
                 name: { dataType: 'string', required: true },
                 homepageUuid: { dataType: 'string', required: true },
@@ -1886,7 +1887,42 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ApiSuccess_PublishedProjectHomepage-or-null_': {
+    ResolvedHomepage: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        homepage: {
+                            ref: 'PublishedProjectHomepage',
+                            required: true,
+                        },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['homepage'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        dashboardUuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['dashboard'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_ResolvedHomepage-or-null_': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -1894,7 +1930,7 @@ const models: TsoaRoute.Models = {
                 results: {
                     dataType: 'union',
                     subSchemas: [
-                        { ref: 'PublishedProjectHomepage' },
+                        { ref: 'ResolvedHomepage' },
                         { dataType: 'enum', enums: [null] },
                     ],
                     required: true,
@@ -1905,10 +1941,37 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiPublishedHomepageResponse: {
+    ApiResolvedHomepageResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_ResolvedHomepage-or-null_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_string-or-null_': {
         dataType: 'refAlias',
         type: {
-            ref: 'ApiSuccess_PublishedProjectHomepage-or-null_',
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SetPersonalHomepageRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                dashboardUuid: { dataType: 'string', required: true },
+            },
             validators: {},
         },
     },
@@ -1928,6 +1991,7 @@ const models: TsoaRoute.Models = {
                     ],
                     required: true,
                 },
+                allowPersonal: { dataType: 'boolean', required: true },
                 isDefault: { dataType: 'boolean', required: true },
                 publishedConfig: {
                     dataType: 'union',
@@ -2220,6 +2284,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                allowPersonal: { dataType: 'boolean', required: true },
                 audience: { ref: 'HomepageAudience', required: true },
             },
             validators: {},
@@ -16408,6 +16473,18 @@ const models: TsoaRoute.Models = {
                                                                                                                                             },
                                                                                                                                         ],
                                                                                                                                 },
+                                                                                                                                required:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'boolean',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                tableName:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
                                                                                                                                 fieldRef:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -16420,22 +16497,10 @@ const models: TsoaRoute.Models = {
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                tableName:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
                                                                                                                                 operator:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                required:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'boolean',
                                                                                                                                         required: true,
                                                                                                                                     },
                                                                                                                             },
@@ -16540,6 +16605,31 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                status: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'enum',
+                                                                                                enums: [
+                                                                                                    'error',
+                                                                                                ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'enum',
+                                                                                                enums: [
+                                                                                                    'success',
+                                                                                                ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
                                                                                 pagination:
                                                                                     {
                                                                                         dataType:
@@ -16582,31 +16672,6 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                status: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'enum',
-                                                                                                enums: [
-                                                                                                    'error',
-                                                                                                ],
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'enum',
-                                                                                                enums: [
-                                                                                                    'success',
-                                                                                                ],
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
                                                                                 error: {
                                                                                     dataType:
                                                                                         'union',
@@ -16932,6 +16997,40 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -16950,40 +17049,6 @@ const models: TsoaRoute.Models = {
                                                                                                     ],
                                                                                                 },
                                                                                             ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
                                                                                         required: true,
                                                                                     },
                                                                                 label: {
@@ -17062,6 +17127,18 @@ const models: TsoaRoute.Models = {
                                                                                                                         },
                                                                                                                     ],
                                                                                                             },
+                                                                                                            required:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'boolean',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            tableName:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
                                                                                                             fieldRef:
                                                                                                                 {
                                                                                                                     dataType:
@@ -17074,22 +17151,10 @@ const models: TsoaRoute.Models = {
                                                                                                                         'string',
                                                                                                                     required: true,
                                                                                                                 },
-                                                                                                            tableName:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
                                                                                                             operator:
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'string',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            required:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'boolean',
                                                                                                                     required: true,
                                                                                                                 },
                                                                                                         },
@@ -17282,14 +17347,11 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
-                                                warnings: {
-                                                    dataType: 'array',
-                                                    array: {
-                                                        dataType: 'string',
-                                                    },
+                                                href: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
-                                                href: {
+                                                slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
@@ -17298,12 +17360,15 @@ const models: TsoaRoute.Models = {
                                                     enums: ['success'],
                                                     required: true,
                                                 },
-                                                slug: {
+                                                uuid: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                uuid: {
-                                                    dataType: 'string',
+                                                warnings: {
+                                                    dataType: 'array',
+                                                    array: {
+                                                        dataType: 'string',
+                                                    },
                                                     required: true,
                                                 },
                                                 name: {
@@ -17454,18 +17519,6 @@ const models: TsoaRoute.Models = {
                                                                                 ],
                                                                             required: true,
                                                                         },
-                                                                        isPrimary:
-                                                                            {
-                                                                                dataType:
-                                                                                    'boolean',
-                                                                                required: true,
-                                                                            },
-                                                                        projectDbtSourceUuid:
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
                                                                         repository:
                                                                             {
                                                                                 dataType:
@@ -17484,6 +17537,18 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         },
                                                                                     ],
+                                                                                required: true,
+                                                                            },
+                                                                        isPrimary:
+                                                                            {
+                                                                                dataType:
+                                                                                    'boolean',
+                                                                                required: true,
+                                                                            },
+                                                                        projectDbtSourceUuid:
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
                                                                                 required: true,
                                                                             },
                                                                         name: {
@@ -17508,6 +17573,77 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'union',
                                                     subSchemas: [
                                                         { dataType: 'boolean' },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
+                                                steps: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'array',
+                                                            array: {
+                                                                dataType:
+                                                                    'nestedObjectLiteral',
+                                                                nestedProperties:
+                                                                    {
+                                                                        kind: {
+                                                                            dataType:
+                                                                                'union',
+                                                                            subSchemas:
+                                                                                [
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'read',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'edit',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'compile',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'stage',
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
+                                                                    },
+                                                            },
+                                                        },
                                                         {
                                                             dataType: 'enum',
                                                             enums: [null],
@@ -17595,77 +17731,6 @@ const models: TsoaRoute.Models = {
                                                         },
                                                     ],
                                                 },
-                                                steps: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'array',
-                                                            array: {
-                                                                dataType:
-                                                                    'nestedObjectLiteral',
-                                                                nestedProperties:
-                                                                    {
-                                                                        kind: {
-                                                                            dataType:
-                                                                                'union',
-                                                                            subSchemas:
-                                                                                [
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'read',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'compile',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'stage',
-                                                                                        ],
-                                                                                    },
-                                                                                ],
-                                                                            required: true,
-                                                                        },
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
-                                                                    },
-                                                            },
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
-                                                        },
-                                                    ],
-                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -17697,12 +17762,6 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
-                                                                'unsupported_source_control',
-                                                            ],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [
                                                                 'github_not_installed',
                                                             ],
                                                         },
@@ -17710,6 +17769,12 @@ const models: TsoaRoute.Models = {
                                                             dataType: 'enum',
                                                             enums: [
                                                                 'gitlab_not_installed',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
+                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -17777,16 +17842,16 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                slug: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
                                                     required: true,
                                                 },
                                                 name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
-                                                slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
@@ -17852,6 +17917,10 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['timeout'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
                                                         {
@@ -17861,10 +17930,6 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['timeout'],
                                                         },
                                                     ],
                                                     required: true,
@@ -18008,14 +18073,14 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'metric',
+                                                                                    'dimension',
                                                                                 ],
                                                                             },
                                                                             {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    'metric',
                                                                                 ],
                                                                             },
                                                                             {
@@ -36068,7 +36133,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -36078,7 +36143,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -36088,7 +36153,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -36101,7 +36166,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -36770,7 +36835,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -36780,7 +36845,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -36790,7 +36855,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -36803,7 +36868,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -49718,7 +49783,7 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsProjectHomepageController_getPublished: Record<
+    const argsProjectHomepageController_getResolved: Record<
         string,
         TsoaRoute.ParameterSchema
     > = {
@@ -49734,10 +49799,10 @@ export function RegisterRoutes(app: Router) {
         '/api/v1/projects/:projectUuid/homepage',
         ...fetchMiddlewares<RequestHandler>(ProjectHomepageController),
         ...fetchMiddlewares<RequestHandler>(
-            ProjectHomepageController.prototype.getPublished,
+            ProjectHomepageController.prototype.getResolved,
         ),
 
-        async function ProjectHomepageController_getPublished(
+        async function ProjectHomepageController_getResolved(
             request: ExRequest,
             response: ExResponse,
             next: any,
@@ -49747,7 +49812,7 @@ export function RegisterRoutes(app: Router) {
             let validatedArgs: any[] = [];
             try {
                 validatedArgs = templateService.getValidatedArgs({
-                    args: argsProjectHomepageController_getPublished,
+                    args: argsProjectHomepageController_getResolved,
                     request,
                     response,
                 });
@@ -49766,7 +49831,196 @@ export function RegisterRoutes(app: Router) {
                 }
 
                 await templateService.apiHandler({
-                    methodName: 'getPublished',
+                    methodName: 'getResolved',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectHomepageController_getPersonalOverride: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/homepage/personal-override',
+        ...fetchMiddlewares<RequestHandler>(ProjectHomepageController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectHomepageController.prototype.getPersonalOverride,
+        ),
+
+        async function ProjectHomepageController_getPersonalOverride(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectHomepageController_getPersonalOverride,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectHomepageController>(
+                        ProjectHomepageController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getPersonalOverride',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectHomepageController_setPersonalOverride: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'SetPersonalHomepageRequest',
+        },
+    };
+    app.patch(
+        '/api/v1/projects/:projectUuid/homepage/personal-override',
+        ...fetchMiddlewares<RequestHandler>(ProjectHomepageController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectHomepageController.prototype.setPersonalOverride,
+        ),
+
+        async function ProjectHomepageController_setPersonalOverride(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectHomepageController_setPersonalOverride,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectHomepageController>(
+                        ProjectHomepageController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'setPersonalOverride',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectHomepageController_clearPersonalOverride: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.delete(
+        '/api/v1/projects/:projectUuid/homepage/personal-override',
+        ...fetchMiddlewares<RequestHandler>(ProjectHomepageController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectHomepageController.prototype.clearPersonalOverride,
+        ),
+
+        async function ProjectHomepageController_clearPersonalOverride(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectHomepageController_clearPersonalOverride,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectHomepageController>(
+                        ProjectHomepageController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'clearPersonalOverride',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1883,6 +1883,9 @@
             },
             "PublishedProjectHomepage": {
                 "properties": {
+                    "allowPersonal": {
+                        "type": "boolean"
+                    },
                     "config": {
                         "$ref": "#/components/schemas/HomepageConfig"
                     },
@@ -1893,15 +1896,47 @@
                         "type": "string"
                     }
                 },
-                "required": ["config", "name", "homepageUuid"],
+                "required": ["allowPersonal", "config", "name", "homepageUuid"],
                 "type": "object"
             },
-            "ApiSuccess_PublishedProjectHomepage-or-null_": {
+            "ResolvedHomepage": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "homepage": {
+                                "$ref": "#/components/schemas/PublishedProjectHomepage"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["homepage"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["homepage", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "dashboardUuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["dashboard"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["dashboardUuid", "type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiSuccess_ResolvedHomepage-or-null_": {
                 "properties": {
                     "results": {
                         "allOf": [
                             {
-                                "$ref": "#/components/schemas/PublishedProjectHomepage"
+                                "$ref": "#/components/schemas/ResolvedHomepage"
                             }
                         ],
                         "nullable": true
@@ -1915,8 +1950,32 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "ApiPublishedHomepageResponse": {
-                "$ref": "#/components/schemas/ApiSuccess_PublishedProjectHomepage-or-null_"
+            "ApiResolvedHomepageResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_ResolvedHomepage-or-null_"
+            },
+            "ApiSuccess_string-or-null_": {
+                "properties": {
+                    "results": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "SetPersonalHomepageRequest": {
+                "properties": {
+                    "dashboardUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["dashboardUuid"],
+                "type": "object"
             },
             "ProjectHomepage": {
                 "properties": {
@@ -1931,6 +1990,9 @@
                     "createdByUserUuid": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "allowPersonal": {
+                        "type": "boolean"
                     },
                     "isDefault": {
                         "type": "boolean"
@@ -1960,6 +2022,7 @@
                     "updatedAt",
                     "createdAt",
                     "createdByUserUuid",
+                    "allowPersonal",
                     "isDefault",
                     "publishedConfig",
                     "draftConfig",
@@ -2226,11 +2289,14 @@
             },
             "PublishProjectHomepageRequest": {
                 "properties": {
+                    "allowPersonal": {
+                        "type": "boolean"
+                    },
                     "audience": {
                         "$ref": "#/components/schemas/HomepageAudience"
                     }
                 },
-                "required": ["audience"],
+                "required": ["allowPersonal", "audience"],
                 "type": "object"
             },
             "ManagedAgentScheduleOption": {
@@ -17900,28 +17966,28 @@
                                                                                         "items": {},
                                                                                         "type": "array"
                                                                                     },
+                                                                                    "required": {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    "tableName": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "fieldRef": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "fieldId": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "operator": {
                                                                                         "type": "string"
-                                                                                    },
-                                                                                    "required": {
-                                                                                        "type": "boolean"
                                                                                     }
                                                                                 },
                                                                                 "required": [
+                                                                                    "required",
+                                                                                    "tableName",
                                                                                     "fieldRef",
                                                                                     "fieldId",
-                                                                                    "tableName",
-                                                                                    "operator",
-                                                                                    "required"
+                                                                                    "operator"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -17976,6 +18042,13 @@
                                                             "searchQueries": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "status": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "error",
+                                                                                "success"
+                                                                            ]
+                                                                        },
                                                                         "pagination": {
                                                                             "properties": {
                                                                                 "totalPageCount": {
@@ -18002,13 +18075,6 @@
                                                                                 "page"
                                                                             ],
                                                                             "type": "object"
-                                                                        },
-                                                                        "status": {
-                                                                            "type": "string",
-                                                                            "enum": [
-                                                                                "error",
-                                                                                "success"
-                                                                            ]
                                                                         },
                                                                         "error": {
                                                                             "type": "string"
@@ -18169,22 +18235,22 @@
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
                                                                                 "fieldType": {
                                                                                     "type": "string",
                                                                                     "enum": [
-                                                                                        "metric",
-                                                                                        "dimension"
+                                                                                        "dimension",
+                                                                                        "metric"
                                                                                     ]
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
                                                                                 },
                                                                                 "table": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
                                                                                 },
                                                                                 "label": {
                                                                                     "type": "string"
@@ -18198,10 +18264,10 @@
                                                                                 "caseSensitiveFilters",
                                                                                 "fieldValueType",
                                                                                 "fieldFilterType",
-                                                                                "description",
                                                                                 "fieldType",
-                                                                                "table",
                                                                                 "fieldId",
+                                                                                "table",
+                                                                                "description",
                                                                                 "label",
                                                                                 "name"
                                                                             ],
@@ -18223,28 +18289,28 @@
                                                                                             "items": {},
                                                                                             "type": "array"
                                                                                         },
+                                                                                        "required": {
+                                                                                            "type": "boolean"
+                                                                                        },
+                                                                                        "tableName": {
+                                                                                            "type": "string"
+                                                                                        },
                                                                                         "fieldRef": {
                                                                                             "type": "string"
                                                                                         },
                                                                                         "fieldId": {
                                                                                             "type": "string"
                                                                                         },
-                                                                                        "tableName": {
-                                                                                            "type": "string"
-                                                                                        },
                                                                                         "operator": {
                                                                                             "type": "string"
-                                                                                        },
-                                                                                        "required": {
-                                                                                            "type": "boolean"
                                                                                         }
                                                                                     },
                                                                                     "required": [
+                                                                                        "required",
+                                                                                        "tableName",
                                                                                         "fieldRef",
                                                                                         "fieldId",
-                                                                                        "tableName",
-                                                                                        "operator",
-                                                                                        "required"
+                                                                                        "operator"
                                                                                     ],
                                                                                     "type": "object"
                                                                                 },
@@ -18384,13 +18450,10 @@
                                                         ],
                                                         "type": "object"
                                                     },
-                                                    "warnings": {
-                                                        "items": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": "array"
-                                                    },
                                                     "href": {
+                                                        "type": "string"
+                                                    },
+                                                    "slug": {
                                                         "type": "string"
                                                     },
                                                     "status": {
@@ -18398,11 +18461,14 @@
                                                         "enum": ["success"],
                                                         "nullable": false
                                                     },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
                                                     "uuid": {
                                                         "type": "string"
+                                                    },
+                                                    "warnings": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
                                                     },
                                                     "name": {
                                                         "type": "string"
@@ -18410,11 +18476,11 @@
                                                 },
                                                 "required": [
                                                     "versionUuids",
-                                                    "warnings",
                                                     "href",
-                                                    "status",
                                                     "slug",
+                                                    "status",
                                                     "uuid",
+                                                    "warnings",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -18449,15 +18515,15 @@
                                                                     "type": "string",
                                                                     "nullable": true
                                                                 },
+                                                                "repository": {
+                                                                    "type": "string",
+                                                                    "nullable": true
+                                                                },
                                                                 "isPrimary": {
                                                                     "type": "boolean"
                                                                 },
                                                                 "projectDbtSourceUuid": {
                                                                     "type": "string"
-                                                                },
-                                                                "repository": {
-                                                                    "type": "string",
-                                                                    "nullable": true
                                                                 },
                                                                 "name": {
                                                                     "type": "string"
@@ -18466,9 +18532,9 @@
                                                             "required": [
                                                                 "projectSubPath",
                                                                 "branch",
+                                                                "repository",
                                                                 "isPrimary",
                                                                 "projectDbtSourceUuid",
-                                                                "repository",
                                                                 "name"
                                                             ],
                                                             "type": "object"
@@ -18478,6 +18544,32 @@
                                                     },
                                                     "needsDbtSourceSelection": {
                                                         "type": "boolean",
+                                                        "nullable": true
+                                                    },
+                                                    "steps": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "kind": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "read",
+                                                                        "edit",
+                                                                        "search",
+                                                                        "compile",
+                                                                        "stage"
+                                                                    ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kind",
+                                                                "label"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
                                                         "nullable": true
                                                     },
                                                     "previewUrl": {
@@ -18507,32 +18599,6 @@
                                                         ],
                                                         "nullable": true
                                                     },
-                                                    "steps": {
-                                                        "items": {
-                                                            "properties": {
-                                                                "kind": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "search",
-                                                                        "read",
-                                                                        "edit",
-                                                                        "compile",
-                                                                        "stage"
-                                                                    ]
-                                                                },
-                                                                "label": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "kind",
-                                                                "label"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array",
-                                                        "nullable": true
-                                                    },
                                                     "prUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -18552,9 +18618,9 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "unknown",
-                                                            "unsupported_source_control",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
+                                                            "unsupported_source_control",
                                                             "pull_request_not_open",
                                                             "git_write_permission",
                                                             null
@@ -18575,6 +18641,9 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
+                                                    "slug": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
@@ -18582,16 +18651,13 @@
                                                     },
                                                     "name": {
                                                         "type": "string"
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "href",
+                                                    "slug",
                                                     "status",
-                                                    "name",
-                                                    "slug"
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -18617,10 +18683,10 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "timeout",
                                                             "error",
                                                             "rejected",
-                                                            "success",
-                                                            "timeout"
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -18674,8 +18740,8 @@
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "metric",
                                                                     "dimension",
+                                                                    "metric",
                                                                     null
                                                                 ],
                                                                 "nullable": true
@@ -36450,22 +36516,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -37033,22 +37099,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -49290,14 +49356,14 @@
         },
         "/api/v1/projects/{projectUuid}/homepage": {
             "get": {
-                "operationId": "getPublishedProjectHomepage",
+                "operationId": "getResolvedProjectHomepage",
                 "responses": {
                     "200": {
                         "description": "Success",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ApiPublishedHomepageResponse"
+                                    "$ref": "#/components/schemas/ApiResolvedHomepageResponse"
                                 }
                             }
                         }
@@ -49372,6 +49438,129 @@
                         }
                     }
                 }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/homepage/personal-override": {
+            "get": {
+                "operationId": "getPersonalHomepage",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccess_string-or-null_"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "setPersonalHomepage",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SetPersonalHomepageRequest"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "clearPersonalHomepage",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/projects/{projectUuid}/homepage/builder": {

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -112,6 +112,7 @@ export type HomepageAudience =
 
 export type PublishProjectHomepageRequest = {
     audience: HomepageAudience;
+    allowPersonal: boolean;
 };
 
 export type HomepageAssignment = {
@@ -180,6 +181,7 @@ export type ProjectHomepage = {
     draftConfig: HomepageConfig;
     publishedConfig: HomepageConfig | null;
     isDefault: boolean;
+    allowPersonal: boolean;
     createdByUserUuid: string | null;
     createdAt: Date;
     updatedAt: Date;
@@ -189,7 +191,18 @@ export type PublishedProjectHomepage = {
     homepageUuid: string;
     name: string;
     config: HomepageConfig;
+    allowPersonal: boolean;
 };
+
+export type ResolvedHomepage =
+    | { type: 'homepage'; homepage: PublishedProjectHomepage }
+    | { type: 'dashboard'; dashboardUuid: string };
+
+export type SetPersonalHomepageRequest = {
+    dashboardUuid: string;
+};
+
+export type ApiResolvedHomepageResponse = ApiSuccess<ResolvedHomepage | null>;
 
 export type CreateProjectHomepageRequest = {
     name: string;
@@ -207,5 +220,3 @@ export type ApiProjectHomepageResponse = ApiSuccess<ProjectHomepage>;
 export type ApiProjectHomepagesResponse = ApiSuccess<ProjectHomepage[]>;
 export type ApiProjectHomepageOrNullResponse =
     ApiSuccess<ProjectHomepage | null>;
-export type ApiPublishedHomepageResponse =
-    ApiSuccess<PublishedProjectHomepage | null>;

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -68,7 +68,7 @@ import type {
     ApiProjectHomepageResponse,
     ApiPromoteAppDiffResponse,
     ApiPromoteAppResponse,
-    ApiPublishedHomepageResponse,
+    ApiResolvedHomepageResponse,
     ApiUpdateAiOrganizationSettingsResponse,
     ApiUpdateUserAgentPreferencesResponse,
     AppExternalConnectionLink,
@@ -1282,7 +1282,7 @@ type ApiResults =
     | ApiOrganizationDesignFileResponse['results']
     | ApiProjectHomepageResponse['results']
     | ApiProjectHomepageOrNullResponse['results']
-    | ApiPublishedHomepageResponse['results']
+    | ApiResolvedHomepageResponse['results']
     | ApiProjectColorPaletteResponse['results']
     | ApiOrganizationBrandResponse['results']
     | ApiManagedAgentRunResponse['results']

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -31,6 +31,8 @@ import {
     IconFolderPlus,
     IconFolderSymlink,
     IconHistory,
+    IconHome,
+    IconHomeOff,
     IconInfoCircle,
     IconMaximize,
     IconMinimize,
@@ -50,6 +52,13 @@ import { useLocation, useNavigate, useParams } from 'react-router';
 import { useToggle } from 'react-use';
 import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
 import AIDashboardSummary from '../../../ee/features/ambientAi/components/aiDashboardSummary';
+import {
+    useClearPersonalHomepage,
+    useHomepageBuilderFlag,
+    usePersonalHomepage,
+    useResolvedHomepage,
+    useSetPersonalHomepage,
+} from '../../../ee/features/homepageBuilder/hooks/useProjectHomepage';
 import { PromotionConfirmDialog } from '../../../features/promotion/components/PromotionConfirmDialog';
 import {
     usePromoteDashboardDiffMutation,
@@ -255,6 +264,29 @@ const DashboardHeader = memo(
             if (!dashboardUuid) return;
             toggleDashboardPinning({ uuid: dashboardUuid });
         }, [dashboardUuid, toggleDashboardPinning]);
+
+        const { isEnabled: isHomepageBuilderEnabled } =
+            useHomepageBuilderFlag();
+        const { data: resolvedHomepage } = useResolvedHomepage(projectUuid, {
+            enabled: isHomepageBuilderEnabled,
+        });
+        const { data: personalHomepage } = usePersonalHomepage(projectUuid, {
+            enabled: isHomepageBuilderEnabled,
+        });
+        const { mutate: setPersonalHomepage } = useSetPersonalHomepage(
+            projectUuid ?? '',
+        );
+        const { mutate: clearPersonalHomepage } = useClearPersonalHomepage(
+            projectUuid ?? '',
+        );
+        const isPersonalHomepage =
+            !!personalHomepage && personalHomepage === dashboardUuid;
+        const canSetPersonalHomepage =
+            isHomepageBuilderEnabled &&
+            !(
+                resolvedHomepage?.type === 'homepage' &&
+                !resolvedHomepage.homepage.allowPersonal
+            );
 
         const { data: favorites } = useFavorites(projectUuid);
         const { mutate: toggleFavorite } = useFavoriteMutation(projectUuid);
@@ -832,6 +864,33 @@ const DashboardHeader = memo(
                                             {isPinned
                                                 ? 'Unpin from homepage'
                                                 : 'Pin to homepage'}
+                                        </Menu.Item>
+                                    )}
+
+                                    {canSetPersonalHomepage && (
+                                        <Menu.Item
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={
+                                                        isPersonalHomepage
+                                                            ? IconHomeOff
+                                                            : IconHome
+                                                    }
+                                                />
+                                            }
+                                            onClick={() => {
+                                                if (isPersonalHomepage) {
+                                                    clearPersonalHomepage();
+                                                } else if (dashboardUuid) {
+                                                    setPersonalHomepage(
+                                                        dashboardUuid,
+                                                    );
+                                                }
+                                            }}
+                                        >
+                                            {isPersonalHomepage
+                                                ? 'Remove as my homepage'
+                                                : 'Make this my homepage'}
                                         </Menu.Item>
                                     )}
 

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -708,10 +708,14 @@ export const HomepageEditor: FC<Props> = ({
                 homepageUuid={homepage.homepageUuid}
                 homepageName={homepage.name}
                 isPublishing={publishMutation.isLoading}
-                onPublish={(audience) =>
-                    publishMutation.mutate(audience, {
-                        onSuccess: () => setIsPublishModalOpen(false),
-                    })
+                initialAllowPersonal={homepage.allowPersonal}
+                onPublish={(audience, allowPersonal) =>
+                    publishMutation.mutate(
+                        { audience, allowPersonal },
+                        {
+                            onSuccess: () => setIsPublishModalOpen(false),
+                        },
+                    )
                 }
             />
             <MantineModal

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
@@ -12,6 +12,7 @@ import {
     Group,
     SegmentedControl,
     Stack,
+    Switch,
     Text,
 } from '@mantine-8/core';
 import {
@@ -37,7 +38,8 @@ type Props = {
     homepageUuid: string;
     homepageName: string;
     isPublishing: boolean;
-    onPublish: (audience: HomepageAudience) => void;
+    initialAllowPersonal: boolean;
+    onPublish: (audience: HomepageAudience, allowPersonal: boolean) => void;
 };
 
 export const PublishModal: FC<Props> = ({
@@ -47,9 +49,11 @@ export const PublishModal: FC<Props> = ({
     homepageUuid,
     homepageName,
     isPublishing,
+    initialAllowPersonal,
     onPublish,
 }) => {
     const [mode, setMode] = useState<string>('everyone');
+    const [allowPersonal, setAllowPersonal] = useState(initialAllowPersonal);
     const [selectedGroups, setSelectedGroups] = useState<string[]>([]);
     const [selectedRoles, setSelectedRoles] = useState<ProjectMemberRole[]>([]);
     const { data: groups } = useOrganizationGroups({}, { enabled: opened });
@@ -93,11 +97,14 @@ export const PublishModal: FC<Props> = ({
 
     const handlePublish = () => {
         if (mode === 'groups') {
-            onPublish({ type: 'groups', groupUuids: selectedGroups });
+            onPublish(
+                { type: 'groups', groupUuids: selectedGroups },
+                allowPersonal,
+            );
         } else if (mode === 'roles') {
-            onPublish({ type: 'roles', roles: selectedRoles });
+            onPublish({ type: 'roles', roles: selectedRoles }, allowPersonal);
         } else {
-            onPublish({ type: 'everyone' });
+            onPublish({ type: 'everyone' }, allowPersonal);
         }
     };
 
@@ -287,6 +294,17 @@ export const PublishModal: FC<Props> = ({
                         </Stack>
                     </Card>
                 )}
+
+                <Card withBorder p="sm">
+                    <Switch
+                        label="Let people set a dashboard as their own homepage"
+                        description="When off, everyone in this audience always lands here — personal picks are ignored."
+                        checked={allowPersonal}
+                        onChange={(e) =>
+                            setAllowPersonal(e.currentTarget.checked)
+                        }
+                    />
+                </Card>
 
                 <Group gap={4} wrap="nowrap">
                     <Text size="xs" c="dimmed">

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
@@ -116,6 +116,22 @@ const FavoritePills: FC<{
     );
 };
 
+export const PersonalFavoritesStrip: FC<{ projectUuid: string }> = ({
+    projectUuid,
+}) => (
+    <Stack gap="xs">
+        <Group gap="xs">
+            <Text size="xs" fw={600} tt="uppercase" c="dimmed">
+                Your favorites
+            </Text>
+            <Badge variant="default" size="xs" tt="none">
+                Only you see this
+            </Badge>
+        </Group>
+        <FavoritePills projectUuid={projectUuid} isInteractive />
+    </Stack>
+);
+
 export const FavoritesBlockView: FC<BlockComponentProps> = ({
     block,
     projectUuid,

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
@@ -5,7 +5,7 @@ import {
     type HomepageAssignment,
     type HomepageAudience,
     type ProjectHomepage,
-    type PublishedProjectHomepage,
+    type ResolvedHomepage,
     type UpdateProjectHomepageDraftRequest,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -15,10 +15,34 @@ import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeature
 
 const PROJECT_HOMEPAGE_QUERY_KEY = 'project_homepage';
 
-const getPublishedHomepage = async (projectUuid: string) =>
-    lightdashApi<PublishedProjectHomepage | null>({
+const getResolvedHomepage = async (projectUuid: string) =>
+    lightdashApi<ResolvedHomepage | null>({
         url: `/projects/${projectUuid}/homepage`,
         method: 'GET',
+        body: undefined,
+    });
+
+const getPersonalHomepageApi = async (projectUuid: string) =>
+    lightdashApi<string | null>({
+        url: `/projects/${projectUuid}/homepage/personal-override`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const setPersonalHomepageApi = async (
+    projectUuid: string,
+    dashboardUuid: string,
+) =>
+    lightdashApi<undefined>({
+        url: `/projects/${projectUuid}/homepage/personal-override`,
+        method: 'PATCH',
+        body: JSON.stringify({ dashboardUuid }),
+    });
+
+const clearPersonalHomepageApi = async (projectUuid: string) =>
+    lightdashApi<undefined>({
+        url: `/projects/${projectUuid}/homepage/personal-override`,
+        method: 'DELETE',
         body: undefined,
     });
 
@@ -73,11 +97,12 @@ const publishHomepageApi = async (
     projectUuid: string,
     homepageUuid: string,
     audience: HomepageAudience,
+    allowPersonal: boolean,
 ) =>
     lightdashApi<ProjectHomepage>({
         url: `/projects/${projectUuid}/homepage/${homepageUuid}/publish`,
         method: 'POST',
-        body: JSON.stringify({ audience }),
+        body: JSON.stringify({ audience, allowPersonal }),
     });
 
 const getAssignmentsApi = async (projectUuid: string) =>
@@ -104,15 +129,75 @@ export const useHomepageBuilderFlag = () => {
     return { isEnabled: !!flag?.enabled, isLoading };
 };
 
-export const usePublishedHomepage = (
+export const useResolvedHomepage = (
     projectUuid: string | undefined,
     { enabled = true }: { enabled?: boolean } = {},
 ) =>
-    useQuery<PublishedProjectHomepage | null, ApiError>({
+    useQuery<ResolvedHomepage | null, ApiError>({
         enabled: !!projectUuid && enabled,
-        queryKey: [PROJECT_HOMEPAGE_QUERY_KEY, projectUuid, 'published'],
-        queryFn: () => getPublishedHomepage(projectUuid!),
+        queryKey: [PROJECT_HOMEPAGE_QUERY_KEY, projectUuid, 'resolved'],
+        queryFn: () => getResolvedHomepage(projectUuid!),
     });
+
+export const usePersonalHomepage = (
+    projectUuid: string | undefined,
+    { enabled = true }: { enabled?: boolean } = {},
+) =>
+    useQuery<string | null, ApiError>({
+        enabled: !!projectUuid && enabled,
+        queryKey: [PROJECT_HOMEPAGE_QUERY_KEY, projectUuid, 'personal'],
+        queryFn: () => getPersonalHomepageApi(projectUuid!),
+    });
+
+export const useSetPersonalHomepage = (projectUuid: string) => {
+    const { showToastSuccess, showToastApiError } = useToaster();
+    const queryClient = useQueryClient();
+    return useMutation<undefined, ApiError, string>(
+        (dashboardUuid) => setPersonalHomepageApi(projectUuid, dashboardUuid),
+        {
+            mutationKey: ['set_personal_homepage'],
+            onSuccess: async () => {
+                await queryClient.invalidateQueries([
+                    PROJECT_HOMEPAGE_QUERY_KEY,
+                    projectUuid,
+                ]);
+                showToastSuccess({
+                    title: 'This dashboard is now your homepage',
+                });
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to set your homepage',
+                    apiError: error,
+                });
+            },
+        },
+    );
+};
+
+export const useClearPersonalHomepage = (projectUuid: string) => {
+    const { showToastSuccess, showToastApiError } = useToaster();
+    const queryClient = useQueryClient();
+    return useMutation<undefined, ApiError, void>(
+        () => clearPersonalHomepageApi(projectUuid),
+        {
+            mutationKey: ['clear_personal_homepage'],
+            onSuccess: async () => {
+                await queryClient.invalidateQueries([
+                    PROJECT_HOMEPAGE_QUERY_KEY,
+                    projectUuid,
+                ]);
+                showToastSuccess({ title: 'Homepage reset to default' });
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to reset your homepage',
+                    apiError: error,
+                });
+            },
+        },
+    );
+};
 
 export const useHomepageForBuilder = (
     projectUuid: string | undefined,
@@ -257,8 +342,18 @@ export const usePublishHomepage = (
 ) => {
     const { showToastSuccess, showToastApiError } = useToaster();
     const queryClient = useQueryClient();
-    return useMutation<ProjectHomepage, ApiError, HomepageAudience>(
-        (audience) => publishHomepageApi(projectUuid, homepageUuid!, audience),
+    return useMutation<
+        ProjectHomepage,
+        ApiError,
+        { audience: HomepageAudience; allowPersonal: boolean }
+    >(
+        ({ audience, allowPersonal }) =>
+            publishHomepageApi(
+                projectUuid,
+                homepageUuid!,
+                audience,
+                allowPersonal,
+            ),
         {
             mutationKey: ['publish_project_homepage'],
             onSuccess: async () => {

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import { DbtProjectType, ProjectType } from '@lightdash/common';
 import { Button, Group, Stack } from '@mantine-8/core';
 import { IconEdit } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { Navigate, useNavigate, useParams } from 'react-router';
 import { useUnmount } from 'react-use';
 import ErrorState from '../components/common/ErrorState';
 import MantineIcon from '../components/common/MantineIcon';
@@ -16,10 +16,11 @@ import PageSpinner from '../components/PageSpinner';
 import PinnedAndFavoritesSection from '../components/PinnedAndFavoritesSection';
 import AiSearchBox from '../ee/components/Home/AiSearchBox';
 import { useAiAgentButtonVisibility } from '../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
+import { PersonalFavoritesStrip } from '../ee/features/homepageBuilder/blocks/FavoritesBlock';
 import { DayOneHomepage } from '../ee/features/homepageBuilder/DayOneHomepage';
 import {
     useHomepageBuilderFlag,
-    usePublishedHomepage,
+    useResolvedHomepage,
 } from '../ee/features/homepageBuilder/hooks/useProjectHomepage';
 import { PublishedHomepage } from '../ee/features/homepageBuilder/PublishedHomepage';
 import { ManagedAgentHomeCard } from '../ee/features/managedAgent/ManagedAgentHomeCard';
@@ -54,7 +55,7 @@ const Home: FC = () => {
     const { user } = useApp();
     const isAiAgentsEnabled = useAiAgentButtonVisibility();
     const { isEnabled: isHomepageBuilderEnabled } = useHomepageBuilderFlag();
-    const publishedHomepage = usePublishedHomepage(selectedProjectUuid, {
+    const resolvedHomepage = useResolvedHomepage(selectedProjectUuid, {
         enabled: isHomepageBuilderEnabled,
     });
 
@@ -89,7 +90,26 @@ const Home: FC = () => {
         project.data.type !== ProjectType.PREVIEW &&
         project.data.dbtConnection.type === DbtProjectType.GITHUB;
 
-    if (isHomepageBuilderEnabled && publishedHomepage.data) {
+    if (
+        isHomepageBuilderEnabled &&
+        resolvedHomepage.data?.type === 'dashboard'
+    ) {
+        return (
+            <Navigate
+                to={`/projects/${project.data.projectUuid}/dashboards/${resolvedHomepage.data.dashboardUuid}/view`}
+                replace
+            />
+        );
+    }
+
+    if (
+        isHomepageBuilderEnabled &&
+        resolvedHomepage.data?.type === 'homepage'
+    ) {
+        const { homepage } = resolvedHomepage.data;
+        const hasFavoritesBlock = homepage.config.rows.some((row) =>
+            row.blocks.some((block) => block.type === 'favorites'),
+        );
         return (
             <Page withFixedContent withPaddedContent withFooter>
                 <Stack gap="md">
@@ -116,9 +136,14 @@ const Home: FC = () => {
                         </Group>
                     </Can>
                     <PublishedHomepage
-                        config={publishedHomepage.data.config}
+                        config={homepage.config}
                         projectUuid={project.data.projectUuid}
                     />
+                    {homepage.allowPersonal && !hasFavoritesBlock && (
+                        <PersonalFavoritesStrip
+                            projectUuid={project.data.projectUuid}
+                        />
+                    )}
                 </Stack>
             </Page>
         );
@@ -126,7 +151,7 @@ const Home: FC = () => {
 
     if (
         isHomepageBuilderEnabled &&
-        publishedHomepage.data === null &&
+        resolvedHomepage.data === null &&
         onboarding.data.ranQuery
     ) {
         return (


### PR DESCRIPTION
Part of the Homepage Builder stack (ZAP-609). Closes ZAP-628.

Adds the **personal layer** on top of audience resolution: any viewer can pick a dashboard as their own homepage, and admins can veto that per published homepage.

## What's here

**Backend (EE)**
- New EE migration: `homepage_personal_overrides` table (PK `user_uuid + project_uuid`, FK cascades) and `homepages.allow_personal boolean NOT NULL DEFAULT true`.
- `GET /homepage` now returns a `ResolvedHomepage` union: `{type:'dashboard', dashboardUuid}` when a personal override wins, `{type:'homepage', homepage}` for the audience homepage, `null` otherwise. Resolution order is **personal → group priority → role → org default**, with the personal step skipped when the resolved audience homepage has `allowPersonal: false`.
- New endpoints on `/homepage/personal-override`: GET (current override or null), PATCH `{dashboardUuid}` (validates the dashboard exists in the project and isn't soft-deleted; 404 otherwise), DELETE. All view-gated — any project viewer can manage their own override.
- `POST /{homepageUuid}/publish` now takes `allowPersonal` alongside `audience`.
- `getPersonalOverride` joins `dashboards` with `deleted_at IS NULL`, so an override pointing at a since-deleted dashboard silently falls back to audience resolution instead of redirecting users to a dead dashboard.

**Frontend (EE)**
- `/home` handles the union: `type:'dashboard'` → `<Navigate replace>` to that dashboard; `type:'homepage'` → curated render, plus a personal "Your favorites" strip when `allowPersonal` is on and the config doesn't already contain a favorites block.
- Dashboard header ··· menu gets "Make this my homepage" / "Remove as my homepage" (flag-gated, hidden when the published homepage disallows personal picks).
- Publish modal gains a "Let people set a dashboard as their own homepage" switch (defaults to the homepage's current setting).

## Verification
- 16/16 unit tests pass (model + service), backend & frontend typecheck clean.
- Live curl cycle: GET null → PATCH set → GET resolved returns `{type:'dashboard',...}` → DELETE → resolved null again.
- Probe: PATCH with a dashboard uuid not in the project → 404 `Dashboard not found in this project`, no row written.

## Who's affected
- Flag-off (default): no behavior change — all routes/UI are gated on `CommercialFeatureFlags.HomepageBuilder`.
- Flag-on: viewers gain a self-serve homepage pick; existing published homepages default to `allow_personal = true` (migration default), so admins keep current behavior until they republish with the toggle off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ