### PR TITLE
feat(slack): improve project grouping in channel agent link picker

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -2674,6 +2674,38 @@ export class AiAgentModel {
         return result?.instruction ?? null;
     }
 
+    async findLastUsedProjectUuid({
+        organizationUuid,
+        userUuid,
+        projectUuids,
+    }: {
+        organizationUuid: string;
+        userUuid: string;
+        projectUuids: string[];
+    }): Promise<string | undefined> {
+        if (projectUuids.length === 0) return undefined;
+
+        const row = await this.database(AiPromptTableName)
+            .join(
+                AiThreadTableName,
+                `${AiPromptTableName}.ai_thread_uuid`,
+                `${AiThreadTableName}.ai_thread_uuid`,
+            )
+            .where(`${AiPromptTableName}.created_by_user_uuid`, userUuid)
+            .andWhere(
+                `${AiThreadTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .whereIn(`${AiThreadTableName}.project_uuid`, projectUuids)
+            .orderBy(`${AiPromptTableName}.created_at`, 'desc')
+            .select<Pick<DbAiThread, 'project_uuid'>>(
+                `${AiThreadTableName}.project_uuid`,
+            )
+            .first();
+
+        return row?.project_uuid;
+    }
+
     async deleteAgent({
         organizationUuid,
         agentUuid,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -10923,6 +10923,27 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         return agentsWithContext;
     }
 
+    // Projects whose summary can't be fetched are omitted — the blocks render a fallback label.
+    private async getAgentSelectProjectMap(
+        agents: Pick<AiAgent, 'projectUuid'>[],
+    ): Promise<Map<string, string>> {
+        const uniqueProjectUuids = [
+            ...new Set(agents.map((a) => a.projectUuid)),
+        ];
+        const entries = await Promise.all(
+            uniqueProjectUuids.map(async (projectUuid) => {
+                try {
+                    const project =
+                        await this.projectModel.getSummary(projectUuid);
+                    return [projectUuid, project.name] as const;
+                } catch {
+                    return undefined;
+                }
+            }),
+        );
+        return new Map(entries.filter((entry) => entry !== undefined));
+    }
+
     /**
      * Show agent selection UI when multiple agents are available
      */
@@ -10933,23 +10954,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         say: SayFn,
         shouldSkipForwardingQuery = false,
     ): Promise<void> {
-        // Fetch project names for grouping
-        const uniqueProjectUuids = [
-            ...new Set(availableAgents.map((a) => a.projectUuid)),
-        ];
-        const projectMap = new Map<string, string>();
-        await Promise.all(
-            uniqueProjectUuids.map(async (projectUuid) => {
-                try {
-                    const project =
-                        await this.projectModel.getSummary(projectUuid);
-                    projectMap.set(projectUuid, project.name);
-                } catch {
-                    // If project fetch fails, use UUID as fallback
-                    projectMap.set(projectUuid, projectUuid);
-                }
-            }),
-        );
+        const projectMap = await this.getAgentSelectProjectMap(availableAgents);
 
         await say({
             blocks: getAgentSelectionBlocks(
@@ -10971,12 +10976,35 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         channelId: string;
         threadTs: string;
         say: SayFn;
+        // Reuses the multi-agent channel "filter agents by project" setting.
+        visibleProjectUuids?: string[] | null;
     }): Promise<AiAgent | undefined> {
-        const { organizationUuid, userUuid, channelId, threadTs, say } = args;
+        const {
+            organizationUuid,
+            userUuid,
+            channelId,
+            threadTs,
+            say,
+            visibleProjectUuids,
+        } = args;
         const { siteUrl } = this.lightdashConfig;
+
+        // Drop deleted projects so a stale filter doesn't hide every agent.
+        const validProjectUuids = visibleProjectUuids?.length
+            ? await this.aiAgentModel.filterExistingProjectUuids(
+                  visibleProjectUuids,
+              )
+            : [];
 
         const allAgents = await this.aiAgentModel.findAllAgents({
             organizationUuid,
+            // Preview-project agents are excluded, matching the multi-agent channel.
+            filter: {
+                projectType: ProjectType.DEFAULT,
+                ...(validProjectUuids.length > 0
+                    ? { projectFilter: { projectUuids: validProjectUuids } }
+                    : {}),
+            },
         });
 
         if (allAgents.length === 0) {
@@ -11051,21 +11079,16 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             return agent;
         }
 
-        const uniqueProjectUuids = [
-            ...new Set(manageableAgents.map((a) => a.projectUuid)),
-        ];
-        const projectMap = new Map<string, string>();
-        await Promise.all(
-            uniqueProjectUuids.map(async (projectUuid) => {
-                try {
-                    const project =
-                        await this.projectModel.getSummary(projectUuid);
-                    projectMap.set(projectUuid, project.name);
-                } catch {
-                    projectMap.set(projectUuid, projectUuid);
-                }
+        const [projectMap, lastUsedProjectUuid] = await Promise.all([
+            this.getAgentSelectProjectMap(manageableAgents),
+            this.aiAgentModel.findLastUsedProjectUuid({
+                organizationUuid,
+                userUuid,
+                projectUuids: [
+                    ...new Set(manageableAgents.map((a) => a.projectUuid)),
+                ],
             }),
-        );
+        ]);
 
         await say({
             text: 'No agent is linked to this channel yet — pick one to answer here.',
@@ -11073,6 +11096,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 manageableAgents,
                 channelId,
                 projectMap,
+                lastUsedProjectUuid,
             ),
             thread_ts: threadTs,
         });
@@ -13048,6 +13072,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         channelId,
                         threadTs: threadTs || messageTs,
                         say,
+                        visibleProjectUuids:
+                            slackSettings.aiMultiAgentProjectUuids,
                     });
                     if (!agentConfig) {
                         return;
@@ -13337,6 +13363,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             channelId: event.channel,
                             threadTs: event.thread_ts ?? event.ts,
                             say,
+                            visibleProjectUuids:
+                                slackSettings.aiMultiAgentProjectUuids,
                         });
                         if (!agentConfig) {
                             return;

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -1038,6 +1038,7 @@ const buildAgentOptionGroups = (
     agents: AgentSelectOption[],
     projectMap: Map<string, string>,
     buildValue: (agent: AgentSelectOption) => string,
+    lastUsedProjectUuid?: string,
 ) => {
     const agentsByProject = new Map<string, AgentSelectOption[]>();
     for (const agent of agents) {
@@ -1051,16 +1052,22 @@ const buildAgentOptionGroups = (
 
     return Array.from(agentsByProject.entries())
         .map(([projectUuid, projectAgents]) => ({
+            projectUuid,
+            name: projectMap.get(projectUuid) ?? 'Other projects',
+            agents: projectAgents,
+        }))
+        .sort((a, b) => {
+            if (a.projectUuid === lastUsedProjectUuid) return -1;
+            if (b.projectUuid === lastUsedProjectUuid) return 1;
+            return a.name.localeCompare(b.name);
+        })
+        .map((group) => ({
             label: {
                 type: 'plain_text' as const,
-                text: truncateSlackText(
-                    projectMap.get(projectUuid) || projectUuid,
-                    75,
-                ),
+                text: truncateSlackText(group.name, 75),
             },
-            options: buildAgentOptions(projectAgents, buildValue),
-        }))
-        .sort((a, b) => a.label.text.localeCompare(b.label.text));
+            options: buildAgentOptions(group.agents, buildValue),
+        }));
 };
 
 const buildAgentSelectBlocks = (args: {
@@ -1222,6 +1229,7 @@ export function getChannelLinkAgentSelectionBlocks(
     agents: AgentSelectOption[],
     channelId: string,
     projectMap: Map<string, string>,
+    lastUsedProjectUuid?: string,
 ): (Block | KnownBlock)[] {
     const limitedAgents = [...agents]
         .sort((a, b) => a.name.localeCompare(b.name))
@@ -1237,6 +1245,7 @@ export function getChannelLinkAgentSelectionBlocks(
                 projectMap,
                 // Slack caps option values at 150 chars — keep names out of the value.
                 (agent) => JSON.stringify({ a: agent.uuid, c: channelId }),
+                lastUsedProjectUuid,
             ),
         },
     });


### PR DESCRIPTION
Follow-up to #25516, improving the agent dropdown shown when no agent is linked to a Slack channel:

- **Project names, never UUIDs** — projects whose summary can't be fetched now render under an "Other projects" label instead of exposing the project UUID as the group label.
- **Last-used project first** — the project of the user's most recent AI agent activity (latest `ai_prompt` joined to its thread's project) is sorted to the top of the dropdown; remaining projects are alphabetical.
- **Preview projects excluded** — the picker now filters to `DEFAULT` projects, matching the multi-agent channel behaviour. We may reintroduce preview projects (sorted last) later.
- **Reuses the "Filter agents by project" setting** (`aiMultiAgentProjectUuids`) from the Slack integration settings, so the link picker offers agents from the same projects as the multi-agent channel. Deleted projects are dropped from the filter so a stale config can't hide every agent.

The multi-agent channel picker shares the group builder, so it also gets the name-fallback and alphabetical sorting.

Relates: ZAP-610

🤖 Generated with [Claude Code](https://claude.com/claude-code)
