### PR TITLE
feat: add users as organization content as code

### DIFF
--- a/docs/content-as-code.md
+++ b/docs/content-as-code.md
@@ -179,6 +179,7 @@ The CLI implementation lives under
 `packages/cli/src/handlers/organizationContent/`. It only:
 
 - reads and writes `lightdash/custom-roles/*.yml`;
+- treats a missing or empty custom-roles directory as a no-op;
 - creates safe filenames and disambiguates normalized filename collisions;
 - rejects duplicate role names within the local bundle;
 - calls the two `/roles/code` endpoints;
@@ -189,6 +190,47 @@ The CLI implementation lives under
 It intentionally does not list roles through the general roles API, validate
 scope names, calculate scope diffs, or call the lower-level create and patch
 role endpoints.
+
+## Users
+
+Organization users are stored under `lightdash/users/*.yml`:
+
+```yaml
+version: 1
+email: analyst@example.com
+disabled: false
+pending: false
+role:
+  type: system
+  name: editor
+```
+
+The endpoints are:
+
+- `GET /api/v2/orgs/{orgUuid}/users/code`
+- `POST /api/v2/orgs/{orgUuid}/users/code`
+
+Email is the portable identity and is normalized to lowercase. An upload
+creates a missing organization member or reconciles the existing member's
+organization role and disabled state. A custom role is referenced by its exact
+organization-level role name, so organization uploads process custom roles
+before users.
+
+Credentials are not portable. A missing user is staged without an
+authentication method and reported as awaiting authentication. Setting
+`pending: true` preserves that staged state; it never removes credentials from
+an authenticated user. Omitting a user file does not remove the remote user.
+
+Invitations are a separate side effect and are not sent by default. Passing
+`lightdash upload --organization --send-invites` sends invitations only to
+eligible staged users. Authenticated users, disabled users, and users with a
+valid invitation are skipped. Without that flag, users authenticate through
+the instance's existing domain, SSO, or manually triggered invitation flows.
+
+Uploads also preserve the organization admin invariant. Enabled admin
+promotions are processed before admin demotions or disables, and the backend
+rejects any individual operation that would leave the organization without an
+enabled authenticated admin.
 
 ## Adding another content-as-code resource
 

--- a/packages/backend/src/ee/controllers/OrganizationUsersAsCodeController.ts
+++ b/packages/backend/src/ee/controllers/OrganizationUsersAsCodeController.ts
@@ -1,0 +1,76 @@
+import {
+    ApiErrorPayload,
+    ApiUserAsCodeListResponse,
+    ApiUserAsCodeUpsertResponse,
+    UserAsCode,
+} from '@lightdash/common';
+import {
+    Body,
+    Get,
+    Middlewares,
+    OperationId,
+    Path,
+    Post,
+    Query,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+
+@Route('/api/v2/orgs/{orgUuid}/users')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('v2', 'Organizations')
+export class OrganizationUsersAsCodeController extends BaseController {
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/code')
+    @OperationId('GetOrganizationUsersAsCode')
+    async getUsersAsCode(
+        @Request() req: express.Request,
+        @Path() orgUuid: string,
+    ): Promise<ApiUserAsCodeListResponse> {
+        const users = await this.services
+            .getRolesService()
+            .getUsersAsCode(req.account!, orgUuid);
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: { users },
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/code')
+    @OperationId('UpsertOrganizationUserAsCode')
+    async upsertUserAsCode(
+        @Request() req: express.Request,
+        @Path() orgUuid: string,
+        @Body() body: UserAsCode,
+        @Query() sendInvite: boolean = false,
+    ): Promise<ApiUserAsCodeUpsertResponse> {
+        const results = await this.services
+            .getRolesService()
+            .upsertUserAsCode(req.account!, orgUuid, body, sendInvite);
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -163,6 +163,8 @@ import { OrganizationDomainVerificationController } from './../ee/controllers/Or
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { OrganizationSsoController } from './../ee/controllers/OrganizationSsoController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { OrganizationUsersAsCodeController } from './../ee/controllers/OrganizationUsersAsCodeController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { OrganizationWarehouseCredentialsController } from './../ee/controllers/OrganizationWarehouseCredentialsController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { PreAggregateController } from './../ee/controllers/PreAggregateController';
@@ -12641,8 +12643,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: ['url'] },
+                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -13447,8 +13449,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: ['url'] },
+                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -15494,13 +15496,13 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                fieldType:
+                                                                                                tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                tableName:
+                                                                                                fieldType:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
@@ -15600,6 +15602,18 @@ const models: TsoaRoute.Models = {
                                                                                                                                             },
                                                                                                                                         ],
                                                                                                                                 },
+                                                                                                                                required:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'boolean',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                tableName:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
                                                                                                                                 fieldRef:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -15612,22 +15626,10 @@ const models: TsoaRoute.Models = {
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                tableName:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
                                                                                                                                 operator:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                required:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'boolean',
                                                                                                                                         required: true,
                                                                                                                                     },
                                                                                                                             },
@@ -15732,6 +15734,31 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                status: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'enum',
+                                                                                                enums: [
+                                                                                                    'error',
+                                                                                                ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'enum',
+                                                                                                enums: [
+                                                                                                    'success',
+                                                                                                ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
                                                                                 pagination:
                                                                                     {
                                                                                         dataType:
@@ -15774,31 +15801,6 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                status: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'enum',
-                                                                                                enums: [
-                                                                                                    'error',
-                                                                                                ],
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'enum',
-                                                                                                enums: [
-                                                                                                    'success',
-                                                                                                ],
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
                                                                                 error: {
                                                                                     dataType:
                                                                                         'union',
@@ -15892,13 +15894,13 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    fieldType:
+                                                                                                    tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    tableName:
+                                                                                                    fieldType:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
@@ -16124,26 +16126,17 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                description:
+                                                                                fieldId:
                                                                                     {
                                                                                         dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
+                                                                                            'string',
                                                                                         required: true,
                                                                                     },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 fieldType:
                                                                                     {
                                                                                         dataType:
@@ -16167,15 +16160,24 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
+                                                                                description:
                                                                                     {
                                                                                         dataType:
-                                                                                            'string',
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
                                                                                         required: true,
                                                                                     },
                                                                                 label: {
@@ -16254,6 +16256,18 @@ const models: TsoaRoute.Models = {
                                                                                                                         },
                                                                                                                     ],
                                                                                                             },
+                                                                                                            required:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'boolean',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            tableName:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
                                                                                                             fieldRef:
                                                                                                                 {
                                                                                                                     dataType:
@@ -16266,22 +16280,10 @@ const models: TsoaRoute.Models = {
                                                                                                                         'string',
                                                                                                                     required: true,
                                                                                                                 },
-                                                                                                            tableName:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
                                                                                                             operator:
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'string',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            required:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'boolean',
                                                                                                                     required: true,
                                                                                                                 },
                                                                                                         },
@@ -16474,13 +16476,6 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
-                                                warnings: {
-                                                    dataType: 'array',
-                                                    array: {
-                                                        dataType: 'string',
-                                                    },
-                                                    required: true,
-                                                },
                                                 href: {
                                                     dataType: 'string',
                                                     required: true,
@@ -16496,6 +16491,13 @@ const models: TsoaRoute.Models = {
                                                 },
                                                 uuid: {
                                                     dataType: 'string',
+                                                    required: true,
+                                                },
+                                                warnings: {
+                                                    dataType: 'array',
+                                                    array: {
+                                                        dataType: 'string',
+                                                    },
                                                     required: true,
                                                 },
                                                 name: {
@@ -17165,13 +17167,13 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                fieldType:
+                                                                                tableName:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                tableName:
+                                                                                fieldType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
@@ -22046,6 +22048,140 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UserAsCodeRole: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { ref: 'OrganizationMemberRole', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['system'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        name: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['custom'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UserAsCode: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                role: { ref: 'UserAsCodeRole', required: true },
+                pending: { dataType: 'boolean', required: true },
+                disabled: { dataType: 'boolean', required: true },
+                email: { dataType: 'string', required: true },
+                version: { dataType: 'enum', enums: [1], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUserAsCodeListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        users: {
+                            dataType: 'array',
+                            array: { dataType: 'refAlias', ref: 'UserAsCode' },
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'PromotionAction.CREATE': {
+        dataType: 'refEnum',
+        enums: ['create'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'PromotionAction.UPDATE': {
+        dataType: 'refEnum',
+        enums: ['update'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'PromotionAction.NO_CHANGES': {
+        dataType: 'refEnum',
+        enums: ['no changes'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UserAsCodeLifecycleStatus: {
+        dataType: 'refEnum',
+        enums: ['ready', 'awaiting authentication'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UserAsCodeInvitationStatus: {
+        dataType: 'refEnum',
+        enums: [
+            'not requested',
+            'sent',
+            'skipped authenticated',
+            'skipped disabled',
+            'skipped valid invite',
+        ],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUserAsCodeUpsertResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        invitation: {
+                            ref: 'UserAsCodeInvitationStatus',
+                            required: true,
+                        },
+                        lifecycle: {
+                            ref: 'UserAsCodeLifecycleStatus',
+                            required: true,
+                        },
+                        action: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'PromotionAction.CREATE' },
+                                { ref: 'PromotionAction.UPDATE' },
+                                { ref: 'PromotionAction.NO_CHANGES' },
+                            ],
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_AzureAdSsoConfig.oauth2ClientId-or-oauth2TenantId_': {
         dataType: 'refAlias',
         type: {
@@ -22828,21 +22964,6 @@ const models: TsoaRoute.Models = {
             },
             validators: {},
         },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PromotionAction.CREATE': {
-        dataType: 'refEnum',
-        enums: ['create'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PromotionAction.UPDATE': {
-        dataType: 'refEnum',
-        enums: ['update'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PromotionAction.NO_CHANGES': {
-        dataType: 'refEnum',
-        enums: ['no changes'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiCustomRoleAsCodeUpsertResponse: {
@@ -34602,7 +34723,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34612,7 +34733,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34622,7 +34743,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -34635,7 +34756,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -59423,6 +59544,135 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationUsersAsCodeController_getUsersAsCode: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        orgUuid: {
+            in: 'path',
+            name: 'orgUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v2/orgs/:orgUuid/users/code',
+        ...fetchMiddlewares<RequestHandler>(OrganizationUsersAsCodeController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationUsersAsCodeController.prototype.getUsersAsCode,
+        ),
+
+        async function OrganizationUsersAsCodeController_getUsersAsCode(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationUsersAsCodeController_getUsersAsCode,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationUsersAsCodeController>(
+                        OrganizationUsersAsCodeController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getUsersAsCode',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationUsersAsCodeController_upsertUserAsCode: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        orgUuid: {
+            in: 'path',
+            name: 'orgUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: { in: 'body', name: 'body', required: true, ref: 'UserAsCode' },
+        sendInvite: {
+            default: false,
+            in: 'query',
+            name: 'sendInvite',
+            dataType: 'boolean',
+        },
+    };
+    app.post(
+        '/api/v2/orgs/:orgUuid/users/code',
+        ...fetchMiddlewares<RequestHandler>(OrganizationUsersAsCodeController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationUsersAsCodeController.prototype.upsertUserAsCode,
+        ),
+
+        async function OrganizationUsersAsCodeController_upsertUserAsCode(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationUsersAsCodeController_upsertUserAsCode,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationUsersAsCodeController>(
+                        OrganizationUsersAsCodeController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'upsertUserAsCode',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
                 });
             } catch (err) {
                 return next(err);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14281,7 +14281,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["upload", "url", null],
+                        "enum": ["url", "upload", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -15095,7 +15095,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["upload", "url", null],
+                        "enum": ["url", "upload", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -17031,10 +17031,10 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "fieldType": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "fieldType": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
@@ -17045,8 +17045,8 @@
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "fieldType",
                                                                         "tableName",
+                                                                        "fieldType",
                                                                         "label",
                                                                         "name"
                                                                     ],
@@ -17070,28 +17070,28 @@
                                                                                         "items": {},
                                                                                         "type": "array"
                                                                                     },
+                                                                                    "required": {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    "tableName": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "fieldRef": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "fieldId": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "operator": {
                                                                                         "type": "string"
-                                                                                    },
-                                                                                    "required": {
-                                                                                        "type": "boolean"
                                                                                     }
                                                                                 },
                                                                                 "required": [
+                                                                                    "required",
+                                                                                    "tableName",
                                                                                     "fieldRef",
                                                                                     "fieldId",
-                                                                                    "tableName",
-                                                                                    "operator",
-                                                                                    "required"
+                                                                                    "operator"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -17146,6 +17146,13 @@
                                                             "searchQueries": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "status": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "error",
+                                                                                "success"
+                                                                            ]
+                                                                        },
                                                                         "pagination": {
                                                                             "properties": {
                                                                                 "totalPageCount": {
@@ -17173,13 +17180,6 @@
                                                                             ],
                                                                             "type": "object"
                                                                         },
-                                                                        "status": {
-                                                                            "type": "string",
-                                                                            "enum": [
-                                                                                "error",
-                                                                                "success"
-                                                                            ]
-                                                                        },
                                                                         "error": {
                                                                             "type": "string"
                                                                         },
@@ -17201,10 +17201,10 @@
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "fieldType": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "fieldType": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "label": {
@@ -17215,8 +17215,8 @@
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "fieldType",
                                                                                     "tableName",
+                                                                                    "fieldType",
                                                                                     "label",
                                                                                     "name"
                                                                                 ],
@@ -17339,9 +17339,11 @@
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
                                                                                 },
                                                                                 "fieldType": {
                                                                                     "type": "string",
@@ -17350,11 +17352,9 @@
                                                                                         "dimension"
                                                                                     ]
                                                                                 },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
                                                                                 },
                                                                                 "label": {
                                                                                     "type": "string"
@@ -17368,10 +17368,10 @@
                                                                                 "caseSensitiveFilters",
                                                                                 "fieldValueType",
                                                                                 "fieldFilterType",
-                                                                                "description",
-                                                                                "fieldType",
-                                                                                "table",
                                                                                 "fieldId",
+                                                                                "table",
+                                                                                "fieldType",
+                                                                                "description",
                                                                                 "label",
                                                                                 "name"
                                                                             ],
@@ -17393,28 +17393,28 @@
                                                                                             "items": {},
                                                                                             "type": "array"
                                                                                         },
+                                                                                        "required": {
+                                                                                            "type": "boolean"
+                                                                                        },
+                                                                                        "tableName": {
+                                                                                            "type": "string"
+                                                                                        },
                                                                                         "fieldRef": {
                                                                                             "type": "string"
                                                                                         },
                                                                                         "fieldId": {
                                                                                             "type": "string"
                                                                                         },
-                                                                                        "tableName": {
-                                                                                            "type": "string"
-                                                                                        },
                                                                                         "operator": {
                                                                                             "type": "string"
-                                                                                        },
-                                                                                        "required": {
-                                                                                            "type": "boolean"
                                                                                         }
                                                                                     },
                                                                                     "required": [
+                                                                                        "required",
+                                                                                        "tableName",
                                                                                         "fieldRef",
                                                                                         "fieldId",
-                                                                                        "tableName",
-                                                                                        "operator",
-                                                                                        "required"
+                                                                                        "operator"
                                                                                     ],
                                                                                     "type": "object"
                                                                                 },
@@ -17554,12 +17554,6 @@
                                                         ],
                                                         "type": "object"
                                                     },
-                                                    "warnings": {
-                                                        "items": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": "array"
-                                                    },
                                                     "href": {
                                                         "type": "string"
                                                     },
@@ -17574,17 +17568,23 @@
                                                     "uuid": {
                                                         "type": "string"
                                                     },
+                                                    "warnings": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
                                                     "name": {
                                                         "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "versionUuids",
-                                                    "warnings",
                                                     "href",
                                                     "slug",
                                                     "status",
                                                     "uuid",
+                                                    "warnings",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -17818,10 +17818,10 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "fieldType": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "fieldType": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
@@ -17832,8 +17832,8 @@
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "fieldType",
                                                                         "tableName",
+                                                                        "fieldType",
                                                                         "label",
                                                                         "name"
                                                                     ],
@@ -22414,6 +22414,146 @@
                 },
                 "type": "object"
             },
+            "UserAsCodeRole": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "name": {
+                                "$ref": "#/components/schemas/OrganizationMemberRole"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["system"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["custom"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["name", "type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "UserAsCode": {
+                "properties": {
+                    "role": {
+                        "$ref": "#/components/schemas/UserAsCodeRole"
+                    },
+                    "pending": {
+                        "type": "boolean"
+                    },
+                    "disabled": {
+                        "type": "boolean"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "version": {
+                        "type": "number",
+                        "enum": [1],
+                        "nullable": false
+                    }
+                },
+                "required": ["role", "pending", "disabled", "email", "version"],
+                "type": "object"
+            },
+            "ApiUserAsCodeListResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "users": {
+                                "items": {
+                                    "$ref": "#/components/schemas/UserAsCode"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["users"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "PromotionAction.CREATE": {
+                "enum": ["create"],
+                "type": "string"
+            },
+            "PromotionAction.UPDATE": {
+                "enum": ["update"],
+                "type": "string"
+            },
+            "PromotionAction.NO_CHANGES": {
+                "enum": ["no changes"],
+                "type": "string"
+            },
+            "UserAsCodeLifecycleStatus": {
+                "enum": ["ready", "awaiting authentication"],
+                "type": "string"
+            },
+            "UserAsCodeInvitationStatus": {
+                "enum": [
+                    "not requested",
+                    "sent",
+                    "skipped authenticated",
+                    "skipped disabled",
+                    "skipped valid invite"
+                ],
+                "type": "string"
+            },
+            "ApiUserAsCodeUpsertResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "invitation": {
+                                "$ref": "#/components/schemas/UserAsCodeInvitationStatus"
+                            },
+                            "lifecycle": {
+                                "$ref": "#/components/schemas/UserAsCodeLifecycleStatus"
+                            },
+                            "action": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/PromotionAction.CREATE"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PromotionAction.UPDATE"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PromotionAction.NO_CHANGES"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["invitation", "lifecycle", "action"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "Pick_AzureAdSsoConfig.oauth2ClientId-or-oauth2TenantId_": {
                 "properties": {
                     "oauth2ClientId": {
@@ -23202,18 +23342,6 @@
                 },
                 "required": ["results", "status"],
                 "type": "object"
-            },
-            "PromotionAction.CREATE": {
-                "enum": ["create"],
-                "type": "string"
-            },
-            "PromotionAction.UPDATE": {
-                "enum": ["update"],
-                "type": "string"
-            },
-            "PromotionAction.NO_CHANGES": {
-                "enum": ["no changes"],
-                "type": "string"
             },
             "ApiCustomRoleAsCodeUpsertResponse": {
                 "properties": {
@@ -35058,22 +35186,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -46399,7 +46527,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3382.2",
+        "version": "0.3383.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -52717,6 +52845,101 @@
                         }
                     }
                 ]
+            }
+        },
+        "/api/v2/orgs/{orgUuid}/users/code": {
+            "get": {
+                "operationId": "GetOrganizationUsersAsCode",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiUserAsCodeListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["v2", "Organizations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "orgUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "UpsertOrganizationUserAsCode",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiUserAsCodeUpsertResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["v2", "Organizations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "orgUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "sendInvite",
+                        "required": false,
+                        "schema": {
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UserAsCode"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/org/sso/azuread": {

--- a/packages/backend/src/models/InviteLinkModel.ts
+++ b/packages/backend/src/models/InviteLinkModel.ts
@@ -110,6 +110,18 @@ export class InviteLinkModel {
         return this.getByCode(inviteCode);
     }
 
+    async hasValidInviteLink(
+        userUuid: string,
+        now: Date = new Date(),
+    ): Promise<boolean> {
+        const inviteLink = await this.database(InviteLinkTableName)
+            .where('user_uuid', userUuid)
+            .andWhere('expires_at', '>', now)
+            .first('user_uuid');
+
+        return inviteLink !== undefined;
+    }
+
     async deleteByOrganization(organizationUuid: string) {
         const orgs = await this.database('organizations')
             .where('organization_uuid', organizationUuid)

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -56,6 +56,7 @@ const SelectColumns = [
     `${EmailTableName}.email`,
     `${OrganizationTableName}.organization_uuid`,
     `${OrganizationMembershipsTableName}.role`,
+    `${OrganizationMembershipsTableName}.role_uuid`,
     `${InviteLinkTableName}.expires_at`,
     `${UserTableName}.created_at as user_created_at`,
     `${UserTableName}.updated_at as user_updated_at`,
@@ -226,6 +227,36 @@ export class OrganizationMemberProfileModel {
                 ),
             ),
         };
+    }
+
+    async getAllOrganizationMembers(
+        organizationUuid: string,
+    ): Promise<OrganizationMemberProfile[]> {
+        const members = await this.queryBuilder()
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .select<DbOrganizationMemberProfile[]>(SelectColumns)
+            .orderBy(`${EmailTableName}.email`, 'asc');
+
+        const usersHaveAuthenticationRows =
+            await UserModel.findIfUsersHaveAuthentication(this.database, {
+                userUuids: members.map((member) => member.user_uuid),
+            });
+        const usersHaveAuthenticationMap = new Map(
+            usersHaveAuthenticationRows.map((row) => [
+                row.user_uuid,
+                row.has_authentication,
+            ]),
+        );
+
+        return members.map((member) =>
+            OrganizationMemberProfileModel.parseRow(
+                member,
+                usersHaveAuthenticationMap.get(member.user_uuid) || false,
+            ),
+        );
     }
 
     async getOrganizationMembersAndGroups(

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -982,6 +982,7 @@ export class UserModel {
     async createPendingUser(
         organizationUuid: string,
         createUser: CreateUserWithRole,
+        isActive: boolean = true,
     ): Promise<LightdashUser> {
         const [org] = await this.database(OrganizationTableName)
             .where('organization_uuid', organizationUuid)
@@ -1007,7 +1008,7 @@ export class UserModel {
         const user = await this.database.transaction(async (trx) => {
             const newUser = await this.createUserTransaction(trx, {
                 ...createUser,
-                isActive: true,
+                isActive,
             });
             await trx(OrganizationMembershipsTableName).insert({
                 organization_id: org.organization_id,

--- a/packages/backend/src/services/RolesService/RolesService.mock.ts
+++ b/packages/backend/src/services/RolesService/RolesService.mock.ts
@@ -23,6 +23,8 @@ export const mockAccount = {
         role: OrganizationMemberRole.ADMIN,
         ability: new Ability<PossibleAbilities>([
             { subject: 'Organization', action: ['manage'] },
+            { subject: 'OrganizationMemberProfile', action: ['manage'] },
+            { subject: 'InviteLink', action: ['manage'] },
             { subject: 'Project', action: ['manage'] },
         ]),
         abilityRules: [] as any, // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -177,7 +179,15 @@ export const mockAnalytics: Record<string, MockFn> = {
     track: vi.fn(),
 };
 
+export const mockEmailClient: Record<string, MockFn> = {
+    sendInviteEmail: vi.fn(),
+};
+
 export const mockUserModel: Record<string, MockFn> = {
+    findUserByEmail: vi.fn(),
+    createPendingUser: vi.fn(),
+    joinOrg: vi.fn(),
+    updateUser: vi.fn(),
     getUserDetailsByUuid: vi.fn().mockResolvedValue({
         firstName: 'Test',
         lastName: 'User',
@@ -212,4 +222,15 @@ export const mockGroupsModel: Record<string, MockFn> = {
 export const mockAdminNotificationService: Record<string, MockFn> = {
     notifyOrgAdminRoleChange: vi.fn().mockResolvedValue(undefined),
     notifyProjectAdminRoleChange: vi.fn().mockResolvedValue(undefined),
+};
+
+export const mockInviteLinkModel: Record<string, MockFn> = {
+    hasValidInviteLink: vi.fn(),
+    upsert: vi.fn(),
+    deleteByCode: vi.fn(),
+};
+
+export const mockOrganizationMemberProfileModel: Record<string, MockFn> = {
+    getAllOrganizationMembers: vi.fn(),
+    getOrganizationAdmins: vi.fn(),
 };

--- a/packages/backend/src/services/RolesService/RolesService.test.ts
+++ b/packages/backend/src/services/RolesService/RolesService.test.ts
@@ -9,11 +9,16 @@ import {
     ParameterError,
     ProjectMemberRole,
     PromotionAction,
+    UserAsCode,
+    UserAsCodeInvitationStatus,
+    UserAsCodeLifecycleStatus,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import EmailClient from '../../clients/EmailClient/EmailClient';
 import { LightdashConfig } from '../../config/parseConfig';
 import { GroupsModel } from '../../models/GroupsModel';
+import { InviteLinkModel } from '../../models/InviteLinkModel';
+import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { RolesModel } from '../../models/RolesModel';
@@ -27,8 +32,11 @@ import {
     mockAnalytics,
     mockCustomRole,
     mockCustomRoleWithScopes,
+    mockEmailClient,
     mockGroupsModel,
+    mockInviteLinkModel,
     mockNewRole,
+    mockOrganizationMemberProfileModel,
     mockOrganizationModel,
     mockProjectModel,
     mockRolesModel,
@@ -45,9 +53,12 @@ describe('RolesService', () => {
             mockOrganizationModel as unknown as OrganizationModel,
         groupsModel: mockGroupsModel as unknown as GroupsModel,
         projectModel: mockProjectModel as unknown as ProjectModel,
-        emailClient: {} as unknown as EmailClient,
+        emailClient: mockEmailClient as unknown as EmailClient,
         adminNotificationService:
             mockAdminNotificationService as unknown as AdminNotificationService,
+        inviteLinkModel: mockInviteLinkModel as unknown as InviteLinkModel,
+        organizationMemberProfileModel:
+            mockOrganizationMemberProfileModel as unknown as OrganizationMemberProfileModel,
     });
     beforeEach(() => {
         vi.clearAllMocks();
@@ -255,6 +266,225 @@ describe('RolesService', () => {
             ).rejects.toThrow(
                 'Cannot change custom role "Custom Role" level from project to organization',
             );
+        });
+    });
+
+    describe('users as code', () => {
+        const userAsCode = (
+            overrides: Partial<UserAsCode> = {},
+        ): UserAsCode => ({
+            version: 1,
+            email: 'new-user@example.com',
+            disabled: false,
+            pending: false,
+            role: {
+                type: 'system',
+                name: OrganizationMemberRole.MEMBER,
+            },
+            ...overrides,
+        });
+
+        const pendingUser = {
+            userUuid: 'pending-user-uuid',
+            email: 'new-user@example.com',
+            organizationUuid: 'test-org-uuid',
+            role: OrganizationMemberRole.MEMBER,
+            roleUuid: undefined,
+            isActive: true,
+            isPending: true,
+            firstName: '',
+            lastName: '',
+        };
+
+        it('downloads users with portable roles and lifecycle flags', async () => {
+            mockOrganizationMemberProfileModel.getAllOrganizationMembers.mockResolvedValue(
+                [
+                    {
+                        ...pendingUser,
+                        email: 'SYSTEM@EXAMPLE.COM',
+                        isActive: false,
+                    },
+                    {
+                        ...pendingUser,
+                        userUuid: 'custom-user-uuid',
+                        email: 'custom@example.com',
+                        roleUuid: 'organization-custom-role-uuid',
+                        isActive: true,
+                        isPending: false,
+                    },
+                ],
+            );
+            mockRolesModel.getRolesWithScopesByOrganizationUuid.mockResolvedValue(
+                [
+                    {
+                        ...mockCustomRoleWithScopes,
+                        roleUuid: 'organization-custom-role-uuid',
+                        name: 'Data steward',
+                        level: 'organization',
+                    },
+                ],
+            );
+
+            await expect(
+                service.getUsersAsCode(mockAccount, 'test-org-uuid'),
+            ).resolves.toStrictEqual([
+                {
+                    version: 1,
+                    email: 'system@example.com',
+                    disabled: true,
+                    pending: true,
+                    role: {
+                        type: 'system',
+                        name: OrganizationMemberRole.MEMBER,
+                    },
+                },
+                {
+                    version: 1,
+                    email: 'custom@example.com',
+                    disabled: false,
+                    pending: false,
+                    role: { type: 'custom', name: 'Data steward' },
+                },
+            ]);
+        });
+
+        it('stages a missing user without sending an invitation by default', async () => {
+            mockUserModel.findUserByEmail.mockResolvedValueOnce(undefined);
+            mockUserModel.createPendingUser.mockResolvedValueOnce(pendingUser);
+            mockUserModel.getUserDetailsByUuid
+                .mockResolvedValueOnce(pendingUser)
+                .mockResolvedValueOnce(pendingUser);
+
+            await expect(
+                service.upsertUserAsCode(
+                    mockAccount,
+                    'test-org-uuid',
+                    userAsCode(),
+                ),
+            ).resolves.toStrictEqual({
+                action: PromotionAction.CREATE,
+                lifecycle: UserAsCodeLifecycleStatus.AWAITING_AUTHENTICATION,
+                invitation: UserAsCodeInvitationStatus.NOT_REQUESTED,
+            });
+            expect(mockUserModel.createPendingUser).toHaveBeenCalledWith(
+                'test-org-uuid',
+                {
+                    email: 'new-user@example.com',
+                    firstName: '',
+                    lastName: '',
+                    role: OrganizationMemberRole.MEMBER,
+                },
+                true,
+            );
+            expect(mockEmailClient.sendInviteEmail).not.toHaveBeenCalled();
+        });
+
+        it('reconciles disabled and declared-pending flags', async () => {
+            mockUserModel.findUserByEmail.mockResolvedValueOnce(pendingUser);
+            mockUserModel.getUserDetailsByUuid.mockResolvedValueOnce({
+                ...pendingUser,
+                isActive: false,
+            });
+
+            await expect(
+                service.upsertUserAsCode(
+                    mockAccount,
+                    'test-org-uuid',
+                    userAsCode({ disabled: true, pending: true }),
+                    true,
+                ),
+            ).resolves.toStrictEqual({
+                action: PromotionAction.UPDATE,
+                lifecycle: UserAsCodeLifecycleStatus.READY,
+                invitation: UserAsCodeInvitationStatus.SKIPPED_DISABLED,
+            });
+            expect(mockUserModel.updateUser).toHaveBeenCalledWith(
+                pendingUser.userUuid,
+                pendingUser.email,
+                { isActive: false },
+            );
+            expect(mockEmailClient.sendInviteEmail).not.toHaveBeenCalled();
+        });
+
+        it('sends an opt-in invitation to an eligible staged user', async () => {
+            mockUserModel.findUserByEmail.mockResolvedValueOnce(pendingUser);
+            mockUserModel.getUserDetailsByUuid
+                .mockResolvedValueOnce(pendingUser)
+                .mockResolvedValueOnce(pendingUser);
+            mockInviteLinkModel.hasValidInviteLink.mockResolvedValueOnce(false);
+            mockInviteLinkModel.upsert.mockResolvedValueOnce({
+                inviteCode: 'invite-code',
+                inviteUrl: 'https://lightdash.example/invite/invite-code',
+                expiresAt: new Date('2026-01-01'),
+                organizationUuid: 'test-org-uuid',
+                userUuid: pendingUser.userUuid,
+                email: pendingUser.email,
+            });
+
+            await expect(
+                service.upsertUserAsCode(
+                    mockAccount,
+                    'test-org-uuid',
+                    userAsCode({ pending: true }),
+                    true,
+                ),
+            ).resolves.toStrictEqual({
+                action: PromotionAction.NO_CHANGES,
+                lifecycle: UserAsCodeLifecycleStatus.READY,
+                invitation: UserAsCodeInvitationStatus.SENT,
+            });
+            expect(mockEmailClient.sendInviteEmail).toHaveBeenCalledOnce();
+        });
+
+        it('does not remove credentials to reproduce a pending state', async () => {
+            mockUserModel.findUserByEmail.mockResolvedValueOnce({
+                ...pendingUser,
+                isPending: false,
+            });
+
+            await expect(
+                service.upsertUserAsCode(
+                    mockAccount,
+                    'test-org-uuid',
+                    userAsCode({ pending: true }),
+                ),
+            ).rejects.toThrow('upload never removes credentials');
+        });
+
+        it('refuses to disable or demote the last usable admin', async () => {
+            const admin = {
+                ...pendingUser,
+                userUuid: 'admin-user-uuid',
+                email: 'admin@example.com',
+                role: OrganizationMemberRole.ADMIN,
+                isPending: false,
+            };
+            mockUserModel.findUserByEmail.mockResolvedValueOnce(admin);
+            mockOrganizationMemberProfileModel.getOrganizationAdmins.mockResolvedValueOnce(
+                [admin],
+            );
+
+            await expect(
+                service.upsertUserAsCode(
+                    mockAccount,
+                    'test-org-uuid',
+                    userAsCode({
+                        email: admin.email,
+                        role: {
+                            type: 'system',
+                            name: OrganizationMemberRole.EDITOR,
+                        },
+                    }),
+                ),
+            ).rejects.toThrow(
+                'Organization must have at least one enabled authenticated admin',
+            );
+        });
+
+        it('requires organization-member permissions', async () => {
+            await expect(
+                service.getUsersAsCode(mockAccountNoAccess, 'test-org-uuid'),
+            ).rejects.toThrow(ForbiddenError);
         });
     });
 

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -3,10 +3,13 @@ import {
     Account,
     AddScopesToRole,
     ApiCustomRoleAsCodeUpsertResponse,
+    ApiUserAsCodeUpsertResponse,
+    assertRegisteredAccount,
     CreateRole,
     CustomRoleAsCode,
     ForbiddenError,
     getAllScopeMap,
+    isOrganizationMemberRole,
     isScopeAssignableAtLevel,
     isSystemRole,
     NotFoundError,
@@ -22,14 +25,22 @@ import {
     UpdateRole,
     UpdateRoleAssignmentRequest,
     UpsertUserRoleAssignmentRequest,
+    UserAsCode,
+    UserAsCodeInvitationStatus,
+    UserAsCodeLifecycleStatus,
+    UserAsCodeRole,
+    validateEmail,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { nanoid } from 'nanoid';
 import { DatabaseError } from 'pg';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import EmailClient from '../../clients/EmailClient/EmailClient';
 import { LightdashConfig } from '../../config/parseConfig';
 import { CaslAuditWrapper } from '../../logging/caslAuditWrapper';
 import { GroupsModel } from '../../models/GroupsModel';
+import { InviteLinkModel } from '../../models/InviteLinkModel';
+import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { RolesModel } from '../../models/RolesModel';
@@ -48,6 +59,8 @@ type RolesServiceArguments = {
     projectModel: ProjectModel;
     emailClient: EmailClient;
     adminNotificationService: AdminNotificationService;
+    inviteLinkModel: InviteLinkModel;
+    organizationMemberProfileModel: OrganizationMemberProfileModel;
 };
 
 export class RolesService extends BaseService {
@@ -69,6 +82,10 @@ export class RolesService extends BaseService {
 
     private readonly adminNotificationService: AdminNotificationService;
 
+    private readonly inviteLinkModel: InviteLinkModel;
+
+    private readonly organizationMemberProfileModel: OrganizationMemberProfileModel;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -79,6 +96,8 @@ export class RolesService extends BaseService {
         projectModel,
         emailClient,
         adminNotificationService,
+        inviteLinkModel,
+        organizationMemberProfileModel,
     }: RolesServiceArguments) {
         super({ serviceName: 'RolesService' });
         this.lightdashConfig = lightdashConfig;
@@ -90,6 +109,8 @@ export class RolesService extends BaseService {
         this.projectModel = projectModel;
         this.emailClient = emailClient;
         this.adminNotificationService = adminNotificationService;
+        this.inviteLinkModel = inviteLinkModel;
+        this.organizationMemberProfileModel = organizationMemberProfileModel;
     }
 
     /**
@@ -457,6 +478,432 @@ export class RolesService extends BaseService {
         return { action: PromotionAction.UPDATE };
     }
 
+    private static validateUserAsCode(desiredUser: UserAsCode): UserAsCode {
+        if (
+            typeof desiredUser !== 'object' ||
+            desiredUser === null ||
+            Array.isArray(desiredUser)
+        ) {
+            throw new ParameterError('User as code must be an object');
+        }
+
+        const expectedKeys = [
+            'version',
+            'email',
+            'disabled',
+            'pending',
+            'role',
+        ];
+        const unknownKeys = Object.keys(desiredUser).filter(
+            (key) => !expectedKeys.includes(key),
+        );
+        if (unknownKeys.length > 0) {
+            throw new ParameterError(
+                `Unknown user fields: ${unknownKeys.sort().join(', ')}`,
+            );
+        }
+        if (desiredUser.version !== 1) {
+            throw new ParameterError(
+                `Unsupported user as-code version ${desiredUser.version}`,
+            );
+        }
+        if (
+            typeof desiredUser.email !== 'string' ||
+            !validateEmail(desiredUser.email)
+        ) {
+            throw new ParameterError(`Invalid email: ${desiredUser.email}`);
+        }
+        if (typeof desiredUser.disabled !== 'boolean') {
+            throw new ParameterError('User disabled must be a boolean');
+        }
+        if (typeof desiredUser.pending !== 'boolean') {
+            throw new ParameterError('User pending must be a boolean');
+        }
+        if (
+            typeof desiredUser.role !== 'object' ||
+            desiredUser.role === null ||
+            Array.isArray(desiredUser.role)
+        ) {
+            throw new ParameterError('User role must be an object');
+        }
+        const unknownRoleKeys = Object.keys(desiredUser.role).filter(
+            (key) => !['type', 'name'].includes(key),
+        );
+        if (unknownRoleKeys.length > 0) {
+            throw new ParameterError(
+                `Unknown user role fields: ${unknownRoleKeys.sort().join(', ')}`,
+            );
+        }
+        if (
+            desiredUser.role.type !== 'system' &&
+            desiredUser.role.type !== 'custom'
+        ) {
+            throw new ParameterError(
+                'User role type must be "system" or "custom"',
+            );
+        }
+        if (
+            typeof desiredUser.role.name !== 'string' ||
+            desiredUser.role.name.trim().length === 0
+        ) {
+            throw new ParameterError('User role name cannot be empty');
+        }
+        if (
+            desiredUser.role.type === 'system' &&
+            !isOrganizationMemberRole(desiredUser.role.name)
+        ) {
+            throw new ParameterError(
+                `Invalid system organization role: ${desiredUser.role.name}`,
+            );
+        }
+
+        return {
+            ...desiredUser,
+            email: desiredUser.email.toLowerCase(),
+        };
+    }
+
+    private static validateUsersAsCodeAccess(
+        account: Account,
+        auditedAbility: CaslAuditWrapper<Ability>,
+        organizationUuid: string,
+        action: 'view' | 'manage',
+    ): void {
+        assertRegisteredAccount(account);
+        if (account.organization.organizationUuid !== organizationUuid) {
+            throw new ForbiddenError();
+        }
+        if (
+            auditedAbility.cannot(
+                action,
+                subject('OrganizationMemberProfile', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+    }
+
+    private async resolveUserAsCodeRole(
+        organizationUuid: string,
+        role: UserAsCodeRole,
+    ): Promise<string> {
+        if (role.type === 'system') {
+            return role.name;
+        }
+
+        const matchingRoles = (
+            await this.rolesModel.getRolesWithScopesByOrganizationUuid(
+                organizationUuid,
+                'user',
+            )
+        ).filter(
+            (candidate) =>
+                candidate.name === role.name &&
+                candidate.level === 'organization',
+        );
+
+        if (matchingRoles.length === 0) {
+            throw new ParameterError(
+                `Organization custom role "${role.name}" not found`,
+            );
+        }
+        if (matchingRoles.length > 1) {
+            throw new ParameterError(
+                `Multiple organization custom roles named "${role.name}" found`,
+            );
+        }
+        if (matchingRoles[0].scopes.length === 0) {
+            throw new ParameterError(
+                `Organization custom role "${role.name}" must have at least one scope`,
+            );
+        }
+
+        return matchingRoles[0].roleUuid;
+    }
+
+    async getUsersAsCode(
+        account: Account,
+        organizationUuid: string,
+    ): Promise<UserAsCode[]> {
+        const auditedAbility = this.createAuditedAbility(account);
+        RolesService.validateUsersAsCodeAccess(
+            account,
+            auditedAbility,
+            organizationUuid,
+            'view',
+        );
+
+        const [members, customRoles] = await Promise.all([
+            this.organizationMemberProfileModel.getAllOrganizationMembers(
+                organizationUuid,
+            ),
+            this.rolesModel.getRolesWithScopesByOrganizationUuid(
+                organizationUuid,
+                'user',
+            ),
+        ]);
+        const customRoleNames = new Map(
+            customRoles
+                .filter((role) => role.level === 'organization')
+                .map((role) => [role.roleUuid, role.name]),
+        );
+
+        return members.map((member) => {
+            let role: UserAsCodeRole;
+            if (member.roleUuid) {
+                const roleName = customRoleNames.get(member.roleUuid);
+                if (!roleName) {
+                    throw new ParameterError(
+                        `Organization custom role ${member.roleUuid} assigned to ${member.email} was not found`,
+                    );
+                }
+                role = { type: 'custom', name: roleName };
+            } else {
+                role = { type: 'system', name: member.role };
+            }
+
+            return {
+                version: 1,
+                email: member.email.toLowerCase(),
+                disabled: !member.isActive,
+                pending: member.isPending ?? false,
+                role,
+            };
+        });
+    }
+
+    private async validateUsableAdminChange(
+        organizationUuid: string,
+        existingUser: Awaited<ReturnType<UserModel['findUserByEmail']>>,
+        desiredRoleId: string,
+        disabled: boolean,
+    ): Promise<void> {
+        if (
+            !existingUser ||
+            existingUser.role !== OrganizationMemberRole.ADMIN ||
+            !existingUser.isActive ||
+            existingUser.isPending ||
+            (desiredRoleId === OrganizationMemberRole.ADMIN && !disabled)
+        ) {
+            return;
+        }
+
+        const usableAdmins = (
+            await this.organizationMemberProfileModel.getOrganizationAdmins(
+                organizationUuid,
+            )
+        ).filter((admin) => admin.isActive && !admin.isPending);
+        if (
+            usableAdmins.length === 1 &&
+            usableAdmins[0].userUuid === existingUser.userUuid
+        ) {
+            throw new ParameterError(
+                'Organization must have at least one enabled authenticated admin',
+            );
+        }
+    }
+
+    private async getUserAsCodeInvitationStatus({
+        account,
+        organizationUuid,
+        userUuid,
+        desiredUser,
+        sendInvite,
+    }: {
+        account: Account;
+        organizationUuid: string;
+        userUuid: string;
+        desiredUser: UserAsCode;
+        sendInvite: boolean;
+    }): Promise<UserAsCodeInvitationStatus> {
+        if (!sendInvite) {
+            return UserAsCodeInvitationStatus.NOT_REQUESTED;
+        }
+        if (desiredUser.disabled) {
+            return UserAsCodeInvitationStatus.SKIPPED_DISABLED;
+        }
+
+        const user = await this.userModel.getUserDetailsByUuid(userUuid);
+        if (!user.isPending) {
+            return UserAsCodeInvitationStatus.SKIPPED_AUTHENTICATED;
+        }
+        if (await this.inviteLinkModel.hasValidInviteLink(userUuid)) {
+            return UserAsCodeInvitationStatus.SKIPPED_VALID_INVITE;
+        }
+
+        assertRegisteredAccount(account);
+        const inviteCode = nanoid(30);
+        const inviteLink = await this.inviteLinkModel.upsert(
+            inviteCode,
+            new Date(Date.now() + 3 * 24 * 60 * 60 * 1000),
+            organizationUuid,
+            userUuid,
+        );
+        try {
+            await this.emailClient.sendInviteEmail(
+                {
+                    firstName: account.user.firstName,
+                    lastName: account.user.lastName,
+                    organizationName: account.organization.name,
+                },
+                inviteLink,
+            );
+        } catch (error) {
+            await this.inviteLinkModel.deleteByCode(inviteCode);
+            throw error;
+        }
+
+        this.analytics.track({
+            userId: account.user.userUuid,
+            event: 'invite_link.created',
+        });
+        return UserAsCodeInvitationStatus.SENT;
+    }
+
+    async upsertUserAsCode(
+        account: Account,
+        organizationUuid: string,
+        desiredUserInput: UserAsCode,
+        sendInvite: boolean = false,
+    ): Promise<ApiUserAsCodeUpsertResponse['results']> {
+        const auditedAbility = this.createAuditedAbility(account);
+        RolesService.validateUsersAsCodeAccess(
+            account,
+            auditedAbility,
+            organizationUuid,
+            'manage',
+        );
+        if (
+            sendInvite &&
+            auditedAbility.cannot(
+                'create',
+                subject('InviteLink', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        assertRegisteredAccount(account);
+        const desiredUser = RolesService.validateUserAsCode(desiredUserInput);
+        const desiredRoleId = await this.resolveUserAsCodeRole(
+            organizationUuid,
+            desiredUser.role,
+        );
+        const existingUser = await this.userModel.findUserByEmail(
+            desiredUser.email,
+        );
+
+        if (
+            existingUser?.organizationUuid &&
+            existingUser.organizationUuid !== organizationUuid
+        ) {
+            throw new ParameterError(
+                'Email is already used by a user in another organization',
+            );
+        }
+        if (existingUser && desiredUser.pending && !existingUser.isPending) {
+            throw new ParameterError(
+                `Cannot make authenticated user ${desiredUser.email} pending because upload never removes credentials`,
+            );
+        }
+
+        const existingRoleId = existingUser
+            ? (existingUser.roleUuid ?? existingUser.role)
+            : undefined;
+        const disabledChanged = existingUser
+            ? existingUser.isActive === desiredUser.disabled
+            : false;
+        const roleChanged = existingRoleId !== desiredRoleId;
+
+        if (
+            existingUser?.userUuid === account.user.userUuid &&
+            (disabledChanged || roleChanged)
+        ) {
+            throw new ForbiddenError(
+                'Upload cannot change the authenticated user role or disabled state',
+            );
+        }
+
+        await this.validateUsableAdminChange(
+            organizationUuid,
+            existingUser,
+            desiredRoleId,
+            desiredUser.disabled,
+        );
+
+        let userUuid: string;
+        let action: ApiUserAsCodeUpsertResponse['results']['action'];
+        if (!existingUser) {
+            const createdUser = await this.userModel.createPendingUser(
+                organizationUuid,
+                {
+                    email: desiredUser.email,
+                    firstName: '',
+                    lastName: '',
+                    role: OrganizationMemberRole.MEMBER,
+                },
+                !desiredUser.disabled,
+            );
+            userUuid = createdUser.userUuid;
+            action = PromotionAction.CREATE;
+        } else if (!existingUser.organizationUuid) {
+            await this.userModel.joinOrg(
+                existingUser.userUuid,
+                organizationUuid,
+                OrganizationMemberRole.MEMBER,
+                undefined,
+            );
+            if (disabledChanged) {
+                await this.userModel.updateUser(
+                    existingUser.userUuid,
+                    existingUser.email,
+                    { isActive: !desiredUser.disabled },
+                );
+            }
+            userUuid = existingUser.userUuid;
+            action = PromotionAction.CREATE;
+        } else {
+            userUuid = existingUser.userUuid;
+            action =
+                roleChanged || disabledChanged
+                    ? PromotionAction.UPDATE
+                    : PromotionAction.NO_CHANGES;
+        }
+
+        if (roleChanged || action === PromotionAction.CREATE) {
+            const user = await this.userModel.getUserDetailsByUuid(userUuid);
+            await this.applyOrganizationUserRoleAssignment(
+                account,
+                organizationUuid,
+                user,
+                desiredRoleId,
+            );
+        }
+        if (
+            existingUser?.organizationUuid === organizationUuid &&
+            disabledChanged
+        ) {
+            await this.userModel.updateUser(userUuid, existingUser.email, {
+                isActive: !desiredUser.disabled,
+            });
+        }
+
+        const currentUser = await this.userModel.getUserDetailsByUuid(userUuid);
+        const lifecycle =
+            currentUser.isPending && !desiredUser.pending
+                ? UserAsCodeLifecycleStatus.AWAITING_AUTHENTICATION
+                : UserAsCodeLifecycleStatus.READY;
+        const invitation = await this.getUserAsCodeInvitationStatus({
+            account,
+            organizationUuid,
+            userUuid,
+            desiredUser,
+            sendInvite,
+        });
+
+        return { action, lifecycle, invitation };
+    }
+
     async createRole(
         account: Account,
         organizationUuid: string,
@@ -622,6 +1069,83 @@ export class RolesService extends BaseService {
      * Assign a system role or an organization-level custom role to a user at
      * the organization level.
      */
+    private async applyOrganizationUserRoleAssignment(
+        account: Account,
+        orgUuid: string,
+        user: Awaited<ReturnType<UserModel['getUserDetailsByUuid']>>,
+        roleId: string,
+    ): Promise<RoleAssignment> {
+        const previousRole = user.role;
+        const isCustomRole =
+            roleId !== OrganizationMemberRole.MEMBER && !isSystemRole(roleId);
+
+        let roleName = roleId;
+        let ownerType: Role['ownerType'] = 'system';
+
+        if (isCustomRole) {
+            const role = await this.rolesModel.getRoleWithScopesByUuid(roleId);
+            if (role.organizationUuid !== orgUuid) {
+                throw new ForbiddenError();
+            }
+            RolesService.validateCustomRoleLevel(role, 'organization');
+
+            if (role.scopes.length === 0) {
+                throw new ParameterError(
+                    'Custom role must have at least one scope',
+                );
+            }
+
+            roleName = role.name;
+            ownerType = 'user';
+        }
+
+        await this.rolesModel.upsertOrganizationUserRoleAssignment(
+            orgUuid,
+            user.userUuid,
+            roleId,
+        );
+
+        this.analytics.track({
+            event: 'organization_role.assigned_to_user',
+            userId: account.user?.id,
+            properties: {
+                organizationUuid: orgUuid,
+                userUuid: user.userUuid,
+                roleId,
+                isSystemRole: !isCustomRole,
+            },
+        });
+
+        if (!isCustomRole) {
+            this.adminNotificationService
+                .notifyOrgAdminRoleChange(
+                    account,
+                    user.userUuid,
+                    orgUuid,
+                    previousRole,
+                    roleId as OrganizationMemberRole,
+                )
+                .catch((err) => {
+                    this.logger.error(
+                        'Failed to send org admin role change notification',
+                        { error: err },
+                    );
+                });
+        }
+
+        return {
+            roleId,
+            roleName,
+            ownerType,
+            assigneeType: 'user',
+            assigneeId: user.userUuid,
+            assigneeName: `${user.firstName} ${user.lastName}`,
+            organizationId: orgUuid,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        };
+    }
+
     async upsertOrganizationUserRoleAssignment(
         account: Account,
         orgUuid: string,
@@ -639,8 +1163,6 @@ export class RolesService extends BaseService {
         );
 
         const user = await this.userModel.getUserDetailsByUuid(userUuid);
-        const previousRole = user.role;
-
         if (user.role === OrganizationMemberRole.ADMIN) {
             // If user is currently an admin, we need to check if there are more admins
             // because every org should have at least one admin
@@ -653,75 +1175,12 @@ export class RolesService extends BaseService {
             }
         }
 
-        const isCustomRole =
-            roleId !== OrganizationMemberRole.MEMBER && !isSystemRole(roleId);
-
-        let roleName = roleId;
-        let ownerType: Role['ownerType'] = 'system';
-
-        if (isCustomRole) {
-            const role = await this.rolesModel.getRoleWithScopesByUuid(roleId);
-            RolesService.validateRoleOwnership(account, auditedAbility, role);
-            RolesService.validateCustomRoleLevel(role, 'organization');
-
-            if (role.scopes.length === 0) {
-                throw new ParameterError(
-                    'Custom role must have at least one scope',
-                );
-            }
-
-            roleName = role.name;
-            ownerType = 'user';
-        }
-
-        await this.rolesModel.upsertOrganizationUserRoleAssignment(
+        return this.applyOrganizationUserRoleAssignment(
+            account,
             orgUuid,
-            userUuid,
+            user,
             roleId,
         );
-
-        this.analytics.track({
-            event: 'organization_role.assigned_to_user',
-            userId: account.user?.id,
-            properties: {
-                organizationUuid: orgUuid,
-                userUuid,
-                roleId,
-                isSystemRole: !isCustomRole,
-            },
-        });
-
-        if (!isCustomRole) {
-            // Safe cast: only system roles reach this branch
-            this.adminNotificationService
-                .notifyOrgAdminRoleChange(
-                    account,
-                    userUuid,
-                    orgUuid,
-                    previousRole,
-                    roleId as OrganizationMemberRole,
-                )
-                .catch((err) => {
-                    this.logger.error(
-                        'Failed to send org admin role change notification',
-                        {
-                            error: err,
-                        },
-                    );
-                });
-        }
-
-        return {
-            roleId,
-            roleName,
-            ownerType,
-            assigneeType: 'user',
-            assigneeId: userUuid,
-            assigneeName: `${user.firstName} ${user.lastName}`,
-            organizationId: orgUuid,
-            createdAt: new Date(),
-            updatedAt: new Date(),
-        };
     }
 
     // =====================================

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1455,6 +1455,9 @@ export class ServiceRepository
                     emailClient: this.clients.getEmailClient(),
                     adminNotificationService:
                         this.getAdminNotificationService(),
+                    inviteLinkModel: this.models.getInviteLinkModel(),
+                    organizationMemberProfileModel:
+                        this.models.getOrganizationMemberProfileModel(),
                 }),
         );
     }

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -146,6 +146,7 @@ export type DownloadHandlerOptions = {
     concurrency: number;
     gzip?: boolean;
     organization: boolean;
+    sendInvites?: boolean;
 };
 
 type FolderScheme = 'flat' | 'nested';
@@ -2420,6 +2421,7 @@ export const uploadHandler = async (
         await uploadOrganizationContent({
             customPath: options.path,
             config,
+            sendInvites: options.sendInvites,
         });
         return;
     }

--- a/packages/cli/src/handlers/organizationContent/customRoles.test.ts
+++ b/packages/cli/src/handlers/organizationContent/customRoles.test.ts
@@ -66,6 +66,9 @@ describe('custom roles as code', () => {
     });
 
     it('downloads portable custom role YAML from the code endpoint', async () => {
+        const folder = getCustomRolesFolder(tmpDir);
+        await fs.mkdir(folder, { recursive: true });
+        await fs.writeFile(path.join(folder, 'stale.yml'), 'stale: true');
         vi.mocked(lightdashApi).mockResolvedValueOnce({
             customRoles: [
                 customRole('Custom Role Name', {
@@ -98,6 +101,9 @@ describe('custom roles as code', () => {
             level: 'organization',
             scopes: ['manage:Space', 'view:Dashboard'],
         });
+        expect((await fs.readdir(folder)).sort()).toStrictEqual([
+            'custom-role-name.yml',
+        ]);
     });
 
     it('uses stable hashes for normalized filename collisions', async () => {
@@ -146,6 +152,30 @@ describe('custom roles as code', () => {
         expect(
             JSON.parse(vi.mocked(lightdashApi).mock.calls[0][0].body as string),
         ).toStrictEqual(customRole('Role A'));
+    });
+
+    it('is a no-op when the custom roles folder is missing or empty', async () => {
+        await expect(
+            uploadCustomRoles('organization-uuid', tmpDir),
+        ).resolves.toStrictEqual({
+            created: 0,
+            updated: 0,
+            unchanged: 0,
+            failed: 0,
+            failures: [],
+        });
+
+        await fs.mkdir(getCustomRolesFolder(tmpDir), { recursive: true });
+        await expect(
+            uploadCustomRoles('organization-uuid', tmpDir),
+        ).resolves.toStrictEqual({
+            created: 0,
+            updated: 0,
+            unchanged: 0,
+            failed: 0,
+            failures: [],
+        });
+        expect(lightdashApi).not.toHaveBeenCalled();
     });
 
     it('rejects duplicate names before calling the API', async () => {

--- a/packages/cli/src/handlers/organizationContent/customRoles.ts
+++ b/packages/cli/src/handlers/organizationContent/customRoles.ts
@@ -86,9 +86,7 @@ const readCustomRoleFileResults = async (
         entries = await fs.readdir(folder, { withFileTypes: true });
     } catch (error) {
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-            throw new ParameterError(
-                `Custom roles folder not found at "${folder}". Run 'lightdash download --organization' first.`,
-            );
+            return { roleFiles: [], failures: [] };
         }
         throw error;
     }
@@ -96,12 +94,6 @@ const readCustomRoleFileResults = async (
     const files = entries
         .filter((entry) => entry.isFile() && entry.name.endsWith('.yml'))
         .sort((left, right) => left.name.localeCompare(right.name));
-    if (files.length === 0) {
-        throw new ParameterError(
-            `No custom role files found in "${folder}". Run 'lightdash download --organization' first.`,
-        );
-    }
-
     const results = await Promise.all(
         files.map(async (file): Promise<CustomRoleFileReadItem> => {
             const filePath = path.join(folder, file.name);
@@ -233,6 +225,13 @@ export const downloadCustomRoles = async (
     });
     const folder = getCustomRolesFolder(organizationContentPath);
     await fs.mkdir(folder, { recursive: true });
+
+    const existingFiles = await fs.readdir(folder, { withFileTypes: true });
+    await Promise.all(
+        existingFiles
+            .filter((entry) => entry.isFile() && entry.name.endsWith('.yml'))
+            .map((entry) => fs.unlink(path.join(folder, entry.name))),
+    );
 
     const filenameBases = customRoles.map(({ name }) =>
         getCustomRoleFilenameBase(name),

--- a/packages/cli/src/handlers/organizationContent/index.ts
+++ b/packages/cli/src/handlers/organizationContent/index.ts
@@ -13,13 +13,16 @@ import {
     formatCustomRoleUploadSummary,
     uploadCustomRoles,
 } from './customRoles';
+import { downloadUsers, formatUserUploadSummary, uploadUsers } from './users';
 
 type OrganizationContentOptions = {
     customPath?: string;
     config: Config;
+    sendInvites?: boolean;
 };
 
 const customRolePartialUploadErrors = new WeakSet<Error>();
+const userPartialUploadErrors = new WeakSet<Error>();
 
 const createCustomRolePartialUploadError = (message: string): Error => {
     const error = new ParameterError(message);
@@ -27,8 +30,16 @@ const createCustomRolePartialUploadError = (message: string): Error => {
     return error;
 };
 
-const isCustomRolePartialUploadError = (error: unknown): boolean =>
-    error instanceof Error && customRolePartialUploadErrors.has(error);
+const createUserPartialUploadError = (message: string): Error => {
+    const error = new ParameterError(message);
+    userPartialUploadErrors.add(error);
+    return error;
+};
+
+const isPartialUploadError = (error: unknown): boolean =>
+    error instanceof Error &&
+    (customRolePartialUploadErrors.has(error) ||
+        userPartialUploadErrors.has(error));
 
 export const getOrganizationContentFolder = (customPath?: string): string =>
     getDownloadFolder(customPath);
@@ -63,6 +74,13 @@ export const downloadOrganizationContent = async ({
         );
         spinner.succeed(`Downloaded ${customRolesTotal} custom roles`);
 
+        spinner.start(`Downloading users`);
+        const usersTotal = await downloadUsers(
+            organizationUuid,
+            organizationContentPath,
+        );
+        spinner.succeed(`Downloaded ${usersTotal} users`);
+
         GlobalState.log(
             styles.success(
                 `Downloaded organization content saved to ${organizationContentPath}`,
@@ -76,6 +94,7 @@ export const downloadOrganizationContent = async ({
                 organizationId: organizationUuid,
                 scope: 'organization',
                 customRolesNum: customRolesTotal,
+                usersNum: usersTotal,
                 timeToCompleted: (Date.now() - start) / 1000,
             },
         });
@@ -99,6 +118,7 @@ export const downloadOrganizationContent = async ({
 export const uploadOrganizationContent = async ({
     customPath,
     config,
+    sendInvites = false,
 }: OrganizationContentOptions): Promise<void> => {
     const organizationUuid = config.user?.organizationUuid;
     if (!organizationUuid) {
@@ -135,6 +155,24 @@ export const uploadOrganizationContent = async ({
             );
         }
         spinner.succeed(`Uploaded custom roles: ${summaryMessage}`);
+
+        spinner.start(`Uploading users`);
+        const userSummary = await uploadUsers(
+            organizationUuid,
+            organizationContentPath,
+            sendInvites,
+        );
+        const userSummaryMessage = formatUserUploadSummary(userSummary);
+        if (userSummary.failed > 0) {
+            userSummary.failures.forEach(({ message }) =>
+                GlobalState.log(styles.error(message)),
+            );
+            spinner.stop();
+            throw createUserPartialUploadError(
+                `Processed users: ${userSummaryMessage}`,
+            );
+        }
+        spinner.succeed(`Uploaded users: ${userSummaryMessage}`);
         GlobalState.log(
             styles.success(
                 `Uploaded organization content from ${organizationContentPath}`,
@@ -149,11 +187,16 @@ export const uploadOrganizationContent = async ({
                 customRolesCreated: summary.created,
                 customRolesUpdated: summary.updated,
                 customRolesUnchanged: summary.unchanged,
+                usersCreated: userSummary.created,
+                usersUpdated: userSummary.updated,
+                usersUnchanged: userSummary.unchanged,
+                usersAwaitingAuthentication: userSummary.awaitingAuthentication,
+                usersInvited: userSummary.invited,
                 timeToCompleted: (Date.now() - start) / 1000,
             },
         });
     } catch (error) {
-        if (!isCustomRolePartialUploadError(error)) {
+        if (!isPartialUploadError(error)) {
             spinner.fail(
                 `Failed to upload organization content: ${getErrorMessage(error)}`,
             );

--- a/packages/cli/src/handlers/organizationContent/users.test.ts
+++ b/packages/cli/src/handlers/organizationContent/users.test.ts
@@ -1,0 +1,195 @@
+import {
+    OrganizationMemberRole,
+    PromotionAction,
+    UserAsCodeInvitationStatus,
+    UserAsCodeLifecycleStatus,
+    type UserAsCode,
+} from '@lightdash/common';
+import { promises as fs } from 'fs';
+import * as yaml from 'js-yaml';
+import * as os from 'os';
+import * as path from 'path';
+import { vi } from 'vitest';
+import { lightdashApi } from '../dbt/apiClient';
+import {
+    downloadUsers,
+    getUsersFolder,
+    readUserFiles,
+    uploadUsers,
+} from './users';
+
+vi.mock('../dbt/apiClient', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../dbt/apiClient')>()),
+    lightdashApi: vi.fn(),
+}));
+
+describe('users as code', () => {
+    let tmpDir: string;
+
+    const user = (
+        email: string,
+        overrides: Partial<UserAsCode> = {},
+    ): UserAsCode => ({
+        version: 1,
+        email,
+        disabled: false,
+        pending: false,
+        role: { type: 'system', name: OrganizationMemberRole.EDITOR },
+        ...overrides,
+    });
+
+    const writeUser = async (filename: string, value: UserAsCode) => {
+        const folder = getUsersFolder(tmpDir);
+        await fs.mkdir(folder, { recursive: true });
+        await fs.writeFile(
+            path.join(folder, filename),
+            yaml.dump(value, { sortKeys: true }),
+        );
+    };
+
+    beforeEach(async () => {
+        vi.mocked(lightdashApi).mockReset();
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'users-test-'));
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('downloads deterministic portable users and removes stale YAML', async () => {
+        const folder = getUsersFolder(tmpDir);
+        await fs.mkdir(folder, { recursive: true });
+        await fs.writeFile(path.join(folder, 'stale.yml'), 'stale: true');
+        vi.mocked(lightdashApi).mockResolvedValueOnce({
+            users: [
+                user('z@example.com', {
+                    disabled: true,
+                    pending: true,
+                    role: { type: 'custom', name: 'Data steward' },
+                }),
+                user('a@example.com'),
+            ],
+        } as never);
+
+        await expect(downloadUsers('organization-uuid', tmpDir)).resolves.toBe(
+            2,
+        );
+
+        expect((await fs.readdir(folder)).sort()).toStrictEqual([
+            'a-example-com.yml',
+            'z-example-com.yml',
+        ]);
+        expect(
+            yaml.load(
+                await fs.readFile(
+                    path.join(folder, 'z-example-com.yml'),
+                    'utf8',
+                ),
+            ),
+        ).toStrictEqual({
+            disabled: true,
+            email: 'z@example.com',
+            pending: true,
+            role: { name: 'Data steward', type: 'custom' },
+            version: 1,
+        });
+    });
+
+    it('rejects case-insensitive duplicate emails before upload', async () => {
+        await writeUser('one.yml', user('duplicate@example.com'));
+        await writeUser('two.yml', user('DUPLICATE@example.com'));
+
+        await expect(readUserFiles(tmpDir)).rejects.toThrow(
+            'Duplicate user email "duplicate@example.com"',
+        );
+        expect(lightdashApi).not.toHaveBeenCalled();
+    });
+
+    it('is a backward-compatible no-op when the users folder is missing', async () => {
+        await expect(
+            uploadUsers('organization-uuid', tmpDir),
+        ).resolves.toMatchObject({
+            created: 0,
+            updated: 0,
+            unchanged: 0,
+            failed: 0,
+        });
+        expect(lightdashApi).not.toHaveBeenCalled();
+    });
+
+    it('does not request invitations by default', async () => {
+        await writeUser('user.yml', user('person@example.com'));
+        vi.mocked(lightdashApi)
+            .mockResolvedValueOnce({ users: [] } as never)
+            .mockResolvedValueOnce({
+                action: PromotionAction.CREATE,
+                lifecycle: UserAsCodeLifecycleStatus.AWAITING_AUTHENTICATION,
+                invitation: UserAsCodeInvitationStatus.NOT_REQUESTED,
+            } as never);
+
+        const summary = await uploadUsers('organization-uuid', tmpDir);
+
+        expect(summary).toMatchObject({
+            created: 1,
+            awaitingAuthentication: 1,
+            invited: 0,
+            failed: 0,
+        });
+        expect(lightdashApi).toHaveBeenNthCalledWith(2, {
+            method: 'POST',
+            url: '/api/v2/orgs/organization-uuid/users/code',
+            body: expect.any(String),
+        });
+    });
+
+    it('passes sendInvite and reports invitation outcomes', async () => {
+        await writeUser('user.yml', user('person@example.com'));
+        vi.mocked(lightdashApi)
+            .mockResolvedValueOnce({ users: [] } as never)
+            .mockResolvedValueOnce({
+                action: PromotionAction.CREATE,
+                lifecycle: UserAsCodeLifecycleStatus.AWAITING_AUTHENTICATION,
+                invitation: UserAsCodeInvitationStatus.SENT,
+            } as never);
+
+        const summary = await uploadUsers('organization-uuid', tmpDir, true);
+
+        expect(summary.invited).toBe(1);
+        expect(lightdashApi).toHaveBeenNthCalledWith(2, {
+            method: 'POST',
+            url: '/api/v2/orgs/organization-uuid/users/code?sendInvite=true',
+            body: expect.any(String),
+        });
+    });
+
+    it('promotes an enabled admin before demoting the current admin', async () => {
+        const currentAdmin = user('current@example.com', {
+            role: { type: 'system', name: OrganizationMemberRole.ADMIN },
+        });
+        const desiredAdmin = user('new@example.com', {
+            role: { type: 'system', name: OrganizationMemberRole.ADMIN },
+        });
+        const desiredDemotion = user('current@example.com');
+        await writeUser('a-demote.yml', desiredDemotion);
+        await writeUser('z-promote.yml', desiredAdmin);
+        vi.mocked(lightdashApi)
+            .mockResolvedValueOnce({ users: [currentAdmin] } as never)
+            .mockResolvedValue({
+                action: PromotionAction.UPDATE,
+                lifecycle: UserAsCodeLifecycleStatus.READY,
+                invitation: UserAsCodeInvitationStatus.NOT_REQUESTED,
+            } as never);
+
+        await uploadUsers('organization-uuid', tmpDir);
+
+        const firstBody = JSON.parse(
+            vi.mocked(lightdashApi).mock.calls[1][0].body as string,
+        );
+        const secondBody = JSON.parse(
+            vi.mocked(lightdashApi).mock.calls[2][0].body as string,
+        );
+        expect(firstBody.email).toBe('new@example.com');
+        expect(secondBody.email).toBe('current@example.com');
+    });
+});

--- a/packages/cli/src/handlers/organizationContent/users.ts
+++ b/packages/cli/src/handlers/organizationContent/users.ts
@@ -1,0 +1,398 @@
+/* eslint-disable no-await-in-loop */
+import {
+    ApiUserAsCodeListResponse,
+    ApiUserAsCodeUpsertResponse,
+    assertUnreachable,
+    getErrorMessage,
+    OrganizationMemberRole,
+    ParameterError,
+    PromotionAction,
+    UserAsCode,
+    UserAsCodeInvitationStatus,
+    UserAsCodeLifecycleStatus,
+} from '@lightdash/common';
+import { createHash } from 'crypto';
+import { Dirent, promises as fs } from 'fs';
+import * as yaml from 'js-yaml';
+import groupBy from 'lodash/groupBy';
+import * as path from 'path';
+import { lightdashApi } from '../dbt/apiClient';
+
+const USER_FILENAME_MAX_LENGTH = 200;
+
+export type UserUploadFailure = {
+    message: string;
+};
+
+export type UserUploadSummary = {
+    created: number;
+    updated: number;
+    unchanged: number;
+    awaitingAuthentication: number;
+    invited: number;
+    skippedAuthenticated: number;
+    skippedDisabled: number;
+    skippedValidInvite: number;
+    failed: number;
+    failures: UserUploadFailure[];
+};
+
+type UserFile = {
+    filePath: string;
+    user: unknown;
+};
+
+type UserFileReadResult = {
+    userFiles: UserFile[];
+    failures: UserUploadFailure[];
+};
+
+type UserFileReadItem =
+    | { kind: 'user'; userFile: UserFile }
+    | { kind: 'failure'; failure: UserUploadFailure };
+
+export const getUsersFolder = (organizationContentPath: string): string =>
+    path.join(organizationContentPath, 'users');
+
+export const formatUserUploadSummary = (summary: UserUploadSummary): string => {
+    const invitationSummary = [
+        `${summary.invited} invited`,
+        `${
+            summary.skippedAuthenticated +
+            summary.skippedDisabled +
+            summary.skippedValidInvite
+        } invitation-skipped`,
+    ];
+    return `${summary.created} created, ${summary.updated} updated, ${summary.unchanged} unchanged, ${summary.awaitingAuthentication} awaiting authentication, ${invitationSummary.join(', ')}, ${summary.failed} failed`;
+};
+
+const getUserEmail = (user: unknown): string | undefined => {
+    if (typeof user !== 'object' || user === null || Array.isArray(user)) {
+        return undefined;
+    }
+    const { email } = user as Record<string, unknown>;
+    return typeof email === 'string' ? email.toLowerCase() : undefined;
+};
+
+const asUserAsCode = (user: unknown): UserAsCode | undefined => {
+    if (typeof user !== 'object' || user === null || Array.isArray(user)) {
+        return undefined;
+    }
+    const record = user as Record<string, unknown>;
+    if (
+        typeof record.email !== 'string' ||
+        typeof record.disabled !== 'boolean' ||
+        typeof record.pending !== 'boolean' ||
+        typeof record.role !== 'object' ||
+        record.role === null ||
+        Array.isArray(record.role)
+    ) {
+        return undefined;
+    }
+    const role = record.role as Record<string, unknown>;
+    if (
+        (role.type !== 'system' && role.type !== 'custom') ||
+        typeof role.name !== 'string'
+    ) {
+        return undefined;
+    }
+    return user as UserAsCode;
+};
+
+const getUserFilenameBase = (email: string): string => {
+    const normalizedEmail = email.toLowerCase();
+    const slug = normalizedEmail
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+    const emailHash = createHash('sha256')
+        .update(normalizedEmail)
+        .digest('hex')
+        .slice(0, 8);
+
+    return (slug || `user-${emailHash}`).slice(0, USER_FILENAME_MAX_LENGTH);
+};
+
+const readUserFileResults = async (
+    organizationContentPath: string,
+): Promise<UserFileReadResult> => {
+    const folder = getUsersFolder(organizationContentPath);
+    let entries: Dirent[];
+    try {
+        entries = await fs.readdir(folder, { withFileTypes: true });
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return { userFiles: [], failures: [] };
+        }
+        throw error;
+    }
+
+    const files = entries
+        .filter((entry) => entry.isFile() && entry.name.endsWith('.yml'))
+        .sort((left, right) => left.name.localeCompare(right.name));
+    const results = await Promise.all(
+        files.map(async (file): Promise<UserFileReadItem> => {
+            const filePath = path.join(folder, file.name);
+            try {
+                return {
+                    kind: 'user',
+                    userFile: {
+                        filePath,
+                        user: yaml.load(await fs.readFile(filePath, 'utf8')),
+                    },
+                };
+            } catch (error) {
+                return {
+                    kind: 'failure',
+                    failure: {
+                        message: `Unable to parse user file "${filePath}": ${getErrorMessage(error)}`,
+                    },
+                };
+            }
+        }),
+    );
+
+    const parsedUserFiles = results.flatMap((result) =>
+        result.kind === 'user' ? [result.userFile] : [],
+    );
+    const failures = results.flatMap((result) =>
+        result.kind === 'failure' ? [result.failure] : [],
+    );
+    const emailFiles = parsedUserFiles.flatMap((userFile) => {
+        const email = getUserEmail(userFile.user);
+        return email === undefined ? [] : [{ email, userFile }];
+    });
+    const filesByEmail = groupBy(emailFiles, ({ email }) => email);
+    const duplicateEmails = new Set(
+        Object.entries(filesByEmail)
+            .filter(([, matchingFiles]) => matchingFiles.length > 1)
+            .map(([email]) => email),
+    );
+    for (const duplicateEmail of [...duplicateEmails].sort()) {
+        for (const { userFile } of filesByEmail[duplicateEmail]) {
+            failures.push({
+                message: `Duplicate user email "${duplicateEmail}" in "${userFile.filePath}"`,
+            });
+        }
+    }
+
+    return {
+        userFiles: parsedUserFiles.filter(
+            ({ user }) => !duplicateEmails.has(getUserEmail(user) ?? ''),
+        ),
+        failures,
+    };
+};
+
+export const readUserFiles = async (
+    organizationContentPath: string,
+): Promise<unknown[]> => {
+    const { userFiles, failures } = await readUserFileResults(
+        organizationContentPath,
+    );
+    if (failures.length > 0) {
+        throw new ParameterError(
+            failures.map(({ message }) => message).join('\n'),
+        );
+    }
+    return userFiles.map(({ user }) => user);
+};
+
+const isSystemAdmin = (user: UserAsCode): boolean =>
+    user.role.type === 'system' &&
+    user.role.name === OrganizationMemberRole.ADMIN;
+
+const orderUserFiles = (
+    userFiles: UserFile[],
+    currentUsers: UserAsCode[],
+): UserFile[] => {
+    const currentByEmail = new Map(
+        currentUsers.map((user) => [user.email.toLowerCase(), user]),
+    );
+
+    return [...userFiles].sort((left, right) => {
+        const getPriority = (userFile: UserFile): number => {
+            const desired = asUserAsCode(userFile.user);
+            if (!desired) return 1;
+            const current = currentByEmail.get(desired.email.toLowerCase());
+            if (isSystemAdmin(desired) && !desired.disabled) return 0;
+            if (
+                current &&
+                isSystemAdmin(current) &&
+                !current.disabled &&
+                (!isSystemAdmin(desired) || desired.disabled || desired.pending)
+            ) {
+                return 2;
+            }
+            return 1;
+        };
+
+        return (
+            getPriority(left) - getPriority(right) ||
+            left.filePath.localeCompare(right.filePath)
+        );
+    });
+};
+
+export const uploadUsers = async (
+    organizationUuid: string,
+    organizationContentPath: string,
+    sendInvites: boolean = false,
+): Promise<UserUploadSummary> => {
+    const { userFiles, failures } = await readUserFileResults(
+        organizationContentPath,
+    );
+    const summary: UserUploadSummary = {
+        created: 0,
+        updated: 0,
+        unchanged: 0,
+        awaitingAuthentication: 0,
+        invited: 0,
+        skippedAuthenticated: 0,
+        skippedDisabled: 0,
+        skippedValidInvite: 0,
+        failed: 0,
+        failures,
+    };
+
+    if (userFiles.length === 0) {
+        summary.failed = summary.failures.length;
+        return summary;
+    }
+
+    const { users: currentUsers } = await lightdashApi<
+        ApiUserAsCodeListResponse['results']
+    >({
+        method: 'GET',
+        url: `/api/v2/orgs/${organizationUuid}/users/code`,
+        body: undefined,
+    });
+
+    for (const { filePath, user } of orderUserFiles(userFiles, currentUsers)) {
+        try {
+            const result = await lightdashApi<
+                ApiUserAsCodeUpsertResponse['results']
+            >({
+                method: 'POST',
+                url: `/api/v2/orgs/${organizationUuid}/users/code${
+                    sendInvites ? '?sendInvite=true' : ''
+                }`,
+                body: JSON.stringify(user),
+            });
+            switch (result.action) {
+                case PromotionAction.CREATE:
+                    summary.created += 1;
+                    break;
+                case PromotionAction.UPDATE:
+                    summary.updated += 1;
+                    break;
+                case PromotionAction.NO_CHANGES:
+                    summary.unchanged += 1;
+                    break;
+                default:
+                    throw new ParameterError(
+                        `Unsupported user promotion action: ${result.action}`,
+                    );
+            }
+            switch (result.lifecycle) {
+                case UserAsCodeLifecycleStatus.READY:
+                    break;
+                case UserAsCodeLifecycleStatus.AWAITING_AUTHENTICATION:
+                    summary.awaitingAuthentication += 1;
+                    break;
+                default:
+                    return assertUnreachable(
+                        result.lifecycle,
+                        'Unsupported user lifecycle status',
+                    );
+            }
+            switch (result.invitation) {
+                case UserAsCodeInvitationStatus.NOT_REQUESTED:
+                    break;
+                case UserAsCodeInvitationStatus.SENT:
+                    summary.invited += 1;
+                    break;
+                case UserAsCodeInvitationStatus.SKIPPED_AUTHENTICATED:
+                    summary.skippedAuthenticated += 1;
+                    break;
+                case UserAsCodeInvitationStatus.SKIPPED_DISABLED:
+                    summary.skippedDisabled += 1;
+                    break;
+                case UserAsCodeInvitationStatus.SKIPPED_VALID_INVITE:
+                    summary.skippedValidInvite += 1;
+                    break;
+                default:
+                    return assertUnreachable(
+                        result.invitation,
+                        'Unsupported user invitation status',
+                    );
+            }
+        } catch (error) {
+            summary.failures.push({
+                message: `Invalid user file "${filePath}": ${getErrorMessage(error)}`,
+            });
+        }
+    }
+
+    summary.failed = summary.failures.length;
+    return summary;
+};
+
+export const downloadUsers = async (
+    organizationUuid: string,
+    organizationContentPath: string,
+): Promise<number> => {
+    const { users } = await lightdashApi<ApiUserAsCodeListResponse['results']>({
+        method: 'GET',
+        url: `/api/v2/orgs/${organizationUuid}/users/code`,
+        body: undefined,
+    });
+    const folder = getUsersFolder(organizationContentPath);
+    await fs.mkdir(folder, { recursive: true });
+
+    const existingFiles = await fs.readdir(folder, { withFileTypes: true });
+    await Promise.all(
+        existingFiles
+            .filter((entry) => entry.isFile() && entry.name.endsWith('.yml'))
+            .map((entry) => fs.unlink(path.join(folder, entry.name))),
+    );
+
+    const sortedUsers = [...users].sort((left, right) =>
+        left.email.localeCompare(right.email),
+    );
+    const filenameBases = sortedUsers.map(({ email }) =>
+        getUserFilenameBase(email),
+    );
+    const baseCounts = filenameBases.reduce<Record<string, number>>(
+        (counts, filenameBase) => ({
+            ...counts,
+            [filenameBase]: (counts[filenameBase] ?? 0) + 1,
+        }),
+        {},
+    );
+
+    await Promise.all(
+        sortedUsers.map(async (user, index) => {
+            const filenameBase = filenameBases[index];
+            const collisionSuffix = `-${createHash('sha256')
+                .update(user.email.toLowerCase())
+                .digest('hex')
+                .slice(0, 8)}`;
+            const uniqueFilenameBase =
+                baseCounts[filenameBase] > 1
+                    ? `${filenameBase.slice(
+                          0,
+                          USER_FILENAME_MAX_LENGTH - collisionSuffix.length,
+                      )}${collisionSuffix}`
+                    : filenameBase;
+
+            await fs.writeFile(
+                path.join(folder, `${uniqueFilenameBase}.yml`),
+                yaml.dump(user, { quotingType: '"', sortKeys: true }),
+            );
+        }),
+    );
+
+    return sortedUsers.length;
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -722,13 +722,24 @@ program
     .option('--verbose', undefined, false)
     .action(stopPreviewHandler);
 
-const ORGANIZATION_MODE_OPTIONS = new Set(['organization', 'path', 'verbose']);
+const ORGANIZATION_MODE_OPTIONS = new Set([
+    'organization',
+    'path',
+    'sendInvites',
+    'verbose',
+]);
 
 const withOrganizationMode =
-    <Options extends { organization: boolean }>(
+    <Options extends { organization: boolean; sendInvites?: boolean }>(
         handler: (options: Options) => Promise<void>,
     ) =>
     async (options: Options, command: Command): Promise<void> => {
+        if (!options.organization && options.sendInvites) {
+            command.error(
+                `error: option '--send-invites' requires option '--organization'`,
+                { code: 'commander.missingMandatoryOptionValue' },
+            );
+        }
         if (options.organization) {
             const conflictingOption = Object.keys(options).find(
                 (optionName) => {
@@ -962,6 +973,11 @@ const uploadCommand = program
     .option(
         '--organization',
         'upload all organization-scoped resources without selecting a project',
+        false,
+    )
+    .option(
+        '--send-invites',
+        'send invitations to eligible pending users during organization upload',
         false,
     );
 

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -199,6 +199,142 @@
                 "idempotentHint": false,
                 "readOnlyHint": false
             },
+            "description": "Create a LIVE scheduled delivery that sends a saved chart or dashboard to Slack channels and/or email recipients on a cron schedule. IMPORTANT: before calling this tool, propose the full configuration to the user (name, schedule in plain words, timezone, destinations, format, AI augmentation prompt if any) and wait for their explicit confirmation in the conversation. Requires an existing saved chart or dashboard — if the content only exists in this conversation, create it with createContent first, then schedule the created uuid. On success, share the returned href with the user — the delivery is managed (paused, edited, deleted) from that page.",
+            "inputSchema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                    "aiAugmentationPrompt": {
+                        "description": "Instructions for the AI-written delivery message, regenerated from the delivered data on every send. null = plain delivery without AI augmentation., ",
+                        "type": "string"
+                    },
+                    "cron": {
+                        "description": "5-part cron expression, e.g. \"0 9 * * 1\". Minimum frequency is hourly — sub-hourly minute patterns (e.g. \"*/15\") are rejected.",
+                        "type": "string"
+                    },
+                    "csvOptions": {
+                        "additionalProperties": false,
+                        "description": "Only used when format is \"csv\". null = defaults (formatted, table limit)., ",
+                        "properties": {
+                            "formatted": {
+                                "description": "Apply Lightdash value formatting.",
+                                "type": "boolean"
+                            },
+                            "limit": {
+                                "anyOf": [
+                                    {
+                                        "const": "table",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": "all",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "exclusiveMinimum": 0,
+                                        "type": "integer"
+                                    }
+                                ],
+                                "description": "\"table\" = the chart's own limit, \"all\" = all results, or an explicit row count."
+                            }
+                        },
+                        "required": ["formatted", "limit"],
+                        "type": "object"
+                    },
+                    "enabled": {
+                        "description": "Whether the delivery starts firing immediately. Use true only when the user explicitly confirmed it should go live; when in doubt, create it paused (false) — the user can enable it from the UI.",
+                        "type": "boolean"
+                    },
+                    "format": {
+                        "description": "\"image\" sends a rendered image of the chart/dashboard; \"csv\" sends the results as CSV.",
+                        "enum": ["csv", "image"],
+                        "type": "string"
+                    },
+                    "message": {
+                        "description": "Optional static message included with every delivery. Ignored when aiAugmentationPrompt is set (the AI writes the message instead)., ",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Human-readable delivery name.",
+                        "minLength": 1,
+                        "type": "string"
+                    },
+                    "resourceType": {
+                        "description": "Type of saved content to deliver.",
+                        "enum": ["chart", "dashboard"],
+                        "type": "string"
+                    },
+                    "resourceUuidOrSlug": {
+                        "description": "UUID (preferred) or slug of the saved chart or dashboard to deliver. Use the uuid from createContent/findContent results — slugs are not guaranteed unique.",
+                        "type": "string"
+                    },
+                    "targets": {
+                        "description": "At least one Slack channel or email recipient.",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "channel": {
+                                            "description": "Slack channel ID (preferred, e.g. \"C0123ABCDEF\") or channel name. The Lightdash Slack app must be able to join it.",
+                                            "minLength": 1,
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "const": "slack",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": ["type", "channel"],
+                                    "type": "object"
+                                },
+                                {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "recipient": {
+                                            "description": "Email address of the recipient.",
+                                            "minLength": 3,
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "const": "email",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": ["type", "recipient"],
+                                    "type": "object"
+                                }
+                            ]
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                    },
+                    "timezone": {
+                        "description": "IANA timezone the cron runs in (e.g. \"Europe/London\"). null = project default., ",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "resourceType",
+                    "resourceUuidOrSlug",
+                    "name",
+                    "cron",
+                    "format",
+                    "targets",
+                    "enabled"
+                ],
+                "type": "object"
+            },
+            "name": "create_scheduled_delivery",
+            "outputSchema": null,
+            "title": "Create scheduled delivery"
+        },
+        {
+            "annotations": {
+                "destructiveHint": false,
+                "idempotentHint": false,
+                "readOnlyHint": false
+            },
             "description": "Edit a dashboard or chart by applying a patch to its JSON, then validate before persisting",
             "inputSchema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -291,6 +291,8 @@ import { type GroupType, type TableBase } from './table';
 import { type ApiCreateTagResponse } from './tags';
 import { type ApiUpstreamDiffResults } from './upstreamDiff';
 import {
+    type ApiUserAsCodeListResponse,
+    type ApiUserAsCodeUpsertResponse,
     type LightdashUser,
     type LoginOptions,
     type UserAllowedOrganization,
@@ -1133,6 +1135,8 @@ type ApiResults =
     | ApiAgentAsCodeUpsertResponse['results']
     | ApiCustomRoleAsCodeListResponse['results']
     | ApiCustomRoleAsCodeUpsertResponse['results']
+    | ApiUserAsCodeListResponse['results']
+    | ApiUserAsCodeUpsertResponse['results']
     | ApiAlertAsCodeListResponse['results']
     | ApiAlertAsCodeUpsertResponse['results']
     | ApiChartAsCodeListResponse['results']

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -3,7 +3,58 @@ import { type MemberAbility } from '../authorization/types';
 import { type AnyType } from './any';
 import { type OpenIdIdentityIssuerType } from './openIdIdentity';
 import { type OrganizationMemberRole } from './organizationMemberProfile';
+import { type PromotionAction } from './promotion';
 import { type UserAvatarColorValue } from './userAvatars';
+
+export type UserAsCodeRole =
+    | {
+          type: 'system';
+          name: OrganizationMemberRole;
+      }
+    | {
+          type: 'custom';
+          name: string;
+      };
+
+export type UserAsCode = {
+    version: 1;
+    email: string;
+    disabled: boolean;
+    pending: boolean;
+    role: UserAsCodeRole;
+};
+
+export enum UserAsCodeLifecycleStatus {
+    READY = 'ready',
+    AWAITING_AUTHENTICATION = 'awaiting authentication',
+}
+
+export enum UserAsCodeInvitationStatus {
+    NOT_REQUESTED = 'not requested',
+    SENT = 'sent',
+    SKIPPED_AUTHENTICATED = 'skipped authenticated',
+    SKIPPED_DISABLED = 'skipped disabled',
+    SKIPPED_VALID_INVITE = 'skipped valid invite',
+}
+
+export type ApiUserAsCodeListResponse = {
+    status: 'ok';
+    results: {
+        users: UserAsCode[];
+    };
+};
+
+export type ApiUserAsCodeUpsertResponse = {
+    status: 'ok';
+    results: {
+        action:
+            | PromotionAction.CREATE
+            | PromotionAction.UPDATE
+            | PromotionAction.NO_CHANGES;
+        lifecycle: UserAsCodeLifecycleStatus;
+        invitation: UserAsCodeInvitationStatus;
+    };
+};
 
 export type AccountUser = {
     /**


### PR DESCRIPTION
## Summary

- add portable organization user YAML download and upload keyed by normalized primary email
- reconcile system or custom roles plus disabled and pending state, processing custom roles before dependent users
- keep credentials non-portable and authentication within the existing domain, SSO, or invitation flows; invitations remain opt-in through --send-invites
- enforce organization boundaries and enabled authenticated admin safety, with deterministic files and empty-resource no-ops

## Testing

- pnpm generate-api
- pnpm -F common typecheck
- pnpm -F backend typecheck
- pnpm -F cli typecheck
- pnpm -F frontend typecheck
- focused common, backend, CLI, and frontend lint checks
- focused backend RolesService and UserService tests
- CLI custom roles and users tests (13 passed)
- pnpm -F cli build
- built CLI organization download/upload round trips against the local development database, including create, update, idempotency, role dependencies, disabled and pending users, multi-email behavior, validation failures, and wrong-organization authorization

Closes: PROD-8885