### PR TITLE
feat(metricflow): carry config.meta hidden and group_label into translated metrics

### DIFF
--- a/examples/metricflow-demo/README.md
+++ b/examples/metricflow-demo/README.md
@@ -107,7 +107,7 @@ explore the result in the Lightdash UI).
 
 ## What translates (and what doesn't)
 
-Both specs produce the identical result: **13 translated, 1 skipped (with
+Both specs produce the identical result: **14 translated, 1 skipped (with
 a warning)**.
 
 ### Supported → Lightdash metrics
@@ -128,6 +128,7 @@ a warning)**.
 | measure `create_metric: true` (no explicit metric) | translated like a simple metric |
 | measure `expr` (bare column or SQL expression) | metric `sql` (bare columns qualified as `${TABLE}.col`) |
 | metric/measure `label` + `description` | carried over (metric-level wins) |
+| metric/measure `config.meta.hidden` + `config.meta.group_label` | carried over to the Lightdash metric's `hidden` / `group_label` (metric-level wins); unknown meta keys (e.g. a third-party `hex:` block) are ignored |
 
 YAML-defined `meta.metrics` win over translated MetricFlow metrics on name
 collision — so you can always override a translated metric by hand.

--- a/examples/metricflow-demo/assert-translation.cjs
+++ b/examples/metricflow-demo/assert-translation.cjs
@@ -37,7 +37,8 @@ const result = translateMetricFlowMetrics({
 
 // Expected Lightdash metrics on the `orders` model (same for both specs).
 const expected = {
-    total_revenue: { type: 'sum', sql: '${TABLE}.amount' },
+    // group_label carried over from config.meta
+    total_revenue: { type: 'sum', sql: '${TABLE}.amount', group_label: 'Order Metrics' },
     order_count: { type: 'count', sql: '${TABLE}.order_id' },
     unique_customers: { type: 'count_distinct', sql: '${TABLE}.customer_id' },
     average_order_value: { type: 'average', sql: '${TABLE}.amount' },
@@ -55,6 +56,14 @@ const expected = {
         type: 'sum',
         sql: 'CASE WHEN (${TABLE}.is_food_order) THEN 1 ELSE 0 END',
     },
+    // create_metric measure (legacy) / simple metric (latest) whose
+    // config.meta hides it and groups it — hidden + group_label carry over.
+    internal_order_count: {
+        type: 'count_distinct',
+        sql: '${TABLE}.customer_id',
+        hidden: true,
+        group_label: 'Internal',
+    },
     // Ratio → number metric over the two input metrics
     revenue_per_order: {
         type: 'number',
@@ -69,6 +78,7 @@ const expected = {
         type: 'count',
         sql: "CASE WHEN (${TABLE}.status = 'completed') THEN (${TABLE}.order_id) END",
         hidden: true,
+        helper: true,
     },
     // Derived → number metric with the expression rewritten over input metrics
     revenue_per_customer: {
@@ -78,8 +88,8 @@ const expected = {
 };
 
 // Hidden helper metrics are emitted alongside a manifest metric and are not
-// counted in translatedCount.
-const helperCount = Object.values(expected).filter((e) => e.hidden).length;
+// counted in translatedCount (unlike a plain hidden metric, which is).
+const helperCount = Object.values(expected).filter((e) => e.helper).length;
 
 // Metrics that must be skipped (unsupported in the Lightdash translation).
 const expectedSkipped = [
@@ -109,8 +119,10 @@ for (const [name, exp] of Object.entries(expected)) {
         fail(`metric "${name}": percentile ${got.percentile} !== ${exp.percentile}`);
     } else if (exp.hidden !== undefined && got.hidden !== exp.hidden) {
         fail(`metric "${name}": hidden ${got.hidden} !== ${exp.hidden}`);
+    } else if (exp.group_label !== undefined && got.group_label !== exp.group_label) {
+        fail(`metric "${name}": group_label ${got.group_label} !== ${exp.group_label}`);
     } else {
-        ok(`${name} → ${exp.type}(${exp.sql})${exp.percentile ? ` p${exp.percentile}` : ''}${exp.hidden ? ' [hidden]' : ''}`);
+        ok(`${name} → ${exp.type}(${exp.sql})${exp.percentile ? ` p${exp.percentile}` : ''}${exp.hidden ? ' [hidden]' : ''}${exp.group_label ? ` {${exp.group_label}}` : ''}`);
     }
 }
 

--- a/examples/metricflow-demo/latest-spec/models/orders.yml
+++ b/examples/metricflow-demo/latest-spec/models/orders.yml
@@ -34,6 +34,10 @@ models:
         type: simple
         agg: sum
         expr: amount
+        # group_label from config.meta carries over to the Lightdash metric.
+        config:
+          meta:
+            group_label: Order Metrics
       - name: order_count
         label: Order count
         type: simple
@@ -88,6 +92,19 @@ models:
         type: simple
         agg: sum_boolean
         expr: is_food_order
+      # Denominator helper hidden via config.meta — Lightdash carries hidden +
+      # group_label over so it doesn't clutter the explore.
+      - name: internal_order_count
+        type: simple
+        agg: count_distinct
+        expr: customer_id
+        config:
+          meta:
+            hidden: true
+            group_label: Internal
+            # Unknown third-party keys are ignored during translation.
+            hex:
+              synced: true
 
 # Advanced (multi-metric) shapes still live in a top-level metrics: block in
 # the latest spec. Ratio and derived metrics translate to Lightdash `number`

--- a/examples/metricflow-demo/legacy-spec/models/schema.yml
+++ b/examples/metricflow-demo/legacy-spec/models/schema.yml
@@ -87,6 +87,19 @@ semantic_models:
         agg: sum_boolean
         expr: is_food_order
         create_metric: true
+      # create_metric denominator helper hidden via config.meta — Lightdash
+      # carries hidden + group_label over so it doesn't clutter the explore.
+      - name: internal_order_count
+        agg: count_distinct
+        expr: customer_id
+        create_metric: true
+        config:
+          meta:
+            hidden: true
+            group_label: Internal
+            # Unknown third-party keys are ignored during translation.
+            hex:
+              synced: true
 
 metrics:
   # ── Supported: simple metrics without filters ──
@@ -96,6 +109,10 @@ metrics:
     type: simple
     type_params:
       measure: total_revenue
+    # group_label from config.meta carries over to the Lightdash metric.
+    config:
+      meta:
+        group_label: Order Metrics
   - name: order_count
     label: Order count
     type: simple

--- a/packages/common/src/dbt/metricFlow.test.ts
+++ b/packages/common/src/dbt/metricFlow.test.ts
@@ -1018,4 +1018,176 @@ describe('translateMetricFlowMetrics', () => {
             '((SUM("myTable".myColumnName)) * 1.0) / NULLIF((SUM("myTable".myOtherColumn)), 0)',
         );
     });
+
+    describe('config.meta', () => {
+        it('carries hidden and group_label from a measure config.meta', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: {
+                    sm: {
+                        ...ordersSemanticModel,
+                        measures: [
+                            {
+                                name: 'clean_claim_count',
+                                agg: MetricFlowAggregation.COUNT_DISTINCT,
+                                expr: 'claim_id',
+                                create_metric: true,
+                                config: {
+                                    meta: {
+                                        hidden: true,
+                                        group_label: 'Clean Claim Metrics',
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+                metrics: {},
+                modelNamesByUniqueId,
+            });
+            expect(result.metricsByModel.orders.clean_claim_count).toEqual({
+                type: MetricType.COUNT_DISTINCT,
+                sql: '${TABLE}.claim_id',
+                label: undefined,
+                description: undefined,
+                hidden: true,
+                group_label: 'Clean Claim Metrics',
+            });
+        });
+
+        it('carries hidden and group_label from a simple metric config.meta', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: { sm: ordersSemanticModel },
+                metrics: {
+                    m: simpleMetric('revenue', 'order_total', {
+                        config: {
+                            meta: {
+                                hidden: true,
+                                group_label: 'Claim Metrics',
+                            },
+                        },
+                    }),
+                },
+                modelNamesByUniqueId,
+            });
+            expect(result.metricsByModel.orders.revenue.hidden).toBe(true);
+            expect(result.metricsByModel.orders.revenue.group_label).toBe(
+                'Claim Metrics',
+            );
+        });
+
+        it('lets metric-level meta win over measure-level meta', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: {
+                    sm: {
+                        ...ordersSemanticModel,
+                        measures: [
+                            {
+                                name: 'order_total',
+                                agg: MetricFlowAggregation.SUM,
+                                expr: 'amount',
+                                config: {
+                                    meta: {
+                                        hidden: true,
+                                        group_label: 'Measure group',
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+                metrics: {
+                    m: simpleMetric('revenue', 'order_total', {
+                        config: {
+                            meta: {
+                                hidden: false,
+                                group_label: 'Metric group',
+                            },
+                        },
+                    }),
+                },
+                modelNamesByUniqueId,
+            });
+            expect(result.metricsByModel.orders.revenue.hidden).toBe(false);
+            expect(result.metricsByModel.orders.revenue.group_label).toBe(
+                'Metric group',
+            );
+        });
+
+        it('falls back to measure meta when the metric has no config.meta', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: {
+                    sm: {
+                        ...ordersSemanticModel,
+                        measures: [
+                            {
+                                name: 'order_total',
+                                agg: MetricFlowAggregation.SUM,
+                                expr: 'amount',
+                                config: {
+                                    meta: { group_label: 'Measure group' },
+                                },
+                            },
+                        ],
+                    },
+                },
+                metrics: { m: simpleMetric('revenue', 'order_total') },
+                modelNamesByUniqueId,
+            });
+            expect(result.metricsByModel.orders.revenue.group_label).toBe(
+                'Measure group',
+            );
+            expect(result.metricsByModel.orders.revenue.hidden).toBeUndefined();
+        });
+
+        it('carries config.meta onto a ratio metric', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: { sm: ordersSemanticModel },
+                metrics: {
+                    n: simpleMetric('revenue', 'order_total'),
+                    d: simpleMetric('orders', 'order_count'),
+                    r: {
+                        name: 'revenue_per_order',
+                        unique_id: 'metric.jaffle.revenue_per_order',
+                        type: 'ratio',
+                        type_params: {
+                            numerator: { name: 'revenue' },
+                            denominator: { name: 'orders' },
+                        },
+                        config: { meta: { group_label: 'Claim Metrics' } },
+                    },
+                },
+                modelNamesByUniqueId,
+            });
+            expect(
+                result.metricsByModel.orders.revenue_per_order.group_label,
+            ).toBe('Claim Metrics');
+        });
+
+        it('ignores unknown meta keys such as a third-party hex block', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: { sm: ordersSemanticModel },
+                metrics: {
+                    m: simpleMetric('revenue', 'order_total', {
+                        config: {
+                            // Real manifests carry third-party keys we ignore.
+                            meta: {
+                                group_label: 'Claim Metrics',
+                                hex: { synced: true },
+                                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            } as any,
+                        },
+                    }),
+                },
+                modelNamesByUniqueId,
+            });
+            expect(result.metricsByModel.orders.revenue).toEqual({
+                type: MetricType.SUM,
+                sql: '${TABLE}.amount',
+                label: undefined,
+                description: undefined,
+                hidden: undefined,
+                group_label: 'Claim Metrics',
+            });
+        });
+    });
 });

--- a/packages/common/src/dbt/metricFlow.ts
+++ b/packages/common/src/dbt/metricFlow.ts
@@ -307,7 +307,12 @@ export const translateMetricFlowMetrics = ({
         semanticModel: DbtSemanticModel,
         measure: DbtSemanticMeasure,
         filterConditions: string[],
-        overrides: { label?: string | null; description?: string | null },
+        overrides: {
+            label?: string | null;
+            description?: string | null;
+            hidden?: boolean | null;
+            groupLabel?: string | null;
+        },
     ):
         | { modelName: string; definition: DbtModelLightdashMetric }
         | { error: string } => {
@@ -333,12 +338,19 @@ export const translateMetricFlowMetrics = ({
                       .join(' AND ')} THEN (${baseSql}) END`
                 : baseSql;
 
+        // Metric-level meta wins over measure-level, mirroring label/description.
         const definition: DbtModelLightdashMetric = {
             type: metricType,
             sql,
             label: overrides.label ?? measure.label ?? undefined,
             description:
                 overrides.description ?? measure.description ?? undefined,
+            hidden:
+                overrides.hidden ?? measure.config?.meta?.hidden ?? undefined,
+            group_label:
+                overrides.groupLabel ??
+                measure.config?.meta?.group_label ??
+                undefined,
         };
 
         if (metricType === MetricType.PERCENTILE) {
@@ -472,7 +484,12 @@ export const translateMetricFlowMetrics = ({
             resolved.semanticModel,
             resolved.measure,
             filterTranslation.conditions,
-            { label: metric.label, description: metric.description },
+            {
+                label: metric.label,
+                description: metric.description,
+                hidden: metric.config?.meta?.hidden,
+                groupLabel: metric.config?.meta?.group_label,
+            },
         );
         if ('error' in built) {
             skip(metric.name, built.error);
@@ -666,6 +683,8 @@ export const translateMetricFlowMetrics = ({
             sql,
             label: metric.label ?? undefined,
             description: metric.description ?? undefined,
+            hidden: metric.config?.meta?.hidden ?? undefined,
+            group_label: metric.config?.meta?.group_label ?? undefined,
         });
         translatedCount += 1;
         return undefined;

--- a/packages/common/src/types/dbtSemanticLayer.ts
+++ b/packages/common/src/types/dbtSemanticLayer.ts
@@ -27,6 +27,19 @@ export type DbtSemanticMeasureAggParams = {
     use_approximate_percentile?: boolean;
 };
 
+/**
+ * Component-level `config.meta` in a MetricFlow manifest. dbt Core and Fusion
+ * both nest arbitrary user metadata under `config.meta` on measures, metrics
+ * and dimensions. Only the keys Lightdash understands are typed; any other
+ * keys (e.g. a third-party `hex:` block) are ignored during translation.
+ */
+export type DbtSemanticConfig = {
+    meta?: {
+        hidden?: boolean | null;
+        group_label?: string | null;
+    } | null;
+};
+
 export type DbtSemanticMeasure = {
     name: string;
     agg: MetricFlowAggregation;
@@ -36,6 +49,7 @@ export type DbtSemanticMeasure = {
     expr?: string | null;
     agg_params?: DbtSemanticMeasureAggParams | null;
     agg_time_dimension?: string | null;
+    config?: DbtSemanticConfig | null;
 };
 
 export type DbtSemanticEntity = {
@@ -48,6 +62,7 @@ export type DbtSemanticDimension = {
     name: string;
     type: 'categorical' | 'time';
     expr?: string | null;
+    config?: DbtSemanticConfig | null;
 };
 
 export type DbtSemanticModel = {
@@ -137,5 +152,6 @@ export type DbtSemanticMetric = {
     label?: string | null;
     description?: string | null;
     filter?: DbtSemanticFilter;
+    config?: DbtSemanticConfig | null;
     depends_on?: { nodes?: string[] };
 };


### PR DESCRIPTION
## Problem

The MetricFlow translator (`packages/common/src/dbt/metricFlow.ts`) never read `config.meta`, so three pieces of metadata were dropped during translation:

- `hidden: true` on a `create_metric` measure — a denominator helper flagged `config.meta.hidden` showed up as a **visible** metric in the explore.
- `group_label` on measures/metrics — translated metrics all landed ungrouped.

This is a zero-touch-migration blocker for MetricFlow projects authored for Hex's sync, which honors this metadata.

## Change

Capture `config.meta` during translation and copy `hidden` + `group_label` onto the translated Lightdash metric:

- `buildMeasureMetric` (simple metrics + `create_metric` measures) and `commitMultiMetric` (ratio/derived) now read `config.meta`.
- Metric-level meta wins over measure-level, mirroring how `label`/`description` already work.
- Unknown meta keys (e.g. a third-party `hex:` block) are ignored.
- Precedence unchanged: YAML-defined `meta.metrics` still win over translated metrics on name collision.

`config` is added to `DbtSemanticMeasure` / `DbtSemanticMetric` / `DbtSemanticDimension` in `dbtSemanticLayer.ts` (dimension is for the follow-up PROD-8917).

## Testing

- Unit tests in `metricFlow.test.ts` cover measure-level meta, metric-level meta, metric-wins-over-measure precedence, measure fallback, ratio-metric meta, and unknown-key ignoring.
- `examples/metricflow-demo/` gains a hidden+grouped `internal_order_count` and a `group_label` on `total_revenue` in both spec projects; `assert-translation.cjs` verifies both carry over (now **14 translated, 1 skipped**). Validated end-to-end against a synthetic manifest of the legacy shape.
