### PR TITLE
feat(backend): opt-in config to emit audit log actor as a JSON string

### DIFF
--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -110,6 +110,17 @@ LIGHTDASH_LOG_FORMAT="json"
 LIGHTDASH_LOG_OUTPUTS="console,file"
 ```
 
+### Emitting the actor as a JSON string
+
+By default the `actor` field is emitted as a nested JSON object. Some log indexers (e.g. Elasticsearch) map this field as `text` and silently drop the
+actor when a nested object arrives on ingest. Set the following to serialize `actor` to a JSON string instead, so it is stored as text:
+
+```bash
+LIGHTDASH_LOG_AUDIT_ACTOR_AS_STRING="true"
+```
+
+This is off by default and only changes the structured JSON `actor` field. The human-readable `message` field already renders the actor as text.
+
 ---
 
 ## How to Add Audit Logging to a Service

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -133,6 +133,7 @@ export const lightdashConfigMock: LightdashConfig = {
         fileFormat: undefined,
         fileLevel: undefined,
         filePath: '',
+        auditActorAsString: false,
     },
     maxPayloadSize: '',
     pivotTable: { maxColumnLimit: 0 },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1235,6 +1235,7 @@ export type LoggingConfig = {
     fileFormat: LoggingFormat | undefined;
     fileLevel: LoggingLevel | undefined;
     filePath: string;
+    auditActorAsString: boolean;
 };
 
 export type MultiProjectSetupEntry = {
@@ -2861,6 +2862,8 @@ export const parseConfig = (): LightdashConfig => {
                     ? undefined
                     : parseLoggingLevel(process.env.LIGHTDASH_LOG_FILE_LEVEL),
             filePath: process.env.LIGHTDASH_LOG_FILE_PATH || './logs/all.log',
+            auditActorAsString:
+                process.env.LIGHTDASH_LOG_AUDIT_ACTOR_AS_STRING === 'true',
         },
         ai: {
             copilot: copilotConfig,

--- a/packages/backend/src/logging/winston.test.ts
+++ b/packages/backend/src/logging/winston.test.ts
@@ -1,5 +1,6 @@
 import { AuditLogEvent } from './auditLog';
 import {
+    buildAuditLogPayload,
     formatAuditAction,
     formatAuditActor,
     formatAuditMessage,
@@ -268,5 +269,48 @@ describe('formatAuditMessage', () => {
         ).toBe(
             'anonymous user viewed Dashboard -> dashboardUuid: dash-uuid, dashboardName: Sales Overview (allowed)',
         );
+    });
+});
+
+describe('buildAuditLogPayload', () => {
+    const event: AuditLogEvent = {
+        id: 'event-uuid',
+        timestamp: '2026-04-02T15:00:00.000Z',
+        actor: {
+            type: 'session',
+            uuid: 'user-uuid',
+            email: 'john@company.com',
+            firstName: 'John',
+            lastName: 'Doe',
+            organizationUuid: 'org-uuid',
+            organizationRole: 'admin',
+        },
+        action: 'update',
+        resource: {
+            type: 'Dashboard',
+            organizationUuid: 'org-uuid',
+            projectUuid: 'proj-uuid',
+        },
+        context: {},
+        status: 'allowed',
+    };
+
+    it('keeps actor as an object when auditActorAsString is disabled', () => {
+        const payload = buildAuditLogPayload(event, false);
+        expect(typeof payload.actor).toBe('object');
+        expect(payload.actor).toEqual(event.actor);
+    });
+
+    it('serializes actor to a JSON string when auditActorAsString is enabled', () => {
+        const payload = buildAuditLogPayload(event, true);
+        expect(typeof payload.actor).toBe('string');
+        expect(payload.actor).toBe(JSON.stringify(event.actor));
+    });
+
+    it('leaves all other event fields unchanged when stringifying', () => {
+        expect(buildAuditLogPayload(event, true)).toEqual({
+            ...event,
+            actor: JSON.stringify(event.actor),
+        });
     });
 });

--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -266,11 +266,28 @@ export const formatAuditMessage = (event: AuditLogEvent): string => {
     return `${actor} ${action} ${resource} ${status}${reason}`;
 };
 
+export type AuditLogPayload = Omit<AuditLogEvent, 'actor'> & {
+    actor: AuditActor | string;
+};
+
+// Serializes the audit `actor` to a JSON string when `auditActorAsString` is
+// enabled, so log indexers that map the field as text don't drop it on ingest.
+export const buildAuditLogPayload = (
+    event: AuditLogEvent,
+    auditActorAsString: boolean,
+): AuditLogPayload =>
+    auditActorAsString
+        ? { ...event, actor: JSON.stringify(event.actor) }
+        : event;
+
 export const logAuditEvent = (event: AuditLogEvent): void => {
     winstonLogger.log({
         level: 'audit',
         message: formatAuditMessage(event),
-        ...event,
+        ...buildAuditLogPayload(
+            event,
+            lightdashConfig.logging.auditActorAsString,
+        ),
     });
 };
 


### PR DESCRIPTION
Closes: #25595

### Description

Adds an opt-in logging option to emit the audit log `actor` field as a JSON string instead of a nested JSON object.

Some deployments forward audit logs to a log index (e.g. Elasticsearch) where the actor field is mapped as `text`. When a nested object arrives for a `text`-mapped field, the indexer rejects it and silently drops the field, so the actor is missing from every indexed audit event.

Setting `LIGHTDASH_LOG_AUDIT_ACTOR_AS_STRING=true` serializes `actor` with `JSON.stringify` on the audit payload so it is stored as text. It is **off by default**, so the audit log shape is unchanged unless explicitly enabled, and it only affects the structured JSON `actor` field (the human-readable `message` field already renders the actor as text).

### Changes

- `LoggingConfig.auditActorAsString`, parsed from `LIGHTDASH_LOG_AUDIT_ACTOR_AS_STRING` (default `false`)
- `buildAuditLogPayload()` in `winston.ts` stringifies `actor` when enabled; `logAuditEvent` uses it
- Unit tests covering both modes
- Documented the env var in `docs/audit-logging.md`

### Testing

- `pnpm -F backend typecheck:fast` — clean
- `pnpm -F backend test src/logging/winston.test.ts` — 22 passing
- Lint clean
