### PR TITLE
style(homepage): design parity for publish/presets modals and day-one homepage

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
@@ -1,6 +1,8 @@
 import {
     ContentSortByColumns,
     ContentType,
+    ResourceViewItemType,
+    type ResourceViewItem,
     type SummaryContent,
 } from '@lightdash/common';
 import {
@@ -18,19 +20,33 @@ import {
     IconChartBar,
     IconFolder,
     IconLayoutDashboard,
+    IconPin,
+    IconSquareRoundedPlus,
 } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useFavoriteMutation } from '../../../hooks/favorites/useFavoriteMutation';
 import { useFavorites } from '../../../hooks/favorites/useFavorites';
+import { usePinnedItems } from '../../../hooks/pinning/usePinnedItems';
 import { useInfiniteContent } from '../../../hooks/useContent';
+import { useProject } from '../../../hooks/useProject';
 import useApp from '../../../providers/App/useApp';
 import AiSearchBox from '../../components/Home/AiSearchBox';
 import { useAiAgentButtonVisibility } from '../aiCopilot/hooks/useAiAgentsButtonVisibility';
+import { BlockHeader } from './blocks/BlockShell';
+import blockClasses from './blocks/blockStyles.module.css';
 import { ContentCard } from './blocks/ContentCard';
+import { PersonalFavoritesStrip } from './blocks/FavoritesBlock';
 import { getDefaultQuickActions } from './blocks/quickActionDefaults';
 import { QuickActionCards } from './blocks/QuickActionsBlock';
+
+const dayPart = (): string => {
+    const hour = new Date().getHours();
+    if (hour < 12) return 'morning';
+    if (hour < 18) return 'afternoon';
+    return 'evening';
+};
 
 type DiscoverGroupDefinition = {
     key: string;
@@ -126,6 +142,67 @@ const GroupSection: FC<{
     );
 };
 
+const PINNED_ICONS: Partial<Record<ResourceViewItemType, typeof IconChartBar>> =
+    {
+        [ResourceViewItemType.CHART]: IconChartBar,
+        [ResourceViewItemType.DASHBOARD]: IconLayoutDashboard,
+        [ResourceViewItemType.SPACE]: IconFolder,
+    };
+
+const pinnedUrl = (projectUuid: string, item: ResourceViewItem): string => {
+    switch (item.type) {
+        case ResourceViewItemType.DASHBOARD:
+            return `/projects/${projectUuid}/dashboards/${item.data.uuid}/view`;
+        case ResourceViewItemType.SPACE:
+            return `/projects/${projectUuid}/spaces/${item.data.uuid}`;
+        default:
+            return `/projects/${projectUuid}/saved/${item.data.uuid}`;
+    }
+};
+
+const PersonalAndPinnedSections: FC<{ projectUuid: string }> = ({
+    projectUuid,
+}) => {
+    const { data: project } = useProject(projectUuid);
+    const { data: pinnedItems } = usePinnedItems(
+        projectUuid,
+        project?.pinnedListUuid,
+    );
+    return (
+        <Stack gap={26}>
+            <PersonalFavoritesStrip projectUuid={projectUuid} />
+            {(pinnedItems ?? []).length > 0 && (
+                <Stack gap={0}>
+                    <BlockHeader
+                        icon={IconPin}
+                        title="Pinned"
+                        pill="Pinned for everyone by admins"
+                        mb={10}
+                    />
+                    <Group gap={8}>
+                        {(pinnedItems ?? []).map((item) => (
+                            <Link
+                                key={item.data.uuid}
+                                to={pinnedUrl(projectUuid, item)}
+                                className={blockClasses.favPill}
+                            >
+                                <MantineIcon
+                                    icon={
+                                        PINNED_ICONS[item.type] ?? IconChartBar
+                                    }
+                                    size={15}
+                                    color="ldGray.6"
+                                />
+                                {item.data.name}
+                            </Link>
+                        ))}
+                    </Group>
+                </Stack>
+            )}
+        </Stack>
+    );
+};
+
 type Props = {
     projectUuid: string;
     projectName: string;
@@ -153,12 +230,17 @@ export const DayOneHomepage: FC<Props> = ({ projectUuid, projectName }) => {
         <Stack gap="xl">
             {isAiEnabled ? (
                 <Stack gap="md" align="center" py="lg">
-                    <Title order={1} fw={600} ta="center">
-                        What do you want to know, {user.data?.firstName}?
-                    </Title>
-                    <Text c="dimmed" ta="center">
-                        Ask in plain English — the agent queries your governed
-                        metrics and builds the chart.
+                    <Text
+                        component="h1"
+                        fz={30}
+                        fw={600}
+                        lts="-0.025em"
+                        lh={1.15}
+                        ta="center"
+                        m={0}
+                    >
+                        Good {dayPart()}, {user.data?.firstName}. What do you
+                        want to know?
                     </Text>
                     <Box w="100%" maw={720}>
                         <AiSearchBox projectUuid={projectUuid} />
@@ -166,21 +248,45 @@ export const DayOneHomepage: FC<Props> = ({ projectUuid, projectName }) => {
                 </Stack>
             ) : (
                 <Stack gap="md">
-                    <Box>
-                        <Title order={2} fw={600}>
-                            Welcome to {projectName}, {user.data?.firstName}
-                        </Title>
-                        <Text c="dimmed" size="sm">
-                            Nothing’s curated here yet — start exploring, or
-                            your data team can build this page.
-                        </Text>
-                    </Box>
+                    <Group
+                        justify="space-between"
+                        align="flex-end"
+                        wrap="nowrap"
+                    >
+                        <Box>
+                            <Text
+                                component="h1"
+                                fz={30}
+                                fw={600}
+                                lts="-0.02em"
+                                m={0}
+                            >
+                                Welcome to {projectName}, {user.data?.firstName}
+                            </Text>
+                            <Text c="dimmed" fz={15} mt={6}>
+                                Nothing’s here yet — start exploring, or your
+                                data team can curate this page.
+                            </Text>
+                        </Box>
+                        <Button
+                            component={Link}
+                            to={`/projects/${projectUuid}/tables`}
+                            leftSection={
+                                <MantineIcon icon={IconSquareRoundedPlus} />
+                            }
+                            style={{ flexShrink: 0 }}
+                        >
+                            New
+                        </Button>
+                    </Group>
                     <QuickActionCards
                         actions={getDefaultQuickActions(false)}
                         projectUuid={projectUuid}
                     />
                 </Stack>
             )}
+
+            <PersonalAndPinnedSections projectUuid={projectUuid} />
 
             <Stack gap="md">
                 <Box>

--- a/packages/frontend/src/ee/features/homepageBuilder/PresetsModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PresetsModal.tsx
@@ -1,9 +1,10 @@
 import { type HomepageConfig } from '@lightdash/common';
-import { Badge, Card, Group, SimpleGrid, Stack, Text } from '@mantine-8/core';
+import { Box, Group, SimpleGrid, Stack, Text } from '@mantine-8/core';
 import { useState, type FC } from 'react';
-import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import { useAiAgentButtonVisibility } from '../aiCopilot/hooks/useAiAgentsButtonVisibility';
+import { IconSquare } from './blocks/BlockShell';
+import blockClasses from './blocks/blockStyles.module.css';
 import { homepagePresets, type HomepagePreset } from './presets';
 
 type Props = {
@@ -45,42 +46,39 @@ export const PresetsModal: FC<Props> = ({ opened, onClose, onApply }) => {
                         Replaces the current draft. You can tweak every block
                         after.
                     </Text>
-                    <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="sm">
+                    <SimpleGrid cols={{ base: 1, sm: 2 }} spacing={12}>
                         {homepagePresets.map((preset) => (
-                            <Card
+                            <Box
                                 key={preset.key}
-                                withBorder
-                                p="md"
+                                className={`${blockClasses.hoverCard} ${blockClasses.clickable}`}
+                                p={15}
                                 style={{ cursor: 'pointer' }}
                                 onClick={() => setPresetToConfirm(preset)}
                             >
-                                <Stack gap="xs">
-                                    <Group gap="sm">
-                                        <MantineIcon
-                                            icon={preset.icon}
-                                            size="lg"
-                                        />
-                                        <Text fw={600} size="sm">
-                                            {preset.name}
-                                        </Text>
-                                    </Group>
-                                    <Text size="xs" c="dimmed">
-                                        {preset.description}
+                                <Group gap={9} mb={7} wrap="nowrap">
+                                    <IconSquare
+                                        icon={preset.icon}
+                                        tint={preset.tint}
+                                        size="lg"
+                                    />
+                                    <Text fw={600} fz={14.5}>
+                                        {preset.name}
                                     </Text>
-                                    <Group gap={4}>
-                                        {preset.blockChips.map((chip) => (
-                                            <Badge
-                                                key={chip}
-                                                variant="default"
-                                                size="xs"
-                                                tt="none"
-                                            >
-                                                {chip}
-                                            </Badge>
-                                        ))}
-                                    </Group>
-                                </Stack>
-                            </Card>
+                                </Group>
+                                <Text fz={12.5} c="dimmed" lh={1.45} mb={10}>
+                                    {preset.description}
+                                </Text>
+                                <Group gap={5}>
+                                    {preset.blockChips.map((chip) => (
+                                        <span
+                                            key={chip}
+                                            className={blockClasses.presetChip}
+                                        >
+                                            {chip}
+                                        </span>
+                                    ))}
+                                </Group>
+                            </Box>
                         ))}
                     </SimpleGrid>
                 </Stack>

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
@@ -6,8 +6,7 @@ import {
 } from '@lightdash/common';
 import {
     ActionIcon,
-    Badge,
-    Card,
+    Box,
     Checkbox,
     Group,
     SegmentedControl,
@@ -19,17 +18,40 @@ import {
     IconArrowDown,
     IconArrowUp,
     IconChevronRight,
+    IconSend,
+    IconShieldCheck,
+    IconUsersGroup,
+    IconWorld,
+    IconWorldCheck,
 } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import { useOrganizationGroups } from '../../../hooks/useOrganizationGroups';
+import { MiniPill } from './blocks/BlockShell';
+import blockClasses from './blocks/blockStyles.module.css';
 import {
     useHomepageAssignments,
     useUpdateGroupPriorities,
 } from './hooks/useProjectHomepage';
 
 const RESOLUTION_STEPS = ['Personal', 'Group priority', 'Role', 'Org default'];
+
+const ROLE_DESCRIPTIONS: Record<ProjectMemberRole, string> = {
+    [ProjectMemberRole.VIEWER]: 'Read-only consumers of dashboards',
+    [ProjectMemberRole.INTERACTIVE_VIEWER]:
+        'Can explore data behind the dashboards',
+    [ProjectMemberRole.EDITOR]: 'Builds charts and dashboards',
+    [ProjectMemberRole.DEVELOPER]: 'Works on the data model itself',
+    [ProjectMemberRole.ADMIN]: 'Full control of the project',
+};
+
+const segmentedLabel = (icon: typeof IconWorld, label: string) => (
+    <Group gap={5} justify="center" wrap="nowrap">
+        <MantineIcon icon={icon} size={15} />
+        {label}
+    </Group>
+);
 
 type Props = {
     opened: boolean;
@@ -79,9 +101,7 @@ export const PublishModal: FC<Props> = ({
 
     const elsewhereBadge = (assignment: HomepageAssignment | undefined) =>
         assignment && assignment.homepageUuid !== homepageUuid ? (
-            <Badge variant="default" size="xs" tt="none">
-                now on {assignment.homepageName}
-            </Badge>
+            <MiniPill>now on {assignment.homepageName}</MiniPill>
         ) : null;
 
     const movePriority = (groupUuid: string, direction: -1 | 1) => {
@@ -108,20 +128,37 @@ export const PublishModal: FC<Props> = ({
         }
     };
 
+    const confirmLabel =
+        mode === 'groups'
+            ? selectedGroups.length > 0
+                ? `Publish to ${selectedGroups.length} group${
+                      selectedGroups.length === 1 ? '' : 's'
+                  }`
+                : 'Publish'
+            : mode === 'roles'
+              ? selectedRoles.length > 0
+                  ? `Publish to ${selectedRoles.length} role${
+                        selectedRoles.length === 1 ? '' : 's'
+                    }`
+                  : 'Publish'
+              : 'Publish to everyone';
+
     return (
         <MantineModal
             opened={opened}
             onClose={onClose}
             title="Publish homepage"
+            icon={IconSend}
             size="lg"
             onConfirm={handlePublish}
+            confirmLabel={confirmLabel}
             confirmLoading={isPublishing}
             confirmDisabled={
                 (mode === 'groups' && selectedGroups.length === 0) ||
                 (mode === 'roles' && selectedRoles.length === 0)
             }
         >
-            <Stack gap="sm">
+            <Stack gap="md">
                 <Text size="sm" c="dimmed">
                     Choose who lands on{' '}
                     <Text span fw={600} c="inherit">
@@ -134,90 +171,156 @@ export const PublishModal: FC<Props> = ({
                     value={mode}
                     onChange={setMode}
                     data={[
-                        { value: 'everyone', label: 'Everyone' },
-                        { value: 'groups', label: 'By group' },
-                        { value: 'roles', label: 'By role' },
+                        {
+                            value: 'everyone',
+                            label: segmentedLabel(IconWorld, 'Everyone'),
+                        },
+                        {
+                            value: 'groups',
+                            label: segmentedLabel(IconUsersGroup, 'By group'),
+                        },
+                        {
+                            value: 'roles',
+                            label: segmentedLabel(IconShieldCheck, 'By role'),
+                        },
                     ]}
                 />
 
                 {mode === 'everyone' && (
-                    <Card withBorder p="sm">
-                        <Text size="sm" c="dimmed">
-                            This becomes the starting point everyone lands on —
-                            unless a group they’re in has its own homepage.
-                        </Text>
-                    </Card>
+                    <Box
+                        p={14}
+                        style={{
+                            border: '1px solid var(--mantine-color-ldGray-2)',
+                            borderRadius: 10,
+                            background: 'var(--mantine-color-ldGray-0)',
+                        }}
+                    >
+                        <Group gap={10} align="flex-start" wrap="nowrap">
+                            <MantineIcon
+                                icon={IconWorldCheck}
+                                size={18}
+                                color="green"
+                                style={{ marginTop: 1, flexShrink: 0 }}
+                            />
+                            <Text size="sm" c="ldGray.7" lh={1.5}>
+                                This becomes the{' '}
+                                <Text span fw={600} c="inherit">
+                                    starting point
+                                </Text>{' '}
+                                everyone lands on — unless a group they’re in
+                                has its own homepage, or they’ve set a personal
+                                one.
+                            </Text>
+                        </Group>
+                    </Box>
                 )}
 
                 {mode === 'groups' && (
                     <>
-                        <Card withBorder p="sm">
-                            <Stack gap="xs">
-                                {(groups ?? []).map((group) => (
-                                    <Group
-                                        key={group.uuid}
-                                        gap="sm"
-                                        wrap="nowrap"
-                                    >
-                                        <Checkbox
-                                            label={group.name}
-                                            checked={selectedGroups.includes(
-                                                group.uuid,
-                                            )}
-                                            onChange={(e) =>
-                                                setSelectedGroups(
-                                                    e.currentTarget.checked
-                                                        ? [
-                                                              ...selectedGroups,
-                                                              group.uuid,
-                                                          ]
-                                                        : selectedGroups.filter(
-                                                              (uuid) =>
-                                                                  uuid !==
-                                                                  group.uuid,
-                                                          ),
-                                                )
-                                            }
-                                        />
-                                        {elsewhereBadge(
-                                            assignmentByGroup.get(group.uuid),
+                        <div className={blockClasses.listCard}>
+                            {(groups ?? []).map((group) => (
+                                <label
+                                    key={group.uuid}
+                                    className={blockClasses.listRow}
+                                    style={{ cursor: 'pointer' }}
+                                >
+                                    <Checkbox
+                                        size="xs"
+                                        checked={selectedGroups.includes(
+                                            group.uuid,
                                         )}
-                                    </Group>
-                                ))}
-                                {(groups ?? []).length === 0 && (
-                                    <Text size="sm" c="dimmed">
-                                        No groups in this organization yet.
+                                        onChange={(e) =>
+                                            setSelectedGroups(
+                                                e.currentTarget.checked
+                                                    ? [
+                                                          ...selectedGroups,
+                                                          group.uuid,
+                                                      ]
+                                                    : selectedGroups.filter(
+                                                          (uuid) =>
+                                                              uuid !==
+                                                              group.uuid,
+                                                      ),
+                                            )
+                                        }
+                                    />
+                                    <MantineIcon
+                                        icon={IconUsersGroup}
+                                        size={16}
+                                        color="ldGray.6"
+                                    />
+                                    <Text
+                                        fz={13.5}
+                                        fw={500}
+                                        style={{ flex: 1 }}
+                                    >
+                                        {group.name}
                                     </Text>
-                                )}
-                            </Stack>
-                        </Card>
+                                    {elsewhereBadge(
+                                        assignmentByGroup.get(group.uuid),
+                                    )}
+                                </label>
+                            ))}
+                            {(groups ?? []).length === 0 && (
+                                <Text size="sm" c="dimmed" p="sm">
+                                    No groups in this organization yet.
+                                </Text>
+                            )}
+                        </div>
                         {groupAssignments.length > 1 && (
-                            <Card withBorder p="sm">
-                                <Stack gap="xs">
-                                    <Text size="xs" fw={600} c="dimmed">
-                                        If someone’s in more than one group, the
-                                        higher-ranked group wins
-                                    </Text>
+                            <Box
+                                p="sm"
+                                style={{
+                                    border: '1px solid var(--mantine-color-ldGray-2)',
+                                    borderRadius: 10,
+                                }}
+                            >
+                                <Text
+                                    fz={11}
+                                    fw={600}
+                                    tt="uppercase"
+                                    lts="0.05em"
+                                    c="ldGray.6"
+                                    mb={4}
+                                >
+                                    If someone’s in more than one group
+                                </Text>
+                                <Text fz={12.5} c="dimmed" lh={1.45} mb={10}>
+                                    The higher-ranked group’s homepage wins.
+                                </Text>
+                                <Stack gap={6}>
                                     {groupAssignments.map(
                                         (assignment, index) => (
                                             <Group
                                                 key={assignment.assignmentUuid}
-                                                gap="xs"
+                                                gap={10}
                                                 wrap="nowrap"
+                                                p="8px 10px"
+                                                style={{
+                                                    border: '1px solid var(--mantine-color-ldGray-2)',
+                                                    borderRadius: 8,
+                                                    background:
+                                                        'var(--mantine-color-ldGray-0)',
+                                                }}
                                             >
-                                                <Badge
-                                                    variant="filled"
-                                                    size="sm"
+                                                <span
+                                                    className={
+                                                        blockClasses.rankBadge
+                                                    }
                                                 >
                                                     {index + 1}
-                                                </Badge>
-                                                <Text
-                                                    size="sm"
-                                                    style={{ flex: 1 }}
-                                                >
-                                                    {assignment.groupName} →{' '}
-                                                    {assignment.homepageName}
-                                                </Text>
+                                                </span>
+                                                <Box style={{ flex: 1 }}>
+                                                    <Text fz={13} fw={500}>
+                                                        {assignment.groupName}
+                                                    </Text>
+                                                    <Text fz={11.5} c="dimmed">
+                                                        →{' '}
+                                                        {
+                                                            assignment.homepageName
+                                                        }
+                                                    </Text>
+                                                </Box>
                                                 <ActionIcon
                                                     variant="subtle"
                                                     color="gray"
@@ -262,18 +365,22 @@ export const PublishModal: FC<Props> = ({
                                         ),
                                     )}
                                 </Stack>
-                            </Card>
+                            </Box>
                         )}
                     </>
                 )}
 
                 {mode === 'roles' && (
-                    <Card withBorder p="sm">
-                        <Stack gap="xs">
+                    <>
+                        <div className={blockClasses.listCard}>
                             {Object.values(ProjectMemberRole).map((role) => (
-                                <Group key={role} gap="sm" wrap="nowrap">
+                                <label
+                                    key={role}
+                                    className={blockClasses.listRow}
+                                    style={{ cursor: 'pointer' }}
+                                >
                                     <Checkbox
-                                        label={ProjectMemberRoleLabels[role]}
+                                        size="xs"
                                         checked={selectedRoles.includes(role)}
                                         onChange={(e) =>
                                             setSelectedRoles(
@@ -285,46 +392,71 @@ export const PublishModal: FC<Props> = ({
                                             )
                                         }
                                     />
+                                    <MantineIcon
+                                        icon={IconShieldCheck}
+                                        size={16}
+                                        color="ldGray.6"
+                                    />
+                                    <Box style={{ flex: 1 }}>
+                                        <Text fz={13.5} fw={500}>
+                                            {ProjectMemberRoleLabels[role]}
+                                        </Text>
+                                        <Text fz={12} c="dimmed">
+                                            {ROLE_DESCRIPTIONS[role]}
+                                        </Text>
+                                    </Box>
                                     {elsewhereBadge(assignmentByRole.get(role))}
-                                </Group>
+                                </label>
                             ))}
-                            <Text size="xs" c="dimmed">
-                                A group assignment always wins over a role.
-                            </Text>
-                        </Stack>
-                    </Card>
+                        </div>
+                        <Text fz={12} c="dimmed" lh={1.45}>
+                            A group assignment always wins over a role, and a
+                            personal choice wins over both.
+                        </Text>
+                    </>
                 )}
 
-                <Card withBorder p="sm">
-                    <Switch
-                        label="Let people set a dashboard as their own homepage"
-                        description="When off, everyone in this audience always lands here — personal picks are ignored."
-                        checked={allowPersonal}
-                        onChange={(e) =>
-                            setAllowPersonal(e.currentTarget.checked)
-                        }
-                    />
-                </Card>
-
-                <Group gap={4} wrap="nowrap">
-                    <Text size="xs" c="dimmed">
+                <Group
+                    gap={7}
+                    p="10px 12px"
+                    style={{
+                        background: 'var(--mantine-color-ldGray-0)',
+                        borderRadius: 9,
+                    }}
+                >
+                    <Text fz={11.5} fw={500} c="ldGray.5">
                         Resolves:
                     </Text>
                     {RESOLUTION_STEPS.map((step, index) => (
-                        <Group key={step} gap={4} wrap="nowrap">
-                            <Badge variant="default" size="xs" tt="none">
-                                {step}
-                            </Badge>
+                        <Group key={step} gap={7} wrap="nowrap">
+                            <MiniPill>{step}</MiniPill>
                             {index < RESOLUTION_STEPS.length - 1 && (
                                 <MantineIcon
                                     icon={IconChevronRight}
-                                    size="sm"
-                                    color="gray"
+                                    size={12}
+                                    color="ldGray.5"
                                 />
                             )}
                         </Group>
                     ))}
                 </Group>
+
+                <Box
+                    p="11px 13px"
+                    style={{
+                        border: '1px solid var(--mantine-color-ldGray-2)',
+                        borderRadius: 10,
+                    }}
+                >
+                    <Switch
+                        label="Allow personal customization"
+                        description="Viewers can favorite items or set a dashboard as their own homepage."
+                        checked={allowPersonal}
+                        onChange={(e) =>
+                            setAllowPersonal(e.currentTarget.checked)
+                        }
+                    />
+                </Box>
             </Stack>
         </MantineModal>
     );

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -209,6 +209,28 @@ a .hoverCard:hover,
     background: light-dark(#fff, var(--mantine-color-dark-6));
 }
 
+.rankBadge {
+    width: 18px;
+    height: 18px;
+    border-radius: 5px;
+    background: var(--mantine-color-foreground-0, var(--mantine-color-dark-9));
+    color: #fff;
+    font-size: 11px;
+    font-weight: 600;
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+}
+
+.presetChip {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--mantine-color-ldGray-6);
+    background: var(--mantine-color-ldGray-1);
+    border-radius: 5px;
+    padding: 2px 7px;
+}
+
 .aiChip {
     font-size: 12px;
     font-weight: 500;

--- a/packages/frontend/src/ee/features/homepageBuilder/presets.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/presets.ts
@@ -16,6 +16,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 export type HomepagePreset = {
     key: string;
+    tint: 'gray' | 'dimension' | 'metric' | 'calculation' | 'violet';
     name: string;
     description: string;
     icon: Icon;
@@ -72,6 +73,7 @@ const config = (...rows: HomepageRow[]): HomepageConfig => ({
 export const homepagePresets: HomepagePreset[] = [
     {
         key: 'exec-overview',
+        tint: 'metric',
         name: 'Exec overview',
         description: 'Company KPIs and the board pack, front and center.',
         icon: IconBriefcase,
@@ -90,6 +92,7 @@ export const homepagePresets: HomepagePreset[] = [
     },
     {
         key: 'team-hub',
+        tint: 'dimension',
         name: 'Team hub',
         description: 'A landing page for one team: dashboards, links, news.',
         icon: IconUsersGroup,
@@ -118,6 +121,7 @@ export const homepagePresets: HomepagePreset[] = [
     },
     {
         key: 'business-user-starter',
+        tint: 'violet',
         name: 'Business-user starter',
         description: 'Curated essentials for people who just need answers.',
         icon: IconUserStar,
@@ -136,6 +140,7 @@ export const homepagePresets: HomepagePreset[] = [
     },
     {
         key: 'analyst-workspace',
+        tint: 'calculation',
         name: 'Analyst workspace',
         description: 'Power-user shortcuts and a scratchpad.',
         icon: IconChartHistogram,
@@ -156,6 +161,7 @@ export const homepagePresets: HomepagePreset[] = [
     },
     {
         key: 'dashboard-as-homepage',
+        tint: 'dimension',
         name: 'Dashboard as homepage',
         description: 'One key dashboard is the whole page.',
         icon: IconLayoutDashboard,
@@ -164,6 +170,7 @@ export const homepagePresets: HomepagePreset[] = [
     },
     {
         key: 'blank',
+        tint: 'gray',
         name: 'Blank',
         description: 'Start from nothing.',
         icon: IconFile,


### PR DESCRIPTION
Part of the Homepage Builder stack (ZAP-609). Polish pass 3 of 3 toward parity with the claude.ai/design prototype.

**Publish modal**
- Segmented audience control with icons (🌐 Everyone / 👥 By group / 🛡 By role).
- "Everyone" explainer card with the world-check icon and the full resolution caveat ("…unless a group they're in has its own homepage, or they've set a personal one").
- Group/role pickers as bordered list rows with checkboxes, kind icons, per-role descriptions, and "now on {homepage}" mini-pills.
- Priority reorder rows with dark rank badges and "→ {homepage}" subtitles.
- "Resolves: Personal › Group priority › Role › Org default" chain as mini-pills in a gray band.
- Allow-personal toggle in its own bordered row; dynamic CTA ("Publish to everyone" / "Publish to 2 groups").

**Presets modal**
- 2-column gallery cards with tinted icon squares (per-preset tint), descriptions, and block-chip pills — hover-lift like the prototype.

**Day-one homepage**
- AI-on greeting is now "Good {morning/afternoon/evening}, {name}. What do you want to know?" at the design's 30px scale.
- AI-off welcome header gains the right-aligned dark "New" CTA.
- New personal layer under the hero: "My favorites · Only you see this" pill strip + "Pinned · Pinned for everyone by admins" strip, matching the prototype's day-one sections.

Verified live via Playwright screenshot — the publish modal renders 1:1 with the design (segments, info card, resolves chain, toggle, CTA). 20/20 feature tests, typecheck + oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ