### PR TITLE
fix(ai-agents): clarify agent access hints for custom roles

### DIFF
--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -1160,7 +1160,8 @@ const scopes: Scope[] = [
     },
     {
         name: 'manage:AiAgent',
-        description: 'Create and manage AI agents in a project',
+        description:
+            'Create and manage all AI agents in a project, including agents restricted to specific users or groups',
         isEnterprise: true,
         group: ScopeGroup.AI,
         dependencies: [{ name: 'view:Project' }],

--- a/packages/frontend/src/ee/components/UserAccessMultiSelect.tsx
+++ b/packages/frontend/src/ee/components/UserAccessMultiSelect.tsx
@@ -206,7 +206,7 @@ export const UserAccessMultiSelect: FC<UserAccessMultiSelectProps> = ({
                         User Access
                     </Text>
                     <Tooltip
-                        label="Admins and developers will always have access."
+                        label="Admins and developers (Manage AI Agents scope) will always have access."
                         withArrow
                         withinPortal
                         multiline

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -533,7 +533,7 @@ export const AiAgentFormSetup = ({
                                     <Radio
                                         value="specific"
                                         label={`Specific users ${isGroupsEnabled ? ' & groups' : ''}`}
-                                        description={`Only the users${isGroupsEnabled ? ' and groups ' : ' '}you choose. Admins and developers always have access.`}
+                                        description={`Only the users${isGroupsEnabled ? ' and groups ' : ' '}you choose. Admins and developers (Manage AI Agents scope) always have access.`}
                                     />
                                 </Stack>
                             </Radio.Group>
@@ -561,7 +561,7 @@ export const AiAgentFormSetup = ({
                                                         Group Access
                                                     </Text>
                                                     <Tooltip
-                                                        label="Admins and developers will always have access to this agent."
+                                                        label="Admins and developers (Manage AI Agents scope) will always have access to this agent."
                                                         withArrow
                                                         withinPortal
                                                         multiline


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8892/custom-roles-with-manage-ai-agent-bypass-agent-specific-users-and

### Description:
The agent access-control hints said "Admins and developers always have access", which is misleading for custom roles — access is actually granted by the Manage AI Agents scope, so any custom role with that scope bypasses the per-agent user/group restrictions.

Name the responsible scope alongside the admins/developers shorthand in the three hint strings, and expand the manage:AiAgent scope description so role authors see that it grants access to all agents, including those restricted to specific users or groups.
