### PR TITLE
feat: generate color palette from brand colors

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -320,6 +320,7 @@ export * from './utils/colors';
 export * from './utils/conditionalFormatExpressions';
 export * from './utils/conditionalFormatting';
 export * from './utils/connectionChanges';
+export * from './utils/generateColorPalette';
 export * from './utils/convertCustomDimensionsToYaml';
 export * from './utils/convertCustomMetricsToYaml';
 export * from './utils/customDimensions';

--- a/packages/common/src/utils/generateColorPalette.test.ts
+++ b/packages/common/src/utils/generateColorPalette.test.ts
@@ -1,0 +1,89 @@
+import { type OrganizationBrandColor } from '../types/organizationBrand';
+import { isHexCodeColor } from './colors';
+import {
+    COLOR_PALETTE_LENGTH,
+    generateColorPalette,
+    generatePaletteFromBrandColors,
+} from './generateColorPalette';
+
+const brandColor = (
+    hex: string,
+    type: string = 'brand',
+): OrganizationBrandColor => ({ hex, type, brightness: null });
+
+describe('generateColorPalette', () => {
+    it('expands a single seed into a full palette of valid hex colors', () => {
+        const palette = generateColorPalette(['#7262ff']);
+        expect(palette).toHaveLength(COLOR_PALETTE_LENGTH);
+        expect(palette.every(isHexCodeColor)).toBe(true);
+    });
+
+    it('keeps the seed colors as the leading anchors in light mode', () => {
+        const palette = generateColorPalette(['#7262ff', '#1a7f37']);
+        expect(palette[0]).toBe('#7262ff');
+        expect(palette[1]).toBe('#1a7f37');
+    });
+
+    it('returns an empty array when there are no valid seeds', () => {
+        expect(generateColorPalette([])).toEqual([]);
+        expect(generateColorPalette(['not-a-color', ''])).toEqual([]);
+    });
+
+    it('ignores invalid seeds but still generates from the valid ones', () => {
+        const palette = generateColorPalette(['nope', '#ff0000']);
+        expect(palette).toHaveLength(COLOR_PALETTE_LENGTH);
+        expect(palette[0]).toBe('#ff0000');
+    });
+
+    it('respects a custom count', () => {
+        expect(generateColorPalette(['#7262ff'], { count: 5 })).toHaveLength(5);
+    });
+
+    it('produces lighter colors in dark mode than a dark seed would give', () => {
+        const [darkFirst] = generateColorPalette(['#00110a'], {
+            darkMode: true,
+        });
+        const [lightFirst] = generateColorPalette(['#00110a'], {
+            darkMode: false,
+        });
+        expect(darkFirst).not.toBe(lightFirst);
+    });
+});
+
+describe('generatePaletteFromBrandColors', () => {
+    it('generates matching-length light and dark palettes', () => {
+        const { colors, darkColors } = generatePaletteFromBrandColors([
+            brandColor('#7262ff', 'brand'),
+            brandColor('#1a7f37', 'accent'),
+        ]);
+        expect(colors).toHaveLength(COLOR_PALETTE_LENGTH);
+        expect(darkColors).toHaveLength(COLOR_PALETTE_LENGTH);
+        expect(colors.every(isHexCodeColor)).toBe(true);
+        expect(darkColors.every(isHexCodeColor)).toBe(true);
+    });
+
+    it('prioritises brand and accent roles over dark/light roles', () => {
+        const { colors } = generatePaletteFromBrandColors([
+            brandColor('#000000', 'dark'),
+            brandColor('#ffffff', 'light'),
+            brandColor('#7262ff', 'brand'),
+        ]);
+        expect(colors[0]).toBe('#7262ff');
+    });
+
+    it('deduplicates repeated brand colors', () => {
+        const { colors } = generatePaletteFromBrandColors([
+            brandColor('#7262ff', 'brand'),
+            brandColor('#7262FF', 'accent'),
+        ]);
+        // Only one unique seed, so the second color must be a generated variant
+        expect(colors[1]).not.toBe('#7262ff');
+    });
+
+    it('returns empty arrays when no brand colors are usable', () => {
+        expect(generatePaletteFromBrandColors([])).toEqual({
+            colors: [],
+            darkColors: [],
+        });
+    });
+});

--- a/packages/common/src/utils/generateColorPalette.ts
+++ b/packages/common/src/utils/generateColorPalette.ts
@@ -1,0 +1,139 @@
+import Color from 'colorjs.io';
+import { type OrganizationBrandColor } from '../types/organizationBrand';
+import { isHexCodeColor } from './colors';
+
+/**
+ * Number of colors a Lightdash color palette must contain.
+ */
+export const COLOR_PALETTE_LENGTH = 20;
+
+/**
+ * Golden-angle hue rotation (in degrees). Spreading generated hues by this
+ * amount keeps successive colors visually distinct instead of clustering.
+ */
+const GOLDEN_ANGLE = 137.508;
+
+const clamp = (value: number, min: number, max: number): number =>
+    Math.min(Math.max(value, min), max);
+
+const toHex = (color: Color): string =>
+    color.to('srgb').toGamut().toString({ format: 'hex' });
+
+type LightnessRange = { min: number; max: number };
+
+// Brand colors are usually tuned for light backgrounds, so the light palette
+// keeps them almost untouched while the dark palette lifts them into a range
+// that stays legible on a dark canvas.
+const LIGHT_LIGHTNESS: LightnessRange = { min: 0.32, max: 0.88 };
+const DARK_LIGHTNESS: LightnessRange = { min: 0.55, max: 0.85 };
+
+/**
+ * Remaps a lightness value into the target range. Colors already inside the
+ * range are left as-is; colors outside are pulled to the nearest bound.
+ */
+const fitLightness = (lightness: number, range: LightnessRange): number =>
+    clamp(lightness, range.min, range.max);
+
+/**
+ * Expands a list of seed colors into exactly `count` distinct colors.
+ *
+ * The seed colors are used as the leading anchors, then additional colors are
+ * derived by rotating the hue of each seed (golden angle) and nudging its
+ * lightness. This keeps the brand's own colors prominent while filling the
+ * palette with harmonious variations.
+ */
+export const generateColorPalette = (
+    seedColors: string[],
+    { darkMode = false, count = COLOR_PALETTE_LENGTH } = {},
+): string[] => {
+    const range = darkMode ? DARK_LIGHTNESS : LIGHT_LIGHTNESS;
+
+    const seeds = seedColors.filter(isHexCodeColor);
+    if (seeds.length === 0) {
+        return [];
+    }
+
+    // Each base is the seed's [lightness, chroma, hue] in OKLCH.
+    const bases = seeds.map((hex) => new Color(hex).to('oklch').coords);
+
+    const makeColor = (
+        [lightness, chroma, hue]: [number, number, number],
+        hueShift: number,
+        lightnessShift: number,
+    ): string => {
+        const safeHue = Number.isNaN(hue) ? 0 : hue;
+        const oklch = new Color('oklch', [
+            fitLightness(lightness + lightnessShift, range),
+            chroma,
+            (safeHue + hueShift) % 360,
+        ]);
+        return toHex(oklch);
+    };
+
+    // Anchor the palette on the brand colors. Light mode keeps their exact hex;
+    // dark mode fits their lightness so a very dark brand color still shows.
+    const result: string[] = darkMode
+        ? bases.map((base) => makeColor(base, 0, 0))
+        : [...seeds];
+
+    // Later rounds fan out around each anchor with a growing hue rotation and
+    // an alternating lightness nudge to avoid repeats when hues wrap around.
+    for (let round = 1; result.length < count; round += 1) {
+        for (let i = 0; i < bases.length && result.length < count; i += 1) {
+            const hueShift = round * GOLDEN_ANGLE;
+            const lightnessShift =
+                (round % 2 === 0 ? 1 : -1) * 0.06 * Math.ceil(round / 2);
+            result.push(makeColor(bases[i], hueShift, lightnessShift));
+        }
+    }
+
+    return result.slice(0, count);
+};
+
+/**
+ * Orders brand colors so the most palette-worthy roles come first. `dark` and
+ * `light` roles are typically background/text colors, so they are pushed to the
+ * back where they only appear if there aren't enough vivid brand colors.
+ */
+const BRAND_COLOR_ROLE_PRIORITY: Record<string, number> = {
+    brand: 0,
+    accent: 1,
+    other: 2,
+    dark: 3,
+    light: 4,
+};
+
+const orderBrandColors = (
+    brandColors: OrganizationBrandColor[],
+): string[] => {
+    const seen = new Set<string>();
+    return [...brandColors]
+        .sort(
+            (a, b) =>
+                (BRAND_COLOR_ROLE_PRIORITY[a.type] ?? 2) -
+                (BRAND_COLOR_ROLE_PRIORITY[b.type] ?? 2),
+        )
+        .map((color) => color.hex)
+        .filter((hex) => isHexCodeColor(hex))
+        .filter((hex) => {
+            const key = hex.toLowerCase();
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+        });
+};
+
+/**
+ * Generates a full light + dark color palette from an organization's brand
+ * colors. Returns empty arrays when there are no usable brand colors so callers
+ * can fall back to a default palette.
+ */
+export const generatePaletteFromBrandColors = (
+    brandColors: OrganizationBrandColor[],
+): { colors: string[]; darkColors: string[] } => {
+    const seeds = orderBrandColors(brandColors);
+    return {
+        colors: generateColorPalette(seeds, { darkMode: false }),
+        darkColors: generateColorPalette(seeds, { darkMode: true }),
+    };
+};

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/CreatePaletteModal.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/CreatePaletteModal.tsx
@@ -7,7 +7,14 @@ import {
 } from '../../../hooks/appearance/useOrganizationAppearance';
 import { PaletteModalBase, type PaletteFormValues } from './PaletteModalBase';
 
-type Props = Pick<ModalProps, 'opened' | 'onClose'>;
+type Props = Pick<ModalProps, 'opened' | 'onClose'> & {
+    /**
+     * Seed values for the form. When omitted the default palette is used. The
+     * "from brand colors" flow passes a palette generated from the org brand.
+     */
+    initialValues?: PaletteFormValues;
+    title?: string;
+};
 
 const DEFAULT_COLOR_PALETTE = {
     name: 'Default',
@@ -28,7 +35,12 @@ const DEFAULT_COLOR_PALETTE = {
     ],
 };
 
-export const CreatePaletteModal: FC<Props> = ({ opened, onClose }) => {
+export const CreatePaletteModal: FC<Props> = ({
+    opened,
+    onClose,
+    initialValues,
+    title = 'Create new palette',
+}) => {
     const { data: palettes = [] } = useColorPalettes();
     const createColorPalette = useCreateColorPalette();
 
@@ -48,13 +60,16 @@ export const CreatePaletteModal: FC<Props> = ({ opened, onClose }) => {
             onClose={onClose}
             onSubmit={handleCreatePalette}
             isLoading={createColorPalette.isLoading}
-            initialValues={{
-                name: '',
-                colors: DEFAULT_COLOR_PALETTE.colors,
-            }}
-            title="Create new palette"
+            initialValues={
+                initialValues ?? {
+                    name: '',
+                    colors: DEFAULT_COLOR_PALETTE.colors,
+                }
+            }
+            title={title}
             submitButtonText="Create palette"
             existingPaletteNames={palettes.map((p) => p.name)}
+            requireDirty={false}
         />
     );
 };

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteModalBase.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteModalBase.tsx
@@ -37,6 +37,12 @@ export type PaletteModalBaseProps = Pick<ModalProps, 'opened' | 'onClose'> & {
     title: string;
     submitButtonText: string;
     existingPaletteNames?: string[];
+    /**
+     * When false, the submit button only requires the form to be valid (not
+     * dirty). Used when the form is pre-seeded — e.g. generating a palette from
+     * brand colors — so the user can submit without editing first.
+     */
+    requireDirty?: boolean;
 };
 
 export const PaletteModalBase: FC<PaletteModalBaseProps> = ({
@@ -48,6 +54,7 @@ export const PaletteModalBase: FC<PaletteModalBaseProps> = ({
     title,
     submitButtonText,
     existingPaletteNames = [],
+    requireDirty = true,
 }) => {
     const [showAllColors, setShowAllColors] = useState(false);
     const { colorScheme } = useMantineColorScheme();
@@ -185,7 +192,7 @@ export const PaletteModalBase: FC<PaletteModalBaseProps> = ({
                     type="submit"
                     form="palette-form"
                     loading={isLoading}
-                    disabled={!form.isDirty() || !form.isValid()}
+                    disabled={(requireDirty && !form.isDirty()) || !form.isValid()}
                 >
                     {submitButtonText}
                 </Button>

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/index.tsx
@@ -1,25 +1,35 @@
+import { generatePaletteFromBrandColors } from '@lightdash/common';
 import {
     ActionIcon,
     Button,
     Group,
+    Menu,
     Skeleton,
     Stack,
     Text,
     Title,
     Tooltip,
 } from '@mantine-8/core';
-import { IconInfoCircle, IconPlus } from '@tabler/icons-react';
-import { useCallback, useState, type FC } from 'react';
+import {
+    IconChevronDown,
+    IconInfoCircle,
+    IconPalette,
+    IconPlus,
+    IconSparkles,
+} from '@tabler/icons-react';
+import { useCallback, useMemo, useState, type FC } from 'react';
 import {
     useColorPalettes,
     useSetActiveColorPalette,
 } from '../../../hooks/appearance/useOrganizationAppearance';
 import useHealth from '../../../hooks/health/useHealth';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
+import { useOrganizationBrand } from '../../../hooks/organization/useOrganizationBrand';
 import MantineIcon from '../../common/MantineIcon';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
 import { BrandAppearanceSettings } from './BrandAppearanceSettings';
 import { CreatePaletteModal } from './CreatePaletteModal';
+import { type PaletteFormValues } from './PaletteModalBase';
 import { PaletteItem } from './PaletteItem';
 
 const AppearanceColorSettings: FC = () => {
@@ -27,11 +37,14 @@ const AppearanceColorSettings: FC = () => {
     const { data: health, isLoading: isHealthLoading } = useHealth();
     const { data: palettes = [], isLoading: isPalettesLoading } =
         useColorPalettes();
+    const { data: brand } = useOrganizationBrand();
 
     const setActivePalette = useSetActiveColorPalette();
 
-    const [isCreatePaletteModalOpen, setIsCreatePaletteModalOpen] =
-        useState(false);
+    const [createModalValues, setCreateModalValues] = useState<{
+        initialValues?: PaletteFormValues;
+        title: string;
+    } | null>(null);
 
     const handleSetActive = useCallback(
         (uuid: string) => {
@@ -39,6 +52,28 @@ const AppearanceColorSettings: FC = () => {
         },
         [setActivePalette],
     );
+
+    const brandPalette = useMemo(
+        () => generatePaletteFromBrandColors(brand?.colors ?? []),
+        [brand?.colors],
+    );
+    const hasBrandColors = brandPalette.colors.length > 0;
+    const brandName = brand?.name ?? 'brand';
+
+    const openCustomPalette = useCallback(() => {
+        setCreateModalValues({ title: 'Create new palette' });
+    }, []);
+
+    const openBrandPalette = useCallback(() => {
+        setCreateModalValues({
+            title: 'Create palette from brand colors',
+            initialValues: {
+                name: `${brand?.name ?? 'Brand'} palette`,
+                colors: brandPalette.colors,
+                darkColors: brandPalette.darkColors,
+            },
+        });
+    }, [brand?.name, brandPalette]);
 
     const hasColorPaletteOverride =
         health?.appearance.overrideColorPalette &&
@@ -52,16 +87,57 @@ const AppearanceColorSettings: FC = () => {
                     visualizations.
                 </Text>
 
-                <Button
-                    leftSection={<MantineIcon icon={IconPlus} />}
-                    onClick={() => setIsCreatePaletteModalOpen(true)}
-                    variant="default"
-                    size="xs"
-                    style={{ alignSelf: 'flex-end' }}
-                    disabled={hasColorPaletteOverride}
-                >
-                    Add new palette
-                </Button>
+                {hasBrandColors ? (
+                    <Menu position="bottom-end" withinPortal>
+                        <Menu.Target>
+                            <Button
+                                leftSection={<MantineIcon icon={IconPlus} />}
+                                rightSection={
+                                    <MantineIcon icon={IconChevronDown} />
+                                }
+                                variant="default"
+                                size="xs"
+                                style={{ alignSelf: 'flex-end' }}
+                                disabled={hasColorPaletteOverride}
+                            >
+                                Add new palette
+                            </Button>
+                        </Menu.Target>
+                        <Menu.Dropdown>
+                            <Menu.Item
+                                leftSection={
+                                    <MantineIcon icon={IconSparkles} />
+                                }
+                                onClick={openBrandPalette}
+                            >
+                                <Text size="sm">From brand colors</Text>
+                                <Text size="xs" c="dimmed">
+                                    Generate from {brandName}
+                                </Text>
+                            </Menu.Item>
+                            <Menu.Item
+                                leftSection={<MantineIcon icon={IconPalette} />}
+                                onClick={openCustomPalette}
+                            >
+                                <Text size="sm">Custom palette</Text>
+                                <Text size="xs" c="dimmed">
+                                    Start from scratch & pick each color
+                                </Text>
+                            </Menu.Item>
+                        </Menu.Dropdown>
+                    </Menu>
+                ) : (
+                    <Button
+                        leftSection={<MantineIcon icon={IconPlus} />}
+                        onClick={openCustomPalette}
+                        variant="default"
+                        size="xs"
+                        style={{ alignSelf: 'flex-end' }}
+                        disabled={hasColorPaletteOverride}
+                    >
+                        Add new palette
+                    </Button>
+                )}
             </Group>
 
             <Stack gap="xs">
@@ -114,11 +190,13 @@ const AppearanceColorSettings: FC = () => {
             </Stack>
 
             <CreatePaletteModal
-                key={`create-palette-modal-${isCreatePaletteModalOpen}`}
-                opened={isCreatePaletteModalOpen}
+                key={`create-palette-modal-${createModalValues?.title ?? ''}`}
+                opened={createModalValues !== null}
                 onClose={() => {
-                    setIsCreatePaletteModalOpen(false);
+                    setCreateModalValues(null);
                 }}
+                initialValues={createModalValues?.initialValues}
+                title={createModalValues?.title}
             />
         </Stack>
     );


### PR DESCRIPTION
Adds a **"From brand colors"** option to the palette creation flow that prepopulates a palette generated from the organization's detected brand colors.

## Changes
- **`generatePaletteFromBrandColors`** (new util in `common`) — expands the brand's colors into a valid 20-color light + dark palette using OKLCH hue rotation. Brand colors are kept as the leading anchors (light mode preserves their exact hex; dark mode lifts lightness so dark brand colors stay legible on a dark canvas), and `brand`/`accent` roles are prioritised over `dark`/`light` background roles. Unit tested.
- **"Add new palette"** becomes a menu with **From brand colors** / **Custom palette** when the org has brand colors; otherwise it stays a plain button. The brand option seeds the create-palette modal (name defaults to the brand name, colors + darkColors from the generated palette) where the user can review/tweak before saving.
- `PaletteModalBase` gains a `requireDirty` flag so a pre-seeded palette can be submitted without editing first.

## Notes
- No backend changes — generation runs client-side and reuses the existing create-palette endpoint (still validates exactly 20 colors).
- The menu only appears when the org has usable brand colors (i.e. Brandfetch is configured and a brand has been fetched/saved), so the plain button remains the default experience otherwise.

Verified via unit tests (`generateColorPalette.test.ts`), typecheck, and lint. The brand-populated UI flow itself requires a configured brand to exercise in a running app.