### PR TITLE
fix(frontend): only show custom role override warning on real scope conflicts

### DIFF
--- a/packages/common/src/authorization/scopes.test.ts
+++ b/packages/common/src/authorization/scopes.test.ts
@@ -1,8 +1,11 @@
+import { ProjectMemberRole } from '../types/projectMemberRole';
+import { getAllScopesForRole } from './roleToScopeMapping';
 import {
     getScopeAncestors,
     getScopeDescendants,
     getScopes,
     getScopeSubstitutes,
+    getUncoveredProjectScopes,
     getUnsatisfiedScopeDependencies,
 } from './scopes';
 
@@ -229,6 +232,83 @@ describe('scope dependency graph helpers', () => {
                     'manage:dashboard',
                 ),
             ).toEqual([]);
+        });
+    });
+
+    describe('getUncoveredProjectScopes', () => {
+        it('returns granted scopes the covering scopes do not include', () => {
+            expect(
+                getUncoveredProjectScopes(
+                    ['manage:Dashboard', 'view:SavedChart'],
+                    ['view:SavedChart'],
+                ),
+            ).toEqual(['manage:Dashboard']);
+        });
+
+        it('treats stronger scopes on the same subject as covering', () => {
+            expect(
+                getUncoveredProjectScopes(
+                    ['view:Dashboard'],
+                    ['manage:Dashboard'],
+                ),
+            ).toEqual([]);
+        });
+
+        it('treats unmodified scopes as covering their modifier variants', () => {
+            expect(
+                getUncoveredProjectScopes(
+                    ['manage:Dashboard@space'],
+                    ['manage:Dashboard'],
+                ),
+            ).toEqual([]);
+        });
+
+        it('does not treat a modifier-restricted scope as covering the unrestricted one', () => {
+            expect(
+                getUncoveredProjectScopes(
+                    ['manage:Dashboard'],
+                    ['manage:Dashboard@space'],
+                ),
+            ).toEqual(['manage:Dashboard']);
+        });
+
+        it('excludes organization-only scopes from the result', () => {
+            expect(
+                getUncoveredProjectScopes(
+                    ['manage:OrganizationMemberProfile'],
+                    [],
+                ),
+            ).toEqual([]);
+        });
+
+        it('ignores unknown scope names on both sides', () => {
+            expect(
+                getUncoveredProjectScopes(
+                    ['not:aScope', 'view:Dashboard'],
+                    ['not-a-scope', 'view:Dashboard'],
+                ),
+            ).toEqual([]);
+        });
+
+        it('reports no conflict when a role is compared against itself', () => {
+            const editorScopes = getAllScopesForRole(ProjectMemberRole.EDITOR);
+
+            expect(
+                getUncoveredProjectScopes(editorScopes, editorScopes, {
+                    isEnterprise: true,
+                }),
+            ).toEqual([]);
+        });
+
+        it('reports conflicts when a system role grants more than a narrow custom role', () => {
+            const uncovered = getUncoveredProjectScopes(
+                getAllScopesForRole(ProjectMemberRole.EDITOR),
+                ['view:Dashboard', 'view:SavedChart', 'view:Project'],
+                { isEnterprise: true },
+            );
+
+            expect(uncovered).toContain('manage:Dashboard@space');
+            expect(uncovered).toContain('create:Space');
         });
     });
 });

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -1716,6 +1716,37 @@ export const getScopeSubstitutes = (
         });
 };
 
+/**
+ * Returns the granted scopes that coveringScopeNames does not satisfy, using
+ * getScopeSubstitutes semantics (manage:X covers view:X, unmodified covers
+ * @modifier variants). Organization-only scopes are excluded.
+ */
+export const getUncoveredProjectScopes = (
+    grantedScopeNames: string[],
+    coveringScopeNames: string[],
+    { isEnterprise = false }: ScopeGraphOptions = {},
+): ScopeName[] => {
+    const scopeMap = getAllScopeMap({ isEnterprise });
+    const coveringParts = getValidScopeNames(coveringScopeNames, scopeMap).map(
+        parseScopeNameParts,
+    );
+
+    const isCovered = (required: ScopeNameParts): boolean =>
+        coveringParts.some(
+            (substitute) =>
+                substitute.subject === required.subject &&
+                canSubstituteActionSatisfy(
+                    substitute.action,
+                    required.action,
+                ) &&
+                canSubstituteModifierSatisfy(substitute, required),
+        );
+
+    return [...new Set(getValidScopeNames(grantedScopeNames, scopeMap))]
+        .filter((scopeName) => !isOrganizationOnlyScope(scopeName))
+        .filter((scopeName) => !isCovered(parseScopeNameParts(scopeName)));
+};
+
 export const getUnsatisfiedScopeDependencies = (
     existingScopeNames: string[],
     scopeName: string,

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -154,7 +154,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
         useProjectUsersWithRoles(projectUuid);
 
     const { data: organizationRoles, isLoading: isLoadingOrganizationRoles } =
-        useOrganizationRoles();
+        useOrganizationRoles(true);
     const {
         data: organizationRoleAssignments,
         isLoading: isLoadingOrganizationRoleAssignments,
@@ -177,6 +177,20 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
                 group:
                     role.ownerType === 'system' ? 'System role' : 'Custom role',
             }));
+    }, [organizationRoles]);
+
+    const roleScopesById = useMemo(() => {
+        if (!organizationRoles) return undefined;
+        return new Map(
+            organizationRoles.map((role) => [role.roleUuid, role.scopes]),
+        );
+    }, [organizationRoles]);
+
+    const roleNamesById = useMemo(() => {
+        if (!organizationRoles) return undefined;
+        return new Map(
+            organizationRoles.map((role) => [role.roleUuid, role.name]),
+        );
     }, [organizationRoles]);
 
     // Convert flat grouped format (v6) to nested grouped format (v8) for Select
@@ -256,24 +270,12 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
         ).length;
     }, [usersWithProjectRole]);
 
-    const filteredUsers = useMemo(() => {
-        if (search && usersAfterMemberFilter) {
-            return new Fuse(usersAfterMemberFilter, {
-                keys: ['firstName', 'lastName', 'email', 'role', 'projectRole'],
-                ignoreLocation: true,
-                threshold: 0.3,
-            })
-                .search(search)
-                .map((result) => result.item);
-        }
-        return usersAfterMemberFilter;
-    }, [usersAfterMemberFilter, search]);
-
-    // Enrich filtered users with pre-computed per-row values
+    // Enrich users with pre-computed per-row values (before the search
+    // filter, so warnings aren't recomputed on every keystroke)
     const enrichedUsers: EnrichedProjectUser[] = useMemo(() => {
-        if (!filteredUsers) return [];
+        if (!usersAfterMemberFilter) return [];
 
-        return filteredUsers.map((u) => {
+        return usersAfterMemberFilter.map((u) => {
             const hasProjectRole = !!u.projectRole;
             const isMember = u.role === OrganizationMemberRole.MEMBER;
 
@@ -328,9 +330,13 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
 
             const accessWarning = getAccessWarning({
                 organizationRole: organizationRoleId,
+                organizationRoleName: organizationRoleId
+                    ? roleNamesById?.get(organizationRoleId)
+                    : undefined,
                 hasProjectRole,
                 projectRole: u.projectRole,
                 userGroupAccesses,
+                roleScopesById,
             });
 
             return {
@@ -346,12 +352,27 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
             };
         });
     }, [
-        filteredUsers,
+        usersAfterMemberFilter,
         organizationRoleAssignments,
         organizationGroups,
         groupRoles,
         rolesData,
+        roleScopesById,
+        roleNamesById,
     ]);
+
+    const filteredUsers = useMemo(() => {
+        if (search && enrichedUsers) {
+            return new Fuse(enrichedUsers, {
+                keys: ['firstName', 'lastName', 'email', 'role', 'projectRole'],
+                ignoreLocation: true,
+                threshold: 0.3,
+            })
+                .search(search)
+                .map((result) => result.item);
+        }
+        return enrichedUsers;
+    }, [enrichedUsers, search]);
 
     const columns: ContentTableColumnDef<EnrichedProjectUser>[] =
         useMemo(() => {
@@ -555,7 +576,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
 
     const table = useContentTable({
         columns,
-        data: enrichedUsers,
+        data: filteredUsers,
         enableColumnResizing: false,
         enableRowNumbers: false,
         enablePagination: true,
@@ -591,7 +612,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
         },
         mantineTableProps: {
             highlightOnHover: true,
-            withColumnBorders: Boolean(enrichedUsers.length),
+            withColumnBorders: Boolean(filteredUsers.length),
         },
         mantinePaginationProps: {
             showRowsPerPage: false,

--- a/packages/frontend/src/hooks/useOrganizationRoles.ts
+++ b/packages/frontend/src/hooks/useOrganizationRoles.ts
@@ -2,18 +2,30 @@ import {
     type ApiError,
     type Role,
     type RoleAssignment,
+    type RoleWithScopes,
 } from '@lightdash/common';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+    useMutation,
+    useQuery,
+    useQueryClient,
+    type UseQueryResult,
+} from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 import useApp from '../providers/App/useApp';
 import useToaster from './toaster/useToaster';
 import useQueryError from './useQueryError';
 
-export const useOrganizationRoles = (loadScopes?: boolean) => {
+export function useOrganizationRoles(
+    loadScopes: true,
+): UseQueryResult<RoleWithScopes[], ApiError>;
+export function useOrganizationRoles(
+    loadScopes?: false,
+): UseQueryResult<Role[], ApiError>;
+export function useOrganizationRoles(loadScopes?: boolean) {
     const { user } = useApp();
     const setErrorResponse = useQueryError();
 
-    return useQuery<Role[], ApiError>(
+    return useQuery<Role[] | RoleWithScopes[], ApiError>(
         ['organization_roles', user.data?.organizationUuid, loadScopes],
         () => {
             if (!user.data?.organizationUuid) {
@@ -32,7 +44,7 @@ export const useOrganizationRoles = (loadScopes?: boolean) => {
             onError: (result: ApiError) => setErrorResponse(result),
         },
     );
-};
+}
 
 export const useOrganizationRoleAssignments = () => {
     const { user } = useApp();

--- a/packages/frontend/src/utils/roleAccessWarnings.test.tsx
+++ b/packages/frontend/src/utils/roleAccessWarnings.test.tsx
@@ -1,0 +1,200 @@
+import {
+    getAllScopesForRole,
+    ProjectMemberRole,
+    type GroupWithMembers,
+    type ProjectMemberRole as ProjectMemberRoleType,
+    type RoleAssignment,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { getAccessWarning, type UserGroupAccess } from './roleAccessWarnings';
+
+const CUSTOM_ROLE_UUID = '4f9f8ffa-9fd7-401b-b0d1-031e3e9ee46b';
+const GROUP_CUSTOM_ROLE_UUID = '8ac126dc-5f47-4d51-a1bc-884a1efd11f4';
+
+const NARROW_CUSTOM_SCOPES = [
+    'view:Project',
+    'view:Dashboard',
+    'view:SavedChart',
+    'view:Space',
+];
+
+const buildRoleScopes = (
+    customScopes: Record<string, string[]> = {},
+): Map<string, string[]> => {
+    const map = new Map<string, string[]>();
+    Object.values(ProjectMemberRole).forEach((role) => {
+        map.set(role, getAllScopesForRole(role));
+    });
+    Object.entries(customScopes).forEach(([roleId, scopes]) => {
+        map.set(roleId, scopes);
+    });
+    return map;
+};
+
+const buildGroupAccess = (
+    roleId: string,
+    roleName: string,
+    groupName = 'Marketing',
+): UserGroupAccess => ({
+    group: { name: groupName, uuid: `group-${groupName}` } as GroupWithMembers,
+    access: { roleId, roleName } as RoleAssignment,
+    roleName,
+});
+
+describe('getAccessWarning', () => {
+    describe('custom project role', () => {
+        it('shows no warning for org role member with no groups', () => {
+            expect(
+                getAccessWarning({
+                    organizationRole: 'member',
+                    hasProjectRole: true,
+                    projectRole: CUSTOM_ROLE_UUID as ProjectMemberRoleType,
+                    userGroupAccesses: [],
+                    roleScopesById: buildRoleScopes({
+                        [CUSTOM_ROLE_UUID]: NARROW_CUSTOM_SCOPES,
+                    }),
+                }),
+            ).toBeUndefined();
+        });
+
+        it('warns when the org role grants scopes beyond the custom role', () => {
+            expect(
+                getAccessWarning({
+                    organizationRole: 'editor',
+                    hasProjectRole: true,
+                    projectRole: CUSTOM_ROLE_UUID as ProjectMemberRoleType,
+                    userGroupAccesses: [],
+                    roleScopesById: buildRoleScopes({
+                        [CUSTOM_ROLE_UUID]: NARROW_CUSTOM_SCOPES,
+                    }),
+                }),
+            ).toBeDefined();
+        });
+
+        it('shows no warning when the custom role covers everything the org role grants', () => {
+            expect(
+                getAccessWarning({
+                    organizationRole: 'editor',
+                    hasProjectRole: true,
+                    projectRole: CUSTOM_ROLE_UUID as ProjectMemberRoleType,
+                    userGroupAccesses: [],
+                    roleScopesById: buildRoleScopes({
+                        [CUSTOM_ROLE_UUID]: getAllScopesForRole(
+                            ProjectMemberRole.EDITOR,
+                        ),
+                    }),
+                }),
+            ).toBeUndefined();
+        });
+
+        it('warns when a group system role grants scopes beyond the custom role', () => {
+            expect(
+                getAccessWarning({
+                    organizationRole: 'member',
+                    hasProjectRole: true,
+                    projectRole: CUSTOM_ROLE_UUID as ProjectMemberRoleType,
+                    userGroupAccesses: [buildGroupAccess('editor', 'Editor')],
+                    roleScopesById: buildRoleScopes({
+                        [CUSTOM_ROLE_UUID]: NARROW_CUSTOM_SCOPES,
+                    }),
+                }),
+            ).toBeDefined();
+        });
+
+        it('shows the conservative warning when scope data is unavailable', () => {
+            expect(
+                getAccessWarning({
+                    organizationRole: 'member',
+                    hasProjectRole: true,
+                    projectRole: CUSTOM_ROLE_UUID as ProjectMemberRoleType,
+                    userGroupAccesses: [],
+                }),
+            ).toBeDefined();
+        });
+    });
+
+    describe('custom group role', () => {
+        it('shows no warning for org role member with no other access', () => {
+            expect(
+                getAccessWarning({
+                    organizationRole: 'member',
+                    hasProjectRole: false,
+                    projectRole: null,
+                    userGroupAccesses: [
+                        buildGroupAccess(GROUP_CUSTOM_ROLE_UUID, 'Analysts'),
+                    ],
+                    roleScopesById: buildRoleScopes({
+                        [GROUP_CUSTOM_ROLE_UUID]: NARROW_CUSTOM_SCOPES,
+                    }),
+                }),
+            ).toBeUndefined();
+        });
+
+        it('warns when the project role grants scopes beyond the group custom role', () => {
+            expect(
+                getAccessWarning({
+                    organizationRole: 'member',
+                    hasProjectRole: true,
+                    projectRole: ProjectMemberRole.EDITOR,
+                    userGroupAccesses: [
+                        buildGroupAccess(GROUP_CUSTOM_ROLE_UUID, 'Analysts'),
+                    ],
+                    roleScopesById: buildRoleScopes({
+                        [GROUP_CUSTOM_ROLE_UUID]: NARROW_CUSTOM_SCOPES,
+                    }),
+                }),
+            ).toBeDefined();
+        });
+
+        it('shows the conservative warning when scope data is unavailable', () => {
+            expect(
+                getAccessWarning({
+                    organizationRole: 'member',
+                    hasProjectRole: false,
+                    projectRole: null,
+                    userGroupAccesses: [
+                        buildGroupAccess(GROUP_CUSTOM_ROLE_UUID, 'Analysts'),
+                    ],
+                }),
+            ).toBeDefined();
+        });
+    });
+
+    describe('system project role', () => {
+        it('warns when the org role ranks higher than the project role', () => {
+            expect(
+                getAccessWarning({
+                    organizationRole: 'admin',
+                    hasProjectRole: true,
+                    projectRole: ProjectMemberRole.VIEWER,
+                    userGroupAccesses: [],
+                    roleScopesById: buildRoleScopes(),
+                }),
+            ).toBeDefined();
+        });
+
+        it('shows no warning when the org role ranks lower than the project role', () => {
+            expect(
+                getAccessWarning({
+                    organizationRole: 'member',
+                    hasProjectRole: true,
+                    projectRole: ProjectMemberRole.EDITOR,
+                    userGroupAccesses: [],
+                    roleScopesById: buildRoleScopes(),
+                }),
+            ).toBeUndefined();
+        });
+
+        it('warns when a group role ranks higher than the project role', () => {
+            expect(
+                getAccessWarning({
+                    organizationRole: 'member',
+                    hasProjectRole: true,
+                    projectRole: ProjectMemberRole.VIEWER,
+                    userGroupAccesses: [buildGroupAccess('editor', 'Editor')],
+                    roleScopesById: buildRoleScopes(),
+                }),
+            ).toBeDefined();
+        });
+    });
+});

--- a/packages/frontend/src/utils/roleAccessWarnings.tsx
+++ b/packages/frontend/src/utils/roleAccessWarnings.tsx
@@ -1,12 +1,15 @@
 import {
+    getUncoveredProjectScopes,
     isSystemRole,
     OrganizationMemberRole,
     type GroupWithMembers,
     type ProjectMemberRole,
     type RoleAssignment,
+    type ScopeName,
 } from '@lightdash/common';
 import { Text } from '@mantine-8/core';
-import { type ReactNode } from 'react';
+import startCase from 'lodash/startCase';
+import { Fragment, type ReactNode } from 'react';
 
 export const systemRolesOrder: string[] = Object.values(OrganizationMemberRole);
 
@@ -18,10 +21,62 @@ export interface UserGroupAccess {
 
 export interface AccessWarningParams {
     organizationRole?: string;
+    organizationRoleName?: string;
     hasProjectRole: boolean;
     projectRole?: ProjectMemberRole | null;
     userGroupAccesses?: UserGroupAccess[] | null;
+    /** Scopes per roleId; when absent, custom-role warnings show unconditionally */
+    roleScopesById?: Map<string, string[]>;
 }
+
+/** e.g. "manage:Dashboard@space" -> "Manage Dashboard" */
+const formatScopeName = (scopeName: string): string =>
+    startCase(scopeName.split('@')[0].replace(':', ' '));
+
+const formatScopeExamples = (scopeNames: ScopeName[]): string => {
+    // Lead with the most meaningful permissions (manage/create over view)
+    const sorted = [...scopeNames].sort(
+        (a, b) => Number(a.startsWith('view:')) - Number(b.startsWith('view:')),
+    );
+    const displayNames = [...new Set(sorted.map(formatScopeName))];
+    const examples = displayNames.slice(0, 3).join(', ');
+    const remaining = displayNames.length - 3;
+    return remaining > 0 ? `${examples} and ${remaining} more` : examples;
+};
+
+const joinWithAnd = (nodes: ReactNode[]): ReactNode =>
+    nodes.map((node, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <Fragment key={index}>
+            {index > 0 && (index === nodes.length - 1 ? ' and ' : ', ')}
+            {node}
+        </Fragment>
+    ));
+
+const getLegacyCustomGroupWarning = (
+    customGroup: UserGroupAccess,
+): ReactNode => (
+    <>
+        <Text fw={300}>
+            This user belongs to a group{' '}
+            <Text fw={600} span>
+                {customGroup.group.name}
+            </Text>{' '}
+        </Text>
+        <Text fw={300}>
+            which has a custom role
+            <Text fw={600} span>
+                {' '}
+                {customGroup.roleName}
+            </Text>{' '}
+            assigned.{' '}
+        </Text>
+        <Text fw={300}>
+            Make sure the organization or project role doesn't override the
+            group role permissions.
+        </Text>
+    </>
+);
 
 /*
   The accessWarning shows alerts when role conflicts or inheritance may cause permission issues:
@@ -32,16 +87,18 @@ export interface AccessWarningParams {
    group" warning
     - Org > Project: If user's organization role ranks higher than project role → Show "inherits
    higher from org" warning
-  3. Custom Group Role: If user belongs to group with custom role → Show "group has custom role"
-   warning
-  4. Custom Project Role: If user has custom project role → Show "custom + org role conflict"
-  warning
+  3. Custom Project Role: warn only when the org or a group role grants scopes
+   the custom role does not cover
+  4. Custom Group Role: same check, protecting the group's custom role from
+   the org/project/other-group roles
 */
 export const getAccessWarning = ({
     organizationRole,
+    organizationRoleName,
     hasProjectRole,
     projectRole,
     userGroupAccesses,
+    roleScopesById,
 }: AccessWarningParams): ReactNode | undefined => {
     try {
         // Check for organization role warnings (existing logic)
@@ -104,54 +161,155 @@ export const getAccessWarning = ({
             }
         }
 
-        // Custom group role warning (if any group has a custom role)
-        const customGroup = (userGroupAccesses || []).find(
-            (uga) =>
-                uga.access.roleId &&
-                !isSystemRole(uga.access.roleId as ProjectMemberRole),
-        );
-        if (customGroup) {
+        // Custom project role warning: only when other roles grant more
+        if (hasProjectRole && !isSystemRole(typedProjectRole)) {
+            const customRoleScopes = roleScopesById?.get(typedProjectRole);
+
+            if (!roleScopesById || !customRoleScopes) {
+                // Scope data unavailable — keep the conservative warning
+                return (
+                    <>
+                        <Text fw={300}>
+                            This user has a custom role and an organization role{' '}
+                            <Text fw={600} span>
+                                {organizationRoleName ?? organizationRole}
+                            </Text>{' '}
+                            assigned.{' '}
+                        </Text>
+                        <Text fw={300}>
+                            Make sure the organization or group role doesn't
+                            override the project role permissions.
+                        </Text>
+                    </>
+                );
+            }
+
+            const additiveSources: { label: ReactNode; scopes: string[] }[] = [
+                {
+                    label: (
+                        <>
+                            organization role{' '}
+                            <Text fw={600} span>
+                                {organizationRoleName ?? organizationRole}
+                            </Text>
+                        </>
+                    ),
+                    scopes: roleScopesById.get(organizationRole) ?? [],
+                },
+                ...(userGroupAccesses ?? []).map((uga) => ({
+                    label: (
+                        <>
+                            group{' '}
+                            <Text fw={600} span>
+                                {uga.group.name}
+                            </Text>{' '}
+                            (role{' '}
+                            <Text fw={600} span>
+                                {uga.roleName}
+                            </Text>
+                            )
+                        </>
+                    ),
+                    scopes: roleScopesById.get(uga.access.roleId) ?? [],
+                })),
+            ];
+
+            const conflicts = additiveSources
+                .map((source) => ({
+                    ...source,
+                    uncoveredScopes: getUncoveredProjectScopes(
+                        source.scopes,
+                        customRoleScopes,
+                        { isEnterprise: true },
+                    ),
+                }))
+                .filter(({ uncoveredScopes }) => uncoveredScopes.length > 0);
+
+            if (conflicts.length === 0) return;
+
+            const uncoveredScopes = [
+                ...new Set(conflicts.flatMap((c) => c.uncoveredScopes)),
+            ];
+
             return (
                 <>
                     <Text fw={300}>
-                        This user belongs to a group{' '}
+                        This user has a custom role, but{' '}
+                        {joinWithAnd(conflicts.map((c) => c.label))} grant
+                        {conflicts.length === 1 ? 's' : ''} them permissions the
+                        custom role does not include (e.g.{' '}
                         <Text fw={600} span>
-                            {customGroup.group.name}
-                        </Text>{' '}
+                            {formatScopeExamples(uncoveredScopes)}
+                        </Text>
+                        ).
                     </Text>
                     <Text fw={300}>
-                        which has a custom role
-                        <Text fw={600} span>
-                            {' '}
-                            {customGroup.roleName}
-                        </Text>{' '}
-                        assigned.{' '}
-                    </Text>
-                    <Text fw={300}>
-                        Make sure the organization or project role doesn't
-                        override the group role permissions.
+                        Organization and group permissions are additive and
+                        cannot be restricted by the project role.
                     </Text>
                 </>
             );
         }
 
-        if (hasProjectRole && !isSystemRole(typedProjectRole)) {
-            // Custom project role warning
-            return (
-                <>
-                    <Text fw={300}>
-                        This user has a custom role and an organization role{' '}
-                        <Text fw={600} span>
-                            {organizationRole}
-                        </Text>{' '}
-                        assigned.{' '}
-                    </Text>
-                    <Text fw={300}>
-                        Make sure the organization or group role doesn't
-                        override the project role permissions.
-                    </Text>
-                </>
+        // Custom group role warning: only when other roles grant more
+        const customGroups = (userGroupAccesses || []).filter(
+            (uga) =>
+                uga.access.roleId &&
+                !isSystemRole(uga.access.roleId as ProjectMemberRole),
+        );
+        for (const customGroup of customGroups) {
+            const groupRoleScopes = roleScopesById?.get(
+                customGroup.access.roleId,
             );
+
+            if (!roleScopesById || !groupRoleScopes) {
+                // Scope data unavailable — keep the conservative warning
+                return getLegacyCustomGroupWarning(customGroup);
+            }
+
+            const additiveScopes = [
+                ...(roleScopesById.get(organizationRole) ?? []),
+                ...(hasProjectRole && projectRole
+                    ? (roleScopesById.get(projectRole) ?? [])
+                    : []),
+                ...(userGroupAccesses ?? [])
+                    .filter((uga) => uga !== customGroup)
+                    .flatMap(
+                        (uga) => roleScopesById.get(uga.access.roleId) ?? [],
+                    ),
+            ];
+            const uncoveredScopes = getUncoveredProjectScopes(
+                additiveScopes,
+                groupRoleScopes,
+                { isEnterprise: true },
+            );
+
+            if (uncoveredScopes.length > 0) {
+                return (
+                    <>
+                        <Text fw={300}>
+                            This user belongs to group{' '}
+                            <Text fw={600} span>
+                                {customGroup.group.name}
+                            </Text>{' '}
+                            which has custom role{' '}
+                            <Text fw={600} span>
+                                {customGroup.roleName}
+                            </Text>{' '}
+                            assigned, but their other roles grant them
+                            permissions beyond it (e.g.{' '}
+                            <Text fw={600} span>
+                                {formatScopeExamples(uncoveredScopes)}
+                            </Text>
+                            ).
+                        </Text>
+                        <Text fw={300}>
+                            Organization and project permissions are additive
+                            and cannot be restricted by the group role.
+                        </Text>
+                    </>
+                );
+            }
         }
     } catch (error) {
         console.error('Error getting access warning', error);


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8876/custom-roles-role-override-warning-shows-when-applying-custom-role-to

### Description:
The project access warning for users with a custom role showed unconditionally, even when the org role was member and could not override anything. Compare the additive roles' scopes (org role, group roles) against the custom role's scopes and warn only when they grant permissions the custom role does not cover, naming the source and example permissions. Falls back to the previous unconditional warning when scope data is unavailable.


### Before:
When using a custom project role, it would ALWAYS show the warning, even if the project role was purely additive

<img width="1009" height="464" alt="before" src="https://github.com/user-attachments/assets/56d4dc60-4b73-49c4-8c1a-2ac3e0ba1626" />


### After:

When all scopes are purely additive there is no warning:
<img width="1009" height="464" alt="after-no-violation" src="https://github.com/user-attachments/assets/7ed64862-a717-4d72-a87a-002a648008c9" />

When the custom project role is missing a scope that the user already has as part of their org role, it warns, specifically mentioning which scopes:
<img width="1009" height="464" alt="after-with-violation" src="https://github.com/user-attachments/assets/1ce34a64-cd00-4caf-be2e-2df4240265c8" />
