### PR TITLE
fix: allow editors with create:ContentAsCode to pass CLI upload preflight

### DIFF
--- a/packages/cli/src/handlers/dbt/apiClient.ts
+++ b/packages/cli/src/handlers/dbt/apiClient.ts
@@ -140,20 +140,20 @@ export const getContentAsCodeUploadPermissions = async (
     ]);
     const ability = new Ability<PossibleAbilities>(user.abilityRules);
 
+    const contentAsCodeSubject = subject('ContentAsCode', {
+        organizationUuid: project.organizationUuid,
+        projectUuid: project.projectUuid,
+        upstreamProjectUuid: project.upstreamProjectUuid,
+        type: project.type,
+        createdByUserUuid: project.createdByUserUuid,
+    });
+
     if (
-        ability.cannot(
-            'manage',
-            subject('ContentAsCode', {
-                organizationUuid: project.organizationUuid,
-                projectUuid: project.projectUuid,
-                upstreamProjectUuid: project.upstreamProjectUuid,
-                type: project.type,
-                createdByUserUuid: project.createdByUserUuid,
-            }),
-        )
+        ability.cannot('create', contentAsCodeSubject) &&
+        ability.cannot('manage', contentAsCodeSubject)
     ) {
         throw new ForbiddenError(
-            `You don't have permission to upload content as code to project "${project.name}". The manage:ContentAsCode permission is required.`,
+            `You don't have permission to upload content as code to project "${project.name}". The create:ContentAsCode or manage:ContentAsCode permission is required.`,
         );
     }
 


### PR DESCRIPTION
Follow-up to #25219, found during manual verification of #25564 (scenario 6.3 of the content-as-code error-messages test plan): the backend now allows Editors to upload content as code via `create:ContentAsCode`, but `lightdash upload` still blocked them client-side because the CLI preflight required `manage:ContentAsCode`.

## Change

Allow the preflight when the user has either `create:ContentAsCode` or `manage:ContentAsCode`, and update the error message accordingly. The explicit `manage` fallback preserves compatibility with older self-hosted backends that do not expose the newer `create` permission.

The per-type checks for charts, dashboards, alerts, and other resources are unchanged. Granular space and SQL denials remain server-side, where the CLI can report detailed per-file errors.

Relates: ZAP-551
