### PR TITLE
style(homepage): day-0 parity — white ask band, day chips, favourites and pinned card grids

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.module.css
@@ -1,0 +1,63 @@
+.band {
+    background: light-dark(#fff, var(--mantine-color-dark-7));
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.bandInner {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 56px 24px 48px;
+}
+
+.container {
+    max-width: 1040px;
+    margin: 0 auto;
+    padding: 40px 32px 60px;
+}
+
+.dayChip {
+    font-size: 13px;
+    font-weight: 500;
+    padding: 7px 13px;
+    border-radius: 999px;
+    cursor: pointer;
+    background: light-dark(#fff, var(--mantine-color-dark-6));
+    border: 1px solid var(--mantine-color-ldGray-2);
+    color: var(--mantine-color-ldGray-7);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: inherit;
+    transition: all 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.dayChip:hover {
+    border-color: var(--mantine-color-ldGray-4);
+    color: var(--mantine-color-ldGray-9);
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.itemRow {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 14px;
+    color: inherit;
+    text-decoration: none;
+}
+
+.itemName {
+    font-size: 13.5px;
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.itemMeta {
+    font-size: 12px;
+    color: var(--mantine-color-ldGray-6);
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
@@ -17,15 +17,18 @@ import {
     Title,
 } from '@mantine-8/core';
 import {
+    IconArrowUpRight,
     IconChartBar,
     IconFolder,
     IconLayoutDashboard,
     IconPin,
     IconSquareRoundedPlus,
+    IconStar,
 } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
-import { Link } from 'react-router';
+import { useState, type FC, type ReactNode } from 'react';
+import { Link, useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { ResourceIcon } from '../../../components/common/ResourceIcon';
 import { useFavoriteMutation } from '../../../hooks/favorites/useFavoriteMutation';
 import { useFavorites } from '../../../hooks/favorites/useFavorites';
 import { usePinnedItems } from '../../../hooks/pinning/usePinnedItems';
@@ -33,13 +36,24 @@ import { useInfiniteContent } from '../../../hooks/useContent';
 import { useProject } from '../../../hooks/useProject';
 import useApp from '../../../providers/App/useApp';
 import AiSearchBox from '../../components/Home/AiSearchBox';
+import {
+    AI_ROUTING_AUTO_VALUE,
+    AI_ROUTING_SEARCH_PARAM,
+} from '../aiCopilot/components/AgentSelector/AgentSelectorUtils';
+import { usePendingPrompt } from '../aiCopilot/components/PendingPromptContext/PendingPromptContext';
 import { useAiAgentButtonVisibility } from '../aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { BlockHeader } from './blocks/BlockShell';
 import blockClasses from './blocks/blockStyles.module.css';
 import { ContentCard } from './blocks/ContentCard';
-import { PersonalFavoritesStrip } from './blocks/FavoritesBlock';
 import { getDefaultQuickActions } from './blocks/quickActionDefaults';
 import { QuickActionCards } from './blocks/QuickActionsBlock';
+import classes from './DayOneHomepage.module.css';
+
+const DAY_CHIPS = [
+    'What drove revenue last month?',
+    'Show me our top customers',
+    'How are orders trending?',
+];
 
 const dayPart = (): string => {
     const hour = new Date().getHours();
@@ -142,14 +156,7 @@ const GroupSection: FC<{
     );
 };
 
-const PINNED_ICONS: Partial<Record<ResourceViewItemType, typeof IconChartBar>> =
-    {
-        [ResourceViewItemType.CHART]: IconChartBar,
-        [ResourceViewItemType.DASHBOARD]: IconLayoutDashboard,
-        [ResourceViewItemType.SPACE]: IconFolder,
-    };
-
-const pinnedUrl = (projectUuid: string, item: ResourceViewItem): string => {
+const itemUrl = (projectUuid: string, item: ResourceViewItem): string => {
     switch (item.type) {
         case ResourceViewItemType.DASHBOARD:
             return `/projects/${projectUuid}/dashboards/${item.data.uuid}/view`;
@@ -160,6 +167,30 @@ const pinnedUrl = (projectUuid: string, item: ResourceViewItem): string => {
     }
 };
 
+const ITEM_TYPE_LABELS: Partial<Record<ResourceViewItemType, string>> = {
+    [ResourceViewItemType.CHART]: 'Chart',
+    [ResourceViewItemType.DASHBOARD]: 'Dashboard',
+    [ResourceViewItemType.SPACE]: 'Space',
+};
+
+const ItemRow: FC<{ projectUuid: string; item: ResourceViewItem }> = ({
+    projectUuid,
+    item,
+}) => (
+    <Link
+        to={itemUrl(projectUuid, item)}
+        className={`${blockClasses.hoverCard} ${blockClasses.clickable} ${classes.itemRow}`}
+    >
+        <ResourceIcon item={item} />
+        <Box style={{ minWidth: 0, flex: 1 }}>
+            <div className={classes.itemName}>{item.data.name}</div>
+            <div className={classes.itemMeta}>
+                {ITEM_TYPE_LABELS[item.type] ?? 'Content'}
+            </div>
+        </Box>
+    </Link>
+);
+
 const PersonalAndPinnedSections: FC<{ projectUuid: string }> = ({
     projectUuid,
 }) => {
@@ -168,47 +199,110 @@ const PersonalAndPinnedSections: FC<{ projectUuid: string }> = ({
         projectUuid,
         project?.pinnedListUuid,
     );
+    const { data: favorites } = useFavorites(projectUuid);
     return (
-        <Stack gap={26}>
-            <PersonalFavoritesStrip projectUuid={projectUuid} />
+        <Stack gap={34}>
+            <Stack gap={0}>
+                <BlockHeader
+                    icon={IconStar}
+                    iconColor="light-dark(#de7f0b, #e08a20)"
+                    title="Your favourites"
+                    pill="Only you"
+                    mb={14}
+                />
+                {(favorites ?? []).length > 0 ? (
+                    <SimpleGrid cols={{ base: 1, sm: 2 }} spacing={10}>
+                        {(favorites ?? []).map((item) => (
+                            <ItemRow
+                                key={item.data.uuid}
+                                projectUuid={projectUuid}
+                                item={item}
+                            />
+                        ))}
+                    </SimpleGrid>
+                ) : (
+                    <div
+                        className={blockClasses.dashedEmpty}
+                        style={{ padding: 16, borderRadius: 10 }}
+                    >
+                        Star any chart or dashboard to keep it here — visible
+                        only to you.
+                    </div>
+                )}
+            </Stack>
             {(pinnedItems ?? []).length > 0 && (
                 <Stack gap={0}>
                     <BlockHeader
                         icon={IconPin}
                         title="Pinned"
                         pill="Pinned for everyone by admins"
-                        mb={10}
+                        mb={14}
                     />
-                    <Group gap={8}>
+                    <SimpleGrid cols={{ base: 1, sm: 2 }} spacing={10}>
                         {(pinnedItems ?? []).map((item) => (
-                            <Link
+                            <ItemRow
                                 key={item.data.uuid}
-                                to={pinnedUrl(projectUuid, item)}
-                                className={blockClasses.favPill}
-                            >
-                                <MantineIcon
-                                    icon={
-                                        PINNED_ICONS[item.type] ?? IconChartBar
-                                    }
-                                    size={15}
-                                    color="ldGray.6"
-                                />
-                                {item.data.name}
-                            </Link>
+                                projectUuid={projectUuid}
+                                item={item}
+                            />
                         ))}
-                    </Group>
+                    </SimpleGrid>
                 </Stack>
             )}
         </Stack>
     );
 };
 
+const DayChips: FC<{ projectUuid: string }> = ({ projectUuid }) => {
+    const navigate = useNavigate();
+    const { setPendingPrompt } = usePendingPrompt();
+    return (
+        <Group gap={8} justify="center" mt={16}>
+            {DAY_CHIPS.map((chip) => (
+                <button
+                    key={chip}
+                    type="button"
+                    className={classes.dayChip}
+                    onClick={() => {
+                        setPendingPrompt(chip);
+                        void navigate(
+                            {
+                                pathname: `/projects/${projectUuid}/ai-agents`,
+                                search: new URLSearchParams({
+                                    [AI_ROUTING_SEARCH_PARAM]:
+                                        AI_ROUTING_AUTO_VALUE,
+                                }).toString(),
+                            },
+                            {
+                                state: { autoSubmitPrompt: chip },
+                                viewTransition: true,
+                            },
+                        );
+                    }}
+                >
+                    <MantineIcon
+                        icon={IconArrowUpRight}
+                        size={14}
+                        color="ldGray.5"
+                    />
+                    {chip}
+                </button>
+            ))}
+        </Group>
+    );
+};
+
 type Props = {
     projectUuid: string;
     projectName: string;
+    adminSlot?: ReactNode;
 };
 
-export const DayOneHomepage: FC<Props> = ({ projectUuid, projectName }) => {
+export const DayOneHomepage: FC<Props> = ({
+    projectUuid,
+    projectName,
+    adminSlot,
+}) => {
     const { user } = useApp();
     const isAiEnabled = useAiAgentButtonVisibility();
     const { data: favorites } = useFavorites(projectUuid);
@@ -227,31 +321,44 @@ export const DayOneHomepage: FC<Props> = ({ projectUuid, projectName }) => {
     };
 
     return (
-        <Stack gap="xl">
+        <Box>
             {isAiEnabled ? (
-                <Stack gap="md" align="center" py="lg">
-                    <Text
-                        component="h1"
-                        fz={30}
-                        fw={600}
-                        lts="-0.025em"
-                        lh={1.15}
-                        ta="center"
-                        m={0}
-                    >
-                        Good {dayPart()}, {user.data?.firstName}. What do you
-                        want to know?
-                    </Text>
-                    <Box w="100%" maw={720}>
+                <div className={classes.band}>
+                    <div className={classes.bandInner}>
+                        {adminSlot ? (
+                            <Group justify="flex-end" mb={20} mt={-32}>
+                                {adminSlot}
+                            </Group>
+                        ) : null}
+                        <Text
+                            component="h1"
+                            fz={30}
+                            fw={600}
+                            lts="-0.025em"
+                            lh={1.15}
+                            ta="center"
+                            m={0}
+                            mb={26}
+                        >
+                            Good {dayPart()}, {user.data?.firstName}. What do
+                            you want to know?
+                        </Text>
                         <AiSearchBox projectUuid={projectUuid} />
-                    </Box>
-                </Stack>
+                        <DayChips projectUuid={projectUuid} />
+                    </div>
+                </div>
             ) : (
-                <Stack gap="md">
+                <div className={classes.container} style={{ paddingBottom: 0 }}>
+                    {adminSlot ? (
+                        <Group justify="flex-end" mb={16}>
+                            {adminSlot}
+                        </Group>
+                    ) : null}
                     <Group
                         justify="space-between"
                         align="flex-end"
                         wrap="nowrap"
+                        mb={26}
                     >
                         <Box>
                             <Text
@@ -283,76 +390,83 @@ export const DayOneHomepage: FC<Props> = ({ projectUuid, projectName }) => {
                         actions={getDefaultQuickActions(false)}
                         projectUuid={projectUuid}
                     />
-                </Stack>
+                </div>
             )}
 
-            <PersonalAndPinnedSections projectUuid={projectUuid} />
+            <div className={classes.container}>
+                <Stack gap="xl">
+                    <PersonalAndPinnedSections projectUuid={projectUuid} />
 
-            <Stack gap="md">
-                <Box>
-                    <Title order={4} fw={600}>
-                        Explore your workspace
-                    </Title>
-                    <Text size="xs" c="dimmed">
-                        Everything the data team has published, grouped by type.
-                        Star anything to keep it handy.
-                    </Text>
-                </Box>
-                <Group gap="xs">
-                    <Button
-                        variant={typeFilter === null ? 'filled' : 'default'}
-                        size="compact-xs"
-                        onClick={() => setTypeFilter(null)}
-                    >
-                        All
-                    </Button>
-                    {DISCOVER_GROUPS.map((definition) => (
-                        <Button
-                            key={definition.key}
-                            variant={
-                                typeFilter === definition.key
-                                    ? 'filled'
-                                    : 'default'
-                            }
-                            size="compact-xs"
-                            leftSection={
-                                <MantineIcon
-                                    icon={
-                                        definition.contentType ===
-                                        ContentType.DASHBOARD
-                                            ? IconLayoutDashboard
-                                            : definition.contentType ===
-                                                ContentType.CHART
-                                              ? IconChartBar
-                                              : IconFolder
+                    <Stack gap="md">
+                        <Box>
+                            <Title order={4} fw={600}>
+                                Explore your workspace
+                            </Title>
+                            <Text size="xs" c="dimmed">
+                                Everything the data team has published, grouped
+                                by type. Star anything to keep it handy.
+                            </Text>
+                        </Box>
+                        <Group gap="xs">
+                            <Button
+                                variant={
+                                    typeFilter === null ? 'filled' : 'default'
+                                }
+                                size="compact-xs"
+                                onClick={() => setTypeFilter(null)}
+                            >
+                                All
+                            </Button>
+                            {DISCOVER_GROUPS.map((definition) => (
+                                <Button
+                                    key={definition.key}
+                                    variant={
+                                        typeFilter === definition.key
+                                            ? 'filled'
+                                            : 'default'
                                     }
-                                />
-                            }
-                            onClick={() =>
-                                setTypeFilter((current) =>
-                                    current === definition.key
-                                        ? null
-                                        : definition.key,
-                                )
-                            }
-                        >
-                            {definition.label}
-                        </Button>
-                    ))}
-                </Group>
-                {DISCOVER_GROUPS.filter(
-                    (definition) =>
-                        typeFilter === null || typeFilter === definition.key,
-                ).map((definition) => (
-                    <GroupSection
-                        key={definition.key}
-                        definition={definition}
-                        projectUuid={projectUuid}
-                        favoriteUuids={favoriteUuids}
-                        onToggleFavorite={handleToggleFavorite}
-                    />
-                ))}
-            </Stack>
-        </Stack>
+                                    size="compact-xs"
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={
+                                                definition.contentType ===
+                                                ContentType.DASHBOARD
+                                                    ? IconLayoutDashboard
+                                                    : definition.contentType ===
+                                                        ContentType.CHART
+                                                      ? IconChartBar
+                                                      : IconFolder
+                                            }
+                                        />
+                                    }
+                                    onClick={() =>
+                                        setTypeFilter((current) =>
+                                            current === definition.key
+                                                ? null
+                                                : definition.key,
+                                        )
+                                    }
+                                >
+                                    {definition.label}
+                                </Button>
+                            ))}
+                        </Group>
+                        {DISCOVER_GROUPS.filter(
+                            (definition) =>
+                                typeFilter === null ||
+                                typeFilter === definition.key,
+                        ).map((definition) => (
+                            <GroupSection
+                                key={definition.key}
+                                definition={definition}
+                                projectUuid={projectUuid}
+                                favoriteUuids={favoriteUuids}
+                                onToggleFavorite={handleToggleFavorite}
+                            />
+                        ))}
+                    </Stack>
+                </Stack>
+            </div>
+        </Box>
     );
 };

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -168,16 +168,18 @@ const Home: FC = () => {
         onboarding.data.ranQuery
     ) {
         return (
-            <Page withPaddedContent withFooter>
-                <Stack gap="md">
-                    <Can
-                        I="manage"
-                        this={subject('ProjectHomepage', {
-                            organizationUuid: project.data.organizationUuid,
-                            projectUuid: project.data.projectUuid,
-                        })}
-                    >
-                        <Group justify="flex-end">
+            <Page withFooter noContentPadding>
+                <DayOneHomepage
+                    projectUuid={project.data.projectUuid}
+                    projectName={project.data.name}
+                    adminSlot={
+                        <Can
+                            I="manage"
+                            this={subject('ProjectHomepage', {
+                                organizationUuid: project.data.organizationUuid,
+                                projectUuid: project.data.projectUuid,
+                            })}
+                        >
                             <Button
                                 variant="default"
                                 size="xs"
@@ -190,13 +192,9 @@ const Home: FC = () => {
                             >
                                 Customize homepage
                             </Button>
-                        </Group>
-                    </Can>
-                    <DayOneHomepage
-                        projectUuid={project.data.projectUuid}
-                        projectName={project.data.name}
-                    />
-                </Stack>
+                        </Can>
+                    }
+                />
             </Page>
         );
     }


### PR DESCRIPTION
Part of the Homepage Builder stack (ZAP-609). Day-0 now matches the claude design artifact.

**AI on** — the ask experience becomes a full-bleed white band with a bottom hairline:
- Centered 30px greeting: "Good {morning/afternoon/evening}, {name}. What do you want to know?"
- The **agent composer** (`AiSearchBox` — agent selector, round arrow-up submit, thread-create + auto routing; the same shell the agent chat uses) centered at 720px.
- Three centered **suggestion chips** (pill, arrow-up-right glyph) that prefill + auto-submit to the AI agent, same path as the Ask-AI block chips.

**AI off** — 1040px container with the 30px "Welcome to {project}, {name}" header, right-aligned dark "New" CTA, and the get-started quick-action cards.

**Below the band** (both modes), per the design's day-one sections:
- "YOUR FAVOURITES · Only you" — 2-column card grid of the viewer's starred content (real `ResourceIcon`s), dashed empty state when nothing is starred.
- "PINNED · Pinned for everyone by admins" — 2-column card grid, hidden when nothing is pinned.
- The Explore-your-workspace discovery section (from ZAP-626) stays below.

The day-one branch of `/home` now renders edge-to-edge (`noContentPadding`) and the admin "Customize homepage" button moved into the band as a slot.

Verified live with a Playwright screenshot against localhost — band, chips, and both grids render as designed. 20/20 tests, typecheck + oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ