### PR TITLE
feat: full-page organization setup experience behind feature flag

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -288,6 +288,13 @@ export enum FeatureFlags {
      * default; enable per-org.
      */
     EmailWhitelabel = 'email-whitelabel',
+
+    /**
+     * Replaces the user-completion modal with a full-page organization setup
+     * experience (name your organization, pick a theme colour, and tell us
+     * about yourself) shown after registration. Off by default.
+     */
+    OrganizationSetupPage = 'organization-setup-page',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -143,6 +143,22 @@ const PUBLIC_ROUTES: RouteObject[] = [
             };
         },
     },
+    {
+        path: '/organization-setup',
+        lazy: async () => {
+            const OrganizationSetup = await loadLazyRouteDefault(
+                './pages/OrganizationSetup',
+                () => import('./pages/OrganizationSetup'),
+            );
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.ORGANIZATION_SETUP}>
+                        <OrganizationSetup />
+                    </TrackPage>
+                ),
+            };
+        },
+    },
 ];
 
 const MINIMAL_ROUTES: RouteObject[] = [

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.test.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.test.tsx
@@ -2,12 +2,29 @@ import { LightdashMode } from '@lightdash/common';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
-import { describe, expect, it } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BASE_API_URL } from '../../api';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import { renderWithProviders } from '../../testing/testUtils';
 import UserCompletionModal from './UserCompletionModal';
 
+vi.mock('../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: vi.fn(),
+}));
+
+const mockFeatureFlag = (enabled: boolean) => {
+    vi.mocked(useServerFeatureFlag).mockReturnValue({
+        data: { id: 'organization-setup-page', enabled },
+        isLoading: false,
+    } as ReturnType<typeof useServerFeatureFlag>);
+};
+
 describe('UserCompletionModal', () => {
+    beforeEach(() => {
+        mockFeatureFlag(false);
+    });
+
     it("should not render anything if user's setup is complete", async () => {
         renderWithProviders(<UserCompletionModal />);
         // Wait a bit to ensure component has rendered, then verify no dialog appears
@@ -288,5 +305,32 @@ describe('UserCompletionModal', () => {
         // wait for api call to be made
         scope.done();
         await waitFor(() => expect(scope.isDone()).toBe(true));
+    });
+
+    it('should redirect to the organization setup page when the flag is enabled and setup is incomplete', async () => {
+        mockFeatureFlag(true);
+
+        renderWithProviders(
+            <MemoryRouter initialEntries={['/']}>
+                <Routes>
+                    <Route path="/" element={<UserCompletionModal />} />
+                    <Route
+                        path="/organization-setup"
+                        element={<div>Organization setup page</div>}
+                    />
+                </Routes>
+            </MemoryRouter>,
+            {
+                user: {
+                    isSetupComplete: false,
+                    organizationName: '',
+                },
+            },
+        );
+
+        expect(
+            await screen.findByText('Organization setup page'),
+        ).toBeInTheDocument();
+        expect(screen.queryByText('Nearly there...')).not.toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
@@ -1,5 +1,6 @@
 import {
     CompleteUserSchema,
+    FeatureFlags,
     getEmailDomain,
     LightdashMode,
     validateOrganizationEmailDomains,
@@ -8,30 +9,14 @@ import {
 import { Button, Checkbox, Select, Stack, TextInput } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import { IconConfetti } from '@tabler/icons-react';
-import shuffle from 'lodash/shuffle';
 import { zodResolver } from 'mantine-form-zod-resolver';
 import { useEffect, useMemo, type FC } from 'react';
+import { Navigate } from 'react-router';
 import { useUserCompleteMutation } from '../../hooks/user/useUserCompleteMutation';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../providers/App/useApp';
 import MantineModal from '../common/MantineModal';
-
-const jobTitles = [
-    ...shuffle([
-        'Data/Analytics Leader (manager, director, etc.)',
-        'Data Scientist',
-        'Data Analyst',
-        'Data Engineer',
-        'Analytics Engineer',
-        'Software Engineer',
-        'Sales',
-        'Marketing',
-        'Product',
-        'Operations',
-        'Customer Service',
-        'Student',
-    ]),
-    'Other',
-];
+import { jobTitles } from './jobTitles';
 
 const UserCompletionModal: FC = () => {
     const { health, user } = useApp();
@@ -192,7 +177,22 @@ const UserCompletionModal: FC = () => {
 };
 
 const UserCompletionModalWithUser = () => {
-    const { user } = useApp();
+    const { user, health } = useApp();
+    const orgSetupPageFlag = useServerFeatureFlag(
+        FeatureFlags.OrganizationSetupPage,
+    );
+
+    if (orgSetupPageFlag.isLoading) {
+        return null;
+    }
+
+    if (orgSetupPageFlag.data?.enabled) {
+        const shouldSetup =
+            user.data &&
+            !user.data.isSetupComplete &&
+            health.data?.rudder.writeKey !== undefined;
+        return shouldSetup ? <Navigate to="/organization-setup" /> : null;
+    }
 
     if (!user.isSuccess) {
         return null;

--- a/packages/frontend/src/components/UserCompletionModal/jobTitles.ts
+++ b/packages/frontend/src/components/UserCompletionModal/jobTitles.ts
@@ -1,0 +1,19 @@
+import shuffle from 'lodash/shuffle';
+
+export const jobTitles = [
+    ...shuffle([
+        'Data/Analytics Leader (manager, director, etc.)',
+        'Data Scientist',
+        'Data Analyst',
+        'Data Engineer',
+        'Analytics Engineer',
+        'Software Engineer',
+        'Sales',
+        'Marketing',
+        'Product',
+        'Operations',
+        'Customer Service',
+        'Student',
+    ]),
+    'Other',
+];

--- a/packages/frontend/src/hooks/organization/useOrganizationBrand.ts
+++ b/packages/frontend/src/hooks/organization/useOrganizationBrand.ts
@@ -33,7 +33,10 @@ const fetchOrganizationBrand = async (data: UpdateOrganizationBrandRequest) =>
  * The caller decides what to do with the result (e.g. populate a form so the
  * user can review and edit before saving).
  */
-export const useFetchOrganizationBrand = () => {
+export const useFetchOrganizationBrand = (options?: {
+    showErrorToast?: boolean;
+}) => {
+    const showErrorToast = options?.showErrorToast ?? true;
     const { showToastApiError } = useToaster();
     return useMutation<
         OrganizationBrand,
@@ -42,6 +45,7 @@ export const useFetchOrganizationBrand = () => {
     >(fetchOrganizationBrand, {
         mutationKey: ['organization_brand_fetch'],
         onError: ({ error }) => {
+            if (!showErrorToast) return;
             showToastApiError({
                 title: 'Failed to fetch brand',
                 apiError: error,

--- a/packages/frontend/src/hooks/organization/useOrganizationBrand.ts
+++ b/packages/frontend/src/hooks/organization/useOrganizationBrand.ts
@@ -33,10 +33,7 @@ const fetchOrganizationBrand = async (data: UpdateOrganizationBrandRequest) =>
  * The caller decides what to do with the result (e.g. populate a form so the
  * user can review and edit before saving).
  */
-export const useFetchOrganizationBrand = (options?: {
-    showErrorToast?: boolean;
-}) => {
-    const showErrorToast = options?.showErrorToast ?? true;
+export const useFetchOrganizationBrand = () => {
     const { showToastApiError } = useToaster();
     return useMutation<
         OrganizationBrand,
@@ -45,7 +42,6 @@ export const useFetchOrganizationBrand = (options?: {
     >(fetchOrganizationBrand, {
         mutationKey: ['organization_brand_fetch'],
         onError: ({ error }) => {
-            if (!showErrorToast) return;
             showToastApiError({
                 title: 'Failed to fetch brand',
                 apiError: error,
@@ -53,6 +49,21 @@ export const useFetchOrganizationBrand = (options?: {
         },
     });
 };
+
+/**
+ * Speculatively detects a brand for a domain during onboarding. A read despite
+ * the POST verb (the endpoint fetches without persisting), so it lives in a
+ * query: results survive StrictMode observer churn and failures stay silent.
+ */
+export const useDetectOrganizationBrand = (domain: string, enabled: boolean) =>
+    useQuery<OrganizationBrand, ApiError>({
+        queryKey: ['organization_brand_detect', domain],
+        queryFn: () => fetchOrganizationBrand({ domain }),
+        enabled: enabled && domain.length > 0,
+        retry: false,
+        staleTime: Infinity,
+        refetchOnWindowFocus: false,
+    });
 
 const saveOrganizationBrand = async (data: SaveOrganizationBrandRequest) =>
     lightdashApi<OrganizationBrand | null>({

--- a/packages/frontend/src/pages/OrganizationSetup.module.css
+++ b/packages/frontend/src/pages/OrganizationSetup.module.css
@@ -121,44 +121,6 @@
     flex-shrink: 0;
 }
 
-.chartGrid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: var(--mantine-spacing-md);
-}
-
-.chartCard {
-    padding: var(--mantine-spacing-md);
-    border-radius: var(--mantine-radius-md);
-    border: 1px solid var(--mantine-color-ldGray-2);
-    background-color: var(--mantine-color-white);
-    display: flex;
-    flex-direction: column;
-    gap: var(--mantine-spacing-xs);
-    min-height: 132px;
-}
-
-.barsRow {
-    display: flex;
-    align-items: flex-end;
-    gap: 8px;
-    height: 76px;
-    margin-top: auto;
-}
-
-.bar {
-    flex: 1;
-    border-radius: 3px 3px 0 0;
-    min-height: 4px;
-}
-
-.donutWrap {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-top: auto;
-}
-
 @media (max-width: 992px) {
     .body {
         flex-direction: column;

--- a/packages/frontend/src/pages/OrganizationSetup.module.css
+++ b/packages/frontend/src/pages/OrganizationSetup.module.css
@@ -1,0 +1,178 @@
+.page {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    background-color: var(--mantine-color-ldGray-0);
+}
+
+.topBar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--mantine-spacing-lg) var(--mantine-spacing-xl);
+    flex-shrink: 0;
+}
+
+.body {
+    flex: 1;
+    display: flex;
+    align-items: stretch;
+    min-height: 0;
+}
+
+.leftPane {
+    flex: 4;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: var(--mantine-spacing-xl) 4rem;
+    max-width: 640px;
+}
+
+.rightPane {
+    flex: 6;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--mantine-spacing-xl) 3rem;
+    background-color: var(--mantine-color-white);
+    border-left: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.heading {
+    line-height: 1.1;
+}
+
+.optionalPill {
+    padding: 2px 10px;
+    border-radius: var(--mantine-radius-xl);
+    background-color: var(--mantine-color-ldGray-1);
+}
+
+.logoTile {
+    width: 48px;
+    height: 48px;
+    border-radius: var(--mantine-radius-md);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    flex-shrink: 0;
+}
+
+.logoTileImage {
+    max-width: 40px;
+    max-height: 40px;
+    object-fit: contain;
+}
+
+.swatchRow {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--mantine-spacing-sm);
+}
+
+.swatch {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    cursor: pointer;
+    border: none;
+    padding: 0;
+}
+
+.swatchSelected {
+    box-shadow:
+        0 0 0 2px var(--mantine-color-body),
+        0 0 0 4px var(--mantine-color-ldGray-6);
+}
+
+.previewCard {
+    width: 100%;
+    max-width: 560px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--mantine-spacing-md);
+}
+
+.pill {
+    align-self: flex-start;
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+    padding: 6px 12px;
+    border-radius: var(--mantine-radius-xl);
+    background-color: var(--mantine-color-ldGray-0);
+    border: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.pillLogo {
+    width: 18px;
+    height: 18px;
+    object-fit: contain;
+    border-radius: var(--mantine-radius-xs);
+}
+
+.pillDot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: var(--mantine-color-green-6);
+    flex-shrink: 0;
+}
+
+.chartGrid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--mantine-spacing-md);
+}
+
+.chartCard {
+    padding: var(--mantine-spacing-md);
+    border-radius: var(--mantine-radius-md);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    background-color: var(--mantine-color-white);
+    display: flex;
+    flex-direction: column;
+    gap: var(--mantine-spacing-xs);
+    min-height: 132px;
+}
+
+.barsRow {
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+    height: 76px;
+    margin-top: auto;
+}
+
+.bar {
+    flex: 1;
+    border-radius: 3px 3px 0 0;
+    min-height: 4px;
+}
+
+.donutWrap {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: auto;
+}
+
+@media (max-width: 992px) {
+    .body {
+        flex-direction: column;
+    }
+
+    .leftPane {
+        flex: none;
+        max-width: none;
+        padding: var(--mantine-spacing-xl);
+    }
+
+    .rightPane {
+        flex: none;
+        border-left: none;
+        border-top: 1px solid var(--mantine-color-ldGray-2);
+    }
+}

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -77,6 +77,29 @@ const pickTileLogo = (logos: OrganizationBrandLogo[]): string | null => {
     return dark?.url ?? neutral?.url ?? logos[0]?.url ?? null;
 };
 
+const inferOrganizationName = (domain: string): string =>
+    (domain.split('.')[0] ?? '')
+        .split(/[-_]/)
+        .filter(Boolean)
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
+
+const buildBrandColors = (
+    selectedColor: string,
+    brandColors: OrganizationBrandColor[],
+): OrganizationBrandColor[] => {
+    const matchesSelected = (hex: string) =>
+        hex.toLowerCase() === selectedColor.toLowerCase();
+    const existing = brandColors.find((color) => matchesSelected(color.hex));
+    const selectedEntry: OrganizationBrandColor = existing
+        ? { ...existing, type: 'accent' }
+        : { hex: selectedColor, type: 'accent', brightness: null };
+    return [
+        selectedEntry,
+        ...brandColors.filter((color) => !matchesSelected(color.hex)),
+    ];
+};
+
 type OrganizationSetupFormValues = {
     organizationName: string;
     jobTitle: string;
@@ -106,7 +129,10 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
 
     const form = useForm<OrganizationSetupFormValues>({
         initialValues: {
-            organizationName: '',
+            organizationName:
+                canEnterOrganizationName && isCompanyDomain
+                    ? inferOrganizationName(emailDomain)
+                    : '',
             jobTitle: '',
             enableEmailDomainAccess: canEnableEmailDomainAccess,
             isMarketingOptedIn: true,
@@ -127,7 +153,7 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
     const saveBrand = useSaveOrganizationBrand();
     const completeMutation = useUserCompleteMutation();
 
-    const { setValues } = form;
+    const { setValues, isDirty } = form;
     const hasAppliedDetectedBrand = useRef(false);
 
     useEffect(() => {
@@ -136,14 +162,14 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
         hasAppliedDetectedBrand.current = true;
         const detected = brandColorsSorted(brand.colors);
         setValues((current) => ({
-            ...(current.organizationName === '' && brand.name
+            ...(brand.name && !isDirty('organizationName')
                 ? { organizationName: brand.name }
                 : {}),
             ...(current.selectedColor === DEFAULT_COLOR && detected[0]
                 ? { selectedColor: detected[0] }
                 : {}),
         }));
-    }, [brandDetection.data, setValues]);
+    }, [brandDetection.data, isDirty, setValues]);
 
     useEffect(() => {
         if (completeMutation.isSuccess) {
@@ -160,6 +186,17 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
         ? pickTileLogo(detectedBrand.logos)
         : null;
     const selectedColor = form.values.selectedColor;
+
+    const previewColors = buildBrandColors(
+        selectedColor,
+        detectedBrand?.colors ?? [],
+    );
+    const previewDomain =
+        detectedBrand?.domain ?? (isCompanyDomain ? emailDomain : '');
+    const titleFont =
+        detectedBrand?.fonts.find((font) => font.type === 'title') ?? null;
+    const bodyFont =
+        detectedBrand?.fonts.find((font) => font.type === 'body') ?? null;
 
     const showWorkspaceStep = canEnterOrganizationName;
     const totalSteps = showWorkspaceStep ? 2 : 1;
@@ -195,23 +232,12 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
         }
 
         if (detectedBrand) {
-            const matchesSelected = (hex: string) =>
-                hex.toLowerCase() === selectedColor.toLowerCase();
-            const existing = detectedBrand.colors.find((color) =>
-                matchesSelected(color.hex),
-            );
-            const selectedEntry: OrganizationBrandColor = existing
-                ? { ...existing, type: 'accent' }
-                : { hex: selectedColor, type: 'accent', brightness: null };
-            const rest = detectedBrand.colors.filter(
-                (color) => !matchesSelected(color.hex),
-            );
             saveBrand.mutate({
                 domain: detectedBrand.domain,
                 name: detectedBrand.name,
                 description: detectedBrand.description,
                 logos: detectedBrand.logos,
-                colors: [selectedEntry, ...rest],
+                colors: buildBrandColors(selectedColor, detectedBrand.colors),
                 fonts: detectedBrand.fonts,
             });
         }
@@ -427,7 +453,12 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
 
                 <Box className={classes.rightPane}>
                     <OrganizationSetupPreview
-                        themeColor={selectedColor}
+                        domain={previewDomain}
+                        name={form.values.organizationName || null}
+                        logos={detectedBrand?.logos ?? []}
+                        colors={previewColors}
+                        titleFont={titleFont}
+                        bodyFont={bodyFont}
                         detectedDomain={detectedBrand?.domain ?? null}
                         detectedLogoUrl={detectedLogoUrl}
                     />

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -29,7 +29,7 @@ import LightdashLogo from '../components/LightdashLogo/LightdashLogo';
 import PageSpinner from '../components/PageSpinner';
 import { jobTitles } from '../components/UserCompletionModal/jobTitles';
 import {
-    useFetchOrganizationBrand,
+    useDetectOrganizationBrand,
     useSaveOrganizationBrand,
 } from '../hooks/organization/useOrganizationBrand';
 import { type UserWithAbility } from '../hooks/user/useUser';
@@ -120,43 +120,30 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
         ),
     });
 
-    const brandFetch = useFetchOrganizationBrand({ showErrorToast: false });
+    const brandDetection = useDetectOrganizationBrand(
+        emailDomain,
+        health.hasBrandfetch && canEnterOrganizationName && isCompanyDomain,
+    );
     const saveBrand = useSaveOrganizationBrand();
     const completeMutation = useUserCompleteMutation();
 
     const { setValues } = form;
-    const hasFetchedBrand = useRef(false);
+    const hasAppliedDetectedBrand = useRef(false);
 
     useEffect(() => {
-        if (hasFetchedBrand.current) return;
-        if (!health.hasBrandfetch) return;
-        if (!canEnterOrganizationName || !isCompanyDomain) return;
-        hasFetchedBrand.current = true;
-        brandFetch.mutate(
-            { domain: emailDomain },
-            {
-                onSuccess: (brand) => {
-                    const detectedColors = brandColorsSorted(brand.colors);
-                    setValues((current) => ({
-                        ...(current.organizationName === '' && brand.name
-                            ? { organizationName: brand.name }
-                            : {}),
-                        ...(current.selectedColor === DEFAULT_COLOR &&
-                        detectedColors[0]
-                            ? { selectedColor: detectedColors[0] }
-                            : {}),
-                    }));
-                },
-            },
-        );
-    }, [
-        brandFetch,
-        canEnterOrganizationName,
-        emailDomain,
-        health.hasBrandfetch,
-        isCompanyDomain,
-        setValues,
-    ]);
+        const brand = brandDetection.data;
+        if (!brand || hasAppliedDetectedBrand.current) return;
+        hasAppliedDetectedBrand.current = true;
+        const detected = brandColorsSorted(brand.colors);
+        setValues((current) => ({
+            ...(current.organizationName === '' && brand.name
+                ? { organizationName: brand.name }
+                : {}),
+            ...(current.selectedColor === DEFAULT_COLOR && detected[0]
+                ? { selectedColor: detected[0] }
+                : {}),
+        }));
+    }, [brandDetection.data, setValues]);
 
     useEffect(() => {
         if (completeMutation.isSuccess) {
@@ -164,7 +151,7 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
         }
     }, [completeMutation.isSuccess, navigate]);
 
-    const detectedBrand = brandFetch.data ?? null;
+    const detectedBrand = brandDetection.data ?? null;
     const detectedColors = detectedBrand
         ? brandColorsSorted(detectedBrand.colors)
         : [];

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -1,0 +1,496 @@
+import {
+    CompleteUserSchema,
+    FeatureFlags,
+    getEmailDomain,
+    LightdashMode,
+    validateOrganizationEmailDomains,
+    type HealthState,
+    type OrganizationBrandColor,
+    type OrganizationBrandLogo,
+} from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Checkbox,
+    Divider,
+    Group,
+    Select,
+    Stack,
+    Text,
+    TextInput,
+    Title,
+} from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { zodResolver } from 'mantine-form-zod-resolver';
+import { useEffect, useRef, useState, type FC } from 'react';
+import { Navigate, useNavigate } from 'react-router';
+import { DocumentTitle } from '../components/common/DocumentTitle';
+import LightdashLogo from '../components/LightdashLogo/LightdashLogo';
+import PageSpinner from '../components/PageSpinner';
+import { jobTitles } from '../components/UserCompletionModal/jobTitles';
+import {
+    useFetchOrganizationBrand,
+    useSaveOrganizationBrand,
+} from '../hooks/organization/useOrganizationBrand';
+import { type UserWithAbility } from '../hooks/user/useUser';
+import { useUserCompleteMutation } from '../hooks/user/useUserCompleteMutation';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+import useApp from '../providers/App/useApp';
+import classes from './OrganizationSetup.module.css';
+import { OrganizationSetupPreview } from './OrganizationSetupPreview';
+
+const PRESET_COLORS = ['#4c6ef5', '#7950f2', '#40c057', '#f59f00', '#fa5252'];
+const DEFAULT_COLOR = PRESET_COLORS[0];
+const MAX_SWATCHES = 7;
+
+const isValidHexColor = (hex: string): boolean =>
+    /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(hex);
+
+const dedupeColors = (colors: string[]): string[] => {
+    const seen = new Set<string>();
+    return colors.filter((color) => {
+        const key = color.toLowerCase();
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+    });
+};
+
+const brandColorsSorted = (colors: OrganizationBrandColor[]): string[] => {
+    const priority = (type: string) =>
+        type === 'accent' ? 0 : type === 'brand' ? 1 : 2;
+    return dedupeColors(
+        colors
+            .filter((color) => isValidHexColor(color.hex))
+            .slice()
+            .sort((a, b) => priority(a.type) - priority(b.type))
+            .map((color) => color.hex),
+    );
+};
+
+const buildSwatches = (brandColors: string[]): string[] =>
+    dedupeColors([...brandColors, ...PRESET_COLORS]).slice(0, MAX_SWATCHES);
+
+const pickTileLogo = (logos: OrganizationBrandLogo[]): string | null => {
+    const dark = logos.find((logo) => logo.theme === 'dark');
+    const neutral = logos.find((logo) => logo.theme === null);
+    return dark?.url ?? neutral?.url ?? logos[0]?.url ?? null;
+};
+
+type OrganizationSetupFormValues = {
+    organizationName: string;
+    jobTitle: string;
+    enableEmailDomainAccess: boolean;
+    isMarketingOptedIn: boolean;
+    isTrackingAnonymized: boolean;
+    selectedColor: string;
+};
+
+type OrganizationSetupContentProps = {
+    user: UserWithAbility;
+    health: HealthState;
+};
+
+const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
+    user,
+    health,
+}) => {
+    const navigate = useNavigate();
+
+    const canEnterOrganizationName = user.organizationName === '';
+    const emailDomain = user.email ? getEmailDomain(user.email) : '';
+    const isCompanyDomain =
+        !!user.email && !validateOrganizationEmailDomains([emailDomain]);
+    const canEnableEmailDomainAccess =
+        canEnterOrganizationName && isCompanyDomain;
+
+    const form = useForm<OrganizationSetupFormValues>({
+        initialValues: {
+            organizationName: '',
+            jobTitle: '',
+            enableEmailDomainAccess: canEnableEmailDomainAccess,
+            isMarketingOptedIn: true,
+            isTrackingAnonymized: false,
+            selectedColor: DEFAULT_COLOR,
+        },
+        validate: zodResolver(
+            canEnterOrganizationName
+                ? CompleteUserSchema
+                : CompleteUserSchema.omit({ organizationName: true }),
+        ),
+    });
+
+    const brandFetch = useFetchOrganizationBrand({ showErrorToast: false });
+    const saveBrand = useSaveOrganizationBrand();
+    const completeMutation = useUserCompleteMutation();
+
+    const { setValues } = form;
+    const hasFetchedBrand = useRef(false);
+
+    useEffect(() => {
+        if (hasFetchedBrand.current) return;
+        if (!health.hasBrandfetch) return;
+        if (!canEnterOrganizationName || !isCompanyDomain) return;
+        hasFetchedBrand.current = true;
+        brandFetch.mutate(
+            { domain: emailDomain },
+            {
+                onSuccess: (brand) => {
+                    const detectedColors = brandColorsSorted(brand.colors);
+                    setValues((current) => ({
+                        ...(current.organizationName === '' && brand.name
+                            ? { organizationName: brand.name }
+                            : {}),
+                        ...(current.selectedColor === DEFAULT_COLOR &&
+                        detectedColors[0]
+                            ? { selectedColor: detectedColors[0] }
+                            : {}),
+                    }));
+                },
+            },
+        );
+    }, [
+        brandFetch,
+        canEnterOrganizationName,
+        emailDomain,
+        health.hasBrandfetch,
+        isCompanyDomain,
+        setValues,
+    ]);
+
+    useEffect(() => {
+        if (completeMutation.isSuccess) {
+            void navigate('/');
+        }
+    }, [completeMutation.isSuccess, navigate]);
+
+    const detectedBrand = brandFetch.data ?? null;
+    const detectedColors = detectedBrand
+        ? brandColorsSorted(detectedBrand.colors)
+        : [];
+    const swatches = buildSwatches(detectedColors);
+    const detectedLogoUrl = detectedBrand
+        ? pickTileLogo(detectedBrand.logos)
+        : null;
+    const selectedColor = form.values.selectedColor;
+
+    const showWorkspaceStep = canEnterOrganizationName;
+    const totalSteps = showWorkspaceStep ? 2 : 1;
+    const [step, setStep] = useState(1);
+
+    const isWorkspaceStep = showWorkspaceStep && step === 1;
+    const stepLabel = isWorkspaceStep ? 'Set up your workspace' : 'About you';
+    const displayStep = showWorkspaceStep ? step : 1;
+
+    const handleSubmit = form.onSubmit((values) => {
+        if (isWorkspaceStep) {
+            if (values.organizationName.trim()) {
+                setStep(2);
+            }
+            return;
+        }
+
+        if (user.organizationName) {
+            completeMutation.mutate({
+                jobTitle: values.jobTitle,
+                enableEmailDomainAccess: values.enableEmailDomainAccess,
+                isMarketingOptedIn: values.isMarketingOptedIn,
+                isTrackingAnonymized: values.isTrackingAnonymized,
+            });
+        } else {
+            completeMutation.mutate({
+                organizationName: values.organizationName,
+                jobTitle: values.jobTitle,
+                enableEmailDomainAccess: values.enableEmailDomainAccess,
+                isMarketingOptedIn: values.isMarketingOptedIn,
+                isTrackingAnonymized: values.isTrackingAnonymized,
+            });
+        }
+
+        if (detectedBrand) {
+            const matchesSelected = (hex: string) =>
+                hex.toLowerCase() === selectedColor.toLowerCase();
+            const existing = detectedBrand.colors.find((color) =>
+                matchesSelected(color.hex),
+            );
+            const selectedEntry: OrganizationBrandColor = existing
+                ? { ...existing, type: 'accent' }
+                : { hex: selectedColor, type: 'accent', brightness: null };
+            const rest = detectedBrand.colors.filter(
+                (color) => !matchesSelected(color.hex),
+            );
+            saveBrand.mutate({
+                domain: detectedBrand.domain,
+                name: detectedBrand.name,
+                description: detectedBrand.description,
+                logos: detectedBrand.logos,
+                colors: [selectedEntry, ...rest],
+                fonts: detectedBrand.fonts,
+            });
+        }
+    });
+
+    const logoTileInitial = (form.values.organizationName || '?')
+        .charAt(0)
+        .toUpperCase();
+
+    return (
+        <Box className={classes.page}>
+            <DocumentTitle title="Set up your organization" />
+            <Box className={classes.topBar}>
+                <LightdashLogo />
+                <Text size="sm" c="dimmed">
+                    Step {displayStep} of {totalSteps} · {stepLabel}
+                </Text>
+            </Box>
+
+            <Box className={classes.body}>
+                <Box className={classes.leftPane}>
+                    <form onSubmit={handleSubmit} noValidate>
+                        {isWorkspaceStep ? (
+                            <Stack gap="lg">
+                                <Stack gap="xs">
+                                    <Title
+                                        order={1}
+                                        fz={44}
+                                        className={classes.heading}
+                                    >
+                                        Name your organization
+                                    </Title>
+                                    <Text c="dimmed" size="lg">
+                                        This is how your team and your agent
+                                        will refer to your workspace.
+                                    </Text>
+                                </Stack>
+
+                                <TextInput
+                                    label="Organization name"
+                                    placeholder="Acme Analytics"
+                                    size="md"
+                                    required
+                                    {...form.getInputProps('organizationName')}
+                                />
+
+                                <Divider />
+
+                                <Stack gap="md">
+                                    <Group gap="sm">
+                                        <Text fw={600}>Brand</Text>
+                                        <Text
+                                            size="xs"
+                                            c="dimmed"
+                                            className={classes.optionalPill}
+                                        >
+                                            Optional · you can change this later
+                                        </Text>
+                                    </Group>
+
+                                    <Group gap="lg" align="flex-start">
+                                        <Box
+                                            className={classes.logoTile}
+                                            bg={
+                                                detectedLogoUrl
+                                                    ? 'var(--mantine-color-ldGray-0)'
+                                                    : selectedColor
+                                            }
+                                        >
+                                            {detectedLogoUrl ? (
+                                                <img
+                                                    src={detectedLogoUrl}
+                                                    alt=""
+                                                    className={
+                                                        classes.logoTileImage
+                                                    }
+                                                />
+                                            ) : (
+                                                <Text
+                                                    fw={700}
+                                                    fz={20}
+                                                    c="white"
+                                                >
+                                                    {logoTileInitial}
+                                                </Text>
+                                            )}
+                                        </Box>
+
+                                        <Stack gap="xs">
+                                            <Text size="sm" fw={500}>
+                                                Theme color
+                                            </Text>
+                                            <Box className={classes.swatchRow}>
+                                                {swatches.map((color) => (
+                                                    <Box
+                                                        key={color}
+                                                        component="button"
+                                                        type="button"
+                                                        aria-label={`Select theme color ${color}`}
+                                                        className={
+                                                            color.toLowerCase() ===
+                                                            selectedColor.toLowerCase()
+                                                                ? `${classes.swatch} ${classes.swatchSelected}`
+                                                                : classes.swatch
+                                                        }
+                                                        bg={color}
+                                                        onClick={() =>
+                                                            form.setFieldValue(
+                                                                'selectedColor',
+                                                                color,
+                                                            )
+                                                        }
+                                                    />
+                                                ))}
+                                            </Box>
+                                        </Stack>
+                                    </Group>
+                                </Stack>
+
+                                <Group>
+                                    <Button
+                                        type="submit"
+                                        color="dark"
+                                        size="md"
+                                        disabled={
+                                            !form.values.organizationName.trim()
+                                        }
+                                    >
+                                        Continue
+                                    </Button>
+                                </Group>
+                            </Stack>
+                        ) : (
+                            <Stack gap="lg">
+                                <Stack gap="xs">
+                                    <Title
+                                        order={1}
+                                        fz={44}
+                                        className={classes.heading}
+                                    >
+                                        Tell us about you
+                                    </Title>
+                                    <Text c="dimmed" size="lg">
+                                        This helps us tailor Lightdash for you.
+                                    </Text>
+                                </Stack>
+
+                                <Select
+                                    label="What's your role?"
+                                    data={jobTitles}
+                                    placeholder="Select your role"
+                                    size="md"
+                                    required
+                                    {...form.getInputProps('jobTitle')}
+                                />
+
+                                <Stack gap="xs">
+                                    {canEnableEmailDomainAccess && (
+                                        <Checkbox
+                                            label={`Allow users with @${emailDomain} to join the organization as a viewer`}
+                                            {...form.getInputProps(
+                                                'enableEmailDomainAccess',
+                                                { type: 'checkbox' },
+                                            )}
+                                        />
+                                    )}
+
+                                    <Checkbox
+                                        label="Keep me updated on new Lightdash features"
+                                        {...form.getInputProps(
+                                            'isMarketingOptedIn',
+                                            { type: 'checkbox' },
+                                        )}
+                                    />
+
+                                    {health.mode !==
+                                        LightdashMode.CLOUD_BETA && (
+                                        <Checkbox
+                                            label="Anonymize my usage data"
+                                            {...form.getInputProps(
+                                                'isTrackingAnonymized',
+                                                { type: 'checkbox' },
+                                            )}
+                                        />
+                                    )}
+                                </Stack>
+
+                                <Group>
+                                    {showWorkspaceStep && (
+                                        <Button
+                                            variant="subtle"
+                                            color="gray"
+                                            size="md"
+                                            onClick={() => setStep(1)}
+                                        >
+                                            Back
+                                        </Button>
+                                    )}
+                                    <Button
+                                        type="submit"
+                                        color="dark"
+                                        size="md"
+                                        loading={completeMutation.isLoading}
+                                        disabled={!form.values.jobTitle}
+                                    >
+                                        Finish
+                                    </Button>
+                                </Group>
+                            </Stack>
+                        )}
+                    </form>
+                </Box>
+
+                <Box className={classes.rightPane}>
+                    <OrganizationSetupPreview
+                        themeColor={selectedColor}
+                        detectedDomain={detectedBrand?.domain ?? null}
+                        detectedLogoUrl={detectedLogoUrl}
+                    />
+                </Box>
+            </Box>
+        </Box>
+    );
+};
+
+const OrganizationSetup: FC = () => {
+    const { health, user } = useApp();
+    const orgSetupPageFlag = useServerFeatureFlag(
+        FeatureFlags.OrganizationSetupPage,
+    );
+
+    if (health.isInitialLoading || health.error) {
+        return <PageSpinner />;
+    }
+
+    if (!health.data?.isAuthenticated) {
+        return <Navigate to="/login" />;
+    }
+
+    if (user.isInitialLoading || orgSetupPageFlag.isLoading) {
+        return <PageSpinner />;
+    }
+
+    if (!user.data) {
+        return <PageSpinner />;
+    }
+
+    if (!user.data.organizationUuid) {
+        return <Navigate to="/join-organization" />;
+    }
+
+    if (user.data.isSetupComplete) {
+        return <Navigate to="/" />;
+    }
+
+    if (!orgSetupPageFlag.data?.enabled) {
+        return <Navigate to="/" />;
+    }
+
+    return (
+        <OrganizationSetupContent
+            key={user.data.userUuid}
+            user={user.data}
+            health={health.data}
+        />
+    );
+};
+
+export default OrganizationSetup;

--- a/packages/frontend/src/pages/OrganizationSetupPreview.tsx
+++ b/packages/frontend/src/pages/OrganizationSetupPreview.tsx
@@ -1,0 +1,193 @@
+import { Box, Text } from '@mantine-8/core';
+import { type FC } from 'react';
+import classes from './OrganizationSetup.module.css';
+
+const toAlphaHex = (alpha: number): string =>
+    Math.round(alpha * 255)
+        .toString(16)
+        .padStart(2, '0');
+
+const normalizeHex = (hex: string): string =>
+    hex.length === 4
+        ? `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`
+        : hex;
+
+const withAlpha = (hex: string, alpha: number): string =>
+    `${normalizeHex(hex)}${toAlphaHex(alpha)}`;
+
+const BAR_HEIGHTS = [38, 54, 66, 80, 96];
+const BAR_ALPHAS = [0.4, 0.55, 0.7, 0.85, 1];
+
+const LINE_POINTS = [22, 30, 26, 42, 36, 52, 60];
+
+const linePath = (points: number[]): string => {
+    const width = 240;
+    const height = 60;
+    const max = Math.max(...points);
+    return points
+        .map((point, index) => {
+            const x = (index / (points.length - 1)) * width;
+            const y = height - (point / max) * height * 0.85 - 4;
+            return `${index === 0 ? 'M' : 'L'} ${x} ${y}`;
+        })
+        .join(' ');
+};
+
+const areaPath = (points: number[]): string =>
+    `${linePath(points)} L 240 60 L 0 60 Z`;
+
+const DONUT_RADIUS = 26;
+const DONUT_CIRCUMFERENCE = 2 * Math.PI * DONUT_RADIUS;
+const CONVERSION = 0.64;
+
+type OrganizationSetupPreviewProps = {
+    themeColor: string;
+    detectedDomain: string | null;
+    detectedLogoUrl: string | null;
+};
+
+const OrganizationSetupPreview: FC<OrganizationSetupPreviewProps> = ({
+    themeColor,
+    detectedDomain,
+    detectedLogoUrl,
+}) => (
+    <Box className={classes.previewCard}>
+        {detectedDomain && (
+            <Box className={classes.pill}>
+                {detectedLogoUrl && (
+                    <img
+                        src={detectedLogoUrl}
+                        alt=""
+                        className={classes.pillLogo}
+                    />
+                )}
+                <Box className={classes.pillDot} />
+                <Text size="xs" c="dimmed">
+                    Theme detected from{' '}
+                    <Text span fw={600} c="dimmed">
+                        {detectedDomain}
+                    </Text>
+                </Text>
+            </Box>
+        )}
+
+        <Box className={classes.chartGrid}>
+            <Box className={classes.chartCard}>
+                <Text size="xs" c="dimmed">
+                    Weekly active users
+                </Text>
+                <Box className={classes.barsRow}>
+                    {BAR_HEIGHTS.map((height, index) => (
+                        <Box
+                            key={height}
+                            className={classes.bar}
+                            h={`${height}%`}
+                            bg={withAlpha(themeColor, BAR_ALPHAS[index])}
+                        />
+                    ))}
+                </Box>
+            </Box>
+
+            <Box className={classes.chartCard}>
+                <Text size="xs" c="dimmed">
+                    Revenue
+                </Text>
+                <Text fw={700} fz={32} mt="auto">
+                    $248k
+                </Text>
+                <Text size="sm" fw={600} c={themeColor}>
+                    ↑ 12.4% MoM
+                </Text>
+            </Box>
+
+            <Box className={classes.chartCard}>
+                <Text size="xs" c="dimmed">
+                    Signups
+                </Text>
+                <Box mt="auto">
+                    <svg viewBox="0 0 240 60" width="100%" height="60">
+                        <defs>
+                            <linearGradient
+                                id="signups-fill"
+                                x1="0"
+                                y1="0"
+                                x2="0"
+                                y2="1"
+                            >
+                                <stop
+                                    offset="0%"
+                                    stopColor={themeColor}
+                                    stopOpacity={0.35}
+                                />
+                                <stop
+                                    offset="100%"
+                                    stopColor={themeColor}
+                                    stopOpacity={0}
+                                />
+                            </linearGradient>
+                        </defs>
+                        <path
+                            d={areaPath(LINE_POINTS)}
+                            fill="url(#signups-fill)"
+                        />
+                        <path
+                            d={linePath(LINE_POINTS)}
+                            fill="none"
+                            stroke={themeColor}
+                            strokeWidth={2.5}
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        />
+                    </svg>
+                </Box>
+            </Box>
+
+            <Box className={classes.chartCard}>
+                <Text size="xs" c="dimmed">
+                    Conversion
+                </Text>
+                <Box className={classes.donutWrap}>
+                    <svg width="72" height="72" viewBox="0 0 72 72">
+                        <circle
+                            cx="36"
+                            cy="36"
+                            r={DONUT_RADIUS}
+                            fill="none"
+                            stroke={withAlpha(themeColor, 0.18)}
+                            strokeWidth={8}
+                        />
+                        <circle
+                            cx="36"
+                            cy="36"
+                            r={DONUT_RADIUS}
+                            fill="none"
+                            stroke={themeColor}
+                            strokeWidth={8}
+                            strokeLinecap="round"
+                            strokeDasharray={`${
+                                CONVERSION * DONUT_CIRCUMFERENCE
+                            } ${DONUT_CIRCUMFERENCE}`}
+                            transform="rotate(-90 36 36)"
+                        />
+                        <text
+                            x="36"
+                            y="40"
+                            textAnchor="middle"
+                            fontSize="15"
+                            fontWeight={700}
+                            fill="currentColor"
+                        >
+                            64%
+                        </text>
+                    </svg>
+                </Box>
+            </Box>
+        </Box>
+
+        <Text size="xs" c="dimmed" ta="center">
+            Example charts — themed to your brand.
+        </Text>
+    </Box>
+);
+
+export { OrganizationSetupPreview };

--- a/packages/frontend/src/pages/OrganizationSetupPreview.tsx
+++ b/packages/frontend/src/pages/OrganizationSetupPreview.tsx
@@ -1,53 +1,31 @@
+import {
+    type OrganizationBrandColor,
+    type OrganizationBrandFont,
+    type OrganizationBrandLogo,
+} from '@lightdash/common';
 import { Box, Text } from '@mantine-8/core';
 import { type FC } from 'react';
+import { BrandPreview } from '../components/UserSettings/AppearanceSettingsPanel/BrandPreview';
 import classes from './OrganizationSetup.module.css';
 
-const toAlphaHex = (alpha: number): string =>
-    Math.round(alpha * 255)
-        .toString(16)
-        .padStart(2, '0');
-
-const normalizeHex = (hex: string): string =>
-    hex.length === 4
-        ? `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`
-        : hex;
-
-const withAlpha = (hex: string, alpha: number): string =>
-    `${normalizeHex(hex)}${toAlphaHex(alpha)}`;
-
-const BAR_HEIGHTS = [38, 54, 66, 80, 96];
-const BAR_ALPHAS = [0.4, 0.55, 0.7, 0.85, 1];
-
-const LINE_POINTS = [22, 30, 26, 42, 36, 52, 60];
-
-const linePath = (points: number[]): string => {
-    const width = 240;
-    const height = 60;
-    const max = Math.max(...points);
-    return points
-        .map((point, index) => {
-            const x = (index / (points.length - 1)) * width;
-            const y = height - (point / max) * height * 0.85 - 4;
-            return `${index === 0 ? 'M' : 'L'} ${x} ${y}`;
-        })
-        .join(' ');
-};
-
-const areaPath = (points: number[]): string =>
-    `${linePath(points)} L 240 60 L 0 60 Z`;
-
-const DONUT_RADIUS = 26;
-const DONUT_CIRCUMFERENCE = 2 * Math.PI * DONUT_RADIUS;
-const CONVERSION = 0.64;
-
 type OrganizationSetupPreviewProps = {
-    themeColor: string;
+    domain: string;
+    name: string | null;
+    logos: OrganizationBrandLogo[];
+    colors: OrganizationBrandColor[];
+    titleFont: OrganizationBrandFont | null;
+    bodyFont: OrganizationBrandFont | null;
     detectedDomain: string | null;
     detectedLogoUrl: string | null;
 };
 
 const OrganizationSetupPreview: FC<OrganizationSetupPreviewProps> = ({
-    themeColor,
+    domain,
+    name,
+    logos,
+    colors,
+    titleFont,
+    bodyFont,
     detectedDomain,
     detectedLogoUrl,
 }) => (
@@ -71,121 +49,17 @@ const OrganizationSetupPreview: FC<OrganizationSetupPreviewProps> = ({
             </Box>
         )}
 
-        <Box className={classes.chartGrid}>
-            <Box className={classes.chartCard}>
-                <Text size="xs" c="dimmed">
-                    Weekly active users
-                </Text>
-                <Box className={classes.barsRow}>
-                    {BAR_HEIGHTS.map((height, index) => (
-                        <Box
-                            key={height}
-                            className={classes.bar}
-                            h={`${height}%`}
-                            bg={withAlpha(themeColor, BAR_ALPHAS[index])}
-                        />
-                    ))}
-                </Box>
-            </Box>
-
-            <Box className={classes.chartCard}>
-                <Text size="xs" c="dimmed">
-                    Revenue
-                </Text>
-                <Text fw={700} fz={32} mt="auto">
-                    $248k
-                </Text>
-                <Text size="sm" fw={600} c={themeColor}>
-                    ↑ 12.4% MoM
-                </Text>
-            </Box>
-
-            <Box className={classes.chartCard}>
-                <Text size="xs" c="dimmed">
-                    Signups
-                </Text>
-                <Box mt="auto">
-                    <svg viewBox="0 0 240 60" width="100%" height="60">
-                        <defs>
-                            <linearGradient
-                                id="signups-fill"
-                                x1="0"
-                                y1="0"
-                                x2="0"
-                                y2="1"
-                            >
-                                <stop
-                                    offset="0%"
-                                    stopColor={themeColor}
-                                    stopOpacity={0.35}
-                                />
-                                <stop
-                                    offset="100%"
-                                    stopColor={themeColor}
-                                    stopOpacity={0}
-                                />
-                            </linearGradient>
-                        </defs>
-                        <path
-                            d={areaPath(LINE_POINTS)}
-                            fill="url(#signups-fill)"
-                        />
-                        <path
-                            d={linePath(LINE_POINTS)}
-                            fill="none"
-                            stroke={themeColor}
-                            strokeWidth={2.5}
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                        />
-                    </svg>
-                </Box>
-            </Box>
-
-            <Box className={classes.chartCard}>
-                <Text size="xs" c="dimmed">
-                    Conversion
-                </Text>
-                <Box className={classes.donutWrap}>
-                    <svg width="72" height="72" viewBox="0 0 72 72">
-                        <circle
-                            cx="36"
-                            cy="36"
-                            r={DONUT_RADIUS}
-                            fill="none"
-                            stroke={withAlpha(themeColor, 0.18)}
-                            strokeWidth={8}
-                        />
-                        <circle
-                            cx="36"
-                            cy="36"
-                            r={DONUT_RADIUS}
-                            fill="none"
-                            stroke={themeColor}
-                            strokeWidth={8}
-                            strokeLinecap="round"
-                            strokeDasharray={`${
-                                CONVERSION * DONUT_CIRCUMFERENCE
-                            } ${DONUT_CIRCUMFERENCE}`}
-                            transform="rotate(-90 36 36)"
-                        />
-                        <text
-                            x="36"
-                            y="40"
-                            textAnchor="middle"
-                            fontSize="15"
-                            fontWeight={700}
-                            fill="currentColor"
-                        >
-                            64%
-                        </text>
-                    </svg>
-                </Box>
-            </Box>
-        </Box>
+        <BrandPreview
+            domain={domain}
+            name={name}
+            logos={logos}
+            colors={colors}
+            titleFont={titleFont}
+            bodyFont={bodyFont}
+        />
 
         <Text size="xs" c="dimmed" ta="center">
-            Example charts — themed to your brand.
+            A preview of Lightdash, themed to your brand.
         </Text>
     </Box>
 );

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -49,6 +49,7 @@ export enum PageName {
     USER_ACTIVITY = 'user_activity',
     VERIFY_EMAIL = 'verify_email',
     JOIN_ORGANIZATION = 'join_organization',
+    ORGANIZATION_SETUP = 'organization_setup',
     EMBED_DASHBOARD = 'embed_dashboard',
     EMBED_SAVED_CHART = 'embed_saved_chart',
     EMBED_EXPLORE = 'embed_explore',


### PR DESCRIPTION
## Summary

Replaces the "Nearly there..." user-completion modal with a full-page organization setup experience, behind the new `organization-setup-page` feature flag (off by default; flag-off behavior is completely unchanged). Goal: simplify first-run onboarding and make it more fun, building on the brand appearance work from #25303.

## What it does (flag on)

Users with incomplete setup are redirected to a new `/organization-setup` page instead of seeing the modal:

- **Step 1 — "Name your organization"**: org name input plus an optional brand section with theme-color swatches. The org name is prefilled by inference from the signup email domain (`acme-analytics.io` → "Acme Analytics"); free-mail domains (gmail, outlook, …) are excluded via the existing `validateOrganizationEmailDomains` blocklist. When Brandfetch is configured and the domain is a company domain, the brand is auto-detected silently: official name upgrades the prefill (until the user edits the field), brand colors lead the swatches, and a "Theme detected from {domain}" pill appears. Skipped entirely for invite joiners.
- **Live preview**: reuses the shared `BrandPreview` browser mock from appearance settings, themed by the selected swatch and live-updating with the typed org name.
- **Step 2 — "Tell us about you"**: identical data collection to the modal (role + email-domain-access / marketing / anonymize-tracking checkboxes, same conditional logic).
- **On finish**: same `PATCH /user/me/complete` contract (zero backend changes); a detected brand is persisted via `PUT /org/brand` with the chosen swatch first as `accent` (non-blocking), and round-trips into the appearance settings panel.

## Notable implementation detail

The speculative brand detection runs as a cached `useQuery` rather than a mutation: firing a mutation from a mount effect loses its result under React StrictMode (dev-only observer detach in TanStack v4), which live testing surfaced as nondeterministic detection. See the PR comment for the full diagnosis.

## Testing

- Unit: existing modal tests pass unchanged plus a new flag-on redirect test; typecheck and lint green across touched packages
- Live: full flow verified end-to-end locally with the flag enabled — fresh-user redirect, swatch re-theming, both steps, completion, and brand detection/persistence against a real brand domain (deterministic across reloads); detection-unavailable fallback verified separately

Closes: PROD-8901

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n1na782qhAqGcvNqqEB9g