### PR TITLE
feat: support MetricFlow ratio/derived metrics and same-model filters

### DIFF
--- a/examples/metricflow-demo/README.md
+++ b/examples/metricflow-demo/README.md
@@ -107,8 +107,8 @@ explore the result in the Lightdash UI).
 
 ## What translates (and what doesn't)
 
-Both specs produce the identical result: **8 translated, 5 skipped (with
-warnings)**.
+Both specs produce the identical result: **13 translated, 1 skipped (with
+a warning)**.
 
 ### Supported → Lightdash metrics
 
@@ -121,6 +121,10 @@ warnings)**.
 | `agg: median` | `median` |
 | `agg: min` / `agg: max` | `min` / `max` |
 | `agg: percentile` | `percentile` (legacy 0–1 fractions and latest 0–100 values both normalized to Lightdash's 0–100) |
+| `agg: sum_boolean` | `sum` over `CASE WHEN bool THEN 1 ELSE 0 END` |
+| metric or measure `filter:` (same-model `Dimension()` refs) | filter compiled into the metric SQL as `CASE WHEN <condition> THEN <expr> END` |
+| `ratio` metrics (inputs on the same model) | `number` metric: `(${numerator} * 1.0) / NULLIF(${denominator}, 0)`; filtered inputs compile to hidden helper metrics |
+| `derived` metrics (inputs on the same model, no offsets) | `number` metric with the expression rewritten over `${metric}` references (aliases supported) |
 | measure `create_metric: true` (no explicit metric) | translated like a simple metric |
 | measure `expr` (bare column or SQL expression) | metric `sql` (bare columns qualified as `${TABLE}.col`) |
 | metric/measure `label` + `description` | carried over (metric-level wins) |
@@ -128,18 +132,33 @@ warnings)**.
 YAML-defined `meta.metrics` win over translated MetricFlow metrics on name
 collision — so you can always override a translated metric by hand.
 
+Notes on filters, ratio, and derived metrics:
+
+- **Filters** translate when every `{{ Dimension('entity__dim') }}` reference
+  resolves on the metric's own semantic model. Cross-model references and
+  other template functions (`TimeDimension()`, `Entity()`, `Metric()`) skip
+  the metric with a warning.
+- **Ratio/derived inputs** must all resolve to metrics on the same dbt model.
+  In MetricFlow, inputs may come from any semantic model because each input is
+  aggregated in its own subquery; Lightdash compiles a single query per
+  explore, so cross-model inputs are skipped with a warning (join the models
+  in a Lightdash explore and author a `number` metric if you need one today).
+- **Filtered inputs** (e.g. a ratio whose numerator has a `filter:`) compile
+  the filter into a hidden helper metric (`<metric>_numerator`, …) which the
+  visible metric references.
+- **Time-offset inputs** (`offset_window` / `offset_to_grain` on a derived
+  metric input) are skipped with a warning.
+
 ### Not currently supported (skipped, warning on deploy; details under `--verbose`)
 
 | MetricFlow feature | Why |
 |---|---|
-| `ratio` metrics | Lightdash has no native multi-metric division |
-| `derived` metrics | expression over other metrics |
 | `cumulative` metrics | needs time-spine semantics Lightdash doesn't have |
 | `conversion` metrics | needs entity-journey semantics |
-| metric `filter:` / measure-level filters | MetricFlow where-filter templates (`{{ Dimension('order__status') }}`) don't map to Lightdash metric filters |
-| `agg: sum_boolean` | no Lightdash equivalent |
+| cross-model `ratio` / `derived` inputs, `offset_window` / `offset_to_grain` | see notes above |
+| cross-model or non-`Dimension()` `filter:` templates | see notes above |
 | **entities / join resolution** | MetricFlow joins semantic models implicitly at query time through shared entity keys (`order`, `customer`). Lightdash joins are explicit, authored per-explore (`meta.joins`). Entities are ignored — each semantic model's metrics land only on its own dbt model, and cross-model dimension access does not happen. |
-| dimensions (`categorical` / `time`) | ignored — Lightdash derives dimensions from the model's real columns, so you keep all columns as dimensions anyway |
+| dimensions (`categorical` / `time`) | ignored — Lightdash derives dimensions from the model's real columns, so you keep all columns as dimensions anyway (dimension `expr` is used when resolving filter references) |
 | `agg_time_dimension` | ignored — Lightdash metrics aggregate over whatever dimension you group by |
 | `join_to_timespine`, `fill_nulls_with`, `non_additive_dimension`, `percentile_type: discrete` | no equivalents (percentiles always compile to `PERCENTILE_CONT`) |
 | saved queries / exports | out of scope |

--- a/examples/metricflow-demo/assert-translation.cjs
+++ b/examples/metricflow-demo/assert-translation.cjs
@@ -45,15 +45,45 @@ const expected = {
     max_order_value: { type: 'max', sql: '${TABLE}.amount' },
     min_order_value: { type: 'min', sql: '${TABLE}.amount' },
     p95_order_value: { type: 'percentile', sql: '${TABLE}.amount', percentile: 95 },
+    // Filtered simple metric → CASE WHEN over the measure
+    completed_revenue: {
+        type: 'sum',
+        sql: "CASE WHEN (${TABLE}.status = 'completed') THEN (${TABLE}.amount) END",
+    },
+    // sum_boolean → sum over CASE WHEN bool THEN 1 ELSE 0
+    food_order_count: {
+        type: 'sum',
+        sql: 'CASE WHEN (${TABLE}.is_food_order) THEN 1 ELSE 0 END',
+    },
+    // Ratio → number metric over the two input metrics
+    revenue_per_order: {
+        type: 'number',
+        sql: '(${total_revenue} * 1.0) / NULLIF(${order_count}, 0)',
+    },
+    // Ratio with a filtered numerator → hidden helper metric + number metric
+    completion_rate: {
+        type: 'number',
+        sql: '(${completion_rate_numerator} * 1.0) / NULLIF(${order_count}, 0)',
+    },
+    completion_rate_numerator: {
+        type: 'count',
+        sql: "CASE WHEN (${TABLE}.status = 'completed') THEN (${TABLE}.order_id) END",
+        hidden: true,
+    },
+    // Derived → number metric with the expression rewritten over input metrics
+    revenue_per_customer: {
+        type: 'number',
+        sql: '${total_revenue} / ${unique_customers}',
+    },
 };
+
+// Hidden helper metrics are emitted alongside a manifest metric and are not
+// counted in translatedCount.
+const helperCount = Object.values(expected).filter((e) => e.hidden).length;
 
 // Metrics that must be skipped (unsupported in the Lightdash translation).
 const expectedSkipped = [
-    'completed_revenue', // metric-level filter
-    'revenue_per_order', // ratio
-    'revenue_per_customer', // derived
-    'cumulative_revenue', // cumulative
-    'food_order_count', // sum_boolean aggregation
+    'cumulative_revenue', // cumulative — needs time-spine semantics
 ];
 
 let failures = 0;
@@ -77,8 +107,10 @@ for (const [name, exp] of Object.entries(expected)) {
         fail(`metric "${name}": sql ${got.sql} !== ${exp.sql}`);
     } else if (exp.percentile !== undefined && got.percentile !== exp.percentile) {
         fail(`metric "${name}": percentile ${got.percentile} !== ${exp.percentile}`);
+    } else if (exp.hidden !== undefined && got.hidden !== exp.hidden) {
+        fail(`metric "${name}": hidden ${got.hidden} !== ${exp.hidden}`);
     } else {
-        ok(`${name} → ${exp.type}(${exp.sql})${exp.percentile ? ` p${exp.percentile}` : ''}`);
+        ok(`${name} → ${exp.type}(${exp.sql})${exp.percentile ? ` p${exp.percentile}` : ''}${exp.hidden ? ' [hidden]' : ''}`);
     }
 }
 
@@ -92,7 +124,7 @@ for (const name of expectedSkipped) {
     }
 }
 
-const expectedCount = Object.keys(expected).length;
+const expectedCount = Object.keys(expected).length - helperCount;
 if (result.translatedCount !== expectedCount) {
     fail(`translatedCount ${result.translatedCount} !== ${expectedCount}`);
 }

--- a/examples/metricflow-demo/latest-spec/models/orders.yml
+++ b/examples/metricflow-demo/latest-spec/models/orders.yml
@@ -72,15 +72,17 @@ models:
         # Latest spec authors percentile on the 0-100 scale
         percentile: 95.0
         expr: amount
-      # ── Unsupported shapes (skipped with a warning on deploy) ──
+      # ── Filtered metrics: same-model Dimension() filters translate to a
+      #    CASE WHEN inside the Lightdash metric SQL ──
       - name: completed_revenue
         label: Completed revenue
-        description: Filtered metrics cannot be translated to Lightdash.
+        description: Revenue from completed orders only.
         type: simple
         agg: sum
         expr: amount
         filter: |
           {{ Dimension('order__status') }} = 'completed'
+      # sum_boolean translates to a Lightdash sum over CASE WHEN bool THEN 1 ELSE 0
       - name: food_order_count
         label: Food order count
         type: simple
@@ -88,12 +90,24 @@ models:
         expr: is_food_order
 
 # Advanced (multi-metric) shapes still live in a top-level metrics: block in
-# the latest spec — all currently skipped by the Lightdash translation.
+# the latest spec. Ratio and derived metrics translate to Lightdash `number`
+# metrics over their input metrics (inputs must live on the same model);
+# cumulative metrics are still skipped.
 metrics:
   - name: revenue_per_order
     label: Revenue per order (ratio)
     type: ratio
     numerator: total_revenue
+    denominator: order_count
+  # A filtered numerator compiles the filter into a hidden helper metric.
+  - name: completion_rate
+    label: Completion rate
+    description: Share of orders that are completed.
+    type: ratio
+    numerator:
+      name: order_count
+      filter: |
+        {{ Dimension('order__status') }} = 'completed'
     denominator: order_count
   - name: revenue_per_customer
     label: Revenue per customer (derived)

--- a/examples/metricflow-demo/legacy-spec/models/schema.yml
+++ b/examples/metricflow-demo/legacy-spec/models/schema.yml
@@ -82,7 +82,7 @@ semantic_models:
         agg: count_distinct
         expr: customer_id
         create_metric: true
-      # ── Unsupported: sum_boolean has no Lightdash equivalent (skipped) ──
+      # sum_boolean translates to a Lightdash sum over CASE WHEN bool THEN 1 ELSE 0
       - name: food_order_count
         agg: sum_boolean
         expr: is_food_order
@@ -127,21 +127,39 @@ metrics:
     type_params:
       measure: p95_order_value
 
-  # ── Unsupported metric shapes (skipped with a warning on deploy) ──
+  # ── Filtered metrics: same-model Dimension() filters translate to a
+  #    CASE WHEN inside the Lightdash metric SQL ──
   - name: completed_revenue
     label: Completed revenue
-    description: Filtered metrics cannot be translated to Lightdash.
+    description: Revenue from completed orders only.
     type: simple
     type_params:
       measure: total_revenue
     filter: |
       {{ Dimension('order__status') }} = 'completed'
+
+  # ── Ratio metrics: translate to a Lightdash `number` metric dividing the
+  #    two input metrics (inputs must live on the same model) ──
   - name: revenue_per_order
     label: Revenue per order (ratio)
     type: ratio
     type_params:
       numerator: total_revenue
       denominator: order_count
+  # A filtered numerator compiles the filter into a hidden helper metric.
+  - name: completion_rate
+    label: Completion rate
+    description: Share of orders that are completed.
+    type: ratio
+    type_params:
+      numerator:
+        name: order_count
+        filter: |
+          {{ Dimension('order__status') }} = 'completed'
+      denominator: order_count
+
+  # ── Derived metrics: translate to a Lightdash `number` metric with the
+  #    expression rewritten over the input metrics ──
   - name: revenue_per_customer
     label: Revenue per customer (derived)
     type: derived
@@ -150,6 +168,8 @@ metrics:
       metrics:
         - name: total_revenue
         - name: unique_customers
+
+  # ── Still unsupported (skipped with a warning on deploy) ──
   - name: cumulative_revenue
     label: Cumulative revenue
     type: cumulative

--- a/packages/common/src/dbt/metricFlow.test.ts
+++ b/packages/common/src/dbt/metricFlow.test.ts
@@ -23,6 +23,14 @@ const ordersSemanticModel: DbtSemanticModel = {
         relation_name: '"db"."jaffle"."orders"',
     },
     depends_on: { nodes: ['model.jaffle.orders'] },
+    entities: [
+        { name: 'order', type: 'primary', expr: 'order_id' },
+        { name: 'customer', type: 'foreign', expr: 'customer_id' },
+    ],
+    dimensions: [
+        { name: 'status', type: 'categorical', expr: null },
+        { name: 'ordered_at', type: 'time', expr: 'ordered_at' },
+    ],
     measures: [
         { name: 'order_total', agg: MetricFlowAggregation.SUM, expr: 'amount' },
         { name: 'order_count', agg: MetricFlowAggregation.COUNT, expr: '1' },
@@ -253,7 +261,16 @@ describe('translateMetricFlowMetrics', () => {
                     name: 'completed_revenue',
                     unique_id: 'metric.jaffle.completed_revenue',
                     type: 'simple',
-                    filter: { where_filters: [{ where_sql_template: '1=1' }] },
+                    // TimeDimension() templates are untranslatable, so this
+                    // metric must be skipped entirely.
+                    filter: {
+                        where_filters: [
+                            {
+                                where_sql_template:
+                                    "{{ TimeDimension('order__ordered_at', 'day') }} >= '2024-01-01'",
+                            },
+                        ],
+                    },
                     type_params: {
                         measure: null,
                         metric_aggregation_params: {
@@ -267,17 +284,16 @@ describe('translateMetricFlowMetrics', () => {
             modelNamesByUniqueId,
         });
 
-        // The filtered metric is skipped and its mirrored create_metric
+        // The untranslatable metric is skipped and its mirrored create_metric
         // measure must not resurface as an unfiltered metric.
         expect(result.metricsByModel.orders?.completed_revenue).toBeUndefined();
         expect(result.skippedCount).toBe(1);
-        expect(result.warnings.join(' ')).toContain('filters');
+        expect(result.warnings.join(' ')).toContain('template functions');
     });
 
     it.each([
-        ['ratio', { type: 'ratio' as const, type_params: {} }],
-        ['derived', { type: 'derived' as const, type_params: {} }],
         ['cumulative', { type: 'cumulative' as const, type_params: {} }],
+        ['conversion', { type: 'conversion' as const, type_params: {} }],
     ])(
         'skips unsupported metric type %s with a warning',
         (_label, overrides) => {
@@ -300,22 +316,165 @@ describe('translateMetricFlowMetrics', () => {
         },
     );
 
-    it('skips filtered metrics', () => {
-        const result = translateMetricFlowMetrics({
-            semanticModels: { sm: ordersSemanticModel },
-            metrics: {
-                m: simpleMetric('filtered', 'order_total', {
-                    filter: { where_filters: [{ where_sql_template: '1=1' }] },
-                }),
-            },
-            modelNamesByUniqueId,
+    describe('where filters', () => {
+        it('translates a metric filter into a CASE WHEN over the measure', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: { sm: ordersSemanticModel },
+                metrics: {
+                    m: simpleMetric('completed_revenue', 'order_total', {
+                        filter: {
+                            where_filters: [
+                                {
+                                    where_sql_template:
+                                        "{{ Dimension('order__status') }} = 'completed'\n",
+                                },
+                            ],
+                        },
+                    }),
+                },
+                modelNamesByUniqueId,
+            });
+            expect(result.metricsByModel.orders.completed_revenue).toEqual({
+                type: MetricType.SUM,
+                sql: "CASE WHEN (${TABLE}.status = 'completed') THEN (${TABLE}.amount) END",
+                label: undefined,
+                description: undefined,
+            });
         });
-        expect(result.metricsByModel.orders?.filtered).toBeUndefined();
-        expect(result.skippedCount).toBe(1);
-        expect(result.warnings[0]).toContain('filters');
+
+        it('combines metric-level and measure-level filters with AND', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: { sm: ordersSemanticModel },
+                metrics: {
+                    m: {
+                        ...simpleMetric('completed_recent', 'order_total', {
+                            filter: {
+                                where_filters: [
+                                    {
+                                        where_sql_template:
+                                            "{{ Dimension('order__status') }} = 'completed'",
+                                    },
+                                ],
+                            },
+                        }),
+                        type_params: {
+                            measure: {
+                                name: 'order_total',
+                                filter: {
+                                    where_filters: [
+                                        {
+                                            where_sql_template:
+                                                "{{ Dimension('order__status') }} != 'returned'",
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    },
+                },
+                modelNamesByUniqueId,
+            });
+            expect(result.metricsByModel.orders.completed_recent.sql).toBe(
+                "CASE WHEN (${TABLE}.status = 'completed') AND (${TABLE}.status != 'returned') THEN (${TABLE}.amount) END",
+            );
+        });
+
+        it('inlines a dimension expr when the dimension is not a plain column', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: {
+                    sm: {
+                        ...ordersSemanticModel,
+                        dimensions: [
+                            {
+                                name: 'status',
+                                type: 'categorical',
+                                expr: "lower(raw_status || '')",
+                            },
+                        ],
+                    },
+                },
+                metrics: {
+                    m: simpleMetric('completed_revenue', 'order_total', {
+                        filter: {
+                            where_filters: [
+                                {
+                                    where_sql_template:
+                                        "{{ Dimension('order__status') }} = 'completed'",
+                                },
+                            ],
+                        },
+                    }),
+                },
+                modelNamesByUniqueId,
+            });
+            expect(result.metricsByModel.orders.completed_revenue.sql).toBe(
+                "CASE WHEN ((lower(raw_status || '')) = 'completed') THEN (${TABLE}.amount) END",
+            );
+        });
+
+        it('skips filters referencing dimensions that do not resolve on the semantic model', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: { sm: ordersSemanticModel },
+                metrics: {
+                    m: simpleMetric('eu_revenue', 'order_total', {
+                        // `customer` is an entity here but `region` lives on
+                        // another semantic model — cross-model filters can't
+                        // be translated.
+                        filter: {
+                            where_filters: [
+                                {
+                                    where_sql_template:
+                                        "{{ Dimension('customer__region') }} = 'EU'",
+                                },
+                            ],
+                        },
+                    }),
+                },
+                modelNamesByUniqueId,
+            });
+            expect(result.metricsByModel.orders?.eu_revenue).toBeUndefined();
+            expect(result.skippedCount).toBe(1);
+            expect(result.warnings[0]).toContain('customer__region');
+        });
+
+        it('skips filters using template functions other than Dimension()', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: { sm: ordersSemanticModel },
+                metrics: {
+                    m: simpleMetric('recent_revenue', 'order_total', {
+                        filter: {
+                            where_filters: [
+                                {
+                                    where_sql_template:
+                                        "{{ TimeDimension('order__ordered_at', 'day') }} >= '2024-01-01'",
+                                },
+                            ],
+                        },
+                    }),
+                },
+                modelNamesByUniqueId,
+            });
+            expect(result.skippedCount).toBe(1);
+            expect(result.warnings[0]).toContain('template functions');
+        });
+
+        it('skips filters in an unrecognised format', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: { sm: ordersSemanticModel },
+                metrics: {
+                    m: simpleMetric('weird', 'order_total', {
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        filter: { not_where_filters: true } as any,
+                    }),
+                },
+                modelNamesByUniqueId,
+            });
+            expect(result.skippedCount).toBe(1);
+            expect(result.warnings[0]).toContain('unrecognised format');
+        });
     });
 
-    it('skips sum_boolean measures', () => {
+    it('translates sum_boolean measures as a sum over CASE WHEN 1/0', () => {
         const result = translateMetricFlowMetrics({
             semanticModels: {
                 sm: {
@@ -332,8 +491,326 @@ describe('translateMetricFlowMetrics', () => {
             metrics: { m: simpleMetric('food_orders', 'is_food') },
             modelNamesByUniqueId,
         });
-        expect(result.skippedCount).toBe(1);
-        expect(result.warnings[0]).toContain('not supported');
+        expect(result.metricsByModel.orders.food_orders).toEqual({
+            type: MetricType.SUM,
+            sql: 'CASE WHEN (${TABLE}.is_food_order) THEN 1 ELSE 0 END',
+            label: undefined,
+            description: undefined,
+        });
+        expect(result.skippedCount).toBe(0);
+    });
+
+    describe('ratio metrics', () => {
+        const ratioMetric = (
+            name: string,
+            numerator: DbtSemanticMetric['type_params']['numerator'],
+            denominator: DbtSemanticMetric['type_params']['denominator'],
+            extra: Partial<DbtSemanticMetric> = {},
+        ): DbtSemanticMetric => ({
+            name,
+            unique_id: `metric.jaffle.${name}`,
+            type: 'ratio',
+            type_params: { numerator, denominator },
+            ...extra,
+        });
+
+        it('translates a same-model ratio into a number metric over its inputs', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: { sm: ordersSemanticModel },
+                metrics: {
+                    m1: simpleMetric('revenue', 'order_total'),
+                    m2: simpleMetric('orders_count', 'order_count'),
+                    m3: ratioMetric(
+                        'revenue_per_order',
+                        { name: 'revenue' },
+                        { name: 'orders_count' },
+                        { label: 'Revenue per order' },
+                    ),
+                },
+                modelNamesByUniqueId,
+            });
+            expect(result.metricsByModel.orders.revenue_per_order).toEqual({
+                type: MetricType.NUMBER,
+                sql: '(${revenue} * 1.0) / NULLIF(${orders_count}, 0)',
+                label: 'Revenue per order',
+                description: undefined,
+            });
+            expect(result.translatedCount).toBe(4); // 2 simple + create_metric + ratio
+            expect(result.skippedCount).toBe(0);
+        });
+
+        it('bakes input filters into hidden helper metrics', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: { sm: ordersSemanticModel },
+                metrics: {
+                    m1: simpleMetric('orders_count', 'order_count'),
+                    m2: ratioMetric(
+                        'completion_rate',
+                        {
+                            name: 'orders_count',
+                            filter: {
+                                where_filters: [
+                                    {
+                                        where_sql_template:
+                                            "{{ Dimension('order__status') }} = 'completed'",
+                                    },
+                                ],
+                            },
+                        },
+                        { name: 'orders_count' },
+                    ),
+                },
+                modelNamesByUniqueId,
+            });
+            expect(
+                result.metricsByModel.orders.completion_rate_numerator,
+            ).toEqual({
+                type: MetricType.COUNT,
+                sql: "CASE WHEN (${TABLE}.status = 'completed') THEN (1) END",
+                label: undefined,
+                description: undefined,
+                hidden: true,
+            });
+            expect(result.metricsByModel.orders.completion_rate.sql).toBe(
+                '(${completion_rate_numerator} * 1.0) / NULLIF(${orders_count}, 0)',
+            );
+        });
+
+        it('applies a ratio-level filter to both inputs', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: { sm: ordersSemanticModel },
+                metrics: {
+                    m1: simpleMetric('revenue', 'order_total'),
+                    m2: simpleMetric('orders_count', 'order_count'),
+                    m3: ratioMetric(
+                        'food_revenue_per_order',
+                        { name: 'revenue' },
+                        { name: 'orders_count' },
+                        {
+                            filter: {
+                                where_filters: [
+                                    {
+                                        where_sql_template:
+                                            "{{ Dimension('order__status') }} = 'completed'",
+                                    },
+                                ],
+                            },
+                        },
+                    ),
+                },
+                modelNamesByUniqueId,
+            });
+            const helpers = result.metricsByModel.orders;
+            expect(helpers.food_revenue_per_order_numerator.hidden).toBe(true);
+            expect(helpers.food_revenue_per_order_denominator.hidden).toBe(
+                true,
+            );
+            expect(helpers.food_revenue_per_order.sql).toBe(
+                '(${food_revenue_per_order_numerator} * 1.0) / NULLIF(${food_revenue_per_order_denominator}, 0)',
+            );
+        });
+
+        it('skips cross-model ratios with a warning', () => {
+            const customersSemanticModel: DbtSemanticModel = {
+                ...ordersSemanticModel,
+                name: 'customers',
+                unique_id: 'semantic_model.jaffle.customers',
+                model: "ref('customers')",
+                depends_on: { nodes: ['model.jaffle.customers'] },
+                measures: [
+                    {
+                        name: 'customer_count',
+                        agg: MetricFlowAggregation.COUNT_DISTINCT,
+                        expr: 'customer_id',
+                    },
+                ],
+            };
+            const result = translateMetricFlowMetrics({
+                semanticModels: {
+                    sm1: ordersSemanticModel,
+                    sm2: customersSemanticModel,
+                },
+                metrics: {
+                    m1: simpleMetric('revenue', 'order_total'),
+                    m2: simpleMetric('customers_count', 'customer_count'),
+                    m3: ratioMetric(
+                        'revenue_per_customer',
+                        { name: 'revenue' },
+                        { name: 'customers_count' },
+                    ),
+                },
+                modelNamesByUniqueId: {
+                    ...modelNamesByUniqueId,
+                    'model.jaffle.customers': 'customers',
+                },
+            });
+            expect(
+                result.metricsByModel.orders?.revenue_per_customer,
+            ).toBeUndefined();
+            expect(result.skippedCount).toBe(1);
+            expect(result.warnings.join(' ')).toContain('different models');
+        });
+
+        it('skips ratios whose inputs were not translated', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: { sm: ordersSemanticModel },
+                metrics: {
+                    m1: simpleMetric('revenue', 'order_total'),
+                    m2: ratioMetric(
+                        'broken_ratio',
+                        { name: 'revenue' },
+                        { name: 'does_not_exist' },
+                    ),
+                },
+                modelNamesByUniqueId,
+            });
+            expect(result.metricsByModel.orders?.broken_ratio).toBeUndefined();
+            expect(result.skippedCount).toBe(1);
+            expect(result.warnings.join(' ')).toContain('does_not_exist');
+        });
+    });
+
+    describe('derived metrics', () => {
+        it('translates a same-model derived metric, rewriting names and aliases', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: { sm: ordersSemanticModel },
+                metrics: {
+                    m1: simpleMetric('revenue', 'order_total'),
+                    m2: {
+                        name: 'double_revenue_per_customer',
+                        unique_id: 'metric.jaffle.double_revenue_per_customer',
+                        type: 'derived',
+                        label: 'Double revenue per customer',
+                        type_params: {
+                            expr: 'rev * 2 / unique_customers',
+                            metrics: [
+                                { name: 'revenue', alias: 'rev' },
+                                { name: 'unique_customers' },
+                            ],
+                        },
+                    },
+                },
+                modelNamesByUniqueId,
+            });
+            expect(
+                result.metricsByModel.orders.double_revenue_per_customer,
+            ).toEqual({
+                type: MetricType.NUMBER,
+                sql: '${revenue} * 2 / ${unique_customers}',
+                label: 'Double revenue per customer',
+                description: undefined,
+            });
+            expect(result.skippedCount).toBe(0);
+        });
+
+        it('bakes input filters into hidden helper metrics named by alias', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: { sm: ordersSemanticModel },
+                metrics: {
+                    m1: simpleMetric('revenue', 'order_total'),
+                    m2: {
+                        name: 'completed_share',
+                        unique_id: 'metric.jaffle.completed_share',
+                        type: 'derived',
+                        type_params: {
+                            expr: 'completed_rev / revenue',
+                            metrics: [
+                                {
+                                    name: 'revenue',
+                                    alias: 'completed_rev',
+                                    filter: {
+                                        where_filters: [
+                                            {
+                                                where_sql_template:
+                                                    "{{ Dimension('order__status') }} = 'completed'",
+                                            },
+                                        ],
+                                    },
+                                },
+                                { name: 'revenue' },
+                            ],
+                        },
+                    },
+                },
+                modelNamesByUniqueId,
+            });
+            const { orders } = result.metricsByModel;
+            expect(orders.completed_share_completed_rev).toEqual({
+                type: MetricType.SUM,
+                sql: "CASE WHEN (${TABLE}.status = 'completed') THEN (${TABLE}.amount) END",
+                label: undefined,
+                description: undefined,
+                hidden: true,
+            });
+            expect(orders.completed_share.sql).toBe(
+                '${completed_share_completed_rev} / ${revenue}',
+            );
+        });
+
+        it('skips derived metrics with time-offset inputs', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: { sm: ordersSemanticModel },
+                metrics: {
+                    m1: simpleMetric('revenue', 'order_total'),
+                    m2: {
+                        name: 'revenue_growth',
+                        unique_id: 'metric.jaffle.revenue_growth',
+                        type: 'derived',
+                        type_params: {
+                            expr: '(revenue - revenue_last_month) / revenue_last_month',
+                            metrics: [
+                                { name: 'revenue' },
+                                {
+                                    name: 'revenue',
+                                    alias: 'revenue_last_month',
+                                    offset_window: '1 month',
+                                },
+                            ],
+                        },
+                    },
+                },
+                modelNamesByUniqueId,
+            });
+            expect(
+                result.metricsByModel.orders?.revenue_growth,
+            ).toBeUndefined();
+            expect(result.skippedCount).toBe(1);
+            expect(result.warnings.join(' ')).toContain('offset_window');
+        });
+
+        it('resolves chains where a derived metric references a later ratio metric', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: { sm: ordersSemanticModel },
+                metrics: {
+                    // Deliberately listed before the ratio it references.
+                    m1: {
+                        name: 'double_aov',
+                        unique_id: 'metric.jaffle.double_aov',
+                        type: 'derived',
+                        type_params: {
+                            expr: 'aov * 2',
+                            metrics: [{ name: 'aov' }],
+                        },
+                    },
+                    m2: simpleMetric('revenue', 'order_total'),
+                    m3: simpleMetric('orders_count', 'order_count'),
+                    m4: {
+                        name: 'aov',
+                        unique_id: 'metric.jaffle.aov',
+                        type: 'ratio',
+                        type_params: {
+                            numerator: { name: 'revenue' },
+                            denominator: { name: 'orders_count' },
+                        },
+                    },
+                },
+                modelNamesByUniqueId,
+            });
+            expect(result.metricsByModel.orders.double_aov.sql).toBe(
+                '${aov} * 2',
+            );
+            expect(result.skippedCount).toBe(0);
+        });
     });
 
     it('skips percentile measures without a numeric percentile value', () => {
@@ -466,5 +943,79 @@ describe('translateMetricFlowMetrics', () => {
         expect(metric.type).toBe(MetricType.SUM);
         expect(metric.label).toBe('Total revenue');
         expect(metric.compiledSql).toBe('SUM("myTable".myColumnName)');
+    });
+
+    // End-to-end: a translated ratio must compile into a real Explore metric
+    // with the referenced input metrics inlined.
+    it('produces a ratio metric that compiles through convertExplores', async () => {
+        const modelUniqueId = 'model.test.myTable';
+        const semanticModel: DbtSemanticModel = {
+            name: 'my_table',
+            unique_id: 'semantic_model.test.my_table',
+            model: "ref('myTable')",
+            node_relation: { alias: 'myTable', schema_name: 'mySchema' },
+            depends_on: { nodes: [modelUniqueId] },
+            measures: [
+                {
+                    name: 'total_column',
+                    agg: MetricFlowAggregation.SUM,
+                    expr: 'myColumnName',
+                },
+                {
+                    // The mock warehouse client only compiles SUM/AVG/MAX
+                    // aggregates, so the denominator is a sum too.
+                    name: 'total_other',
+                    agg: MetricFlowAggregation.SUM,
+                    expr: 'myOtherColumn',
+                },
+            ],
+        };
+
+        const { metricsByModel, translatedCount } = translateMetricFlowMetrics({
+            semanticModels: { [semanticModel.unique_id]: semanticModel },
+            metrics: {
+                m1: simpleMetric('total_revenue', 'total_column'),
+                m2: simpleMetric('order_count', 'total_other'),
+                m3: {
+                    name: 'revenue_per_order',
+                    unique_id: 'metric.test.revenue_per_order',
+                    type: 'ratio',
+                    label: 'Revenue per order',
+                    type_params: {
+                        numerator: { name: 'total_revenue' },
+                        denominator: { name: 'order_count' },
+                    },
+                },
+            },
+            modelNamesByUniqueId: { [modelUniqueId]: MOCK_MODEL.name },
+        });
+        expect(translatedCount).toBe(3);
+
+        const modelWithMetrics: DbtModelNode = {
+            ...MOCK_MODEL,
+            unique_id: modelUniqueId,
+            meta: {
+                ...MOCK_MODEL.meta,
+                metrics: metricsByModel[MOCK_MODEL.name],
+            },
+        };
+
+        const explores = await convertExplores(
+            [modelWithMetrics],
+            false,
+            SupportedDbtAdapter.POSTGRES,
+            warehouseClientMock,
+            { spotlight: DEFAULT_SPOTLIGHT_CONFIG },
+        );
+
+        const explore = explores.find(
+            (e) => 'name' in e && e.name === MOCK_MODEL.name,
+        ) as Explore;
+        const metric =
+            explore.tables[MOCK_MODEL.name].metrics.revenue_per_order;
+        expect(metric.type).toBe(MetricType.NUMBER);
+        expect(metric.compiledSql).toBe(
+            '((SUM("myTable".myColumnName)) * 1.0) / NULLIF((SUM("myTable".myOtherColumn)), 0)',
+        );
     });
 });

--- a/packages/common/src/dbt/metricFlow.ts
+++ b/packages/common/src/dbt/metricFlow.ts
@@ -2,8 +2,10 @@ import { type AnyType } from '../types/any';
 import { type DbtModelLightdashMetric } from '../types/dbt';
 import {
     MetricFlowAggregation,
+    type DbtSemanticFilter,
     type DbtSemanticMeasure,
     type DbtSemanticMetric,
+    type DbtSemanticMetricInput,
     type DbtSemanticModel,
 } from '../types/dbtSemanticLayer';
 import { MetricType } from '../types/field';
@@ -41,6 +43,9 @@ const MEASURE_AGG_TO_METRIC_TYPE: Partial<
     [MetricFlowAggregation.PERCENTILE]: MetricType.PERCENTILE,
     [MetricFlowAggregation.MEDIAN]: MetricType.MEDIAN,
     [MetricFlowAggregation.COUNT]: MetricType.COUNT,
+    // sum_boolean has no Lightdash metric type; it compiles to a sum over a
+    // CASE WHEN that maps the boolean to 1/0 (see measureSql).
+    [MetricFlowAggregation.SUM_BOOLEAN]: MetricType.SUM,
 };
 
 const SIMPLE_COLUMN_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
@@ -58,11 +63,18 @@ const measuresOf = (semanticModel: DbtSemanticModel): DbtSemanticMeasure[] =>
  * (or the measure name when `expr` is null) is SQL evaluated against the
  * underlying model's columns. A bare column reference is qualified with
  * `${TABLE}` so it resolves unambiguously; anything more complex is passed
- * through verbatim.
+ * through verbatim. `sum_boolean` maps the boolean expression to 1/0 so it can
+ * compile as a plain `sum`.
  */
 const measureSql = (measure: DbtSemanticMeasure): string => {
     const expr = measure.expr ?? measure.name;
-    return SIMPLE_COLUMN_REGEX.test(expr) ? `\${TABLE}.${expr}` : expr;
+    const qualified = SIMPLE_COLUMN_REGEX.test(expr)
+        ? `\${TABLE}.${expr}`
+        : expr;
+    if (measure.agg === MetricFlowAggregation.SUM_BOOLEAN) {
+        return `CASE WHEN (${qualified}) THEN 1 ELSE 0 END`;
+    }
+    return qualified;
 };
 
 /**
@@ -86,6 +98,130 @@ const resolveModelName = (
     return null;
 };
 
+/**
+ * Extract the raw where-filter SQL templates from a manifest `filter:` value.
+ * Both dbt Core and Fusion normalise the YAML string into
+ * `{ where_filters: [{ where_sql_template }] }`; a plain string is accepted
+ * too. Returns null when the shape is unrecognisable.
+ */
+const extractWhereTemplates = (filter: DbtSemanticFilter): string[] | null => {
+    if (filter === null || filter === undefined) {
+        return [];
+    }
+    if (typeof filter === 'string') {
+        return [filter];
+    }
+    if (typeof filter === 'object' && Array.isArray(filter.where_filters)) {
+        const templates: string[] = [];
+        const allValid = filter.where_filters.every((whereFilter) => {
+            const template = whereFilter?.where_sql_template;
+            if (typeof template !== 'string') {
+                return false;
+            }
+            templates.push(template);
+            return true;
+        });
+        return allValid ? templates : null;
+    }
+    return null;
+};
+
+/**
+ * Resolve a MetricFlow dimension reference path (`entity__dimension`) against
+ * a semantic model, returning the SQL for the dimension. Only same-model
+ * references resolve: the entity and the dimension must both live on the given
+ * semantic model. Entity and dimension names may themselves contain `__`, so
+ * every split point is tried. Cross-model references (the entity resolves to
+ * another semantic model) and time-granularity suffixes fail to resolve.
+ */
+const resolveDimensionSql = (
+    path: string,
+    semanticModel: DbtSemanticModel,
+): string | null => {
+    const entities = Array.isArray(semanticModel.entities)
+        ? semanticModel.entities
+        : [];
+    const dimensions = Array.isArray(semanticModel.dimensions)
+        ? semanticModel.dimensions
+        : [];
+    const parts = path.split('__');
+    for (let i = 1; i < parts.length; i += 1) {
+        const entityName = parts.slice(0, i).join('__');
+        const dimensionName = parts.slice(i).join('__');
+        if (entities.some((entity) => entity.name === entityName)) {
+            const dimension = dimensions.find(
+                (candidate) => candidate.name === dimensionName,
+            );
+            if (dimension) {
+                const expr = dimension.expr ?? dimension.name;
+                return SIMPLE_COLUMN_REGEX.test(expr)
+                    ? `\${TABLE}.${expr}`
+                    : `(${expr})`;
+            }
+        }
+    }
+    return null;
+};
+
+const DIMENSION_REF_REGEX =
+    /\{\{\s*Dimension\(\s*(['"])([^'"]*)\1\s*\)\s*\}\}/g;
+const JINJA_RESIDUE_REGEX = /\{\{|\{%/;
+
+type FilterTranslation = { conditions: string[] } | { error: string };
+
+/**
+ * Translate MetricFlow where-filters into plain SQL conditions against a
+ * single semantic model. `{{ Dimension('entity__dim') }}` references are
+ * inlined when both the entity and the dimension live on that model; any other
+ * template function (TimeDimension, Entity, Metric, …) or a cross-model
+ * reference makes the filter untranslatable.
+ */
+const translateWhereFilters = (
+    filters: DbtSemanticFilter[],
+    semanticModel: DbtSemanticModel,
+): FilterTranslation => {
+    const conditions: string[] = [];
+    for (let i = 0; i < filters.length; i += 1) {
+        const templates = extractWhereTemplates(filters[i]);
+        if (templates === null) {
+            return { error: 'has a filter in an unrecognised format' };
+        }
+        for (let j = 0; j < templates.length; j += 1) {
+            let unresolvedPath: string | null = null;
+            const sql = templates[j]
+                .trim()
+                .replace(
+                    DIMENSION_REF_REGEX,
+                    (match: string, _quote: string, path: string) => {
+                        const dimensionSql = resolveDimensionSql(
+                            path,
+                            semanticModel,
+                        );
+                        if (dimensionSql === null) {
+                            unresolvedPath = path;
+                            return match;
+                        }
+                        return dimensionSql;
+                    },
+                );
+            if (unresolvedPath !== null) {
+                return {
+                    error: `filter references dimension "${unresolvedPath}" which does not resolve on semantic model "${semanticModel.name}" (cross-model filters are not supported)`,
+                };
+            }
+            if (JINJA_RESIDUE_REGEX.test(sql)) {
+                return {
+                    error: 'filter uses template functions other than Dimension(), which are not supported',
+                };
+            }
+            if (sql.length > 0) {
+                conditions.push(sql);
+            }
+        }
+    }
+    return { conditions };
+};
+
 export type TranslateMetricFlowArgs = {
     /** `manifest.semantic_models` */
     semanticModels: Record<string, DbtSemanticModel>;
@@ -107,10 +243,12 @@ export type TranslateMetricFlowResult = {
  * Translate supported MetricFlow metric definitions into Lightdash model
  * metrics, grouped by the dbt model they belong to.
  *
- * Supported: `simple` metrics and measures flagged `create_metric: true`, both
- * without filters (Lightdash cannot faithfully represent MetricFlow where
- * filters). Everything else (ratio / derived / cumulative / conversion,
- * filtered metrics, and `sum_boolean` measures) is skipped with a warning.
+ * Supported: `simple` metrics and measures flagged `create_metric: true`
+ * (including `sum_boolean` and same-model where-filters), plus `ratio` and
+ * `derived` metrics whose inputs all resolve to metrics on the same model
+ * (compiled to non-aggregate `number` metrics referencing them). Everything
+ * else (cumulative / conversion metrics, cross-model inputs, time-offset
+ * inputs, cross-model or non-Dimension filters) is skipped with a warning.
  */
 export const translateMetricFlowMetrics = ({
     semanticModels,
@@ -138,14 +276,17 @@ export const translateMetricFlowMetrics = ({
         });
     });
 
-    // Names of explicit manifest metrics. Measures mirroring one of these are
-    // owned by the metrics pass below — translating the bare measure would
+    // Explicit manifest metrics indexed by name. Measures mirroring one of
+    // these are owned by the metrics pass — translating the bare measure would
     // silently drop metric-level config such as filters.
-    const manifestMetricNames = new Set(
-        Object.values(metrics)
-            .filter(isSemanticMetric)
-            .map((metric) => metric.name),
-    );
+    const metricDefsByName = new Map<string, DbtSemanticMetric>();
+    Object.values(metrics)
+        .filter(isSemanticMetric)
+        .forEach((metric) => metricDefsByName.set(metric.name, metric));
+
+    // Which model each successfully translated metric landed on — ratio and
+    // derived metrics reference their inputs through this.
+    const modelByTranslatedMetric = new Map<string, string>();
 
     const addMetric = (
         modelName: string,
@@ -156,35 +297,45 @@ export const translateMetricFlowMetrics = ({
             metricsByModel[modelName] = {};
         }
         metricsByModel[modelName][metricName] = definition;
+        modelByTranslatedMetric.set(metricName, modelName);
     };
 
-    // Build a Lightdash metric definition from a single measure. Returns null
-    // (and records a warning) when the measure can't be represented.
+    // Build a Lightdash metric definition from a single measure plus optional
+    // pre-translated filter conditions. Returns an error description when the
+    // measure can't be represented (the caller formats the skip warning).
     const buildMeasureMetric = (
-        metricName: string,
         semanticModel: DbtSemanticModel,
         measure: DbtSemanticMeasure,
+        filterConditions: string[],
         overrides: { label?: string | null; description?: string | null },
-    ): { modelName: string; definition: DbtModelLightdashMetric } | null => {
+    ):
+        | { modelName: string; definition: DbtModelLightdashMetric }
+        | { error: string } => {
         const metricType = MEASURE_AGG_TO_METRIC_TYPE[measure.agg];
         if (!metricType) {
-            warnings.push(
-                `Skipped MetricFlow metric "${metricName}": measure aggregation "${measure.agg}" is not supported.`,
-            );
-            return null;
+            return {
+                error: `measure aggregation "${measure.agg}" is not supported`,
+            };
         }
 
         const modelName = resolveModelName(semanticModel, modelNamesByUniqueId);
         if (!modelName) {
-            warnings.push(
-                `Skipped MetricFlow metric "${metricName}": could not resolve the dbt model for semantic model "${semanticModel.name}".`,
-            );
-            return null;
+            return {
+                error: `could not resolve the dbt model for semantic model "${semanticModel.name}"`,
+            };
         }
+
+        const baseSql = measureSql(measure);
+        const sql =
+            filterConditions.length > 0
+                ? `CASE WHEN ${filterConditions
+                      .map((condition) => `(${condition})`)
+                      .join(' AND ')} THEN (${baseSql}) END`
+                : baseSql;
 
         const definition: DbtModelLightdashMetric = {
             type: metricType,
-            sql: measureSql(measure),
+            sql,
             label: overrides.label ?? measure.label ?? undefined,
             description:
                 overrides.description ?? measure.description ?? undefined,
@@ -195,12 +346,11 @@ export const translateMetricFlowMetrics = ({
             if (typeof p !== 'number' || Number.isNaN(p)) {
                 // Translating without a value would silently fall back to the
                 // warehouse default (p50) — wrong results are worse than a gap.
-                warnings.push(
-                    `Skipped MetricFlow metric "${metricName}": percentile aggregation requires a numeric agg_params.percentile (got ${JSON.stringify(
+                return {
+                    error: `percentile aggregation requires a numeric agg_params.percentile (got ${JSON.stringify(
                         p,
-                    )}).`,
-                );
-                return null;
+                    )})`,
+                };
             }
             // MetricFlow stores percentile as a 0-1 decimal in the compiled
             // manifest (e.g. 0.95); Lightdash uses a 0-100 scale. The latest
@@ -212,7 +362,71 @@ export const translateMetricFlowMetrics = ({
         return { modelName, definition };
     };
 
-    // 1. Explicit `simple` metrics.
+    // Resolve a simple metric definition to the semantic model + measure it
+    // aggregates, collecting any filters defined on the metric or its measure
+    // reference along the way. Legacy manifests (dbt Core) reference a measure
+    // by name; Fusion / latest-spec manifests inline the aggregation as
+    // `metric_aggregation_params`.
+    const resolveSimpleMetricMeasure = (
+        metric: DbtSemanticMetric,
+    ):
+        | {
+              semanticModel: DbtSemanticModel;
+              measure: DbtSemanticMeasure;
+              filters: DbtSemanticFilter[];
+          }
+        | { error: string } => {
+        const filters: DbtSemanticFilter[] = [];
+        if (metric.filter !== null && metric.filter !== undefined) {
+            filters.push(metric.filter);
+        }
+
+        const measureRef = metric.type_params.measure;
+        const inlineAggParams = metric.type_params.metric_aggregation_params;
+
+        if (measureRef?.name) {
+            if (measureRef.filter !== null && measureRef.filter !== undefined) {
+                filters.push(measureRef.filter);
+            }
+            const indexed = measureIndex.get(measureRef.name);
+            if (!indexed) {
+                return {
+                    error: `referenced measure "${measureRef.name}" was not found in any semantic model`,
+                };
+            }
+            return { ...indexed, filters };
+        }
+        if (inlineAggParams) {
+            const semanticModel = semanticModelsByName.get(
+                inlineAggParams.semantic_model,
+            );
+            if (!semanticModel) {
+                return {
+                    error: `semantic model "${inlineAggParams.semantic_model}" was not found`,
+                };
+            }
+            return {
+                semanticModel,
+                measure: {
+                    name: metric.name,
+                    agg: inlineAggParams.agg,
+                    expr: inlineAggParams.expr,
+                    agg_params: inlineAggParams.agg_params,
+                },
+                filters,
+            };
+        }
+        return { error: 'no measure reference found' };
+    };
+
+    const skip = (metricName: string, reason: string) => {
+        warnings.push(`Skipped MetricFlow metric "${metricName}": ${reason}.`);
+        skippedCount += 1;
+    };
+
+    // 1. Explicit `simple` metrics. Ratio/derived are deferred to pass 3 so
+    //    they can reference the metrics translated here.
+    const deferredMultiMetricDefs: DbtSemanticMetric[] = [];
     Object.entries(metrics).forEach(([manifestKey, rawMetric]) => {
         if (!isSemanticMetric(rawMetric)) {
             const name =
@@ -221,94 +435,47 @@ export const translateMetricFlowMetrics = ({
                 typeof (rawMetric as { name?: unknown }).name === 'string'
                     ? (rawMetric as { name: string }).name
                     : manifestKey;
-            warnings.push(
-                `Skipped MetricFlow metric "${name}": malformed metric definition in the manifest.`,
-            );
-            skippedCount += 1;
+            skip(name, 'malformed metric definition in the manifest');
             return;
         }
         const metric = rawMetric;
 
+        if (metric.type === 'ratio' || metric.type === 'derived') {
+            deferredMultiMetricDefs.push(metric);
+            return;
+        }
+
         if (metric.type !== 'simple') {
-            warnings.push(
-                `Skipped MetricFlow metric "${metric.name}": metric type "${metric.type}" is not supported yet (only "simple" metrics are translated).`,
+            skip(
+                metric.name,
+                `metric type "${metric.type}" is not supported yet`,
             );
-            skippedCount += 1;
             return;
         }
 
-        if (metric.filter) {
-            warnings.push(
-                `Skipped MetricFlow metric "${metric.name}": metric filters cannot be translated to Lightdash metrics.`,
-            );
-            skippedCount += 1;
+        const resolved = resolveSimpleMetricMeasure(metric);
+        if ('error' in resolved) {
+            skip(metric.name, resolved.error);
             return;
         }
 
-        // Resolve the metric to a semantic model + measure. Legacy manifests
-        // (dbt Core) reference a measure by name; Fusion / latest-spec
-        // manifests inline the aggregation as `metric_aggregation_params`.
-        const measureRef = metric.type_params.measure;
-        const inlineAggParams = metric.type_params.metric_aggregation_params;
-
-        let resolved: {
-            semanticModel: DbtSemanticModel;
-            measure: DbtSemanticMeasure;
-        } | null = null;
-
-        if (measureRef?.name) {
-            if (measureRef.filter) {
-                warnings.push(
-                    `Skipped MetricFlow metric "${metric.name}": measure-level filters cannot be translated to Lightdash metrics.`,
-                );
-                skippedCount += 1;
-                return;
-            }
-            const indexed = measureIndex.get(measureRef.name);
-            if (!indexed) {
-                warnings.push(
-                    `Skipped MetricFlow metric "${metric.name}": referenced measure "${measureRef.name}" was not found in any semantic model.`,
-                );
-                skippedCount += 1;
-                return;
-            }
-            resolved = indexed;
-        } else if (inlineAggParams) {
-            const semanticModel = semanticModelsByName.get(
-                inlineAggParams.semantic_model,
-            );
-            if (!semanticModel) {
-                warnings.push(
-                    `Skipped MetricFlow metric "${metric.name}": semantic model "${inlineAggParams.semantic_model}" was not found.`,
-                );
-                skippedCount += 1;
-                return;
-            }
-            resolved = {
-                semanticModel,
-                measure: {
-                    name: metric.name,
-                    agg: inlineAggParams.agg,
-                    expr: inlineAggParams.expr,
-                    agg_params: inlineAggParams.agg_params,
-                },
-            };
-        } else {
-            warnings.push(
-                `Skipped MetricFlow metric "${metric.name}": no measure reference found.`,
-            );
-            skippedCount += 1;
+        const filterTranslation = translateWhereFilters(
+            resolved.filters,
+            resolved.semanticModel,
+        );
+        if ('error' in filterTranslation) {
+            skip(metric.name, filterTranslation.error);
             return;
         }
 
         const built = buildMeasureMetric(
-            metric.name,
             resolved.semanticModel,
             resolved.measure,
+            filterTranslation.conditions,
             { label: metric.label, description: metric.description },
         );
-        if (!built) {
-            skippedCount += 1;
+        if ('error' in built) {
+            skip(metric.name, built.error);
             return;
         }
 
@@ -324,19 +491,17 @@ export const translateMetricFlowMetrics = ({
             if (!measure.create_metric) {
                 return;
             }
-            if (manifestMetricNames.has(measure.name)) {
+            if (metricDefsByName.has(measure.name)) {
                 // An explicit manifest metric owns this name — the metrics
                 // pass above already translated or skipped it.
                 return;
             }
-            const built = buildMeasureMetric(
-                measure.name,
-                semanticModel,
-                measure,
-                { label: measure.label, description: measure.description },
-            );
-            if (!built) {
-                skippedCount += 1;
+            const built = buildMeasureMetric(semanticModel, measure, [], {
+                label: measure.label,
+                description: measure.description,
+            });
+            if ('error' in built) {
+                skip(measure.name, built.error);
                 return;
             }
             if (metricsByModel[built.modelName]?.[measure.name]) {
@@ -346,6 +511,287 @@ export const translateMetricFlowMetrics = ({
             addMetric(built.modelName, measure.name, built.definition);
             translatedCount += 1;
         });
+    });
+
+    // Resolve one ratio/derived input to a `${metric}` reference. Unfiltered
+    // inputs point at an already-translated metric; filtered inputs compile
+    // the underlying measure with the filter baked in, as a hidden helper
+    // metric the visible metric references.
+    type ResolvedInput = {
+        ref: string;
+        modelName: string;
+        helper?: { name: string; definition: DbtModelLightdashMetric };
+    };
+    const resolveMetricInput = (
+        parentMetric: DbtSemanticMetric,
+        input: DbtSemanticMetricInput,
+        helperSuffix: string,
+    ): { value: ResolvedInput } | { error: string } => {
+        if (typeof input?.name !== 'string' || input.name.length === 0) {
+            return { error: 'input metric reference is missing a name' };
+        }
+        if (input.offset_window || input.offset_to_grain) {
+            return {
+                error: `input metric "${input.name}" uses offset_window/offset_to_grain, which is not supported`,
+            };
+        }
+
+        // The parent metric's own filter applies to every input.
+        const extraFilters: DbtSemanticFilter[] = [];
+        if (parentMetric.filter !== null && parentMetric.filter !== undefined) {
+            extraFilters.push(parentMetric.filter);
+        }
+        if (input.filter !== null && input.filter !== undefined) {
+            extraFilters.push(input.filter);
+        }
+
+        if (extraFilters.length === 0) {
+            const modelName = modelByTranslatedMetric.get(input.name);
+            if (!modelName) {
+                return {
+                    error: `input metric "${input.name}" was not translated to a Lightdash metric`,
+                };
+            }
+            return {
+                value: { ref: `\${${input.name}}`, modelName },
+            };
+        }
+
+        // Filtered input: rebuild the input metric's measure with the filter
+        // baked in. Only simple inputs (or bare create_metric measures) work.
+        const inputDef = metricDefsByName.get(input.name);
+        let resolved: {
+            semanticModel: DbtSemanticModel;
+            measure: DbtSemanticMeasure;
+            filters: DbtSemanticFilter[];
+        };
+        if (inputDef) {
+            if (inputDef.type !== 'simple') {
+                return {
+                    error: `filtered input metric "${input.name}" is not a simple metric`,
+                };
+            }
+            const resolvedSimple = resolveSimpleMetricMeasure(inputDef);
+            if ('error' in resolvedSimple) {
+                return {
+                    error: `input metric "${input.name}": ${resolvedSimple.error}`,
+                };
+            }
+            resolved = resolvedSimple;
+        } else {
+            const indexed = measureIndex.get(input.name);
+            if (!indexed) {
+                return {
+                    error: `input metric "${input.name}" was not found in the manifest`,
+                };
+            }
+            resolved = { ...indexed, filters: [] };
+        }
+
+        const filterTranslation = translateWhereFilters(
+            [...resolved.filters, ...extraFilters],
+            resolved.semanticModel,
+        );
+        if ('error' in filterTranslation) {
+            return {
+                error: `input metric "${input.name}" ${filterTranslation.error}`,
+            };
+        }
+
+        const built = buildMeasureMetric(
+            resolved.semanticModel,
+            resolved.measure,
+            filterTranslation.conditions,
+            { label: null, description: null },
+        );
+        if ('error' in built) {
+            return { error: `input metric "${input.name}": ${built.error}` };
+        }
+
+        const helperName = `${parentMetric.name}_${helperSuffix}`;
+        if (
+            modelByTranslatedMetric.has(helperName) ||
+            metricsByModel[built.modelName]?.[helperName]
+        ) {
+            return {
+                error: `helper metric name "${helperName}" collides with an existing metric`,
+            };
+        }
+        return {
+            value: {
+                ref: `\${${helperName}}`,
+                modelName: built.modelName,
+                helper: {
+                    name: helperName,
+                    definition: {
+                        ...built.definition,
+                        label: undefined,
+                        description: undefined,
+                        hidden: true,
+                    },
+                },
+            },
+        };
+    };
+
+    // Commit a ratio/derived metric plus any hidden helper metrics its inputs
+    // needed, after checking every input landed on the same model.
+    const commitMultiMetric = (
+        metric: DbtSemanticMetric,
+        inputs: ResolvedInput[],
+        sql: string,
+    ): { error: string } | undefined => {
+        const modelNames = new Set(inputs.map((input) => input.modelName));
+        if (modelNames.size > 1) {
+            return {
+                error: `its input metrics live on different models (${[
+                    ...modelNames,
+                ].join(
+                    ', ',
+                )}); cross-model ${metric.type} metrics are not supported`,
+            };
+        }
+        const [modelName] = [...modelNames];
+        inputs.forEach((input) => {
+            if (input.helper) {
+                addMetric(
+                    modelName,
+                    input.helper.name,
+                    input.helper.definition,
+                );
+            }
+        });
+        addMetric(modelName, metric.name, {
+            type: MetricType.NUMBER,
+            sql,
+            label: metric.label ?? undefined,
+            description: metric.description ?? undefined,
+        });
+        translatedCount += 1;
+        return undefined;
+    };
+
+    const translateMultiMetric = (
+        metric: DbtSemanticMetric,
+    ): { error: string } | undefined => {
+        if (metric.type === 'ratio') {
+            const numeratorInput = metric.type_params.numerator;
+            const denominatorInput = metric.type_params.denominator;
+            if (!numeratorInput?.name || !denominatorInput?.name) {
+                return {
+                    error: 'ratio metric is missing a numerator or denominator',
+                };
+            }
+            const numerator = resolveMetricInput(
+                metric,
+                numeratorInput,
+                'numerator',
+            );
+            if ('error' in numerator) {
+                return numerator;
+            }
+            const denominator = resolveMetricInput(
+                metric,
+                denominatorInput,
+                'denominator',
+            );
+            if ('error' in denominator) {
+                return denominator;
+            }
+            // * 1.0 avoids integer division on warehouses that truncate
+            // (Postgres, Trino); NULLIF avoids division-by-zero errors.
+            return commitMultiMetric(
+                metric,
+                [numerator.value, denominator.value],
+                `(${numerator.value.ref} * 1.0) / NULLIF(${denominator.value.ref}, 0)`,
+            );
+        }
+
+        // Derived: an expression over named input metrics.
+        const { expr, metrics: inputDefs } = metric.type_params;
+        if (
+            typeof expr !== 'string' ||
+            expr.length === 0 ||
+            !Array.isArray(inputDefs) ||
+            inputDefs.length === 0
+        ) {
+            return {
+                error: 'derived metric is missing an expr or input metrics',
+            };
+        }
+
+        const resolvedInputs: { token: string; value: ResolvedInput }[] = [];
+        let inputError: string | null = null;
+        inputDefs.some((input) => {
+            const result = resolveMetricInput(
+                metric,
+                input,
+                input?.alias ?? input?.name ?? 'input',
+            );
+            if ('error' in result) {
+                inputError = result.error;
+                return true;
+            }
+            resolvedInputs.push({
+                token: input.alias ?? input.name,
+                value: result.value,
+            });
+            return false;
+        });
+        if (inputError !== null) {
+            return { error: inputError };
+        }
+
+        // Rewrite input metric names/aliases in the expression to Lightdash
+        // `${metric}` references. Longest tokens first so a name that is a
+        // prefix of another can't clobber it.
+        const sql = resolvedInputs
+            .sort((a, b) => b.token.length - a.token.length)
+            .reduce((acc, { token, value }) => {
+                const escapedToken = token.replace(
+                    /[.*+?^${}()|[\]\\]/g,
+                    '\\$&',
+                );
+                return acc.replace(
+                    new RegExp(`\\b${escapedToken}\\b`, 'g'),
+                    () => value.ref,
+                );
+            }, expr.trim());
+
+        return commitMultiMetric(
+            metric,
+            resolvedInputs.map((input) => input.value),
+            sql,
+        );
+    };
+
+    // 3. Ratio and derived metrics, now that their inputs are translated.
+    //    Retried until a fixpoint so chains (a derived metric referencing
+    //    another ratio/derived metric) resolve regardless of manifest order.
+    let pendingMultiMetrics = deferredMultiMetricDefs;
+    const lastMultiMetricErrors = new Map<string, string>();
+    let previousPendingCount = Number.POSITIVE_INFINITY;
+    while (
+        pendingMultiMetrics.length > 0 &&
+        pendingMultiMetrics.length < previousPendingCount
+    ) {
+        previousPendingCount = pendingMultiMetrics.length;
+        pendingMultiMetrics = pendingMultiMetrics.filter((metric) => {
+            const result = translateMultiMetric(metric);
+            if (result === undefined) {
+                lastMultiMetricErrors.delete(metric.name);
+                return false;
+            }
+            lastMultiMetricErrors.set(metric.name, result.error);
+            return true;
+        });
+    }
+    pendingMultiMetrics.forEach((metric) => {
+        skip(
+            metric.name,
+            lastMultiMetricErrors.get(metric.name) ??
+                `metric type "${metric.type}" could not be translated`,
+        );
     });
 
     return { metricsByModel, warnings, translatedCount, skippedCount };

--- a/packages/common/src/types/dbtSemanticLayer.ts
+++ b/packages/common/src/types/dbtSemanticLayer.ts
@@ -69,10 +69,36 @@ export type DbtSemanticModel = {
     depends_on?: { nodes?: string[] };
 };
 
+/** A single rendered-SQL where filter (dbt manifest `WhereFilter`). */
+export type DbtSemanticWhereFilter = {
+    where_sql_template?: string | null;
+};
+
+/**
+ * Metric/measure `filter:` as it appears in the manifest. dbt Core and Fusion
+ * both normalise the YAML string into `{ where_filters: [...] }`.
+ */
+export type DbtSemanticFilter =
+    | string
+    | { where_filters?: DbtSemanticWhereFilter[] | null }
+    | null;
+
 export type DbtSemanticMetricInputMeasure = {
     name: string;
-    filter?: AnyType | null;
+    filter?: DbtSemanticFilter;
     alias?: string | null;
+};
+
+/**
+ * Reference to another metric used as an input to a ratio/derived metric
+ * (dbt manifest `MetricInput`).
+ */
+export type DbtSemanticMetricInput = {
+    name: string;
+    filter?: DbtSemanticFilter;
+    alias?: string | null;
+    offset_window?: AnyType | null;
+    offset_to_grain?: string | null;
 };
 
 /**
@@ -89,10 +115,10 @@ export type DbtSemanticMetricAggregationParams = {
 
 export type DbtSemanticMetricTypeParams = {
     measure?: DbtSemanticMetricInputMeasure | null;
-    numerator?: AnyType | null;
-    denominator?: AnyType | null;
+    numerator?: DbtSemanticMetricInput | null;
+    denominator?: DbtSemanticMetricInput | null;
     expr?: string | null;
-    metrics?: AnyType[] | null;
+    metrics?: DbtSemanticMetricInput[] | null;
     metric_aggregation_params?: DbtSemanticMetricAggregationParams | null;
 };
 
@@ -110,6 +136,6 @@ export type DbtSemanticMetric = {
     type_params: DbtSemanticMetricTypeParams;
     label?: string | null;
     description?: string | null;
-    filter?: AnyType | null;
+    filter?: DbtSemanticFilter;
     depends_on?: { nodes?: string[] };
 };


### PR DESCRIPTION
Closes: <!-- reference the related issue -->

### Description:

This PR significantly expands MetricFlow metric translation support in Lightdash:

**New Features:**
1. **Same-model where-filters**: Metrics and measures with `filter:` values now translate to Lightdash metrics. Filters using `{{ Dimension('entity__dim') }}` references are inlined when both the entity and dimension live on the same semantic model, compiled as `CASE WHEN <condition> THEN <expr> END` in the metric SQL.

2. **`sum_boolean` aggregation**: Previously skipped, `sum_boolean` measures now translate to `sum` metrics over `CASE WHEN bool THEN 1 ELSE 0 END`, matching MetricFlow's compilation strategy.

3. **Ratio metrics**: `ratio` metrics whose numerator and denominator both resolve to metrics on the same model now translate to `number` metrics with the formula `(${numerator} * 1.0) / NULLIF(${denominator}, 0)`. Filtered inputs compile to hidden helper metrics.

4. **Derived metrics**: `derived` metrics with same-model inputs (no time offsets) now translate to `number` metrics with the expression rewritten over `${metric}` references, supporting aliases.

**Implementation Details:**
- Added `extractWhereTemplates()` to normalize filter shapes (string, `where_filters` array, or null)
- Added `resolveDimensionSql()` to resolve dimension references against a semantic model, handling both plain columns and complex expressions
- Added `translateWhereFilters()` to compile MetricFlow where-filter templates into SQL conditions, rejecting cross-model references and non-Dimension template functions
- Refactored `buildMeasureMetric()` to accept pre-translated filter conditions and return error descriptions instead of null
- Added `resolveSimpleMetricMeasure()` to extract the measure and filters from simple metric definitions
- Added `resolveMetricInput()` to handle ratio/derived metric inputs, creating hidden helper metrics for filtered inputs
- Updated type definitions in `dbtSemanticLayer.ts` to properly model filters and metric inputs

**Skipped Cases:**
- Cumulative and conversion metrics (unsupported metric types)
- Cross-model filters (dimension doesn't resolve on the semantic model)
- Filters using template functions other than `Dimension()` (TimeDimension, Entity, Metric, etc.)
- Ratio/derived metrics with cross-model inputs or time-offset inputs
- Filters in unrecognized formats

The demo project examples have been updated to showcase filtered metrics, `sum_boolean`, ratio, and derived metric translations.

**Test Coverage:**
Comprehensive test suite added covering:
- Filter translation with dimension inlining
- Metric-level and measure-level filter combination
- Cross-model filter rejection
- Non-Dimension template function rejection
- `sum_boolean` translation
- Ratio metrics (same-model, filtered inputs, ratio-level filters, cross-model rejection)
- Derived metrics (expression rewriting, alias handling, filtered inputs)

All existing tests pass; new tests validate the expanded functionality.

https://claude.ai/code/session_01VCxuhre4Ls1EoawTxhW2pH