### PR TITLE
style(homepage): full-bleed builder chrome — 52px toolbar, docked block rail, block chrome, drop zones

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
@@ -144,9 +144,9 @@ export const HomepageBuilderPage: FC = () => {
     const openHomepage = (created: ProjectHomepage) =>
         setSearchParams({ homepage: created.homepageUuid });
 
-    return (
-        <Page withFixedContent withPaddedContent>
-            {isCreating || !homepage.data ? (
+    if (isCreating || !homepage.data) {
+        return (
+            <Page withFixedContent withPaddedContent>
                 <CreateHomepageForm
                     projectUuid={projectUuid}
                     homepages={homepages.data ?? []}
@@ -157,7 +157,13 @@ export const HomepageBuilderPage: FC = () => {
                             : null
                     }
                 />
-            ) : (
+            </Page>
+        );
+    }
+
+    return (
+        <Page>
+            {
                 <HomepageEditor
                     key={`${homepage.data.homepageUuid}-${editorEpoch}`}
                     homepage={homepage.data}
@@ -177,7 +183,7 @@ export const HomepageBuilderPage: FC = () => {
                         setEditorEpoch((epoch) => epoch + 1);
                     }}
                 />
-            )}
+            }
         </Page>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.module.css
@@ -1,0 +1,160 @@
+.builderRoot {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - var(--navbar-height));
+    overflow: hidden;
+}
+
+.toolbar {
+    height: 52px;
+    flex-shrink: 0;
+    background: light-dark(#fff, var(--mantine-color-dark-7));
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 0 16px;
+    position: relative;
+    z-index: 30;
+}
+
+.toolbarDivider {
+    width: 1px;
+    height: 22px;
+    background: var(--mantine-color-ldGray-2);
+    flex-shrink: 0;
+}
+
+.conflictBanner {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 16px;
+    background: var(--mantine-color-orange-0);
+    border-bottom: 1px solid var(--mantine-color-orange-4);
+}
+
+.body {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+}
+
+.rail {
+    width: 264px;
+    flex-shrink: 0;
+    background: light-dark(#fff, var(--mantine-color-dark-7));
+    border-right: 1px solid var(--mantine-color-ldGray-2);
+    overflow-y: auto;
+    padding: 16px 12px;
+}
+
+.railTitle {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--mantine-color-ldGray-6);
+    padding: 0 4px 10px;
+}
+
+.railCard {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 10px;
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: 9px;
+    cursor: grab;
+    background: light-dark(#fff, var(--mantine-color-dark-6));
+    transition: all 0.15s ease-in-out;
+}
+
+.railCard:hover {
+    border-color: var(--mantine-color-ldGray-4);
+    box-shadow: var(--mantine-shadow-subtle);
+    background: var(--mantine-color-ldGray-0);
+}
+
+.railCard:active {
+    transform: scale(0.98);
+}
+
+.railCardLabel {
+    font-size: 13px;
+    font-weight: 500;
+}
+
+.railCardDesc {
+    font-size: 11.5px;
+    color: var(--mantine-color-ldGray-6);
+    line-height: 1.35;
+}
+
+.railHint {
+    margin-top: 14px;
+    padding: 10px;
+    border-radius: 9px;
+    background: var(--mantine-color-ldGray-0);
+    border: 1px dashed var(--mantine-color-ldGray-3);
+    font-size: 12px;
+    color: var(--mantine-color-ldGray-6);
+    line-height: 1.45;
+}
+
+.canvas {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.canvasInner {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 32px 32px 120px;
+}
+
+.blockChrome {
+    position: relative;
+    min-width: 0;
+    flex: 1;
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: 12px;
+    background: light-dark(#fff, var(--mantine-color-dark-6));
+    padding: 14px;
+}
+
+.blockTypeLabel {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--mantine-color-ldGray-5);
+}
+
+.endZone {
+    margin-top: 10px;
+    border: 2px dashed var(--mantine-color-ldGray-3);
+    border-radius: 12px;
+    padding: 26px;
+    text-align: center;
+    color: var(--mantine-color-ldGray-5);
+    font-size: 13px;
+    font-weight: 500;
+    transition: all 0.15s ease-in-out;
+}
+
+.endZoneActive {
+    border-color: var(--mantine-color-blue-5);
+    background: var(--mantine-color-blue-0);
+}
+
+.savedIndicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 12px;
+    color: var(--mantine-color-ldGray-5);
+    white-space: nowrap;
+}

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -6,10 +6,8 @@ import {
     ActionIcon,
     Box,
     Button,
-    Card,
     Group,
     Menu,
-    Paper,
     Stack,
     Text,
     Tooltip,
@@ -18,6 +16,7 @@ import { useDebouncedValue } from '@mantine/hooks';
 import {
     IconArrowDown,
     IconArrowLeft,
+    IconArrowRight,
     IconArrowUp,
     IconCheck,
     IconChevronDown,
@@ -28,7 +27,6 @@ import {
     IconLayoutGrid,
     IconPencil,
     IconPlus,
-    IconSend,
     IconTrash,
     IconUserSearch,
     IconUsers,
@@ -38,6 +36,7 @@ import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import { useAiAgentButtonVisibility } from '../aiCopilot/hooks/useAiAgentsButtonVisibility';
+import { IconSquare } from './blocks/BlockShell';
 import {
     blockLibrary,
     getBlockDefinition,
@@ -57,6 +56,7 @@ import {
     replaceBlock,
     type DropTarget,
 } from './configOps';
+import classes from './HomepageEditor.module.css';
 import {
     useDeleteHomepage,
     usePublishHomepage,
@@ -214,37 +214,18 @@ export const HomepageEditor: FC<Props> = ({
     const draggedBlockId = drag?.kind === 'existing' ? drag.blockId : undefined;
 
     return (
-        <Stack gap="lg" w="100%">
-            {hasConflict && (
-                <Group
-                    justify="space-between"
-                    p="sm"
-                    style={{
-                        border: '1px solid var(--mantine-color-orange-4)',
-                        borderRadius: 8,
-                        background: 'var(--mantine-color-orange-0)',
-                    }}
+        <div className={classes.builderRoot}>
+            <div className={classes.toolbar}>
+                <Button
+                    variant="default"
+                    size="sm"
+                    leftSection={<MantineIcon icon={IconArrowLeft} />}
+                    onClick={() => navigate(`/projects/${projectUuid}/home`)}
                 >
-                    <Text size="sm" fw={500}>
-                        This homepage was changed somewhere else — your latest
-                        edits here can’t be saved.
-                    </Text>
-                    <Button size="xs" onClick={onConflictReload}>
-                        Reload homepage
-                    </Button>
-                </Group>
-            )}
-            <Group justify="space-between">
-                <Group gap="sm">
-                    <Button
-                        variant="default"
-                        leftSection={<MantineIcon icon={IconArrowLeft} />}
-                        onClick={() =>
-                            navigate(`/projects/${projectUuid}/home`)
-                        }
-                    >
-                        Exit
-                    </Button>
+                    Exit
+                </Button>
+                <div className={classes.toolbarDivider} />
+                <Group gap={10} wrap="nowrap">
                     <Menu position="bottom-start" width={280}>
                         <Menu.Target>
                             <Button
@@ -298,68 +279,76 @@ export const HomepageEditor: FC<Props> = ({
                     </Menu>
                     <Button
                         variant="default"
+                        size="sm"
                         leftSection={<MantineIcon icon={IconLayoutGrid} />}
                         onClick={() => setIsPresetsModalOpen(true)}
                     >
                         Presets
                     </Button>
                 </Group>
-                <Group gap="sm">
-                    {isDirty ? (
-                        <Text size="xs" c="dimmed">
-                            Saving…
-                        </Text>
-                    ) : (
-                        <Group gap={4}>
-                            <MantineIcon icon={IconCircleCheck} color="green" />
-                            <Text size="xs" c="dimmed">
-                                Draft saved
-                            </Text>
-                        </Group>
-                    )}
-                    <Button
-                        variant="default"
-                        leftSection={
-                            <MantineIcon
-                                icon={isPreviewing ? IconPencil : IconEye}
-                            />
-                        }
-                        onClick={() => setIsPreviewing((prev) => !prev)}
-                    >
-                        {isPreviewing ? 'Back to editing' : 'Preview'}
+                <Box style={{ flex: 1 }} />
+                {isDirty ? (
+                    <span className={classes.savedIndicator}>Saving…</span>
+                ) : (
+                    <span className={classes.savedIndicator}>
+                        <MantineIcon
+                            icon={IconCircleCheck}
+                            size={14}
+                            color="green"
+                        />
+                        Draft saved
+                    </span>
+                )}
+                <Button
+                    variant="default"
+                    size="sm"
+                    leftSection={
+                        <MantineIcon
+                            icon={isPreviewing ? IconPencil : IconEye}
+                        />
+                    }
+                    onClick={() => setIsPreviewing((prev) => !prev)}
+                >
+                    {isPreviewing ? 'Back to editing' : 'Preview'}
+                </Button>
+                <Button
+                    variant="default"
+                    size="sm"
+                    leftSection={<MantineIcon icon={IconUserSearch} />}
+                    onClick={() => setIsViewAsModalOpen(true)}
+                >
+                    View as
+                </Button>
+                <Button
+                    size="sm"
+                    rightSection={<MantineIcon icon={IconArrowRight} />}
+                    loading={publishMutation.isLoading}
+                    onClick={handleOpenPublish}
+                >
+                    Publish
+                </Button>
+            </div>
+            {hasConflict && (
+                <div className={classes.conflictBanner}>
+                    <Text size="sm" fw={500}>
+                        This homepage was changed somewhere else — your latest
+                        edits here can’t be saved.
+                    </Text>
+                    <Button size="xs" onClick={onConflictReload}>
+                        Reload homepage
                     </Button>
-                    <Button
-                        variant="default"
-                        leftSection={<MantineIcon icon={IconUserSearch} />}
-                        onClick={() => setIsViewAsModalOpen(true)}
-                    >
-                        View as
-                    </Button>
-                    <Button
-                        leftSection={<MantineIcon icon={IconSend} />}
-                        loading={publishMutation.isLoading}
-                        onClick={handleOpenPublish}
-                    >
-                        Publish
-                    </Button>
-                </Group>
-            </Group>
+                </div>
+            )}
 
-            {isPreviewing ? (
-                <PublishedHomepage config={draft} projectUuid={projectUuid} />
-            ) : (
-                <Group align="flex-start" gap="lg" wrap="nowrap">
-                    <Card withBorder w={264} p="sm" style={{ flexShrink: 0 }}>
-                        <Stack gap="xs">
-                            <Text size="xs" fw={600} tt="uppercase" c="dimmed">
-                                Blocks
-                            </Text>
+            <div className={classes.body}>
+                {!isPreviewing && (
+                    <aside className={classes.rail}>
+                        <div className={classes.railTitle}>Blocks</div>
+                        <Stack gap={6}>
                             {availableBlocks.map((definition) => (
-                                <Paper
+                                <div
                                     key={definition.type}
-                                    withBorder
-                                    p="sm"
-                                    style={{ cursor: 'grab' }}
+                                    className={classes.railCard}
                                     draggable
                                     onDragStart={() =>
                                         setDrag({ kind: 'new', definition })
@@ -371,142 +360,145 @@ export const HomepageEditor: FC<Props> = ({
                                         )
                                     }
                                 >
-                                    <Group gap="sm" wrap="nowrap">
-                                        <MantineIcon
-                                            icon={definition.icon}
-                                            size="lg"
-                                        />
-                                        <Box>
-                                            <Text size="sm" fw={500}>
-                                                {definition.label}
-                                            </Text>
-                                            <Text size="xs" c="dimmed">
-                                                {definition.description}
-                                            </Text>
-                                        </Box>
-                                    </Group>
-                                </Paper>
+                                    <IconSquare
+                                        icon={definition.icon}
+                                        tint={definition.tint}
+                                    />
+                                    <Box style={{ minWidth: 0 }}>
+                                        <div className={classes.railCardLabel}>
+                                            {definition.label}
+                                        </div>
+                                        <div className={classes.railCardDesc}>
+                                            {definition.description}
+                                        </div>
+                                    </Box>
+                                </div>
                             ))}
-                            <Text size="xs" c="dimmed">
-                                Click to add, or drag a block onto the page.
-                            </Text>
                         </Stack>
-                    </Card>
-
-                    <Stack gap={0} style={{ flex: 1, minWidth: 0 }}>
-                        {draft.rows.map((row, rowIndex) => (
-                            <Box key={row.id}>
-                                <Box
-                                    h={drag ? 18 : 12}
-                                    {...dropZoneProps({
-                                        kind: 'row',
-                                        rowIndex,
-                                    })}
-                                >
-                                    <Box
-                                        h={3}
-                                        style={{
-                                            borderRadius: 2,
-                                            marginTop: drag ? 7 : 4,
-                                            background: isDropTarget({
+                        <div className={classes.railHint}>
+                            Click to add, or drag a block onto the page.
+                        </div>
+                    </aside>
+                )}
+                <div className={classes.canvas}>
+                    <div className={classes.canvasInner}>
+                        {isPreviewing ? (
+                            <PublishedHomepage
+                                config={draft}
+                                projectUuid={projectUuid}
+                            />
+                        ) : (
+                            <Stack gap={0} style={{ flex: 1, minWidth: 0 }}>
+                                {draft.rows.map((row, rowIndex) => (
+                                    <Box key={row.id}>
+                                        <Box
+                                            h={drag ? 18 : 12}
+                                            {...dropZoneProps({
                                                 kind: 'row',
                                                 rowIndex,
-                                            })
-                                                ? 'var(--mantine-color-blue-5)'
-                                                : 'transparent',
-                                        }}
-                                    />
-                                </Box>
-                                <Group gap="md" align="stretch" wrap="nowrap">
-                                    {row.blocks.map((block, blockIndex) => {
-                                        const definition = getBlockDefinition(
-                                            block.type,
-                                        );
-                                        if (!definition) return null;
-                                        const { Build } = definition;
-                                        const showSideZones =
-                                            drag !== null &&
-                                            canDropInRow(
-                                                draft,
-                                                rowIndex,
-                                                draggedBlockId,
-                                            );
-                                        return (
-                                            <Card
-                                                key={block.id}
-                                                withBorder
-                                                p="sm"
+                                            })}
+                                        >
+                                            <Box
+                                                h={3}
                                                 style={{
-                                                    flex: 1,
-                                                    minWidth: 0,
-                                                    position: 'relative',
+                                                    borderRadius: 2,
+                                                    marginTop: drag ? 7 : 4,
+                                                    background: isDropTarget({
+                                                        kind: 'row',
+                                                        rowIndex,
+                                                    })
+                                                        ? 'var(--mantine-color-blue-5)'
+                                                        : 'transparent',
                                                 }}
-                                            >
-                                                {showSideZones && (
-                                                    <>
-                                                        <Box
-                                                            style={{
-                                                                position:
-                                                                    'absolute',
-                                                                left: -14,
-                                                                top: 0,
-                                                                bottom: 0,
-                                                                width: 24,
-                                                                zIndex: 20,
-                                                                display: 'flex',
-                                                                justifyContent:
-                                                                    'center',
-                                                            }}
-                                                            {...dropZoneProps({
-                                                                kind: 'cell',
-                                                                rowIndex,
-                                                                blockIndex,
-                                                            })}
+                                            />
+                                        </Box>
+                                        <Group
+                                            gap="md"
+                                            align="stretch"
+                                            wrap="nowrap"
+                                        >
+                                            {row.blocks.map(
+                                                (block, blockIndex) => {
+                                                    const definition =
+                                                        getBlockDefinition(
+                                                            block.type,
+                                                        );
+                                                    if (!definition)
+                                                        return null;
+                                                    const { Build } =
+                                                        definition;
+                                                    const showSideZones =
+                                                        drag !== null &&
+                                                        canDropInRow(
+                                                            draft,
+                                                            rowIndex,
+                                                            draggedBlockId,
+                                                        );
+                                                    return (
+                                                        <div
+                                                            key={block.id}
+                                                            className={
+                                                                classes.blockChrome
+                                                            }
                                                         >
-                                                            <Box
-                                                                w={3}
-                                                                style={{
-                                                                    borderRadius: 2,
-                                                                    background:
-                                                                        isDropTarget(
+                                                            {showSideZones && (
+                                                                <>
+                                                                    <Box
+                                                                        style={{
+                                                                            position:
+                                                                                'absolute',
+                                                                            left: -14,
+                                                                            top: 0,
+                                                                            bottom: 0,
+                                                                            width: 24,
+                                                                            zIndex: 20,
+                                                                            display:
+                                                                                'flex',
+                                                                            justifyContent:
+                                                                                'center',
+                                                                        }}
+                                                                        {...dropZoneProps(
                                                                             {
                                                                                 kind: 'cell',
                                                                                 rowIndex,
                                                                                 blockIndex,
                                                                             },
-                                                                        )
-                                                                            ? 'var(--mantine-color-blue-5)'
-                                                                            : 'transparent',
-                                                                }}
-                                                            />
-                                                        </Box>
-                                                        <Box
-                                                            style={{
-                                                                position:
-                                                                    'absolute',
-                                                                right: -14,
-                                                                top: 0,
-                                                                bottom: 0,
-                                                                width: 24,
-                                                                zIndex: 20,
-                                                                display: 'flex',
-                                                                justifyContent:
-                                                                    'center',
-                                                            }}
-                                                            {...dropZoneProps({
-                                                                kind: 'cell',
-                                                                rowIndex,
-                                                                blockIndex:
-                                                                    blockIndex +
-                                                                    1,
-                                                            })}
-                                                        >
-                                                            <Box
-                                                                w={3}
-                                                                style={{
-                                                                    borderRadius: 2,
-                                                                    background:
-                                                                        isDropTarget(
+                                                                        )}
+                                                                    >
+                                                                        <Box
+                                                                            w={
+                                                                                3
+                                                                            }
+                                                                            style={{
+                                                                                borderRadius: 2,
+                                                                                background:
+                                                                                    isDropTarget(
+                                                                                        {
+                                                                                            kind: 'cell',
+                                                                                            rowIndex,
+                                                                                            blockIndex,
+                                                                                        },
+                                                                                    )
+                                                                                        ? 'var(--mantine-color-blue-5)'
+                                                                                        : 'transparent',
+                                                                            }}
+                                                                        />
+                                                                    </Box>
+                                                                    <Box
+                                                                        style={{
+                                                                            position:
+                                                                                'absolute',
+                                                                            right: -14,
+                                                                            top: 0,
+                                                                            bottom: 0,
+                                                                            width: 24,
+                                                                            zIndex: 20,
+                                                                            display:
+                                                                                'flex',
+                                                                            justifyContent:
+                                                                                'center',
+                                                                        }}
+                                                                        {...dropZoneProps(
                                                                             {
                                                                                 kind: 'cell',
                                                                                 rowIndex,
@@ -514,198 +506,232 @@ export const HomepageEditor: FC<Props> = ({
                                                                                     blockIndex +
                                                                                     1,
                                                                             },
-                                                                        )
-                                                                            ? 'var(--mantine-color-blue-5)'
-                                                                            : 'transparent',
-                                                                }}
+                                                                        )}
+                                                                    >
+                                                                        <Box
+                                                                            w={
+                                                                                3
+                                                                            }
+                                                                            style={{
+                                                                                borderRadius: 2,
+                                                                                background:
+                                                                                    isDropTarget(
+                                                                                        {
+                                                                                            kind: 'cell',
+                                                                                            rowIndex,
+                                                                                            blockIndex:
+                                                                                                blockIndex +
+                                                                                                1,
+                                                                                        },
+                                                                                    )
+                                                                                        ? 'var(--mantine-color-blue-5)'
+                                                                                        : 'transparent',
+                                                                            }}
+                                                                        />
+                                                                    </Box>
+                                                                </>
+                                                            )}
+                                                            <Group
+                                                                gap={4}
+                                                                mb="xs"
+                                                                justify="space-between"
+                                                            >
+                                                                <Group
+                                                                    gap={6}
+                                                                    style={{
+                                                                        cursor: 'grab',
+                                                                    }}
+                                                                    draggable
+                                                                    onDragStart={(
+                                                                        e,
+                                                                    ) => {
+                                                                        e.stopPropagation();
+                                                                        setDrag(
+                                                                            {
+                                                                                kind: 'existing',
+                                                                                blockId:
+                                                                                    block.id,
+                                                                            },
+                                                                        );
+                                                                    }}
+                                                                    onDragEnd={
+                                                                        clearDrag
+                                                                    }
+                                                                >
+                                                                    <MantineIcon
+                                                                        icon={
+                                                                            IconGripVertical
+                                                                        }
+                                                                        color="gray"
+                                                                    />
+                                                                    <span
+                                                                        className={
+                                                                            classes.blockTypeLabel
+                                                                        }
+                                                                    >
+                                                                        {
+                                                                            definition.label
+                                                                        }
+                                                                    </span>
+                                                                </Group>
+                                                                <Group gap={2}>
+                                                                    <Tooltip label="Move up">
+                                                                        <ActionIcon
+                                                                            variant="subtle"
+                                                                            color="gray"
+                                                                            disabled={
+                                                                                !canMoveUp(
+                                                                                    draft,
+                                                                                    block.id,
+                                                                                )
+                                                                            }
+                                                                            onClick={() =>
+                                                                                setDraft(
+                                                                                    (
+                                                                                        prev,
+                                                                                    ) =>
+                                                                                        moveBlockUp(
+                                                                                            prev,
+                                                                                            block.id,
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                        >
+                                                                            <MantineIcon
+                                                                                icon={
+                                                                                    IconArrowUp
+                                                                                }
+                                                                            />
+                                                                        </ActionIcon>
+                                                                    </Tooltip>
+                                                                    <Tooltip label="Move down">
+                                                                        <ActionIcon
+                                                                            variant="subtle"
+                                                                            color="gray"
+                                                                            disabled={
+                                                                                !canMoveDown(
+                                                                                    draft,
+                                                                                    block.id,
+                                                                                )
+                                                                            }
+                                                                            onClick={() =>
+                                                                                setDraft(
+                                                                                    (
+                                                                                        prev,
+                                                                                    ) =>
+                                                                                        moveBlockDown(
+                                                                                            prev,
+                                                                                            block.id,
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                        >
+                                                                            <MantineIcon
+                                                                                icon={
+                                                                                    IconArrowDown
+                                                                                }
+                                                                            />
+                                                                        </ActionIcon>
+                                                                    </Tooltip>
+                                                                    <Tooltip label="Duplicate">
+                                                                        <ActionIcon
+                                                                            variant="subtle"
+                                                                            color="gray"
+                                                                            onClick={() =>
+                                                                                setDraft(
+                                                                                    (
+                                                                                        prev,
+                                                                                    ) =>
+                                                                                        duplicateBlock(
+                                                                                            prev,
+                                                                                            block.id,
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                        >
+                                                                            <MantineIcon
+                                                                                icon={
+                                                                                    IconCopy
+                                                                                }
+                                                                            />
+                                                                        </ActionIcon>
+                                                                    </Tooltip>
+                                                                    <Tooltip label="Remove">
+                                                                        <ActionIcon
+                                                                            variant="subtle"
+                                                                            color="red"
+                                                                            onClick={() =>
+                                                                                setDraft(
+                                                                                    (
+                                                                                        prev,
+                                                                                    ) =>
+                                                                                        removeBlock(
+                                                                                            prev,
+                                                                                            block.id,
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                        >
+                                                                            <MantineIcon
+                                                                                icon={
+                                                                                    IconTrash
+                                                                                }
+                                                                            />
+                                                                        </ActionIcon>
+                                                                    </Tooltip>
+                                                                </Group>
+                                                            </Group>
+                                                            <Build
+                                                                block={block}
+                                                                projectUuid={
+                                                                    projectUuid
+                                                                }
+                                                                onChange={(
+                                                                    updated,
+                                                                ) =>
+                                                                    setDraft(
+                                                                        (
+                                                                            prev,
+                                                                        ) =>
+                                                                            replaceBlock(
+                                                                                prev,
+                                                                                updated,
+                                                                            ),
+                                                                    )
+                                                                }
                                                             />
-                                                        </Box>
-                                                    </>
-                                                )}
-                                                <Group
-                                                    gap={4}
-                                                    mb="xs"
-                                                    justify="space-between"
-                                                >
-                                                    <Group
-                                                        gap={6}
-                                                        style={{
-                                                            cursor: 'grab',
-                                                        }}
-                                                        draggable
-                                                        onDragStart={(e) => {
-                                                            e.stopPropagation();
-                                                            setDrag({
-                                                                kind: 'existing',
-                                                                blockId:
-                                                                    block.id,
-                                                            });
-                                                        }}
-                                                        onDragEnd={clearDrag}
-                                                    >
-                                                        <MantineIcon
-                                                            icon={
-                                                                IconGripVertical
-                                                            }
-                                                            color="gray"
-                                                        />
-                                                        <Text
-                                                            size="xs"
-                                                            fw={600}
-                                                            tt="uppercase"
-                                                            c="dimmed"
-                                                        >
-                                                            {definition.label}
-                                                        </Text>
-                                                    </Group>
-                                                    <Group gap={2}>
-                                                        <Tooltip label="Move up">
-                                                            <ActionIcon
-                                                                variant="subtle"
-                                                                color="gray"
-                                                                disabled={
-                                                                    !canMoveUp(
-                                                                        draft,
-                                                                        block.id,
-                                                                    )
-                                                                }
-                                                                onClick={() =>
-                                                                    setDraft(
-                                                                        (
-                                                                            prev,
-                                                                        ) =>
-                                                                            moveBlockUp(
-                                                                                prev,
-                                                                                block.id,
-                                                                            ),
-                                                                    )
-                                                                }
-                                                            >
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        IconArrowUp
-                                                                    }
-                                                                />
-                                                            </ActionIcon>
-                                                        </Tooltip>
-                                                        <Tooltip label="Move down">
-                                                            <ActionIcon
-                                                                variant="subtle"
-                                                                color="gray"
-                                                                disabled={
-                                                                    !canMoveDown(
-                                                                        draft,
-                                                                        block.id,
-                                                                    )
-                                                                }
-                                                                onClick={() =>
-                                                                    setDraft(
-                                                                        (
-                                                                            prev,
-                                                                        ) =>
-                                                                            moveBlockDown(
-                                                                                prev,
-                                                                                block.id,
-                                                                            ),
-                                                                    )
-                                                                }
-                                                            >
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        IconArrowDown
-                                                                    }
-                                                                />
-                                                            </ActionIcon>
-                                                        </Tooltip>
-                                                        <Tooltip label="Duplicate">
-                                                            <ActionIcon
-                                                                variant="subtle"
-                                                                color="gray"
-                                                                onClick={() =>
-                                                                    setDraft(
-                                                                        (
-                                                                            prev,
-                                                                        ) =>
-                                                                            duplicateBlock(
-                                                                                prev,
-                                                                                block.id,
-                                                                            ),
-                                                                    )
-                                                                }
-                                                            >
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        IconCopy
-                                                                    }
-                                                                />
-                                                            </ActionIcon>
-                                                        </Tooltip>
-                                                        <Tooltip label="Remove">
-                                                            <ActionIcon
-                                                                variant="subtle"
-                                                                color="red"
-                                                                onClick={() =>
-                                                                    setDraft(
-                                                                        (
-                                                                            prev,
-                                                                        ) =>
-                                                                            removeBlock(
-                                                                                prev,
-                                                                                block.id,
-                                                                            ),
-                                                                    )
-                                                                }
-                                                            >
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        IconTrash
-                                                                    }
-                                                                />
-                                                            </ActionIcon>
-                                                        </Tooltip>
-                                                    </Group>
-                                                </Group>
-                                                <Build
-                                                    block={block}
-                                                    projectUuid={projectUuid}
-                                                    onChange={(updated) =>
-                                                        setDraft((prev) =>
-                                                            replaceBlock(
-                                                                prev,
-                                                                updated,
-                                                            ),
-                                                        )
-                                                    }
-                                                />
-                                            </Card>
-                                        );
-                                    })}
-                                </Group>
-                            </Box>
-                        ))}
-                        <Box
-                            mt="md"
-                            p="lg"
-                            style={{
-                                border: `2px dashed ${
-                                    isDropTarget({ kind: 'end' })
-                                        ? 'var(--mantine-color-blue-5)'
-                                        : 'var(--mantine-color-gray-4)'
-                                }`,
-                                borderRadius: 12,
-                                textAlign: 'center',
-                            }}
-                            {...dropZoneProps({ kind: 'end' })}
-                        >
-                            <Text size="sm" c="dimmed" fw={500}>
-                                {draft.rows.length === 0
-                                    ? 'No blocks yet — click or drag one from the library.'
-                                    : 'Drag a block here, or click one in the library.'}
-                            </Text>
-                        </Box>
-                    </Stack>
-                </Group>
-            )}
+                                                        </div>
+                                                    );
+                                                },
+                                            )}
+                                        </Group>
+                                    </Box>
+                                ))}
+                                <div
+                                    className={
+                                        isDropTarget({ kind: 'end' })
+                                            ? `${classes.endZone} ${classes.endZoneActive}`
+                                            : classes.endZone
+                                    }
+                                    {...dropZoneProps({ kind: 'end' })}
+                                >
+                                    <MantineIcon
+                                        icon={IconPlus}
+                                        size={15}
+                                        style={{
+                                            marginRight: 6,
+                                            verticalAlign: -2,
+                                        }}
+                                    />
+                                    {draft.rows.length === 0
+                                        ? 'No blocks yet — click or drag one from the library.'
+                                        : 'Drag a block here, or click one in the library.'}
+                                </div>
+                            </Stack>
+                        )}
+                    </div>
+                </div>
+            </div>
             <PresetsModal
                 opened={isPresetsModalOpen}
                 onClose={() => setIsPresetsModalOpen(false)}
@@ -750,6 +776,6 @@ export const HomepageEditor: FC<Props> = ({
                 }
                 confirmLoading={deleteMutation.isLoading}
             />
-        </Stack>
+        </div>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
@@ -19,6 +19,7 @@ import {
     AnnouncementsBlockBuild,
     AnnouncementsBlockView,
 } from './AnnouncementsBlock';
+import { type IconTint } from './BlockShell';
 import { CollectionBlockBuild, CollectionBlockView } from './CollectionBlock';
 import { FavoritesBlockBuild, FavoritesBlockView } from './FavoritesBlock';
 import { HeroBlockBuild, HeroBlockView } from './HeroBlock';
@@ -38,6 +39,7 @@ export type BlockDefinition = {
     label: string;
     description: string;
     icon: Icon;
+    tint: IconTint;
     requiresAi?: boolean;
     create: () => HomepageBlock;
     View: FC<BlockComponentProps>;
@@ -47,6 +49,7 @@ export type BlockDefinition = {
 export const blockLibrary: BlockDefinition[] = [
     {
         type: 'hero',
+        tint: 'gray',
         label: 'Greeting',
         description:
             'Personalized welcome headline — {name} becomes the viewer.',
@@ -64,6 +67,7 @@ export const blockLibrary: BlockDefinition[] = [
     },
     {
         type: 'ai',
+        tint: 'violet',
         label: 'Ask AI',
         description: 'Natural-language ask box with curated suggestions.',
         icon: IconSparkles,
@@ -78,6 +82,7 @@ export const blockLibrary: BlockDefinition[] = [
     },
     {
         type: 'quick-actions',
+        tint: 'calculation',
         label: 'Quick actions',
         description: 'Primary CTA cards — tailor the main action per audience.',
         icon: IconBolt,
@@ -91,6 +96,7 @@ export const blockLibrary: BlockDefinition[] = [
     },
     {
         type: 'metrics',
+        tint: 'metric',
         label: 'Metrics',
         description: 'KPI cards from the metrics catalog, with deltas.',
         icon: IconChartDots,
@@ -104,6 +110,7 @@ export const blockLibrary: BlockDefinition[] = [
     },
     {
         type: 'collection',
+        tint: 'dimension',
         label: 'Collection',
         description: 'A curated set of dashboards and charts.',
         icon: IconLayoutGrid,
@@ -117,6 +124,7 @@ export const blockLibrary: BlockDefinition[] = [
     },
     {
         type: 'resources',
+        tint: 'gray',
         label: 'Resources',
         description: 'Curated links — docs, videos, request forms.',
         icon: IconBook,
@@ -130,6 +138,7 @@ export const blockLibrary: BlockDefinition[] = [
     },
     {
         type: 'announcements',
+        tint: 'violet',
         label: 'Announcements',
         description: 'Updates from the data team, newest first.',
         icon: IconSpeakerphone,
@@ -143,6 +152,7 @@ export const blockLibrary: BlockDefinition[] = [
     },
     {
         type: 'favorites',
+        tint: 'metric',
         label: 'Favorites',
         description: 'Each viewer’s starred content, only visible to them.',
         icon: IconStar,
@@ -156,6 +166,7 @@ export const blockLibrary: BlockDefinition[] = [
     },
     {
         type: 'recent',
+        tint: 'gray',
         label: 'Recently viewed',
         description: 'Each viewer’s recently opened charts and dashboards.',
         icon: IconClock,
@@ -169,6 +180,7 @@ export const blockLibrary: BlockDefinition[] = [
     },
     {
         type: 'markdown',
+        tint: 'gray',
         label: 'Text / banner',
         description: 'Markdown text, notes or a welcome banner.',
         icon: IconMarkdown,


### PR DESCRIPTION
Part of the Homepage Builder stack (ZAP-609). Polish pass 2 of 3 toward parity with the claude.ai/design prototype — this is the "wider builder + beautiful control navbar" ask.

## What changed

**Full-bleed builder layout** (was: everything squeezed into the 900px page column)
- The builder now owns the whole viewport below the app navbar: `height: calc(100vh - var(--navbar-height))`, flex column.
- **52px toolbar** spanning the page: Exit ｜ divider ｜ "Editing: {name}" switcher menu ｜ Presets — spacer — "Draft saved ✓" indicator, Preview, View as, dark **Publish →**. Matches the prototype's control bar 1:1 (minus Draft-with-AI, which was cancelled).
- **Block library rail** docked to the left edge (264px, border-right, own scroll): cards with tinted icon squares per block type (violet Ask AI, metric-orange Metrics/Favorites, dimension-blue Collection, green Quick actions), 13px labels + 11.5px descriptions, dashed "Click to add, or drag" hint card at the bottom.
- **Canvas** fills the remainder with its own scroll; content centered at 960px max with the design's 32/120 padding. Preview mode hides the rail and renders the published view in the same canvas.
- Conflict banner is now a slim strip under the toolbar instead of a floating card.

**Block chrome**
- Blocks sit in 12px-radius chrome cards with the design's build-header: grip + uppercase type label + up/down/duplicate/remove icon actions.
- End drop zone restyled: 2px dashed, 26px padding, plus-icon copy, blue highlight when a drag is over it.

Create flow keeps the fixed-width page (it's a form, not a canvas).

Verified live via Playwright screenshot against localhost — toolbar, rail tints, chrome, and add-content tile all render as designed. 20/20 feature tests, typecheck + oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ