### PR TITLE
feat: pass dashboard filters to Ask AI

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -1,6 +1,7 @@
 import {
     type AiAgentModelConfig,
     type AiChartRuntimeOverrides,
+    type AiDashboardRuntimeOverrides,
     type AiOrgModelVisibility,
     type AiProviderApiKeyHints,
     type AiThreadCreatedFrom,
@@ -412,7 +413,10 @@ export type DbAiPromptContext = {
     entity_ref: string | null;
     pinned_version_uuid: string | null;
     display_name: string | null;
-    runtime_overrides: AiChartRuntimeOverrides | null;
+    runtime_overrides:
+        | AiChartRuntimeOverrides
+        | AiDashboardRuntimeOverrides
+        | null;
     created_at: Date;
 };
 

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -78,6 +78,8 @@ import {
     type AgentAsCode,
     type AiAgent,
     type AiAgentIntegration,
+    type AiChartRuntimeOverrides,
+    type AiDashboardRuntimeOverrides,
     type VerifiedContentListItem,
 } from '@lightdash/common';
 import { Knex } from 'knex';
@@ -5426,6 +5428,7 @@ export class AiAgentModel {
                         pinned_version_uuid:
                             dashboard?.dashboard_version_uuid ?? null,
                         display_name: dashboard?.name ?? null,
+                        runtime_overrides: ctx.runtimeOverrides ?? null,
                     };
                 }
                 case 'thread': {
@@ -5732,7 +5735,8 @@ export class AiAgentModel {
                     chartSlug: chartData?.slug ?? null,
                     pinnedVersionUuid: row.pinned_version_uuid,
                     displayName: row.display_name,
-                    runtimeOverrides: row.runtime_overrides,
+                    runtimeOverrides:
+                        row.runtime_overrides as AiChartRuntimeOverrides | null,
                     chartKind: chartData?.chartKind ?? null,
                 };
             }
@@ -5744,6 +5748,8 @@ export class AiAgentModel {
                     dashboardSlug: dashboardSlugByUuid.get(entityUuid) ?? null,
                     pinnedVersionUuid: row.pinned_version_uuid,
                     displayName: row.display_name,
+                    runtimeOverrides:
+                        row.runtime_overrides as AiDashboardRuntimeOverrides | null,
                 };
             }
             case 'thread':

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -91,6 +91,7 @@ import {
     PullRequestProvider,
     QueryExecutionContext,
     ReadinessScore,
+    serializeDashboardFiltersForAiContext,
     ShareUrl,
     SlackPrompt,
     sleep,
@@ -6322,7 +6323,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                     const overrideLines: string[] = [];
                     if (overrides.dashboardFilters) {
                         overrideLines.push(
-                            `    Dashboard filters: ${JSON.stringify(overrides.dashboardFilters)}`,
+                            `    Dashboard filters: ${JSON.stringify(serializeDashboardFiltersForAiContext(overrides.dashboardFilters))}`,
                         );
                     }
                     if (overrides.dashboardParameters) {
@@ -6340,7 +6341,11 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                 }
                 case 'dashboard': {
                     const name = item.displayName ?? '(name unavailable)';
-                    return `- Dashboard "${name}" (dashboardSlug: ${item.dashboardSlug ?? '(slug unavailable)'})`;
+                    const headline = `- Dashboard "${name}" (dashboardSlug: ${item.dashboardSlug ?? '(slug unavailable)'})`;
+                    const filters = item.runtimeOverrides?.dashboardFilters;
+                    return filters
+                        ? `${headline}\n  Filters applied:\n    ${JSON.stringify(serializeDashboardFiltersForAiContext(filters))}`
+                        : headline;
                 }
                 case 'thread': {
                     const name = item.displayName ?? '(name unavailable)';

--- a/packages/backend/src/ee/services/AiAgentService/pinnedContextMessage.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/pinnedContextMessage.test.ts
@@ -1,4 +1,8 @@
-import { AiPromptContext } from '@lightdash/common';
+import {
+    AiPromptContext,
+    FilterOperator,
+    type DashboardFilters,
+} from '@lightdash/common';
 import { AiAgentService } from './AiAgentService';
 
 vi.mock('../ai/AiAgentMcpRuntimeClient', () => ({
@@ -25,11 +29,57 @@ describe('AiAgentService.createPinnedContextMessage review pins', () => {
                 dashboardSlug: 'exec-dashboard',
                 displayName: 'Executive dashboard',
                 pinnedVersionUuid: null,
+                runtimeOverrides: null,
             },
         ]);
         expect(content).toContain(
             '- Dashboard "Executive dashboard" (dashboardSlug: exec-dashboard)',
         );
+    });
+
+    it('renders dashboard filter overrides', () => {
+        const dashboardFilters: DashboardFilters = {
+            dimensions: [
+                {
+                    id: 'country-filter-uuid',
+                    label: 'Country',
+                    operator: FilterOperator.EQUALS,
+                    target: {
+                        fieldId: 'orders.country',
+                        tableName: 'orders',
+                    },
+                    values: ['US'],
+                    tileTargets: {
+                        'tile-uuid': {
+                            fieldId: 'orders.country',
+                            tableName: 'orders',
+                        },
+                    },
+                    lockedTabUuids: ['tab-uuid'],
+                    requiredGroupId: 'group-uuid',
+                },
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const content = buildMessage([
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dashboard-1',
+                dashboardSlug: 'exec-dashboard',
+                displayName: 'Executive dashboard',
+                pinnedVersionUuid: null,
+                runtimeOverrides: {
+                    dashboardFilters,
+                },
+            },
+        ]);
+        expect(content).toContain('Filters applied:');
+        expect(content).toContain('"values":["US"]');
+        expect(content).not.toContain('country-filter-uuid');
+        expect(content).not.toContain('tileTargets');
+        expect(content).not.toContain('lockedTabUuids');
+        expect(content).not.toContain('requiredGroupId');
     });
 
     it('renders a pull_request line with number, status and title', () => {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -13622,8 +13622,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: ['upload'] },
+                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -14428,8 +14428,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: ['upload'] },
+                            { dataType: 'enum', enums: ['url'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -15348,6 +15348,132 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_DashboardFilterRule.Exclude_keyofDashboardFilterRule.id-or-tileTargets-or-lockedTabUuids-or-requiredGroupId__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    label: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                        required: true,
+                    },
+                    target: { ref: 'DashboardFieldTarget', required: true },
+                    settings: { dataType: 'any' },
+                    disabled: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'boolean' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    required: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'boolean' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    caseSensitive: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'boolean' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    operator: { ref: 'FilterOperator', required: true },
+                    values: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'array', array: { dataType: 'any' } },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    includeNull: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'boolean' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    singleValue: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'boolean' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_DashboardFilterRule.id-or-tileTargets-or-lockedTabUuids-or-requiredGroupId_':
+        {
+            dataType: 'refAlias',
+            type: {
+                ref: 'Pick_DashboardFilterRule.Exclude_keyofDashboardFilterRule.id-or-tileTargets-or-lockedTabUuids-or-requiredGroupId__',
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDashboardFilterRule: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Omit_DashboardFilterRule.id-or-tileTargets-or-lockedTabUuids-or-requiredGroupId_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDashboardFilters: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                tableCalculations: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiDashboardFilterRule',
+                    },
+                    required: true,
+                },
+                metrics: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiDashboardFilterRule',
+                    },
+                    required: true,
+                },
+                dimensions: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiDashboardFilterRule',
+                    },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDashboardRuntimeOverrides: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                dashboardFilters: { ref: 'AiDashboardFilters' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     PullRequestProvider: {
         dataType: 'refEnum',
         enums: ['github', 'gitlab'],
@@ -15843,6 +15969,14 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        runtimeOverrides: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'AiDashboardRuntimeOverrides' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
                         displayName: {
                             dataType: 'union',
                             subSchemas: [
@@ -17466,13 +17600,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                slug: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
-                                                    required: true,
-                                                },
-                                                slug: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 uuid: {
@@ -17950,13 +18084,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                slug: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
-                                                    required: true,
-                                                },
-                                                slug: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
@@ -18838,6 +18972,9 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        runtimeOverrides: {
+                            ref: 'AiDashboardRuntimeOverrides',
+                        },
                         dashboardSlug: {
                             dataType: 'union',
                             subSchemas: [
@@ -36781,6 +36918,27 @@ const models: TsoaRoute.Models = {
                     ],
                     required: true,
                 },
+                tileTargets: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'Record_string.DashboardTileTarget_' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                lockedTabUuids: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                requiredGroupId: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                },
                 target: { ref: 'DashboardFieldTarget', required: true },
                 settings: { dataType: 'any' },
                 disabled: {
@@ -36819,31 +36977,10 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
-                tileTargets: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'Record_string.DashboardTileTarget_' },
-                        { dataType: 'undefined' },
-                    ],
-                },
                 singleValue: {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'boolean' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                requiredGroupId: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                lockedTabUuids: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'array', array: { dataType: 'string' } },
                         { dataType: 'undefined' },
                     ],
                 },
@@ -42667,17 +42804,17 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'string' },
                     required: true,
                 },
-                warehouse: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'undefined' },
-                    ],
-                },
                 caseSensitive: {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'boolean' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                warehouse: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
                         { dataType: 'undefined' },
                     ],
                 },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1596,7 +1596,8 @@
                         "type": "string"
                     },
                     "text": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Markdown —"
                     }
                 },
                 "required": ["author", "date", "text"],
@@ -15268,7 +15269,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["url", "upload", null],
+                        "enum": ["upload", "url", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -16082,7 +16083,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["url", "upload", null],
+                        "enum": ["upload", "url", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -16982,6 +16983,90 @@
                 "type": "object",
                 "description": "Runtime state captured at pin time for a chart context. When a user pins a\nchart from a dashboard view, these are the dashboard-level overrides that\nwere applied to the chart on screen at that moment."
             },
+            "Pick_DashboardFilterRule.Exclude_keyofDashboardFilterRule.id-or-tileTargets-or-lockedTabUuids-or-requiredGroupId__": {
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "target": {
+                        "$ref": "#/components/schemas/DashboardFieldTarget",
+                        "description": "Target field for the filter"
+                    },
+                    "settings": {
+                        "description": "Additional settings for date/time filters"
+                    },
+                    "disabled": {
+                        "type": "boolean",
+                        "description": "Whether this filter is disabled"
+                    },
+                    "required": {
+                        "type": "boolean",
+                        "description": "Whether this filter is required"
+                    },
+                    "caseSensitive": {
+                        "type": "boolean",
+                        "description": "Overrides the field/explore case-sensitivity for this rule only.\nUsed by internal features like autocomplete search that must always\nmatch case-insensitively regardless of the field's configured setting."
+                    },
+                    "operator": {
+                        "$ref": "#/components/schemas/FilterOperator",
+                        "description": "Filter operator"
+                    },
+                    "values": {
+                        "items": {},
+                        "type": "array",
+                        "description": "Values to filter by"
+                    },
+                    "includeNull": {
+                        "type": "boolean",
+                        "description": "For the `equals` operator on string fields, also match rows where the\nfield is null (compiles to `field IN (...) OR field IS NULL`). Lets users\ncombine null with selected values in a single \"is\" rule."
+                    },
+                    "singleValue": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["target", "operator"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_DashboardFilterRule.id-or-tileTargets-or-lockedTabUuids-or-requiredGroupId_": {
+                "$ref": "#/components/schemas/Pick_DashboardFilterRule.Exclude_keyofDashboardFilterRule.id-or-tileTargets-or-lockedTabUuids-or-requiredGroupId__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "AiDashboardFilterRule": {
+                "$ref": "#/components/schemas/Omit_DashboardFilterRule.id-or-tileTargets-or-lockedTabUuids-or-requiredGroupId_"
+            },
+            "AiDashboardFilters": {
+                "properties": {
+                    "tableCalculations": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiDashboardFilterRule"
+                        },
+                        "type": "array"
+                    },
+                    "metrics": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiDashboardFilterRule"
+                        },
+                        "type": "array"
+                    },
+                    "dimensions": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiDashboardFilterRule"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["tableCalculations", "metrics", "dimensions"],
+                "type": "object"
+            },
+            "AiDashboardRuntimeOverrides": {
+                "properties": {
+                    "dashboardFilters": {
+                        "$ref": "#/components/schemas/AiDashboardFilters"
+                    }
+                },
+                "type": "object"
+            },
             "PullRequestProvider": {
                 "enum": ["github", "gitlab"],
                 "type": "string"
@@ -17469,6 +17554,14 @@
                     },
                     {
                         "properties": {
+                            "runtimeOverrides": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/AiDashboardRuntimeOverrides"
+                                    }
+                                ],
+                                "nullable": true
+                            },
                             "displayName": {
                                 "type": "string",
                                 "nullable": true
@@ -17491,6 +17584,7 @@
                             }
                         },
                         "required": [
+                            "runtimeOverrides",
                             "displayName",
                             "pinnedVersionUuid",
                             "dashboardSlug",
@@ -18550,13 +18644,13 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
+                                                    "slug": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
                                                     },
                                                     "uuid": {
                                                         "type": "string"
@@ -18569,8 +18663,8 @@
                                                     "versionUuids",
                                                     "warnings",
                                                     "href",
-                                                    "status",
                                                     "slug",
+                                                    "status",
                                                     "uuid",
                                                     "name"
                                                 ],
@@ -18732,13 +18826,13 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
+                                                    "slug": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
@@ -18746,8 +18840,8 @@
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "status",
                                                     "slug",
+                                                    "status",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -19354,6 +19448,9 @@
                     },
                     {
                         "properties": {
+                            "runtimeOverrides": {
+                                "$ref": "#/components/schemas/AiDashboardRuntimeOverrides"
+                            },
                             "dashboardSlug": {
                                 "type": "string",
                                 "nullable": true
@@ -37037,6 +37134,20 @@
                     "label": {
                         "type": "string"
                     },
+                    "tileTargets": {
+                        "$ref": "#/components/schemas/Record_string.DashboardTileTarget_"
+                    },
+                    "lockedTabUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "description": "Tab UUIDs where this filter is locked. When the active tab is in this\nlist, viewers see the filter but cannot change it, and URL / embed\nfilter overrides targeting the same field are ignored on that tab.\nEmpty or omitted means the filter is not locked anywhere."
+                    },
+                    "requiredGroupId": {
+                        "type": "string",
+                        "description": "Dashboard filters sharing a requiredGroupId form an \"any-one required\"\ngroup: the dashboard is locked until at least one member has a value."
+                    },
                     "target": {
                         "$ref": "#/components/schemas/DashboardFieldTarget",
                         "description": "Target field for the filter"
@@ -37069,22 +37180,8 @@
                         "type": "boolean",
                         "description": "For the `equals` operator on string fields, also match rows where the\nfield is null (compiles to `field IN (...) OR field IS NULL`). Lets users\ncombine null with selected values in a single \"is\" rule."
                     },
-                    "tileTargets": {
-                        "$ref": "#/components/schemas/Record_string.DashboardTileTarget_"
-                    },
                     "singleValue": {
                         "type": "boolean"
-                    },
-                    "requiredGroupId": {
-                        "type": "string",
-                        "description": "Dashboard filters sharing a requiredGroupId form an \"any-one required\"\ngroup: the dashboard is locked until at least one member has a value."
-                    },
-                    "lockedTabUuids": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "description": "Tab UUIDs where this filter is locked. When the active tab is in this\nlist, viewers see the filter but cannot change it, and URL / embed\nfilter overrides targeting the same field are ignored on that tab.\nEmpty or omitted means the filter is not locked anywhere."
                     }
                 },
                 "required": ["target", "operator"],
@@ -42832,11 +42929,11 @@
                         },
                         "type": "array"
                     },
-                    "warehouse": {
-                        "type": "string"
-                    },
                     "caseSensitive": {
                         "type": "boolean"
+                    },
+                    "warehouse": {
+                        "type": "string"
                     },
                     "groupLabel": {
                         "type": "string",

--- a/packages/common/src/ee/AiAgent/dashboardContext.test.ts
+++ b/packages/common/src/ee/AiAgent/dashboardContext.test.ts
@@ -1,0 +1,61 @@
+import { FilterOperator, type DashboardFilters } from '../..';
+import { serializeDashboardFiltersForAiContext } from './dashboardContext';
+
+const filter = {
+    id: 'filter-uuid',
+    label: 'Country',
+    operator: FilterOperator.EQUALS,
+    target: { fieldId: 'orders.country', tableName: 'orders' },
+    values: ['US'],
+    tileTargets: {
+        'tile-uuid': { fieldId: 'orders.country', tableName: 'orders' },
+    },
+    lockedTabUuids: ['tab-uuid'],
+    requiredGroupId: 'group-uuid',
+};
+
+describe('serializeDashboardFiltersForAiContext', () => {
+    it('removes opaque identifiers from every filter group', () => {
+        const filters: DashboardFilters = {
+            dimensions: [filter],
+            metrics: [filter],
+            tableCalculations: [filter],
+        };
+
+        expect(serializeDashboardFiltersForAiContext(filters)).toEqual({
+            dimensions: [
+                {
+                    label: 'Country',
+                    operator: FilterOperator.EQUALS,
+                    target: {
+                        fieldId: 'orders.country',
+                        tableName: 'orders',
+                    },
+                    values: ['US'],
+                },
+            ],
+            metrics: [
+                {
+                    label: 'Country',
+                    operator: FilterOperator.EQUALS,
+                    target: {
+                        fieldId: 'orders.country',
+                        tableName: 'orders',
+                    },
+                    values: ['US'],
+                },
+            ],
+            tableCalculations: [
+                {
+                    label: 'Country',
+                    operator: FilterOperator.EQUALS,
+                    target: {
+                        fieldId: 'orders.country',
+                        tableName: 'orders',
+                    },
+                    values: ['US'],
+                },
+            ],
+        });
+    });
+});

--- a/packages/common/src/ee/AiAgent/dashboardContext.ts
+++ b/packages/common/src/ee/AiAgent/dashboardContext.ts
@@ -1,0 +1,39 @@
+import { type DashboardFilterRule } from '../../types/filter';
+import {
+    type AiDashboardFilterRule,
+    type AiDashboardFilters,
+} from './requestTypes';
+
+type AiDashboardFilterRuleInput = AiDashboardFilterRule &
+    Partial<
+        Pick<
+            DashboardFilterRule,
+            'id' | 'tileTargets' | 'lockedTabUuids' | 'requiredGroupId'
+        >
+    >;
+
+type AiDashboardFiltersInput = {
+    dimensions: AiDashboardFilterRuleInput[];
+    metrics: AiDashboardFilterRuleInput[];
+    tableCalculations: AiDashboardFilterRuleInput[];
+};
+
+const serializeDashboardFilterRuleForAiContext = ({
+    id: _id,
+    tileTargets: _tileTargets,
+    lockedTabUuids: _lockedTabUuids,
+    requiredGroupId: _requiredGroupId,
+    ...filter
+}: AiDashboardFilterRuleInput): AiDashboardFilterRule => filter;
+
+export const serializeDashboardFiltersForAiContext = (
+    filters: AiDashboardFiltersInput,
+): AiDashboardFilters => ({
+    dimensions: filters.dimensions.map(
+        serializeDashboardFilterRuleForAiContext,
+    ),
+    metrics: filters.metrics.map(serializeDashboardFilterRuleForAiContext),
+    tableCalculations: filters.tableCalculations.map(
+        serializeDashboardFilterRuleForAiContext,
+    ),
+});

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -32,6 +32,7 @@ export * from './chartConfig/slack';
 export * from './chartConfig/web';
 export * from './constants';
 export * from './coder';
+export * from './dashboardContext';
 export * from './aiAgentReviewClassifierTypes';
 export * from './documentTypes';
 export * from './filterExploreByTags';

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -1,5 +1,8 @@
 import { type DateZoom } from '../../types/api/paginatedQuery';
-import { type DashboardFilters } from '../../types/filter';
+import {
+    type DashboardFilterRule,
+    type DashboardFilters,
+} from '../../types/filter';
 import { type PullRequestProvider } from '../../types/gitIntegration';
 import { type ParametersValuesMap } from '../../types/parameters';
 import { type ChartKind } from '../../types/savedCharts';
@@ -28,6 +31,21 @@ export type AiChartRuntimeOverrides = {
     dashboardFilters?: DashboardFilters;
     dashboardParameters?: ParametersValuesMap;
     dateZoom?: DateZoom;
+};
+
+export type AiDashboardFilterRule = Omit<
+    DashboardFilterRule,
+    'id' | 'tileTargets' | 'lockedTabUuids' | 'requiredGroupId'
+>;
+
+export type AiDashboardFilters = {
+    dimensions: AiDashboardFilterRule[];
+    metrics: AiDashboardFilterRule[];
+    tableCalculations: AiDashboardFilterRule[];
+};
+
+export type AiDashboardRuntimeOverrides = {
+    dashboardFilters?: AiDashboardFilters;
 };
 
 export type AiThread = {
@@ -154,6 +172,7 @@ export type AiPromptContextItemInput =
           type: 'dashboard';
           dashboardUuid: string;
           dashboardSlug?: string | null;
+          runtimeOverrides?: AiDashboardRuntimeOverrides;
       }
     | {
           type: 'thread';
@@ -219,6 +238,7 @@ export type AiPromptContextItem =
           dashboardSlug: string | null;
           pinnedVersionUuid: string | null;
           displayName: string | null;
+          runtimeOverrides: AiDashboardRuntimeOverrides | null;
       }
     | {
           type: 'thread';

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -902,6 +902,7 @@ export const extractContentMentionContext = (
                 dashboardSlug: attrs.dashboardSlug ?? null,
                 displayName: attrs.dashboardName ?? null,
                 pinnedVersionUuid: null,
+                runtimeOverrides: null,
             });
         }
 
@@ -935,6 +936,7 @@ export const extractContentMentionContext = (
                 dashboardSlug: attrs.slug ?? null,
                 displayName: attrs.label ?? null,
                 pinnedVersionUuid: null,
+                runtimeOverrides: null,
             });
             return;
         }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts
@@ -13,6 +13,7 @@ describe('contentReferenceUtils', () => {
                     dashboardSlug: 'table-calculations-tests-dashboard',
                     displayName: 'Table Calculations Tests Dashboard',
                     pinnedVersionUuid: null,
+                    runtimeOverrides: null,
                 },
                 {
                     type: 'chart',

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -25,6 +25,7 @@ import { createPath, useLocation, useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import useApp from '../../../../../providers/App/useApp';
 import { useAiAgentSqlModeAvailable } from '../../hooks/useAiAgentSqlModeAvailable';
+import { useDashboardPageContextCuration } from '../../hooks/useDashboardPageContextCuration';
 import { usePendingThreadRefetch } from '../../hooks/usePendingThreadRefetch';
 import { usePinnedContext } from '../../hooks/usePinnedContext';
 import {
@@ -46,11 +47,7 @@ import { getDashboardNavigationUrlFromContentToolResult } from '../../utils/cont
 import { AiAgentNewThreadMcpConnections } from '../AiAgentNewThreadMcpConnections';
 import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
 import { AgentChatInput } from '../ChatElements/AgentChatInput';
-import {
-    contextItemsToContentMentionSuggestions,
-    mergeAiPromptContextInput,
-    mergeAiPromptContextItems,
-} from '../ChatElements/contentMentions';
+import { contextItemsToContentMentionSuggestions } from '../ChatElements/contentMentions';
 import { getPromptContextItemKey } from '../ChatElements/contentReferenceUtils';
 import { PinnedContextCard } from '../PinnedContextCard/PinnedContextCard';
 import styles from './AiAgentsLauncher.module.css';
@@ -73,68 +70,6 @@ type Props = {
     activeThreadId: string | null;
     style?: CSSProperties;
 };
-
-const getCurrentDashboardPromptContext = ({
-    currentDashboard,
-    previousDashboardUuid,
-    projectUuid,
-}: {
-    currentDashboard: {
-        projectUuid: string;
-        uuid: string;
-    } | null;
-    previousDashboardUuid?: string | null;
-    projectUuid: string;
-}): AiPromptContextInput =>
-    currentDashboard?.projectUuid === projectUuid &&
-    currentDashboard.uuid !== previousDashboardUuid
-        ? [
-              {
-                  type: 'dashboard',
-                  dashboardUuid: currentDashboard.uuid,
-              },
-          ]
-        : [];
-
-const getCurrentDashboardOptimisticContext = ({
-    currentDashboard,
-    previousDashboardUuid,
-    projectUuid,
-}: {
-    currentDashboard: {
-        projectUuid: string;
-        uuid: string;
-        name: string;
-    } | null;
-    previousDashboardUuid?: string | null;
-    projectUuid: string;
-}): AiPromptContext =>
-    currentDashboard?.projectUuid === projectUuid &&
-    currentDashboard.uuid !== previousDashboardUuid
-        ? [
-              {
-                  type: 'dashboard',
-                  dashboardUuid: currentDashboard.uuid,
-                  dashboardSlug: null,
-                  displayName: currentDashboard.name,
-                  pinnedVersionUuid: null,
-              },
-          ]
-        : [];
-
-const getLastDashboardUuid = (
-    context: Array<AiPromptContextInput[number] | AiPromptContext[number]>,
-) => {
-    for (let index = context.length - 1; index >= 0; index -= 1) {
-        const item = context[index];
-        if (item.type === 'dashboard') return item.dashboardUuid;
-    }
-    return null;
-};
-
-const hasDashboardContext = (
-    context: Array<AiPromptContextInput[number] | AiPromptContext[number]>,
-) => context.some((item) => item.type === 'dashboard');
 
 export const LauncherPanel: FC<Props> = ({
     projectUuid,
@@ -189,9 +124,6 @@ const NewThreadPanel: FC<{
     const pendingContext = useAiAgentStoreSelector(
         (state) => state.aiAgentLauncher.pendingContext,
     );
-    const currentDashboard = useAiAgentStoreSelector(
-        (state) => state.aiAgentLauncher.currentDashboard,
-    );
 
     const chartUuid = pendingContext?.chartUuid;
     const dashboardUuid = pendingContext?.dashboardUuid;
@@ -210,29 +142,20 @@ const NewThreadPanel: FC<{
         chartUuidOrSlug: chartUuid,
         dashboardUuidOrSlug: dashboardUuid,
     });
-    const contextInputWithPageContext = useMemo(
+    const { curateContext } = useDashboardPageContextCuration({
+        previousContext: contextInput,
+        projectUuid,
+    });
+    const {
+        context: contextInputWithPageContext = [],
+        optimisticContext: previewItemsWithPageContext = [],
+    } = useMemo(
         () =>
-            mergeAiPromptContextInput(
-                getCurrentDashboardPromptContext({
-                    currentDashboard,
-                    previousDashboardUuid: getLastDashboardUuid(contextInput),
-                    projectUuid,
-                }),
-                contextInput,
-            ) ?? [],
-        [contextInput, currentDashboard, projectUuid],
-    );
-    const previewItemsWithPageContext = useMemo(
-        () =>
-            mergeAiPromptContextItems(
-                getCurrentDashboardOptimisticContext({
-                    currentDashboard,
-                    previousDashboardUuid: getLastDashboardUuid(previewItems),
-                    projectUuid,
-                }),
-                previewItems,
-            ) ?? [],
-        [currentDashboard, previewItems, projectUuid],
+            curateContext({
+                context: contextInput,
+                optimisticContext: previewItems,
+            }),
+        [contextInput, curateContext, previewItems],
     );
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
@@ -507,21 +430,25 @@ const ExistingThreadPanel: FC<{
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
     const sqlMode = useAiAgentStoreSelector(selectThreadSqlMode(threadId));
-    const currentDashboard = useAiAgentStoreSelector(
-        (state) => state.aiAgentLauncher.currentDashboard,
-    );
     const dispatchToStore = useAiAgentStoreDispatch();
+    const threadContext = useMemo(
+        () =>
+            thread?.messages.flatMap((message) =>
+                message.role === 'user' ? message.context : [],
+            ) ?? [],
+        [thread?.messages],
+    );
+    const { curateContext, recordSubmittedContext } =
+        useDashboardPageContextCuration({
+            previousContext: threadContext,
+            projectUuid,
+            threadId,
+        });
 
     const isThreadFromCurrentUser = thread?.user.uuid === user?.data?.userUuid;
     const contentMentionItems = useMemo(
-        () =>
-            contextItemsToContentMentionSuggestions(
-                thread?.messages.flatMap((message) =>
-                    message.role === 'user' ? message.context : [],
-                ) ?? [],
-                'thread',
-            ),
-        [thread?.messages],
+        () => contextItemsToContentMentionSuggestions(threadContext, 'thread'),
+        [threadContext],
     );
 
     const handleSubmit = ({
@@ -541,36 +468,17 @@ const ExistingThreadPanel: FC<{
             (m) => m.role === 'assistant',
         );
         const modelConfig = firstAssistantMessage?.modelConfig ?? undefined;
-        const previousDashboardUuid = getLastDashboardUuid(
-            thread?.messages.flatMap((m) =>
-                m.role === 'user' ? m.context : [],
-            ) ?? [],
-        );
+        const curatedContext = curateContext({ context, optimisticContext });
+
         void createAgentThreadMessage({
             prompt: message,
             modelConfig,
-            context: mergeAiPromptContextInput(
-                hasDashboardContext(context ?? [])
-                    ? []
-                    : getCurrentDashboardPromptContext({
-                          currentDashboard,
-                          previousDashboardUuid,
-                          projectUuid,
-                      }),
-                context,
-            ),
-            optimisticContext: mergeAiPromptContextItems(
-                hasDashboardContext(optimisticContext ?? [])
-                    ? []
-                    : getCurrentDashboardOptimisticContext({
-                          currentDashboard,
-                          previousDashboardUuid,
-                          projectUuid,
-                      }),
-                optimisticContext,
-            ),
+            context: curatedContext.context,
+            optimisticContext: curatedContext.optimisticContext,
             enableSqlMode: sqlModeAvailable && sqlMode,
             toolHints,
+        }).then(() => {
+            recordSubmittedContext(curatedContext.context);
         });
     };
 

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDashboardPageContextCuration.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDashboardPageContextCuration.test.ts
@@ -1,0 +1,106 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type LauncherCurrentDashboard } from '../store/aiAgentLauncherSlice';
+import { useAiAgentStoreSelector } from '../store/hooks';
+import { useDashboardPageContextCuration } from './useDashboardPageContextCuration';
+
+vi.mock('../store/hooks', () => ({
+    useAiAgentStoreSelector: vi.fn(),
+}));
+
+const runtimeOverrides = {
+    dashboardFilters: {
+        dimensions: [],
+        metrics: [],
+        tableCalculations: [],
+    },
+};
+
+const currentDashboard: LauncherCurrentDashboard = {
+    projectUuid: 'project-1',
+    uuid: 'dashboard-a',
+    name: 'Orders',
+    activeTabUuid: null,
+    runtimeOverrides,
+};
+
+describe('useDashboardPageContextCuration', () => {
+    beforeEach(() => {
+        vi.mocked(useAiAgentStoreSelector).mockReturnValue(currentDashboard);
+    });
+
+    it('enriches an explicit mention of the open dashboard', () => {
+        const explicitContext = [
+            { type: 'dashboard' as const, dashboardUuid: 'dashboard-a' },
+        ];
+        const { result } = renderHook(() =>
+            useDashboardPageContextCuration({
+                previousContext: [],
+                projectUuid: 'project-1',
+            }),
+        );
+
+        expect(
+            result.current.curateContext({ context: explicitContext }),
+        ).toMatchObject({
+            context: [
+                {
+                    type: 'dashboard',
+                    dashboardUuid: 'dashboard-a',
+                    runtimeOverrides,
+                },
+            ],
+        });
+    });
+
+    it('does not reattach unchanged context after submission', () => {
+        const { result } = renderHook(() =>
+            useDashboardPageContextCuration({
+                previousContext: [],
+                projectUuid: 'project-1',
+                threadId: 'thread-1',
+            }),
+        );
+        const curated = result.current.curateContext({});
+
+        act(() => result.current.recordSubmittedContext(curated.context));
+
+        expect(result.current.curateContext({})).toEqual({
+            context: undefined,
+            optimisticContext: undefined,
+        });
+    });
+
+    it('reattaches the open dashboard after submitting another dashboard', () => {
+        const { result } = renderHook(() =>
+            useDashboardPageContextCuration({
+                previousContext: [
+                    {
+                        type: 'dashboard',
+                        dashboardUuid: 'dashboard-a',
+                        runtimeOverrides,
+                    },
+                ],
+                projectUuid: 'project-1',
+                threadId: 'thread-1',
+            }),
+        );
+        const otherDashboard = result.current.curateContext({
+            context: [{ type: 'dashboard', dashboardUuid: 'dashboard-b' }],
+        });
+
+        act(() =>
+            result.current.recordSubmittedContext(otherDashboard.context),
+        );
+
+        expect(result.current.curateContext({})).toMatchObject({
+            context: [
+                {
+                    type: 'dashboard',
+                    dashboardUuid: 'dashboard-a',
+                    runtimeOverrides,
+                },
+            ],
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDashboardPageContextCuration.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDashboardPageContextCuration.ts
@@ -1,0 +1,120 @@
+import {
+    type AiPromptContext,
+    type AiPromptContextInput,
+} from '@lightdash/common';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import {
+    mergeAiPromptContextInput,
+    mergeAiPromptContextItems,
+} from '../components/ChatElements/contentMentions';
+import {
+    getCurrentDashboardOptimisticContext,
+    getCurrentDashboardPromptContext,
+    getLastDashboardContext,
+} from '../store/dashboardPageContext';
+import { useAiAgentStoreSelector } from '../store/hooks';
+
+type PromptContext = Array<
+    AiPromptContextInput[number] | AiPromptContext[number]
+>;
+
+type ContextToCurate = {
+    context?: AiPromptContextInput;
+    optimisticContext?: AiPromptContext;
+};
+
+export const useDashboardPageContextCuration = ({
+    previousContext,
+    projectUuid,
+    threadId,
+}: {
+    previousContext: PromptContext;
+    projectUuid: string;
+    threadId?: string;
+}) => {
+    const currentDashboard = useAiAgentStoreSelector(
+        (state) => state.aiAgentLauncher.currentDashboard,
+    );
+    const previousDashboardContext = useMemo(
+        () => getLastDashboardContext(previousContext),
+        [previousContext],
+    );
+    const lastSubmittedDashboardContext = useRef<{
+        threadId: string;
+        context: ReturnType<typeof getLastDashboardContext>;
+    } | null>(null);
+
+    useEffect(() => {
+        if (
+            threadId &&
+            previousDashboardContext &&
+            lastSubmittedDashboardContext.current?.threadId !== threadId
+        ) {
+            lastSubmittedDashboardContext.current = {
+                threadId,
+                context: previousDashboardContext,
+            };
+        }
+    }, [previousDashboardContext, threadId]);
+
+    const curateContext = useCallback(
+        ({ context, optimisticContext }: ContextToCurate) => {
+            const comparisonDashboardContext =
+                threadId &&
+                lastSubmittedDashboardContext.current?.threadId === threadId
+                    ? lastSubmittedDashboardContext.current.context
+                    : previousDashboardContext;
+            const explicitDashboardContext = getLastDashboardContext(
+                context ?? [],
+            );
+            const shouldAttachPageContext =
+                !explicitDashboardContext ||
+                explicitDashboardContext.dashboardUuid ===
+                    currentDashboard?.uuid;
+            const pageComparisonDashboardContext =
+                explicitDashboardContext ?? comparisonDashboardContext;
+            const pagePromptContext = shouldAttachPageContext
+                ? getCurrentDashboardPromptContext({
+                      currentDashboard,
+                      previousDashboardContext: pageComparisonDashboardContext,
+                      projectUuid,
+                  })
+                : [];
+            const pageOptimisticContext = shouldAttachPageContext
+                ? getCurrentDashboardOptimisticContext({
+                      currentDashboard,
+                      previousDashboardContext: pageComparisonDashboardContext,
+                      projectUuid,
+                  })
+                : [];
+
+            return {
+                context: mergeAiPromptContextInput(pagePromptContext, context),
+                optimisticContext: mergeAiPromptContextItems(
+                    pageOptimisticContext,
+                    optimisticContext,
+                ),
+            };
+        },
+        [currentDashboard, previousDashboardContext, projectUuid, threadId],
+    );
+
+    const recordSubmittedContext = useCallback(
+        (context: AiPromptContextInput | undefined) => {
+            if (!threadId) return;
+
+            const submittedDashboardContext = getLastDashboardContext(
+                context ?? [],
+            );
+            if (submittedDashboardContext) {
+                lastSubmittedDashboardContext.current = {
+                    threadId,
+                    context: submittedDashboardContext,
+                };
+            }
+        },
+        [threadId],
+    );
+
+    return { curateContext, recordSubmittedContext };
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/usePinnedContext.ts
@@ -103,6 +103,7 @@ export const usePinnedContext = ({
                 dashboardSlug: dashboard?.slug ?? null,
                 displayName: dashboard?.name ?? null,
                 pinnedVersionUuid: null,
+                runtimeOverrides: null,
             });
         }
         return sortPinnedContext(items);

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -665,6 +665,7 @@ const toOptimisticContextItem = (
                 dashboardSlug: item.dashboardSlug ?? null,
                 displayName: null,
                 pinnedVersionUuid: null,
+                runtimeOverrides: item.runtimeOverrides ?? null,
             };
         case 'thread':
             return {

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
@@ -1,3 +1,4 @@
+import { type AiDashboardRuntimeOverrides } from '@lightdash/common';
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { type LauncherActiveAgentUuid } from '../components/Launcher/launcherAgentSelection';
 
@@ -17,6 +18,7 @@ export type LauncherCurrentDashboard = {
     uuid: string;
     name: string;
     activeTabUuid: string | null;
+    runtimeOverrides: AiDashboardRuntimeOverrides | null;
 };
 
 export type DashboardRefreshRequest = {

--- a/packages/frontend/src/ee/features/aiCopilot/store/dashboardPageContext.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/dashboardPageContext.test.ts
@@ -1,0 +1,150 @@
+import { type DashboardFilters } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { type LauncherCurrentDashboard } from './aiAgentLauncherSlice';
+import {
+    getCurrentDashboardPromptContext,
+    getNonDefaultDashboardRuntimeOverrides,
+} from './dashboardPageContext';
+
+const emptyFilters: DashboardFilters = {
+    dimensions: [],
+    metrics: [],
+    tableCalculations: [],
+};
+
+const filtered: DashboardFilters = {
+    dimensions: [
+        {
+            id: 'country-filter',
+            label: 'Country',
+            operator: 'equals',
+            target: { fieldId: 'orders.country', tableName: 'orders' },
+            values: ['US'],
+            lockedTabUuids: ['tab-1'],
+            requiredGroupId: 'group-1',
+            tileTargets: {
+                'tile-1': {
+                    fieldId: 'orders.country',
+                    tableName: 'orders',
+                },
+            },
+        },
+    ],
+    metrics: [],
+    tableCalculations: [],
+} as DashboardFilters;
+
+const currentDashboard = (
+    runtimeOverrides: LauncherCurrentDashboard['runtimeOverrides'],
+): LauncherCurrentDashboard => ({
+    projectUuid: 'project-1',
+    uuid: 'dashboard-1',
+    name: 'Orders',
+    activeTabUuid: null,
+    runtimeOverrides,
+});
+
+describe('dashboard page context', () => {
+    it('omits default filters', () => {
+        expect(
+            getNonDefaultDashboardRuntimeOverrides({
+                defaultFilters: emptyFilters,
+                effectiveFilters: { ...emptyFilters },
+            }),
+        ).toBeNull();
+    });
+
+    it('captures non-default filters without opaque identifiers', () => {
+        const overrides = getNonDefaultDashboardRuntimeOverrides({
+            defaultFilters: emptyFilters,
+            effectiveFilters: filtered,
+        });
+        expect(overrides?.dashboardFilters?.dimensions[0]).toEqual({
+            label: 'Country',
+            operator: 'equals',
+            target: { fieldId: 'orders.country', tableName: 'orders' },
+            values: ['US'],
+        });
+    });
+
+    it('does not attach unchanged filters again', () => {
+        const runtimeOverrides = { dashboardFilters: filtered };
+        expect(
+            getCurrentDashboardPromptContext({
+                currentDashboard: currentDashboard(runtimeOverrides),
+                previousDashboardContext: {
+                    type: 'dashboard',
+                    dashboardUuid: 'dashboard-1',
+                    runtimeOverrides,
+                },
+                projectUuid: 'project-1',
+            }),
+        ).toEqual([]);
+    });
+
+    it('attaches changed filters', () => {
+        const runtimeOverrides = { dashboardFilters: filtered };
+        expect(
+            getCurrentDashboardPromptContext({
+                currentDashboard: currentDashboard(runtimeOverrides),
+                previousDashboardContext: {
+                    type: 'dashboard',
+                    dashboardUuid: 'dashboard-1',
+                },
+                projectUuid: 'project-1',
+            }),
+        ).toEqual([
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dashboard-1',
+                runtimeOverrides,
+            },
+        ]);
+    });
+
+    it('attaches one reset to defaults', () => {
+        expect(
+            getCurrentDashboardPromptContext({
+                currentDashboard: currentDashboard(null),
+                previousDashboardContext: {
+                    type: 'dashboard',
+                    dashboardUuid: 'dashboard-1',
+                    runtimeOverrides: { dashboardFilters: filtered },
+                },
+                projectUuid: 'project-1',
+            }),
+        ).toEqual([
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dashboard-1',
+                runtimeOverrides: undefined,
+            },
+        ]);
+    });
+
+    it('does not attach defaults again after reset', () => {
+        expect(
+            getCurrentDashboardPromptContext({
+                currentDashboard: currentDashboard(null),
+                previousDashboardContext: {
+                    type: 'dashboard',
+                    dashboardUuid: 'dashboard-1',
+                },
+                projectUuid: 'project-1',
+            }),
+        ).toEqual([]);
+    });
+
+    it('attaches a different dashboard', () => {
+        expect(
+            getCurrentDashboardPromptContext({
+                currentDashboard: currentDashboard(null),
+                previousDashboardContext: {
+                    type: 'dashboard',
+                    dashboardUuid: 'dashboard-2',
+                },
+                projectUuid: 'project-1',
+            }),
+        ).toHaveLength(1);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/store/dashboardPageContext.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/dashboardPageContext.ts
@@ -1,0 +1,114 @@
+import {
+    serializeDashboardFiltersForAiContext,
+    type AiDashboardRuntimeOverrides,
+    type AiPromptContext,
+    type AiPromptContextInput,
+    type DashboardFilters,
+} from '@lightdash/common';
+import isEqual from 'lodash/isEqual';
+import { type LauncherCurrentDashboard } from './aiAgentLauncherSlice';
+
+type DashboardContextInput = Extract<
+    AiPromptContextInput[number],
+    { type: 'dashboard' }
+>;
+type DashboardContextItem = Extract<
+    AiPromptContext[number],
+    { type: 'dashboard' }
+>;
+type DashboardContext = DashboardContextInput | DashboardContextItem;
+
+export const getNonDefaultDashboardRuntimeOverrides = ({
+    defaultFilters,
+    effectiveFilters,
+}: {
+    defaultFilters: DashboardFilters;
+    effectiveFilters: DashboardFilters;
+}): AiDashboardRuntimeOverrides | null =>
+    isEqual(defaultFilters, effectiveFilters)
+        ? null
+        : {
+              dashboardFilters:
+                  serializeDashboardFiltersForAiContext(effectiveFilters),
+          };
+
+export const getLastDashboardContext = (
+    context: Array<AiPromptContextInput[number] | AiPromptContext[number]>,
+): DashboardContext | null => {
+    for (let index = context.length - 1; index >= 0; index -= 1) {
+        const item = context[index];
+        if (item.type === 'dashboard') return item;
+    }
+    return null;
+};
+
+const shouldAttachCurrentDashboard = ({
+    currentDashboard,
+    previousDashboardContext,
+    projectUuid,
+}: {
+    currentDashboard: LauncherCurrentDashboard | null;
+    previousDashboardContext?: DashboardContext | null;
+    projectUuid: string;
+}) => {
+    if (currentDashboard?.projectUuid !== projectUuid) return false;
+    if (previousDashboardContext?.dashboardUuid !== currentDashboard.uuid)
+        return true;
+
+    return !isEqual(
+        previousDashboardContext.runtimeOverrides ?? null,
+        currentDashboard.runtimeOverrides,
+    );
+};
+
+export const getCurrentDashboardPromptContext = ({
+    currentDashboard,
+    previousDashboardContext,
+    projectUuid,
+}: {
+    currentDashboard: LauncherCurrentDashboard | null;
+    previousDashboardContext?: DashboardContext | null;
+    projectUuid: string;
+}): AiPromptContextInput =>
+    currentDashboard &&
+    shouldAttachCurrentDashboard({
+        currentDashboard,
+        previousDashboardContext,
+        projectUuid,
+    })
+        ? [
+              {
+                  type: 'dashboard',
+                  dashboardUuid: currentDashboard.uuid,
+                  runtimeOverrides:
+                      currentDashboard.runtimeOverrides ?? undefined,
+              },
+          ]
+        : [];
+
+export const getCurrentDashboardOptimisticContext = ({
+    currentDashboard,
+    previousDashboardContext,
+    projectUuid,
+}: {
+    currentDashboard: LauncherCurrentDashboard | null;
+    previousDashboardContext?: DashboardContext | null;
+    projectUuid: string;
+}): AiPromptContext =>
+    currentDashboard &&
+    shouldAttachCurrentDashboard({
+        currentDashboard,
+        previousDashboardContext,
+        projectUuid,
+    })
+        ? [
+              {
+                  type: 'dashboard',
+                  dashboardUuid: currentDashboard.uuid,
+                  dashboardSlug: null,
+                  displayName: currentDashboard.name,
+                  pinnedVersionUuid: null,
+                  runtimeOverrides: currentDashboard.runtimeOverrides,
+              },
+          ]
+        : [];

--- a/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useParams } from 'react-router';
 import { scrollToDashboardTile } from '../../components/common/Dashboard/scrollToDashboardTile';
 import { setCurrentDashboard } from '../../ee/features/aiCopilot/store/aiAgentLauncherSlice';
+import { getNonDefaultDashboardRuntimeOverrides } from '../../ee/features/aiCopilot/store/dashboardPageContext';
 import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
@@ -54,6 +55,10 @@ const DashboardAiAgentContextBridge = () => {
     );
     const dashboard = useDashboardContext((c) => c.dashboard);
     const activeTab = useDashboardContext((c) => c.activeTab);
+    const allFilters = useDashboardContext((c) => c.allFilters);
+    const originalDashboardFilters = useDashboardContext(
+        (c) => c.originalDashboardFilters,
+    );
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
     const setDashboardTiles = useDashboardContext((c) => c.setDashboardTiles);
     const setDashboardTabs = useDashboardContext((c) => c.setDashboardTabs);
@@ -76,6 +81,14 @@ const DashboardAiAgentContextBridge = () => {
 
     const currentDashboardSlug = dashboard?.slug;
     const currentDashboardUuid = dashboard?.uuid;
+    const dashboardRuntimeOverrides = useMemo(
+        () =>
+            getNonDefaultDashboardRuntimeOverrides({
+                defaultFilters: originalDashboardFilters,
+                effectiveFilters: allFilters,
+            }),
+        [allFilters, originalDashboardFilters],
+    );
     const dashboardQueryKey = useMemo(
         () => ['saved_dashboard_query', dashboardUuidOrSlug, projectUuid],
         [dashboardUuidOrSlug, projectUuid],
@@ -285,6 +298,7 @@ const DashboardAiAgentContextBridge = () => {
                 uuid: currentDashboardUuid,
                 name: dashboard.name,
                 activeTabUuid: activeTab?.uuid ?? null,
+                runtimeOverrides: dashboardRuntimeOverrides,
             }),
         );
     }, [
@@ -293,6 +307,7 @@ const DashboardAiAgentContextBridge = () => {
         currentDashboardUuid,
         dashboard,
         activeTab?.uuid,
+        dashboardRuntimeOverrides,
         isEditMode,
     ]);
 

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -1699,6 +1699,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         setActiveTab,
         setDashboardTemporaryFilters,
         dashboardFilters,
+        originalDashboardFilters,
         dashboardTemporaryFilters: safeTemporaryFilters,
         addDimensionDashboardFilter,
         updateDimensionDashboardFilter,

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -58,6 +58,7 @@ export type DashboardContextType = {
         SetStateAction<Dashboard['tabs'][number] | undefined>
     >;
     dashboardFilters: DashboardFilters;
+    originalDashboardFilters: DashboardFilters;
     dashboardTemporaryFilters: DashboardFilters;
     allFilters: DashboardFilters;
     isLoadingDashboardFilters: boolean;

--- a/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
+++ b/packages/frontend/src/stories/AiAgentChatWorkbench.stories.tsx
@@ -57,6 +57,7 @@ const contextItems: AiPromptContextItem[] = [
         dashboardSlug: 'executive-overview',
         pinnedVersionUuid: null,
         displayName: 'Executive overview',
+        runtimeOverrides: null,
     },
     {
         type: 'thread',
@@ -326,6 +327,7 @@ const verifyContext: AiPromptContextItem[] = [
         dashboardSlug: 'preview-executive-overview',
         pinnedVersionUuid: null,
         displayName: 'Preview Executive overview',
+        runtimeOverrides: null,
     },
     {
         type: 'chart',


### PR DESCRIPTION
## Summary

* pass non-default dashboard filters into Ask AI launcher context
* serialize runtime filters through a shared AI-context module that removes opaque identifiers
* reattach dashboard context only when the active filter snapshot changes
* persist sanitized filter overrides and sanitize again before prompt rendering for historical data
* encapsulate frontend context curation and submission tracking in a custom hook
* publish the dashboard runtime-override shape in the generated API contract

## Verification

* common, frontend, backend `typecheck:fast`
* common Vitest: 1 serializer test passed
* frontend Vitest: 20 focused tests passed
* backend Vitest: 9 tests passed
* targeted lint and formatting checks
* Browser: filtered request included the full effective snapshot without `id`, `tileTargets`, `lockedTabUuids`, or `requiredGroupId`
* Browser: unchanged follow-up omitted context
* Browser: reset defaults attached dashboard identity only and the agent resolved saved default filters
* independent review: clean after generated-contract finding was fixed

Closes: lightdash/lightdash#23201  <br>Closes: lightdash/lightdash#23201