### PR TITLE
style(homepage): design parity for view-mode blocks — shared block shell, pills, list rows, KPI and content cards

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -44,9 +44,9 @@ export const PublishedHomepage: FC<Props> = ({
     projectUuid,
     personalPlaceholders = false,
 }) => (
-    <Stack gap="lg" maw={920} mx="auto" w="100%">
+    <Stack gap={26} maw={1100} mx="auto" w="100%">
         {config.rows.map((row) => (
-            <Group key={row.id} gap="md" align="stretch" wrap="nowrap">
+            <Group key={row.id} gap={14} align="stretch" wrap="nowrap">
                 {row.blocks.map((block) => (
                     <Box key={block.id} style={{ flex: 1, minWidth: 0 }}>
                         <BlockRenderer

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AiBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AiBlock.tsx
@@ -7,7 +7,7 @@ import {
     Text,
     TextInput,
 } from '@mantine-8/core';
-import { IconArrowUpRight, IconPlus, IconX } from '@tabler/icons-react';
+import { IconPlus, IconX } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
@@ -18,6 +18,7 @@ import {
 } from '../../aiCopilot/components/AgentSelector/AgentSelectorUtils';
 import { usePendingPrompt } from '../../aiCopilot/components/PendingPromptContext/PendingPromptContext';
 import { useAiAgentButtonVisibility } from '../../aiCopilot/hooks/useAiAgentsButtonVisibility';
+import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const SuggestionChips: FC<{ chips: string[]; projectUuid: string }> = ({
@@ -28,17 +29,12 @@ const SuggestionChips: FC<{ chips: string[]; projectUuid: string }> = ({
     const { setPendingPrompt } = usePendingPrompt();
     if (chips.length === 0) return null;
     return (
-        <Group gap="xs" mt="xs">
+        <Group gap={6} mt={13}>
             {chips.map((chip) => (
-                <Badge
+                <button
                     key={chip}
-                    variant="default"
-                    size="lg"
-                    radius="sm"
-                    tt="none"
-                    fw={500}
-                    style={{ cursor: 'pointer' }}
-                    leftSection={<MantineIcon icon={IconArrowUpRight} />}
+                    type="button"
+                    className={classes.aiChip}
                     onClick={() => {
                         setPendingPrompt(chip);
                         void navigate(
@@ -57,7 +53,7 @@ const SuggestionChips: FC<{ chips: string[]; projectUuid: string }> = ({
                     }}
                 >
                     {chip}
-                </Badge>
+                </button>
             ))}
         </Group>
     );

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
@@ -1,18 +1,12 @@
 import { type HomepageAnnouncementItem } from '@lightdash/common';
-import {
-    ActionIcon,
-    Box,
-    Card,
-    Group,
-    Stack,
-    Text,
-    Textarea,
-} from '@mantine-8/core';
-import { IconSend, IconX } from '@tabler/icons-react';
+import { ActionIcon, Group, Stack, Textarea } from '@mantine-8/core';
+import { IconSend, IconSpeakerphone, IconX } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { useTimeAgo } from '../../../../hooks/useTimeAgo';
 import useApp from '../../../../providers/App/useApp';
+import { BlockHeader } from './BlockShell';
+import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const AnnouncementRow: FC<{
@@ -21,20 +15,16 @@ const AnnouncementRow: FC<{
 }> = ({ item, onRemove }) => {
     const timeAgo = useTimeAgo(item.date);
     return (
-        <Group gap="sm" wrap="nowrap" p="sm" align="flex-start">
-            <Box
-                w={7}
-                h={7}
-                mt={6}
-                bg="violet"
-                style={{ borderRadius: '50%', flexShrink: 0 }}
-            />
-            <Box style={{ flex: 1, minWidth: 0 }}>
-                <Text size="sm">{item.text}</Text>
-                <Text size="xs" c="dimmed" mt={2}>
+        <div className={classes.listRow} style={{ alignItems: 'flex-start' }}>
+            <span className={classes.announcementDot} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 13.5, lineHeight: 1.45 }}>
+                    {item.text}
+                </div>
+                <div className={classes.rowAside} style={{ marginTop: 2 }}>
                     {timeAgo} · {item.author}
-                </Text>
-            </Box>
+                </div>
+            </div>
             {onRemove && (
                 <ActionIcon
                     variant="subtle"
@@ -46,7 +36,7 @@ const AnnouncementRow: FC<{
                     <MantineIcon icon={IconX} />
                 </ActionIcon>
             )}
-        </Group>
+        </div>
     );
 };
 
@@ -55,20 +45,20 @@ export const AnnouncementsBlockView: FC<BlockComponentProps> = ({ block }) => {
         return null;
     }
     return (
-        <Stack gap="xs">
-            <Text size="xs" fw={600} tt="uppercase" c="dimmed">
-                {block.config.title}
-            </Text>
-            <Card withBorder p={0}>
-                <Stack gap={0}>
-                    {block.config.items.map((item) => (
-                        <AnnouncementRow
-                            key={`${item.date}-${item.author}`}
-                            item={item}
-                        />
-                    ))}
-                </Stack>
-            </Card>
+        <Stack gap={0}>
+            <BlockHeader
+                icon={IconSpeakerphone}
+                iconColor="#7262FF"
+                title={block.config.title}
+            />
+            <div className={classes.listCard}>
+                {block.config.items.map((item) => (
+                    <AnnouncementRow
+                        key={`${item.date}-${item.author}`}
+                        item={item}
+                    />
+                ))}
+            </div>
         </Stack>
     );
 };
@@ -105,31 +95,31 @@ export const AnnouncementsBlockBuild: FC<BuildComponentProps> = ({
     };
 
     return (
-        <Stack gap="xs">
-            <Text size="xs" fw={600} tt="uppercase" c="dimmed">
-                {block.config.title}
-            </Text>
-            <Card withBorder p={0}>
-                <Stack gap={0}>
-                    {block.config.items.map((item, index) => (
-                        <AnnouncementRow
-                            key={`${item.date}-${item.author}`}
-                            item={item}
-                            onRemove={() =>
-                                onChange({
-                                    ...block,
-                                    config: {
-                                        ...block.config,
-                                        items: block.config.items.filter(
-                                            (_, i) => i !== index,
-                                        ),
-                                    },
-                                })
-                            }
-                        />
-                    ))}
-                </Stack>
-            </Card>
+        <Stack gap={0}>
+            <BlockHeader
+                icon={IconSpeakerphone}
+                iconColor="#7262FF"
+                title={block.config.title}
+            />
+            <div className={classes.listCard} style={{ marginBottom: 8 }}>
+                {block.config.items.map((item, index) => (
+                    <AnnouncementRow
+                        key={`${item.date}-${item.author}`}
+                        item={item}
+                        onRemove={() =>
+                            onChange({
+                                ...block,
+                                config: {
+                                    ...block.config,
+                                    items: block.config.items.filter(
+                                        (_, i) => i !== index,
+                                    ),
+                                },
+                            })
+                        }
+                    />
+                ))}
+            </div>
             <Group gap="xs" align="flex-end">
                 <Textarea
                     aria-label="New announcement"

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/BlockShell.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/BlockShell.tsx
@@ -1,0 +1,70 @@
+import { Box } from '@mantine-8/core';
+import { type Icon } from '@tabler/icons-react';
+import { type FC, type PropsWithChildren, type ReactNode } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import classes from './blockStyles.module.css';
+
+export const MiniPill: FC<PropsWithChildren> = ({ children }) => (
+    <span className={classes.miniPill}>{children}</span>
+);
+
+type BlockHeaderProps = {
+    icon: Icon;
+    iconColor?: string;
+    title: ReactNode;
+    pill?: string;
+    mb?: number;
+};
+
+export const BlockHeader: FC<PropsWithChildren<BlockHeaderProps>> = ({
+    icon,
+    iconColor,
+    title,
+    pill,
+    mb = 12,
+    children,
+}) => (
+    <Box className={classes.sectionHeader} mb={mb}>
+        <MantineIcon icon={icon} size={14} color={iconColor ?? 'ldGray.6'} />
+        {typeof title === 'string' ? (
+            <span className={classes.sectionTitle}>{title}</span>
+        ) : (
+            title
+        )}
+        {pill ? <MiniPill>{pill}</MiniPill> : null}
+        {children}
+    </Box>
+);
+
+export type IconTint =
+    | 'gray'
+    | 'dimension'
+    | 'metric'
+    | 'calculation'
+    | 'violet';
+
+const TINT_CLASSES: Record<IconTint, string | undefined> = {
+    gray: undefined,
+    dimension: classes.tintDimension,
+    metric: classes.tintMetric,
+    calculation: classes.tintCalculation,
+    violet: classes.tintViolet,
+};
+
+export const IconSquare: FC<{
+    icon: Icon;
+    tint?: IconTint;
+    size?: 'md' | 'lg';
+}> = ({ icon, tint = 'gray', size = 'md' }) => (
+    <div
+        className={[
+            classes.iconSquare,
+            size === 'lg' ? classes.iconSquareLg : undefined,
+            TINT_CLASSES[tint],
+        ]
+            .filter(Boolean)
+            .join(' ')}
+    >
+        <MantineIcon icon={icon} size={size === 'lg' ? 18 : 16} />
+    </div>
+);

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -1,6 +1,7 @@
 import {
     ContentType,
     contentToResourceViewItem,
+    ResourceViewItemType,
     type HomepageCollectionItemRef,
     type SummaryContent,
 } from '@lightdash/common';
@@ -16,17 +17,26 @@ import {
     TextInput,
 } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine/hooks';
-import { IconPin, IconPlus } from '@tabler/icons-react';
+import { IconLayoutGrid, IconPin, IconPlus } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
 import { ResourceIcon } from '../../../../components/common/ResourceIcon';
+import { useFavoriteMutation } from '../../../../hooks/favorites/useFavoriteMutation';
+import { useFavorites } from '../../../../hooks/favorites/useFavorites';
 import { usePinnedItems } from '../../../../hooks/pinning/usePinnedItems';
 import { useInfiniteContent } from '../../../../hooks/useContent';
 import { useProject } from '../../../../hooks/useProject';
 import { useCollectionContent } from '../hooks/useCollectionContent';
+import { BlockHeader } from './BlockShell';
+import classes from './blockStyles.module.css';
 import { ContentCard } from './ContentCard';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
+
+const toFavoriteType = (content: SummaryContent) =>
+    content.contentType === ContentType.DASHBOARD
+        ? ResourceViewItemType.DASHBOARD
+        : ResourceViewItemType.CHART;
 
 const toItemRef = (content: SummaryContent): HomepageCollectionItemRef => ({
     contentType:
@@ -117,27 +127,39 @@ export const CollectionBlockView: FC<BlockComponentProps> = ({
         projectUuid,
         uuids,
     );
+    const { data: favorites } = useFavorites(projectUuid);
+    const { mutate: toggleFavorite } = useFavoriteMutation(projectUuid);
     if (block.type !== 'collection' || block.config.items.length === 0) {
         return null;
     }
+    const favoriteUuids = new Set(
+        (favorites ?? []).map((item) => item.data.uuid),
+    );
     return (
-        <Stack gap="xs">
-            <Text size="xs" fw={600} tt="uppercase" c="dimmed">
-                {block.config.title}
-            </Text>
+        <Stack gap={0}>
+            <BlockHeader icon={IconLayoutGrid} title={block.config.title} />
             {isInitialLoading ? (
-                <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+                <SimpleGrid cols={{ base: 1, sm: 3 }} spacing={12}>
                     {uuids.slice(0, 3).map((uuid) => (
-                        <Skeleton key={uuid} h={72} radius="md" />
+                        <Skeleton key={uuid} h={108} radius="md" />
                     ))}
                 </SimpleGrid>
             ) : (
-                <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+                <SimpleGrid cols={{ base: 1, sm: 3 }} spacing={12}>
                     {(contents ?? []).map((content) => (
                         <ContentCard
                             key={content.uuid}
                             content={content}
                             projectUuid={projectUuid}
+                            variant="tile"
+                            star={{
+                                isFavorite: favoriteUuids.has(content.uuid),
+                                onToggle: () =>
+                                    toggleFavorite({
+                                        contentType: toFavoriteType(content),
+                                        contentUuid: content.uuid,
+                                    }),
+                            }}
                         />
                     ))}
                 </SimpleGrid>
@@ -197,12 +219,13 @@ export const CollectionBlockBuild: FC<BuildComponentProps> = ({
                     })
                 }
             />
-            <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+            <SimpleGrid cols={{ base: 1, sm: 3 }} spacing={12}>
                 {(contents ?? []).map((content) => (
                     <ContentCard
                         key={content.uuid}
                         content={content}
                         projectUuid={projectUuid}
+                        variant="tile"
                         onRemove={() =>
                             onChange({
                                 ...block,
@@ -216,14 +239,20 @@ export const CollectionBlockBuild: FC<BuildComponentProps> = ({
                         }
                     />
                 ))}
-                <Button
-                    variant="default"
-                    h={72}
-                    leftSection={<MantineIcon icon={IconPlus} />}
+                <button
+                    type="button"
+                    className={classes.addContentTile}
                     onClick={() => setIsPickerOpen(true)}
                 >
-                    Add content
-                </Button>
+                    <span>
+                        <MantineIcon
+                            icon={IconPlus}
+                            size={14}
+                            style={{ marginRight: 5, verticalAlign: -2 }}
+                        />
+                        Add content
+                    </span>
+                </button>
             </SimpleGrid>
             {block.config.items.length === 0 && importablePins.length > 0 && (
                 <Button

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
@@ -3,15 +3,7 @@ import {
     contentToResourceViewItem,
     type SummaryContent,
 } from '@lightdash/common';
-import {
-    ActionIcon,
-    Anchor,
-    Box,
-    Card,
-    Group,
-    Text,
-    Tooltip,
-} from '@mantine-8/core';
+import { ActionIcon, Box, Group, Text, Tooltip } from '@mantine-8/core';
 import {
     IconCircleCheckFilled,
     IconEye,
@@ -19,10 +11,11 @@ import {
     IconStarFilled,
     IconX,
 } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { type FC, type PropsWithChildren } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { ResourceIcon } from '../../../../components/common/ResourceIcon';
+import classes from './blockStyles.module.css';
 
 const contentUrl = (projectUuid: string, content: SummaryContent): string => {
     switch (content.contentType) {
@@ -40,91 +33,151 @@ type Props = {
     projectUuid: string;
     onRemove?: () => void;
     star?: { isFavorite: boolean; onToggle: () => void };
+    variant?: 'row' | 'tile';
 };
+
+const VerifiedBadge: FC<{ content: SummaryContent }> = ({ content }) =>
+    content.verification ? (
+        <Tooltip label="Verified by the data team">
+            <Box component="span" lh={0} c="green.6">
+                <MantineIcon icon={IconCircleCheckFilled} size={15} />
+            </Box>
+        </Tooltip>
+    ) : null;
+
+const KindAndViews: FC<{ content: SummaryContent }> = ({ content }) => (
+    <Group gap={5} wrap="nowrap" className={classes.rowMeta}>
+        <Text size="xs" c="dimmed" tt="capitalize" span>
+            {content.contentType}
+        </Text>
+        <Text size="xs" c="dimmed" span>
+            ·
+        </Text>
+        <MantineIcon icon={IconEye} size={12} color="ldGray.6" />
+        <Text size="xs" c="dimmed" span>
+            {content.views}
+        </Text>
+    </Group>
+);
+
+const CardActions: FC<Pick<Props, 'content' | 'onRemove' | 'star'>> = ({
+    content,
+    onRemove,
+    star,
+}) => (
+    <>
+        {star && (
+            <ActionIcon
+                variant="subtle"
+                color={star.isFavorite ? 'yellow' : 'gray'}
+                size="sm"
+                aria-label={
+                    star.isFavorite
+                        ? `Remove ${content.name} from favorites`
+                        : `Add ${content.name} to favorites`
+                }
+                onClick={(e) => {
+                    e.preventDefault();
+                    star.onToggle();
+                }}
+            >
+                <MantineIcon
+                    icon={star.isFavorite ? IconStarFilled : IconStar}
+                />
+            </ActionIcon>
+        )}
+        {onRemove && (
+            <ActionIcon
+                variant="subtle"
+                color="gray"
+                size="sm"
+                aria-label={`Remove ${content.name} from collection`}
+                onClick={(e) => {
+                    e.preventDefault();
+                    onRemove();
+                }}
+            >
+                <MantineIcon icon={IconX} />
+            </ActionIcon>
+        )}
+    </>
+);
+
+const MaybeLink: FC<
+    PropsWithChildren<{ to: string | null; className: string }>
+> = ({ to, className, children }) =>
+    to ? (
+        <Link
+            to={to}
+            className={className}
+            style={{ color: 'inherit', textDecoration: 'none' }}
+        >
+            {children}
+        </Link>
+    ) : (
+        <div className={className}>{children}</div>
+    );
 
 export const ContentCard: FC<Props> = ({
     content,
     projectUuid,
     onRemove,
     star,
+    variant = 'row',
 }) => {
-    const card = (
-        <Card withBorder p="sm" h="100%">
-            <Group gap="sm" wrap="nowrap" align="flex-start">
+    const to = onRemove ? null : contentUrl(projectUuid, content);
+    const cardClass = `${classes.hoverCard}${to ? ` ${classes.clickable}` : ''}`;
+
+    if (variant === 'tile') {
+        return (
+            <MaybeLink to={to} className={cardClass}>
+                <Box p={14} h="100%">
+                    <Group
+                        justify="space-between"
+                        align="flex-start"
+                        mb={10}
+                        wrap="nowrap"
+                    >
+                        <ResourceIcon
+                            item={contentToResourceViewItem(content)}
+                        />
+                        <CardActions
+                            content={content}
+                            onRemove={onRemove}
+                            star={star}
+                        />
+                    </Group>
+                    <Group gap={5} wrap="nowrap" mb={2}>
+                        <Text size="sm" fw={600} truncate>
+                            {content.name}
+                        </Text>
+                        <VerifiedBadge content={content} />
+                    </Group>
+                    <KindAndViews content={content} />
+                </Box>
+            </MaybeLink>
+        );
+    }
+
+    return (
+        <MaybeLink to={to} className={cardClass}>
+            <Group gap="sm" wrap="nowrap" align="center" p="sm" h="100%">
                 <ResourceIcon item={contentToResourceViewItem(content)} />
                 <Box style={{ flex: 1, minWidth: 0 }}>
                     <Group gap={4} wrap="nowrap">
                         <Text size="sm" fw={600} truncate>
                             {content.name}
                         </Text>
-                        {content.verification && (
-                            <Tooltip label="Verified by the data team">
-                                <MantineIcon
-                                    icon={IconCircleCheckFilled}
-                                    color="green"
-                                />
-                            </Tooltip>
-                        )}
+                        <VerifiedBadge content={content} />
                     </Group>
-                    <Group gap={4}>
-                        <Text size="xs" c="dimmed" tt="capitalize">
-                            {content.contentType}
-                        </Text>
-                        <Text size="xs" c="dimmed">
-                            ·
-                        </Text>
-                        <MantineIcon icon={IconEye} color="gray" size="sm" />
-                        <Text size="xs" c="dimmed">
-                            {content.views}
-                        </Text>
-                    </Group>
+                    <KindAndViews content={content} />
                 </Box>
-                {star && (
-                    <ActionIcon
-                        variant="subtle"
-                        color={star.isFavorite ? 'yellow' : 'gray'}
-                        size="sm"
-                        aria-label={
-                            star.isFavorite
-                                ? `Remove ${content.name} from favorites`
-                                : `Add ${content.name} to favorites`
-                        }
-                        onClick={(e) => {
-                            e.preventDefault();
-                            star.onToggle();
-                        }}
-                    >
-                        <MantineIcon
-                            icon={star.isFavorite ? IconStarFilled : IconStar}
-                        />
-                    </ActionIcon>
-                )}
-                {onRemove && (
-                    <ActionIcon
-                        variant="subtle"
-                        color="gray"
-                        size="sm"
-                        aria-label={`Remove ${content.name} from collection`}
-                        onClick={(e) => {
-                            e.preventDefault();
-                            onRemove();
-                        }}
-                    >
-                        <MantineIcon icon={IconX} />
-                    </ActionIcon>
-                )}
+                <CardActions
+                    content={content}
+                    onRemove={onRemove}
+                    star={star}
+                />
             </Group>
-        </Card>
-    );
-    if (onRemove) return card;
-    return (
-        <Anchor
-            component={Link}
-            to={contentUrl(projectUuid, content)}
-            underline="never"
-            c="inherit"
-        >
-            {card}
-        </Anchor>
+        </MaybeLink>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
@@ -1,19 +1,24 @@
 import { ResourceViewItemType, type ResourceViewItem } from '@lightdash/common';
-import { ActionIcon, Anchor, Badge, Group, Stack, Text } from '@mantine-8/core';
+import { Group, Stack } from '@mantine-8/core';
 import {
     IconChartBar,
     IconFolder,
     IconLayoutDashboard,
+    IconStar,
     IconStarFilled,
     IconTerminal2,
     type Icon,
 } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { type FC, type MouseEvent } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { useFavoriteMutation } from '../../../../hooks/favorites/useFavoriteMutation';
 import { useFavorites } from '../../../../hooks/favorites/useFavorites';
+import { BlockHeader } from './BlockShell';
+import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
+
+const STAR_COLOR = 'light-dark(#de7f0b, #e08a20)';
 
 const FAVORITE_ICONS: Partial<Record<ResourceViewItemType, Icon>> = {
     [ResourceViewItemType.CHART]: IconChartBar,
@@ -38,79 +43,54 @@ const favoriteUrl = (projectUuid: string, item: ResourceViewItem): string => {
 const FavoritePills: FC<{
     projectUuid: string;
     isInteractive: boolean;
-}> = ({ projectUuid, isInteractive }) => {
+    emptyText: string;
+}> = ({ projectUuid, isInteractive, emptyText }) => {
     const { data: favorites } = useFavorites(projectUuid);
     const { mutate: toggleFavorite } = useFavoriteMutation(projectUuid);
 
     if (!favorites || favorites.length === 0) {
-        return (
-            <Text
-                size="xs"
-                c="dimmed"
-                p="sm"
-                style={{
-                    border: '1px dashed var(--mantine-color-gray-4)',
-                    borderRadius: 8,
-                }}
-            >
-                Star any dashboard or chart to keep it here — each person sees
-                their own favorites.
-            </Text>
-        );
+        return <div className={classes.dashedEmpty}>{emptyText}</div>;
     }
 
+    const handleUnfavorite = (e: MouseEvent, item: ResourceViewItem) => {
+        e.preventDefault();
+        toggleFavorite({
+            contentType: item.type,
+            contentUuid: item.data.uuid,
+        });
+    };
+
     return (
-        <Group gap="xs">
+        <Group gap={8}>
             {favorites.map((item) => (
-                <Anchor
+                <Link
                     key={item.data.uuid}
-                    component={Link}
                     to={favoriteUrl(projectUuid, item)}
-                    underline="never"
-                    c="inherit"
+                    className={classes.favPill}
                 >
-                    <Group
-                        gap={6}
-                        px="sm"
-                        py={6}
-                        style={{
-                            border: '1px solid var(--mantine-color-gray-3)',
-                            borderRadius: 8,
-                        }}
-                        wrap="nowrap"
-                    >
+                    <MantineIcon
+                        icon={FAVORITE_ICONS[item.type] ?? IconChartBar}
+                        size={15}
+                        color="ldGray.6"
+                    />
+                    {item.data.name}
+                    {isInteractive ? (
                         <MantineIcon
-                            icon={FAVORITE_ICONS[item.type] ?? IconChartBar}
-                            color="gray"
+                            icon={IconStarFilled}
+                            size={13}
+                            color={STAR_COLOR}
+                            style={{ cursor: 'pointer' }}
+                            aria-label={`Remove ${item.data.name} from favorites`}
+                            onClick={(e) => handleUnfavorite(e, item)}
                         />
-                        <Text size="sm" fw={500}>
-                            {item.data.name}
-                        </Text>
-                        {isInteractive ? (
-                            <ActionIcon
-                                variant="transparent"
-                                color="yellow"
-                                size="xs"
-                                aria-label={`Remove ${item.data.name} from favorites`}
-                                onClick={(e) => {
-                                    e.preventDefault();
-                                    toggleFavorite({
-                                        contentType: item.type,
-                                        contentUuid: item.data.uuid,
-                                    });
-                                }}
-                            >
-                                <MantineIcon icon={IconStarFilled} />
-                            </ActionIcon>
-                        ) : (
-                            <MantineIcon
-                                icon={IconStarFilled}
-                                color="yellow"
-                                size="sm"
-                            />
-                        )}
-                    </Group>
-                </Anchor>
+                    ) : (
+                        <MantineIcon
+                            icon={IconStarFilled}
+                            size={13}
+                            color={STAR_COLOR}
+                        />
+                    )}
+                </Link>
             ))}
         </Group>
     );
@@ -119,16 +99,19 @@ const FavoritePills: FC<{
 export const PersonalFavoritesStrip: FC<{ projectUuid: string }> = ({
     projectUuid,
 }) => (
-    <Stack gap="xs">
-        <Group gap="xs">
-            <Text size="xs" fw={600} tt="uppercase" c="dimmed">
-                Your favorites
-            </Text>
-            <Badge variant="default" size="xs" tt="none">
-                Only you see this
-            </Badge>
-        </Group>
-        <FavoritePills projectUuid={projectUuid} isInteractive />
+    <Stack gap={0}>
+        <BlockHeader
+            icon={IconStar}
+            iconColor={STAR_COLOR}
+            title="My favorites"
+            pill="Only you see this"
+            mb={10}
+        />
+        <FavoritePills
+            projectUuid={projectUuid}
+            isInteractive
+            emptyText="Star any dashboard or chart below to keep it here, on every homepage."
+        />
     </Stack>
 );
 
@@ -138,16 +121,18 @@ export const FavoritesBlockView: FC<BlockComponentProps> = ({
 }) => {
     if (block.type !== 'favorites') return null;
     return (
-        <Stack gap="xs">
-            <Group gap="xs">
-                <Text size="xs" fw={600} tt="uppercase" c="dimmed">
-                    {block.config.title}
-                </Text>
-                <Badge variant="default" size="xs" tt="none">
-                    Only you see this
-                </Badge>
-            </Group>
-            <FavoritePills projectUuid={projectUuid} isInteractive />
+        <Stack gap={0}>
+            <BlockHeader
+                icon={IconStar}
+                iconColor={STAR_COLOR}
+                title={block.config.title}
+                pill="Only you see this"
+            />
+            <FavoritePills
+                projectUuid={projectUuid}
+                isInteractive
+                emptyText="Star any dashboard or chart to keep it here — each person sees their own favorites."
+            />
         </Stack>
     );
 };
@@ -158,20 +143,22 @@ export const FavoritesBlockBuild: FC<BuildComponentProps> = ({
 }) => {
     if (block.type !== 'favorites') return null;
     return (
-        <Stack gap="xs">
-            <Group gap="xs">
-                <Text size="xs" fw={600} tt="uppercase" c="dimmed">
-                    {block.config.title}
-                </Text>
-                <Badge variant="default" size="xs" tt="none">
-                    Personal per viewer
-                </Badge>
-            </Group>
-            <FavoritePills projectUuid={projectUuid} isInteractive={false} />
-            <Text size="xs" c="dimmed">
+        <Stack gap={0}>
+            <BlockHeader
+                icon={IconStar}
+                iconColor={STAR_COLOR}
+                title={block.config.title}
+                pill="Personal per viewer"
+            />
+            <FavoritePills
+                projectUuid={projectUuid}
+                isInteractive={false}
+                emptyText="Empty until this viewer stars something — each person sees their own favorites here."
+            />
+            <div className={classes.buildHint}>
                 Showing your favorites as a sample — every viewer sees their
                 own.
-            </Text>
+            </div>
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/HeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/HeroBlock.tsx
@@ -1,23 +1,64 @@
-import { Code, Stack, Text, TextInput, Title } from '@mantine-8/core';
+import { subject } from '@casl/ability';
+import {
+    Box,
+    Button,
+    Code,
+    Group,
+    Stack,
+    Text,
+    TextInput,
+} from '@mantine-8/core';
+import { IconSquareRoundedPlus } from '@tabler/icons-react';
 import { type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import { Can } from '../../../../providers/Ability';
 import useApp from '../../../../providers/App/useApp';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const resolveTokens = (text: string, firstName: string | undefined): string =>
     text.replaceAll('{name}', firstName ?? 'there');
 
-export const HeroBlockView: FC<BlockComponentProps> = ({ block }) => {
+export const HeroBlockView: FC<BlockComponentProps> = ({
+    block,
+    projectUuid,
+}) => {
     const { user } = useApp();
     if (block.type !== 'hero') return null;
     return (
-        <Stack gap={4}>
-            <Title order={1} fw={600}>
-                {resolveTokens(block.config.title, user.data?.firstName)}
-            </Title>
-            <Text size="md" c="dimmed">
-                {resolveTokens(block.config.subtitle, user.data?.firstName)}
-            </Text>
-        </Stack>
+        <Group justify="space-between" align="flex-end" gap="md" wrap="nowrap">
+            <Box>
+                <Text
+                    component="h1"
+                    fz={28}
+                    fw={600}
+                    lts="-0.02em"
+                    m={0}
+                    lh={1.2}
+                >
+                    {resolveTokens(block.config.title, user.data?.firstName)}
+                </Text>
+                <Text fz={15} c="dimmed" mt={5}>
+                    {resolveTokens(block.config.subtitle, user.data?.firstName)}
+                </Text>
+            </Box>
+            <Can
+                I="manage"
+                this={subject('Explore', {
+                    organizationUuid: user.data?.organizationUuid,
+                    projectUuid,
+                })}
+            >
+                <Button
+                    component={Link}
+                    to={`/projects/${projectUuid}/tables`}
+                    leftSection={<MantineIcon icon={IconSquareRoundedPlus} />}
+                    style={{ flexShrink: 0 }}
+                >
+                    New
+                </Button>
+            </Can>
+        </Group>
     );
 };
 
@@ -27,10 +68,11 @@ export const HeroBlockBuild: FC<BuildComponentProps> = ({
 }) => {
     if (block.type !== 'hero') return null;
     return (
-        <Stack gap="xs">
+        <Stack gap={4}>
             <TextInput
                 aria-label="Hero title"
-                size="lg"
+                variant="unstyled"
+                size="xl"
                 fw={600}
                 value={block.config.title}
                 onChange={(e) =>
@@ -45,6 +87,7 @@ export const HeroBlockBuild: FC<BuildComponentProps> = ({
             />
             <TextInput
                 aria-label="Hero subtitle"
+                variant="unstyled"
                 value={block.config.subtitle}
                 onChange={(e) =>
                     onChange({
@@ -56,7 +99,7 @@ export const HeroBlockBuild: FC<BuildComponentProps> = ({
                     })
                 }
             />
-            <Text size="xs" c="dimmed">
+            <Text size="xs" c="dimmed" mt={2}>
                 <Code>{'{name}'}</Code> personalizes per viewer
             </Text>
         </Stack>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
@@ -11,7 +11,6 @@ import {
 import {
     ActionIcon,
     Anchor,
-    Badge,
     Box,
     Button,
     Card,
@@ -24,7 +23,7 @@ import {
     TextInput,
 } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine/hooks';
-import { IconHash, IconPlus, IconX } from '@tabler/icons-react';
+import { IconChartDots, IconHash, IconPlus, IconX } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
@@ -32,6 +31,8 @@ import MantineModal from '../../../../components/common/MantineModal';
 import { useMetricsCatalog } from '../../../../features/metricsCatalog/hooks/useMetricsCatalog';
 import { useRunMetricTotal } from '../../../../features/metricsCatalog/hooks/useRunMetricExplorerQuery';
 import { calculateComparisonValue } from '../../../../hooks/useBigNumberConfig';
+import { BlockHeader } from './BlockShell';
+import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const KPI_TIME_FRAME = TimeFrames.MONTH;
@@ -79,48 +80,53 @@ const MetricKpiCard: FC<{
             underline="never"
             c="inherit"
         >
-            <Card withBorder p="sm" h="100%">
-                <Stack gap={4}>
-                    <Text size="xs" c="dimmed" fw={500} truncate>
-                        {totalQuery.data?.metric.label ?? metricRef.label}
+            <Box
+                className={`${classes.hoverCard} ${classes.clickable}`}
+                p={14}
+                h="100%"
+            >
+                <div className={classes.kpiLabel}>
+                    {totalQuery.data?.metric.label ?? metricRef.label}
+                </div>
+                {totalQuery.isError ? (
+                    <Text size="sm" c="dimmed">
+                        Couldn’t load this metric
                     </Text>
-                    {totalQuery.isError ? (
-                        <Text size="sm" c="dimmed">
-                            Couldn’t load this metric
-                        </Text>
-                    ) : (
-                        <>
-                            <Text size="xl" fw={600}>
-                                {totalQuery.data
-                                    ? formatItemValue(
-                                          totalQuery.data.metric,
-                                          totalQuery.data.value,
-                                      )
-                                    : '-'}
+                ) : (
+                    <>
+                        <div className={classes.kpiValue}>
+                            {totalQuery.data
+                                ? formatItemValue(
+                                      totalQuery.data.metric,
+                                      totalQuery.data.value,
+                                  )
+                                : '-'}
+                        </div>
+                        <Group gap={6}>
+                            {change !== undefined && (
+                                <span
+                                    className={classes.kpiDelta}
+                                    style={{
+                                        color:
+                                            change >= 0
+                                                ? 'var(--mantine-color-teal-7)'
+                                                : 'var(--mantine-color-red-7)',
+                                    }}
+                                >
+                                    {change >= 0 ? '↑' : '↓'}{' '}
+                                    {applyCustomFormat(change, {
+                                        round: 2,
+                                        type: CustomFormatType.PERCENT,
+                                    })}
+                                </span>
+                            )}
+                            <Text size="xs" c="dimmed">
+                                vs previous period
                             </Text>
-                            <Group gap={4}>
-                                {change !== undefined && (
-                                    <Badge
-                                        variant="light"
-                                        size="sm"
-                                        tt="none"
-                                        color={change >= 0 ? 'teal' : 'red'}
-                                    >
-                                        {change >= 0 ? '↑' : '↓'}{' '}
-                                        {applyCustomFormat(change, {
-                                            round: 2,
-                                            type: CustomFormatType.PERCENT,
-                                        })}
-                                    </Badge>
-                                )}
-                                <Text size="xs" c="dimmed">
-                                    vs previous period
-                                </Text>
-                            </Group>
-                        </>
-                    )}
-                </Stack>
-            </Card>
+                        </Group>
+                    </>
+                )}
+            </Box>
         </Anchor>
     );
 };
@@ -211,11 +217,13 @@ export const MetricsBlockView: FC<BlockComponentProps> = ({
         return null;
     }
     return (
-        <Stack gap="xs">
-            <Text size="xs" fw={600} tt="uppercase" c="dimmed">
-                {block.config.title}
-            </Text>
-            <SimpleGrid cols={{ base: 1, sm: 2, md: 4 }} spacing="sm">
+        <Stack gap={0}>
+            <BlockHeader
+                icon={IconChartDots}
+                iconColor="light-dark(#de7f0b, #e08a20)"
+                title={block.config.title}
+            />
+            <SimpleGrid cols={{ base: 1, sm: 2, md: 4 }} spacing={12}>
                 {block.config.items.map((metricRef) => (
                     <MetricKpiCard
                         key={`${metricRef.tableName}-${metricRef.metricName}`}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
@@ -4,7 +4,6 @@ import {
     Anchor,
     Box,
     Button,
-    Card,
     Group,
     Loader,
     Menu,
@@ -33,6 +32,8 @@ import { useInfiniteContent } from '../../../../hooks/useContent';
 import useTracking from '../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../types/Events';
 import { useAiAgentButtonVisibility } from '../../aiCopilot/hooks/useAiAgentsButtonVisibility';
+import { IconSquare } from './BlockShell';
+import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 type StaticActionDefinition = {
@@ -116,20 +117,25 @@ export const QuickActionCards: FC<{
                             })
                         }
                     >
-                        <Card withBorder p="md" h="100%">
-                            <Stack gap="xs">
-                                <MantineIcon
-                                    icon={presentation.icon}
-                                    size="xl"
-                                />
-                                <Text fw={600} size="sm">
-                                    {presentation.title}
-                                </Text>
-                                <Text size="xs" c="dimmed">
-                                    {presentation.description}
-                                </Text>
-                            </Stack>
-                        </Card>
+                        <Box
+                            className={`${classes.hoverCard} ${classes.clickable}`}
+                            p={18}
+                            h="100%"
+                        >
+                            <IconSquare
+                                icon={presentation.icon}
+                                tint={
+                                    action.type === 'ask-ai' ? 'violet' : 'gray'
+                                }
+                                size="lg"
+                            />
+                            <Text fw={600} fz={15} mt={13} mb={3}>
+                                {presentation.title}
+                            </Text>
+                            <Text fz={13} c="dimmed" lh={1.45}>
+                                {presentation.description}
+                            </Text>
+                        </Box>
                     </Anchor>
                 );
             })}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
@@ -1,14 +1,23 @@
 import {
+    ContentType,
     type ApiError,
     type HomepageRecentlyViewedItem,
+    type SummaryContent,
 } from '@lightdash/common';
-import { Badge, Card, Group, Skeleton, Stack, Text } from '@mantine-8/core';
+import { Skeleton, Stack } from '@mantine-8/core';
+import {
+    IconChartBar,
+    IconClock,
+    IconLayoutDashboard,
+} from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 import { type FC } from 'react';
+import { Link } from 'react-router';
 import { lightdashApi } from '../../../../api';
 import { useTimeAgo } from '../../../../hooks/useTimeAgo';
 import { useCollectionContent } from '../hooks/useCollectionContent';
-import { ContentCard } from './ContentCard';
+import { BlockHeader } from './BlockShell';
+import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const getRecentlyViewed = async (projectUuid: string) =>
@@ -24,12 +33,41 @@ const useRecentlyViewed = (projectUuid: string) =>
         queryFn: () => getRecentlyViewed(projectUuid),
     });
 
-const ViewedAt: FC<{ date: Date }> = ({ date }) => {
-    const timeAgo = useTimeAgo(date);
+const contentUrl = (projectUuid: string, content: SummaryContent): string =>
+    content.contentType === ContentType.DASHBOARD
+        ? `/projects/${projectUuid}/dashboards/${content.uuid}/view`
+        : `/projects/${projectUuid}/saved/${content.uuid}`;
+
+const RecentRow: FC<{
+    content: SummaryContent;
+    projectUuid: string;
+    viewedAt: Date | undefined;
+}> = ({ content, projectUuid, viewedAt }) => {
+    const timeAgo = useTimeAgo(viewedAt ?? new Date(0));
+    const isDashboard = content.contentType === ContentType.DASHBOARD;
     return (
-        <Text size="xs" c="dimmed" style={{ whiteSpace: 'nowrap' }}>
-            {timeAgo}
-        </Text>
+        <Link
+            to={contentUrl(projectUuid, content)}
+            className={`${classes.listRow} ${classes.clickable}`}
+            style={{ color: 'inherit', textDecoration: 'none' }}
+        >
+            <div className={classes.iconSquare}>
+                {isDashboard ? (
+                    <IconLayoutDashboard size={16} />
+                ) : (
+                    <IconChartBar size={16} />
+                )}
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+                <div className={classes.rowName}>{content.name}</div>
+                <div className={classes.rowMeta}>
+                    {isDashboard ? 'Dashboard' : 'Chart'}
+                </div>
+            </div>
+            {viewedAt ? (
+                <span className={classes.rowAside}>{timeAgo}</span>
+            ) : null}
+        </Link>
     );
 };
 
@@ -43,53 +81,32 @@ const RecentList: FC<{ projectUuid: string }> = ({ projectUuid }) => {
         return (
             <Stack gap="xs">
                 {[0, 1, 2].map((i) => (
-                    <Skeleton key={i} h={56} radius="md" />
+                    <Skeleton key={i} h={52} radius="md" />
                 ))}
             </Stack>
         );
     }
     if (!contents || contents.length === 0) {
         return (
-            <Text
-                size="xs"
-                c="dimmed"
-                p="sm"
-                style={{
-                    border: '1px dashed var(--mantine-color-gray-4)',
-                    borderRadius: 8,
-                }}
-            >
+            <div className={classes.dashedEmpty}>
                 Charts and dashboards you open will show up here.
-            </Text>
+            </div>
         );
     }
     const viewedAtByUuid = new Map(
         (recents ?? []).map((item) => [item.uuid, item.viewedAt]),
     );
     return (
-        <Card withBorder p="sm">
-            <Stack gap="xs">
-                {contents.map((content) => {
-                    const viewedAt = viewedAtByUuid.get(content.uuid);
-                    return (
-                        <Group
-                            key={content.uuid}
-                            gap="sm"
-                            wrap="nowrap"
-                            align="center"
-                        >
-                            <div style={{ flex: 1, minWidth: 0 }}>
-                                <ContentCard
-                                    content={content}
-                                    projectUuid={projectUuid}
-                                />
-                            </div>
-                            {viewedAt && <ViewedAt date={viewedAt} />}
-                        </Group>
-                    );
-                })}
-            </Stack>
-        </Card>
+        <div className={classes.listCard}>
+            {contents.map((content) => (
+                <RecentRow
+                    key={content.uuid}
+                    content={content}
+                    projectUuid={projectUuid}
+                    viewedAt={viewedAtByUuid.get(content.uuid)}
+                />
+            ))}
+        </div>
     );
 };
 
@@ -99,15 +116,12 @@ export const RecentBlockView: FC<BlockComponentProps> = ({
 }) => {
     if (block.type !== 'recent') return null;
     return (
-        <Stack gap="xs">
-            <Group gap="xs">
-                <Text size="xs" fw={600} tt="uppercase" c="dimmed">
-                    {block.config.title}
-                </Text>
-                <Badge variant="default" size="xs" tt="none">
-                    Personal per viewer
-                </Badge>
-            </Group>
+        <Stack gap={0}>
+            <BlockHeader
+                icon={IconClock}
+                title={block.config.title}
+                pill="Personal per viewer"
+            />
             <RecentList projectUuid={projectUuid} />
         </Stack>
     );
@@ -119,20 +133,17 @@ export const RecentBlockBuild: FC<BuildComponentProps> = ({
 }) => {
     if (block.type !== 'recent') return null;
     return (
-        <Stack gap="xs">
-            <Group gap="xs">
-                <Text size="xs" fw={600} tt="uppercase" c="dimmed">
-                    {block.config.title}
-                </Text>
-                <Badge variant="default" size="xs" tt="none">
-                    Personal per viewer
-                </Badge>
-            </Group>
+        <Stack gap={0}>
+            <BlockHeader
+                icon={IconClock}
+                title={block.config.title}
+                pill="Personal per viewer"
+            />
             <RecentList projectUuid={projectUuid} />
-            <Text size="xs" c="dimmed">
+            <div className={classes.buildHint}>
                 Showing your recent activity as a sample — every viewer sees
                 their own.
-            </Text>
+            </div>
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -2,18 +2,7 @@ import {
     type HomepageResourceItem,
     type HomepageResourceKind,
 } from '@lightdash/common';
-import {
-    ActionIcon,
-    Anchor,
-    Badge,
-    Box,
-    Card,
-    Group,
-    Select,
-    Stack,
-    Text,
-    TextInput,
-} from '@mantine-8/core';
+import { ActionIcon, Group, Select, Stack, TextInput } from '@mantine-8/core';
 import {
     IconBook,
     IconExternalLink,
@@ -25,6 +14,8 @@ import {
 } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
+import { BlockHeader, IconSquare, MiniPill } from './BlockShell';
+import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const KIND_ICONS: Record<HomepageResourceKind, Icon> = {
@@ -33,24 +24,24 @@ const KIND_ICONS: Record<HomepageResourceKind, Icon> = {
     link: IconLink,
 };
 
+const KIND_LABELS: Record<HomepageResourceKind, string> = {
+    video: 'Video',
+    doc: 'Doc',
+    link: 'Link',
+};
+
 const ResourceRow: FC<{
     item: HomepageResourceItem;
     onRemove?: () => void;
 }> = ({ item, onRemove }) => {
-    const row = (
-        <Group gap="sm" wrap="nowrap" p="xs">
-            <MantineIcon icon={KIND_ICONS[item.kind] ?? IconLink} size="lg" />
-            <Box style={{ flex: 1, minWidth: 0 }}>
-                <Text size="sm" fw={500} truncate>
-                    {item.title}
-                </Text>
-                <Text size="xs" c="dimmed" truncate>
-                    {item.url}
-                </Text>
-            </Box>
-            <Badge variant="default" size="sm" tt="capitalize">
-                {item.kind}
-            </Badge>
+    const body = (
+        <>
+            <IconSquare icon={KIND_ICONS[item.kind] ?? IconLink} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+                <div className={classes.rowName}>{item.title}</div>
+                <div className={classes.rowMeta}>{item.url}</div>
+            </div>
+            <MiniPill>{KIND_LABELS[item.kind] ?? 'Link'}</MiniPill>
             {onRemove ? (
                 <ActionIcon
                     variant="subtle"
@@ -62,21 +53,25 @@ const ResourceRow: FC<{
                     <MantineIcon icon={IconX} />
                 </ActionIcon>
             ) : (
-                <MantineIcon icon={IconExternalLink} color="gray" />
+                <MantineIcon
+                    icon={IconExternalLink}
+                    size={14}
+                    color="ldGray.4"
+                />
             )}
-        </Group>
+        </>
     );
-    if (onRemove) return row;
+    if (onRemove) return <div className={classes.listRow}>{body}</div>;
     return (
-        <Anchor
+        <a
             href={item.url}
             target="_blank"
             rel="noopener noreferrer"
-            underline="never"
-            c="inherit"
+            className={`${classes.listRow} ${classes.clickable}`}
+            style={{ color: 'inherit', textDecoration: 'none' }}
         >
-            {row}
-        </Anchor>
+            {body}
+        </a>
     );
 };
 
@@ -85,17 +80,13 @@ export const ResourcesBlockView: FC<BlockComponentProps> = ({ block }) => {
         return null;
     }
     return (
-        <Stack gap="xs">
-            <Text size="xs" fw={600} tt="uppercase" c="dimmed">
-                {block.config.title}
-            </Text>
-            <Card withBorder p={0}>
-                <Stack gap={0}>
-                    {block.config.items.map((item) => (
-                        <ResourceRow key={item.url} item={item} />
-                    ))}
-                </Stack>
-            </Card>
+        <Stack gap={0}>
+            <BlockHeader icon={IconBook} title={block.config.title} />
+            <div className={classes.listCard}>
+                {block.config.items.map((item) => (
+                    <ResourceRow key={item.url} item={item} />
+                ))}
+            </div>
         </Stack>
     );
 };
@@ -148,27 +139,25 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
                     })
                 }
             />
-            <Card withBorder p={0}>
-                <Stack gap={0}>
-                    {block.config.items.map((item) => (
-                        <ResourceRow
-                            key={item.url}
-                            item={item}
-                            onRemove={() =>
-                                onChange({
-                                    ...block,
-                                    config: {
-                                        ...block.config,
-                                        items: block.config.items.filter(
-                                            (i) => i.url !== item.url,
-                                        ),
-                                    },
-                                })
-                            }
-                        />
-                    ))}
-                </Stack>
-            </Card>
+            <div className={classes.listCard}>
+                {block.config.items.map((item) => (
+                    <ResourceRow
+                        key={item.url}
+                        item={item}
+                        onRemove={() =>
+                            onChange({
+                                ...block,
+                                config: {
+                                    ...block.config,
+                                    items: block.config.items.filter(
+                                        (i) => i.url !== item.url,
+                                    ),
+                                },
+                            })
+                        }
+                    />
+                ))}
+            </div>
             <Group gap="xs" align="flex-end">
                 <TextInput
                     label="Title"

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -1,0 +1,230 @@
+.sectionHeader {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+}
+
+.sectionTitle {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--mantine-color-ldGray-6);
+}
+
+.miniPill {
+    font-size: 11px;
+    color: var(--mantine-color-ldGray-5);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: 5px;
+    padding: 1px 6px;
+    white-space: nowrap;
+}
+
+.hoverCard {
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: 10px;
+    background: light-dark(#fff, var(--mantine-color-dark-6));
+    box-shadow: var(--mantine-shadow-subtle);
+    transition: all 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+a .hoverCard:hover,
+.hoverCard.clickable:hover {
+    box-shadow: var(--mantine-shadow-heavy);
+    transform: translateY(-1px);
+}
+
+.listCard {
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: 10px;
+    background: light-dark(#fff, var(--mantine-color-dark-6));
+    box-shadow: var(--mantine-shadow-subtle);
+    overflow: hidden;
+}
+
+.listRow {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 11px 14px;
+}
+
+.listRow + .listRow {
+    border-top: 1px solid var(--mantine-color-ldGray-1);
+}
+
+.listRow.clickable:hover {
+    background: var(--mantine-color-ldGray-0);
+}
+
+.iconSquare {
+    width: 30px;
+    height: 30px;
+    border-radius: 7px;
+    background: var(--mantine-color-ldGray-1);
+    display: grid;
+    place-items: center;
+    color: var(--mantine-color-ldGray-7);
+    flex-shrink: 0;
+}
+
+.iconSquareLg {
+    width: 34px;
+    height: 34px;
+    border-radius: 8px;
+}
+
+.tintDimension {
+    background: light-dark(#edf0fd, #202539);
+    color: light-dark(#3b5bdb, #95aaf0);
+}
+
+.tintMetric {
+    background: light-dark(#fbe9e0, #3e2f1a);
+    color: light-dark(#de7f0b, #e08a20);
+}
+
+.tintCalculation {
+    background: light-dark(#ebf5ed, #1d3525);
+    color: light-dark(#2b8a3e, #38af4d);
+}
+
+.tintViolet {
+    background: linear-gradient(135deg, #7262ff, #9a8cff);
+    color: #fff;
+}
+
+.dashedEmpty {
+    font-size: 12.5px;
+    color: var(--mantine-color-ldGray-5);
+    border: 1px dashed var(--mantine-color-ldGray-3);
+    border-radius: 8px;
+    padding: 10px 12px;
+}
+
+.favPill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: light-dark(#fff, var(--mantine-color-dark-6));
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: 8px;
+    padding: 7px 11px;
+    font-size: 13px;
+    font-weight: 500;
+    color: inherit;
+    text-decoration: none;
+    box-shadow: var(--mantine-shadow-subtle);
+    transition: all 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+    cursor: pointer;
+}
+
+.favPill:hover {
+    color: inherit;
+}
+
+.favPill:hover {
+    box-shadow: var(--mantine-shadow-heavy);
+    transform: translateY(-1px);
+    text-decoration: none;
+}
+
+.starAccent {
+    color: light-dark(#de7f0b, #e08a20);
+}
+
+.violetAccent {
+    color: #7262ff;
+}
+
+.rowName {
+    font-size: 13.5px;
+    font-weight: 500;
+}
+
+.rowMeta {
+    font-size: 12px;
+    color: var(--mantine-color-ldGray-6);
+}
+
+.rowAside {
+    font-size: 12px;
+    color: var(--mantine-color-ldGray-5);
+    white-space: nowrap;
+}
+
+.announcementDot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #7262ff;
+    margin-top: 6px;
+    flex-shrink: 0;
+}
+
+.kpiLabel {
+    font-size: 12px;
+    color: var(--mantine-color-ldGray-6);
+    font-weight: 500;
+    margin-bottom: 5px;
+}
+
+.kpiValue {
+    font-size: 22px;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    margin-bottom: 2px;
+}
+
+.kpiDelta {
+    font-size: 12px;
+    font-weight: 500;
+}
+
+.buildHint {
+    font-size: 11.5px;
+    color: var(--mantine-color-ldGray-5);
+    margin-top: 8px;
+}
+
+.addContentTile {
+    border: 1px dashed var(--mantine-color-ldGray-3);
+    border-radius: 10px;
+    min-height: 108px;
+    display: grid;
+    place-items: center;
+    color: var(--mantine-color-ldGray-5);
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 500;
+    background: transparent;
+    font-family: inherit;
+    transition: all 0.15s ease-in-out;
+}
+
+.addContentTile:hover {
+    border-color: var(--mantine-color-ldGray-5);
+    color: var(--mantine-color-ldGray-7);
+    background: light-dark(#fff, var(--mantine-color-dark-6));
+}
+
+.aiChip {
+    font-size: 12px;
+    font-weight: 500;
+    padding: 5px 11px;
+    border-radius: 7px;
+    cursor: pointer;
+    background: var(--mantine-color-ldGray-0);
+    border: 1px solid transparent;
+    color: var(--mantine-color-ldGray-7);
+    transition: all 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+    font-family: inherit;
+}
+
+.aiChip:hover {
+    background: light-dark(#fff, var(--mantine-color-dark-6));
+    border-color: var(--mantine-color-ldGray-3);
+    color: var(--mantine-color-ldGray-9);
+    box-shadow: var(--mantine-shadow-subtle);
+}

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { DbtProjectType, ProjectType } from '@lightdash/common';
-import { Button, Group, Stack } from '@mantine-8/core';
-import { IconEdit } from '@tabler/icons-react';
+import { Box, Button, Group, Stack } from '@mantine-8/core';
+import { IconEdit, IconPlus } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
 import { useUnmount } from 'react-use';
@@ -111,7 +111,7 @@ const Home: FC = () => {
             row.blocks.some((block) => block.type === 'favorites'),
         );
         return (
-            <Page withFixedContent withPaddedContent withFooter>
+            <Page withPaddedContent withFooter>
                 <Stack gap="md">
                     <Can
                         I="manage"
@@ -120,9 +120,20 @@ const Home: FC = () => {
                             projectUuid: project.data.projectUuid,
                         })}
                     >
-                        <Group justify="flex-end">
+                        <Group justify="flex-end" gap="xs">
                             <Button
                                 variant="default"
+                                size="xs"
+                                leftSection={<MantineIcon icon={IconPlus} />}
+                                onClick={() =>
+                                    navigate(
+                                        `/projects/${project.data.projectUuid}/homepage-builder?create=1`,
+                                    )
+                                }
+                            >
+                                New homepage
+                            </Button>
+                            <Button
                                 size="xs"
                                 leftSection={<MantineIcon icon={IconEdit} />}
                                 onClick={() =>
@@ -135,15 +146,17 @@ const Home: FC = () => {
                             </Button>
                         </Group>
                     </Can>
+                    {homepage.allowPersonal && !hasFavoritesBlock && (
+                        <Box maw={1100} mx="auto" w="100%">
+                            <PersonalFavoritesStrip
+                                projectUuid={project.data.projectUuid}
+                            />
+                        </Box>
+                    )}
                     <PublishedHomepage
                         config={homepage.config}
                         projectUuid={project.data.projectUuid}
                     />
-                    {homepage.allowPersonal && !hasFavoritesBlock && (
-                        <PersonalFavoritesStrip
-                            projectUuid={project.data.projectUuid}
-                        />
-                    )}
                 </Stack>
             </Page>
         );
@@ -155,7 +168,7 @@ const Home: FC = () => {
         onboarding.data.ranQuery
     ) {
         return (
-            <Page withFixedContent withPaddedContent withFooter>
+            <Page withPaddedContent withFooter>
                 <Stack gap="md">
                     <Can
                         I="manage"


### PR DESCRIPTION
Part of the Homepage Builder stack (ZAP-609). Polish pass 1 of 3 toward parity with the claude.ai/design prototype.

Encodes the prototype's visual language once — `blocks/blockStyles.module.css` + `BlockShell.tsx` (`BlockHeader`, `MiniPill`, `IconSquare`) — and applies it across every block:

- **Section headers**: 14px accent icon + 11px uppercase tracked title + bordered mini-pill ("Only you see this", "Personal per viewer"), exactly per design.
- **Favorites / personal strip**: pill chips with kind icon + metric-orange star (click to unfavorite), dashed empty states with design copy. Strip now renders *above* the curated blocks.
- **Recently viewed & Resources**: bordered list cards with 30px icon squares, 13.5/500 names, meta line, right-aligned time-ago / kind pill + external-link glyph.
- **Announcements**: violet speakerphone header + violet-dot rows.
- **Metrics**: KPI cards — 12px label, 22px value, colored delta, hover-lift.
- **Collection**: new `tile` variant of ContentCard (icon top-left, star/remove top-right, name + verified, "kind · 👁 views"); build mode gets the dashed "Add content" tile.
- **Hero**: 28px title + right-aligned dark-primary "New" CTA (→ /tables, gated on manage Explore); build mode inline unstyled inputs + `{name}` hint.
- **Ask AI chips & Quick actions**: design chip styling; quick-action cards with tinted icon squares (violet gradient for Ask AI) and hover-lift.
- **Wider homepage**: view-mode drops the 900px `withFixedContent` cap; canvas is now 1100px max (design uses full-bleed rows at 920 — we go wider per feedback).
- All colors are theme-aware (`ldGray` ramp + `light-dark()` accents) so dark mode holds up.

Verified live against localhost with Playwright screenshots (published homepage + favorites strip + hero CTA). 20/20 feature tests pass, typecheck + oxlint clean.

Next in this polish series: builder chrome full-width layout + toolbar (PR 20), modals + day-one (PR 21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ