### PR TITLE
feat(data-apps): handle apps with no ready version gracefully in preview

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -210,6 +210,7 @@ describe('AppGenerateService data app vizs', () => {
                     makeVersion({ version: 1, viz_schema: null }),
                 ],
             }),
+            getLatestReadyVersion: vi.fn().mockResolvedValue({ version: 2 }),
         };
         const service = buildService(appModel);
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -6033,6 +6033,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             dependencies?: { custom: AppVersionDependencies['custom'] };
         }[];
         hasMore: boolean;
+        latestReadyVersion: number | null;
     }> {
         await this.assertDataAppsEnabled(user);
 
@@ -6056,6 +6057,10 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             organization_uuid: organizationUuid,
             created_by_user_uuid: createdByUserUuid,
         });
+
+        // The latest ready version can be older than the returned page of
+        // versions, so resolve it independently of pagination.
+        const latestReady = await this.appModel.getLatestReadyVersion(appUuid);
 
         return {
             appUuid,
@@ -6111,6 +6116,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                         : null,
             })),
             hasMore,
+            latestReadyVersion: latestReady?.version ?? null,
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10183,7 +10183,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--spaceName-string-or-null--template-Exclude_DataAppTemplate.custom_-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__':
+    'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--spaceName-string-or-null--template-Exclude_DataAppTemplate.custom_-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean--latestReadyVersion-number-or-null__':
         {
             dataType: 'refAlias',
             type: {
@@ -10192,6 +10192,14 @@ const models: TsoaRoute.Models = {
                     results: {
                         dataType: 'nestedObjectLiteral',
                         nestedProperties: {
+                            latestReadyVersion: {
+                                dataType: 'union',
+                                subSchemas: [
+                                    { dataType: 'double' },
+                                    { dataType: 'enum', enums: [null] },
+                                ],
+                                required: true,
+                            },
                             hasMore: { dataType: 'boolean', required: true },
                             versions: {
                                 dataType: 'array',
@@ -10260,7 +10268,7 @@ const models: TsoaRoute.Models = {
     ApiGetAppResponse: {
         dataType: 'refAlias',
         type: {
-            ref: 'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--spaceName-string-or-null--template-Exclude_DataAppTemplate.custom_-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__',
+            ref: 'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--spaceName-string-or-null--template-Exclude_DataAppTemplate.custom_-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean--latestReadyVersion-number-or-null__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -11552,10 +11552,15 @@
                 ],
                 "type": "object"
             },
-            "ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--spaceName-string-or-null--template-Exclude_DataAppTemplate.custom_-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__": {
+            "ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--spaceName-string-or-null--template-Exclude_DataAppTemplate.custom_-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean--latestReadyVersion-number-or-null__": {
                 "properties": {
                     "results": {
                         "properties": {
+                            "latestReadyVersion": {
+                                "type": "number",
+                                "format": "double",
+                                "nullable": true
+                            },
                             "hasMore": {
                                 "type": "boolean"
                             },
@@ -11604,6 +11609,7 @@
                             }
                         },
                         "required": [
+                            "latestReadyVersion",
                             "hasMore",
                             "versions",
                             "pinnedListOrder",
@@ -11628,7 +11634,7 @@
                 "type": "object"
             },
             "ApiGetAppResponse": {
-                "$ref": "#/components/schemas/ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--spaceName-string-or-null--template-Exclude_DataAppTemplate.custom_-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__"
+                "$ref": "#/components/schemas/ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--spaceName-string-or-null--template-Exclude_DataAppTemplate.custom_-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean--latestReadyVersion-number-or-null__"
             },
             "ApiCancelAppVersionResponse": {
                 "$ref": "#/components/schemas/ApiSuccessEmpty"

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -308,6 +308,10 @@ export type ApiGetAppResponse = ApiSuccess<{
     pinnedListOrder: number | null;
     versions: ApiAppVersionSummary[];
     hasMore: boolean;
+    // Latest ready version across ALL versions, not just the returned page.
+    // Viewers must use this (not scan `versions`) to decide whether the app
+    // can be previewed — the ready version may be older than the page window.
+    latestReadyVersion: number | null;
 }>;
 
 export type ApiUpdateAppRequest = {

--- a/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
@@ -92,9 +92,10 @@ const DataAppTile: FC<Props> = (props) => {
         shouldFetch ? appUuid : undefined,
     );
 
-    const latestReadyVersion = appQuery.data?.pages[0]?.versions.find(
-        (v) => v.status === 'ready',
-    )?.version;
+    // Authoritative across ALL versions — the ready version may be older than
+    // the fetched page of versions, so never scan `versions` for it.
+    const latestReadyVersion =
+        appQuery.data?.pages[0]?.latestReadyVersion ?? undefined;
 
     // Mirror the "Continue building" affordance from the app preview page
     // (AppPreviewTest.tsx) — same space-aware ability check.

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -1,7 +1,7 @@
-import { FeatureFlags } from '@lightdash/common';
+import { FeatureFlags, isAppVersionInProgress } from '@lightdash/common';
 import { Box, Loader, Menu, Stack, Text } from '@mantine-8/core';
 import { IconAppsOff, IconCode } from '@tabler/icons-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useState, type ReactNode } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
 import MantineIcon from '../components/common/MantineIcon';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
@@ -11,6 +11,7 @@ import AppInspectorPanel from '../features/apps/AppInspectorPanel';
 import AppHeader from '../features/apps/components/AppHeader';
 import AppHeaderActions from '../features/apps/components/AppHeaderActions';
 import AppSpaceChip from '../features/apps/components/AppSpaceChip';
+import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
@@ -40,23 +41,41 @@ export default function AppPreviewTest() {
     // The backend enforces space-aware view permissions and will 403 if the
     // user doesn't have access — we surface that as the error state below.
     const appQuery = useGetApp(projectUuid, appUuid);
+    const firstPage = appQuery.data?.pages[0];
 
-    const latestReadyVersion = appQuery.data?.pages[0]?.versions.find(
-        (v) => v.status === 'ready',
-    )?.version;
+    // Authoritative across ALL versions — the ready version may be older than
+    // the fetched page of versions, so never scan `versions` for it.
+    const latestReadyVersion = firstPage?.latestReadyVersion ?? undefined;
 
-    const appName = appQuery.data?.pages[0]?.name ?? '';
-    const appDescription = appQuery.data?.pages[0]?.description ?? null;
-    const appSpaceUuid = appQuery.data?.pages[0]?.spaceUuid ?? null;
-    const appSpaceName = appQuery.data?.pages[0]?.spaceName ?? null;
-    const appCreatedByUserUuid =
-        appQuery.data?.pages[0]?.createdByUserUuid ?? null;
+    const appName = firstPage?.name ?? '';
+    const appDescription = firstPage?.description ?? null;
+    const appSpaceUuid = firstPage?.spaceUuid ?? null;
+    const appSpaceName = firstPage?.spaceName ?? null;
+    const appCreatedByUserUuid = firstPage?.createdByUserUuid ?? null;
     const canEditApp = useCanEditDataApp(projectUuid, {
         spaceUuid: appSpaceUuid,
         createdByUserUuid: appCreatedByUserUuid,
     });
 
     const version = explicitVersion ?? latestReadyVersion;
+
+    // No successful build yet — distinguish "still building" (poll so the
+    // preview swaps in automatically when the build finishes) from "failed" /
+    // "never built".
+    const latestVersion = firstPage?.versions[0];
+    const hasNoReadyVersion =
+        !!firstPage && firstPage.latestReadyVersion === null;
+    const isBuildInProgress =
+        hasNoReadyVersion &&
+        !!latestVersion &&
+        isAppVersionInProgress(latestVersion.status);
+    const handleBuildDone = useCallback(() => {}, []);
+    useAppBuildPoller(
+        projectUuid,
+        appUuid,
+        !explicitVersion && isBuildInProgress,
+        handleBuildDone,
+    );
 
     const {
         data: token,
@@ -134,8 +153,6 @@ export default function AppPreviewTest() {
         return <div>Missing route params</div>;
     }
 
-    const isLoading =
-        appQuery.isLoading || (version !== undefined && isTokenLoading);
     const error = appQuery.error ?? tokenError;
 
     const isForbidden =
@@ -159,26 +176,7 @@ export default function AppPreviewTest() {
         );
     }
 
-    if (
-        !explicitVersion &&
-        !appQuery.isLoading &&
-        !appQuery.error &&
-        !latestReadyVersion
-    ) {
-        return (
-            <Stack align="center" justify="center" h="calc(100vh - 50px)">
-                <Text c="red" size="sm">
-                    No ready version found for this app
-                </Text>
-            </Stack>
-        );
-    }
-
-    const previewUrl = token
-        ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/t/${token}/?r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}`
-        : undefined;
-
-    if (isLoading) {
+    if (appQuery.isLoading) {
         return (
             <Stack align="center" justify="center" h="calc(100vh - 50px)">
                 <Loader size="md" />
@@ -200,72 +198,36 @@ export default function AppPreviewTest() {
         );
     }
 
-    if (!previewUrl) return null;
+    const previewUrl = token
+        ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/t/${token}/?r=${refreshKey}#transport=postMessage&projectUuid=${projectUuid}`
+        : undefined;
 
-    return (
-        <Box className={classes.previewContainer}>
-            <AppHeader
-                appUuid={appUuid}
-                name={appName}
-                description={appDescription}
-                spaceChip={
-                    <AppSpaceChip
-                        projectUuid={projectUuid}
-                        spaceName={appSpaceName}
-                        app={{
-                            uuid: appUuid,
-                            name: appName,
-                            description: appDescription ?? undefined,
-                            spaceUuid: appSpaceUuid,
-                            createdByUserUuid: appCreatedByUserUuid,
-                            latestVersionNumber: latestReadyVersion ?? null,
-                            latestVersionStatus: latestReadyVersion
-                                ? 'ready'
-                                : null,
-                        }}
-                    />
-                }
-                rightSection={
-                    <AppHeaderActions
-                        projectUuid={projectUuid}
-                        appUuid={appUuid}
-                        appName={appName}
-                        appDescription={appDescription}
-                        appSpaceUuid={appSpaceUuid}
-                        appCreatedByUserUuid={appCreatedByUserUuid}
-                        latestVersionNumber={latestReadyVersion ?? null}
-                        latestVersionStatus={
-                            latestReadyVersion ? 'ready' : null
-                        }
-                        onRefresh={handleRefresh}
-                        refreshDisabled={false}
-                        onViewNetwork={() => setNetworkPanelHidden(false)}
-                        onDeleted={() => {
-                            void navigate(`/projects/${projectUuid}/home`);
-                        }}
-                        navItem={
-                            canEditApp ? (
-                                <Menu.Item
-                                    leftSection={
-                                        <MantineIcon
-                                            icon={IconCode}
-                                            size={14}
-                                        />
-                                    }
-                                    onClick={() =>
-                                        navigate(
-                                            `/projects/${projectUuid}/apps/${appUuid}`,
-                                        )
-                                    }
-                                >
-                                    Continue building
-                                </Menu.Item>
-                            ) : null
-                        }
-                    />
-                }
+    // App data is loaded — always render the header chrome so users can still
+    // navigate (rename, delete, "Continue building", …) when there's nothing
+    // to preview yet.
+    let body: ReactNode;
+    if (!explicitVersion && hasNoReadyVersion) {
+        // Deliberately neutral: don't surface build failures or their status
+        // messages here — that's builder territory and too technical (and
+        // potentially too revealing) for viewers of the preview.
+        body = isBuildInProgress ? (
+            <SuboptimalState
+                loading
+                title="This app is still building"
+                description="The preview will load automatically once the build is ready."
             />
-            <Box className={classes.previewBody}>
+        ) : (
+            <SuboptimalState
+                icon={IconAppsOff}
+                title="This app hasn't been built yet"
+                description="There's no ready version of this app to preview yet."
+            />
+        );
+    } else if (isTokenLoading || !previewUrl) {
+        body = <SuboptimalState loading title="Loading app..." />;
+    } else {
+        body = (
+            <>
                 <AppIframePreview
                     src={previewUrl}
                     expectedPreviewOrigin={previewOrigin}
@@ -303,7 +265,74 @@ export default function AppPreviewTest() {
                         onToggleLineage={handleToggleLineage}
                     />
                 )}
-            </Box>
+            </>
+        );
+    }
+
+    return (
+        <Box className={classes.previewContainer}>
+            <AppHeader
+                appUuid={appUuid}
+                name={appName}
+                description={appDescription}
+                spaceChip={
+                    <AppSpaceChip
+                        projectUuid={projectUuid}
+                        spaceName={appSpaceName}
+                        app={{
+                            uuid: appUuid,
+                            name: appName,
+                            description: appDescription ?? undefined,
+                            spaceUuid: appSpaceUuid,
+                            createdByUserUuid: appCreatedByUserUuid,
+                            latestVersionNumber: latestReadyVersion ?? null,
+                            latestVersionStatus: latestReadyVersion
+                                ? 'ready'
+                                : null,
+                        }}
+                    />
+                }
+                rightSection={
+                    <AppHeaderActions
+                        projectUuid={projectUuid}
+                        appUuid={appUuid}
+                        appName={appName}
+                        appDescription={appDescription}
+                        appSpaceUuid={appSpaceUuid}
+                        appCreatedByUserUuid={appCreatedByUserUuid}
+                        latestVersionNumber={latestReadyVersion ?? null}
+                        latestVersionStatus={
+                            latestReadyVersion ? 'ready' : null
+                        }
+                        onRefresh={handleRefresh}
+                        refreshDisabled={version === undefined}
+                        onViewNetwork={() => setNetworkPanelHidden(false)}
+                        onDeleted={() => {
+                            void navigate(`/projects/${projectUuid}/home`);
+                        }}
+                        navItem={
+                            canEditApp ? (
+                                <Menu.Item
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconCode}
+                                            size={14}
+                                        />
+                                    }
+                                    onClick={() =>
+                                        navigate(
+                                            `/projects/${projectUuid}/apps/${appUuid}`,
+                                        )
+                                    }
+                                >
+                                    Continue building
+                                </Menu.Item>
+                            ) : null
+                        }
+                    />
+                }
+            />
+            <Box className={classes.previewBody}>{body}</Box>
         </Box>
     );
 }

--- a/packages/frontend/src/pages/MinimalApp.tsx
+++ b/packages/frontend/src/pages/MinimalApp.tsx
@@ -50,9 +50,10 @@ export default function MinimalApp() {
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
 
     const appQuery = useGetApp(projectUuid, appUuid);
-    const latestReadyVersion = appQuery.data?.pages[0]?.versions.find(
-        (v) => v.status === 'ready',
-    )?.version;
+    // Authoritative across ALL versions — the ready version may be older than
+    // the fetched page of versions, so never scan `versions` for it.
+    const latestReadyVersion =
+        appQuery.data?.pages[0]?.latestReadyVersion ?? undefined;
 
     const {
         data: token,
@@ -147,11 +148,13 @@ export default function MinimalApp() {
 
     if (!appQuery.isLoading && !appQuery.error && !latestReadyVersion) {
         return (
-            <Stack align="center" justify="center" h="100vh">
-                <Text c="red" size="sm">
-                    No ready version found for this app
-                </Text>
-            </Stack>
+            <Box h="100vh">
+                <SuboptimalState
+                    icon={IconAppsOff}
+                    title="No ready version"
+                    description="This data app hasn't finished building yet."
+                />
+            </Box>
         );
     }
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8763/data-apps-handle-no-ready-version-more-gracefully

### Description:
The app preview page showed a bare red error with no header when an app had no ready version. It now keeps the app header chrome and shows a proper empty state: a loader while the first build runs (polling so the preview loads automatically when it's ready) and a neutral message otherwise, without leaking build errors to viewers.

The get-app endpoint now returns an authoritative latestReadyVersion so the preview page, minimal app page, and dashboard tile no longer scan only the first page of versions — previously 5+ consecutive failed builds hid an older working version.


### Before:
<img width="5196" height="3302" alt="image" src="https://github.com/user-attachments/assets/30918ec0-c1f7-4482-8fb6-3fa58179029c" />


### After:
Now it renders the header no matter what and it also differentiates between the following two cases.

Running build:
<img width="2598" height="1651" alt="Screenshot 2026-07-15 at 15 39 33" src="https://github.com/user-attachments/assets/4a4a9ef8-2083-4886-85cd-0494c4ba7ef5" />


No ready build at all:
<img width="2603" height="1656" alt="Screenshot 2026-07-15 at 15 48 23" src="https://github.com/user-attachments/assets/45f43fae-f562-4202-a89c-3d5c9edd6a07" />
