### PR TITLE
feat(homepage): admin view-as — preview any audience through the real resolver

### DIFF
--- a/packages/backend/src/ee/controllers/projectHomepageController.ts
+++ b/packages/backend/src/ee/controllers/projectHomepageController.ts
@@ -1,7 +1,9 @@
 import {
     assertRegisteredAccount,
+    ParameterError,
     type ApiErrorPayload,
     type ApiHomepageAssignmentsResponse,
+    type ApiHomepageViewAsResponse,
     type ApiProjectHomepageOrNullResponse,
     type ApiProjectHomepageResponse,
     type ApiProjectHomepagesResponse,
@@ -10,6 +12,8 @@ import {
     type ApiSuccess,
     type ApiSuccessEmpty,
     type CreateProjectHomepageRequest,
+    type HomepageViewAsTarget,
+    type ProjectMemberRole,
     type PublishProjectHomepageRequest,
     type SetPersonalHomepageRequest,
     type UpdateHomepageGroupPrioritiesRequest,
@@ -130,6 +134,42 @@ export class ProjectHomepageController extends BaseController {
         );
         this.setStatus(200);
         return { status: 'ok', results: undefined };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/view-as')
+    @OperationId('viewHomepageAs')
+    async viewAs(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Query() targetType: 'user' | 'group' | 'role',
+        @Query() userUuid?: UUID,
+        @Query() groupUuid?: UUID,
+        @Query() role?: ProjectMemberRole,
+    ): Promise<ApiHomepageViewAsResponse> {
+        assertRegisteredAccount(req.account);
+        let target: HomepageViewAsTarget;
+        if (targetType === 'user' && userUuid) {
+            target = { type: 'user', userUuid };
+        } else if (targetType === 'group' && groupUuid) {
+            target = { type: 'group', groupUuid };
+        } else if (targetType === 'role' && role) {
+            target = { type: 'role', role };
+        } else {
+            throw new ParameterError(
+                'View-as target requires a matching userUuid, groupUuid or role',
+            );
+        }
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().viewAsHomepage(
+                toSessionUser(req.account),
+                projectUuid,
+                target,
+            ),
+        };
     }
 
     // Literal route must be declared before '/{homepageUuid}' param routes

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -8,6 +8,7 @@ import {
     type ProjectHomepage,
     type ProjectMemberRole,
     type PublishedProjectHomepage,
+    type ResolvedPublishedHomepage,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
 import {
@@ -409,7 +410,7 @@ export class ProjectHomepageModel {
     async resolvePublished(
         projectUuid: string,
         viewer: { groupUuids: string[]; role: ProjectMemberRole | undefined },
-    ): Promise<PublishedProjectHomepage | undefined> {
+    ): Promise<ResolvedPublishedHomepage | undefined> {
         const publishedAssigned = async (
             builderFilter: (builder: Knex.QueryBuilder) => void,
         ) => {
@@ -425,7 +426,11 @@ export class ProjectHomepageModel {
                 )
                 .whereNotNull(`${HomepagesTableName}.published_config`)
                 .orderBy(`${HomepageAssignmentsTableName}.priority`, 'asc')
-                .select(`${HomepagesTableName}.*`)
+                .select(
+                    `${HomepagesTableName}.*`,
+                    `${HomepageAssignmentsTableName}.group_uuid as assignment_group_uuid`,
+                    `${HomepageAssignmentsTableName}.priority as assignment_priority`,
+                )
                 .first();
             builderFilter(query);
             return query;
@@ -439,10 +444,17 @@ export class ProjectHomepageModel {
             });
             if (byGroup && byGroup.published_config) {
                 return {
-                    homepageUuid: byGroup.homepage_uuid,
-                    name: byGroup.name,
-                    config: byGroup.published_config,
-                    allowPersonal: byGroup.allow_personal,
+                    homepage: {
+                        homepageUuid: byGroup.homepage_uuid,
+                        name: byGroup.name,
+                        config: byGroup.published_config,
+                        allowPersonal: byGroup.allow_personal,
+                    },
+                    source: {
+                        type: 'group',
+                        groupUuid: byGroup.assignment_group_uuid,
+                        priority: byGroup.assignment_priority,
+                    },
                 };
             }
         }
@@ -454,13 +466,19 @@ export class ProjectHomepageModel {
             });
             if (byRole && byRole.published_config) {
                 return {
-                    homepageUuid: byRole.homepage_uuid,
-                    name: byRole.name,
-                    config: byRole.published_config,
-                    allowPersonal: byRole.allow_personal,
+                    homepage: {
+                        homepageUuid: byRole.homepage_uuid,
+                        name: byRole.name,
+                        config: byRole.published_config,
+                        allowPersonal: byRole.allow_personal,
+                    },
+                    source: { type: 'role', role: viewer.role },
                 };
             }
         }
-        return this.getPublishedDefault(projectUuid);
+        const publishedDefault = await this.getPublishedDefault(projectUuid);
+        return publishedDefault
+            ? { homepage: publishedDefault, source: { type: 'default' } }
+            : undefined;
     }
 }

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -4,6 +4,7 @@ import {
     NotFoundError,
     OrganizationMemberRole,
     ParameterError,
+    ProjectMemberRole,
     type HomepageConfig,
     type PossibleAbilities,
     type ProjectHomepage,
@@ -295,10 +296,13 @@ describe('ProjectHomepageService', () => {
 
     it('getPublishedHomepage resolves with the viewer’s groups and role', async () => {
         const resolvePublished = vi.fn().mockResolvedValue({
-            homepageUuid: HOMEPAGE_UUID,
-            name: 'Sales homepage',
-            config: validConfig,
-            allowPersonal: true,
+            homepage: {
+                homepageUuid: HOMEPAGE_UUID,
+                name: 'Sales homepage',
+                config: validConfig,
+                allowPersonal: true,
+            },
+            source: { type: 'group', groupUuid: 'group-1', priority: 1 },
         });
         const service = makeService({
             projectHomepageModel: { resolvePublished },
@@ -334,5 +338,71 @@ describe('ProjectHomepageService', () => {
                 homepage: expect.objectContaining({ name: 'Sales homepage' }),
             }),
         );
+    });
+
+    it('viewAsHomepage is forbidden for a viewer', async () => {
+        const service = makeService();
+
+        await expect(
+            service.viewAsHomepage(makeViewerUser(), PROJECT_UUID, {
+                type: 'role',
+                role: ProjectMemberRole.EDITOR,
+            }),
+        ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('viewAsHomepage resolves a role target through the shared resolver with a reason', async () => {
+        const resolvePublished = vi.fn().mockResolvedValue({
+            homepage: {
+                homepageUuid: HOMEPAGE_UUID,
+                name: 'Editors homepage',
+                config: validConfig,
+                allowPersonal: true,
+            },
+            source: { type: 'role', role: 'editor' },
+        });
+        const getPersonalOverride = vi.fn();
+        const service = makeService({
+            projectHomepageModel: { resolvePublished, getPersonalOverride },
+        });
+
+        const result = await service.viewAsHomepage(
+            makeAdminUser(),
+            PROJECT_UUID,
+            { type: 'role', role: ProjectMemberRole.EDITOR },
+        );
+
+        expect(resolvePublished).toHaveBeenCalledWith(PROJECT_UUID, {
+            groupUuids: [],
+            role: 'editor',
+        });
+        // group/role targets never consult the target's personal override
+        expect(getPersonalOverride).not.toHaveBeenCalled();
+        expect(result.reason).toEqual({ type: 'role', role: 'editor' });
+        expect(result.resolved).toEqual(
+            expect.objectContaining({ type: 'homepage' }),
+        );
+    });
+
+    it("viewAsHomepage for a user target applies the target's personal override", async () => {
+        const service = makeService({
+            projectHomepageModel: {
+                getPersonalOverride: vi
+                    .fn()
+                    .mockResolvedValue('dashboard-uuid-1'),
+                resolvePublished: vi.fn().mockResolvedValue(undefined),
+            },
+        });
+
+        const result = await service.viewAsHomepage(
+            makeAdminUser(),
+            PROJECT_UUID,
+            { type: 'user', userUuid: USER_UUID },
+        );
+
+        expect(result).toEqual({
+            resolved: { type: 'dashboard', dashboardUuid: 'dashboard-uuid-1' },
+            reason: { type: 'personal', dashboardUuid: 'dashboard-uuid-1' },
+        });
     });
 });

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    assertUnreachable,
     CommercialFeatureFlags,
     defaultHomepageConfig,
     ForbiddenError,
@@ -11,8 +12,10 @@ import {
     type HomepageAudience,
     type HomepageConfig,
     type HomepageRecentlyViewedItem,
+    type HomepageViewAsResult,
+    type HomepageViewAsTarget,
     type ProjectHomepage,
-    type PublishedProjectHomepage,
+    type ProjectMemberRole,
     type ResolvedHomepage,
     type SessionUser,
     type UpdateProjectHomepageDraftRequest,
@@ -139,43 +142,118 @@ export class ProjectHomepageService extends BaseService {
     }
 
     // Resolution: personal → group priority → role → project default
+    private async resolveForViewer(
+        projectUuid: string,
+        viewer: {
+            groupUuids: string[];
+            role: ProjectMemberRole | undefined;
+            personalOverride: string | undefined;
+        },
+    ): Promise<HomepageViewAsResult> {
+        const published = await this.projectHomepageModel.resolvePublished(
+            projectUuid,
+            { groupUuids: viewer.groupUuids, role: viewer.role },
+        );
+        // Personal choice wins unless the audience homepage disallows it
+        if (
+            viewer.personalOverride &&
+            (published?.homepage.allowPersonal ?? true)
+        ) {
+            return {
+                resolved: {
+                    type: 'dashboard',
+                    dashboardUuid: viewer.personalOverride,
+                },
+                reason: {
+                    type: 'personal',
+                    dashboardUuid: viewer.personalOverride,
+                },
+            };
+        }
+        if (published) {
+            return {
+                resolved: { type: 'homepage', homepage: published.homepage },
+                reason: published.source,
+            };
+        }
+        return { resolved: null, reason: null };
+    }
+
+    private async getViewerContext(
+        organizationUuid: string | undefined,
+        projectUuid: string,
+        userUuid: string,
+    ): Promise<{
+        groupUuids: string[];
+        role: ProjectMemberRole | undefined;
+        personalOverride: string | undefined;
+    }> {
+        const [override, groups, membership] = await Promise.all([
+            this.projectHomepageModel.getPersonalOverride(
+                userUuid,
+                projectUuid,
+            ),
+            organizationUuid
+                ? this.groupsModel.findUserGroups({
+                      userUuid,
+                      organizationUuid,
+                  })
+                : Promise.resolve([]),
+            this.projectModel.getProjectMemberAccess(projectUuid, userUuid),
+        ]);
+        return {
+            groupUuids: groups.map((group) => group.uuid),
+            role: membership?.role,
+            personalOverride: override,
+        };
+    }
+
     async getResolvedHomepage(
         user: SessionUser,
         projectUuid: string,
     ): Promise<ResolvedHomepage | null> {
         await this.assertFlagEnabled(user);
         this.assertCanView(user, projectUuid);
-        const [override, groups, membership] = await Promise.all([
-            this.projectHomepageModel.getPersonalOverride(
-                user.userUuid,
-                projectUuid,
-            ),
-            user.organizationUuid
-                ? this.groupsModel.findUserGroups({
-                      userUuid: user.userUuid,
-                      organizationUuid: user.organizationUuid,
-                  })
-                : Promise.resolve([]),
-            this.projectModel.getProjectMemberAccess(
-                projectUuid,
-                user.userUuid,
-            ),
-        ]);
-        const published = await this.projectHomepageModel.resolvePublished(
+        const viewer = await this.getViewerContext(
+            user.organizationUuid,
             projectUuid,
-            {
-                groupUuids: groups.map((group) => group.uuid),
-                role: membership?.role,
-            },
+            user.userUuid,
         );
-        // Personal choice wins unless the audience homepage disallows it
-        if (override && (published?.allowPersonal ?? true)) {
-            return { type: 'dashboard', dashboardUuid: override };
+        const { resolved } = await this.resolveForViewer(projectUuid, viewer);
+        return resolved;
+    }
+
+    async viewAsHomepage(
+        user: SessionUser,
+        projectUuid: string,
+        target: HomepageViewAsTarget,
+    ): Promise<HomepageViewAsResult> {
+        await this.assertFlagEnabled(user);
+        this.assertCanManage(user, projectUuid);
+        switch (target.type) {
+            case 'user': {
+                const viewer = await this.getViewerContext(
+                    user.organizationUuid,
+                    projectUuid,
+                    target.userUuid,
+                );
+                return this.resolveForViewer(projectUuid, viewer);
+            }
+            case 'group':
+                return this.resolveForViewer(projectUuid, {
+                    groupUuids: [target.groupUuid],
+                    role: undefined,
+                    personalOverride: undefined,
+                });
+            case 'role':
+                return this.resolveForViewer(projectUuid, {
+                    groupUuids: [],
+                    role: target.role,
+                    personalOverride: undefined,
+                });
+            default:
+                return assertUnreachable(target, 'Unknown view-as target type');
         }
-        if (published) {
-            return { type: 'homepage', homepage: published };
-        }
-        return null;
     }
 
     async setPersonalHomepage(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -71,8 +71,6 @@ import { ProjectDbtSourcesController } from './../controllers/projectDbtSourcesC
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ProjectRolesController } from './../controllers/ProjectRolesController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { PromptController } from './../controllers/promptController';
-// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { PullRequestsController } from './../controllers/pullRequestsController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { RenameController } from './../controllers/renameController';
@@ -131,8 +129,6 @@ import { ValidationControllerV2 } from './../controllers/v2/ValidationController
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ValidationController } from './../controllers/validationController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { WarehouseConnectController } from './../controllers/warehouseConnectController';
-// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AiAgentAdminController } from './../ee/controllers/AiAgentAdminController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AiAgentController } from './../ee/controllers/aiAgentController';
@@ -165,11 +161,7 @@ import { ManagedAgentController } from './../ee/controllers/managedAgentControll
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { OrganizationDomainVerificationController } from './../ee/controllers/OrganizationDomainVerificationController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { OrganizationGroupsAsCodeController } from './../ee/controllers/OrganizationGroupsAsCodeController';
-// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { OrganizationSsoController } from './../ee/controllers/OrganizationSsoController';
-// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { OrganizationUsersAsCodeController } from './../ee/controllers/OrganizationUsersAsCodeController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { OrganizationWarehouseCredentialsController } from './../ee/controllers/OrganizationWarehouseCredentialsController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -1974,6 +1966,114 @@ const models: TsoaRoute.Models = {
             },
             validators: {},
         },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageResolutionSource: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        priority: { dataType: 'double', required: true },
+                        groupUuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['group'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        role: { ref: 'ProjectMemberRole', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['role'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        type: {
+                            dataType: 'enum',
+                            enums: ['default'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageViewAsReason: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        dashboardUuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['personal'],
+                            required: true,
+                        },
+                    },
+                },
+                { ref: 'HomepageResolutionSource' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageViewAsResult: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                reason: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'HomepageViewAsReason' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                resolved: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'ResolvedHomepage' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_HomepageViewAsResult_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'HomepageViewAsResult', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiHomepageViewAsResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_HomepageViewAsResult_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ProjectHomepage: {
@@ -11638,10 +11738,7 @@ const models: TsoaRoute.Models = {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                pagePerTab: { dataType: 'boolean' },
-                withPdf: { dataType: 'boolean' },
-            },
+            nestedProperties: { withPdf: { dataType: 'boolean' } },
             validators: {},
         },
     },
@@ -11661,13 +11758,18 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    SchedulerPdfOptions: {
+    'Record_string.never_': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
-            nestedProperties: { pagePerTab: { dataType: 'boolean' } },
+            nestedProperties: {},
             validators: {},
         },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerPdfOptions: {
+        dataType: 'refAlias',
+        type: { ref: 'Record_string.never_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SchedulerOptions: {
@@ -12904,71 +13006,6 @@ const models: TsoaRoute.Models = {
                     array: {
                         dataType: 'refAlias',
                         ref: 'TableCalculationFieldContext',
-                    },
-                    required: true,
-                },
-                tableName: { dataType: 'string', required: true },
-                prompt: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    GeneratedCustomDimension: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                dimensionType: { ref: 'DimensionType', required: true },
-                displayName: { dataType: 'string', required: true },
-                sql: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiAiGenerateCustomDimensionResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'GeneratedCustomDimension', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    CustomDimensionFieldContext: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                {
-                    ref: 'Pick_Field.name-or-label-or-description-or-type-or-table_',
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        id: { dataType: 'string', required: true },
-                    },
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    GenerateCustomDimensionRequest: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                currentSql: { dataType: 'string' },
-                fieldsContext: {
-                    dataType: 'array',
-                    array: {
-                        dataType: 'refAlias',
-                        ref: 'CustomDimensionFieldContext',
                     },
                     required: true,
                 },
@@ -16225,11 +16262,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16244,11 +16281,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16263,11 +16300,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16373,17 +16410,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -16421,6 +16458,33 @@ const models: TsoaRoute.Models = {
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                joinedTables:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -16512,33 +16576,6 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 label: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -16605,24 +16642,14 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                status: {
+                                                                                error: {
                                                                                     dataType:
                                                                                         'union',
                                                                                     subSchemas:
                                                                                         [
                                                                                             {
                                                                                                 dataType:
-                                                                                                    'enum',
-                                                                                                enums: [
-                                                                                                    'error',
-                                                                                                ],
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'enum',
-                                                                                                enums: [
-                                                                                                    'success',
-                                                                                                ],
+                                                                                                    'string',
                                                                                             },
                                                                                             {
                                                                                                 dataType:
@@ -16672,14 +16699,24 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                error: {
+                                                                                status: {
                                                                                     dataType:
                                                                                         'union',
                                                                                     subSchemas:
                                                                                         [
                                                                                             {
                                                                                                 dataType:
-                                                                                                    'string',
+                                                                                                    'enum',
+                                                                                                enums: [
+                                                                                                    'error',
+                                                                                                ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'enum',
+                                                                                                enums: [
+                                                                                                    'success',
+                                                                                                ],
                                                                                             },
                                                                                             {
                                                                                                 dataType:
@@ -16771,17 +16808,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -16832,11 +16869,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16851,11 +16888,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16898,11 +16935,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -16941,6 +16978,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -16985,13 +17041,13 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldValueType:
+                                                                                fieldFilterType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                fieldFilterType:
+                                                                                fieldValueType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
@@ -17020,17 +17076,6 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -17056,32 +17101,24 @@ const models: TsoaRoute.Models = {
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
                                                                                 name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                table: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
                                                                             },
                                                                     },
-                                                                    required: true,
-                                                                },
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 explore: {
@@ -17223,17 +17260,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -17351,8 +17388,11 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                slug: {
-                                                    dataType: 'string',
+                                                warnings: {
+                                                    dataType: 'array',
+                                                    array: {
+                                                        dataType: 'string',
+                                                    },
                                                     required: true,
                                                 },
                                                 status: {
@@ -17360,15 +17400,12 @@ const models: TsoaRoute.Models = {
                                                     enums: ['success'],
                                                     required: true,
                                                 },
-                                                uuid: {
+                                                slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                warnings: {
-                                                    dataType: 'array',
-                                                    array: {
-                                                        dataType: 'string',
-                                                    },
+                                                uuid: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
@@ -17404,25 +17441,6 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
                                                         {
@@ -17442,11 +17460,30 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -17814,11 +17851,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -17842,13 +17879,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                slug: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                slug: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
@@ -17898,11 +17935,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -17965,25 +18002,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -18044,17 +18062,17 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 tableName:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -18062,6 +18080,25 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
+                                                                    required: true,
+                                                                },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 type: {
@@ -18125,11 +18162,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -20720,14 +20757,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SnowflakeAuthenticationType: {
         dataType: 'refEnum',
-        enums: [
-            'password',
-            'private_key',
-            'sso',
-            'external_browser',
-            'oauth_authorization_code',
-            'none',
-        ],
+        enums: ['password', 'private_key', 'sso', 'external_browser', 'none'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     WeekDay: {
@@ -22926,139 +22956,6 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UserAsCodeRole: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        name: { ref: 'OrganizationMemberRole', required: true },
-                        type: {
-                            dataType: 'enum',
-                            enums: ['system'],
-                            required: true,
-                        },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        name: { dataType: 'string', required: true },
-                        type: {
-                            dataType: 'enum',
-                            enums: ['custom'],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UserAsCode: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                role: { ref: 'UserAsCodeRole', required: true },
-                disabled: { dataType: 'boolean', required: true },
-                email: { dataType: 'string', required: true },
-                version: { dataType: 'enum', enums: [1], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiUserAsCodeListResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        users: {
-                            dataType: 'array',
-                            array: { dataType: 'refAlias', ref: 'UserAsCode' },
-                            required: true,
-                        },
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PromotionAction.CREATE': {
-        dataType: 'refEnum',
-        enums: ['create'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PromotionAction.UPDATE': {
-        dataType: 'refEnum',
-        enums: ['update'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PromotionAction.NO_CHANGES': {
-        dataType: 'refEnum',
-        enums: ['no changes'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UserAsCodeLifecycleStatus: {
-        dataType: 'refEnum',
-        enums: ['ready', 'awaiting authentication'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    UserAsCodeInvitationStatus: {
-        dataType: 'refEnum',
-        enums: [
-            'not requested',
-            'sent',
-            'skipped authenticated',
-            'skipped disabled',
-            'skipped valid invite',
-        ],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiUserAsCodeUpsertResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        invitation: {
-                            ref: 'UserAsCodeInvitationStatus',
-                            required: true,
-                        },
-                        lifecycle: {
-                            ref: 'UserAsCodeLifecycleStatus',
-                            required: true,
-                        },
-                        action: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { ref: 'PromotionAction.CREATE' },
-                                { ref: 'PromotionAction.UPDATE' },
-                                { ref: 'PromotionAction.NO_CHANGES' },
-                            ],
-                            required: true,
-                        },
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_AzureAdSsoConfig.oauth2ClientId-or-oauth2TenantId_': {
         dataType: 'refAlias',
         type: {
@@ -23551,71 +23448,6 @@ const models: TsoaRoute.Models = {
         type: { ref: 'Partial_OrganizationSsoMethodFlags_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    GroupAsCode: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                members: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
-                name: { dataType: 'string', required: true },
-                version: { dataType: 'enum', enums: [1], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiGroupAsCodeListResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        groups: {
-                            dataType: 'array',
-                            array: { dataType: 'refAlias', ref: 'GroupAsCode' },
-                            required: true,
-                        },
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiGroupAsCodeUpsertResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        action: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { ref: 'PromotionAction.CREATE' },
-                                { ref: 'PromotionAction.UPDATE' },
-                                { ref: 'PromotionAction.NO_CHANGES' },
-                            ],
-                            required: true,
-                        },
-                    },
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     VerifiedDomain: {
         dataType: 'refAlias',
         type: {
@@ -23906,6 +23738,21 @@ const models: TsoaRoute.Models = {
             },
             validators: {},
         },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'PromotionAction.CREATE': {
+        dataType: 'refEnum',
+        enums: ['create'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'PromotionAction.UPDATE': {
+        dataType: 'refEnum',
+        enums: ['update'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'PromotionAction.NO_CHANGES': {
+        dataType: 'refEnum',
+        enums: ['no changes'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiCustomRoleAsCodeUpsertResponse: {
@@ -24849,15 +24696,6 @@ const models: TsoaRoute.Models = {
                 effort: { ref: 'AiDeepResearchEffort' },
                 prompt: { dataType: 'string', required: true },
             },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Record_string.never_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {},
             validators: {},
         },
     },
@@ -27774,411 +27612,6 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    WarehouseConnectCode: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                expiresAt: { dataType: 'datetime', required: true },
-                code: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiWarehouseConnectCodeResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'WarehouseConnectCode', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiDepositWarehouseConnectionResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { dataType: 'undefined', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.database-or-warehouse-or-schema__':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    type: { ref: 'WarehouseTypes.SNOWFLAKE', required: true },
-                    user: { dataType: 'string', required: true },
-                    password: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    privateKey: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    privateKeyPass: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    token: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    refreshToken: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    account: { dataType: 'string', required: true },
-                    requireUserCredentials: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'boolean' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    authenticationType: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { ref: 'SnowflakeAuthenticationType' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    role: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    threads: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    clientSessionKeepAlive: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'boolean' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    queryTag: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    accessUrl: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    startOfWeek: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { ref: 'WeekDay' },
-                            { dataType: 'enum', enums: [null] },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    dataTimezone: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    quotedIdentifiersIgnoreCase: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'boolean' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    disableTimestampConversion: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'boolean' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    timeoutSeconds: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    override: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'boolean' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    organizationWarehouseCredentialsUuid: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                },
-                validators: {},
-            },
-        },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_CreateSnowflakeCredentials.database-or-warehouse-or-schema_': {
-        dataType: 'refAlias',
-        type: {
-            ref: 'Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.database-or-warehouse-or-schema__',
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Pick_CreateSnowflakeCredentials.database-or-warehouse-or-schema__':
-        {
-            dataType: 'refAlias',
-            type: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    database: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    warehouse: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    schema: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                },
-                validators: {},
-            },
-        },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DepositSnowflakeCredentials: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'intersection',
-            subSchemas: [
-                {
-                    ref: 'Omit_CreateSnowflakeCredentials.database-or-warehouse-or-schema_',
-                },
-                {
-                    ref: 'Partial_Pick_CreateSnowflakeCredentials.database-or-warehouse-or-schema__',
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    WarehouseConnectInventory: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                schemas: {
-                    dataType: 'array',
-                    array: {
-                        dataType: 'nestedObjectLiteral',
-                        nestedProperties: {
-                            name: { dataType: 'string', required: true },
-                            database: { dataType: 'string', required: true },
-                        },
-                    },
-                    required: true,
-                },
-                roles: {
-                    dataType: 'array',
-                    array: {
-                        dataType: 'nestedObjectLiteral',
-                        nestedProperties: {
-                            isDefault: { dataType: 'boolean', required: true },
-                            name: { dataType: 'string', required: true },
-                        },
-                    },
-                    required: true,
-                },
-                warehouses: {
-                    dataType: 'array',
-                    array: {
-                        dataType: 'nestedObjectLiteral',
-                        nestedProperties: {
-                            state: {
-                                dataType: 'union',
-                                subSchemas: [
-                                    { dataType: 'string' },
-                                    { dataType: 'enum', enums: [null] },
-                                ],
-                                required: true,
-                            },
-                            size: {
-                                dataType: 'union',
-                                subSchemas: [
-                                    { dataType: 'string' },
-                                    { dataType: 'enum', enums: [null] },
-                                ],
-                                required: true,
-                            },
-                            name: { dataType: 'string', required: true },
-                        },
-                    },
-                    required: true,
-                },
-                databases: {
-                    dataType: 'array',
-                    array: {
-                        dataType: 'nestedObjectLiteral',
-                        nestedProperties: {
-                            comment: {
-                                dataType: 'union',
-                                subSchemas: [
-                                    { dataType: 'string' },
-                                    { dataType: 'enum', enums: [null] },
-                                ],
-                                required: true,
-                            },
-                            name: { dataType: 'string', required: true },
-                        },
-                    },
-                    required: true,
-                },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DepositWarehouseConnectionRequest: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                inventory: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'WarehouseConnectInventory' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                credentials: {
-                    ref: 'DepositSnowflakeCredentials',
-                    required: true,
-                },
-                code: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    WarehouseConnectCodeClaimResult: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        status: {
-                            dataType: 'enum',
-                            enums: ['pending'],
-                            required: true,
-                        },
-                    },
-                },
-                {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        inventory: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { ref: 'WarehouseConnectInventory' },
-                                { dataType: 'enum', enums: [null] },
-                            ],
-                            required: true,
-                        },
-                        credentials: {
-                            ref: 'DepositSnowflakeCredentials',
-                            required: true,
-                        },
-                        status: {
-                            dataType: 'enum',
-                            enums: ['deposited'],
-                            required: true,
-                        },
-                    },
-                },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiWarehouseConnectCodeClaimResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: {
-                    ref: 'WarehouseConnectCodeClaimResult',
-                    required: true,
-                },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ClaimWarehouseConnectCodeRequest: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: { code: { dataType: 'string', required: true } },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiJobScheduledResponse: {
         dataType: 'refAlias',
         type: {
@@ -28805,15 +28238,6 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    CreateEmailOnlyUserArgs: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: { email: { ref: 'Email', required: true } },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     RegisterOrActivateUser: {
         dataType: 'refAlias',
         type: {
@@ -28821,7 +28245,6 @@ const models: TsoaRoute.Models = {
             subSchemas: [
                 { ref: 'ActivateUserWithInviteCode' },
                 { ref: 'CreateUserArgs' },
-                { ref: 'CreateEmailOnlyUserArgs' },
             ],
             validators: {},
         },
@@ -29525,7 +28948,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     LocalIssuerTypes: {
         dataType: 'refEnum',
-        enums: ['email', 'emailOtp', 'apiToken'],
+        enums: ['email', 'apiToken'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     LoginOptionTypes: {
@@ -29564,50 +28987,6 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 results: { ref: 'LoginOptions', required: true },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiLoginEmailOtpResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiLoginEmailOtpRequest: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: { email: { dataType: 'string', required: true } },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiVerifyLoginEmailOtpResponse: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                results: { ref: 'LightdashUser', required: true },
-                status: { dataType: 'enum', enums: ['ok'], required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiVerifyLoginEmailOtpRequest: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                passcode: { dataType: 'string', required: true },
-                email: { dataType: 'string', required: true },
             },
             validators: {},
         },
@@ -36133,7 +35512,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -36143,7 +35522,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -36153,7 +35532,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -36166,7 +35545,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -36835,7 +36214,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -36845,7 +36224,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -36855,7 +36234,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -36868,7 +36247,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -50033,6 +49412,81 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectHomepageController_viewAs: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        targetType: {
+            in: 'query',
+            name: 'targetType',
+            required: true,
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['user'] },
+                { dataType: 'enum', enums: ['group'] },
+                { dataType: 'enum', enums: ['role'] },
+            ],
+        },
+        userUuid: { in: 'query', name: 'userUuid', ref: 'UUID' },
+        groupUuid: { in: 'query', name: 'groupUuid', ref: 'UUID' },
+        role: { in: 'query', name: 'role', ref: 'ProjectMemberRole' },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/homepage/view-as',
+        ...fetchMiddlewares<RequestHandler>(ProjectHomepageController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectHomepageController.prototype.viewAs,
+        ),
+
+        async function ProjectHomepageController_viewAs(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectHomepageController_viewAs,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectHomepageController>(
+                        ProjectHomepageController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'viewAs',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsProjectHomepageController_getForBuilder: Record<
         string,
         TsoaRoute.ParameterSchema
@@ -55894,71 +55348,6 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsAiController_generateCustomDimension: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        projectUuid: {
-            in: 'path',
-            name: 'projectUuid',
-            required: true,
-            dataType: 'string',
-        },
-        body: {
-            in: 'body',
-            name: 'body',
-            required: true,
-            ref: 'GenerateCustomDimensionRequest',
-        },
-    };
-    app.post(
-        '/api/v1/ai/:projectUuid/custom-dimension/generate',
-        ...fetchMiddlewares<RequestHandler>(AiController),
-        ...fetchMiddlewares<RequestHandler>(
-            AiController.prototype.generateCustomDimension,
-        ),
-
-        async function AiController_generateCustomDimension(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsAiController_generateCustomDimension,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<AiController>(AiController);
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'generateCustomDimension',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsAiController_generateFormulaTableCalculation: Record<
         string,
         TsoaRoute.ParameterSchema
@@ -61803,135 +61192,6 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsOrganizationUsersAsCodeController_getUsersAsCode: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        orgUuid: {
-            in: 'path',
-            name: 'orgUuid',
-            required: true,
-            dataType: 'string',
-        },
-    };
-    app.get(
-        '/api/v2/orgs/:orgUuid/users/code',
-        ...fetchMiddlewares<RequestHandler>(OrganizationUsersAsCodeController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationUsersAsCodeController.prototype.getUsersAsCode,
-        ),
-
-        async function OrganizationUsersAsCodeController_getUsersAsCode(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsOrganizationUsersAsCodeController_getUsersAsCode,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<OrganizationUsersAsCodeController>(
-                        OrganizationUsersAsCodeController,
-                    );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'getUsersAsCode',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsOrganizationUsersAsCodeController_upsertUserAsCode: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        orgUuid: {
-            in: 'path',
-            name: 'orgUuid',
-            required: true,
-            dataType: 'string',
-        },
-        body: { in: 'body', name: 'body', required: true, ref: 'UserAsCode' },
-        sendInvite: {
-            default: false,
-            in: 'query',
-            name: 'sendInvite',
-            dataType: 'boolean',
-        },
-    };
-    app.post(
-        '/api/v2/orgs/:orgUuid/users/code',
-        ...fetchMiddlewares<RequestHandler>(OrganizationUsersAsCodeController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationUsersAsCodeController.prototype.upsertUserAsCode,
-        ),
-
-        async function OrganizationUsersAsCodeController_upsertUserAsCode(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsOrganizationUsersAsCodeController_upsertUserAsCode,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<OrganizationUsersAsCodeController>(
-                        OrganizationUsersAsCodeController,
-                    );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'upsertUserAsCode',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsOrganizationSsoController_getAzureAdConfig: Record<
         string,
         TsoaRoute.ParameterSchema
@@ -62780,129 +62040,6 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: undefined,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsOrganizationGroupsAsCodeController_getGroupsAsCode: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        orgUuid: {
-            in: 'path',
-            name: 'orgUuid',
-            required: true,
-            dataType: 'string',
-        },
-    };
-    app.get(
-        '/api/v2/orgs/:orgUuid/groups/code',
-        ...fetchMiddlewares<RequestHandler>(OrganizationGroupsAsCodeController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationGroupsAsCodeController.prototype.getGroupsAsCode,
-        ),
-
-        async function OrganizationGroupsAsCodeController_getGroupsAsCode(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsOrganizationGroupsAsCodeController_getGroupsAsCode,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<OrganizationGroupsAsCodeController>(
-                        OrganizationGroupsAsCodeController,
-                    );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'getGroupsAsCode',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsOrganizationGroupsAsCodeController_upsertGroupAsCode: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        orgUuid: {
-            in: 'path',
-            name: 'orgUuid',
-            required: true,
-            dataType: 'string',
-        },
-        body: { in: 'body', name: 'body', required: true, ref: 'GroupAsCode' },
-    };
-    app.post(
-        '/api/v2/orgs/:orgUuid/groups/code',
-        ...fetchMiddlewares<RequestHandler>(OrganizationGroupsAsCodeController),
-        ...fetchMiddlewares<RequestHandler>(
-            OrganizationGroupsAsCodeController.prototype.upsertGroupAsCode,
-        ),
-
-        async function OrganizationGroupsAsCodeController_upsertGroupAsCode(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsOrganizationGroupsAsCodeController_upsertGroupAsCode,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<OrganizationGroupsAsCodeController>(
-                        OrganizationGroupsAsCodeController,
-                    );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'upsertGroupAsCode',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
                 });
             } catch (err) {
                 return next(err);
@@ -66242,182 +65379,6 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsWarehouseConnectController_mintCode: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-    };
-    app.post(
-        '/api/v1/warehouse-connect/code',
-        ...fetchMiddlewares<RequestHandler>(WarehouseConnectController),
-        ...fetchMiddlewares<RequestHandler>(
-            WarehouseConnectController.prototype.mintCode,
-        ),
-
-        async function WarehouseConnectController_mintCode(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsWarehouseConnectController_mintCode,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<WarehouseConnectController>(
-                        WarehouseConnectController,
-                    );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'mintCode',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsWarehouseConnectController_deposit: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        body: {
-            in: 'body',
-            name: 'body',
-            required: true,
-            ref: 'DepositWarehouseConnectionRequest',
-        },
-    };
-    app.post(
-        '/api/v1/warehouse-connect/deposit',
-        ...fetchMiddlewares<RequestHandler>(WarehouseConnectController),
-        ...fetchMiddlewares<RequestHandler>(
-            WarehouseConnectController.prototype.deposit,
-        ),
-
-        async function WarehouseConnectController_deposit(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsWarehouseConnectController_deposit,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<WarehouseConnectController>(
-                        WarehouseConnectController,
-                    );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'deposit',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsWarehouseConnectController_claim: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        body: {
-            in: 'body',
-            name: 'body',
-            required: true,
-            ref: 'ClaimWarehouseConnectCodeRequest',
-        },
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-    };
-    app.post(
-        '/api/v1/warehouse-connect/claim',
-        ...fetchMiddlewares<RequestHandler>(WarehouseConnectController),
-        ...fetchMiddlewares<RequestHandler>(
-            WarehouseConnectController.prototype.claim,
-        ),
-
-        async function WarehouseConnectController_claim(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsWarehouseConnectController_claim,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<WarehouseConnectController>(
-                        WarehouseConnectController,
-                    );
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'claim',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsValidationController_post: Record<
         string,
         TsoaRoute.ParameterSchema
@@ -67586,123 +66547,6 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getLoginOptions',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: undefined,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsUserController_requestEmailOtpLogin: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        body: {
-            in: 'body',
-            name: 'body',
-            required: true,
-            ref: 'ApiLoginEmailOtpRequest',
-        },
-    };
-    app.post(
-        '/api/v1/user/login-email-otp',
-        ...fetchMiddlewares<RequestHandler>(UserController),
-        ...fetchMiddlewares<RequestHandler>(
-            UserController.prototype.requestEmailOtpLogin,
-        ),
-
-        async function UserController_requestEmailOtpLogin(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsUserController_requestEmailOtpLogin,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<UserController>(UserController);
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'requestEmailOtpLogin',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: undefined,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsUserController_verifyEmailOtpLogin: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
-        body: {
-            in: 'body',
-            name: 'body',
-            required: true,
-            ref: 'ApiVerifyLoginEmailOtpRequest',
-        },
-    };
-    app.post(
-        '/api/v1/user/login-email-otp/verify',
-        ...fetchMiddlewares<RequestHandler>(UserController),
-        ...fetchMiddlewares<RequestHandler>(
-            UserController.prototype.verifyEmailOtpLogin,
-        ),
-
-        async function UserController_verifyEmailOtpLogin(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsUserController_verifyEmailOtpLogin,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<UserController>(UserController);
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'verifyEmailOtpLogin',
                     controller,
                     response,
                     next,
@@ -74069,59 +72913,6 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'listPullRequests',
-                    controller,
-                    response,
-                    next,
-                    validatedArgs,
-                    successStatus: 200,
-                });
-            } catch (err) {
-                return next(err);
-            }
-        },
-    );
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsPromptController_getPrompt: Record<
-        string,
-        TsoaRoute.ParameterSchema
-    > = {
-        name: { in: 'path', name: 'name', required: true, dataType: 'string' },
-    };
-    app.get(
-        '/api/v1/prompts/:name',
-        ...fetchMiddlewares<RequestHandler>(PromptController),
-        ...fetchMiddlewares<RequestHandler>(
-            PromptController.prototype.getPrompt,
-        ),
-
-        async function PromptController_getPrompt(
-            request: ExRequest,
-            response: ExResponse,
-            next: any,
-        ) {
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({
-                    args: argsPromptController_getPrompt,
-                    request,
-                    response,
-                });
-
-                const container: IocContainer =
-                    typeof iocContainer === 'function'
-                        ? (iocContainer as IocContainerFactory)(request)
-                        : iocContainer;
-
-                const controller: any =
-                    await container.get<PromptController>(PromptController);
-                if (typeof controller['setStatus'] === 'function') {
-                    controller.setStatus(undefined);
-                }
-
-                await templateService.apiHandler({
-                    methodName: 'getPrompt',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1977,6 +1977,113 @@
                 "required": ["dashboardUuid"],
                 "type": "object"
             },
+            "HomepageResolutionSource": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "priority": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "groupUuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["group"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["priority", "groupUuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "role": {
+                                "$ref": "#/components/schemas/ProjectMemberRole"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["role"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["role", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["default"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "HomepageViewAsReason": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "dashboardUuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["personal"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["dashboardUuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "$ref": "#/components/schemas/HomepageResolutionSource"
+                    }
+                ]
+            },
+            "HomepageViewAsResult": {
+                "properties": {
+                    "reason": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/HomepageViewAsReason"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "resolved": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ResolvedHomepage"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "required": ["reason", "resolved"],
+                "type": "object"
+            },
+            "ApiSuccess_HomepageViewAsResult_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/HomepageViewAsResult"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiHomepageViewAsResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_HomepageViewAsResult_"
+            },
             "ProjectHomepage": {
                 "properties": {
                     "updatedAt": {
@@ -13041,9 +13148,6 @@
             },
             "SchedulerImageOptions": {
                 "properties": {
-                    "pagePerTab": {
-                        "type": "boolean"
-                    },
                     "withPdf": {
                         "type": "boolean"
                     }
@@ -13076,13 +13180,13 @@
                 ],
                 "type": "object"
             },
+            "Record_string.never_": {
+                "properties": {},
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
             "SchedulerPdfOptions": {
-                "properties": {
-                    "pagePerTab": {
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
+                "$ref": "#/components/schemas/Record_string.never_"
             },
             "SchedulerOptions": {
                 "anyOf": [
@@ -14499,72 +14603,6 @@
                     "fieldsContext": {
                         "items": {
                             "$ref": "#/components/schemas/TableCalculationFieldContext"
-                        },
-                        "type": "array"
-                    },
-                    "tableName": {
-                        "type": "string"
-                    },
-                    "prompt": {
-                        "type": "string"
-                    }
-                },
-                "required": ["fieldsContext", "tableName", "prompt"],
-                "type": "object"
-            },
-            "GeneratedCustomDimension": {
-                "properties": {
-                    "dimensionType": {
-                        "$ref": "#/components/schemas/DimensionType"
-                    },
-                    "displayName": {
-                        "type": "string"
-                    },
-                    "sql": {
-                        "type": "string"
-                    }
-                },
-                "required": ["dimensionType", "displayName", "sql"],
-                "type": "object"
-            },
-            "ApiAiGenerateCustomDimensionResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/GeneratedCustomDimension"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "CustomDimensionFieldContext": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pick_Field.name-or-label-or-description-or-type-or-table_"
-                    },
-                    {
-                        "properties": {
-                            "id": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["id"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "GenerateCustomDimensionRequest": {
-                "properties": {
-                    "currentSql": {
-                        "type": "string"
-                    },
-                    "fieldsContext": {
-                        "items": {
-                            "$ref": "#/components/schemas/CustomDimensionFieldContext"
                         },
                         "type": "array"
                     },
@@ -17894,19 +17932,6 @@
                                             },
                                             {
                                                 "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
                                                     "ranking": {
                                                         "properties": {
                                                             "topMatchingFields": {
@@ -17930,10 +17955,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -17942,8 +17967,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -17956,6 +17981,13 @@
                                                                         "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "joinedTables": {
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array",
                                                                             "nullable": true
                                                                         },
                                                                         "requiredFilters": {
@@ -17992,13 +18024,6 @@
                                                                                 "type": "object"
                                                                             },
                                                                             "type": "array"
-                                                                        },
-                                                                        "joinedTables": {
-                                                                            "items": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "type": "array",
-                                                                            "nullable": true
                                                                         },
                                                                         "label": {
                                                                             "type": "string"
@@ -18042,12 +18067,8 @@
                                                             "searchQueries": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "status": {
-                                                                            "type": "string",
-                                                                            "enum": [
-                                                                                "error",
-                                                                                "success"
-                                                                            ]
+                                                                        "error": {
+                                                                            "type": "string"
                                                                         },
                                                                         "pagination": {
                                                                             "properties": {
@@ -18076,8 +18097,12 @@
                                                                             ],
                                                                             "type": "object"
                                                                         },
-                                                                        "error": {
-                                                                            "type": "string"
+                                                                        "status": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "error",
+                                                                                "success"
+                                                                            ]
                                                                         },
                                                                         "results": {
                                                                             "items": {
@@ -18100,10 +18125,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -18112,8 +18137,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "tableName",
                                                                                     "label",
+                                                                                    "tableName",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -18187,8 +18212,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
                                                             "error",
+                                                            "success",
                                                             "not_found"
                                                         ]
                                                     }
@@ -18215,6 +18240,10 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
@@ -18229,10 +18258,10 @@
                                                                                         "not_applicable"
                                                                                     ]
                                                                                 },
-                                                                                "fieldValueType": {
+                                                                                "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldFilterType": {
+                                                                                "fieldValueType": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldType": {
@@ -18242,12 +18271,6 @@
                                                                                         "metric"
                                                                                     ]
                                                                                 },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
                                                                                 "description": {
                                                                                     "type": "string",
                                                                                     "nullable": true
@@ -18255,29 +18278,31 @@
                                                                                 "label": {
                                                                                     "type": "string"
                                                                                 },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
                                                                                 "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "table": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
                                                                             "required": [
                                                                                 "isFromJoinedTable",
                                                                                 "caseSensitiveFilters",
-                                                                                "fieldValueType",
                                                                                 "fieldFilterType",
+                                                                                "fieldValueType",
                                                                                 "fieldType",
-                                                                                "fieldId",
-                                                                                "table",
                                                                                 "description",
                                                                                 "label",
-                                                                                "name"
+                                                                                "fieldId",
+                                                                                "name",
+                                                                                "table"
                                                                             ],
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
-                                                                    },
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
                                                                     },
                                                                     "explore": {
                                                                         "properties": {
@@ -18349,8 +18374,8 @@
                                                                     }
                                                                 },
                                                                 "required": [
-                                                                    "fields",
                                                                     "rationale",
+                                                                    "fields",
                                                                     "explore",
                                                                     "status"
                                                                 ],
@@ -18364,10 +18389,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -18375,8 +18400,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "exploreLabel",
                                                                                 "reason",
+                                                                                "exploreLabel",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -18453,22 +18478,22 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "slug": {
-                                                        "type": "string"
+                                                    "warnings": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
                                                     },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
                                                     },
-                                                    "uuid": {
+                                                    "slug": {
                                                         "type": "string"
                                                     },
-                                                    "warnings": {
-                                                        "items": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": "array"
+                                                    "uuid": {
+                                                        "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
@@ -18477,10 +18502,10 @@
                                                 "required": [
                                                     "versionUuids",
                                                     "href",
-                                                    "slug",
-                                                    "status",
-                                                    "uuid",
                                                     "warnings",
+                                                    "status",
+                                                    "slug",
+                                                    "uuid",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -18641,13 +18666,13 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "slug": {
+                                                        "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
@@ -18655,8 +18680,8 @@
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "slug",
                                                     "status",
+                                                    "slug",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -18697,10 +18722,6 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -18717,10 +18738,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -18729,13 +18750,17 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
                                                                 },
                                                                 "type": "array"
+                                                            },
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
                                                             },
                                                             "type": {
                                                                 "type": "string",
@@ -18748,8 +18773,8 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "searchQuery",
                                                             "fields",
+                                                            "searchQuery",
                                                             "type"
                                                         ],
                                                         "type": "object"
@@ -21216,7 +21241,6 @@
                     "private_key",
                     "sso",
                     "external_browser",
-                    "oauth_authorization_code",
                     "none"
                 ],
                 "type": "string"
@@ -23311,143 +23335,6 @@
                 },
                 "type": "object"
             },
-            "UserAsCodeRole": {
-                "anyOf": [
-                    {
-                        "properties": {
-                            "name": {
-                                "$ref": "#/components/schemas/OrganizationMemberRole"
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": ["system"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["name", "type"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": ["custom"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["name", "type"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "UserAsCode": {
-                "properties": {
-                    "role": {
-                        "$ref": "#/components/schemas/UserAsCodeRole"
-                    },
-                    "disabled": {
-                        "type": "boolean"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "version": {
-                        "type": "number",
-                        "enum": [1],
-                        "nullable": false
-                    }
-                },
-                "required": ["role", "disabled", "email", "version"],
-                "type": "object"
-            },
-            "ApiUserAsCodeListResponse": {
-                "properties": {
-                    "results": {
-                        "properties": {
-                            "users": {
-                                "items": {
-                                    "$ref": "#/components/schemas/UserAsCode"
-                                },
-                                "type": "array"
-                            }
-                        },
-                        "required": ["users"],
-                        "type": "object"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "PromotionAction.CREATE": {
-                "enum": ["create"],
-                "type": "string"
-            },
-            "PromotionAction.UPDATE": {
-                "enum": ["update"],
-                "type": "string"
-            },
-            "PromotionAction.NO_CHANGES": {
-                "enum": ["no changes"],
-                "type": "string"
-            },
-            "UserAsCodeLifecycleStatus": {
-                "enum": ["ready", "awaiting authentication"],
-                "type": "string"
-            },
-            "UserAsCodeInvitationStatus": {
-                "enum": [
-                    "not requested",
-                    "sent",
-                    "skipped authenticated",
-                    "skipped disabled",
-                    "skipped valid invite"
-                ],
-                "type": "string"
-            },
-            "ApiUserAsCodeUpsertResponse": {
-                "properties": {
-                    "results": {
-                        "properties": {
-                            "invitation": {
-                                "$ref": "#/components/schemas/UserAsCodeInvitationStatus"
-                            },
-                            "lifecycle": {
-                                "$ref": "#/components/schemas/UserAsCodeLifecycleStatus"
-                            },
-                            "action": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/components/schemas/PromotionAction.CREATE"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/PromotionAction.UPDATE"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/PromotionAction.NO_CHANGES"
-                                    }
-                                ]
-                            }
-                        },
-                        "required": ["invitation", "lifecycle", "action"],
-                        "type": "object"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
             "Pick_AzureAdSsoConfig.oauth2ClientId-or-oauth2TenantId_": {
                 "properties": {
                     "oauth2ClientId": {
@@ -23939,79 +23826,6 @@
             "UpsertGoogleSsoConfig": {
                 "$ref": "#/components/schemas/Partial_OrganizationSsoMethodFlags_"
             },
-            "GroupAsCode": {
-                "properties": {
-                    "members": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "version": {
-                        "type": "number",
-                        "enum": [1],
-                        "nullable": false
-                    }
-                },
-                "required": ["members", "name", "version"],
-                "type": "object"
-            },
-            "ApiGroupAsCodeListResponse": {
-                "properties": {
-                    "results": {
-                        "properties": {
-                            "groups": {
-                                "items": {
-                                    "$ref": "#/components/schemas/GroupAsCode"
-                                },
-                                "type": "array"
-                            }
-                        },
-                        "required": ["groups"],
-                        "type": "object"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiGroupAsCodeUpsertResponse": {
-                "properties": {
-                    "results": {
-                        "properties": {
-                            "action": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/components/schemas/PromotionAction.CREATE"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/PromotionAction.UPDATE"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/PromotionAction.NO_CHANGES"
-                                    }
-                                ]
-                            }
-                        },
-                        "required": ["action"],
-                        "type": "object"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
             "VerifiedDomain": {
                 "properties": {
                     "verifiedByUserUuid": {
@@ -24309,6 +24123,18 @@
                 },
                 "required": ["results", "status"],
                 "type": "object"
+            },
+            "PromotionAction.CREATE": {
+                "enum": ["create"],
+                "type": "string"
+            },
+            "PromotionAction.UPDATE": {
+                "enum": ["update"],
+                "type": "string"
+            },
+            "PromotionAction.NO_CHANGES": {
+                "enum": ["no changes"],
+                "type": "string"
             },
             "ApiCustomRoleAsCodeUpsertResponse": {
                 "properties": {
@@ -25235,11 +25061,6 @@
                 },
                 "required": ["prompt"],
                 "type": "object"
-            },
-            "Record_string.never_": {
-                "properties": {},
-                "type": "object",
-                "description": "Construct a type with a set of properties K of type T"
             },
             "AiDeepResearchPhase": {
                 "type": "string",
@@ -27927,306 +27748,6 @@
                 },
                 "type": "object"
             },
-            "WarehouseConnectCode": {
-                "properties": {
-                    "expiresAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "code": {
-                        "type": "string"
-                    }
-                },
-                "required": ["expiresAt", "code"],
-                "type": "object"
-            },
-            "ApiWarehouseConnectCodeResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/WarehouseConnectCode"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiDepositWarehouseConnectionResponse": {
-                "properties": {
-                    "results": {},
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["status"],
-                "type": "object"
-            },
-            "Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.database-or-warehouse-or-schema__": {
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/WarehouseTypes.SNOWFLAKE"
-                    },
-                    "user": {
-                        "type": "string"
-                    },
-                    "password": {
-                        "type": "string"
-                    },
-                    "privateKey": {
-                        "type": "string"
-                    },
-                    "privateKeyPass": {
-                        "type": "string"
-                    },
-                    "token": {
-                        "type": "string"
-                    },
-                    "refreshToken": {
-                        "type": "string"
-                    },
-                    "account": {
-                        "type": "string"
-                    },
-                    "requireUserCredentials": {
-                        "type": "boolean"
-                    },
-                    "authenticationType": {
-                        "$ref": "#/components/schemas/SnowflakeAuthenticationType"
-                    },
-                    "role": {
-                        "type": "string"
-                    },
-                    "threads": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "clientSessionKeepAlive": {
-                        "type": "boolean"
-                    },
-                    "queryTag": {
-                        "type": "string"
-                    },
-                    "accessUrl": {
-                        "type": "string"
-                    },
-                    "startOfWeek": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WeekDay"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "dataTimezone": {
-                        "type": "string"
-                    },
-                    "quotedIdentifiersIgnoreCase": {
-                        "type": "boolean"
-                    },
-                    "disableTimestampConversion": {
-                        "type": "boolean"
-                    },
-                    "timeoutSeconds": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "override": {
-                        "type": "boolean"
-                    },
-                    "organizationWarehouseCredentialsUuid": {
-                        "type": "string"
-                    }
-                },
-                "required": ["type", "user", "account"],
-                "type": "object",
-                "description": "From T, pick a set of properties whose keys are in the union K"
-            },
-            "Omit_CreateSnowflakeCredentials.database-or-warehouse-or-schema_": {
-                "$ref": "#/components/schemas/Pick_CreateSnowflakeCredentials.Exclude_keyofCreateSnowflakeCredentials.database-or-warehouse-or-schema__",
-                "description": "Construct a type with the properties of T except for those in type K."
-            },
-            "Partial_Pick_CreateSnowflakeCredentials.database-or-warehouse-or-schema__": {
-                "properties": {
-                    "database": {
-                        "type": "string"
-                    },
-                    "warehouse": {
-                        "type": "string"
-                    },
-                    "schema": {
-                        "type": "string"
-                    }
-                },
-                "type": "object",
-                "description": "Make all properties in T optional"
-            },
-            "DepositSnowflakeCredentials": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Omit_CreateSnowflakeCredentials.database-or-warehouse-or-schema_"
-                    },
-                    {
-                        "$ref": "#/components/schemas/Partial_Pick_CreateSnowflakeCredentials.database-or-warehouse-or-schema__"
-                    }
-                ]
-            },
-            "WarehouseConnectInventory": {
-                "properties": {
-                    "schemas": {
-                        "items": {
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "database": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": ["name", "database"],
-                            "type": "object"
-                        },
-                        "type": "array"
-                    },
-                    "roles": {
-                        "items": {
-                            "properties": {
-                                "isDefault": {
-                                    "type": "boolean"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": ["isDefault", "name"],
-                            "type": "object"
-                        },
-                        "type": "array"
-                    },
-                    "warehouses": {
-                        "items": {
-                            "properties": {
-                                "state": {
-                                    "type": "string",
-                                    "nullable": true
-                                },
-                                "size": {
-                                    "type": "string",
-                                    "nullable": true
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": ["state", "size", "name"],
-                            "type": "object"
-                        },
-                        "type": "array"
-                    },
-                    "databases": {
-                        "items": {
-                            "properties": {
-                                "comment": {
-                                    "type": "string",
-                                    "nullable": true
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": ["comment", "name"],
-                            "type": "object"
-                        },
-                        "type": "array"
-                    }
-                },
-                "required": ["schemas", "roles", "warehouses", "databases"],
-                "type": "object"
-            },
-            "DepositWarehouseConnectionRequest": {
-                "properties": {
-                    "inventory": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WarehouseConnectInventory"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "credentials": {
-                        "$ref": "#/components/schemas/DepositSnowflakeCredentials"
-                    },
-                    "code": {
-                        "type": "string"
-                    }
-                },
-                "required": ["inventory", "credentials", "code"],
-                "type": "object"
-            },
-            "WarehouseConnectCodeClaimResult": {
-                "anyOf": [
-                    {
-                        "properties": {
-                            "status": {
-                                "type": "string",
-                                "enum": ["pending"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["status"],
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "inventory": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/WarehouseConnectInventory"
-                                    }
-                                ],
-                                "nullable": true
-                            },
-                            "credentials": {
-                                "$ref": "#/components/schemas/DepositSnowflakeCredentials"
-                            },
-                            "status": {
-                                "type": "string",
-                                "enum": ["deposited"],
-                                "nullable": false
-                            }
-                        },
-                        "required": ["inventory", "credentials", "status"],
-                        "type": "object"
-                    }
-                ]
-            },
-            "ApiWarehouseConnectCodeClaimResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/WarehouseConnectCodeClaimResult"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ClaimWarehouseConnectCodeRequest": {
-                "properties": {
-                    "code": {
-                        "type": "string"
-                    }
-                },
-                "required": ["code"],
-                "type": "object"
-            },
             "ApiJobScheduledResponse": {
                 "properties": {
                     "results": {
@@ -28868,15 +28389,6 @@
                 "required": ["password", "email", "lastName", "firstName"],
                 "type": "object"
             },
-            "CreateEmailOnlyUserArgs": {
-                "properties": {
-                    "email": {
-                        "$ref": "#/components/schemas/Email"
-                    }
-                },
-                "required": ["email"],
-                "type": "object"
-            },
             "RegisterOrActivateUser": {
                 "anyOf": [
                     {
@@ -28884,9 +28396,6 @@
                     },
                     {
                         "$ref": "#/components/schemas/CreateUserArgs"
-                    },
-                    {
-                        "$ref": "#/components/schemas/CreateEmailOnlyUserArgs"
                     }
                 ]
             },
@@ -29544,7 +29053,7 @@
                 "type": "string"
             },
             "LocalIssuerTypes": {
-                "enum": ["email", "emailOtp", "apiToken"],
+                "enum": ["email", "apiToken"],
                 "type": "string"
             },
             "LoginOptionTypes": {
@@ -29587,52 +29096,6 @@
                     }
                 },
                 "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiLoginEmailOtpResponse": {
-                "properties": {
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["status"],
-                "type": "object"
-            },
-            "ApiLoginEmailOtpRequest": {
-                "properties": {
-                    "email": {
-                        "type": "string"
-                    }
-                },
-                "required": ["email"],
-                "type": "object"
-            },
-            "ApiVerifyLoginEmailOtpResponse": {
-                "properties": {
-                    "results": {
-                        "$ref": "#/components/schemas/LightdashUser"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiVerifyLoginEmailOtpRequest": {
-                "properties": {
-                    "passcode": {
-                        "type": "string"
-                    },
-                    "email": {
-                        "type": "string"
-                    }
-                },
-                "required": ["passcode", "email"],
                 "type": "object"
             },
             "PersonalAccessToken": {
@@ -36516,22 +35979,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -37099,22 +36562,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -47857,7 +47320,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3389.0",
+        "version": "0.3382.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -49558,6 +49021,78 @@
                         "required": true,
                         "schema": {
                             "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/homepage/view-as": {
+            "get": {
+                "operationId": "viewHomepageAs",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiHomepageViewAsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "targetType",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": ["user", "group", "role"]
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "userUuid",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "groupUuid",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "role",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/ProjectMemberRole"
                         }
                     }
                 ]
@@ -54758,101 +54293,6 @@
                 ]
             }
         },
-        "/api/v2/orgs/{orgUuid}/users/code": {
-            "get": {
-                "operationId": "GetOrganizationUsersAsCode",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiUserAsCodeListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": ["v2", "Organizations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "orgUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "post": {
-                "operationId": "UpsertOrganizationUserAsCode",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiUserAsCodeUpsertResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": ["v2", "Organizations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "orgUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "in": "query",
-                        "name": "sendInvite",
-                        "required": false,
-                        "schema": {
-                            "default": false,
-                            "type": "boolean"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UserAsCode"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/v1/org/sso/azuread": {
             "get": {
                 "operationId": "GetAzureAdSsoConfig",
@@ -55361,92 +54801,6 @@
                 "tags": ["Organizations"],
                 "security": [],
                 "parameters": []
-            }
-        },
-        "/api/v2/orgs/{orgUuid}/groups/code": {
-            "get": {
-                "operationId": "GetOrganizationGroupsAsCode",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiGroupAsCodeListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": ["v2", "Organizations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "orgUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            "post": {
-                "operationId": "UpsertOrganizationGroupAsCode",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiGroupAsCodeUpsertResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": ["v2", "Organizations"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "orgUuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/GroupAsCode"
-                            }
-                        }
-                    }
-                }
             }
         },
         "/api/v1/org/domains": {
@@ -57622,122 +56976,6 @@
                 }
             }
         },
-        "/api/v1/warehouse-connect/code": {
-            "post": {
-                "operationId": "CreateWarehouseConnectCode",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiWarehouseConnectCodeResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Creates a short-lived, single-use connect code the Lightdash CLI can use\nto deposit warehouse credentials on behalf of the current user",
-                "summary": "Create connect code",
-                "tags": ["Projects"],
-                "security": [],
-                "parameters": []
-            }
-        },
-        "/api/v1/warehouse-connect/deposit": {
-            "post": {
-                "operationId": "DepositWarehouseConnection",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiDepositWarehouseConnectionResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Deposits durable warehouse credentials against a connect code. Called by\nthe Lightdash CLI; the connect code is the bearer credential, so this\nendpoint is intentionally unauthenticated",
-                "summary": "Deposit connection",
-                "tags": ["Projects"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/DepositWarehouseConnectionRequest"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/warehouse-connect/claim": {
-            "post": {
-                "operationId": "ClaimWarehouseConnectCode",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiWarehouseConnectCodeClaimResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Retrieves credentials deposited against a connect code created by the\ncurrent user. Returns them once and deletes the code",
-                "summary": "Claim connect code",
-                "tags": ["Projects"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ClaimWarehouseConnectCodeRequest"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/v1/projects/{projectUuid}/validate": {
             "post": {
                 "operationId": "ValidateProject",
@@ -58622,86 +57860,6 @@
                         }
                     }
                 ]
-            }
-        },
-        "/api/v1/user/login-email-otp": {
-            "post": {
-                "operationId": "LoginEmailOtp",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiLoginEmailOtpResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": ["My Account"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ApiLoginEmailOtpRequest"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/user/login-email-otp/verify": {
-            "post": {
-                "operationId": "VerifyLoginEmailOtp",
-                "responses": {
-                    "200": {
-                        "description": "Ok",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiVerifyLoginEmailOtpResponse"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "tags": ["My Account"],
-                "security": [],
-                "parameters": [],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ApiVerifyLoginEmailOtpRequest"
-                            }
-                        }
-                    }
-                }
             }
         },
         "/api/v1/user/me/personal-access-tokens": {
@@ -63927,48 +63085,6 @@
                         "schema": {
                             "format": "double",
                             "type": "number"
-                        }
-                    }
-                ]
-            }
-        },
-        "/api/v1/prompts/{name}": {
-            "get": {
-                "operationId": "GetPrompt",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "text/markdown": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "byte"
-                                }
-                            }
-                        }
-                    },
-                    "default": {
-                        "description": "Error",
-                        "content": {
-                            "text/markdown": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiErrorPayload"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "Get public instructions for a named prompt",
-                "summary": "Get prompt",
-                "tags": ["Prompts"],
-                "security": [],
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "name",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
                         }
                     }
                 ]

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -198,6 +198,32 @@ export type ResolvedHomepage =
     | { type: 'homepage'; homepage: PublishedProjectHomepage }
     | { type: 'dashboard'; dashboardUuid: string };
 
+export type HomepageResolutionSource =
+    | { type: 'group'; groupUuid: string; priority: number }
+    | { type: 'role'; role: ProjectMemberRole }
+    | { type: 'default' };
+
+export type ResolvedPublishedHomepage = {
+    homepage: PublishedProjectHomepage;
+    source: HomepageResolutionSource;
+};
+
+export type HomepageViewAsTarget =
+    | { type: 'user'; userUuid: string }
+    | { type: 'group'; groupUuid: string }
+    | { type: 'role'; role: ProjectMemberRole };
+
+export type HomepageViewAsReason =
+    | { type: 'personal'; dashboardUuid: string }
+    | HomepageResolutionSource;
+
+export type HomepageViewAsResult = {
+    resolved: ResolvedHomepage | null;
+    reason: HomepageViewAsReason | null;
+};
+
+export type ApiHomepageViewAsResponse = ApiSuccess<HomepageViewAsResult>;
+
 export type SetPersonalHomepageRequest = {
     dashboardUuid: string;
 };

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -53,6 +53,7 @@ import type {
     ApiGetAppResponse,
     ApiGetDataAppVizResponse,
     ApiGetUserAgentPreferencesResponse,
+    ApiHomepageViewAsResponse,
     ApiListDataAppVizsResponse,
     ApiManagedAgentActionResponse,
     ApiManagedAgentRunResponse,
@@ -1283,6 +1284,7 @@ type ApiResults =
     | ApiProjectHomepageResponse['results']
     | ApiProjectHomepageOrNullResponse['results']
     | ApiResolvedHomepageResponse['results']
+    | ApiHomepageViewAsResponse['results']
     | ApiProjectColorPaletteResponse['results']
     | ApiOrganizationBrandResponse['results']
     | ApiManagedAgentRunResponse['results']

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -30,6 +30,7 @@ import {
     IconPlus,
     IconSend,
     IconTrash,
+    IconUserSearch,
     IconUsers,
 } from '@tabler/icons-react';
 import { useEffect, useRef, useState, type FC } from 'react';
@@ -64,6 +65,7 @@ import {
 import { PresetsModal } from './PresetsModal';
 import { PublishedHomepage } from './PublishedHomepage';
 import { PublishModal } from './PublishModal';
+import { ViewAsModal } from './ViewAsModal';
 
 type Props = {
     homepage: ProjectHomepageType;
@@ -97,6 +99,7 @@ export const HomepageEditor: FC<Props> = ({
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const [isPresetsModalOpen, setIsPresetsModalOpen] = useState(false);
     const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
+    const [isViewAsModalOpen, setIsViewAsModalOpen] = useState(false);
 
     const isAiEnabled = useAiAgentButtonVisibility();
     const availableBlocks = blockLibrary.filter(
@@ -324,6 +327,13 @@ export const HomepageEditor: FC<Props> = ({
                         onClick={() => setIsPreviewing((prev) => !prev)}
                     >
                         {isPreviewing ? 'Back to editing' : 'Preview'}
+                    </Button>
+                    <Button
+                        variant="default"
+                        leftSection={<MantineIcon icon={IconUserSearch} />}
+                        onClick={() => setIsViewAsModalOpen(true)}
+                    >
+                        View as
                     </Button>
                     <Button
                         leftSection={<MantineIcon icon={IconSend} />}
@@ -700,6 +710,11 @@ export const HomepageEditor: FC<Props> = ({
                 opened={isPresetsModalOpen}
                 onClose={() => setIsPresetsModalOpen(false)}
                 onApply={setDraft}
+            />
+            <ViewAsModal
+                opened={isViewAsModalOpen}
+                onClose={() => setIsViewAsModalOpen(false)}
+                projectUuid={projectUuid}
             />
             <PublishModal
                 opened={isPublishModalOpen}

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -1,15 +1,33 @@
 import { type HomepageBlock, type HomepageConfig } from '@lightdash/common';
-import { Box, Group, Stack } from '@mantine-8/core';
+import { Box, Group, Paper, Stack, Text } from '@mantine-8/core';
 import { type FC } from 'react';
 import { getBlockDefinition } from './blocks/registry';
 
+const PERSONAL_BLOCK_TYPES: HomepageBlock['type'][] = ['favorites', 'recent'];
+
 // Unknown block types render nothing so newer configs degrade gracefully
-const BlockRenderer: FC<{ block: HomepageBlock; projectUuid: string }> = ({
-    block,
-    projectUuid,
-}) => {
+const BlockRenderer: FC<{
+    block: HomepageBlock;
+    projectUuid: string;
+    personalPlaceholders: boolean;
+}> = ({ block, projectUuid, personalPlaceholders }) => {
     const definition = getBlockDefinition(block.type);
     if (!definition) return null;
+    if (personalPlaceholders && PERSONAL_BLOCK_TYPES.includes(block.type)) {
+        return (
+            <Paper withBorder p="md" h="100%">
+                <Text size="sm" fw={600}>
+                    {block.type === 'favorites'
+                        ? 'Favorites'
+                        : 'Recently viewed'}
+                </Text>
+                <Text size="xs" c="dimmed">
+                    Personal to each viewer — the target user sees their own
+                    content here.
+                </Text>
+            </Paper>
+        );
+    }
     const { View } = definition;
     return <View block={block} projectUuid={projectUuid} />;
 };
@@ -17,9 +35,15 @@ const BlockRenderer: FC<{ block: HomepageBlock; projectUuid: string }> = ({
 type Props = {
     config: HomepageConfig;
     projectUuid: string;
+    /** Render personal blocks as placeholders (admin view-as preview) */
+    personalPlaceholders?: boolean;
 };
 
-export const PublishedHomepage: FC<Props> = ({ config, projectUuid }) => (
+export const PublishedHomepage: FC<Props> = ({
+    config,
+    projectUuid,
+    personalPlaceholders = false,
+}) => (
     <Stack gap="lg" maw={920} mx="auto" w="100%">
         {config.rows.map((row) => (
             <Group key={row.id} gap="md" align="stretch" wrap="nowrap">
@@ -28,6 +52,7 @@ export const PublishedHomepage: FC<Props> = ({ config, projectUuid }) => (
                         <BlockRenderer
                             block={block}
                             projectUuid={projectUuid}
+                            personalPlaceholders={personalPlaceholders}
                         />
                     </Box>
                 ))}

--- a/packages/frontend/src/ee/features/homepageBuilder/ViewAsModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/ViewAsModal.tsx
@@ -1,0 +1,254 @@
+import {
+    ProjectMemberRole,
+    ProjectMemberRoleLabels,
+    type HomepageViewAsReason,
+    type HomepageViewAsTarget,
+} from '@lightdash/common';
+import {
+    Anchor,
+    Badge,
+    Card,
+    Group,
+    Loader,
+    SegmentedControl,
+    Select,
+    Stack,
+    Text,
+} from '@mantine-8/core';
+import { IconExternalLink, IconEye } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
+import { useOrganizationGroups } from '../../../hooks/useOrganizationGroups';
+import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
+import { useHomepageViewAs } from './hooks/useProjectHomepage';
+import { PublishedHomepage } from './PublishedHomepage';
+
+const reasonLabel = (
+    reason: HomepageViewAsReason,
+    groupNames: Map<string, string>,
+): string => {
+    switch (reason.type) {
+        case 'personal':
+            return 'their personal pick';
+        case 'group':
+            return `via group ${
+                groupNames.get(reason.groupUuid) ?? 'unknown'
+            } (priority ${reason.priority})`;
+        case 'role':
+            return `via role ${ProjectMemberRoleLabels[reason.role]}`;
+        case 'default':
+            return 'org default';
+        default:
+            return '';
+    }
+};
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+};
+
+export const ViewAsModal: FC<Props> = ({ opened, onClose, projectUuid }) => {
+    const [targetType, setTargetType] = useState<string>('user');
+    const [target, setTarget] = useState<HomepageViewAsTarget | null>(null);
+    const { data: users } = useOrganizationUsers({
+        projectUuid,
+        enabled: opened,
+    });
+    const { data: groups } = useOrganizationGroups({}, { enabled: opened });
+    const result = useHomepageViewAs(projectUuid, target);
+
+    const groupNames = new Map(
+        (groups ?? []).map((group) => [group.uuid, group.name]),
+    );
+    const targetLabel =
+        target?.type === 'user'
+            ? (users ?? []).find((user) => user.userUuid === target.userUuid)
+                  ?.email
+            : target?.type === 'group'
+              ? groupNames.get(target.groupUuid)
+              : target?.type === 'role'
+                ? ProjectMemberRoleLabels[target.role]
+                : undefined;
+
+    const handleTypeChange = (value: string) => {
+        setTargetType(value);
+        setTarget(null);
+    };
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="View homepage as"
+            icon={IconEye}
+            size="xl"
+        >
+            <Stack gap="sm">
+                <Text size="sm" c="dimmed">
+                    Preview which homepage an audience lands on, resolved
+                    through the real precedence chain (personal → group priority
+                    → role → org default).
+                </Text>
+                <Group gap="sm" wrap="nowrap">
+                    <SegmentedControl
+                        value={targetType}
+                        onChange={handleTypeChange}
+                        data={[
+                            { value: 'user', label: 'User' },
+                            { value: 'group', label: 'Group' },
+                            { value: 'role', label: 'Role' },
+                        ]}
+                    />
+                    {targetType === 'user' && (
+                        <Select
+                            placeholder="Pick a user"
+                            searchable
+                            style={{ flex: 1 }}
+                            data={(users ?? []).map((user) => ({
+                                value: user.userUuid,
+                                label: `${user.firstName} ${user.lastName} (${user.email})`,
+                            }))}
+                            value={
+                                target?.type === 'user' ? target.userUuid : null
+                            }
+                            onChange={(value) =>
+                                setTarget(
+                                    value
+                                        ? { type: 'user', userUuid: value }
+                                        : null,
+                                )
+                            }
+                        />
+                    )}
+                    {targetType === 'group' && (
+                        <Select
+                            placeholder="Pick a group"
+                            searchable
+                            style={{ flex: 1 }}
+                            data={(groups ?? []).map((group) => ({
+                                value: group.uuid,
+                                label: group.name,
+                            }))}
+                            value={
+                                target?.type === 'group'
+                                    ? target.groupUuid
+                                    : null
+                            }
+                            onChange={(value) =>
+                                setTarget(
+                                    value
+                                        ? { type: 'group', groupUuid: value }
+                                        : null,
+                                )
+                            }
+                        />
+                    )}
+                    {targetType === 'role' && (
+                        <Select
+                            placeholder="Pick a role"
+                            style={{ flex: 1 }}
+                            data={Object.values(ProjectMemberRole).map(
+                                (role) => ({
+                                    value: role,
+                                    label: ProjectMemberRoleLabels[role],
+                                }),
+                            )}
+                            value={target?.type === 'role' ? target.role : null}
+                            onChange={(value) =>
+                                setTarget(
+                                    value
+                                        ? {
+                                              type: 'role',
+                                              role: value as ProjectMemberRole,
+                                          }
+                                        : null,
+                                )
+                            }
+                        />
+                    )}
+                </Group>
+
+                {target && result.isInitialLoading && (
+                    <Group justify="center" p="lg">
+                        <Loader size="sm" />
+                    </Group>
+                )}
+
+                {target && result.data && (
+                    <>
+                        {result.data.resolved === null && (
+                            <Card withBorder p="md">
+                                <Text size="sm" c="dimmed">
+                                    No published homepage applies — they land on
+                                    the day-one default.
+                                </Text>
+                            </Card>
+                        )}
+                        {result.data.resolved?.type === 'dashboard' && (
+                            <Card withBorder p="md">
+                                <Group gap="xs">
+                                    <Text size="sm">
+                                        Lands directly on a dashboard (
+                                        {result.data.reason &&
+                                            reasonLabel(
+                                                result.data.reason,
+                                                groupNames,
+                                            )}
+                                        ).
+                                    </Text>
+                                    <Anchor
+                                        component={Link}
+                                        to={`/projects/${projectUuid}/dashboards/${result.data.resolved.dashboardUuid}/view`}
+                                        target="_blank"
+                                        size="sm"
+                                    >
+                                        <Group gap={4} wrap="nowrap">
+                                            Open dashboard
+                                            <MantineIcon
+                                                icon={IconExternalLink}
+                                                size="sm"
+                                            />
+                                        </Group>
+                                    </Anchor>
+                                </Group>
+                            </Card>
+                        )}
+                        {result.data.resolved?.type === 'homepage' && (
+                            <Stack gap="sm">
+                                <Group gap="xs">
+                                    <Badge variant="filled" tt="none">
+                                        Viewing as {targetLabel}
+                                    </Badge>
+                                    <Text size="sm" c="dimmed">
+                                        sees{' '}
+                                        <Text span fw={600} c="inherit">
+                                            {result.data.resolved.homepage.name}
+                                        </Text>{' '}
+                                        {result.data.reason &&
+                                            `· ${reasonLabel(
+                                                result.data.reason,
+                                                groupNames,
+                                            )}`}
+                                    </Text>
+                                </Group>
+                                <Card withBorder p="lg">
+                                    <PublishedHomepage
+                                        config={
+                                            result.data.resolved.homepage.config
+                                        }
+                                        projectUuid={projectUuid}
+                                        personalPlaceholders
+                                    />
+                                </Card>
+                            </Stack>
+                        )}
+                    </>
+                )}
+            </Stack>
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
@@ -4,6 +4,8 @@ import {
     type CreateProjectHomepageRequest,
     type HomepageAssignment,
     type HomepageAudience,
+    type HomepageViewAsResult,
+    type HomepageViewAsTarget,
     type ProjectHomepage,
     type ResolvedHomepage,
     type UpdateProjectHomepageDraftRequest,
@@ -104,6 +106,18 @@ const publishHomepageApi = async (
         method: 'POST',
         body: JSON.stringify({ audience, allowPersonal }),
     });
+
+const viewAsApi = async (projectUuid: string, target: HomepageViewAsTarget) => {
+    const params = new URLSearchParams({ targetType: target.type });
+    if (target.type === 'user') params.set('userUuid', target.userUuid);
+    if (target.type === 'group') params.set('groupUuid', target.groupUuid);
+    if (target.type === 'role') params.set('role', target.role);
+    return lightdashApi<HomepageViewAsResult>({
+        url: `/projects/${projectUuid}/homepage/view-as?${params.toString()}`,
+        method: 'GET',
+        body: undefined,
+    });
+};
 
 const getAssignmentsApi = async (projectUuid: string) =>
     lightdashApi<HomepageAssignment[]>({
@@ -301,6 +315,16 @@ export const useUpdateHomepageDraft = (
         },
     });
 };
+
+export const useHomepageViewAs = (
+    projectUuid: string,
+    target: HomepageViewAsTarget | null,
+) =>
+    useQuery<HomepageViewAsResult, ApiError>({
+        enabled: !!target,
+        queryKey: [PROJECT_HOMEPAGE_QUERY_KEY, projectUuid, 'view-as', target],
+        queryFn: () => viewAsApi(projectUuid, target!),
+    });
 
 export const useHomepageAssignments = (
     projectUuid: string,


### PR DESCRIPTION
Part of the Homepage Builder stack (ZAP-609). Closes ZAP-629.

Admins can preview exactly what any audience lands on, resolved through the **real precedence chain** (personal → group priority → role → org default) — no parallel resolver implementation.

## What's here

**Backend (EE)**
- `resolvePublished` now returns `{homepage, source}` where `source` says *why* it matched: `{type:'group', groupUuid, priority}`, `{type:'role', role}`, or `{type:'default'}`. The regular `GET /homepage` path uses the same method, so view-as and real resolution can never drift.
- Service refactor: resolution core extracted into private `resolveForViewer` + `getViewerContext`; `getResolvedHomepage` (viewer path) and the new `viewAsHomepage` (admin path) both call it.
- New endpoint `GET /homepage/view-as?targetType=user|group|role&…` — gated on `manage:ProjectHomepage`. User targets include the target's personal override and group/role memberships; group/role targets never consult any personal override. Returns `{resolved: ResolvedHomepage|null, reason}`.
- Malformed targets → 400; TSOA validates `userUuid`/`groupUuid` as UUIDs and `role` against the enum (422).

**Frontend (EE)**
- "View as" button in the builder toolbar opens a read-only modal: pick a user / group / role, see a "Viewing as … · sees {homepage} · via {reason}" banner and the rendered homepage. Closing the modal is the exit — no state mutations are possible inside it.
- **Privacy guardrail:** `PublishedHomepage` gains a `personalPlaceholders` prop; in view-as mode, favorites and recently-viewed blocks render a "Personal to each viewer" placeholder instead of anyone's actual data (the target user's personal content is never fetched).

## Verification
- 19/19 unit tests (incl. new: viewer forbidden on view-as; role target resolves via shared resolver with reason and without touching personal overrides; user target applies the target's override).
- Live curl with scratch entities: group-published scratch homepage → view-as group returns the homepage with `reason: {type:'group', groupUuid, priority:0}`; missing param → 400; bogus role → 422; scratch cleaned up after.

## Who's affected
Flag-off: no change (all gated on `CommercialFeatureFlags.HomepageBuilder`). Flag-on: endpoint and UI are admin-only (`manage:ProjectHomepage`); viewers see nothing new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ