### PR TITLE
fix: scheduler filter requirement display parity and requirements popover polish

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.test.tsx
@@ -141,6 +141,14 @@ describe('FilterRequirementsButton explicit save', () => {
         expect(removeButton).not.toBeNull();
         await userEvent.click(removeButton!);
 
+        // Last member of the rule: removal asks for confirmation first
+        await userEvent.click(
+            await screen.findByRole('button', {
+                name: 'Remove rule',
+                hidden: true,
+            }),
+        );
+
         // Staged: the chip is gone from the draft view, nothing committed yet
         expect(queryRemoveChipButton()).toBeNull();
         expect(updateFilterRule).not.toHaveBeenCalled();
@@ -150,6 +158,21 @@ describe('FilterRequirementsButton explicit save', () => {
             required: false,
             requiredGroupId: undefined,
         });
+    });
+
+    it('keeps the member when last-member removal is cancelled', async () => {
+        renderWithProviders(<FilterRequirementsButton />);
+
+        await userEvent.click(queryRemoveChipButton()!);
+        await userEvent.click(
+            await screen.findByRole('button', {
+                name: 'Cancel',
+                hidden: true,
+            }),
+        );
+
+        expect(queryRemoveChipButton()).not.toBeNull();
+        expect(updateFilterRule).not.toHaveBeenCalled();
     });
 
     it('saves via keyboard activation of the Save button', async () => {

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.test.tsx
@@ -149,6 +149,10 @@ describe('FilterRequirementsButton explicit save', () => {
             }),
         );
 
+        // Clicks inside the portalled confirm modal must not count as
+        // popover outside clicks
+        expect(closeRulesPopover).not.toHaveBeenCalled();
+
         // Staged: the chip is gone from the draft view, nothing committed yet
         expect(queryRemoveChipButton()).toBeNull();
         expect(updateFilterRule).not.toHaveBeenCalled();
@@ -171,6 +175,7 @@ describe('FilterRequirementsButton explicit save', () => {
             }),
         );
 
+        expect(closeRulesPopover).not.toHaveBeenCalled();
         expect(queryRemoveChipButton()).not.toBeNull();
         expect(updateFilterRule).not.toHaveBeenCalled();
     });

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.tsx
@@ -20,6 +20,8 @@ import { v4 as uuidv4 } from 'uuid';
 import FieldIcon from '../../../components/common/Filters/FieldIcon';
 import MantineIcon from '../../../components/common/MantineIcon';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 import classes from './FilterRequirements.module.css';
 import FilterSelect, { type SelectableFilter } from './FilterSelect';
 import { AndSeparator } from './RuleSeparators';
@@ -122,10 +124,12 @@ const FilterRequirementsButton: FC = () => {
     const close = popovers?.closeRulesPopover ?? closeLocal;
     const [draftRuleIds, setDraftRuleIds] = useState<string[]>([]);
 
+    const dashboard = useDashboardContext((c) => c.dashboard);
     const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
     const requiredFiltersNote = useDashboardContext(
         (c) => c.requiredFiltersNote,
     );
+    const { track } = useTracking();
     const setRequiredFiltersNote = useDashboardContext(
         (c) => c.setRequiredFiltersNote,
     );
@@ -280,6 +284,18 @@ const FilterRequirementsButton: FC = () => {
         if (noteDraft !== null) {
             setRequiredFiltersNote(noteDraft);
         }
+        track({
+            name: EventName.DASHBOARD_FILTER_REQUIREMENTS_SAVED,
+            properties: {
+                dashboardUuid: dashboard?.uuid,
+                ruleCount: requirementRules.length,
+                memberCount: requirementRules.reduce(
+                    (count, rule) => count + rule.members.length,
+                    0,
+                ),
+                hasNote: (noteDraft ?? requiredFiltersNote ?? '').length > 0,
+            },
+        });
         setStagedRuleUpdates(null);
         setNoteDraft(null);
         setDraftRuleIds([]);
@@ -290,6 +306,10 @@ const FilterRequirementsButton: FC = () => {
         updateFilterRule,
         setRequiredFiltersNote,
         close,
+        track,
+        dashboard?.uuid,
+        requirementRules,
+        requiredFiltersNote,
     ]);
 
     const handleClose = useCallback(() => {

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.tsx
@@ -514,6 +514,7 @@ const FilterRequirementsButton: FC = () => {
                     // Modals default below popovers; lift it above the
                     // rules popover it is opened from
                     modalRootProps={{ zIndex: getDefaultZIndex('popover') }}
+                    size="md"
                     confirmLabel="Remove rule"
                     description="This is the only filter in this rule. Removing it deletes the rule, so viewers will no longer be required to set a filter before this dashboard loads."
                     onConfirm={() => {

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.tsx
@@ -6,6 +6,7 @@ import {
     Badge,
     Button,
     CloseButton,
+    getDefaultZIndex,
     Group,
     Popover,
     Stack,
@@ -510,6 +511,9 @@ const FilterRequirementsButton: FC = () => {
                     onClose={() => setMemberIdPendingRemoval(null)}
                     title="Remove filter rule?"
                     variant="delete"
+                    // Modals default below popovers; lift it above the
+                    // rules popover it is opened from
+                    modalRootProps={{ zIndex: getDefaultZIndex('popover') }}
                     confirmLabel="Remove rule"
                     description="This is the only filter in this rule. Removing it deletes the rule, so viewers will no longer be required to set a filter before this dashboard loads."
                     onConfirm={() => {

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.tsx
@@ -19,6 +19,7 @@ import { Fragment, useCallback, useMemo, useState, type FC } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import FieldIcon from '../../../components/common/Filters/FieldIcon';
 import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -251,7 +252,11 @@ const FilterRequirementsButton: FC = () => {
         [addMemberToGroup],
     );
 
-    const handleRemoveMember = useCallback(
+    const [memberIdPendingRemoval, setMemberIdPendingRemoval] = useState<
+        string | null
+    >(null);
+
+    const stageMemberRemoval = useCallback(
         (filterId: string) => {
             stageRuleUpdate(filterId, {
                 required: false,
@@ -259,6 +264,24 @@ const FilterRequirementsButton: FC = () => {
             });
         },
         [stageRuleUpdate],
+    );
+
+    const handleRemoveMember = useCallback(
+        (filterId: string) => {
+            // Removing the only member silently dissolves the rule, so that
+            // one asks for confirmation
+            const rule = requirementRules.find((requirementRule) =>
+                requirementRule.members.some(
+                    (member) => member.id === filterId,
+                ),
+            );
+            if (rule && rule.members.length === 1) {
+                setMemberIdPendingRemoval(filterId);
+                return;
+            }
+            stageMemberRemoval(filterId);
+        },
+        [requirementRules, stageMemberRemoval],
     );
 
     const handleDeleteRule = useCallback(
@@ -477,6 +500,20 @@ const FilterRequirementsButton: FC = () => {
                         </Button>
                     </Group>
                 )}
+                <MantineModal
+                    opened={memberIdPendingRemoval !== null}
+                    onClose={() => setMemberIdPendingRemoval(null)}
+                    title="Remove filter rule?"
+                    variant="delete"
+                    confirmLabel="Remove rule"
+                    description="This is the only filter in this rule. Removing it deletes the rule, so viewers will no longer be required to set a filter before this dashboard loads."
+                    onConfirm={() => {
+                        if (memberIdPendingRemoval) {
+                            stageMemberRemoval(memberIdPendingRemoval);
+                        }
+                        setMemberIdPendingRemoval(null);
+                    }}
+                />
             </Popover.Dropdown>
         </Popover>
     );

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterRequirementsButton.tsx
@@ -340,6 +340,7 @@ const FilterRequirementsButton: FC = () => {
         setStagedRuleUpdates(null);
         setNoteDraft(null);
         setDraftRuleIds([]);
+        setMemberIdPendingRemoval(null);
     }, [close]);
 
     const requirementCount = savedRequirementRules.length;
@@ -355,6 +356,10 @@ const FilterRequirementsButton: FC = () => {
             opened={isPopoverOpen}
             onClose={handleClose}
             onDismiss={handleClose}
+            // The removal confirm modal portals outside the dropdown, so its
+            // clicks would otherwise count as outside clicks and close the
+            // popover, discarding staged edits
+            closeOnClickOutside={memberIdPendingRemoval === null}
             transitionProps={{ transition: 'pop-top-left' }}
             withArrow
             shadow="md"

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterSelect.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/FilterSelect.tsx
@@ -27,6 +27,7 @@ const FilterSelect: FC<FilterSelectProps> = ({
     <Select
         size="xs"
         w={150}
+        aria-label="Add filter to rule"
         placeholder={placeholder}
         value={null}
         data={selectableFilters}

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.tsx
@@ -45,6 +45,7 @@ import { hasFilterValueSet } from '../FilterConfiguration/utils';
 import classes from './GuidedFilterSetup.module.css';
 import { AndSeparator, OrSeparator } from './RuleSeparators';
 import { useFilterableItemsMap } from './useFilterableItemsMap';
+import { useUpdateDashboardFilterRule } from './useUpdateDashboardFilterRule';
 import {
     getDashboardFilterRuleLabel,
     getFilterRequirementRules,
@@ -183,12 +184,9 @@ const GuidedFilterSetup: FC<Props> = ({
         (c) => c.requiredFiltersNote,
     );
     const activeTab = useDashboardContext((c) => c.activeTab);
-    const updateDimensionDashboardFilter = useDashboardContext(
-        (c) => c.updateDimensionDashboardFilter,
-    );
-    const updateMetricDashboardFilter = useDashboardContext(
-        (c) => c.updateMetricDashboardFilter,
-    );
+    const updateFilterRule = useUpdateDashboardFilterRule({
+        isEditMode: false,
+    });
 
     // Rules a viewer re-opened via "Change"; satisfied rules collapse to a
     // summary line unless they're in here
@@ -221,39 +219,12 @@ const GuidedFilterSetup: FC<Props> = ({
         (newRule: DashboardFilterRule) => {
             // Mirrors the chip popover's view-mode behavior: a value enables the
             // filter, clearing it goes back to "any value" (and re-locks)
-            const updatedRule = {
+            updateFilterRule(newRule.id, {
                 ...newRule,
                 disabled: !hasFilterValueSet(newRule),
-            };
-            const dimensionIndex = dashboardFilters.dimensions.findIndex(
-                (filter) => filter.id === newRule.id,
-            );
-            if (dimensionIndex >= 0) {
-                updateDimensionDashboardFilter(
-                    updatedRule,
-                    dimensionIndex,
-                    false,
-                    false,
-                );
-                return;
-            }
-            const metricIndex = dashboardFilters.metrics.findIndex(
-                (filter) => filter.id === newRule.id,
-            );
-            if (metricIndex >= 0) {
-                updateMetricDashboardFilter(
-                    updatedRule,
-                    metricIndex,
-                    false,
-                    false,
-                );
-            }
+            });
         },
-        [
-            dashboardFilters,
-            updateDimensionDashboardFilter,
-            updateMetricDashboardFilter,
-        ],
+        [updateFilterRule],
     );
 
     if (!allFilterableFieldsMap) return null;

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.tsx
@@ -275,7 +275,7 @@ const GuidedFilterSetup: FC<Props> = ({
                         align="flex-start"
                         wrap="nowrap"
                     >
-                        <Group gap="sm" wrap="nowrap">
+                        <Group gap="sm" wrap="nowrap" miw={0}>
                             <Paper p="6px" withBorder radius="md">
                                 <MantineIcon
                                     icon={IconFilterExclamation}
@@ -283,7 +283,14 @@ const GuidedFilterSetup: FC<Props> = ({
                                     color="yellow.7"
                                 />
                             </Paper>
-                            <Text c="ldDark.9" fw={700} fz="md" lh="28px">
+                            <Text
+                                c="ldDark.9"
+                                fw={700}
+                                fz="md"
+                                lh="28px"
+                                miw={0}
+                                lineClamp={2}
+                            >
                                 Set filters to load{' '}
                                 {dashboard?.name ?? 'this dashboard'}
                             </Text>

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/useUpdateDashboardFilterRule.ts
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/useUpdateDashboardFilterRule.ts
@@ -5,9 +5,14 @@ import useDashboardContext from '../../../providers/Dashboard/useDashboardContex
 /**
  * Immediately applies a partial update to a saved dashboard filter
  * (dimension or metric) by id. Used by the filter-rule editors, whose edits
- * take effect without an Apply step.
+ * take effect without an Apply step. `isEditMode` mirrors the dashboard
+ * context updaters: true for author-side editors (default), false for
+ * viewer-side value setting (e.g. the guided setup card).
  */
-export const useUpdateDashboardFilterRule = () => {
+export const useUpdateDashboardFilterRule = (options?: {
+    isEditMode?: boolean;
+}) => {
+    const isEditMode = options?.isEditMode ?? true;
     const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
     const updateDimensionDashboardFilter = useDashboardContext(
         (c) => c.updateDimensionDashboardFilter,
@@ -29,7 +34,7 @@ export const useUpdateDashboardFilterRule = () => {
                     },
                     dimensionIndex,
                     false,
-                    true,
+                    isEditMode,
                 );
                 return;
             }
@@ -41,12 +46,13 @@ export const useUpdateDashboardFilterRule = () => {
                     { ...dashboardFilters.metrics[metricIndex], ...updates },
                     metricIndex,
                     false,
-                    true,
+                    isEditMode,
                 );
             }
         },
         [
             dashboardFilters,
+            isEditMode,
             updateDimensionDashboardFilter,
             updateMetricDashboardFilter,
         ],

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.tsx
@@ -434,9 +434,11 @@ export const SchedulerFormFiltersTab: FC<SchedulerFiltersProps> = ({
         );
     }
 
+    // Same base as the submit gate in useSchedulerFormModal: the saved
+    // dashboard filters, not the live session filters.
     const { unmetRequirements, filtersWithUnmetRequirements } =
         getSchedulerFilterRequirements(
-            currentDashboardFilters,
+            dashboard?.filters,
             draftFilters,
             isFilterRequirementsEnabled,
         );

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
@@ -102,6 +102,7 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
         numericMetrics,
         isDashboardTabsAvailable,
         requiredFiltersWithoutValues,
+        hasOnlyUnmetGroupRequirements,
     } = useSchedulerFormModal({
         schedulerUuid: schedulerUuidToEdit,
         resourceUuid,
@@ -158,7 +159,9 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
         : isThresholdAlert && !form.values.thresholds?.[0]?.fieldId
           ? 'Pick an alert field'
           : requiredFiltersWithoutValues.length > 0
-            ? 'Some required filters are missing values'
+            ? hasOnlyUnmetGroupRequirements
+                ? 'Set a value for at least one filter in each requirement group'
+                : 'Some required filters are missing values'
             : !form.isValid()
               ? 'Complete the required fields'
               : null;

--- a/packages/frontend/src/features/scheduler/hooks/useSchedulerFormModal.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useSchedulerFormModal.ts
@@ -7,13 +7,12 @@ import {
     type ApiError,
     type CreateSchedulerAndTargets,
     type CreateSchedulerAndTargetsWithoutIds,
-    type DashboardFilters,
     type ItemsMap,
     type ParametersValuesMap,
     type SchedulerAndTargets,
 } from '@lightdash/common';
 import { type UseMutationResult } from '@tanstack/react-query';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useAiAgentButtonVisibility } from '../../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { useDashboardQuery } from '../../../hooks/dashboard/useDashboard';
 import useToaster from '../../../hooks/toaster/useToaster';
@@ -152,15 +151,6 @@ export const useSchedulerFormModal = ({
     const isFilterRequirementsEnabled =
         filterRequirementsFlag?.enabled === true;
 
-    // The form's validate closure is captured once, so it reads the saved
-    // filters and flag through refs updated on every render.
-    const savedDashboardFiltersRef = useRef<DashboardFilters | undefined>(
-        undefined,
-    );
-    savedDashboardFiltersRef.current = dashboard?.filters;
-    const isFilterRequirementsEnabledRef = useRef(false);
-    isFilterRequirementsEnabledRef.current = isFilterRequirementsEnabled;
-
     // Use the explicitly passed parameter values
     const dashboardParameterValues = currentParameterValues || {};
 
@@ -212,15 +202,19 @@ export const useSchedulerFormModal = ({
                     // Dashboard filters are undefined/null for charts
                     return null;
                 }
-                const { filtersWithUnmetRequirements } =
+                const { unmetRequirements, filtersWithUnmetRequirements } =
                     getSchedulerFilterRequirements(
-                        savedDashboardFiltersRef.current,
+                        dashboard?.filters,
                         value,
-                        isFilterRequirementsEnabledRef.current,
+                        isFilterRequirementsEnabled,
                     );
 
                 if (filtersWithUnmetRequirements.length > 0) {
-                    return `Required filters must have values`;
+                    return unmetRequirements.every(
+                        (requirement) => requirement.type === 'group',
+                    )
+                        ? 'Set a value for at least one filter in each requirement group'
+                        : 'Required filters must have values';
                 }
                 return null;
             },
@@ -256,12 +250,17 @@ export const useSchedulerFormModal = ({
     const isThresholdAlertWithNoFields =
         isThresholdAlert && Object.keys(numericMetrics).length === 0;
 
-    const { filtersWithUnmetRequirements: requiredFiltersWithoutValues } =
-        getSchedulerFilterRequirements(
-            dashboard?.filters,
-            form.values.dashboardFilters,
-            isFilterRequirementsEnabled,
-        );
+    const {
+        unmetRequirements,
+        filtersWithUnmetRequirements: requiredFiltersWithoutValues,
+    } = getSchedulerFilterRequirements(
+        dashboard?.filters,
+        form.values.dashboardFilters,
+        isFilterRequirementsEnabled,
+    );
+    const hasOnlyUnmetGroupRequirements =
+        unmetRequirements.length > 0 &&
+        unmetRequirements.every((requirement) => requirement.type === 'group');
 
     // Sync form values when data is loaded. The AI augmentation is omitted —
     // it loads via a separate query and is synced by the effect below, so a
@@ -466,5 +465,6 @@ export const useSchedulerFormModal = ({
         numericMetrics,
         isDashboardTabsAvailable,
         requiredFiltersWithoutValues,
+        hasOnlyUnmetGroupRequirements,
     };
 };

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -559,6 +559,16 @@ type DashboardFilterLockToggledEvent = {
     };
 };
 
+type DashboardFilterRequirementsSavedEvent = {
+    name: EventName.DASHBOARD_FILTER_REQUIREMENTS_SAVED;
+    properties: {
+        dashboardUuid: string | undefined;
+        ruleCount: number;
+        memberCount: number;
+        hasNote: boolean;
+    };
+};
+
 export type EventData =
     | GenericEvent
     | HomepageQuickActionClickedEvent
@@ -569,6 +579,7 @@ export type EventData =
     | GlobalSearchClosedEvent
     | OnboardingStepClickedEvent
     | CrossFilterDashboardAppliedEvent
+    | DashboardFilterRequirementsSavedEvent
     | ViewUnderlyingDataClickedEvent
     | DrillByClickedEvent
     | DashboardAutoRefreshUpdateEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -105,6 +105,7 @@ export enum EventName {
     SETUP_STEP_CLICKED = 'setup_step.click',
     ADD_FILTER_CLICKED = 'add_filter.click',
     DASHBOARD_FILTER_LOCK_TOGGLED = 'dashboard_filter_lock.toggled',
+    DASHBOARD_FILTER_REQUIREMENTS_SAVED = 'dashboard_filter_requirements.saved',
     GO_TO_LINK_CLICKED = 'go_to_link.click',
     ADD_CUSTOM_METRIC_CLICKED = 'add_custom_metric.click',
     REMOVE_CUSTOM_METRIC_CLICKED = 'remove_custom_metric.click',


### PR DESCRIPTION
## Description

Follow-ups from the PR #25449 review plus the task's outstanding polish items, all flag-gated or parity-safe:

**From the review:**
- **Align the scheduler Filters tab with the submit gate.** The tab evaluated requirements against live session filters while the gate used saved dashboard filters, so editing a scheduler while a requirement member had an unsaved session value showed no asterisk yet still blocked Save. Both now evaluate the saved dashboard base (what the delivery actually runs with).
- **Group-aware copy.** The blocked-reason tooltip and form validation error now say "Set a value for at least one filter in each requirement group" when only any-of groups are unmet, matching the Filters tab. Legacy required filters keep the legacy copy verbatim.
- **Drop the refs indirection in `useSchedulerFormModal`.** `@mantine/form@7.5.2` rebuilds validators from the fresh options object every render, so plain closures are always current; the comment claiming otherwise was wrong.
- **Usage tracking for the requirements popover.** One `dashboard_filter_requirements.saved` event on popover Save with rule count, member count, and whether a note is set — adoption data for the flag rollout decision.
- **A11y:** the add-filter-to-rule select now has an accessible label.

**Task follow-ups:**
- **Clamp long dashboard names in the guided setup header** (user-reported overflow: unbounded 28px-line-height title squeezed the close button). Two-line clamp with ellipsis.
- **Confirm before removing the last member of a filter rule.** Removing the only member silently dissolved the rule; it now asks (`MantineModal` delete variant). Multi-member removal and the explicit Delete rule button stay immediate.
- **Reuse `useUpdateDashboardFilterRule` in the guided setup card.** The hook gains an `isEditMode` option (default true = existing popover behavior); the card drops its duplicated find-and-update logic.

Also assessed and deliberately unchanged: `FilterBarPopoversContext` stays nullable (its absence on the embed page is a meaningful "no coordinated filter bar" signal that hides the chip's Edit rules action), and the requirement rule models are already unified in common (`getUnmetFilterRequirements` derives from `getFilterRequirementRules`).

## Feature flag behavior

Flag off (`dashboard-filter-requirements`) remains exact main parity: every touched component either only mounts flag-on or keeps its flag-off arm untouched; `useUpdateDashboardFilterRule`'s default preserves existing consumer behavior byte-for-byte.

## Verification

- 59/59 unit tests across the scheduler helper and FilterRequirements suites (including two new tests for the removal confirm), `typecheck:fast` clean, full frontend lint clean (4 pre-existing warnings in unrelated files).
- Browser (flag on): overflow clamp verified with a 130-char dashboard name; last-member confirm verified (multi-member removal silent, last-member confirms, cancel preserves); guided card still sets values and unlocks through the shared hook; scheduler group tooltip/asterisks against the saved base; legacy required keeps legacy copy.
- Browser (flag off): main parity re-verified for the scheduler surfaces.
- Rebased on latest main.

Contributes to PROD-8661