### PR TITLE
fix(custom-roles): keep permissions panel usable on short viewports

### DIFF
--- a/packages/frontend/src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.module.css
+++ b/packages/frontend/src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.module.css
@@ -10,7 +10,8 @@
     min-height: 0;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
+    overflow-y: auto;
+    overflow-x: hidden;
 }
 
 .contentStack {
@@ -107,9 +108,10 @@
     flex-direction: column;
     position: relative;
     flex: 1 1 0;
-    min-height: 0;
-    max-height: min(calc(100vh - 280px), 650px);
-    height: min(calc(100vh - 280px), 650px);
+    /* Floor so the permissions list stays usable on short viewports — the
+       page scrolls instead of crushing this card. */
+    min-height: 450px;
+    max-height: 650px;
     overflow: hidden;
 }
 


### PR DESCRIPTION
### Description:
The role-type option cards added in #25340 made the section above the permissions panel ~200px taller, but the role builder page was viewport-locked (overflow: hidden) with min-height: 0 on the permissions card, so the panel absorbed the entire loss and could shrink to a single visible row. Let the form scroll instead and give the permissions card a 450px floor.
