### PR TITLE
fix(mcp): gate run_sql tool on manage:SqlRunner permission

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -574,6 +574,7 @@ const makeMcpService = ({
             aiWritebackEnabled: false,
             grepFieldsEnabled: true,
             mcpContentWritesEnabled: true,
+            runSqlEnabled: true,
         });
     }
 

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -2611,7 +2611,8 @@ export class McpService extends BaseService {
                         500,
                         this.lightdashConfig.mcp.runSqlMaxLimit,
                     ),
-                    inputSchema: createMcpCompatibleInputShape(runSqlArgsSchema),
+                    inputSchema:
+                        createMcpCompatibleInputShape(runSqlArgsSchema),
                     outputSchema: mcpRunSqlTool.outputSchema,
                     annotations: mcpRunSqlTool.annotations,
                 },
@@ -2648,7 +2649,9 @@ export class McpService extends BaseService {
                         if (
                             McpService.isQueryRunningStatus(queryHistory.status)
                         ) {
-                            return McpService.getRunningQueryResponse(queryUuid);
+                            return McpService.getRunningQueryResponse(
+                                queryUuid,
+                            );
                         }
 
                         if (queryHistory.status !== QueryHistoryStatus.READY) {

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1357,11 +1357,13 @@ export class McpService extends BaseService {
             aiWritebackEnabled: boolean;
             grepFieldsEnabled: boolean;
             mcpContentWritesEnabled: boolean;
+            runSqlEnabled: boolean;
         } = {
             projectPinned: false,
             aiWritebackEnabled: false,
             grepFieldsEnabled: false,
             mcpContentWritesEnabled: true,
+            runSqlEnabled: true,
         },
     ): void {
         this.registerTrackedTool(
@@ -2589,98 +2591,107 @@ export class McpService extends BaseService {
             },
         );
 
-        // TODO: move config-dependent tool contracts into defineTool so
-        // description and inputSchema can be resolved from one runtime-aware
-        // definition instead of being rebuilt here.
-        const runSqlArgsSchema = createToolRunSqlArgsSchema({
-            maxLimit: this.lightdashConfig.mcp.runSqlMaxLimit,
-        });
-        this.registerTrackedTool(
-            mcpRunSqlTool.name,
-            {
-                title: mcpRunSqlTool.title,
-                description: buildRunSqlDescription(
-                    500,
-                    this.lightdashConfig.mcp.runSqlMaxLimit,
-                ),
-                inputSchema: createMcpCompatibleInputShape(runSqlArgsSchema),
-                outputSchema: mcpRunSqlTool.outputSchema,
-                annotations: mcpRunSqlTool.annotations,
-            },
-            async (args, extra) => {
-                const ctx = getMcpContext(extra);
+        // run_sql is only registered (and thus only listed/invocable) when the
+        // caller has manage:SqlRunner. executeAsyncSqlQuery still enforces the
+        // permission per-project at invocation time; gating registration keeps
+        // the tool out of tools/list for users who can never run SQL, so the
+        // LLM doesn't loop on a tool it isn't allowed to call.
+        if (options.runSqlEnabled) {
+            // TODO: move config-dependent tool contracts into defineTool so
+            // description and inputSchema can be resolved from one runtime-aware
+            // definition instead of being rebuilt here.
+            const runSqlArgsSchema = createToolRunSqlArgsSchema({
+                maxLimit: this.lightdashConfig.mcp.runSqlMaxLimit,
+            });
+            this.registerTrackedTool(
+                mcpRunSqlTool.name,
+                {
+                    title: mcpRunSqlTool.title,
+                    description: buildRunSqlDescription(
+                        500,
+                        this.lightdashConfig.mcp.runSqlMaxLimit,
+                    ),
+                    inputSchema: createMcpCompatibleInputShape(runSqlArgsSchema),
+                    outputSchema: mcpRunSqlTool.outputSchema,
+                    annotations: mcpRunSqlTool.annotations,
+                },
+                async (args, extra) => {
+                    const ctx = getMcpContext(extra);
 
-                const { account } = McpService.getAccount(ctx);
-                const projectUuid = await this.resolveProjectUuid(ctx);
+                    const { account } = McpService.getAccount(ctx);
+                    const projectUuid = await this.resolveProjectUuid(ctx);
 
-                try {
-                    const deadlineMs =
-                        Date.now() + McpService.getMcpQueryWaitMs(extra);
-                    const { queryUuid } =
-                        await this.asyncQueryService.executeAsyncSqlQuery({
-                            account,
+                    try {
+                        const deadlineMs =
+                            Date.now() + McpService.getMcpQueryWaitMs(extra);
+                        const { queryUuid } =
+                            await this.asyncQueryService.executeAsyncSqlQuery({
+                                account,
+                                projectUuid,
+                                sql: args.sql,
+                                limit: args.limit ?? 500,
+                                context: QueryExecutionContext.MCP_RUN_SQL,
+                            });
+
+                        const queryHistory =
+                            await this.asyncQueryService.pollQueryHistoryUntilDeadline(
+                                {
+                                    account,
+                                    projectUuid,
+                                    queryUuid,
+                                    deadlineMs,
+                                    pollIntervalMs: MCP_QUERY_POLL_INTERVAL_MS,
+                                    signal: extra.signal,
+                                },
+                            );
+
+                        if (
+                            McpService.isQueryRunningStatus(queryHistory.status)
+                        ) {
+                            return McpService.getRunningQueryResponse(queryUuid);
+                        }
+
+                        if (queryHistory.status !== QueryHistoryStatus.READY) {
+                            throw new UnexpectedServerError(
+                                queryHistory.error ??
+                                    `SQL query finished with status ${queryHistory.status}`,
+                            );
+                        }
+
+                        const sqlRunnerUrl = await this.buildSqlRunnerUrl({
+                            ctx,
                             projectUuid,
                             sql: args.sql,
                             limit: args.limit ?? 500,
-                            context: QueryExecutionContext.MCP_RUN_SQL,
                         });
 
-                    const queryHistory =
-                        await this.asyncQueryService.pollQueryHistoryUntilDeadline(
-                            {
-                                account,
-                                projectUuid,
-                                queryUuid,
-                                deadlineMs,
-                                pollIntervalMs: MCP_QUERY_POLL_INTERVAL_MS,
-                                signal: extra.signal,
-                            },
+                        return await this.buildSqlQueryResultResponse({
+                            ctx,
+                            queryUuid,
+                            projectUuid,
+                            pageSize: args.limit ?? 500,
+                            includeStatus: false,
+                            sqlRunnerUrl,
+                        });
+                    } catch (e) {
+                        const errorMessage =
+                            e instanceof Error ? e.message : String(e);
+                        this.logger.error(
+                            `[McpService] Error in run_sql tool: ${errorMessage}`,
                         );
-
-                    if (McpService.isQueryRunningStatus(queryHistory.status)) {
-                        return McpService.getRunningQueryResponse(queryUuid);
+                        return {
+                            content: [
+                                {
+                                    type: 'text' as const,
+                                    text: `Error running SQL query: ${errorMessage}`,
+                                },
+                            ],
+                            isError: true,
+                        };
                     }
-
-                    if (queryHistory.status !== QueryHistoryStatus.READY) {
-                        throw new UnexpectedServerError(
-                            queryHistory.error ??
-                                `SQL query finished with status ${queryHistory.status}`,
-                        );
-                    }
-
-                    const sqlRunnerUrl = await this.buildSqlRunnerUrl({
-                        ctx,
-                        projectUuid,
-                        sql: args.sql,
-                        limit: args.limit ?? 500,
-                    });
-
-                    return await this.buildSqlQueryResultResponse({
-                        ctx,
-                        queryUuid,
-                        projectUuid,
-                        pageSize: args.limit ?? 500,
-                        includeStatus: false,
-                        sqlRunnerUrl,
-                    });
-                } catch (e) {
-                    const errorMessage =
-                        e instanceof Error ? e.message : String(e);
-                    this.logger.error(
-                        `[McpService] Error in run_sql tool: ${errorMessage}`,
-                    );
-                    return {
-                        content: [
-                            {
-                                type: 'text' as const,
-                                text: `Error running SQL query: ${errorMessage}`,
-                            },
-                        ],
-                        isError: true,
-                    };
-                }
-            },
-        );
+                },
+            );
+        }
 
         this.registerTrackedTool(
             mcpGetQueryResultTool.name,
@@ -3245,6 +3256,7 @@ export class McpService extends BaseService {
         aiWritebackEnabled?: boolean;
         grepFieldsEnabled?: boolean;
         mcpContentWritesEnabled?: boolean;
+        runSqlEnabled?: boolean;
     }): Promise<McpServer> {
         const newServer = Sentry.wrapMcpServerWithSentry(
             new McpServer({
@@ -3280,6 +3292,7 @@ export class McpService extends BaseService {
             aiWritebackEnabled: options?.aiWritebackEnabled ?? false,
             grepFieldsEnabled: options?.grepFieldsEnabled ?? false,
             mcpContentWritesEnabled: options?.mcpContentWritesEnabled ?? true,
+            runSqlEnabled: options?.runSqlEnabled ?? true,
         });
         this.mcpServer = originalServer;
 
@@ -3517,6 +3530,17 @@ export class McpService extends BaseService {
         return this.aiOrganizationSettingsService.isMcpContentWritesEnabled(
             user,
         );
+    }
+
+    /**
+     * Whether the run_sql tool should be registered for this caller. Gated on
+     * manage:SqlRunner so users who can never run SQL (interactive viewers and
+     * below) don't see the tool in tools/list. This is a coarse capability
+     * check — executeAsyncSqlQuery still enforces the permission per-project at
+     * invocation time.
+     */
+    public isRunSqlEnabled(user: SessionUser): boolean {
+        return this.createAuditedAbility(user).can('manage', 'SqlRunner');
     }
 
     public getLightdashVersion(context: McpProtocolContext): string {

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -180,14 +180,14 @@ describe('MCP tool contracts', () => {
 
         mockRegisteredMcpTools.length = 0;
         await mcpService.createServer({ runSqlEnabled: true });
-        expect(
-            mockRegisteredMcpTools.map(({ name }) => name),
-        ).toContain(McpToolName.RUN_SQL);
+        expect(mockRegisteredMcpTools.map(({ name }) => name)).toContain(
+            McpToolName.RUN_SQL,
+        );
 
         mockRegisteredMcpTools.length = 0;
         await mcpService.createServer({ runSqlEnabled: false });
-        expect(
-            mockRegisteredMcpTools.map(({ name }) => name),
-        ).not.toContain(McpToolName.RUN_SQL);
+        expect(mockRegisteredMcpTools.map(({ name }) => name)).not.toContain(
+            McpToolName.RUN_SQL,
+        );
     });
 });

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -174,4 +174,20 @@ describe('MCP tool contracts', () => {
 
         expect({ prompts, tools }).toMatchSnapshot();
     });
+
+    it('registers run_sql only when runSqlEnabled', async () => {
+        const mcpService = makeMcpService();
+
+        mockRegisteredMcpTools.length = 0;
+        await mcpService.createServer({ runSqlEnabled: true });
+        expect(
+            mockRegisteredMcpTools.map(({ name }) => name),
+        ).toContain(McpToolName.RUN_SQL);
+
+        mockRegisteredMcpTools.length = 0;
+        await mcpService.createServer({ runSqlEnabled: false });
+        expect(
+            mockRegisteredMcpTools.map(({ name }) => name),
+        ).not.toContain(McpToolName.RUN_SQL);
+    });
 });

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -283,6 +283,9 @@ mcpRouter.all(
                 // afterwards).
                 // Content-write tools are only registered when the org-level
                 // setting allows it, so admins can lock down MCP edits.
+                // run_sql is only registered when the caller has
+                // manage:SqlRunner, so viewers don't see (and the LLM doesn't
+                // loop on) a tool they can never invoke.
                 // These lookups are independent, so resolve them together
                 // rather than paying each round trip serially per request.
                 const [grepFieldsEnabled, mcpContentWritesEnabled] =
@@ -297,6 +300,7 @@ mcpRouter.all(
                     aiWritebackEnabled: true,
                     grepFieldsEnabled,
                     mcpContentWritesEnabled,
+                    runSqlEnabled: mcpService.isRunSqlEnabled(req.user!),
                 });
                 const transport = new StreamableHTTPServerTransport({
                     enableJsonResponse: true,


### PR DESCRIPTION
Closes: lightdash/lightdash#25611

### Description:

`run_sql` was unconditionally registered in the MCP `tools/list` for all users. Users without `manage:SqlRunner` (interactive viewers and below) saw the tool, so the LLM would keep attempting it — receiving a `ForbiddenError` from `executeAsyncSqlQuery` — instead of falling back to `run_metric_query`, causing a consistent failure loop.

This adds a `runSqlEnabled` option threaded through `createServer` → `setupHandlers` (mirroring the existing `grepFieldsEnabled` / `mcpContentWritesEnabled` gates) and resolves the caller's `manage:SqlRunner` ability per-request in the MCP router. Users without the permission no longer see `run_sql` in `tools/list`.

The existing per-project permission check in `executeAsyncSqlQuery` still enforces access at invocation time — this gate is a coarse capability check for tool visibility, not a replacement for it.