### PR TITLE
feat: agentic onboarding — Aurora agent with live SQL-mode chat, Snowflake golden path, and server-side agent provisioning

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -42,6 +42,10 @@ const venvBinPath = path.join(__dirname, 'venv', 'bin');
 const envWithPath = {
     ...env,
     PATH: `${venvBinPath}:${process.env.PATH}`,
+    // Production runs UTC. Without this, node-postgres parses the DB's naive-UTC
+    // timestamps as local time, skewing every timestamp by the host's UTC offset
+    // (false "message timed out" errors, wrong relative times in the UI).
+    TZ: 'UTC',
 };
 
 // Instance ID for namespacing PM2 process names (supports multiple worktrees)

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -2018,6 +2018,7 @@ export type AiAgentCreatedEvent = BaseTrack & {
         agentName: string;
         tagsCount: number;
         integrationsCount: number;
+        autoProvisioned?: boolean;
     };
 };
 

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -689,6 +689,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     // silent no-op in EE builds.
                     getAppGenerateService: () =>
                         repository.getAppGenerateService<AppGenerateService>(),
+                    getAiAgentService: () =>
+                        repository.getAiAgentService<AiAgentService>(),
                 }),
             instanceConfigurationService: ({
                 models,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -174,6 +174,7 @@ import {
 } from '../../../clients/github/Github';
 import { type SlackClient } from '../../../clients/Slack/SlackClient';
 import { LightdashConfig } from '../../../config/parseConfig';
+import { isUniqueConstraintViolation } from '../../../database/errors';
 import Logger from '../../../logging/logger';
 import {
     CatalogModel,
@@ -2813,7 +2814,11 @@ export class AiAgentService extends BaseService {
         });
     }
 
-    public async createAgent(user: SessionUser, body: ApiCreateAiAgent) {
+    public async createAgent(
+        user: SessionUser,
+        body: ApiCreateAiAgent,
+        options?: { autoProvisioned?: boolean },
+    ) {
         const { organizationUuid } = user;
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
@@ -2875,10 +2880,71 @@ export class AiAgentService extends BaseService {
                 agentName: agent.name,
                 tagsCount: agent.tags?.length ?? 0,
                 integrationsCount: agent.integrations?.length ?? 0,
+                ...(options?.autoProvisioned ? { autoProvisioned: true } : {}),
             },
         });
 
         return agent;
+    }
+
+    public async provisionDefaultAgent(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<void> {
+        try {
+            if (!(await this.getIsCopilotEnabled(user))) {
+                return;
+            }
+
+            const { organizationUuid } = user;
+            if (!organizationUuid) {
+                return;
+            }
+
+            const agents = await this.aiAgentModel.findAllAgents({
+                organizationUuid,
+                filter: { projectFilter: { projectUuid } },
+            });
+            if (agents.length > 0) {
+                return;
+            }
+
+            await this.createAgent(
+                user,
+                {
+                    name: 'Aurora',
+                    projectUuid,
+                    description: null,
+                    integrations: [],
+                    tags: null,
+                    instruction:
+                        "You are Aurora, this organization's analytics agent. Help people explore and understand their data, and answer questions with clear, concise analysis. If no explores are available yet, use your warehouse tools to discover the schema and answer with SQL.",
+                    imageUrl: null,
+                    groupAccess: [],
+                    userAccess: [],
+                    spaceAccess: [],
+                    enableDataAccess: true,
+                    enableSelfImprovement: false,
+                    version: 2,
+                },
+                { autoProvisioned: true },
+            );
+        } catch (error) {
+            if (
+                error instanceof ForbiddenError ||
+                isUniqueConstraintViolation(error)
+            ) {
+                this.logger.debug(
+                    `Default AI agent provisioning skipped for project ${projectUuid}`,
+                    error,
+                );
+                return;
+            }
+
+            this.logger.warn(
+                `Failed to provision default AI agent for project ${projectUuid}: ${getErrorMessage(error)}`,
+            );
+        }
     }
 
     private async assertCanManageMcpServers(

--- a/packages/backend/src/ee/services/AiAgentService/provisionDefaultAgent.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/provisionDefaultAgent.test.ts
@@ -1,0 +1,122 @@
+import { ForbiddenError, type SessionUser } from '@lightdash/common';
+import { DatabaseError } from 'pg';
+import type { AiAgentModel } from '../../models/AiAgentModel';
+import { AiAgentService } from './AiAgentService';
+
+vi.mock('../ai/AiAgentMcpRuntimeClient', () => ({
+    AiAgentMcpRuntimeClient: vi
+        .fn()
+        // eslint-disable-next-line prefer-arrow-callback
+        .mockImplementation(function MockAiAgentMcpRuntimeClient() {
+            return {};
+        }),
+}));
+
+const ORGANIZATION_UUID = 'organization-uuid';
+const PROJECT_UUID = 'project-uuid';
+
+const user = {
+    userUuid: 'user-uuid',
+    organizationUuid: ORGANIZATION_UUID,
+} as unknown as SessionUser;
+
+const createUniqueViolation = (): DatabaseError => {
+    const error = new DatabaseError('duplicate agent', 0, 'error');
+    error.code = '23505';
+    return error;
+};
+
+const buildService = () => {
+    const findAllAgents = vi.fn<AiAgentModel['findAllAgents']>();
+    const service = new AiAgentService({
+        aiAgentModel: { findAllAgents },
+    } as unknown as ConstructorParameters<typeof AiAgentService>[0]);
+    const getIsCopilotEnabled = vi.spyOn(service, 'getIsCopilotEnabled');
+    const createAgent = vi.spyOn(service, 'createAgent');
+
+    return {
+        service,
+        findAllAgents: vi.mocked(findAllAgents),
+        getIsCopilotEnabled: vi.mocked(getIsCopilotEnabled),
+        createAgent: vi.mocked(createAgent),
+    };
+};
+
+describe('AiAgentService.provisionDefaultAgent', () => {
+    it('does not create an agent when copilot is disabled', async () => {
+        const { service, findAllAgents, getIsCopilotEnabled, createAgent } =
+            buildService();
+        getIsCopilotEnabled.mockResolvedValue(false);
+
+        await service.provisionDefaultAgent(user, PROJECT_UUID);
+
+        expect(findAllAgents).not.toHaveBeenCalled();
+        expect(createAgent).not.toHaveBeenCalled();
+    });
+
+    it('does not create an agent when the project already has one', async () => {
+        const { service, findAllAgents, getIsCopilotEnabled, createAgent } =
+            buildService();
+        getIsCopilotEnabled.mockResolvedValue(true);
+        findAllAgents.mockResolvedValue([{}] as Awaited<
+            ReturnType<AiAgentModel['findAllAgents']>
+        >);
+
+        await service.provisionDefaultAgent(user, PROJECT_UUID);
+
+        expect(findAllAgents).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            filter: { projectFilter: { projectUuid: PROJECT_UUID } },
+        });
+        expect(createAgent).not.toHaveBeenCalled();
+    });
+
+    it('creates Aurora with the starter configuration', async () => {
+        const { service, findAllAgents, getIsCopilotEnabled, createAgent } =
+            buildService();
+        getIsCopilotEnabled.mockResolvedValue(true);
+        findAllAgents.mockResolvedValue([]);
+        createAgent.mockResolvedValue(
+            {} as Awaited<ReturnType<AiAgentService['createAgent']>>,
+        );
+
+        await service.provisionDefaultAgent(user, PROJECT_UUID);
+
+        expect(createAgent).toHaveBeenCalledWith(
+            user,
+            {
+                name: 'Aurora',
+                projectUuid: PROJECT_UUID,
+                description: null,
+                integrations: [],
+                tags: null,
+                instruction:
+                    "You are Aurora, this organization's analytics agent. Help people explore and understand their data, and answer questions with clear, concise analysis. If no explores are available yet, use your warehouse tools to discover the schema and answer with SQL.",
+                imageUrl: null,
+                groupAccess: [],
+                userAccess: [],
+                spaceAccess: [],
+                enableDataAccess: true,
+                enableSelfImprovement: false,
+                version: 2,
+            },
+            { autoProvisioned: true },
+        );
+    });
+
+    it.each([
+        ['a forbidden error', new ForbiddenError()],
+        ['a unique constraint violation', createUniqueViolation()],
+        ['an unexpected error', new Error('create failed')],
+    ])('does not propagate %s from createAgent', async (_name, error) => {
+        const { service, findAllAgents, getIsCopilotEnabled, createAgent } =
+            buildService();
+        getIsCopilotEnabled.mockResolvedValue(true);
+        findAllAgents.mockResolvedValue([]);
+        createAgent.mockRejectedValue(error);
+
+        await expect(
+            service.provisionDefaultAgent(user, PROJECT_UUID),
+        ).resolves.toBeUndefined();
+    });
+});

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.ts
@@ -152,8 +152,9 @@ export const getSystemPromptV2 = (args: {
     const AVAILABLE_EXPLORES_INLINE_LIMIT = 15;
     let availableExploresContent: string;
     if (args.availableExplores.length === 0) {
-        availableExploresContent =
-            'No explores are available to this agent. Tell the user there is no data you can query and suggest they ask an administrator to set up explores or adjust the agent configuration.';
+        availableExploresContent = canRunSql
+            ? 'No explores are available to this agent yet, but you DO have direct warehouse access. Do not tell the user there is no data. Instead, use listWarehouseTables and describeWarehouseTable to discover the schema, then answer questions with runSql.'
+            : 'No explores are available to this agent. Tell the user there is no data you can query and suggest they ask an administrator to set up explores or adjust the agent configuration.';
     } else if (
         args.availableExplores.length <= AVAILABLE_EXPLORES_INLINE_LIMIT
     ) {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -7265,6 +7265,9 @@ export class ProjectService extends BaseService {
             return warehouseCatalog[database][schemaName][tableName];
         } catch (error) {
             this.logger.error('Error fetching warehouse fields', { error });
+            if (error instanceof WarehouseConnectionError) {
+                throw error;
+            }
             throw new NotFoundError(
                 `Could not find table "${tableName}" in schema "${schemaName}" of database "${database}". Please verify the table exists and you have access to it.`,
             );

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -229,6 +229,7 @@ import { type DbPreAggregateDefinitionIn } from '../../ee/database/entities/preA
 import { PreAggregateModel } from '../../ee/models/PreAggregateModel';
 import { enhanceExploresForPreAggregates } from '../../ee/preAggregates/enhanceExploresForPreAggregates';
 import { preAggregatePostProcessor } from '../../ee/preAggregates/postProcessor';
+import type { AiAgentService } from '../../ee/services/AiAgentService/AiAgentService';
 import type { AppGenerateService } from '../../ee/services/AppGenerateService/AppGenerateService';
 import { buildMaterializationMetricQuery } from '../../ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery';
 import { errorHandler } from '../../errors';
@@ -352,6 +353,7 @@ export type ProjectServiceArguments = {
     // AppGenerateService depends on ProjectService, so eager injection would
     // create a construction cycle. Resolves undefined in core (non-EE) builds.
     getAppGenerateService?: () => AppGenerateService | undefined;
+    getAiAgentService?: () => AiAgentService | undefined;
 };
 
 const isValidDbtCloudWebhookSignature = (
@@ -460,6 +462,8 @@ export class ProjectService extends BaseService {
 
     getAppGenerateService: (() => AppGenerateService | undefined) | undefined;
 
+    getAiAgentService: (() => AiAgentService | undefined) | undefined;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -501,6 +505,7 @@ export class ProjectService extends BaseService {
         projectContextModel,
         isProjectContextEnabled,
         getAppGenerateService,
+        getAiAgentService,
     }: ProjectServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -545,6 +550,47 @@ export class ProjectService extends BaseService {
         this.projectContextModel = projectContextModel;
         this.isProjectContextEnabled = isProjectContextEnabled;
         this.getAppGenerateService = getAppGenerateService;
+        this.getAiAgentService = getAiAgentService;
+    }
+
+    private async provisionDefaultAiAgent(
+        user: SessionUser,
+        projectUuid: string,
+        projectType: ProjectType,
+    ): Promise<void> {
+        if (projectType === ProjectType.PREVIEW) {
+            return;
+        }
+
+        try {
+            const { organizationUuid } = user;
+            if (!organizationUuid) {
+                return;
+            }
+
+            const projects =
+                await this.projectModel.getAllByOrganizationUuid(
+                    organizationUuid,
+                );
+            const nonPreviewProjects = projects.filter(
+                (project) => project.type !== ProjectType.PREVIEW,
+            );
+            if (
+                nonPreviewProjects.length !== 1 ||
+                nonPreviewProjects[0].projectUuid !== projectUuid
+            ) {
+                return;
+            }
+
+            await this.getAiAgentService?.()?.provisionDefaultAgent(
+                user,
+                projectUuid,
+            );
+        } catch (error) {
+            this.logger.warn(
+                `Failed to provision default AI agent for project ${projectUuid}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+        }
     }
 
     static getMetricQueryExecutionProperties({
@@ -2317,6 +2363,12 @@ export class ProjectService extends BaseService {
             ),
         });
 
+        await this.provisionDefaultAiAgent(
+            user,
+            projectUuid,
+            createProject.type,
+        );
+
         // For preview projects: if the upstream requires user warehouse credentials
         // and the request includes CLI-obtained tokens, create user warehouse
         // credentials so the user doesn't have to re-authenticate in the UI
@@ -2737,6 +2789,12 @@ export class ProjectService extends BaseService {
                     method,
                 ),
             });
+
+            await this.provisionDefaultAiAgent(
+                user,
+                projectUuid,
+                createProject.type,
+            );
 
             return { projectUuid };
         } catch (error) {

--- a/packages/cli/src/handlers/connectSnowflake.test.ts
+++ b/packages/cli/src/handlers/connectSnowflake.test.ts
@@ -148,7 +148,7 @@ describe('connectSnowflakeHandler', () => {
         vi.mocked(setUserPublicKey).mockResolvedValue(undefined);
         vi.mocked(unsetUserPublicKey).mockResolvedValue(undefined);
         vi.mocked(createProgrammaticAccessToken).mockResolvedValue({
-            tokenName: 'LIGHTDASH_ONBOARDING',
+            tokenName: 'LIGHTDASH_ONBOARDING_1234567890',
             tokenSecret: 'pat-secret',
         });
         vi.mocked(openDiagnosticConnection).mockResolvedValue({
@@ -329,7 +329,7 @@ describe('connectSnowflakeHandler', () => {
         expect(createProgrammaticAccessToken).not.toHaveBeenCalled();
     });
 
-    it('uses the stable PAT name for collision replacement when both key slots are occupied', async () => {
+    it('uses a unique PAT name when both key slots are occupied', async () => {
         vi.mocked(getUserPublicKeySlots).mockResolvedValue({
             RSA_PUBLIC_KEY: 'SHA256:existing-key-1',
             RSA_PUBLIC_KEY_2: 'SHA256:existing-key-2',
@@ -341,7 +341,7 @@ describe('connectSnowflakeHandler', () => {
 
         expect(setUserPublicKey).not.toHaveBeenCalled();
         expect(createProgrammaticAccessToken).toHaveBeenCalledWith(
-            'LIGHTDASH_ONBOARDING',
+            expect.stringMatching(/^LIGHTDASH_ONBOARDING_\d+$/),
             365,
             1440,
         );
@@ -394,7 +394,7 @@ describe('connectSnowflakeHandler', () => {
         ).resolves.toBeUndefined();
 
         expect(createProgrammaticAccessToken).toHaveBeenCalledWith(
-            'LIGHTDASH_ONBOARDING',
+            expect.stringMatching(/^LIGHTDASH_ONBOARDING_\d+$/),
             365,
             1440,
         );

--- a/packages/cli/src/handlers/connectSnowflake.ts
+++ b/packages/cli/src/handlers/connectSnowflake.ts
@@ -392,7 +392,7 @@ const createDurableCredential = async (
     try {
         const { tokenSecret } =
             await warehouseClient.createProgrammaticAccessToken(
-                'LIGHTDASH_ONBOARDING',
+                `LIGHTDASH_ONBOARDING_${Date.now()}`,
                 PAT_EXPIRY_DAYS,
                 PAT_NETWORK_POLICY_BYPASS_MINUTES,
             );

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -784,6 +784,23 @@ const PRIVATE_ROUTES: RouteObject[] = [
                 },
             },
             {
+                path: '/onboarding/data-source/:warehouse?',
+                handle: { hideAILauncher: true },
+                lazy: async () => {
+                    const OnboardingDataSource = await loadLazyRouteDefault(
+                        './pages/OnboardingDataSource',
+                        () => import('./pages/OnboardingDataSource'),
+                    );
+                    return {
+                        Component: () => (
+                            <TrackPage name={PageName.ONBOARDING_DATA_SOURCE}>
+                                <OnboardingDataSource />
+                            </TrackPage>
+                        ),
+                    };
+                },
+            },
+            {
                 path: '/createProject/:method?',
                 lazy: async () => {
                     const CreateProject = await loadLazyRouteDefault(

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -801,6 +801,23 @@ const PRIVATE_ROUTES: RouteObject[] = [
                 },
             },
             {
+                path: '/onboarding/project-ready/:projectUuid',
+                handle: { hideAILauncher: true },
+                lazy: async () => {
+                    const OnboardingProjectReady = await loadLazyRouteDefault(
+                        './pages/OnboardingProjectReady',
+                        () => import('./pages/OnboardingProjectReady'),
+                    );
+                    return {
+                        Component: () => (
+                            <TrackPage name={PageName.ONBOARDING_PROJECT_READY}>
+                                <OnboardingProjectReady />
+                            </TrackPage>
+                        ),
+                    };
+                },
+            },
+            {
                 path: '/createProject/:method?',
                 lazy: async () => {
                     const CreateProject = await loadLazyRouteDefault(

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -764,6 +764,26 @@ const PRIVATE_ROUTES: RouteObject[] = [
                 element: <Navigate to="/projects" replace />,
             },
             {
+                path: '/onboarding/agent',
+                handle: { hideAILauncher: true },
+                lazy: async () => {
+                    const OnboardingAgent = await loadLazyRouteDefault(
+                        './pages/OnboardingAgent',
+                        () => import('./pages/OnboardingAgent'),
+                    );
+                    return {
+                        Component: () => (
+                            <>
+                                <NavBar />
+                                <TrackPage name={PageName.ONBOARDING_AGENT}>
+                                    <OnboardingAgent />
+                                </TrackPage>
+                            </>
+                        ),
+                    };
+                },
+            },
+            {
                 path: '/createProject/:method?',
                 lazy: async () => {
                     const CreateProject = await loadLazyRouteDefault(

--- a/packages/frontend/src/components/JobDetailsDrawer/index.tsx
+++ b/packages/frontend/src/components/JobDetailsDrawer/index.tsx
@@ -159,7 +159,10 @@ const JobDetailsDrawer: FC = () => {
 
                     <Box>
                         <Title order={4} fw={600}>
-                            {jobStatusLabel(activeJob.jobStatus)}
+                            {jobStatusLabel(
+                                activeJob.jobStatus,
+                                activeJob.jobType,
+                            )}
                         </Title>
                         {hasSteps && (
                             <Text c="ldGray.6" fz="sm" fw={500}>{`${

--- a/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
@@ -27,12 +27,14 @@ interface CreateProjectConnectionProps {
     isCreatingFirstProject: boolean;
     selectedWarehouse?: WarehouseTypes | undefined;
     warehouseOnly?: boolean;
+    successRedirect?: (projectUuid: string) => string;
 }
 
 const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
     isCreatingFirstProject,
     selectedWarehouse,
     warehouseOnly = false,
+    successRedirect,
 }) => {
     const navigate = useNavigate();
     const { user, health } = useApp();
@@ -103,11 +105,14 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
             isCreateProjectJob(activeJob) &&
             activeJob.jobResults?.projectUuid
         ) {
+            const { projectUuid } = activeJob.jobResults;
             void navigate({
-                pathname: `/createProjectSettings/${activeJob?.jobResults?.projectUuid}`,
+                pathname: successRedirect
+                    ? successRedirect(projectUuid)
+                    : `/createProjectSettings/${projectUuid}`,
             });
         }
-    }, [activeJob, createProjectJobId, navigate]);
+    }, [activeJob, createProjectJobId, navigate, successRedirect]);
 
     const isSavingProject = useMemo<boolean>(
         () =>
@@ -133,7 +138,9 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
                             type="submit"
                             loading={isSavingProject}
                         >
-                            Test & deploy project
+                            {warehouseOnly
+                                ? 'Test & save'
+                                : 'Test & deploy project'}
                         </Button>
                     </ProjectFormProvider>
                 </FormContainer>

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectManually/ConnectManuallyStep2.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectManually/ConnectManuallyStep2.tsx
@@ -12,6 +12,7 @@ interface ConnectManuallyStep2Props {
     selectedWarehouse: WarehouseTypes;
     warehouseOnly?: boolean;
     onBack: () => void;
+    successRedirect?: (projectUuid: string) => string;
 }
 
 const ConnectManuallyStep2: FC<ConnectManuallyStep2Props> = ({
@@ -19,6 +20,7 @@ const ConnectManuallyStep2: FC<ConnectManuallyStep2Props> = ({
     selectedWarehouse,
     warehouseOnly = false,
     onBack,
+    successRedirect,
 }) => {
     return (
         <>
@@ -40,6 +42,7 @@ const ConnectManuallyStep2: FC<ConnectManuallyStep2Props> = ({
                     isCreatingFirstProject={isCreatingFirstProject}
                     selectedWarehouse={selectedWarehouse}
                     warehouseOnly={warehouseOnly}
+                    successRedirect={successRedirect}
                 />
             </Stack>
         </>

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -101,7 +101,7 @@ const SnowflakeForm: FC<{
     const form = useFormContext();
     const {
         data,
-        isLoading: isLoadingAuth,
+        isInitialLoading: isLoadingAuth,
         error: snowflakeAuthError,
         refetch: refetchAuth,
     } = useIsSnowflakeAuthenticated();

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -17,7 +17,7 @@ import {
 } from '@mantine-8/core';
 import { NumberInput, PasswordInput, Tooltip } from '@mantine/core';
 import { IconCheck } from '@tabler/icons-react';
-import { useCallback, useEffect, useState, type FC } from 'react';
+import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { useToggle } from 'react-use';
 import { useOrganizationWarehouseCredentials } from '../../../hooks/organization/useOrganizationWarehouseCredentials';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
@@ -142,6 +142,7 @@ const SnowflakeForm: FC<{
     const isCliSsoEnabled =
         !savedProject && (warehouseConnectFlag.data?.enabled ?? false);
     const [isCliSsoMode, setIsCliSsoMode] = useState(false);
+    const userSelectedAuthType = useRef(false);
     const [cliSsoCredentials, setCliSsoCredentials] =
         useState<DepositSnowflakeCredentials | null>(null);
 
@@ -171,6 +172,13 @@ const SnowflakeForm: FC<{
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [defaultAuthType]);
+
+    useEffect(() => {
+        if (isCliSsoEnabled && !userSelectedAuthType.current) {
+            setIsCliSsoMode(true);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isCliSsoEnabled]);
     const authenticationType: SnowflakeAuthenticationType =
         form.values.warehouse.authenticationType ?? defaultAuthType;
 
@@ -313,6 +321,7 @@ const SnowflakeForm: FC<{
                         <TextInput
                             name="warehouse.account"
                             label="Account"
+                            placeholder="AAA99827"
                             description={
                                 isCliSsoMode && cliSsoCredentials !== null
                                     ? 'Your CLI SSO connection is bound to this account.'
@@ -337,6 +346,7 @@ const SnowflakeForm: FC<{
                                         : authenticationType
                                 }
                                 onChange={(value) => {
+                                    userSelectedAuthType.current = true;
                                     if (value === CLI_SSO_OPTION_VALUE) {
                                         track({
                                             name: EventName.CREATE_PROJECT_CLI_SSO_OPTION_CLICKED,

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -177,7 +177,6 @@ const SnowflakeForm: FC<{
         if (isCliSsoEnabled && !userSelectedAuthType.current) {
             setIsCliSsoMode(true);
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isCliSsoEnabled]);
     const authenticationType: SnowflakeAuthenticationType =
         form.values.warehouse.authenticationType ?? defaultAuthType;

--- a/packages/frontend/src/components/common/Authentication/SnowflakeOAuthInput.tsx
+++ b/packages/frontend/src/components/common/Authentication/SnowflakeOAuthInput.tsx
@@ -16,7 +16,7 @@ type Props = {
 export const SnowflakeOAuthInput: FC<Props> = ({ onAuthenticated }) => {
     const {
         data,
-        isLoading,
+        isInitialLoading,
         error: snowflakeAuthError,
         refetch: refetchAuth,
     } = useIsSnowflakeAuthenticated();
@@ -25,10 +25,10 @@ export const SnowflakeOAuthInput: FC<Props> = ({ onAuthenticated }) => {
 
     // Notify parent component when authentication status changes
     React.useEffect(() => {
-        if (!isLoading) {
+        if (!isInitialLoading) {
             onAuthenticated?.(isAuthenticated);
         }
-    }, [isAuthenticated, isLoading, onAuthenticated]);
+    }, [isAuthenticated, isInitialLoading, onAuthenticated]);
 
     const { mutate: openLoginPopup } = useSnowflakeLoginPopup({
         onLogin: async () => {
@@ -36,7 +36,7 @@ export const SnowflakeOAuthInput: FC<Props> = ({ onAuthenticated }) => {
         },
     });
 
-    if (isLoading) {
+    if (isInitialLoading) {
         return null;
     }
 

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -166,6 +166,7 @@ export const useProjectCreateAiAgentMutation = (
     projectUuid: string,
     options?: {
         skipNavigation?: boolean;
+        skipSuccessToast?: boolean;
     },
 ) => {
     const navigate = useNavigate();
@@ -179,9 +180,11 @@ export const useProjectCreateAiAgentMutation = (
     >({
         mutationFn: (data) => createProjectAgent(projectUuid, data),
         onSuccess: (result) => {
-            showToastSuccess({
-                title: 'AI agent created successfully',
-            });
+            if (!options?.skipSuccessToast) {
+                showToastSuccess({
+                    title: 'AI agent created successfully',
+                });
+            }
             void queryClient.invalidateQueries({
                 queryKey: [PROJECT_AI_AGENTS_KEY, projectUuid],
             });

--- a/packages/frontend/src/hooks/useOnboardingPageGuard.tsx
+++ b/packages/frontend/src/hooks/useOnboardingPageGuard.tsx
@@ -1,0 +1,47 @@
+import { FeatureFlags } from '@lightdash/common';
+import { type ReactElement } from 'react';
+import { Navigate } from 'react-router';
+import PageSpinner from '../components/PageSpinner';
+import useApp from '../providers/App/useApp';
+import { type UserWithAbility } from './user/useUser';
+import { useServerFeatureFlag } from './useServerOrClientFeatureFlag';
+
+type OnboardingPageGuardResult =
+    | { status: 'blocked'; element: ReactElement }
+    | { status: 'ready'; user: UserWithAbility };
+
+export const useOnboardingPageGuard = (): OnboardingPageGuardResult => {
+    const { health, user } = useApp();
+    const orgSetupPageFlag = useServerFeatureFlag(
+        FeatureFlags.OrganizationSetupPage,
+    );
+
+    if (health.isInitialLoading || health.error) {
+        return { status: 'blocked', element: <PageSpinner /> };
+    }
+
+    if (!health.data?.isAuthenticated) {
+        return { status: 'blocked', element: <Navigate to="/login" /> };
+    }
+
+    if (user.isInitialLoading || orgSetupPageFlag.isLoading) {
+        return { status: 'blocked', element: <PageSpinner /> };
+    }
+
+    if (!user.data) {
+        return { status: 'blocked', element: <PageSpinner /> };
+    }
+
+    if (!user.data.organizationUuid) {
+        return {
+            status: 'blocked',
+            element: <Navigate to="/join-organization" />,
+        };
+    }
+
+    if (!orgSetupPageFlag.data?.enabled) {
+        return { status: 'blocked', element: <Navigate to="/" /> };
+    }
+
+    return { status: 'ready', user: user.data };
+};

--- a/packages/frontend/src/hooks/useRefreshServer.ts
+++ b/packages/frontend/src/hooks/useRefreshServer.ts
@@ -1,6 +1,7 @@
 import {
     JobStatusType,
     JobStepStatusType,
+    JobType,
     type ApiError,
     type ApiRefreshResults,
     type Job,
@@ -28,7 +29,21 @@ export const jobStepStatusLabel = (status: JobStepStatusType) => {
             throw new Error('Unknown job step status');
     }
 };
-export const jobStatusLabel = (status: JobStatusType) => {
+export const jobStatusLabel = (status: JobStatusType, jobType?: JobType) => {
+    if (jobType === JobType.CREATE_PROJECT) {
+        switch (status) {
+            case JobStatusType.DONE:
+                return 'Project created!';
+            case JobStatusType.STARTED:
+                return 'Pending project creation';
+            case JobStatusType.ERROR:
+                return 'Error while creating project';
+            case JobStatusType.RUNNING:
+                return 'Creating your project';
+            default:
+                throw new Error('Unknown job status');
+        }
+    }
     switch (status) {
         case JobStatusType.DONE:
             return 'Successfully synced dbt project!';

--- a/packages/frontend/src/hooks/useSnowflake.ts
+++ b/packages/frontend/src/hooks/useSnowflake.ts
@@ -82,9 +82,13 @@ const getIsAuthenticated = async () =>
     });
 
 export const useIsSnowflakeAuthenticated = () => {
+    const health = useHealth();
+
     return useQuery<ApiSuccessEmpty['results'], ApiError>({
-        queryKey: [],
+        queryKey: ['snowflake-sso-is-authenticated'],
         queryFn: getIsAuthenticated,
+        enabled: health.data?.auth.snowflake.enabled === true,
+        retry: false,
     });
 };
 

--- a/packages/frontend/src/hooks/user/useUserCompleteMutation.ts
+++ b/packages/frontend/src/hooks/user/useUserCompleteMutation.ts
@@ -13,7 +13,13 @@ const completeUserQuery = async (data: CompleteUserArgs) =>
         body: JSON.stringify(data),
     });
 
-export const useUserCompleteMutation = () => {
+type UserCompleteMutationOptions = {
+    onSuccess?: () => void;
+};
+
+export const useUserCompleteMutation = (
+    options?: UserCompleteMutationOptions,
+) => {
     const queryClient = useQueryClient();
     return useMutation<LightdashUser, ApiError, CompleteUserArgs>(
         completeUserQuery,
@@ -22,6 +28,7 @@ export const useUserCompleteMutation = () => {
             onSuccess: async () => {
                 await queryClient.invalidateQueries(['user']);
                 await queryClient.invalidateQueries(['organization']);
+                options?.onSuccess?.();
             },
         },
     );

--- a/packages/frontend/src/pages/OnboardingAgent.module.css
+++ b/packages/frontend/src/pages/OnboardingAgent.module.css
@@ -1,0 +1,43 @@
+.page {
+    min-height: calc(100vh - var(--navbar-height));
+    background-color: var(--mantine-color-white);
+}
+
+.column {
+    width: 100%;
+    max-width: 62rem;
+    margin: 0 auto;
+    padding: 14vh var(--mantine-spacing-sm) var(--mantine-spacing-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--mantine-spacing-xl);
+}
+
+.avatar {
+    width: 72px;
+    height: 72px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-image: linear-gradient(135deg, #7ad6c8, #7a8ee8);
+    flex-shrink: 0;
+}
+
+.nameInput {
+    font-weight: 600;
+    font-size: 26px;
+    line-height: 1.2;
+    text-align: center;
+}
+
+.dataSourceTile {
+    width: 40px;
+    height: 40px;
+    border-radius: var(--mantine-radius-md);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--mantine-color-orange-0);
+    flex-shrink: 0;
+}

--- a/packages/frontend/src/pages/OnboardingAgent.module.css
+++ b/packages/frontend/src/pages/OnboardingAgent.module.css
@@ -24,7 +24,7 @@
     flex-shrink: 0;
 }
 
-.dataSourceTile {
+.iconTile {
     width: 40px;
     height: 40px;
     border-radius: var(--mantine-radius-md);

--- a/packages/frontend/src/pages/OnboardingAgent.module.css
+++ b/packages/frontend/src/pages/OnboardingAgent.module.css
@@ -24,13 +24,6 @@
     flex-shrink: 0;
 }
 
-.nameInput {
-    font-weight: 600;
-    font-size: 26px;
-    line-height: 1.2;
-    text-align: center;
-}
-
 .dataSourceTile {
     width: 40px;
     height: 40px;
@@ -40,4 +33,8 @@
     justify-content: center;
     background-color: var(--mantine-color-orange-0);
     flex-shrink: 0;
+}
+
+.dataSourceTileConnected {
+    background-color: var(--mantine-color-green-0);
 }

--- a/packages/frontend/src/pages/OnboardingAgent.module.css
+++ b/packages/frontend/src/pages/OnboardingAgent.module.css
@@ -34,7 +34,3 @@
     background-color: var(--mantine-color-orange-0);
     flex-shrink: 0;
 }
-
-.dataSourceTileConnected {
-    background-color: var(--mantine-color-green-0);
-}

--- a/packages/frontend/src/pages/OnboardingAgent.tsx
+++ b/packages/frontend/src/pages/OnboardingAgent.tsx
@@ -1,15 +1,12 @@
-import { FeatureFlags } from '@lightdash/common';
 import { Box, Button, Group, Paper, Stack, Text, Title } from '@mantine-8/core';
-import { IconDatabase, IconDatabaseHeart } from '@tabler/icons-react';
+import { IconDatabase } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { Navigate, useNavigate } from 'react-router';
+import { useNavigate } from 'react-router';
 import { DocumentTitle } from '../components/common/DocumentTitle';
 import MantineIcon from '../components/common/MantineIcon';
-import PageSpinner from '../components/PageSpinner';
 import { AgentChatInput } from '../ee/features/aiCopilot/components/ChatElements/AgentChatInput';
 import { useOrganization } from '../hooks/organization/useOrganization';
-import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
-import useApp from '../providers/App/useApp';
+import { useOnboardingPageGuard } from '../hooks/useOnboardingPageGuard';
 import classes from './OnboardingAgent.module.css';
 
 const DEFAULT_AGENT_NAME = 'Aurora';
@@ -73,52 +70,27 @@ const OnboardingAgentContent: FC = () => {
                     showSuggestions={false}
                 />
 
-                <Paper withBorder radius="md" p="lg">
-                    <Group justify="space-between" gap="lg">
-                        <Group gap="md">
-                            {isConnected ? (
-                                <>
-                                    <Box
-                                        className={`${classes.dataSourceTile} ${classes.dataSourceTileConnected}`}
-                                    >
-                                        <MantineIcon
-                                            icon={IconDatabaseHeart}
-                                            color="green"
-                                            size={24}
-                                        />
-                                    </Box>
-                                    <Stack gap={2}>
-                                        <Text fw={600}>
-                                            Data source connected
-                                        </Text>
-                                        <Text size="sm" c="dimmed">
-                                            {agentName} is getting ready to
-                                            answer questions.
-                                        </Text>
-                                    </Stack>
-                                </>
-                            ) : (
-                                <>
-                                    <Box className={classes.dataSourceTile}>
-                                        <MantineIcon
-                                            icon={IconDatabase}
-                                            color="orange"
-                                            size={24}
-                                        />
-                                    </Box>
-                                    <Stack gap={2}>
-                                        <Text fw={600}>
-                                            Connect a data source to get started
-                                        </Text>
-                                        <Text size="sm" c="dimmed">
-                                            {agentName} needs data before it can
-                                            answer anything.
-                                        </Text>
-                                    </Stack>
-                                </>
-                            )}
-                        </Group>
-                        {!isConnected && (
+                {organization && !isConnected && (
+                    <Paper withBorder radius="md" p="lg">
+                        <Group justify="space-between" gap="lg">
+                            <Group gap="md">
+                                <Box className={classes.dataSourceTile}>
+                                    <MantineIcon
+                                        icon={IconDatabase}
+                                        color="orange"
+                                        size={24}
+                                    />
+                                </Box>
+                                <Stack gap={2}>
+                                    <Text fw={600}>
+                                        Connect a data source to get started
+                                    </Text>
+                                    <Text size="sm" c="dimmed">
+                                        {agentName} needs data before it can
+                                        answer anything.
+                                    </Text>
+                                </Stack>
+                            </Group>
                             <Button
                                 color="dark"
                                 onClick={() =>
@@ -127,45 +99,22 @@ const OnboardingAgentContent: FC = () => {
                             >
                                 Add data source
                             </Button>
-                        )}
-                    </Group>
-                </Paper>
+                        </Group>
+                    </Paper>
+                )}
             </Box>
         </Box>
     );
 };
 
 const OnboardingAgent: FC = () => {
-    const { health, user } = useApp();
-    const orgSetupPageFlag = useServerFeatureFlag(
-        FeatureFlags.OrganizationSetupPage,
-    );
+    const guard = useOnboardingPageGuard();
 
-    if (health.isInitialLoading || health.error) {
-        return <PageSpinner />;
+    if (guard.status === 'blocked') {
+        return guard.element;
     }
 
-    if (!health.data?.isAuthenticated) {
-        return <Navigate to="/login" />;
-    }
-
-    if (user.isInitialLoading || orgSetupPageFlag.isLoading) {
-        return <PageSpinner />;
-    }
-
-    if (!user.data) {
-        return <PageSpinner />;
-    }
-
-    if (!user.data.organizationUuid) {
-        return <Navigate to="/join-organization" />;
-    }
-
-    if (!orgSetupPageFlag.data?.enabled) {
-        return <Navigate to="/" />;
-    }
-
-    return <OnboardingAgentContent key={user.data.userUuid} />;
+    return <OnboardingAgentContent key={guard.user.userUuid} />;
 };
 
 export default OnboardingAgent;

--- a/packages/frontend/src/pages/OnboardingAgent.tsx
+++ b/packages/frontend/src/pages/OnboardingAgent.tsx
@@ -1,11 +1,17 @@
 import { Box, Button, Group, Paper, Stack, Text, Title } from '@mantine-8/core';
 import { IconDatabase } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import { DocumentTitle } from '../components/common/DocumentTitle';
 import MantineIcon from '../components/common/MantineIcon';
 import { AgentChatInput } from '../ee/features/aiCopilot/components/ChatElements/AgentChatInput';
+import {
+    useCreateAgentThreadMutation,
+    useProjectAiAgents,
+    useProjectCreateAiAgentMutation,
+} from '../ee/features/aiCopilot/hooks/useProjectAiAgents';
 import { useOrganization } from '../hooks/organization/useOrganization';
+import { useActiveProjectUuid } from '../hooks/useActiveProject';
 import { useOnboardingPageGuard } from '../hooks/useOnboardingPageGuard';
 import classes from './OnboardingAgent.module.css';
 
@@ -35,9 +41,69 @@ const AuroraAvatar: FC = () => (
 const OnboardingAgentContent: FC = () => {
     const navigate = useNavigate();
     const { data: organization } = useOrganization();
-    const agentName = DEFAULT_AGENT_NAME;
 
     const isConnected = !!organization && !organization.needsProject;
+
+    const { activeProjectUuid, isLoading: isLoadingProject } =
+        useActiveProjectUuid();
+    const projectUuid = isConnected ? activeProjectUuid : undefined;
+
+    const { data: agents, isLoading: isLoadingAgents } = useProjectAiAgents({
+        projectUuid,
+        redirectOnUnauthorized: false,
+    });
+
+    const existingAgent = agents?.[0];
+    const agentName = existingAgent?.name ?? DEFAULT_AGENT_NAME;
+
+    const { mutateAsync: createAgent } = useProjectCreateAiAgentMutation(
+        projectUuid ?? '',
+        { skipNavigation: true },
+    );
+    const { mutateAsync: createAgentThread } = useCreateAgentThreadMutation(
+        projectUuid ?? '',
+    );
+
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const isComposerLoading =
+        isConnected && (isLoadingProject || !projectUuid || isLoadingAgents);
+
+    const handleSubmit = async ({ message }: { message: string }) => {
+        const prompt = message.trim();
+        if (!prompt || !projectUuid || isSubmitting) {
+            return;
+        }
+        setIsSubmitting(true);
+        try {
+            let agentUuid = existingAgent?.uuid;
+            if (!agentUuid) {
+                const createdAgent = await createAgent({
+                    name: DEFAULT_AGENT_NAME,
+                    projectUuid,
+                    description: null,
+                    integrations: [],
+                    tags: null,
+                    instruction: null,
+                    imageUrl: null,
+                    groupAccess: [],
+                    userAccess: [],
+                    spaceAccess: [],
+                    enableDataAccess: true,
+                    enableSelfImprovement: false,
+                    version: 2,
+                });
+                agentUuid = createdAgent.uuid;
+            }
+            await createAgentThread({
+                agentUuid,
+                prompt,
+                enableSqlMode: true,
+            });
+        } catch {
+            setIsSubmitting(false);
+        }
+    };
 
     return (
         <Box className={classes.page}>
@@ -59,11 +125,12 @@ const OnboardingAgentContent: FC = () => {
                 </Stack>
 
                 <AgentChatInput
-                    onSubmit={() => {}}
-                    disabled
+                    onSubmit={(args) => void handleSubmit(args)}
+                    loading={isSubmitting}
+                    disabled={!isConnected || isComposerLoading || isSubmitting}
                     disabledReason={
                         isConnected
-                            ? 'Chat is coming soon'
+                            ? undefined
                             : 'Connect a data source to start asking questions'
                     }
                     placeholder={`Ask ${agentName} anything about your data...`}

--- a/packages/frontend/src/pages/OnboardingAgent.tsx
+++ b/packages/frontend/src/pages/OnboardingAgent.tsx
@@ -1,10 +1,11 @@
 import { Box, Button, Group, Paper, Stack, Text, Title } from '@mantine-8/core';
-import { IconDatabase } from '@tabler/icons-react';
+import { IconDatabase, IconSparkles } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import { DocumentTitle } from '../components/common/DocumentTitle';
 import MantineIcon from '../components/common/MantineIcon';
 import { AgentChatInput } from '../ee/features/aiCopilot/components/ChatElements/AgentChatInput';
+import { useAiOrganizationSettings } from '../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
 import {
     useCreateAgentThreadMutation,
     useProjectAiAgents,
@@ -13,6 +14,8 @@ import {
 import { useOrganization } from '../hooks/organization/useOrganization';
 import { useActiveProjectUuid } from '../hooks/useActiveProject';
 import { useOnboardingPageGuard } from '../hooks/useOnboardingPageGuard';
+import useTracking from '../providers/Tracking/useTracking';
+import { EventName } from '../types/Events';
 import classes from './OnboardingAgent.module.css';
 
 const DEFAULT_AGENT_NAME = 'Aurora';
@@ -48,10 +51,21 @@ const OnboardingAgentContent: FC = () => {
         useActiveProjectUuid();
     const projectUuid = isConnected ? activeProjectUuid : undefined;
 
-    const { data: agents, isLoading: isLoadingAgents } = useProjectAiAgents({
-        projectUuid,
-        redirectOnUnauthorized: false,
-    });
+    const aiOrganizationSettingsQuery = useAiOrganizationSettings();
+    const isAiCopilotEnabledOrTrial =
+        aiOrganizationSettingsQuery.isSuccess &&
+        (aiOrganizationSettingsQuery.data.isCopilotEnabled ||
+            aiOrganizationSettingsQuery.data.isTrial);
+    const isCopilotUnavailable =
+        !aiOrganizationSettingsQuery.isInitialLoading &&
+        !isAiCopilotEnabledOrTrial;
+
+    const { data: agents, isInitialLoading: isLoadingAgents } =
+        useProjectAiAgents({
+            projectUuid,
+            redirectOnUnauthorized: false,
+            options: { enabled: isAiCopilotEnabledOrTrial },
+        });
 
     const existingAgent = agents?.[0];
     const agentName = existingAgent?.name ?? DEFAULT_AGENT_NAME;
@@ -65,16 +79,25 @@ const OnboardingAgentContent: FC = () => {
     );
 
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const { track } = useTracking();
 
     const isComposerLoading =
-        isConnected && (isLoadingProject || !projectUuid || isLoadingAgents);
+        aiOrganizationSettingsQuery.isInitialLoading ||
+        (isConnected && (isLoadingProject || !projectUuid || isLoadingAgents));
 
     const handleSubmit = async ({ message }: { message: string }) => {
         const prompt = message.trim();
-        if (!prompt || !projectUuid || isSubmitting) {
+        if (!prompt || !projectUuid || isCopilotUnavailable || isSubmitting) {
             return;
         }
         setIsSubmitting(true);
+        track({
+            name: EventName.ONBOARDING_AGENT_MESSAGE_SUBMITTED,
+            properties: {
+                projectUuid,
+                isNewAgent: !existingAgent,
+            },
+        });
         try {
             let agentUuid = existingAgent?.uuid;
             if (!agentUuid) {
@@ -127,21 +150,51 @@ const OnboardingAgentContent: FC = () => {
                 <AgentChatInput
                     onSubmit={(args) => void handleSubmit(args)}
                     loading={isSubmitting}
-                    disabled={!isConnected || isComposerLoading || isSubmitting}
+                    disabled={
+                        !isConnected ||
+                        isCopilotUnavailable ||
+                        isComposerLoading ||
+                        isSubmitting
+                    }
                     disabledReason={
-                        isConnected
-                            ? undefined
-                            : 'Connect a data source to start asking questions'
+                        isCopilotUnavailable
+                            ? "AI isn't enabled for your organization"
+                            : isConnected
+                              ? undefined
+                              : 'Connect a data source to start asking questions'
                     }
                     placeholder={`Ask ${agentName} anything about your data...`}
                     showSuggestions={false}
                 />
 
-                {organization && !isConnected && (
+                {isCopilotUnavailable && (
+                    <Paper withBorder radius="md" p="lg">
+                        <Group gap="md">
+                            <Box className={classes.iconTile}>
+                                <MantineIcon
+                                    icon={IconSparkles}
+                                    color="orange"
+                                    size={24}
+                                />
+                            </Box>
+                            <Stack gap={2}>
+                                <Text fw={600}>
+                                    AI isn't enabled for your organization
+                                </Text>
+                                <Text size="sm" c="dimmed">
+                                    Ask an organization admin to enable AI
+                                    features so you can chat with {agentName}.
+                                </Text>
+                            </Stack>
+                        </Group>
+                    </Paper>
+                )}
+
+                {organization && !isConnected && !isCopilotUnavailable && (
                     <Paper withBorder radius="md" p="lg">
                         <Group justify="space-between" gap="lg">
                             <Group gap="md">
-                                <Box className={classes.dataSourceTile}>
+                                <Box className={classes.iconTile}>
                                     <MantineIcon
                                         icon={IconDatabase}
                                         color="orange"

--- a/packages/frontend/src/pages/OnboardingAgent.tsx
+++ b/packages/frontend/src/pages/OnboardingAgent.tsx
@@ -58,7 +58,7 @@ const OnboardingAgentContent: FC = () => {
 
     const { mutateAsync: createAgent } = useProjectCreateAiAgentMutation(
         projectUuid ?? '',
-        { skipNavigation: true },
+        { skipNavigation: true, skipSuccessToast: true },
     );
     const { mutateAsync: createAgentThread } = useCreateAgentThreadMutation(
         projectUuid ?? '',

--- a/packages/frontend/src/pages/OnboardingAgent.tsx
+++ b/packages/frontend/src/pages/OnboardingAgent.tsx
@@ -1,22 +1,13 @@
 import { FeatureFlags } from '@lightdash/common';
-import {
-    ActionIcon,
-    Box,
-    Button,
-    Group,
-    Paper,
-    Stack,
-    Text,
-    TextInput,
-    Title,
-} from '@mantine-8/core';
-import { IconDatabase, IconPencil } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
-import { Navigate } from 'react-router';
+import { Box, Button, Group, Paper, Stack, Text, Title } from '@mantine-8/core';
+import { IconDatabase, IconDatabaseHeart } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Navigate, useNavigate } from 'react-router';
 import { DocumentTitle } from '../components/common/DocumentTitle';
 import MantineIcon from '../components/common/MantineIcon';
 import PageSpinner from '../components/PageSpinner';
 import { AgentChatInput } from '../ee/features/aiCopilot/components/ChatElements/AgentChatInput';
+import { useOrganization } from '../hooks/organization/useOrganization';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import useApp from '../providers/App/useApp';
 import classes from './OnboardingAgent.module.css';
@@ -45,22 +36,11 @@ const AuroraAvatar: FC = () => (
 );
 
 const OnboardingAgentContent: FC = () => {
-    const [agentName, setAgentName] = useState(DEFAULT_AGENT_NAME);
-    const [isEditingName, setIsEditingName] = useState(false);
-    const [nameDraft, setNameDraft] = useState(DEFAULT_AGENT_NAME);
+    const navigate = useNavigate();
+    const { data: organization } = useOrganization();
+    const agentName = DEFAULT_AGENT_NAME;
 
-    const startEditing = () => {
-        setNameDraft(agentName);
-        setIsEditingName(true);
-    };
-
-    const commitName = () => {
-        const trimmed = nameDraft.trim();
-        if (trimmed) {
-            setAgentName(trimmed);
-        }
-        setIsEditingName(false);
-    };
+    const isConnected = !!organization && !organization.needsProject;
 
     return (
         <Box className={classes.page}>
@@ -72,37 +52,9 @@ const OnboardingAgentContent: FC = () => {
                         <AuroraAvatar />
                     </Box>
 
-                    {isEditingName ? (
-                        <TextInput
-                            variant="unstyled"
-                            autoFocus
-                            value={nameDraft}
-                            onChange={(event) =>
-                                setNameDraft(event.currentTarget.value)
-                            }
-                            onBlur={commitName}
-                            onKeyDown={(event) => {
-                                if (event.key === 'Enter') {
-                                    commitName();
-                                }
-                            }}
-                            classNames={{ input: classes.nameInput }}
-                        />
-                    ) : (
-                        <Group justify="center" gap={4}>
-                            <Title order={2} ta="center">
-                                {agentName}
-                            </Title>
-                            <ActionIcon
-                                variant="subtle"
-                                color="ldGray.6"
-                                aria-label="Edit agent name"
-                                onClick={startEditing}
-                            >
-                                <MantineIcon icon={IconPencil} />
-                            </ActionIcon>
-                        </Group>
-                    )}
+                    <Title order={2} ta="center">
+                        {agentName}
+                    </Title>
 
                     <Text size="sm" c="ldGray.6" ta="center">
                         Your organization's analytics agent
@@ -112,7 +64,11 @@ const OnboardingAgentContent: FC = () => {
                 <AgentChatInput
                     onSubmit={() => {}}
                     disabled
-                    disabledReason="Connect a data source to start asking questions"
+                    disabledReason={
+                        isConnected
+                            ? 'Chat is coming soon'
+                            : 'Connect a data source to start asking questions'
+                    }
                     placeholder={`Ask ${agentName} anything about your data...`}
                     showSuggestions={false}
                 />
@@ -120,24 +76,58 @@ const OnboardingAgentContent: FC = () => {
                 <Paper withBorder radius="md" p="lg">
                     <Group justify="space-between" gap="lg">
                         <Group gap="md">
-                            <Box className={classes.dataSourceTile}>
-                                <MantineIcon
-                                    icon={IconDatabase}
-                                    color="orange"
-                                    size={24}
-                                />
-                            </Box>
-                            <Stack gap={2}>
-                                <Text fw={600}>
-                                    Connect a data source to get started
-                                </Text>
-                                <Text size="sm" c="dimmed">
-                                    {agentName} needs data before it can answer
-                                    anything.
-                                </Text>
-                            </Stack>
+                            {isConnected ? (
+                                <>
+                                    <Box
+                                        className={`${classes.dataSourceTile} ${classes.dataSourceTileConnected}`}
+                                    >
+                                        <MantineIcon
+                                            icon={IconDatabaseHeart}
+                                            color="green"
+                                            size={24}
+                                        />
+                                    </Box>
+                                    <Stack gap={2}>
+                                        <Text fw={600}>
+                                            Data source connected
+                                        </Text>
+                                        <Text size="sm" c="dimmed">
+                                            {agentName} is getting ready to
+                                            answer questions.
+                                        </Text>
+                                    </Stack>
+                                </>
+                            ) : (
+                                <>
+                                    <Box className={classes.dataSourceTile}>
+                                        <MantineIcon
+                                            icon={IconDatabase}
+                                            color="orange"
+                                            size={24}
+                                        />
+                                    </Box>
+                                    <Stack gap={2}>
+                                        <Text fw={600}>
+                                            Connect a data source to get started
+                                        </Text>
+                                        <Text size="sm" c="dimmed">
+                                            {agentName} needs data before it can
+                                            answer anything.
+                                        </Text>
+                                    </Stack>
+                                </>
+                            )}
                         </Group>
-                        <Button color="dark">Add data source</Button>
+                        {!isConnected && (
+                            <Button
+                                color="dark"
+                                onClick={() =>
+                                    void navigate('/onboarding/data-source')
+                                }
+                            >
+                                Add data source
+                            </Button>
+                        )}
                     </Group>
                 </Paper>
             </Box>

--- a/packages/frontend/src/pages/OnboardingAgent.tsx
+++ b/packages/frontend/src/pages/OnboardingAgent.tsx
@@ -1,0 +1,181 @@
+import { FeatureFlags } from '@lightdash/common';
+import {
+    ActionIcon,
+    Box,
+    Button,
+    Group,
+    Paper,
+    Stack,
+    Text,
+    TextInput,
+    Title,
+} from '@mantine-8/core';
+import { IconDatabase, IconPencil } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import { Navigate } from 'react-router';
+import { DocumentTitle } from '../components/common/DocumentTitle';
+import MantineIcon from '../components/common/MantineIcon';
+import PageSpinner from '../components/PageSpinner';
+import { AgentChatInput } from '../ee/features/aiCopilot/components/ChatElements/AgentChatInput';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+import useApp from '../providers/App/useApp';
+import classes from './OnboardingAgent.module.css';
+
+const DEFAULT_AGENT_NAME = 'Aurora';
+
+const AuroraAvatar: FC = () => (
+    <svg width="40" height="40" viewBox="0 0 48 48" fill="none">
+        <path
+            d="M19 12 Q24 7 29 12"
+            stroke="#2E2E3A"
+            strokeWidth="2"
+            strokeLinecap="round"
+            fill="none"
+        />
+        <circle cx="18.5" cy="23" r="2.4" fill="#2E2E3A" />
+        <circle cx="29.5" cy="23" r="2.4" fill="#2E2E3A" />
+        <path
+            d="M18 29 Q24 35 30 29"
+            stroke="#2E2E3A"
+            strokeWidth="2"
+            strokeLinecap="round"
+            fill="none"
+        />
+    </svg>
+);
+
+const OnboardingAgentContent: FC = () => {
+    const [agentName, setAgentName] = useState(DEFAULT_AGENT_NAME);
+    const [isEditingName, setIsEditingName] = useState(false);
+    const [nameDraft, setNameDraft] = useState(DEFAULT_AGENT_NAME);
+
+    const startEditing = () => {
+        setNameDraft(agentName);
+        setIsEditingName(true);
+    };
+
+    const commitName = () => {
+        const trimmed = nameDraft.trim();
+        if (trimmed) {
+            setAgentName(trimmed);
+        }
+        setIsEditingName(false);
+    };
+
+    return (
+        <Box className={classes.page}>
+            <DocumentTitle title={agentName} />
+
+            <Box className={classes.column}>
+                <Stack align="center" gap={6}>
+                    <Box className={classes.avatar}>
+                        <AuroraAvatar />
+                    </Box>
+
+                    {isEditingName ? (
+                        <TextInput
+                            variant="unstyled"
+                            autoFocus
+                            value={nameDraft}
+                            onChange={(event) =>
+                                setNameDraft(event.currentTarget.value)
+                            }
+                            onBlur={commitName}
+                            onKeyDown={(event) => {
+                                if (event.key === 'Enter') {
+                                    commitName();
+                                }
+                            }}
+                            classNames={{ input: classes.nameInput }}
+                        />
+                    ) : (
+                        <Group justify="center" gap={4}>
+                            <Title order={2} ta="center">
+                                {agentName}
+                            </Title>
+                            <ActionIcon
+                                variant="subtle"
+                                color="ldGray.6"
+                                aria-label="Edit agent name"
+                                onClick={startEditing}
+                            >
+                                <MantineIcon icon={IconPencil} />
+                            </ActionIcon>
+                        </Group>
+                    )}
+
+                    <Text size="sm" c="ldGray.6" ta="center">
+                        Your organization's analytics agent
+                    </Text>
+                </Stack>
+
+                <AgentChatInput
+                    onSubmit={() => {}}
+                    disabled
+                    disabledReason="Connect a data source to start asking questions"
+                    placeholder={`Ask ${agentName} anything about your data...`}
+                    showSuggestions={false}
+                />
+
+                <Paper withBorder radius="md" p="lg">
+                    <Group justify="space-between" gap="lg">
+                        <Group gap="md">
+                            <Box className={classes.dataSourceTile}>
+                                <MantineIcon
+                                    icon={IconDatabase}
+                                    color="orange"
+                                    size={24}
+                                />
+                            </Box>
+                            <Stack gap={2}>
+                                <Text fw={600}>
+                                    Connect a data source to get started
+                                </Text>
+                                <Text size="sm" c="dimmed">
+                                    {agentName} needs data before it can answer
+                                    anything.
+                                </Text>
+                            </Stack>
+                        </Group>
+                        <Button color="dark">Add data source</Button>
+                    </Group>
+                </Paper>
+            </Box>
+        </Box>
+    );
+};
+
+const OnboardingAgent: FC = () => {
+    const { health, user } = useApp();
+    const orgSetupPageFlag = useServerFeatureFlag(
+        FeatureFlags.OrganizationSetupPage,
+    );
+
+    if (health.isInitialLoading || health.error) {
+        return <PageSpinner />;
+    }
+
+    if (!health.data?.isAuthenticated) {
+        return <Navigate to="/login" />;
+    }
+
+    if (user.isInitialLoading || orgSetupPageFlag.isLoading) {
+        return <PageSpinner />;
+    }
+
+    if (!user.data) {
+        return <PageSpinner />;
+    }
+
+    if (!user.data.organizationUuid) {
+        return <Navigate to="/join-organization" />;
+    }
+
+    if (!orgSetupPageFlag.data?.enabled) {
+        return <Navigate to="/" />;
+    }
+
+    return <OnboardingAgentContent key={user.data.userUuid} />;
+};
+
+export default OnboardingAgent;

--- a/packages/frontend/src/pages/OnboardingDataSource.module.css
+++ b/packages/frontend/src/pages/OnboardingDataSource.module.css
@@ -1,0 +1,98 @@
+.page {
+    min-height: 100vh;
+    background-color: var(--mantine-color-white);
+    display: flex;
+    flex-direction: column;
+}
+
+.topBar {
+    display: flex;
+    align-items: center;
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+    background-color: var(--mantine-color-white);
+}
+
+.backButton {
+    font-weight: 500;
+}
+
+.column {
+    width: 100%;
+    max-width: 1140px;
+    margin: 0 auto;
+    padding: 56px var(--mantine-spacing-sm) var(--mantine-spacing-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--mantine-spacing-xl);
+}
+
+.warehouseCard {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--mantine-spacing-sm);
+    padding: 24px 12px;
+    transition:
+        box-shadow 100ms ease,
+        border-color 100ms ease;
+}
+
+.warehouseCardEnabled {
+    cursor: pointer;
+}
+
+.warehouseCardEnabled:hover {
+    box-shadow: var(--mantine-shadow-md);
+    border-color: var(--mantine-color-ldGray-4);
+}
+
+.warehouseCardDisabled {
+    cursor: not-allowed;
+}
+
+.disabledContent {
+    opacity: 0.45;
+}
+
+.warehouseLabel {
+    font-weight: 600;
+    font-size: 15px;
+}
+
+.otherCard {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--mantine-spacing-md);
+    cursor: not-allowed;
+}
+
+.iconTile {
+    width: 40px;
+    height: 40px;
+    border-radius: var(--mantine-radius-md);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.iconTileViolet {
+    background-color: var(--mantine-color-violet-0);
+}
+
+.iconTileTeal {
+    background-color: var(--mantine-color-teal-0);
+}
+
+.iconTileBlue {
+    background-color: var(--mantine-color-blue-0);
+}
+
+.connectColumn {
+    width: 100%;
+    max-width: 62rem;
+    margin: 0 auto;
+    padding: var(--mantine-spacing-xl) var(--mantine-spacing-sm);
+}

--- a/packages/frontend/src/pages/OnboardingDataSource.tsx
+++ b/packages/frontend/src/pages/OnboardingDataSource.tsx
@@ -1,0 +1,310 @@
+import { FeatureFlags, WarehouseTypes } from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Group,
+    Paper,
+    SimpleGrid,
+    Stack,
+    Text,
+    Title,
+    Tooltip,
+} from '@mantine-8/core';
+import {
+    IconChevronLeft,
+    IconFileCode,
+    IconFileSpreadsheet,
+    IconPlugConnected,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Navigate, useNavigate, useParams } from 'react-router';
+import { DocumentTitle } from '../components/common/DocumentTitle';
+import MantineIcon from '../components/common/MantineIcon';
+import PageSpinner from '../components/PageSpinner';
+import ConnectManuallyStep2 from '../components/ProjectConnection/ProjectConnectFlow/ConnectManually/ConnectManuallyStep2';
+import InviteExpertFooter from '../components/ProjectConnection/ProjectConnectFlow/InviteExpertFooter';
+import { OtherWarehouse } from '../components/ProjectConnection/ProjectConnectFlow/types';
+import {
+    getWarehouseIcon,
+    WarehouseTypeLabels,
+} from '../components/ProjectConnection/ProjectConnectFlow/utils';
+import { ProjectFormProvider } from '../components/ProjectConnection/ProjectFormProvider';
+import { useOrganization } from '../hooks/organization/useOrganization';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+import useApp from '../providers/App/useApp';
+import classes from './OnboardingDataSource.module.css';
+
+const WAREHOUSE_ORDER = [
+    WarehouseTypes.BIGQUERY,
+    WarehouseTypes.SNOWFLAKE,
+    WarehouseTypes.DATABRICKS,
+    WarehouseTypes.POSTGRES,
+    WarehouseTypes.REDSHIFT,
+    WarehouseTypes.CLICKHOUSE,
+    WarehouseTypes.ATHENA,
+    WarehouseTypes.TRINO,
+    WarehouseTypes.DUCKDB,
+    OtherWarehouse.Other,
+];
+
+const orderedWarehouses = WAREHOUSE_ORDER.map((key) =>
+    WarehouseTypeLabels.find((warehouse) => warehouse.key === key),
+).filter((warehouse) => warehouse !== undefined);
+
+const OTHER_SOURCES = [
+    {
+        icon: IconPlugConnected,
+        tileClass: classes.iconTileViolet,
+        iconColor: 'violet',
+        title: 'MCP server',
+        subtitle: 'Connect a tool via MCP',
+    },
+    {
+        icon: IconFileCode,
+        tileClass: classes.iconTileTeal,
+        iconColor: 'teal',
+        title: 'dbt project',
+        subtitle: 'Import models & metrics',
+    },
+    {
+        icon: IconFileSpreadsheet,
+        tileClass: classes.iconTileBlue,
+        iconColor: 'blue',
+        title: 'CSV / Sheet',
+        subtitle: 'Upload a flat file',
+    },
+];
+
+const SectionHeader: FC<{ title: string; hint?: string }> = ({
+    title,
+    hint,
+}) => (
+    <Group justify="space-between" align="baseline">
+        <Text size="xs" fw={600} c="dimmed" tt="uppercase" lts={0.5}>
+            {title}
+        </Text>
+        {hint && (
+            <Text size="sm" c="dimmed">
+                {hint}
+            </Text>
+        )}
+    </Group>
+);
+
+const BackToChat: FC = () => {
+    const navigate = useNavigate();
+    return (
+        <Box className={classes.topBar}>
+            <Button
+                variant="subtle"
+                size="sm"
+                color="blue"
+                className={classes.backButton}
+                leftSection={<MantineIcon icon={IconChevronLeft} />}
+                onClick={() => void navigate('/onboarding/agent')}
+            >
+                Back to chat
+            </Button>
+        </Box>
+    );
+};
+
+const DataSourcePicker: FC = () => {
+    const navigate = useNavigate();
+
+    return (
+        <Box className={classes.column}>
+            <Stack align="center" gap="xs">
+                <Title order={1} ta="center" fw={700}>
+                    Add a data source
+                </Title>
+                <Text size="md" c="dimmed" ta="center">
+                    Connecting a warehouse is the main event — it's what makes
+                    Aurora useful.
+                </Text>
+            </Stack>
+
+            <Stack gap="md">
+                <SectionHeader
+                    title="Data warehouses"
+                    hint="Pick yours to connect"
+                />
+                <SimpleGrid cols={{ base: 2, sm: 3, md: 5 }} spacing="md">
+                    {orderedWarehouses.map((warehouse) => {
+                        const isEnabled =
+                            warehouse.key === WarehouseTypes.SNOWFLAKE;
+
+                        const card = (
+                            <Paper
+                                key={warehouse.key}
+                                withBorder
+                                radius="md"
+                                className={`${classes.warehouseCard} ${
+                                    isEnabled
+                                        ? classes.warehouseCardEnabled
+                                        : classes.warehouseCardDisabled
+                                }`}
+                                onClick={
+                                    isEnabled
+                                        ? () =>
+                                              void navigate(
+                                                  '/onboarding/data-source/snowflake',
+                                              )
+                                        : undefined
+                                }
+                            >
+                                <Box
+                                    className={
+                                        isEnabled
+                                            ? undefined
+                                            : classes.disabledContent
+                                    }
+                                >
+                                    {getWarehouseIcon(warehouse.key, 40)}
+                                </Box>
+                                <Text
+                                    className={`${classes.warehouseLabel} ${
+                                        isEnabled ? '' : classes.disabledContent
+                                    }`}
+                                >
+                                    {warehouse.label}
+                                </Text>
+                            </Paper>
+                        );
+
+                        if (isEnabled) {
+                            return card;
+                        }
+
+                        return (
+                            <Tooltip
+                                key={warehouse.key}
+                                label="Coming soon"
+                                position="top"
+                            >
+                                <Box>{card}</Box>
+                            </Tooltip>
+                        );
+                    })}
+                </SimpleGrid>
+            </Stack>
+
+            <Stack gap="md">
+                <SectionHeader title="Other sources" />
+                <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
+                    {OTHER_SOURCES.map((source) => (
+                        <Tooltip
+                            key={source.title}
+                            label="Coming soon"
+                            position="top"
+                        >
+                            <Paper
+                                withBorder
+                                radius="md"
+                                p="md"
+                                className={`${classes.otherCard} ${classes.disabledContent}`}
+                            >
+                                <Box
+                                    className={`${classes.iconTile} ${source.tileClass}`}
+                                >
+                                    <MantineIcon
+                                        icon={source.icon}
+                                        color={source.iconColor}
+                                        size={24}
+                                    />
+                                </Box>
+                                <Stack gap={2}>
+                                    <Text fw={600}>{source.title}</Text>
+                                    <Text size="sm" c="dimmed">
+                                        {source.subtitle}
+                                    </Text>
+                                </Stack>
+                            </Paper>
+                        </Tooltip>
+                    ))}
+                </SimpleGrid>
+            </Stack>
+
+            <InviteExpertFooter />
+        </Box>
+    );
+};
+
+const SnowflakeConnect: FC = () => {
+    const navigate = useNavigate();
+    const { isInitialLoading: isLoadingOrganization, data: organization } =
+        useOrganization();
+
+    if (isLoadingOrganization || !organization) {
+        return <PageSpinner />;
+    }
+
+    return (
+        <Box className={classes.connectColumn}>
+            <ProjectFormProvider>
+                <ConnectManuallyStep2
+                    isCreatingFirstProject={!!organization.needsProject}
+                    selectedWarehouse={WarehouseTypes.SNOWFLAKE}
+                    warehouseOnly
+                    onBack={() => void navigate('/onboarding/data-source')}
+                    successRedirect={() => '/onboarding/agent'}
+                />
+            </ProjectFormProvider>
+        </Box>
+    );
+};
+
+const OnboardingDataSourceContent: FC = () => {
+    const { warehouse } = useParams<{ warehouse?: string }>();
+
+    if (warehouse && warehouse !== 'snowflake') {
+        return <Navigate to="/onboarding/data-source" replace />;
+    }
+
+    return (
+        <Box className={classes.page}>
+            <DocumentTitle title="Add a data source" />
+            <BackToChat />
+            {warehouse === 'snowflake' ? (
+                <SnowflakeConnect />
+            ) : (
+                <DataSourcePicker />
+            )}
+        </Box>
+    );
+};
+
+const OnboardingDataSource: FC = () => {
+    const { health, user } = useApp();
+    const orgSetupPageFlag = useServerFeatureFlag(
+        FeatureFlags.OrganizationSetupPage,
+    );
+
+    if (health.isInitialLoading || health.error) {
+        return <PageSpinner />;
+    }
+
+    if (!health.data?.isAuthenticated) {
+        return <Navigate to="/login" />;
+    }
+
+    if (user.isInitialLoading || orgSetupPageFlag.isLoading) {
+        return <PageSpinner />;
+    }
+
+    if (!user.data) {
+        return <PageSpinner />;
+    }
+
+    if (!user.data.organizationUuid) {
+        return <Navigate to="/join-organization" />;
+    }
+
+    if (!orgSetupPageFlag.data?.enabled) {
+        return <Navigate to="/" />;
+    }
+
+    return <OnboardingDataSourceContent key={user.data.userUuid} />;
+};
+
+export default OnboardingDataSource;

--- a/packages/frontend/src/pages/OnboardingDataSource.tsx
+++ b/packages/frontend/src/pages/OnboardingDataSource.tsx
@@ -1,4 +1,5 @@
-import { FeatureFlags, WarehouseTypes } from '@lightdash/common';
+import { subject } from '@casl/ability';
+import { ProjectType, WarehouseTypes } from '@lightdash/common';
 import {
     Box,
     Button,
@@ -19,6 +20,7 @@ import {
 import { type FC } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
 import { DocumentTitle } from '../components/common/DocumentTitle';
+import ErrorState from '../components/common/ErrorState';
 import MantineIcon from '../components/common/MantineIcon';
 import PageSpinner from '../components/PageSpinner';
 import ConnectManuallyStep2 from '../components/ProjectConnection/ProjectConnectFlow/ConnectManually/ConnectManuallyStep2';
@@ -30,8 +32,7 @@ import {
 } from '../components/ProjectConnection/ProjectConnectFlow/utils';
 import { ProjectFormProvider } from '../components/ProjectConnection/ProjectFormProvider';
 import { useOrganization } from '../hooks/organization/useOrganization';
-import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
-import useApp from '../providers/App/useApp';
+import { useOnboardingPageGuard } from '../hooks/useOnboardingPageGuard';
 import classes from './OnboardingDataSource.module.css';
 
 const WAREHOUSE_ORDER = [
@@ -232,11 +233,18 @@ const DataSourcePicker: FC = () => {
 
 const SnowflakeConnect: FC = () => {
     const navigate = useNavigate();
-    const { isInitialLoading: isLoadingOrganization, data: organization } =
-        useOrganization();
+    const {
+        isInitialLoading: isLoadingOrganization,
+        data: organization,
+        error: organizationError,
+    } = useOrganization();
 
-    if (isLoadingOrganization || !organization) {
+    if (isLoadingOrganization) {
         return <PageSpinner />;
+    }
+
+    if (organizationError || !organization) {
+        return <ErrorState error={organizationError?.error} />;
     }
 
     return (
@@ -247,7 +255,9 @@ const SnowflakeConnect: FC = () => {
                     selectedWarehouse={WarehouseTypes.SNOWFLAKE}
                     warehouseOnly
                     onBack={() => void navigate('/onboarding/data-source')}
-                    successRedirect={() => '/onboarding/agent'}
+                    successRedirect={(projectUuid) =>
+                        `/onboarding/project-ready/${projectUuid}`
+                    }
                 />
             </ProjectFormProvider>
         </Box>
@@ -275,36 +285,25 @@ const OnboardingDataSourceContent: FC = () => {
 };
 
 const OnboardingDataSource: FC = () => {
-    const { health, user } = useApp();
-    const orgSetupPageFlag = useServerFeatureFlag(
-        FeatureFlags.OrganizationSetupPage,
+    const guard = useOnboardingPageGuard();
+
+    if (guard.status === 'blocked') {
+        return guard.element;
+    }
+
+    const canCreateProject = guard.user.ability.can(
+        'create',
+        subject('Project', {
+            organizationUuid: guard.user.organizationUuid,
+            type: ProjectType.DEFAULT,
+        }),
     );
 
-    if (health.isInitialLoading || health.error) {
-        return <PageSpinner />;
+    if (!canCreateProject) {
+        return <Navigate to="/onboarding/agent" replace />;
     }
 
-    if (!health.data?.isAuthenticated) {
-        return <Navigate to="/login" />;
-    }
-
-    if (user.isInitialLoading || orgSetupPageFlag.isLoading) {
-        return <PageSpinner />;
-    }
-
-    if (!user.data) {
-        return <PageSpinner />;
-    }
-
-    if (!user.data.organizationUuid) {
-        return <Navigate to="/join-organization" />;
-    }
-
-    if (!orgSetupPageFlag.data?.enabled) {
-        return <Navigate to="/" />;
-    }
-
-    return <OnboardingDataSourceContent key={user.data.userUuid} />;
+    return <OnboardingDataSourceContent key={guard.user.userUuid} />;
 };
 
 export default OnboardingDataSource;

--- a/packages/frontend/src/pages/OnboardingProjectReady.module.css
+++ b/packages/frontend/src/pages/OnboardingProjectReady.module.css
@@ -1,0 +1,86 @@
+.page {
+    min-height: 100vh;
+    background-color: var(--mantine-color-white);
+}
+
+.column {
+    width: 100%;
+    max-width: 580px;
+    margin: 0 auto;
+    padding: 15vh var(--mantine-spacing-md) var(--mantine-spacing-xl);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.checkCircle {
+    width: 72px;
+    height: 72px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--mantine-color-green-6);
+    flex-shrink: 0;
+}
+
+.heading {
+    margin-top: 24px;
+}
+
+.progressSection {
+    width: 100%;
+    margin-top: 32px;
+}
+
+.percentText {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 13px;
+    text-align: right;
+    margin-top: 6px;
+}
+
+.checklist {
+    width: 100%;
+    margin-top: 24px;
+}
+
+.pendingDot {
+    width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.pendingDot::after {
+    content: '';
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: var(--mantine-color-ldGray-3);
+}
+
+.annotation {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 14px;
+}
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.startButton {
+    width: 100%;
+    margin-top: 32px;
+    animation: fadeInUp 400ms ease;
+}

--- a/packages/frontend/src/pages/OnboardingProjectReady.tsx
+++ b/packages/frontend/src/pages/OnboardingProjectReady.tsx
@@ -1,0 +1,201 @@
+import { type WarehouseTablesCatalog } from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Group,
+    Progress,
+    Stack,
+    Text,
+    Title,
+} from '@mantine-8/core';
+import { IconCheck } from '@tabler/icons-react';
+import { useEffect, useMemo, useState, type FC } from 'react';
+import { Navigate, useNavigate, useParams } from 'react-router';
+import { DocumentTitle } from '../components/common/DocumentTitle';
+import MantineIcon from '../components/common/MantineIcon';
+import { useTables } from '../features/sqlRunner/hooks/useTables';
+import { useOnboardingPageGuard } from '../hooks/useOnboardingPageGuard';
+import { useProject } from '../hooks/useProject';
+import classes from './OnboardingProjectReady.module.css';
+
+const TOTAL_STEPS = 4;
+const STEP_CADENCE_MS = 600;
+
+const OnboardingProjectReadyContent: FC<{ projectUuid: string }> = ({
+    projectUuid,
+}) => {
+    const navigate = useNavigate();
+    const { data: project } = useProject(projectUuid);
+    const {
+        data: tables,
+        isFetched: tablesFetched,
+        isSuccess: tablesSuccess,
+    } = useTables({ projectUuid });
+
+    const [completedSteps, setCompletedSteps] = useState(0);
+
+    const { schemaCount, tableCount } = useMemo(() => {
+        const catalog = tables
+            ? (tables as unknown as WarehouseTablesCatalog)
+            : undefined;
+        if (!catalog) {
+            return { schemaCount: 0, tableCount: 0 };
+        }
+        let schemas = 0;
+        let allTables = 0;
+        Object.values(catalog).forEach((schemasByDatabase) => {
+            Object.values(schemasByDatabase).forEach((tablesBySchema) => {
+                schemas += 1;
+                allTables += Object.keys(tablesBySchema).length;
+            });
+        });
+        return { schemaCount: schemas, tableCount: allTables };
+    }, [tables]);
+
+    useEffect(() => {
+        if (completedSteps >= TOTAL_STEPS) {
+            return;
+        }
+        const stepBeingCompleted = completedSteps;
+        const needsData = stepBeingCompleted === 1 || stepBeingCompleted === 2;
+        if (needsData && !tablesFetched) {
+            return;
+        }
+        const timer = setTimeout(() => {
+            setCompletedSteps((current) => current + 1);
+        }, STEP_CADENCE_MS);
+        return () => clearTimeout(timer);
+    }, [completedSteps, tablesFetched]);
+
+    const warehouseType = project?.warehouseConnection?.type;
+
+    const steps = [
+        {
+            label: 'Connecting to warehouse',
+            annotation: warehouseType ? warehouseType.toLowerCase() : null,
+        },
+        {
+            label: 'Reading schemas',
+            annotation: tablesSuccess ? `${schemaCount} schemas` : null,
+        },
+        {
+            label: 'Indexing tables & columns',
+            annotation: tablesSuccess ? `${tableCount} tables` : null,
+        },
+        {
+            label: 'Building semantic catalog',
+            annotation: null,
+        },
+    ];
+
+    const progress = (completedSteps / TOTAL_STEPS) * 100;
+    const allDone = completedSteps >= TOTAL_STEPS;
+
+    return (
+        <Box className={classes.page}>
+            <DocumentTitle title="Your project is ready" />
+
+            <Box className={classes.column}>
+                <Box className={classes.checkCircle}>
+                    <MantineIcon
+                        icon={IconCheck}
+                        color="white"
+                        size={36}
+                        stroke={3}
+                    />
+                </Box>
+
+                <Stack gap={6} className={classes.heading}>
+                    <Title order={2} ta="center" fw={700}>
+                        Your project is ready
+                    </Title>
+                    <Text c="dimmed" size="lg" ta="center">
+                        Aurora now understands your data.
+                    </Text>
+                </Stack>
+
+                <Box className={classes.progressSection}>
+                    <Progress
+                        value={progress}
+                        color="blue"
+                        size="md"
+                        radius="xl"
+                    />
+                    <Text c="dimmed" className={classes.percentText}>
+                        {Math.round(progress)}%
+                    </Text>
+                </Box>
+
+                <Stack gap="md" className={classes.checklist}>
+                    {steps.map((step, index) => {
+                        const isDone = index < completedSteps;
+                        return (
+                            <Group
+                                key={step.label}
+                                justify="space-between"
+                                wrap="nowrap"
+                            >
+                                <Group gap="sm" wrap="nowrap">
+                                    {isDone ? (
+                                        <MantineIcon
+                                            icon={IconCheck}
+                                            color="green"
+                                            size={20}
+                                        />
+                                    ) : (
+                                        <Box className={classes.pendingDot} />
+                                    )}
+                                    <Text fw={600} fz={16}>
+                                        {step.label}
+                                    </Text>
+                                </Group>
+                                {isDone && step.annotation && (
+                                    <Text
+                                        c="dimmed"
+                                        className={classes.annotation}
+                                    >
+                                        {step.annotation}
+                                    </Text>
+                                )}
+                            </Group>
+                        );
+                    })}
+                </Stack>
+
+                {allDone && (
+                    <Button
+                        color="dark"
+                        size="lg"
+                        radius="md"
+                        className={classes.startButton}
+                        onClick={() => void navigate('/onboarding/agent')}
+                    >
+                        Start chatting with Aurora
+                    </Button>
+                )}
+            </Box>
+        </Box>
+    );
+};
+
+const OnboardingProjectReady: FC = () => {
+    const { projectUuid } = useParams<{ projectUuid?: string }>();
+    const guard = useOnboardingPageGuard();
+
+    if (guard.status === 'blocked') {
+        return guard.element;
+    }
+
+    if (!projectUuid) {
+        return <Navigate to="/onboarding/agent" replace />;
+    }
+
+    return (
+        <OnboardingProjectReadyContent
+            key={projectUuid}
+            projectUuid={projectUuid}
+        />
+    );
+};
+
+export default OnboardingProjectReady;

--- a/packages/frontend/src/pages/OnboardingProjectReady.tsx
+++ b/packages/frontend/src/pages/OnboardingProjectReady.tsx
@@ -9,7 +9,8 @@ import {
     Title,
 } from '@mantine-8/core';
 import { IconCheck } from '@tabler/icons-react';
-import { useEffect, useMemo, useState, type FC } from 'react';
+import confetti from 'canvas-confetti';
+import { useEffect, useMemo, useRef, useState, type FC } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
 import { DocumentTitle } from '../components/common/DocumentTitle';
 import MantineIcon from '../components/common/MantineIcon';
@@ -91,12 +92,40 @@ const OnboardingProjectReadyContent: FC<{ projectUuid: string }> = ({
     const progress = (completedSteps / TOTAL_STEPS) * 100;
     const allDone = completedSteps >= TOTAL_STEPS;
 
+    const checkCircleRef = useRef<HTMLDivElement>(null);
+    const hasFiredConfettiRef = useRef(false);
+
+    useEffect(() => {
+        if (!allDone || hasFiredConfettiRef.current) {
+            return;
+        }
+        hasFiredConfettiRef.current = true;
+
+        const el = checkCircleRef.current;
+        const rect = el?.getBoundingClientRect();
+        const origin = rect
+            ? {
+                  x: (rect.left + rect.width / 2) / window.innerWidth,
+                  y: (rect.top + rect.height / 2) / window.innerHeight,
+              }
+            : { x: 0.5, y: 0.3 };
+
+        void confetti({
+            disableForReducedMotion: true,
+            startVelocity: 35,
+            particleCount: 120,
+            spread: 100,
+            gravity: 0.7,
+            origin,
+        });
+    }, [allDone]);
+
     return (
         <Box className={classes.page}>
             <DocumentTitle title="Your project is ready" />
 
             <Box className={classes.column}>
-                <Box className={classes.checkCircle}>
+                <Box className={classes.checkCircle} ref={checkCircleRef}>
                     <MantineIcon
                         icon={IconCheck}
                         color="white"

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -112,14 +112,14 @@ type OrganizationSetupFormValues = {
 type OrganizationSetupContentProps = {
     user: UserWithAbility;
     health: HealthState;
+    completeMutation: ReturnType<typeof useUserCompleteMutation>;
 };
 
 const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
     user,
     health,
+    completeMutation,
 }) => {
-    const navigate = useNavigate();
-
     const canEnterOrganizationName = user.organizationName === '';
     const emailDomain = user.email ? getEmailDomain(user.email) : '';
     const isCompanyDomain =
@@ -151,7 +151,6 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
         health.hasBrandfetch && canEnterOrganizationName && isCompanyDomain,
     );
     const saveBrand = useSaveOrganizationBrand();
-    const completeMutation = useUserCompleteMutation();
 
     const { setValues, isDirty } = form;
     const hasAppliedDetectedBrand = useRef(false);
@@ -170,12 +169,6 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                 : {}),
         }));
     }, [brandDetection.data, isDirty, setValues]);
-
-    useEffect(() => {
-        if (completeMutation.isSuccess) {
-            void navigate('/');
-        }
-    }, [completeMutation.isSuccess, navigate]);
 
     const detectedBrand = brandDetection.data ?? null;
     const detectedColors = detectedBrand
@@ -470,9 +463,19 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
 
 const OrganizationSetup: FC = () => {
     const { health, user } = useApp();
+    const navigate = useNavigate();
     const orgSetupPageFlag = useServerFeatureFlag(
         FeatureFlags.OrganizationSetupPage,
     );
+    const completeMutation = useUserCompleteMutation();
+    const isCompletingSetup =
+        completeMutation.isLoading || completeMutation.isSuccess;
+
+    useEffect(() => {
+        if (completeMutation.isSuccess) {
+            void navigate('/onboarding/agent');
+        }
+    }, [completeMutation.isSuccess, navigate]);
 
     if (health.isInitialLoading || health.error) {
         return <PageSpinner />;
@@ -494,7 +497,7 @@ const OrganizationSetup: FC = () => {
         return <Navigate to="/join-organization" />;
     }
 
-    if (user.data.isSetupComplete) {
+    if (user.data.isSetupComplete && !isCompletingSetup) {
         return <Navigate to="/" />;
     }
 
@@ -507,6 +510,7 @@ const OrganizationSetup: FC = () => {
             key={user.data.userUuid}
             user={user.data}
             health={health.data}
+            completeMutation={completeMutation}
         />
     );
 };

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -467,15 +467,11 @@ const OrganizationSetup: FC = () => {
     const orgSetupPageFlag = useServerFeatureFlag(
         FeatureFlags.OrganizationSetupPage,
     );
-    const completeMutation = useUserCompleteMutation();
+    const completeMutation = useUserCompleteMutation({
+        onSuccess: () => void navigate('/onboarding/agent'),
+    });
     const isCompletingSetup =
         completeMutation.isLoading || completeMutation.isSuccess;
-
-    useEffect(() => {
-        if (completeMutation.isSuccess) {
-            void navigate('/onboarding/agent');
-        }
-    }, [completeMutation.isSuccess, navigate]);
 
     if (health.isInitialLoading || health.error) {
         return <PageSpinner />;

--- a/packages/frontend/src/providers/ActiveJob/ActiveJobProvider.tsx
+++ b/packages/frontend/src/providers/ActiveJob/ActiveJobProvider.tsx
@@ -37,6 +37,7 @@ const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
                             'projects',
                             'defaultProject',
                         ]);
+                        await queryClient.invalidateQueries(['organization']);
                     }
                     await queryClient.invalidateQueries(['parameters']);
                     showToastSuccess({

--- a/packages/frontend/src/providers/ActiveJob/ActiveJobProvider.tsx
+++ b/packages/frontend/src/providers/ActiveJob/ActiveJobProvider.tsx
@@ -27,7 +27,7 @@ const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
         async (job: Job | undefined) => {
             if (!job || isJobsDrawerOpen) return;
 
-            const toastTitle = jobStatusLabel(job?.jobStatus);
+            const toastTitle = jobStatusLabel(job?.jobStatus, job?.jobType);
 
             switch (job.jobStatus) {
                 case 'DONE':

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -569,9 +569,18 @@ type DashboardFilterRequirementsSavedEvent = {
     };
 };
 
+export type OnboardingAgentMessageSubmittedEvent = {
+    name: EventName.ONBOARDING_AGENT_MESSAGE_SUBMITTED;
+    properties: {
+        projectUuid: string;
+        isNewAgent: boolean;
+    };
+};
+
 export type EventData =
     | GenericEvent
     | HomepageQuickActionClickedEvent
+    | OnboardingAgentMessageSubmittedEvent
     | SetupStepClickedEvent
     | DocumentationClickedEvent
     | SearchResultClickedEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -51,6 +51,7 @@ export enum PageName {
     JOIN_ORGANIZATION = 'join_organization',
     ORGANIZATION_SETUP = 'organization_setup',
     ONBOARDING_AGENT = 'onboarding_agent',
+    ONBOARDING_DATA_SOURCE = 'onboarding_data_source',
     EMBED_DASHBOARD = 'embed_dashboard',
     EMBED_SAVED_CHART = 'embed_saved_chart',
     EMBED_EXPLORE = 'embed_explore',

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -50,6 +50,7 @@ export enum PageName {
     VERIFY_EMAIL = 'verify_email',
     JOIN_ORGANIZATION = 'join_organization',
     ORGANIZATION_SETUP = 'organization_setup',
+    ONBOARDING_AGENT = 'onboarding_agent',
     EMBED_DASHBOARD = 'embed_dashboard',
     EMBED_SAVED_CHART = 'embed_saved_chart',
     EMBED_EXPLORE = 'embed_explore',

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -52,6 +52,7 @@ export enum PageName {
     ORGANIZATION_SETUP = 'organization_setup',
     ONBOARDING_AGENT = 'onboarding_agent',
     ONBOARDING_DATA_SOURCE = 'onboarding_data_source',
+    ONBOARDING_PROJECT_READY = 'onboarding_project_ready',
     EMBED_DASHBOARD = 'embed_dashboard',
     EMBED_SAVED_CHART = 'embed_saved_chart',
     EMBED_EXPLORE = 'embed_explore',

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -104,6 +104,7 @@ export enum EventName {
     CREATE_PROJECT_CLI_SSO_OPTION_CLICKED = 'create_project_cli_sso_option.click',
     COPY_CREATE_PROJECT_CODE_BUTTON_CLICKED = 'copy_create_project_code_click.click',
     ONBOARDING_STEP_CLICKED = 'onboarding_step.click',
+    ONBOARDING_AGENT_MESSAGE_SUBMITTED = 'onboarding_agent_message.submit',
     LANDING_RUN_QUERY_CLICKED = 'landing_run_query.click',
     SETUP_STEP_CLICKED = 'setup_step.click',
     ADD_FILTER_CLICKED = 'add_filter.click',

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
@@ -281,7 +281,12 @@ describe('SnowflakeWarehouseClient', () => {
                 }) => {
                     let rows: Record<string, string>[] = [];
                     if (sqlText.startsWith('SHOW USER')) {
-                        rows = [{ name: 'LIGHTDASH_ONBOARDING_11111111' }];
+                        rows = [
+                            {
+                                name: 'LIGHTDASH_ONBOARDING_11111111',
+                                status: 'ACTIVE',
+                            },
+                        ];
                     } else if (sqlText.startsWith('ALTER USER ADD')) {
                         rows = [{ TOKEN_SECRET: 'pat-secret' }];
                     }
@@ -328,6 +333,149 @@ describe('SnowflakeWarehouseClient', () => {
             );
         },
     );
+
+    it('prunes only non-active Lightdash onboarding PATs', async () => {
+        const execute = vi.fn(
+            ({
+                sqlText,
+                complete,
+            }: {
+                sqlText: string;
+                complete: (
+                    error: undefined,
+                    statement: { getColumns: () => typeof queryColumnsMock },
+                    rows: Record<string, string>[],
+                ) => void;
+            }) => {
+                let rows: Record<string, string>[] = [];
+                if (sqlText.startsWith('SHOW USER')) {
+                    rows = [
+                        {
+                            name: 'LIGHTDASH_ONBOARDING_EXPIRED',
+                            status: 'EXPIRED',
+                        },
+                        {
+                            name: 'LIGHTDASH_ONBOARDING_DISABLED',
+                            status: 'DISABLED',
+                        },
+                        {
+                            name: 'LIGHTDASH_ONBOARDING_ACTIVE',
+                            status: 'ACTIVE',
+                        },
+                        { name: 'OTHER_EXPIRED', status: 'EXPIRED' },
+                        { name: 'OTHER_ACTIVE', status: 'ACTIVE' },
+                    ];
+                } else if (sqlText.startsWith('ALTER USER ADD')) {
+                    rows = [{ TOKEN_SECRET: 'pat-secret' }];
+                }
+                complete(
+                    undefined,
+                    { getColumns: () => queryColumnsMock },
+                    rows,
+                );
+            },
+        );
+        vi.mocked(createConnection).mockImplementationOnce(() =>
+            interactiveConnectionMock(execute),
+        );
+        const warehouse = new SnowflakeWarehouseClient({
+            ...credentials,
+            authenticationType:
+                SnowflakeAuthenticationType.OAUTH_AUTHORIZATION_CODE,
+        });
+
+        await expect(
+            warehouse.createProgrammaticAccessToken('LIGHTDASH_ONBOARDING_NEW'),
+        ).resolves.toEqual({
+            tokenName: 'LIGHTDASH_ONBOARDING_NEW',
+            tokenSecret: 'pat-secret',
+        });
+
+        expect(execute).toHaveBeenCalledWith(
+            expect.objectContaining({
+                sqlText:
+                    'ALTER USER REMOVE PROGRAMMATIC ACCESS TOKEN LIGHTDASH_ONBOARDING_EXPIRED',
+            }),
+        );
+        expect(execute).toHaveBeenCalledWith(
+            expect.objectContaining({
+                sqlText:
+                    'ALTER USER REMOVE PROGRAMMATIC ACCESS TOKEN LIGHTDASH_ONBOARDING_DISABLED',
+            }),
+        );
+        expect(execute).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                sqlText:
+                    'ALTER USER REMOVE PROGRAMMATIC ACCESS TOKEN LIGHTDASH_ONBOARDING_ACTIVE',
+            }),
+        );
+        expect(execute).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                sqlText:
+                    'ALTER USER REMOVE PROGRAMMATIC ACCESS TOKEN OTHER_EXPIRED',
+            }),
+        );
+        expect(execute).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                sqlText:
+                    'ALTER USER REMOVE PROGRAMMATIC ACCESS TOKEN OTHER_ACTIVE',
+            }),
+        );
+    });
+
+    it('creates a PAT when pruning an inactive PAT fails', async () => {
+        const execute = vi.fn(
+            ({
+                sqlText,
+                complete,
+            }: {
+                sqlText: string;
+                complete: (
+                    error: Error | undefined,
+                    statement: { getColumns: () => typeof queryColumnsMock },
+                    rows: Record<string, string>[],
+                ) => void;
+            }) => {
+                const statement = { getColumns: () => queryColumnsMock };
+                if (sqlText.startsWith('SHOW USER')) {
+                    complete(undefined, statement, [
+                        {
+                            name: 'LIGHTDASH_ONBOARDING_EXPIRED',
+                            status: 'EXPIRED',
+                        },
+                    ]);
+                } else if (sqlText.startsWith('ALTER USER REMOVE')) {
+                    complete(new Error('Failed to remove PAT'), statement, []);
+                } else {
+                    complete(undefined, statement, [
+                        { TOKEN_SECRET: 'pat-secret' },
+                    ]);
+                }
+            },
+        );
+        vi.mocked(createConnection).mockImplementationOnce(() =>
+            interactiveConnectionMock(execute),
+        );
+        const warehouse = new SnowflakeWarehouseClient({
+            ...credentials,
+            authenticationType:
+                SnowflakeAuthenticationType.OAUTH_AUTHORIZATION_CODE,
+        });
+
+        await expect(
+            warehouse.createProgrammaticAccessToken('LIGHTDASH_ONBOARDING_NEW'),
+        ).resolves.toEqual({
+            tokenName: 'LIGHTDASH_ONBOARDING_NEW',
+            tokenSecret: 'pat-secret',
+        });
+        expect(execute).toHaveBeenCalledWith(
+            expect.objectContaining({
+                sqlText: expect.stringMatching(
+                    /^ALTER USER ADD PROGRAMMATIC ACCESS TOKEN LIGHTDASH_ONBOARDING_NEW/,
+                ),
+            }),
+        );
+    });
 
     it('discovers session defaults and capped inventory for interactive sessions', async () => {
         const execute = vi.fn(

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -1006,6 +1006,41 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                     `ALTER USER REMOVE PROGRAMMATIC ACCESS TOKEN ${tokenName}`,
                 );
             }
+            const inactiveLightdashTokenNames = existingTokens.rows.flatMap(
+                (row) => {
+                    const name = Object.entries(row).find(
+                        ([key]) => key.toLowerCase() === 'name',
+                    )?.[1];
+                    const status = Object.entries(row).find(
+                        ([key]) => key.toLowerCase() === 'status',
+                    )?.[1];
+                    return name !== undefined &&
+                        /^[A-Za-z_][A-Za-z0-9_$]*$/.test(String(name)) &&
+                        String(name)
+                            .toUpperCase()
+                            .startsWith('LIGHTDASH_ONBOARDING') &&
+                        String(name).toUpperCase() !==
+                            tokenName.toUpperCase() &&
+                        status !== undefined &&
+                        String(status).toUpperCase() !== 'ACTIVE'
+                        ? [String(name)]
+                        : [];
+                },
+            );
+            try {
+                await inactiveLightdashTokenNames.reduce<Promise<void>>(
+                    async (previousRemoval, inactiveTokenName) => {
+                        await previousRemoval;
+                        await this.executeStatements(
+                            connection,
+                            `ALTER USER REMOVE PROGRAMMATIC ACCESS TOKEN ${inactiveTokenName}`,
+                        );
+                    },
+                    Promise.resolve(),
+                );
+            } catch {
+                // Stale-token cleanup must not prevent minting a new token.
+            }
             const roleClause = roleRestriction
                 ? ` ROLE_RESTRICTION = '${roleRestriction.replace(/'/g, "''")}'`
                 : '';


### PR DESCRIPTION
## Summary

End-to-end agentic onboarding: a new user signs up (email-only), sets up their organization with brand theming, connects a warehouse through a guided golden path, and lands in a live chat with "Aurora" — an AI agent that is auto-provisioned server-side and can query the connected warehouse from day one, before any dbt models or explores exist.

## The flow

Signup → org setup (2-step, brand pulled from the email domain) → `/onboarding/agent` (Aurora intro) → `/onboarding/data-source` (picker; Snowflake golden path with CLI SSO connect pre-selected) → warehouse-only project creation → `/onboarding/project-ready/:projectUuid` (staged checklist with real schema/table counts, completion confetti) → live Aurora chat.

All gated behind existing feature flags: `email-only-signup`, `organization-setup-page`, `warehouse-connect-onboarding`.

## What's included

**Onboarding flow (PROD-8916)**
- Agent intro page inside the app shell, data-source picker, warehouse-only Snowflake connect with CLI SSO defaulted, project-ready screen with live warehouse catalog counts
- Shared `useOnboardingPageGuard`; org query invalidation on CREATE_PROJECT completion

**Live Aurora chat (PROD-8921)**
- Onboarding composer creates a real agent thread and hands off into the existing AI-agents thread UI with SQL mode enabled, so a zero-explores project is queryable immediately
- Zero-explores system prompt is now SQL-mode-aware (steers to warehouse discovery tools instead of "there is no data")
- **Server-side auto-provisioning**: an org's first non-preview project gets the Aurora agent created automatically on both creation paths — EE-injected via a lazy thunk, copilot-gated, idempotent, non-throwing; `ai_agent.created` analytics carry an `autoProvisioned` flag
- Graceful frontend states: composer disabled with an explanatory callout when copilot isn't enabled for the org; submit analytics

**Fixes shipped along the way**
- Snowflake CLI-SSO connects minted PATs under one fixed name and revoked every previously connected project's credentials — now unique per-mint names with best-effort pruning of non-active tokens (relates to the CLI SSO work in #25581)
- Warehouse connection errors were masked as "table not found" in `getWarehouseFields` — `WarehouseConnectionError` now re-thrown
- Snowflake SSO `is-authenticated` check no longer fires (and 500s) when legacy Snowflake OAuth isn't configured
- Local dev backend now runs `TZ=UTC` (matches production; prevents naive-UTC timestamp skew causing false AI-chat error cards and wrong relative times — driver-level fix tracked in PROD-8924)

## Testing

Full journey live-verified repeatedly on local EE builds, including a real Snowflake round-trip in SQL mode and server-side provisioning verified on the scheduler path (agent row created before the chat page is ever opened). Unit tests cover PAT rotation/pruning and provisioning gating/no-throw behaviour.

Closes: PROD-8916
Closes: PROD-8921
Relates: PROD-8903

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jguhb33ZTEDJZKECLwL21G
