### PR TITLE
feat: support row fields in number formats

### DIFF
--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -2,6 +2,7 @@ import {
     DimensionType,
     FieldType,
     ItemsMap,
+    MetricType,
     type Dimension,
 } from '@lightdash/common';
 import * as fs from 'fs/promises';
@@ -196,6 +197,50 @@ $4.00,value_4,2020-03-16
 
         expect(csv).toEqual(['$1.00', 'value_1', '2020-03-16']);
     });
+
+    it('Should use row fields in formatted CSV values', () => {
+        const rowAwareItemMap: ItemsMap = {
+            orders_amount: {
+                fieldType: FieldType.METRIC,
+                type: MetricType.SUM,
+                name: 'amount',
+                label: 'Amount',
+                table: 'orders',
+                tableLabel: 'Orders',
+                sql: '${TABLE}.amount',
+                hidden: false,
+                format: '${ld.fields.orders_currency_symbol}#,##0.00',
+            },
+            orders_currency_symbol: {
+                fieldType: FieldType.DIMENSION,
+                type: DimensionType.STRING,
+                name: 'currency_symbol',
+                label: 'Currency symbol',
+                table: 'orders',
+                tableLabel: 'Orders',
+                sql: '${TABLE}.currency_symbol',
+                hidden: false,
+            },
+        };
+        const row = {
+            orders_amount: 1234.56,
+            orders_currency_symbol: '€',
+        };
+
+        expect(
+            CsvService.convertRowToCsv(row, rowAwareItemMap, false, [
+                'orders_amount',
+                'orders_currency_symbol',
+            ]),
+        ).toEqual(['€1,234.56', '€']);
+        expect(
+            CsvService.convertRowToCsv(row, rowAwareItemMap, true, [
+                'orders_amount',
+                'orders_currency_symbol',
+            ]),
+        ).toEqual([1234.56, '€']);
+    });
+
     it('Should convert RAW rows to csv', async () => {
         const row = {
             column_number: 1,

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -257,7 +257,15 @@ export class CsvService extends BaseService {
             if (onlyRaw) return data;
 
             // Use standard Lightdash formatting based on the item formatting configuration
-            return formatItemValue(item, data, undefined, undefined, timezone);
+            return formatItemValue(
+                item,
+                data,
+                undefined,
+                undefined,
+                timezone,
+                undefined,
+                row,
+            );
         });
     }
 

--- a/packages/common/src/index.test.ts
+++ b/packages/common/src/index.test.ts
@@ -1,11 +1,16 @@
 import moment from 'moment';
 import {
     DimensionType,
+    FieldType,
     formatRawValue,
+    formatRow,
     getDateGroupLabel,
     getFilterRuleFromFieldWithDefaultValue,
     getPasswordSchema,
     isValidEmailAddress,
+    MetricType,
+    VizAggregationOptions,
+    type ItemsMap,
 } from '.';
 import {
     dateDayDimension,
@@ -17,6 +22,97 @@ import {
 } from './index.mock';
 
 describe('Common index', () => {
+    describe('formatRow', () => {
+        test('makes current row fields available to format expressions', () => {
+            const itemsMap: ItemsMap = {
+                orders_amount: {
+                    fieldType: FieldType.METRIC,
+                    type: MetricType.SUM,
+                    name: 'amount',
+                    label: 'Amount',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.amount',
+                    hidden: false,
+                    format: '${ld.fields.orders_currency_symbol}${ld.parameters.unit=="M"?"#,##0.00,,\\"M\\"":"#,##0.00,\\"K\\""}',
+                },
+                orders_currency_symbol: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'currency_symbol',
+                    label: 'Currency symbol',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.currency_symbol',
+                    hidden: false,
+                },
+            };
+
+            const result = formatRow(
+                {
+                    orders_amount: 1_234_567,
+                    orders_currency_symbol: '€',
+                },
+                itemsMap,
+                undefined,
+                { unit: 'M' },
+            );
+
+            expect(result.orders_amount.value).toEqual({
+                raw: 1_234_567,
+                formatted: '€1.23M',
+            });
+        });
+
+        test('uses passthrough fields when formatting a pivot value', () => {
+            const itemsMap: ItemsMap = {
+                orders_amount: {
+                    fieldType: FieldType.METRIC,
+                    type: MetricType.SUM,
+                    name: 'amount',
+                    label: 'Amount',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.amount',
+                    hidden: false,
+                    format: '${ld.fields.orders_currency_symbol}#,##0.00',
+                },
+                orders_currency_symbol: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'currency_symbol',
+                    label: 'Currency symbol',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.currency_symbol',
+                    hidden: false,
+                },
+            };
+            const pivotColumn = 'orders_amount_completed';
+
+            const result = formatRow(
+                {
+                    [pivotColumn]: 1234.56,
+                    orders_currency_symbol: '$',
+                },
+                itemsMap,
+                {
+                    [pivotColumn]: {
+                        aggregation: VizAggregationOptions.ANY,
+                        pivotColumnName: pivotColumn,
+                        pivotValues: [],
+                        referenceField: 'orders_amount',
+                    },
+                },
+            );
+
+            expect(result[pivotColumn].value).toEqual({
+                raw: 1234.56,
+                formatted: '$1,234.56',
+            });
+        });
+    });
+
     describe('default values on filter rule', () => {
         // TODO mock some timezones
         test('should return right default day value', async () => {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -911,6 +911,8 @@ export function formatRow(
                     false,
                     parameters,
                     timezone,
+                    undefined,
+                    row,
                 ),
             },
         };

--- a/packages/common/src/utils/conditionalFormatExpressions.test.ts
+++ b/packages/common/src/utils/conditionalFormatExpressions.test.ts
@@ -293,4 +293,62 @@ describe('evaluateConditionalFormatExpression', () => {
             expect(result).toBe('Different');
         });
     });
+
+    describe('result row fields', () => {
+        it('should substitute a field value', () => {
+            const result = evaluateConditionalFormatExpression(
+                '${ld.fields.orders_currency_symbol}#,##0.00',
+                {},
+                { orders_currency_symbol: '£' },
+            );
+            expect(result).toBe('£#,##0.00');
+        });
+
+        it('should support the long field prefix', () => {
+            const result = evaluateConditionalFormatExpression(
+                '${lightdash.fields.orders_currency_symbol}#,##0.00',
+                {},
+                { orders_currency_symbol: '€' },
+            );
+            expect(result).toBe('€#,##0.00');
+        });
+
+        it('should unwrap a formatted result row value', () => {
+            const result = evaluateConditionalFormatExpression(
+                '${ld.fields.orders_currency_symbol}#,##0.00',
+                {},
+                {
+                    orders_currency_symbol: {
+                        value: { raw: '$', formatted: '$' },
+                    },
+                },
+            );
+            expect(result).toBe('$#,##0.00');
+        });
+
+        it('should use a field in a ternary condition', () => {
+            const result = evaluateConditionalFormatExpression(
+                '${ld.fields.orders_metric_format=="percent"?"#,##0.0%":"#,##0.00"}',
+                {},
+                { orders_metric_format: 'percent' },
+            );
+            expect(result).toBe('#,##0.0%');
+        });
+
+        it('should combine a field prefix with a parameter format', () => {
+            const result = evaluateConditionalFormatExpression(
+                '${ld.fields.orders_currency_symbol}${ld.parameters.unit=="M"?"#,##0.00,,\\"M\\"":"#,##0.00,\\"K\\""}',
+                { unit: 'M' },
+                { orders_currency_symbol: '$' },
+            );
+            expect(result).toBe('$#,##0.00,,"M"');
+        });
+
+        it('should leave a missing field reference unchanged', () => {
+            const result = evaluateConditionalFormatExpression(
+                '${ld.fields.orders_currency_symbol}#,##0.00',
+            );
+            expect(result).toBe('${ld.fields.orders_currency_symbol}#,##0.00');
+        });
+    });
 });

--- a/packages/common/src/utils/conditionalFormatExpressions.ts
+++ b/packages/common/src/utils/conditionalFormatExpressions.ts
@@ -1,5 +1,6 @@
 /**
  * Utilities for evaluating conditional expressions in format strings with parameters
+ * and values from the current result row.
  */
 
 import { LightdashParameters } from '../compiler/parameters';
@@ -23,6 +24,38 @@ function stripParameterPrefix(paramName: string): string {
     return paramName;
 }
 
+function stripFieldPrefix(fieldName: string): string | undefined {
+    const shortPrefix = 'ld.fields.';
+    const longPrefix = 'lightdash.fields.';
+
+    if (fieldName.startsWith(shortPrefix)) {
+        return fieldName.substring(shortPrefix.length);
+    }
+    if (fieldName.startsWith(longPrefix)) {
+        return fieldName.substring(longPrefix.length);
+    }
+    return undefined;
+}
+
+function getFieldValue(
+    fieldValues: Record<string, unknown>,
+    fieldName: string,
+): unknown {
+    const fieldValue = fieldValues[fieldName];
+    if (fieldValue !== null && typeof fieldValue === 'object') {
+        if ('value' in fieldValue) {
+            const { value } = fieldValue;
+            if (value !== null && typeof value === 'object' && 'raw' in value) {
+                return value.raw;
+            }
+        }
+        if ('raw' in fieldValue) {
+            return fieldValue.raw;
+        }
+    }
+    return fieldValue;
+}
+
 /**
  * Removes surrounding quotes from a string if present and handles escape sequences
  */
@@ -41,9 +74,10 @@ function removeQuotes(value: string): string {
 /**
  * Gets the value from either a parameter or a literal (quoted string)
  */
-function getConditionValue(
+function getExpressionValue(
     value: string,
     parameters: Record<string, unknown>,
+    fieldValues: Record<string, unknown>,
 ): unknown {
     // Check if it's a quoted string literal
     if (
@@ -51,6 +85,11 @@ function getConditionValue(
         (value.startsWith("'") && value.endsWith("'"))
     ) {
         return value.slice(1, -1);
+    }
+
+    const fieldName = stripFieldPrefix(value);
+    if (fieldName !== undefined) {
+        return getFieldValue(fieldValues, fieldName);
     }
 
     // Otherwise, treat as parameter name - strip ld.parameters. prefix if present
@@ -64,14 +103,15 @@ function getConditionValue(
 function evaluateCondition(
     condition: string,
     parameters: Record<string, unknown>,
+    fieldValues: Record<string, unknown>,
 ): boolean {
     // Check for != operator
     if (condition.includes('!=')) {
         const [left, right] = condition
             .split('!=')
             .map((s: string) => s.trim());
-        const leftValue = getConditionValue(left, parameters);
-        const rightValue = getConditionValue(right, parameters);
+        const leftValue = getExpressionValue(left, parameters, fieldValues);
+        const rightValue = getExpressionValue(right, parameters, fieldValues);
         return leftValue !== rightValue;
     }
 
@@ -80,13 +120,13 @@ function evaluateCondition(
         const [left, right] = condition
             .split('==')
             .map((s: string) => s.trim());
-        const leftValue = getConditionValue(left, parameters);
-        const rightValue = getConditionValue(right, parameters);
+        const leftValue = getExpressionValue(left, parameters, fieldValues);
+        const rightValue = getExpressionValue(right, parameters, fieldValues);
         return leftValue === rightValue;
     }
 
     // If no operator, treat as truthy check
-    const value = getConditionValue(condition, parameters);
+    const value = getExpressionValue(condition, parameters, fieldValues);
     return Boolean(value);
 }
 
@@ -133,6 +173,7 @@ function findIndexOutsideQuotes(str: string, searchChar: string): number {
 function evaluateTernaryExpression(
     expression: string,
     parameters: Record<string, unknown>,
+    fieldValues: Record<string, unknown>,
 ): string {
     // Find the ? operator outside of quotes
     const questionIndex = findIndexOutsideQuotes(expression, '?');
@@ -153,7 +194,11 @@ function evaluateTernaryExpression(
     const falseValue = valuesPart.substring(colonIndex + 1).trim();
 
     // Evaluate condition
-    const conditionResult = evaluateCondition(conditionPart, parameters);
+    const conditionResult = evaluateCondition(
+        conditionPart,
+        parameters,
+        fieldValues,
+    );
 
     // Return the appropriate value, removing quotes if present
     const result = conditionResult ? trueValue : falseValue;
@@ -166,10 +211,12 @@ function evaluateTernaryExpression(
  * Examples:
  *   - ${ld.parameters.currency=="USD"?"$":"€"}0,0.00
  *   - ${ld.parameters.prefix}0,0.00  (simple substitution still works)
+ *   - ${ld.fields.orders_currency_symbol}0,0.00
  */
 export function evaluateConditionalFormatExpression(
     formatString: string,
     parameters: Record<string, unknown> = {},
+    fieldValues: Record<string, unknown> = {},
 ): string {
     // Find all ${...} placeholders
     const placeholderRegex = /\$\{([^}]+)\}/g;
@@ -184,7 +231,17 @@ export function evaluateConditionalFormatExpression(
                 findIndexOutsideQuotes(trimmedExpr, '?') !== -1 &&
                 findIndexOutsideQuotes(trimmedExpr, ':') !== -1
             ) {
-                return evaluateTernaryExpression(trimmedExpr, parameters);
+                return evaluateTernaryExpression(
+                    trimmedExpr,
+                    parameters,
+                    fieldValues,
+                );
+            }
+
+            const fieldName = stripFieldPrefix(trimmedExpr);
+            if (fieldName !== undefined) {
+                const value = getFieldValue(fieldValues, fieldName);
+                return value !== undefined ? String(value) : match;
             }
 
             // Simple parameter substitution - strip ld.parameters. prefix if present

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -2907,6 +2907,48 @@ describe('Formatting', () => {
         });
     });
 
+    describe('formatItemValue with result row fields', () => {
+        const rowAwareMetric = {
+            ...metric,
+            type: MetricType.NUMBER,
+            format: '${ld.fields.orders_currency_symbol}${ld.parameters.unit=="M"?"#,##0.00,,\\"M\\"":"#,##0.00,\\"K\\""}',
+        };
+
+        it('should combine a row currency symbol with a parameter unit', () => {
+            expect(
+                formatItemValue(
+                    rowAwareMetric,
+                    1_234_567,
+                    false,
+                    { unit: 'M' },
+                    undefined,
+                    undefined,
+                    { orders_currency_symbol: '€' },
+                ),
+            ).toBe('€1.23M');
+
+            expect(
+                formatItemValue(
+                    rowAwareMetric,
+                    1_234_567,
+                    false,
+                    { unit: 'K' },
+                    undefined,
+                    undefined,
+                    { orders_currency_symbol: '$' },
+                ),
+            ).toBe('$1,234.57K');
+        });
+
+        it('should fall back to default formatting when the field is missing', () => {
+            expect(
+                formatItemValue(rowAwareMetric, 1_234_567, false, {
+                    unit: 'M',
+                }),
+            ).toBe('1,234,567');
+        });
+    });
+
     describe('timezone-aware formatting', () => {
         const utcTimestamp = '2020-04-04T02:00:00.000Z';
 

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -1203,6 +1203,7 @@ export function formatItemValue(
     parameters?: Record<string, unknown>,
     timezone?: string,
     displayTimezone?: string,
+    fieldValues?: Record<string, unknown>,
 ): string {
     if (value === null) return '∅';
     if (value === undefined) return '-';
@@ -1215,21 +1216,25 @@ export function formatItemValue(
             // numfmt otherwise renders with US separators regardless of locale.
             const separatorLocale = getFormatExpressionLocale(item);
 
-            // Check if format uses parameter placeholders
-            const hasParameterPlaceholders =
+            const hasDynamicPlaceholders =
                 item.format.includes(
                     `\${${LightdashParameters.PREFIX_SHORT}`,
-                ) || item.format.includes(`\${${LightdashParameters.PREFIX}`);
+                ) ||
+                item.format.includes(`\${${LightdashParameters.PREFIX}`) ||
+                item.format.includes('${ld.fields.') ||
+                item.format.includes('${lightdash.fields.');
 
-            // NEW: Handle parameter-based formats separately
-            if (hasParameterPlaceholders) {
-                // If parameters are provided, evaluate and apply the format
-                if (parameters) {
+            if (hasDynamicPlaceholders) {
+                if (parameters || fieldValues) {
                     const formatExpression =
                         evaluateConditionalFormatExpression(
                             item.format,
                             parameters,
+                            fieldValues,
                         );
+                    if (formatExpression.includes('${')) {
+                        return applyDefaultFormat(value);
+                    }
                     try {
                         const result = formatValueWithExpression(
                             formatExpression,

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -57,16 +57,33 @@ const formatBigNumberValue = (
     style: CompactOrAlias | undefined,
     parameters?: ParametersValuesMap,
     timezone?: string,
+    fieldValues?: Record<string, unknown>,
 ): string => {
     if (item !== undefined && isTableCalculation(item)) {
-        return formatItemValue(item, value, false, parameters, timezone);
+        return formatItemValue(
+            item,
+            value,
+            false,
+            parameters,
+            timezone,
+            undefined,
+            fieldValues,
+        );
     } else if (
         item !== undefined &&
         hasValidFormatExpression(item) &&
         // When a compact style is set, fall through so the style is applied
         !style
     ) {
-        return formatItemValue(item, value, false, parameters, timezone);
+        return formatItemValue(
+            item,
+            value,
+            false,
+            parameters,
+            timezone,
+            undefined,
+            fieldValues,
+        );
     } else if (item !== undefined && hasFormatOptions(item)) {
         // If the format has no explicit type but a compact style is set, treat
         // it as a number so the style can be applied
@@ -89,7 +106,15 @@ const formatBigNumberValue = (
     } else if (!style) {
         // No compact override: honour the field's full format (legacy compact,
         // separator, round), matching the results table
-        return formatItemValue(item, value, false, parameters, timezone);
+        return formatItemValue(
+            item,
+            value,
+            false,
+            parameters,
+            timezone,
+            undefined,
+            fieldValues,
+        );
     } else {
         const metricRound = isField(item) ? item.round : undefined;
         return applyCustomFormat(
@@ -112,6 +137,7 @@ const formatComparisonValue = (
     bigNumberComparisonStyle: CompactOrAlias | undefined,
     parameters?: ParametersValuesMap,
     timezone?: string,
+    fieldValues?: Record<string, unknown>,
 ) => {
     const prefix =
         comparisonDiff === ComparisonDiffTypes.POSITIVE ||
@@ -135,6 +161,7 @@ const formatComparisonValue = (
                 bigNumberComparisonStyle,
                 parameters,
                 timezone,
+                fieldValues,
             )}`;
     }
 };
@@ -306,6 +333,8 @@ const useBigNumberConfig = (
         return itemsMap[comparisonField] ?? item;
     }, [itemsMap, comparisonField, item]);
 
+    const firstRowFields = resultsData?.rows?.[0];
+
     // big number value (first row)
     const firstRowValueRaw = useMemo(() => {
         if (!selectedField || !resultsData) return;
@@ -336,7 +365,7 @@ const useBigNumberConfig = (
         if (!isNumber(item, firstRowValueRaw)) {
             return (
                 selectedField &&
-                resultsData?.rows?.[0]?.[selectedField]?.value.formatted
+                firstRowFields?.[selectedField]?.value.formatted
             );
         }
         return formatBigNumberValue(
@@ -345,14 +374,16 @@ const useBigNumberConfig = (
             bigNumberStyle,
             parameters,
             resultsData?.resolvedTimezone,
+            firstRowFields,
         );
     }, [
         item,
         firstRowValueRaw,
         selectedField,
         bigNumberStyle,
-        resultsData,
+        resultsData?.resolvedTimezone,
         parameters,
+        firstRowFields,
     ]);
 
     const unformattedValue = useMemo(() => {
@@ -405,6 +436,7 @@ const useBigNumberConfig = (
                   bigNumberComparisonStyle,
                   parameters,
                   resultsData?.resolvedTimezone,
+                  firstRowFields,
               );
     }, [
         comparisonFormat,
@@ -415,6 +447,7 @@ const useBigNumberConfig = (
         bigNumberComparisonStyle,
         parameters,
         resultsData?.resolvedTimezone,
+        firstRowFields,
     ]);
 
     const comparisonTooltip = useMemo(() => {

--- a/packages/frontend/src/hooks/useColumns.test.tsx
+++ b/packages/frontend/src/hooks/useColumns.test.tsx
@@ -672,4 +672,56 @@ describe('formatCellContent - Parameter-based formatting', () => {
             '¥5,000.75',
         );
     });
+
+    test('should combine a result row field with a parameter format', () => {
+        const mockItem = {
+            name: 'revenue',
+            table: 'orders',
+            fieldType: FieldType.METRIC,
+            type: MetricType.SUM,
+            label: 'Revenue',
+            sql: 'revenue',
+            tableLabel: 'Orders',
+            hidden: false,
+            format: '${ld.fields.orders_currency_symbol}${ld.parameters.unit=="M"?"#,##0.00,,\\"M\\"":"#,##0.00,\\"K\\""}',
+        };
+        const data = {
+            value: { raw: 2_815_413.64, formatted: '2,815,413.64' },
+        };
+        const row: ResultRow = {
+            orders_currency_symbol: {
+                value: { raw: '€', formatted: '€' },
+            },
+        };
+
+        expect(formatCellContent(data, mockItem, { unit: 'M' }, row)).toBe(
+            '€2.82M',
+        );
+    });
+
+    test('should support a result row field without parameters', () => {
+        const mockItem = {
+            name: 'revenue',
+            table: 'orders',
+            fieldType: FieldType.METRIC,
+            type: MetricType.SUM,
+            label: 'Revenue',
+            sql: 'revenue',
+            tableLabel: 'Orders',
+            hidden: false,
+            format: '${ld.fields.orders_currency_symbol}#,##0.00',
+        };
+        const data = {
+            value: { raw: 1234.56, formatted: '1,234.56' },
+        };
+        const row: ResultRow = {
+            orders_currency_symbol: {
+                value: { raw: '$', formatted: '$' },
+            },
+        };
+
+        expect(formatCellContent(data, mockItem, undefined, row)).toBe(
+            '$1,234.56',
+        );
+    });
 });

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -79,20 +79,31 @@ export const formatCellContent = (
     data?: { value: ResultValue },
     item?: Field | AdditionalMetric | TableCalculation | CustomDimension,
     parameters?: ParametersValuesMap,
+    fieldValues?: ResultRow,
 ) => {
     if (!data) return '-';
 
-    // Only re-format on frontend when there are parameters and the format uses them
-    // Otherwise, use the pre-formatted value from backend
-    const hasParameterFormat =
+    // Re-format dynamic expressions with the current parameter and row values.
+    // Otherwise, use the pre-formatted value from the backend.
+    const hasDynamicFormat =
         item &&
         'format' in item &&
         typeof item.format === 'string' &&
         (item.format.includes('${ld.parameters') ||
-            item.format.includes('${lightdash.parameters'));
+            item.format.includes('${lightdash.parameters') ||
+            item.format.includes('${ld.fields.') ||
+            item.format.includes('${lightdash.fields.'));
 
-    if (hasParameterFormat && parameters) {
-        return formatItemValue(item, data.value.raw, false, parameters);
+    if (hasDynamicFormat && (parameters || fieldValues)) {
+        return formatItemValue(
+            item,
+            data.value.raw,
+            false,
+            parameters,
+            undefined,
+            undefined,
+            fieldValues,
+        );
     }
 
     // Use backend-formatted value by default
@@ -115,6 +126,7 @@ export const formatResultsTableCell = (
         | undefined,
     parameters: ParametersValuesMap | undefined,
     timezone: string | undefined,
+    fieldValues?: ResultRow,
 ): string => {
     if (!data) return '-';
 
@@ -126,7 +138,15 @@ export const formatResultsTableCell = (
         return data.value.formatted;
     }
 
-    return formatItemValue(item, data.value.raw, false, parameters, timezone);
+    return formatItemValue(
+        item,
+        data.value.raw,
+        false,
+        parameters,
+        timezone,
+        undefined,
+        fieldValues,
+    );
 };
 
 const getResultJsonCellValue = (
@@ -187,7 +207,12 @@ const formatBarDisplayCell = (
 
         // Only render bar if value is a valid number
         if (Number.isNaN(value)) {
-            return formatCellContent(cellValue, item, parameters);
+            return formatCellContent(
+                cellValue,
+                item,
+                parameters,
+                info.row.original as ResultRow,
+            );
         }
     } else {
         value = Number(cellValue);
@@ -204,7 +229,12 @@ const formatBarDisplayCell = (
     if (!minMax) {
         // Handle both ResultRow and RawResultRow formats
         if (isResultValue(cellValue)) {
-            return formatCellContent(cellValue, item, parameters);
+            return formatCellContent(
+                cellValue,
+                item,
+                parameters,
+                info.row.original as ResultRow,
+            );
         } else {
             // For raw string values, return formatted value
             return <span>{formatted}</span>;
@@ -425,7 +455,7 @@ export const getFormattedValueCell = (
         }
     }
 
-    return formatCellContent(cellValue, item, parameters);
+    return formatCellContent(cellValue, item, parameters, info.row.original);
 };
 
 const getJsonFormattedValueCell = (
@@ -684,6 +714,7 @@ export const useColumns = (): TableColumn[] => {
                             info.column.columnDef.meta?.item,
                             parameters,
                             timezone,
+                            info.row.original,
                         );
                     },
                     footer: () => {


### PR DESCRIPTION
## Summary

- Allow custom number format expressions to resolve result-row fields through `${ld.fields.<field_id>}` and `${lightdash.fields.<field_id>}`.
- Pass row context through backend formatting, result tables, pivot tables, big-number cards, and formatted CSV exports.
- Preserve raw numeric values and raw CSV output.
- Fall back to default numeric formatting when a referenced field or parameter is unavailable.

## Example

```yaml
format: "${ld.fields.orders_currency_symbol}${ld.parameters.financial_display_unit==\"M\"?\"#,##0.00,,\\\"M\\\"\":\"#,##0.00,\\\"K\\\"\"}"
```

The referenced field must be selected by the query. Hidden table dimensions continue through the existing pivot passthrough path, so they can supply formatting metadata without rendering as columns.

## Validation

- Common row-expression tests: 74 passed.
- Common numeric-format tests: 2 passed.
- Frontend table-format tests: 9 passed.
- Backend formatted/raw CSV tests: passed.
- Common, backend, and frontend fast typechecks: passed.
- Targeted common, backend, and frontend lint: passed.

A broad common test run also exposed an unrelated host-ICU difference for COP and HUF decimal defaults; the tests added by this change pass independently.