### PR TITLE
feat: add groups as organization content as code

### DIFF
--- a/docs/content-as-code.md
+++ b/docs/content-as-code.md
@@ -231,6 +231,43 @@ promotions are processed before admin demotions or disables, and the backend
 rejects any individual operation that would leave the organization without an
 enabled authenticated admin.
 
+## Groups
+
+Organization groups are stored under `lightdash/groups/*.yml`:
+
+```yaml
+version: 1
+name: Finance
+members:
+  - alice@example.com
+  - bob@example.com
+```
+
+The endpoints are:
+
+- `GET /api/v2/orgs/{orgUuid}/groups/code`
+- `POST /api/v2/orgs/{orgUuid}/groups/code`
+
+The exact, case-sensitive group name is the portable identity. Upload creates a
+missing group or replaces the complete membership of an existing group. Every
+member email must resolve to the primary email of a non-internal user in the
+destination organization before any mutation begins. Empty membership is
+represented explicitly as `members: []`.
+
+Group files intentionally exclude UUIDs, project roles, space access, AI-agent
+access, user attributes, and ownership metadata. Changing the name creates a
+new group and leaves the original group intact; missing files do not delete
+groups.
+
+Organization uploads run dependency phases sequentially: custom roles, then
+users, then groups. A failed phase prevents every dependent phase from
+starting, so group emails are resolved only after the complete users phase has
+succeeded.
+
+SCIM and content as code should not manage the same group. Groups do not yet
+record management provenance, so this limitation cannot be enforced by the
+first version.
+
 ## Adding another content-as-code resource
 
 Use this sequence when adding a new resource:

--- a/packages/backend/src/database/entities/groups.ts
+++ b/packages/backend/src/database/entities/groups.ts
@@ -15,9 +15,8 @@ type DbGroupCreate = Pick<
     'organization_id' | 'name' | 'created_by_user_uuid' | 'updated_by_user_uuid'
 > &
     Partial<Pick<DbGroup, 'group_uuid'>>;
-type DbGroupUpdate = Pick<
-    DbGroup,
-    'name' | 'updated_at' | 'updated_by_user_uuid'
+type DbGroupUpdate = Partial<
+    Pick<DbGroup, 'name' | 'updated_at' | 'updated_by_user_uuid'>
 >;
 
 export const GroupTableName = 'groups';

--- a/packages/backend/src/ee/controllers/OrganizationGroupsAsCodeController.ts
+++ b/packages/backend/src/ee/controllers/OrganizationGroupsAsCodeController.ts
@@ -1,0 +1,74 @@
+import {
+    ApiErrorPayload,
+    ApiGroupAsCodeListResponse,
+    ApiGroupAsCodeUpsertResponse,
+    GroupAsCode,
+} from '@lightdash/common';
+import {
+    Body,
+    Get,
+    Middlewares,
+    OperationId,
+    Path,
+    Post,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+
+@Route('/api/v2/orgs/{orgUuid}/groups')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('v2', 'Organizations')
+export class OrganizationGroupsAsCodeController extends BaseController {
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/code')
+    @OperationId('GetOrganizationGroupsAsCode')
+    async getGroupsAsCode(
+        @Request() req: express.Request,
+        @Path() orgUuid: string,
+    ): Promise<ApiGroupAsCodeListResponse> {
+        const groups = await this.services
+            .getGroupService()
+            .getGroupsAsCode(req.account!, orgUuid);
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: { groups },
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/code')
+    @OperationId('UpsertOrganizationGroupAsCode')
+    async upsertGroupAsCode(
+        @Request() req: express.Request,
+        @Path() orgUuid: string,
+        @Body() body: GroupAsCode,
+    ): Promise<ApiGroupAsCodeUpsertResponse> {
+        const results = await this.services
+            .getGroupService()
+            .upsertGroupAsCode(req.account!, orgUuid, body);
+
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -161,6 +161,8 @@ import { ManagedAgentController } from './../ee/controllers/managedAgentControll
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { OrganizationDomainVerificationController } from './../ee/controllers/OrganizationDomainVerificationController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { OrganizationGroupsAsCodeController } from './../ee/controllers/OrganizationGroupsAsCodeController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { OrganizationSsoController } from './../ee/controllers/OrganizationSsoController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { OrganizationUsersAsCodeController } from './../ee/controllers/OrganizationUsersAsCodeController';
@@ -15500,17 +15502,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -15539,6 +15541,29 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
                                                                                                 requiredFilters:
                                                                                                     {
                                                                                                         dataType:
@@ -15577,18 +15602,6 @@ const models: TsoaRoute.Models = {
                                                                                                                                             },
                                                                                                                                         ],
                                                                                                                                 },
-                                                                                                                                required:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'boolean',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                tableName:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
                                                                                                                                 fieldRef:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -15601,37 +15614,26 @@ const models: TsoaRoute.Models = {
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
+                                                                                                                                tableName:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
                                                                                                                                 operator:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
+                                                                                                                                required:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'boolean',
+                                                                                                                                        required: true,
+                                                                                                                                    },
                                                                                                                             },
                                                                                                                     },
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -22669,6 +22671,71 @@ const models: TsoaRoute.Models = {
     UpsertGoogleSsoConfig: {
         dataType: 'refAlias',
         type: { ref: 'Partial_OrganizationSsoMethodFlags_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    GroupAsCode: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                members: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+                version: { dataType: 'enum', enums: [1], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiGroupAsCodeListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        groups: {
+                            dataType: 'array',
+                            array: { dataType: 'refAlias', ref: 'GroupAsCode' },
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiGroupAsCodeUpsertResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        action: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'PromotionAction.CREATE' },
+                                { ref: 'PromotionAction.UPDATE' },
+                                { ref: 'PromotionAction.NO_CHANGES' },
+                            ],
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     VerifiedDomain: {
@@ -34739,7 +34806,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34749,7 +34816,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -34759,7 +34826,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -34772,7 +34839,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -35441,7 +35508,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -35451,7 +35518,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -35461,7 +35528,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -35474,7 +35541,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -60544,6 +60611,129 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationGroupsAsCodeController_getGroupsAsCode: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        orgUuid: {
+            in: 'path',
+            name: 'orgUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v2/orgs/:orgUuid/groups/code',
+        ...fetchMiddlewares<RequestHandler>(OrganizationGroupsAsCodeController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationGroupsAsCodeController.prototype.getGroupsAsCode,
+        ),
+
+        async function OrganizationGroupsAsCodeController_getGroupsAsCode(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationGroupsAsCodeController_getGroupsAsCode,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationGroupsAsCodeController>(
+                        OrganizationGroupsAsCodeController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getGroupsAsCode',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationGroupsAsCodeController_upsertGroupAsCode: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        orgUuid: {
+            in: 'path',
+            name: 'orgUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: { in: 'body', name: 'body', required: true, ref: 'GroupAsCode' },
+    };
+    app.post(
+        '/api/v2/orgs/:orgUuid/groups/code',
+        ...fetchMiddlewares<RequestHandler>(OrganizationGroupsAsCodeController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationGroupsAsCodeController.prototype.upsertGroupAsCode,
+        ),
+
+        async function OrganizationGroupsAsCodeController_upsertGroupAsCode(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationGroupsAsCodeController_upsertGroupAsCode,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationGroupsAsCodeController>(
+                        OrganizationGroupsAsCodeController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'upsertGroupAsCode',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
                 });
             } catch (err) {
                 return next(err);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -17037,10 +17037,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -17049,8 +17049,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -17060,6 +17060,11 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "requiredFilters": {
                                                                             "items": {
                                                                                 "properties": {
@@ -17068,37 +17073,32 @@
                                                                                         "items": {},
                                                                                         "type": "array"
                                                                                     },
-                                                                                    "required": {
-                                                                                        "type": "boolean"
-                                                                                    },
-                                                                                    "tableName": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "fieldRef": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "fieldId": {
                                                                                         "type": "string"
                                                                                     },
+                                                                                    "tableName": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "operator": {
                                                                                         "type": "string"
+                                                                                    },
+                                                                                    "required": {
+                                                                                        "type": "boolean"
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "required",
-                                                                                    "tableName",
                                                                                     "fieldRef",
                                                                                     "fieldId",
-                                                                                    "operator"
+                                                                                    "tableName",
+                                                                                    "operator",
+                                                                                    "required"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
                                                                             "type": "array"
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
                                                                         },
                                                                         "joinedTables": {
                                                                             "items": {
@@ -23044,6 +23044,79 @@
             },
             "UpsertGoogleSsoConfig": {
                 "$ref": "#/components/schemas/Partial_OrganizationSsoMethodFlags_"
+            },
+            "GroupAsCode": {
+                "properties": {
+                    "members": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "version": {
+                        "type": "number",
+                        "enum": [1],
+                        "nullable": false
+                    }
+                },
+                "required": ["members", "name", "version"],
+                "type": "object"
+            },
+            "ApiGroupAsCodeListResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "groups": {
+                                "items": {
+                                    "$ref": "#/components/schemas/GroupAsCode"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["groups"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiGroupAsCodeUpsertResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "action": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/PromotionAction.CREATE"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PromotionAction.UPDATE"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PromotionAction.NO_CHANGES"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["action"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
             },
             "VerifiedDomain": {
                 "properties": {
@@ -35203,22 +35276,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -35786,22 +35859,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -53467,6 +53540,92 @@
                 "tags": ["Organizations"],
                 "security": [],
                 "parameters": []
+            }
+        },
+        "/api/v2/orgs/{orgUuid}/groups/code": {
+            "get": {
+                "operationId": "GetOrganizationGroupsAsCode",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGroupAsCodeListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["v2", "Organizations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "orgUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "UpsertOrganizationGroupAsCode",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGroupAsCodeUpsertResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["v2", "Organizations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "orgUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/GroupAsCode"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/org/domains": {

--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -11,6 +11,7 @@ import {
     ParameterError,
     ProjectGroupAccess,
     ProjectMemberRole,
+    PromotionAction,
     UnexpectedDatabaseError,
     UpdateGroupWithMembers,
     type KnexPaginateArgs,
@@ -27,6 +28,7 @@ import {
     GroupMembershipTableName,
 } from '../database/entities/groupMemberships';
 import { DbGroup, GroupTableName } from '../database/entities/groups';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import {
     OrganizationTableName,
     type DbOrganization,
@@ -618,6 +620,162 @@ export class GroupsModel {
             }
         });
         return this.getGroupWithMembers(groupUuid, 10000);
+    }
+
+    async upsertGroupAsCode({
+        organizationUuid,
+        name,
+        memberEmails,
+        actorUserUuid,
+    }: {
+        organizationUuid: string;
+        name: string;
+        memberEmails: string[];
+        actorUserUuid: string;
+    }): Promise<{
+        action:
+            | PromotionAction.CREATE
+            | PromotionAction.UPDATE
+            | PromotionAction.NO_CHANGES;
+        groupUuid: string;
+    }> {
+        return this.database.transaction(async (trx) => {
+            const organization = await trx(OrganizationTableName)
+                .where('organization_uuid', organizationUuid)
+                .first('organization_id');
+            if (!organization) {
+                throw new NotFoundError('Cannot find organization');
+            }
+
+            const normalizedEmails = memberEmails.map((email) =>
+                email.toLowerCase(),
+            );
+            const members =
+                normalizedEmails.length === 0
+                    ? []
+                    : await trx(UserTableName)
+                          .innerJoin(
+                              OrganizationMembershipsTableName,
+                              `${UserTableName}.user_id`,
+                              `${OrganizationMembershipsTableName}.user_id`,
+                          )
+                          .innerJoin(
+                              EmailTableName,
+                              `${UserTableName}.user_id`,
+                              `${EmailTableName}.user_id`,
+                          )
+                          .where(
+                              `${OrganizationMembershipsTableName}.organization_id`,
+                              organization.organization_id,
+                          )
+                          .where(`${UserTableName}.is_internal`, false)
+                          .where(`${EmailTableName}.is_primary`, true)
+                          .whereRaw(`LOWER(??) = ANY(?::text[])`, [
+                              `${EmailTableName}.email`,
+                              normalizedEmails,
+                          ])
+                          .select<
+                              Array<
+                                  Pick<DbUser, 'user_id'> &
+                                      Pick<DbEmail, 'email'>
+                              >
+                          >(
+                              `${UserTableName}.user_id`,
+                              `${EmailTableName}.email`,
+                          );
+
+            const resolvedEmails = new Set(
+                members.map((member) => member.email.toLowerCase()),
+            );
+            const unresolvedEmails = normalizedEmails.filter(
+                (email) => !resolvedEmails.has(email),
+            );
+            if (unresolvedEmails.length > 0) {
+                throw new ParameterError(
+                    `Users are not members of this organization: ${unresolvedEmails.join(', ')}`,
+                );
+            }
+
+            const existingGroup = await trx(GroupTableName)
+                .where({
+                    organization_id: organization.organization_id,
+                    name,
+                })
+                .first<Pick<DbGroup, 'group_uuid'>>('group_uuid');
+
+            if (!existingGroup) {
+                const [createdGroup] = await trx(GroupTableName)
+                    .insert({
+                        organization_id: organization.organization_id,
+                        name,
+                        created_by_user_uuid: actorUserUuid,
+                        updated_by_user_uuid: actorUserUuid,
+                    })
+                    .returning<Pick<DbGroup, 'group_uuid'>[]>('group_uuid');
+                if (!createdGroup) {
+                    throw new UnexpectedDatabaseError('Failed to create group');
+                }
+                if (members.length > 0) {
+                    await trx(GroupMembershipTableName).insert(
+                        members.map((member) => ({
+                            group_uuid: createdGroup.group_uuid,
+                            user_id: member.user_id,
+                            organization_id: organization.organization_id,
+                        })),
+                    );
+                }
+                return {
+                    action: PromotionAction.CREATE,
+                    groupUuid: createdGroup.group_uuid,
+                };
+            }
+
+            const existingMemberships = await trx(GroupMembershipTableName)
+                .where('group_uuid', existingGroup.group_uuid)
+                .select<Pick<DbGroupMembership, 'user_id'>[]>('user_id');
+            const existingUserIds = existingMemberships
+                .map((membership) => membership.user_id)
+                .sort((left, right) => left - right);
+            const desiredUserIds = members
+                .map((member) => member.user_id)
+                .sort((left, right) => left - right);
+            const membershipChanged =
+                existingUserIds.length !== desiredUserIds.length ||
+                existingUserIds.some(
+                    (userId, index) => userId !== desiredUserIds[index],
+                );
+
+            if (!membershipChanged) {
+                return {
+                    action: PromotionAction.NO_CHANGES,
+                    groupUuid: existingGroup.group_uuid,
+                };
+            }
+
+            await trx(GroupMembershipTableName)
+                .where('group_uuid', existingGroup.group_uuid)
+                .delete();
+            if (members.length > 0) {
+                await trx(GroupMembershipTableName).insert(
+                    members.map((member) => ({
+                        group_uuid: existingGroup.group_uuid,
+                        user_id: member.user_id,
+                        organization_id: organization.organization_id,
+                    })),
+                );
+            }
+            await trx(GroupTableName)
+                .where('group_uuid', existingGroup.group_uuid)
+                .update({
+                    updated_at: new Date(),
+                    updated_by_user_uuid: actorUserUuid,
+                });
+
+            return {
+                action: PromotionAction.UPDATE,
+                groupUuid: existingGroup.group_uuid,
+            };
+        });
     }
 
     async addProjectAccess({

--- a/packages/backend/src/services/GroupService.test.ts
+++ b/packages/backend/src/services/GroupService.test.ts
@@ -1,0 +1,205 @@
+import { Ability } from '@casl/ability';
+import {
+    PromotionAction,
+    type Account,
+    type GroupAsCode,
+    type PossibleAbilities,
+} from '@lightdash/common';
+import { GroupsService } from './GroupService';
+
+const createAuthentication = (
+    authenticationType: 'session' | 'pat' | 'service-account',
+) => {
+    if (authenticationType === 'service-account') {
+        return {
+            type: 'service-account' as const,
+            source: 'service-account-token',
+            serviceAccountUuid: 'service-account-uuid',
+            serviceAccountDescription: 'CI',
+        };
+    }
+    if (authenticationType === 'pat') {
+        return { type: 'pat' as const, source: 'pat-token' };
+    }
+    return { type: 'session' as const, source: 'session-cookie' };
+};
+
+const createAccount = (
+    authenticationType: 'session' | 'pat' | 'service-account' = 'session',
+    canManageGroups: boolean = true,
+): Account =>
+    ({
+        authentication: createAuthentication(authenticationType),
+        user: {
+            type: 'registered',
+            userUuid: 'actor-user-uuid',
+            ability: new Ability<PossibleAbilities>(
+                canManageGroups
+                    ? [
+                          {
+                              action: 'manage',
+                              subject: 'Group',
+                              conditions: {
+                                  organizationUuid: 'organization-uuid',
+                              },
+                          },
+                      ]
+                    : [],
+            ),
+        },
+        organization: {
+            organizationUuid: 'organization-uuid',
+            name: 'Organization',
+            createdAt: new Date('2026-01-01'),
+        },
+        isAuthenticated: () => true,
+        isRegisteredUser: () => true,
+        isAnonymousUser: () => false,
+        isSessionUser: () => authenticationType === 'session',
+        isJwtUser: () => false,
+        isServiceAccount: () => authenticationType === 'service-account',
+        isPatUser: () => authenticationType === 'pat',
+        isOauthUser: () => false,
+    }) as Account;
+
+describe('GroupsService groups as code', () => {
+    const analytics = { track: vi.fn() };
+    const groupsModel = {
+        find: vi.fn(),
+        findGroupMembers: vi.fn(),
+        upsertGroupAsCode: vi.fn(),
+    };
+    const featureFlagService = {
+        get: vi.fn().mockResolvedValue({ enabled: true }),
+    };
+    const service = new GroupsService({
+        analytics: analytics as never,
+        groupsModel: groupsModel as never,
+        projectModel: {} as never,
+        featureFlagService: featureFlagService as never,
+    });
+    const group = (overrides: Partial<GroupAsCode> = {}): GroupAsCode => ({
+        version: 1,
+        name: 'Finance',
+        members: ['analyst@example.com'],
+        ...overrides,
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        featureFlagService.get.mockResolvedValue({ enabled: true });
+        groupsModel.upsertGroupAsCode.mockResolvedValue({
+            action: PromotionAction.NO_CHANGES,
+            groupUuid: 'group-uuid',
+        });
+    });
+
+    it('downloads deterministic groups including empty groups', async () => {
+        groupsModel.find.mockResolvedValue({
+            data: [
+                { uuid: 'group-z', name: 'Zeta' },
+                { uuid: 'group-a', name: 'Alpha' },
+            ],
+        });
+        groupsModel.findGroupMembers.mockResolvedValue({
+            data: [
+                { groupUuid: 'group-z', email: 'z@example.com' },
+                { groupUuid: 'group-z', email: 'A@example.com' },
+            ],
+        });
+
+        await expect(
+            service.getGroupsAsCode(createAccount(), 'organization-uuid'),
+        ).resolves.toStrictEqual([
+            { version: 1, name: 'Alpha', members: [] },
+            {
+                version: 1,
+                name: 'Zeta',
+                members: ['a@example.com', 'z@example.com'],
+            },
+        ]);
+    });
+
+    it.each(['pat', 'service-account'] as const)(
+        'supports %s authorization through the account path',
+        async (authenticationType) => {
+            groupsModel.upsertGroupAsCode.mockResolvedValue({
+                action: PromotionAction.CREATE,
+                groupUuid: 'group-uuid',
+            });
+
+            await expect(
+                service.upsertGroupAsCode(
+                    createAccount(authenticationType),
+                    'organization-uuid',
+                    group({
+                        members: ['SECOND@example.com', 'first@example.com'],
+                    }),
+                ),
+            ).resolves.toStrictEqual({ action: PromotionAction.CREATE });
+            expect(groupsModel.upsertGroupAsCode).toHaveBeenCalledWith({
+                organizationUuid: 'organization-uuid',
+                name: 'Finance',
+                memberEmails: ['first@example.com', 'second@example.com'],
+                actorUserUuid: 'actor-user-uuid',
+            });
+        },
+    );
+
+    it('rejects unknown fields, untrimmed names, and duplicate emails', async () => {
+        await expect(
+            service.upsertGroupAsCode(createAccount(), 'organization-uuid', {
+                ...group(),
+                extra: true,
+            } as GroupAsCode),
+        ).rejects.toThrow('Unknown group fields: extra');
+        await expect(
+            service.upsertGroupAsCode(
+                createAccount(),
+                'organization-uuid',
+                group({ name: ' Finance ' }),
+            ),
+        ).rejects.toThrow('must not have surrounding whitespace');
+        await expect(
+            service.upsertGroupAsCode(
+                createAccount(),
+                'organization-uuid',
+                group({
+                    members: ['person@example.com', 'PERSON@example.com'],
+                }),
+            ),
+        ).rejects.toThrow('Duplicate group member emails');
+        expect(groupsModel.upsertGroupAsCode).not.toHaveBeenCalled();
+    });
+
+    it('rejects cross-organization access and accounts without manage Group', async () => {
+        await expect(
+            service.upsertGroupAsCode(
+                createAccount(),
+                'different-organization',
+                group(),
+            ),
+        ).rejects.toThrow();
+        await expect(
+            service.upsertGroupAsCode(
+                createAccount('session', false),
+                'organization-uuid',
+                group(),
+            ),
+        ).rejects.toThrow();
+        expect(groupsModel.upsertGroupAsCode).not.toHaveBeenCalled();
+    });
+
+    it('respects the existing groups feature flag', async () => {
+        featureFlagService.get.mockResolvedValueOnce({ enabled: false });
+
+        await expect(
+            service.upsertGroupAsCode(
+                createAccount(),
+                'organization-uuid',
+                group(),
+            ),
+        ).rejects.toThrow('Group service is not enabled');
+        expect(groupsModel.upsertGroupAsCode).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/services/GroupService.ts
+++ b/packages/backend/src/services/GroupService.ts
@@ -1,16 +1,24 @@
 import { subject } from '@casl/ability';
 import {
+    Account,
+    ApiGroupAsCodeUpsertResponse,
+    assertRegisteredAccount,
     FeatureFlags,
     ForbiddenError,
     Group,
+    GroupAsCode,
     GroupMember,
     GroupMembership,
     GroupWithMembers,
     LightdashUser,
+    ParameterError,
     ProjectGroupAccess,
     ProjectMemberRole,
+    PromotionAction,
+    RegisteredAccount,
     SessionUser,
     UpdateGroupWithMembers,
+    validateEmail,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { UpdateDBProjectGroupAccess } from '../database/entities/projectGroupAccess';
@@ -41,6 +49,157 @@ export class GroupsService extends BaseService {
         this.groupsModel = args.groupsModel;
         this.projectModel = args.projectModel;
         this.featureFlagService = args.featureFlagService;
+    }
+
+    private validateGroupsAsCodeAccess(
+        account: Account,
+        organizationUuid: string,
+    ): asserts account is RegisteredAccount {
+        assertRegisteredAccount(account);
+        if (account.organization.organizationUuid !== organizationUuid) {
+            throw new ForbiddenError();
+        }
+        const auditedAbility = this.createAuditedAbility(account);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('Group', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+    }
+
+    private static validateGroupAsCode(group: GroupAsCode): GroupAsCode {
+        if (
+            typeof group !== 'object' ||
+            group === null ||
+            Array.isArray(group)
+        ) {
+            throw new ParameterError('Group as code must be an object');
+        }
+        const unknownKeys = Object.keys(group).filter(
+            (key) => !['version', 'name', 'members'].includes(key),
+        );
+        if (unknownKeys.length > 0) {
+            throw new ParameterError(
+                `Unknown group fields: ${unknownKeys.sort().join(', ')}`,
+            );
+        }
+        if (group.version !== 1) {
+            throw new ParameterError(
+                `Unsupported group as-code version ${group.version}`,
+            );
+        }
+        if (
+            typeof group.name !== 'string' ||
+            group.name.length === 0 ||
+            group.name !== group.name.trim()
+        ) {
+            throw new ParameterError(
+                'Group name must be non-empty and must not have surrounding whitespace',
+            );
+        }
+        if (!Array.isArray(group.members)) {
+            throw new ParameterError('Group members must be an array');
+        }
+        const normalizedMembers = group.members.map((email) => {
+            if (typeof email !== 'string' || !validateEmail(email)) {
+                throw new ParameterError(
+                    `Invalid group member email: ${email}`,
+                );
+            }
+            return email.toLowerCase();
+        });
+        const duplicateEmails = normalizedMembers.filter(
+            (email, index) => normalizedMembers.indexOf(email) !== index,
+        );
+        if (duplicateEmails.length > 0) {
+            throw new ParameterError(
+                `Duplicate group member emails: ${[...new Set(duplicateEmails)]
+                    .sort()
+                    .join(', ')}`,
+            );
+        }
+        return {
+            version: 1,
+            name: group.name,
+            members: normalizedMembers.sort(),
+        };
+    }
+
+    async getGroupsAsCode(
+        account: Account,
+        organizationUuid: string,
+    ): Promise<GroupAsCode[]> {
+        this.validateGroupsAsCodeAccess(account, organizationUuid);
+        if (!(await this.isGroupServiceEnabled(account.user))) {
+            throw new ForbiddenError('Group service is not enabled');
+        }
+
+        const { data: groups } = await this.groupsModel.find({
+            organizationUuid,
+        });
+        const { data: members } = await this.groupsModel.findGroupMembers({
+            organizationUuid,
+            groupUuids: groups.map((group) => group.uuid),
+        });
+        const membersByGroupUuid = members.reduce<Map<string, string[]>>(
+            (map, member) => {
+                const groupMembers = map.get(member.groupUuid) ?? [];
+                groupMembers.push(member.email.toLowerCase());
+                map.set(member.groupUuid, groupMembers);
+                return map;
+            },
+            new Map(),
+        );
+
+        return groups
+            .map((group) => ({
+                version: 1 as const,
+                name: group.name,
+                members: (membersByGroupUuid.get(group.uuid) ?? []).sort(),
+            }))
+            .sort((left, right) => left.name.localeCompare(right.name));
+    }
+
+    async upsertGroupAsCode(
+        account: Account,
+        organizationUuid: string,
+        groupInput: GroupAsCode,
+    ): Promise<ApiGroupAsCodeUpsertResponse['results']> {
+        this.validateGroupsAsCodeAccess(account, organizationUuid);
+        if (!(await this.isGroupServiceEnabled(account.user))) {
+            throw new ForbiddenError('Group service is not enabled');
+        }
+
+        const group = GroupsService.validateGroupAsCode(groupInput);
+        const result = await this.groupsModel.upsertGroupAsCode({
+            organizationUuid,
+            name: group.name,
+            memberEmails: group.members,
+            actorUserUuid: account.user.userUuid,
+        });
+
+        if (result.action !== PromotionAction.NO_CHANGES) {
+            this.analytics.track({
+                userId: account.user.userUuid,
+                event:
+                    result.action === PromotionAction.CREATE
+                        ? 'group.created'
+                        : 'group.updated',
+                properties: {
+                    organizationId: organizationUuid,
+                    groupId: result.groupUuid,
+                    name: group.name,
+                    countUsersInGroup: group.members.length,
+                    viaSso: false,
+                    context: 'content_as_code',
+                },
+            });
+        }
+
+        return { action: result.action };
     }
 
     private async isGroupServiceEnabled(

--- a/packages/cli/src/handlers/organizationContent/customRoles.ts
+++ b/packages/cli/src/handlers/organizationContent/customRoles.ts
@@ -7,14 +7,12 @@ import {
     ParameterError,
     PromotionAction,
 } from '@lightdash/common';
-import { createHash } from 'crypto';
 import { Dirent, promises as fs } from 'fs';
 import * as yaml from 'js-yaml';
 import groupBy from 'lodash/groupBy';
 import * as path from 'path';
 import { lightdashApi } from '../dbt/apiClient';
-
-const CUSTOM_ROLE_FILENAME_MAX_LENGTH = 200;
+import { getOrganizationContentFileNames } from './fileNames';
 
 export type CustomRoleUploadFailure = {
     message: string;
@@ -57,24 +55,6 @@ const getCustomRoleName = (role: unknown): string | undefined => {
     return typeof (role as Record<string, unknown>).name === 'string'
         ? ((role as Record<string, unknown>).name as string)
         : undefined;
-};
-
-const getCustomRoleFilenameBase = (name: string): string => {
-    const slug = name
-        .normalize('NFKD')
-        .replace(/[\u0300-\u036f]/g, '')
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-+|-+$/g, '');
-    const nameHash = createHash('sha256')
-        .update(name)
-        .digest('hex')
-        .slice(0, 8);
-
-    return (slug || `role-${nameHash}`).slice(
-        0,
-        CUSTOM_ROLE_FILENAME_MAX_LENGTH,
-    );
 };
 
 const readCustomRoleFileResults = async (
@@ -233,35 +213,15 @@ export const downloadCustomRoles = async (
             .map((entry) => fs.unlink(path.join(folder, entry.name))),
     );
 
-    const filenameBases = customRoles.map(({ name }) =>
-        getCustomRoleFilenameBase(name),
-    );
-    const baseCounts = filenameBases.reduce<Record<string, number>>(
-        (counts, filenameBase) => ({
-            ...counts,
-            [filenameBase]: (counts[filenameBase] ?? 0) + 1,
-        }),
-        {},
-    );
+    const filenames = getOrganizationContentFileNames({
+        values: customRoles.map(({ name }) => name),
+        fallbackPrefix: 'role',
+    });
 
     await Promise.all(
         customRoles.map(async (role: CustomRoleAsCode, index) => {
-            const filenameBase = filenameBases[index];
-            const collisionSuffix = `-${createHash('sha256')
-                .update(role.name)
-                .digest('hex')
-                .slice(0, 8)}`;
-            const uniqueFilenameBase =
-                baseCounts[filenameBase] > 1
-                    ? `${filenameBase.slice(
-                          0,
-                          CUSTOM_ROLE_FILENAME_MAX_LENGTH -
-                              collisionSuffix.length,
-                      )}${collisionSuffix}`
-                    : filenameBase;
-
             await fs.writeFile(
-                path.join(folder, `${uniqueFilenameBase}.yml`),
+                path.join(folder, filenames[index]),
                 yaml.dump(role, { quotingType: '"', sortKeys: true }),
             );
         }),

--- a/packages/cli/src/handlers/organizationContent/fileNames.test.ts
+++ b/packages/cli/src/handlers/organizationContent/fileNames.test.ts
@@ -1,0 +1,47 @@
+import { createHash } from 'crypto';
+import { getOrganizationContentFileNames } from './fileNames';
+
+describe('organization content filenames', () => {
+    it('uses generateSlug with normalized accents', () => {
+        expect(
+            getOrganizationContentFileNames({
+                values: ['Málaga Finance'],
+                fallbackPrefix: 'group',
+            }),
+        ).toStrictEqual(['malaga-finance.yml']);
+    });
+
+    it('uses a deterministic hash when no slug can be generated', () => {
+        const value = '🎉';
+        const hash = createHash('sha256')
+            .update(value)
+            .digest('hex')
+            .slice(0, 8);
+
+        expect(
+            getOrganizationContentFileNames({
+                values: [value],
+                fallbackPrefix: 'group',
+            }),
+        ).toStrictEqual([`group-${hash}.yml`]);
+    });
+
+    it('adds stable hashes when different values generate the same slug', () => {
+        const values = ['Finance?', 'Finance!'];
+
+        expect(
+            getOrganizationContentFileNames({
+                values,
+                fallbackPrefix: 'group',
+            }),
+        ).toStrictEqual(
+            values.map((value) => {
+                const hash = createHash('sha256')
+                    .update(value)
+                    .digest('hex')
+                    .slice(0, 8);
+                return `finance-${hash}.yml`;
+            }),
+        );
+    });
+});

--- a/packages/cli/src/handlers/organizationContent/fileNames.ts
+++ b/packages/cli/src/handlers/organizationContent/fileNames.ts
@@ -1,0 +1,52 @@
+import { generateSlug } from '@lightdash/common';
+import { createHash } from 'crypto';
+
+const ORGANIZATION_CONTENT_FILENAME_MAX_LENGTH = 200;
+const FILENAME_HASH_LENGTH = 8;
+
+const getStableHash = (value: string): string =>
+    createHash('sha256')
+        .update(value)
+        .digest('hex')
+        .slice(0, FILENAME_HASH_LENGTH);
+
+const getFilenameBase = (value: string, fallbackPrefix: string): string => {
+    const normalizedValue = value
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '');
+    const slug = /[a-z0-9]/i.test(normalizedValue)
+        ? generateSlug(normalizedValue)
+        : `${fallbackPrefix}-${getStableHash(value)}`;
+
+    return slug.slice(0, ORGANIZATION_CONTENT_FILENAME_MAX_LENGTH);
+};
+
+export const getOrganizationContentFileNames = ({
+    values,
+    fallbackPrefix,
+}: {
+    values: string[];
+    fallbackPrefix: string;
+}): string[] => {
+    const filenameBases = values.map((value) =>
+        getFilenameBase(value, fallbackPrefix),
+    );
+    const baseCounts = filenameBases.reduce<Map<string, number>>(
+        (counts, filenameBase) =>
+            counts.set(filenameBase, (counts.get(filenameBase) ?? 0) + 1),
+        new Map(),
+    );
+
+    return filenameBases.map((filenameBase, index) => {
+        if ((baseCounts.get(filenameBase) ?? 0) === 1) {
+            return `${filenameBase}.yml`;
+        }
+
+        const collisionSuffix = `-${getStableHash(values[index])}`;
+        const uniqueFilenameBase = `${filenameBase.slice(
+            0,
+            ORGANIZATION_CONTENT_FILENAME_MAX_LENGTH - collisionSuffix.length,
+        )}${collisionSuffix}`;
+        return `${uniqueFilenameBase}.yml`;
+    });
+};

--- a/packages/cli/src/handlers/organizationContent/groups.test.ts
+++ b/packages/cli/src/handlers/organizationContent/groups.test.ts
@@ -1,0 +1,190 @@
+import { PromotionAction, type GroupAsCode } from '@lightdash/common';
+import { createHash } from 'crypto';
+import { promises as fs } from 'fs';
+import * as yaml from 'js-yaml';
+import * as os from 'os';
+import * as path from 'path';
+import { vi } from 'vitest';
+import { lightdashApi } from '../dbt/apiClient';
+import {
+    countDependencySkippedGroups,
+    downloadGroups,
+    getGroupsFolder,
+    readGroupFiles,
+    uploadGroups,
+} from './groups';
+
+vi.mock('../dbt/apiClient', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../dbt/apiClient')>()),
+    lightdashApi: vi.fn(),
+}));
+
+describe('groups as code', () => {
+    let tmpDir: string;
+
+    const group = (name: string, members: string[] = []): GroupAsCode => ({
+        version: 1,
+        name,
+        members,
+    });
+
+    const writeGroup = async (
+        filename: string,
+        value: GroupAsCode | string,
+    ) => {
+        const folder = getGroupsFolder(tmpDir);
+        await fs.mkdir(folder, { recursive: true });
+        await fs.writeFile(
+            path.join(folder, filename),
+            typeof value === 'string'
+                ? value
+                : yaml.dump(value, { sortKeys: true }),
+        );
+    };
+
+    beforeEach(async () => {
+        vi.mocked(lightdashApi).mockReset();
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'groups-test-'));
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('downloads deterministic groups, empty groups, and collision-safe filenames', async () => {
+        const folder = getGroupsFolder(tmpDir);
+        await fs.mkdir(folder, { recursive: true });
+        await fs.writeFile(path.join(folder, 'stale.yml'), 'stale: true');
+        vi.mocked(lightdashApi).mockResolvedValueOnce({
+            groups: [
+                group('Finance?', ['z@example.com', 'a@example.com']),
+                group('Empty'),
+                group('Finance!'),
+            ],
+        } as never);
+
+        await expect(downloadGroups('organization-uuid', tmpDir)).resolves.toBe(
+            3,
+        );
+
+        const financeBangHash = createHash('sha256')
+            .update('Finance!')
+            .digest('hex')
+            .slice(0, 8);
+        const financeQuestionHash = createHash('sha256')
+            .update('Finance?')
+            .digest('hex')
+            .slice(0, 8);
+        expect((await fs.readdir(folder)).sort()).toStrictEqual(
+            [
+                'empty.yml',
+                `finance-${financeBangHash}.yml`,
+                `finance-${financeQuestionHash}.yml`,
+            ].sort(),
+        );
+        expect(
+            yaml.load(
+                await fs.readFile(
+                    path.join(folder, `finance-${financeQuestionHash}.yml`),
+                    'utf8',
+                ),
+            ),
+        ).toStrictEqual({
+            version: 1,
+            name: 'Finance?',
+            members: ['a@example.com', 'z@example.com'],
+        });
+        expect(
+            yaml.load(
+                await fs.readFile(path.join(folder, 'empty.yml'), 'utf8'),
+            ),
+        ).toStrictEqual({ version: 1, name: 'Empty', members: [] });
+    });
+
+    it('rejects duplicate exact names but preserves case-sensitive identity', async () => {
+        await writeGroup('one.yml', group('Finance'));
+        await writeGroup('two.yml', group('Finance'));
+
+        await expect(readGroupFiles(tmpDir)).rejects.toThrow(
+            'Duplicate group name "Finance"',
+        );
+
+        await fs.rm(getGroupsFolder(tmpDir), { recursive: true });
+        await writeGroup('upper.yml', group('Finance'));
+        await writeGroup('lower.yml', group('finance'));
+        await expect(readGroupFiles(tmpDir)).resolves.toHaveLength(2);
+    });
+
+    it('is a backward-compatible no-op when the groups folder is missing', async () => {
+        await expect(
+            uploadGroups('organization-uuid', tmpDir),
+        ).resolves.toMatchObject({
+            created: 0,
+            updated: 0,
+            unchanged: 0,
+            failed: 0,
+            dependencySkipped: 0,
+        });
+        expect(lightdashApi).not.toHaveBeenCalled();
+    });
+
+    it('continues after malformed and API-failing group files', async () => {
+        await writeGroup('bad-yaml.yml', 'name: [unterminated');
+        await writeGroup('api-error.yml', group('API error'));
+        await writeGroup('valid.yml', group('Valid'));
+        vi.mocked(lightdashApi)
+            .mockRejectedValueOnce(new Error('unknown member'))
+            .mockResolvedValueOnce({ action: PromotionAction.CREATE } as never);
+
+        await expect(
+            uploadGroups('organization-uuid', tmpDir),
+        ).resolves.toMatchObject({
+            created: 1,
+            updated: 0,
+            unchanged: 0,
+            failed: 2,
+        });
+        expect(lightdashApi).toHaveBeenCalledTimes(2);
+    });
+
+    it('reports all promotion actions and sends the portable body', async () => {
+        await writeGroup('create.yml', group('Create'));
+        await writeGroup('same.yml', group('Same'));
+        await writeGroup('update.yml', group('Update', ['member@example.com']));
+        vi.mocked(lightdashApi)
+            .mockResolvedValueOnce({ action: PromotionAction.CREATE } as never)
+            .mockResolvedValueOnce({
+                action: PromotionAction.NO_CHANGES,
+            } as never)
+            .mockResolvedValueOnce({ action: PromotionAction.UPDATE } as never);
+
+        await expect(
+            uploadGroups('organization-uuid', tmpDir),
+        ).resolves.toMatchObject({
+            created: 1,
+            updated: 1,
+            unchanged: 1,
+            failed: 0,
+        });
+        expect(lightdashApi).toHaveBeenNthCalledWith(3, {
+            method: 'POST',
+            url: '/api/v2/orgs/organization-uuid/groups/code',
+            body: expect.any(String),
+        });
+        expect(
+            JSON.parse(vi.mocked(lightdashApi).mock.calls[2][0].body as string),
+        ).toStrictEqual(group('Update', ['member@example.com']));
+    });
+
+    it('counts files skipped because a dependency phase failed', async () => {
+        await writeGroup('one.yml', group('One'));
+        await writeGroup('two.yml', 'invalid: [yaml');
+        await fs.writeFile(
+            path.join(getGroupsFolder(tmpDir), 'ignored.yaml'),
+            'name: ignored',
+        );
+
+        await expect(countDependencySkippedGroups(tmpDir)).resolves.toBe(2);
+    });
+});

--- a/packages/cli/src/handlers/organizationContent/groups.ts
+++ b/packages/cli/src/handlers/organizationContent/groups.ts
@@ -1,0 +1,253 @@
+/* eslint-disable no-await-in-loop */
+import {
+    ApiGroupAsCodeListResponse,
+    ApiGroupAsCodeUpsertResponse,
+    getErrorMessage,
+    GroupAsCode,
+    ParameterError,
+    PromotionAction,
+} from '@lightdash/common';
+import { Dirent, promises as fs } from 'fs';
+import * as yaml from 'js-yaml';
+import groupBy from 'lodash/groupBy';
+import * as path from 'path';
+import { lightdashApi } from '../dbt/apiClient';
+import { getOrganizationContentFileNames } from './fileNames';
+
+export type GroupUploadFailure = {
+    message: string;
+};
+
+export type GroupUploadSummary = {
+    created: number;
+    updated: number;
+    unchanged: number;
+    failed: number;
+    dependencySkipped: number;
+    failures: GroupUploadFailure[];
+};
+
+type GroupFile = {
+    filePath: string;
+    group: unknown;
+};
+
+type GroupFileReadResult = {
+    groupFiles: GroupFile[];
+    failures: GroupUploadFailure[];
+};
+
+type GroupFileReadItem =
+    | { kind: 'group'; groupFile: GroupFile }
+    | { kind: 'failure'; failure: GroupUploadFailure };
+
+export const getGroupsFolder = (organizationContentPath: string): string =>
+    path.join(organizationContentPath, 'groups');
+
+export const formatGroupUploadSummary = (summary: GroupUploadSummary): string =>
+    `${summary.created} created, ${summary.updated} updated, ${summary.unchanged} unchanged, ${summary.failed} failed, ${summary.dependencySkipped} dependency-skipped`;
+
+const getGroupName = (group: unknown): string | undefined => {
+    if (typeof group !== 'object' || group === null || Array.isArray(group)) {
+        return undefined;
+    }
+    const { name } = group as Record<string, unknown>;
+    return typeof name === 'string' ? name : undefined;
+};
+
+const readGroupFileResults = async (
+    organizationContentPath: string,
+): Promise<GroupFileReadResult> => {
+    const folder = getGroupsFolder(organizationContentPath);
+    let entries: Dirent[];
+    try {
+        entries = await fs.readdir(folder, { withFileTypes: true });
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return { groupFiles: [], failures: [] };
+        }
+        throw error;
+    }
+
+    const files = entries
+        .filter((entry) => entry.isFile() && entry.name.endsWith('.yml'))
+        .sort((left, right) => left.name.localeCompare(right.name));
+    const results = await Promise.all(
+        files.map(async (file): Promise<GroupFileReadItem> => {
+            const filePath = path.join(folder, file.name);
+            try {
+                return {
+                    kind: 'group',
+                    groupFile: {
+                        filePath,
+                        group: yaml.load(await fs.readFile(filePath, 'utf8')),
+                    },
+                };
+            } catch (error) {
+                return {
+                    kind: 'failure',
+                    failure: {
+                        message: `Unable to parse group file "${filePath}": ${getErrorMessage(error)}`,
+                    },
+                };
+            }
+        }),
+    );
+
+    const parsedGroupFiles = results.flatMap((result) =>
+        result.kind === 'group' ? [result.groupFile] : [],
+    );
+    const failures = results.flatMap((result) =>
+        result.kind === 'failure' ? [result.failure] : [],
+    );
+    const namedGroupFiles = parsedGroupFiles.flatMap((groupFile) => {
+        const name = getGroupName(groupFile.group);
+        return name === undefined ? [] : [{ name, groupFile }];
+    });
+    const filesByName = groupBy(namedGroupFiles, ({ name }) => name);
+    const duplicateNames = new Set(
+        Object.entries(filesByName)
+            .filter(([, matchingFiles]) => matchingFiles.length > 1)
+            .map(([name]) => name),
+    );
+    for (const duplicateName of [...duplicateNames].sort()) {
+        for (const { groupFile } of filesByName[duplicateName]) {
+            failures.push({
+                message: `Duplicate group name "${duplicateName}" in "${groupFile.filePath}"`,
+            });
+        }
+    }
+
+    return {
+        groupFiles: parsedGroupFiles.filter(
+            ({ group }) => !duplicateNames.has(getGroupName(group) ?? ''),
+        ),
+        failures,
+    };
+};
+
+export const readGroupFiles = async (
+    organizationContentPath: string,
+): Promise<unknown[]> => {
+    const { groupFiles, failures } = await readGroupFileResults(
+        organizationContentPath,
+    );
+    if (failures.length > 0) {
+        throw new ParameterError(
+            failures.map(({ message }) => message).join('\n'),
+        );
+    }
+    return groupFiles.map(({ group }) => group);
+};
+
+export const countDependencySkippedGroups = async (
+    organizationContentPath: string,
+): Promise<number> => {
+    const folder = getGroupsFolder(organizationContentPath);
+    try {
+        const entries = await fs.readdir(folder, { withFileTypes: true });
+        return entries.filter(
+            (entry) => entry.isFile() && entry.name.endsWith('.yml'),
+        ).length;
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return 0;
+        }
+        throw error;
+    }
+};
+
+export const uploadGroups = async (
+    organizationUuid: string,
+    organizationContentPath: string,
+): Promise<GroupUploadSummary> => {
+    const { groupFiles, failures } = await readGroupFileResults(
+        organizationContentPath,
+    );
+    const summary: GroupUploadSummary = {
+        created: 0,
+        updated: 0,
+        unchanged: 0,
+        failed: 0,
+        dependencySkipped: 0,
+        failures,
+    };
+
+    for (const { filePath, group } of groupFiles) {
+        try {
+            const result = await lightdashApi<
+                ApiGroupAsCodeUpsertResponse['results']
+            >({
+                method: 'POST',
+                url: `/api/v2/orgs/${organizationUuid}/groups/code`,
+                body: JSON.stringify(group),
+            });
+            switch (result.action) {
+                case PromotionAction.CREATE:
+                    summary.created += 1;
+                    break;
+                case PromotionAction.UPDATE:
+                    summary.updated += 1;
+                    break;
+                case PromotionAction.NO_CHANGES:
+                    summary.unchanged += 1;
+                    break;
+                default:
+                    throw new ParameterError(
+                        `Unsupported group promotion action: ${result.action}`,
+                    );
+            }
+        } catch (error) {
+            summary.failures.push({
+                message: `Invalid group file "${filePath}": ${getErrorMessage(error)}`,
+            });
+        }
+    }
+
+    summary.failed = summary.failures.length;
+    return summary;
+};
+
+export const downloadGroups = async (
+    organizationUuid: string,
+    organizationContentPath: string,
+): Promise<number> => {
+    const { groups } = await lightdashApi<
+        ApiGroupAsCodeListResponse['results']
+    >({
+        method: 'GET',
+        url: `/api/v2/orgs/${organizationUuid}/groups/code`,
+        body: undefined,
+    });
+    const folder = getGroupsFolder(organizationContentPath);
+    await fs.mkdir(folder, { recursive: true });
+
+    const existingFiles = await fs.readdir(folder, { withFileTypes: true });
+    await Promise.all(
+        existingFiles
+            .filter((entry) => entry.isFile() && entry.name.endsWith('.yml'))
+            .map((entry) => fs.unlink(path.join(folder, entry.name))),
+    );
+
+    const sortedGroups = [...groups]
+        .map((group) => ({
+            ...group,
+            members: [...group.members].sort(),
+        }))
+        .sort((left, right) => left.name.localeCompare(right.name));
+    const filenames = getOrganizationContentFileNames({
+        values: sortedGroups.map(({ name }) => name),
+        fallbackPrefix: 'group',
+    });
+
+    await Promise.all(
+        sortedGroups.map(async (group: GroupAsCode, index) => {
+            await fs.writeFile(
+                path.join(folder, filenames[index]),
+                yaml.dump(group, { quotingType: '"', sortKeys: true }),
+            );
+        }),
+    );
+
+    return sortedGroups.length;
+};

--- a/packages/cli/src/handlers/organizationContent/index.test.ts
+++ b/packages/cli/src/handlers/organizationContent/index.test.ts
@@ -1,0 +1,198 @@
+import { LightdashError } from '@lightdash/common';
+import { LightdashAnalytics } from '../../analytics/analytics';
+import GlobalState from '../../globalState';
+import {
+    downloadCustomRoles,
+    uploadCustomRoles,
+    type CustomRoleUploadSummary,
+} from './customRoles';
+import {
+    countDependencySkippedGroups,
+    downloadGroups,
+    uploadGroups,
+    type GroupUploadSummary,
+} from './groups';
+import {
+    downloadOrganizationContent,
+    uploadOrganizationContent,
+} from './index';
+import { downloadUsers, uploadUsers, type UserUploadSummary } from './users';
+
+vi.mock('./customRoles', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('./customRoles')>()),
+    downloadCustomRoles: vi.fn(),
+    uploadCustomRoles: vi.fn(),
+}));
+vi.mock('./users', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('./users')>()),
+    downloadUsers: vi.fn(),
+    uploadUsers: vi.fn(),
+}));
+vi.mock('./groups', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('./groups')>()),
+    downloadGroups: vi.fn(),
+    uploadGroups: vi.fn(),
+    countDependencySkippedGroups: vi.fn(),
+}));
+
+describe('organization content download', () => {
+    const spinner = {
+        start: vi.fn(),
+        succeed: vi.fn(),
+        stop: vi.fn(),
+        fail: vi.fn(),
+    };
+    const config = {
+        user: {
+            userUuid: 'user-uuid',
+            organizationUuid: 'organization-uuid',
+        },
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.spyOn(GlobalState, 'startSpinner').mockReturnValue(spinner as never);
+        vi.spyOn(GlobalState, 'log').mockImplementation(() => undefined);
+        vi.spyOn(GlobalState, 'debug').mockImplementation(() => undefined);
+        vi.spyOn(LightdashAnalytics, 'track').mockResolvedValue(undefined);
+        vi.mocked(downloadCustomRoles).mockResolvedValue(2);
+        vi.mocked(downloadUsers).mockResolvedValue(3);
+        vi.mocked(downloadGroups).mockResolvedValue(4);
+    });
+
+    it('skips groups when the group service is disabled', async () => {
+        vi.mocked(downloadGroups).mockRejectedValue(
+            new LightdashError({
+                message: 'Group service is not enabled',
+                name: 'ForbiddenError',
+                statusCode: 403,
+                data: {},
+            }),
+        );
+
+        await expect(
+            downloadOrganizationContent({ config }),
+        ).resolves.toBeUndefined();
+
+        expect(spinner.stop).toHaveBeenCalledOnce();
+        expect(spinner.fail).not.toHaveBeenCalled();
+        expect(GlobalState.debug).toHaveBeenCalledWith(
+            '> Warning: groups were not downloaded because the group service is not enabled',
+        );
+    });
+
+    it('still fails for other group download errors', async () => {
+        vi.mocked(downloadGroups).mockRejectedValue(new Error('Network error'));
+
+        await expect(downloadOrganizationContent({ config })).rejects.toThrow(
+            'Network error',
+        );
+
+        expect(spinner.fail).toHaveBeenCalledOnce();
+    });
+});
+
+describe('organization content upload sequencing', () => {
+    const spinner = {
+        start: vi.fn(),
+        succeed: vi.fn(),
+        stop: vi.fn(),
+        fail: vi.fn(),
+    };
+    const config = {
+        user: {
+            userUuid: 'user-uuid',
+            organizationUuid: 'organization-uuid',
+        },
+    };
+    const customRoleSummary = (
+        failed: number = 0,
+    ): CustomRoleUploadSummary => ({
+        created: 0,
+        updated: 0,
+        unchanged: 0,
+        failed,
+        failures: failed > 0 ? [{ message: 'role failure' }] : [],
+    });
+    const userSummary = (failed: number = 0): UserUploadSummary => ({
+        created: 0,
+        updated: 0,
+        unchanged: 0,
+        awaitingAuthentication: 0,
+        invited: 0,
+        skippedAuthenticated: 0,
+        skippedDisabled: 0,
+        skippedValidInvite: 0,
+        failed,
+        failures: failed > 0 ? [{ message: 'user failure' }] : [],
+    });
+    const groupSummary = (failed: number = 0): GroupUploadSummary => ({
+        created: 0,
+        updated: 0,
+        unchanged: 0,
+        failed,
+        dependencySkipped: 0,
+        failures: failed > 0 ? [{ message: 'group failure' }] : [],
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.spyOn(GlobalState, 'startSpinner').mockReturnValue(spinner as never);
+        vi.spyOn(GlobalState, 'log').mockImplementation(() => undefined);
+        vi.spyOn(LightdashAnalytics, 'track').mockResolvedValue(undefined);
+        vi.mocked(uploadCustomRoles).mockResolvedValue(customRoleSummary());
+        vi.mocked(uploadUsers).mockResolvedValue(userSummary());
+        vi.mocked(uploadGroups).mockResolvedValue(groupSummary());
+        vi.mocked(countDependencySkippedGroups).mockResolvedValue(2);
+    });
+
+    it('awaits custom roles, then users, then groups', async () => {
+        const phaseOrder: string[] = [];
+        vi.mocked(uploadCustomRoles).mockImplementation(async () => {
+            phaseOrder.push('roles:start', 'roles:end');
+            return customRoleSummary();
+        });
+        vi.mocked(uploadUsers).mockImplementation(async () => {
+            phaseOrder.push('users:start', 'users:end');
+            return userSummary();
+        });
+        vi.mocked(uploadGroups).mockImplementation(async () => {
+            phaseOrder.push('groups:start', 'groups:end');
+            return groupSummary();
+        });
+
+        await uploadOrganizationContent({ config });
+
+        expect(phaseOrder).toStrictEqual([
+            'roles:start',
+            'roles:end',
+            'users:start',
+            'users:end',
+            'groups:start',
+            'groups:end',
+        ]);
+    });
+
+    it('does not start users or groups when custom roles fail', async () => {
+        vi.mocked(uploadCustomRoles).mockResolvedValue(customRoleSummary(1));
+
+        await expect(uploadOrganizationContent({ config })).rejects.toThrow(
+            'Processed custom roles',
+        );
+
+        expect(uploadUsers).not.toHaveBeenCalled();
+        expect(uploadGroups).not.toHaveBeenCalled();
+        expect(countDependencySkippedGroups).toHaveBeenCalledOnce();
+    });
+
+    it('does not start groups when users fail', async () => {
+        vi.mocked(uploadUsers).mockResolvedValue(userSummary(1));
+
+        await expect(uploadOrganizationContent({ config })).rejects.toThrow(
+            'Processed users',
+        );
+
+        expect(uploadGroups).not.toHaveBeenCalled();
+        expect(countDependencySkippedGroups).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/cli/src/handlers/organizationContent/index.ts
+++ b/packages/cli/src/handlers/organizationContent/index.ts
@@ -1,6 +1,7 @@
 import {
     AuthorizationError,
     getErrorMessage,
+    LightdashError,
     ParameterError,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../../analytics/analytics';
@@ -13,6 +14,12 @@ import {
     formatCustomRoleUploadSummary,
     uploadCustomRoles,
 } from './customRoles';
+import {
+    countDependencySkippedGroups,
+    downloadGroups,
+    formatGroupUploadSummary,
+    uploadGroups,
+} from './groups';
 import { downloadUsers, formatUserUploadSummary, uploadUsers } from './users';
 
 type OrganizationContentOptions = {
@@ -22,6 +29,7 @@ type OrganizationContentOptions = {
 };
 
 const customRolePartialUploadErrors = new WeakSet<Error>();
+const groupPartialUploadErrors = new WeakSet<Error>();
 const userPartialUploadErrors = new WeakSet<Error>();
 
 const createCustomRolePartialUploadError = (message: string): Error => {
@@ -36,10 +44,22 @@ const createUserPartialUploadError = (message: string): Error => {
     return error;
 };
 
+const createGroupPartialUploadError = (message: string): Error => {
+    const error = new ParameterError(message);
+    groupPartialUploadErrors.add(error);
+    return error;
+};
+
 const isPartialUploadError = (error: unknown): boolean =>
     error instanceof Error &&
     (customRolePartialUploadErrors.has(error) ||
+        groupPartialUploadErrors.has(error) ||
         userPartialUploadErrors.has(error));
+
+const isGroupServiceDisabledError = (error: unknown): boolean =>
+    error instanceof LightdashError &&
+    error.statusCode === 403 &&
+    error.message === 'Group service is not enabled';
 
 export const getOrganizationContentFolder = (customPath?: string): string =>
     getDownloadFolder(customPath);
@@ -81,6 +101,24 @@ export const downloadOrganizationContent = async ({
         );
         spinner.succeed(`Downloaded ${usersTotal} users`);
 
+        spinner.start(`Downloading groups`);
+        let groupsTotal = 0;
+        try {
+            groupsTotal = await downloadGroups(
+                organizationUuid,
+                organizationContentPath,
+            );
+            spinner.succeed(`Downloaded ${groupsTotal} groups`);
+        } catch (error) {
+            if (!isGroupServiceDisabledError(error)) {
+                throw error;
+            }
+            spinner.stop();
+            GlobalState.debug(
+                '> Warning: groups were not downloaded because the group service is not enabled',
+            );
+        }
+
         GlobalState.log(
             styles.success(
                 `Downloaded organization content saved to ${organizationContentPath}`,
@@ -95,6 +133,7 @@ export const downloadOrganizationContent = async ({
                 scope: 'organization',
                 customRolesNum: customRolesTotal,
                 usersNum: usersTotal,
+                groupsNum: groupsTotal,
                 timeToCompleted: (Date.now() - start) / 1000,
             },
         });
@@ -150,6 +189,14 @@ export const uploadOrganizationContent = async ({
                 GlobalState.log(styles.error(message)),
             );
             spinner.stop();
+            const skippedGroups = await countDependencySkippedGroups(
+                organizationContentPath,
+            );
+            GlobalState.log(
+                styles.warning(
+                    `Skipped users and ${skippedGroups} groups because custom roles failed`,
+                ),
+            );
             throw createCustomRolePartialUploadError(
                 `Processed custom roles: ${summaryMessage}`,
             );
@@ -168,11 +215,36 @@ export const uploadOrganizationContent = async ({
                 GlobalState.log(styles.error(message)),
             );
             spinner.stop();
+            const skippedGroups = await countDependencySkippedGroups(
+                organizationContentPath,
+            );
+            GlobalState.log(
+                styles.warning(
+                    `Skipped ${skippedGroups} groups because users failed`,
+                ),
+            );
             throw createUserPartialUploadError(
                 `Processed users: ${userSummaryMessage}`,
             );
         }
         spinner.succeed(`Uploaded users: ${userSummaryMessage}`);
+
+        spinner.start(`Uploading groups`);
+        const groupSummary = await uploadGroups(
+            organizationUuid,
+            organizationContentPath,
+        );
+        const groupSummaryMessage = formatGroupUploadSummary(groupSummary);
+        if (groupSummary.failed > 0) {
+            groupSummary.failures.forEach(({ message }) =>
+                GlobalState.log(styles.error(message)),
+            );
+            spinner.stop();
+            throw createGroupPartialUploadError(
+                `Processed groups: ${groupSummaryMessage}`,
+            );
+        }
+        spinner.succeed(`Uploaded groups: ${groupSummaryMessage}`);
         GlobalState.log(
             styles.success(
                 `Uploaded organization content from ${organizationContentPath}`,
@@ -192,6 +264,9 @@ export const uploadOrganizationContent = async ({
                 usersUnchanged: userSummary.unchanged,
                 usersAwaitingAuthentication: userSummary.awaitingAuthentication,
                 usersInvited: userSummary.invited,
+                groupsCreated: groupSummary.created,
+                groupsUpdated: groupSummary.updated,
+                groupsUnchanged: groupSummary.unchanged,
                 timeToCompleted: (Date.now() - start) / 1000,
             },
         });

--- a/packages/cli/src/handlers/organizationContent/users.ts
+++ b/packages/cli/src/handlers/organizationContent/users.ts
@@ -11,14 +11,12 @@ import {
     UserAsCodeInvitationStatus,
     UserAsCodeLifecycleStatus,
 } from '@lightdash/common';
-import { createHash } from 'crypto';
 import { Dirent, promises as fs } from 'fs';
 import * as yaml from 'js-yaml';
 import groupBy from 'lodash/groupBy';
 import * as path from 'path';
 import { lightdashApi } from '../dbt/apiClient';
-
-const USER_FILENAME_MAX_LENGTH = 200;
+import { getOrganizationContentFileNames } from './fileNames';
 
 export type UserUploadFailure = {
     message: string;
@@ -96,21 +94,6 @@ const asUserAsCode = (user: unknown): UserAsCode | undefined => {
         return undefined;
     }
     return user as UserAsCode;
-};
-
-const getUserFilenameBase = (email: string): string => {
-    const normalizedEmail = email.toLowerCase();
-    const slug = normalizedEmail
-        .normalize('NFKD')
-        .replace(/[\u0300-\u036f]/g, '')
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-+|-+$/g, '');
-    const emailHash = createHash('sha256')
-        .update(normalizedEmail)
-        .digest('hex')
-        .slice(0, 8);
-
-    return (slug || `user-${emailHash}`).slice(0, USER_FILENAME_MAX_LENGTH);
 };
 
 const readUserFileResults = async (
@@ -360,34 +343,15 @@ export const downloadUsers = async (
     const sortedUsers = [...users].sort((left, right) =>
         left.email.localeCompare(right.email),
     );
-    const filenameBases = sortedUsers.map(({ email }) =>
-        getUserFilenameBase(email),
-    );
-    const baseCounts = filenameBases.reduce<Record<string, number>>(
-        (counts, filenameBase) => ({
-            ...counts,
-            [filenameBase]: (counts[filenameBase] ?? 0) + 1,
-        }),
-        {},
-    );
+    const filenames = getOrganizationContentFileNames({
+        values: sortedUsers.map(({ email }) => email.toLowerCase()),
+        fallbackPrefix: 'user',
+    });
 
     await Promise.all(
         sortedUsers.map(async (user, index) => {
-            const filenameBase = filenameBases[index];
-            const collisionSuffix = `-${createHash('sha256')
-                .update(user.email.toLowerCase())
-                .digest('hex')
-                .slice(0, 8)}`;
-            const uniqueFilenameBase =
-                baseCounts[filenameBase] > 1
-                    ? `${filenameBase.slice(
-                          0,
-                          USER_FILENAME_MAX_LENGTH - collisionSuffix.length,
-                      )}${collisionSuffix}`
-                    : filenameBase;
-
             await fs.writeFile(
-                path.join(folder, `${uniqueFilenameBase}.yml`),
+                path.join(folder, filenames[index]),
                 yaml.dump(user, { quotingType: '"', sortKeys: true }),
             );
         }),

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -169,7 +169,11 @@ import {
     type PullRequestCreated,
     type PullRequestPreview,
 } from './gitIntegration';
-import type { ApiGroupListResponse } from './groups';
+import type {
+    ApiGroupAsCodeListResponse,
+    ApiGroupAsCodeUpsertResponse,
+    ApiGroupListResponse,
+} from './groups';
 import { type ApiImpersonationOrganizationSettingsResponse } from './impersonationOrganizationSettings';
 import { type MetricQuery, type QueryWarning } from './metricQuery';
 import type {
@@ -1145,6 +1149,8 @@ type ApiResults =
     | ApiMetricsCatalog['results']
     | ApiMetricsExplorerQueryResults['results']
     | ApiGroupListResponse['results']
+    | ApiGroupAsCodeListResponse['results']
+    | ApiGroupAsCodeUpsertResponse['results']
     | ApiPullRequestsResponse['results']
     | ApiCreateTagResponse['results']
     | ApiAgentAsCodeListResponse['results']

--- a/packages/common/src/types/groups.ts
+++ b/packages/common/src/types/groups.ts
@@ -1,4 +1,28 @@
 import type { KnexPaginatedData } from './knex-paginate';
+import type { PromotionAction } from './promotion';
+
+export type GroupAsCode = {
+    version: 1;
+    name: string;
+    members: string[];
+};
+
+export type ApiGroupAsCodeListResponse = {
+    status: 'ok';
+    results: {
+        groups: GroupAsCode[];
+    };
+};
+
+export type ApiGroupAsCodeUpsertResponse = {
+    status: 'ok';
+    results: {
+        action:
+            | PromotionAction.CREATE
+            | PromotionAction.UPDATE
+            | PromotionAction.NO_CHANGES;
+    };
+};
 
 export type Group = {
     /**


### PR DESCRIPTION
![CleanShot 2026-07-15 at 14.15.43@2x.png](https://app.graphite.com/user-attachments/assets/3b8c404e-a726-4c34-bb20-fedbe64b484c.png)





## Summary

- add organization groups as code using deterministic `groups/*.yml` files keyed by exact group name
- resolve group membership by primary email and atomically create groups or replace existing memberships
- run organization uploads sequentially in dependency order: custom roles, users, then groups
- skip group downloads when the groups feature is disabled, with an explanation under `--verbose`
- document the portable group contract and SCIM ownership limitation

## Testing

- `pnpm generate-api`
- `pnpm -F common typecheck`
- `pnpm -F backend typecheck`
- `pnpm -F cli typecheck`
- `pnpm -F common lint`
- `pnpm -F backend lint`
- `pnpm -F cli lint`
- `pnpm -F backend test src/services/GroupService.test.ts src/models/GroupsModel.test.ts`
- `pnpm -F cli test src/handlers/organizationContent/groups.test.ts src/handlers/organizationContent/index.test.ts`
- real CLI download with groups enabled and disabled
- real CLI upload covering create, update, unchanged, and atomic invalid-member rejection

Closes: PROD-8884