### PR TITLE
fix(ai): ignore field-less default_time_dimension instead of crashing field discovery

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.grepPrecision.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.grepPrecision.test.ts
@@ -166,6 +166,38 @@ describe('getDefaultTimeDimensionFieldIds', () => {
             defaultTimeDimensionGranularity: 'orders_shipped_at_day',
         });
     });
+
+    // Malformed dbt YAML (wrong keys inside default_time_dimension) compiles
+    // to {}; must not crash the whole grep_fields index build
+    it('returns null when the model default time dimension has no field', () => {
+        const explore = makeExplore({
+            name: 'orders',
+            fields: [{ name: 'created_at' }],
+        });
+        explore.tables.orders.defaultTimeDimension =
+            {} as (typeof explore.tables.orders)['defaultTimeDimension'];
+
+        expect(
+            getDefaultTimeDimensionFieldIds(
+                makeMetric('orders', 'revenue'),
+                explore.tables.orders,
+            ),
+        ).toBeNull();
+    });
+
+    it('does not throw when building an index over a field-less model default', () => {
+        const explore = makeExplore({
+            name: 'orders',
+            fields: [{ name: 'created_at' }],
+        });
+        explore.tables.orders.defaultTimeDimension =
+            {} as (typeof explore.tables.orders)['defaultTimeDimension'];
+        explore.tables.orders.metrics = {
+            revenue: makeMetric('orders', 'revenue'),
+        };
+
+        expect(() => buildFieldIndex([explore])).not.toThrow();
+    });
 });
 
 describe('compileMatcher word boundaries for short terms', () => {

--- a/packages/common/src/utils/metricsExplorer.test.ts
+++ b/packages/common/src/utils/metricsExplorer.test.ts
@@ -1,14 +1,18 @@
 import dayjs from 'dayjs';
 import type { CatalogField } from '../types/catalog';
+import type { CompiledTable } from '../types/explore';
 import {
     DimensionType,
     FieldType,
+    MetricType,
     type CompiledDimension,
+    type CompiledMetric,
 } from '../types/field';
 import { FilterOperator } from '../types/filter';
-import { TimeFrames } from '../types/timeFrames';
+import { TimeFrames, type DefaultTimeDimension } from '../types/timeFrames';
 import {
     getDateCalcUtils,
+    getDefaultTimeDimension,
     getInitialDefaultFilterRule,
     getInitialDefaultSegment,
 } from './metricsExplorer';
@@ -176,5 +180,53 @@ describe('getInitialDefaultFilterRule', () => {
                 [dimRegion],
             ),
         ).toBeUndefined();
+    });
+});
+
+describe('getDefaultTimeDimension', () => {
+    const metric: CompiledMetric = {
+        name: 'revenue',
+        table: 'orders',
+        fieldType: FieldType.METRIC,
+        type: MetricType.SUM,
+        label: 'Revenue',
+        tableLabel: 'Orders',
+        sql: '${TABLE}.revenue',
+        compiledSql: 'SUM("orders".revenue)',
+        tablesReferences: ['orders'],
+        hidden: false,
+    };
+
+    // Malformed dbt YAML (wrong keys inside default_time_dimension) compiles
+    // to an empty object; treat it as absent instead of returning
+    // { field: undefined } that crashes downstream getItemId calls.
+    test('ignores a metric-level default time dimension without a field', () => {
+        expect(
+            getDefaultTimeDimension({
+                ...metric,
+                defaultTimeDimension: {} as DefaultTimeDimension,
+            }),
+        ).toBeUndefined();
+    });
+
+    test('ignores a model-level default time dimension without a field', () => {
+        const table = {
+            name: 'orders',
+            defaultTimeDimension: {} as DefaultTimeDimension,
+        } as CompiledTable;
+
+        expect(getDefaultTimeDimension(metric, table)).toBeUndefined();
+    });
+
+    test('returns the metric-level default time dimension when valid', () => {
+        expect(
+            getDefaultTimeDimension({
+                ...metric,
+                defaultTimeDimension: {
+                    field: 'created_at',
+                    interval: TimeFrames.DAY,
+                },
+            }),
+        ).toEqual({ field: 'created_at', interval: TimeFrames.DAY });
     });
 });

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -522,8 +522,10 @@ export const getDefaultTimeDimension = (
     metric: CompiledMetric,
     table?: CompiledTable,
 ): DefaultTimeDimension | undefined => {
+    // Malformed yml (e.g. wrong keys inside default_time_dimension) compiles
+    // to a field-less object — treat it as absent
     // Priority 1: Use metric-level default time dimension if defined in yml
-    if (metric.defaultTimeDimension) {
+    if (metric.defaultTimeDimension?.field) {
         return {
             field: metric.defaultTimeDimension.field,
             interval:
@@ -533,7 +535,7 @@ export const getDefaultTimeDimension = (
     }
 
     // Priority 2: Use model-level default time dimension if defined in yml
-    if (table?.defaultTimeDimension) {
+    if (table?.defaultTimeDimension?.field) {
         return {
             field: table.defaultTimeDimension.field,
             interval:


### PR DESCRIPTION
## Summary

A `default_time_dimension` yml block with unrecognized inner keys compiles to an empty object (`translator.ts` copies only `.field`/`.interval` and compile-time validation doesn't cover the block). Since #25407, the AI field-discovery enrichment dereferences that object's `field` via `getItemId`, which crashes with `TypeError: Cannot read properties of undefined (reading 'replaceAll')` — one malformed model breaks every `grep_fields`/`get_metadata` call whose scope includes it. In a customer's workspace this cascaded into Claude falling back to raw SQL and surfacing permission denials, reported as "lack of access errors".

Fix: `getDefaultTimeDimension` now treats a default time dimension without a `field` as absent (covers metric-level and model-level blocks, and all consumers — grep_fields, get_metadata, metrics explorer).

## Test plan

- New regression tests reproducing the exact production TypeError at both levels:
  - `common`: `getDefaultTimeDimension` returns `undefined` for field-less metric/model blocks
  - `backend`: `getDefaultTimeDimensionFieldIds` returns `null` and `buildFieldIndex` doesn't throw
- `pnpm -F common test`, `pnpm -F backend test -- "ai/tools"` green
- `typecheck:fast` + lint clean in both packages

## Follow-ups (not in this PR)

- Validate `default_time_dimension` in `lightdashMetadata.json` at compile time / stop the translator emitting field-less blocks
- Unsupported `interval` values (e.g. `QUARTER`) still throw in `getFieldIdForDateDimension` via the same enrichment

Closes: PROD-8915
Closes: #25608

🤖 Generated with [Claude Code](https://claude.com/claude-code)