### PR TITLE
feat(ai): add Deep Research mode to AI Agent

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
@@ -174,7 +174,13 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                             />
                         )}
 
-                        <Box className={styles.chatContent}>{children}</Box>
+                        <Box className={styles.chatBody}>
+                            <Box className={styles.chatContent}>{children}</Box>
+                            <Box
+                                className={styles.deepResearchReportTarget}
+                                data-deep-research-report-target
+                            />
+                        </Box>
                     </Panel>
                 </ErrorBoundary>
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
@@ -167,6 +167,13 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                             <Box className={styles.chatHeader}>{Header}</Box>
                         )}
 
+                        {Header && (
+                            <Box
+                                className={styles.deepResearchBar}
+                                data-deep-research-control-target
+                            />
+                        )}
+
                         <Box className={styles.chatContent}>{children}</Box>
                     </Panel>
                 </ErrorBoundary>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
@@ -174,13 +174,7 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                             />
                         )}
 
-                        <Box className={styles.chatBody}>
-                            <Box className={styles.chatContent}>{children}</Box>
-                            <Box
-                                className={styles.deepResearchReportTarget}
-                                data-deep-research-report-target
-                            />
-                        </Box>
+                        <Box className={styles.chatContent}>{children}</Box>
                     </Panel>
                 </ErrorBoundary>
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/aiAgentPageLayout.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/aiAgentPageLayout.module.css
@@ -67,32 +67,13 @@
     }
 }
 
-.chatBody {
-    flex: 1;
-    min-height: 0;
-    position: relative;
-}
-
 .chatContent {
-    height: 100%;
+    flex: 1;
     overflow-y: auto;
     background-color: light-dark(
         var(--mantine-color-white),
         var(--mantine-color-dark-8)
     );
-}
-
-.deepResearchReportTarget {
-    position: absolute;
-    inset: 0;
-    z-index: 3;
-    min-width: 0;
-    min-height: 0;
-    pointer-events: none;
-}
-
-.deepResearchReportTarget:empty {
-    display: none;
 }
 
 .deepResearchBar {

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/aiAgentPageLayout.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/aiAgentPageLayout.module.css
@@ -67,13 +67,32 @@
     }
 }
 
-.chatContent {
+.chatBody {
     flex: 1;
+    min-height: 0;
+    position: relative;
+}
+
+.chatContent {
+    height: 100%;
     overflow-y: auto;
     background-color: light-dark(
         var(--mantine-color-white),
         var(--mantine-color-dark-8)
     );
+}
+
+.deepResearchReportTarget {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    min-width: 0;
+    min-height: 0;
+    pointer-events: none;
+}
+
+.deepResearchReportTarget:empty {
+    display: none;
 }
 
 .deepResearchBar {

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/aiAgentPageLayout.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/aiAgentPageLayout.module.css
@@ -76,6 +76,17 @@
     );
 }
 
+.deepResearchBar {
+    display: flex;
+    flex-shrink: 0;
+    justify-content: flex-end;
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-md) 0;
+}
+
+.deepResearchBar:empty {
+    display: none;
+}
+
 .resizeHandle {
     width: 1px;
     background-color: var(--mantine-color-ldGray-2);

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -19,6 +19,7 @@ import {
 import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
 import { useAgentAiMcpServers } from '../../hooks/useProjectAiMcpServers';
 import { AddToEvalModal } from '../Admin/AddToEvalModal';
+import { DeepResearchThreadRuns } from '../DeepResearch/DeepResearchThreadRuns';
 import { AssistantBubble } from './AgentChatAssistantBubble';
 import styles from './AgentChatDisplay.module.css';
 import { UserBubble } from './AgentChatUserBubble';
@@ -202,6 +203,13 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
                                     )}
                                 </Fragment>
                             ))}
+
+                        {projectUuid && (
+                            <DeepResearchThreadRuns
+                                projectUuid={projectUuid}
+                                threadUuid={thread.uuid}
+                            />
+                        )}
                     </Stack>
 
                     {enableAutoScroll && projectUuid && agentUuid ? (

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
@@ -35,7 +35,7 @@ describe('AgentChatInput Deep Research mode', () => {
             screen.queryByRole('button', { name: 'Send message' }),
         ).not.toBeInTheDocument();
 
-        await user.click(screen.getByText('Deep'));
+        await user.click(screen.getByText('high'));
         await user.click(
             screen.getByRole('button', { name: 'Start research' }),
         );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
@@ -35,7 +35,7 @@ describe('AgentChatInput Deep Research mode', () => {
             screen.queryByRole('button', { name: 'Send message' }),
         ).not.toBeInTheDocument();
 
-        await user.click(screen.getByText('high'));
+        await user.click(screen.getByText('High'));
         await user.click(
             screen.getByRole('button', { name: 'Start research' }),
         );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
@@ -7,7 +7,7 @@ import { renderWithProviders } from '../../../../../testing/testUtils';
 import { store } from '../../store';
 import { AgentChatInput } from './AgentChatInput';
 
-describe('AgentChatInput Deep Research mode', () => {
+describe('AgentChatInput Deep research mode', () => {
     it('starts inline research instead of submitting a normal Ask message', async () => {
         const user = userEvent.setup();
         const onSubmit = vi.fn();

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
@@ -1,0 +1,49 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { store } from '../../store';
+import { AgentChatInput } from './AgentChatInput';
+
+describe('AgentChatInput Deep Research mode', () => {
+    it('starts inline research instead of submitting a normal Ask message', async () => {
+        const user = userEvent.setup();
+        const onSubmit = vi.fn();
+        const onStartDeepResearch = vi.fn().mockResolvedValue(undefined);
+
+        renderWithProviders(
+            <Provider store={store}>
+                <MemoryRouter>
+                    <AgentChatInput
+                        onSubmit={onSubmit}
+                        onStartDeepResearch={onStartDeepResearch}
+                        defaultValue="Why did enterprise retention fall in Q2?"
+                        showSuggestions={false}
+                    />
+                </MemoryRouter>
+            </Provider>,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Deep research' }));
+
+        expect(
+            screen.getByRole('region', { name: 'Deep research settings' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Send message' }),
+        ).not.toBeInTheDocument();
+
+        await user.click(screen.getByText('Deep'));
+        await user.click(
+            screen.getByRole('button', { name: 'Start research' }),
+        );
+
+        expect(onStartDeepResearch).toHaveBeenCalledWith({
+            question: 'Why did enterprise retention fall in Q2?',
+            depth: 'deep',
+        });
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
@@ -31,6 +31,7 @@ describe('AgentChatInput Deep research mode', () => {
         expect(
             screen.getByRole('region', { name: 'Deep research settings' }),
         ).toBeInTheDocument();
+        expect(screen.getAllByText('Beta')).toHaveLength(2);
         expect(
             screen.queryByRole('button', { name: 'Send message' }),
         ).not.toBeInTheDocument();

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.deepResearch.test.tsx
@@ -47,4 +47,35 @@ describe('AgentChatInput Deep research mode', () => {
         });
         expect(onSubmit).not.toHaveBeenCalled();
     });
+
+    it('is unavailable after the conversation has started', async () => {
+        const user = userEvent.setup();
+        const onSubmit = vi.fn();
+        const onStartDeepResearch = vi.fn().mockResolvedValue(undefined);
+
+        renderWithProviders(
+            <Provider store={store}>
+                <MemoryRouter>
+                    <AgentChatInput
+                        onSubmit={onSubmit}
+                        onStartDeepResearch={onStartDeepResearch}
+                        messageCount={1}
+                        defaultValue="What changed this month?"
+                        showSuggestions={false}
+                    />
+                </MemoryRouter>
+            </Provider>,
+        );
+
+        expect(
+            screen.queryByRole('button', { name: 'Deep research' }),
+        ).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Send message' }));
+
+        expect(onSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({ message: 'What changed this month?' }),
+        );
+        expect(onStartDeepResearch).not.toHaveBeenCalled();
+    });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -372,6 +372,10 @@
     border-radius: var(--mantine-radius-xl);
 }
 
+.minimalResearchBeta {
+    flex-shrink: 0;
+}
+
 .minimalInputWrapper.deepResearchInput,
 .minimalInputWrapper.deepResearchInput:focus-within {
     @mixin light {
@@ -394,7 +398,7 @@
 }
 
 .minimalInputWrapper.deepResearchInput .minimalPlaceholder {
-    left: rem(48px);
+    left: rem(88px);
 }
 
 .minimalTextarea {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -70,6 +70,54 @@
     }
 }
 
+.deepResearchInput {
+    @mixin light {
+        border-color: var(--mantine-color-indigo-3);
+        background-color: color-mix(
+            in srgb,
+            var(--mantine-color-indigo-0) 38%,
+            var(--mantine-color-white)
+        );
+        box-shadow:
+            0 8px 24px rgba(76, 110, 245, 0.08),
+            0 0 0 1px rgba(76, 110, 245, 0.06);
+    }
+
+    @mixin dark {
+        border-color: var(--mantine-color-indigo-8);
+        background-color: color-mix(
+            in srgb,
+            var(--mantine-color-indigo-9) 16%,
+            var(--mantine-color-dark-6)
+        );
+    }
+}
+
+.inputCard.deepResearchInput:focus-within {
+    @mixin light {
+        border-color: var(--mantine-color-indigo-4);
+        box-shadow:
+            0 10px 28px rgba(76, 110, 245, 0.1),
+            0 0 0 2px rgba(76, 110, 245, 0.08);
+    }
+
+    @mixin dark {
+        border-color: var(--mantine-color-indigo-7);
+    }
+}
+
+.deepResearchIndicator {
+    position: absolute;
+    top: rem(12px);
+    left: rem(20px);
+    z-index: 2;
+    color: var(--mantine-color-indigo-6);
+}
+
+.deepResearchEditorContent {
+    padding-top: rem(42px);
+}
+
 .textarea {
     border: none;
     background: transparent;
@@ -312,6 +360,43 @@
     }
 }
 
+.minimalResearchIndicator {
+    display: flex;
+    flex: 0 0 rem(26px);
+    align-items: center;
+    justify-content: center;
+    width: rem(26px);
+    height: rem(26px);
+    color: var(--mantine-color-indigo-6);
+    background-color: var(--mantine-color-indigo-light);
+    border-radius: var(--mantine-radius-xl);
+}
+
+.minimalInputWrapper.deepResearchInput,
+.minimalInputWrapper.deepResearchInput:focus-within {
+    @mixin light {
+        border-color: var(--mantine-color-indigo-3);
+        background-color: color-mix(
+            in srgb,
+            var(--mantine-color-indigo-0) 38%,
+            var(--mantine-color-white)
+        );
+    }
+
+    @mixin dark {
+        border-color: var(--mantine-color-indigo-8);
+        background-color: color-mix(
+            in srgb,
+            var(--mantine-color-indigo-9) 16%,
+            var(--ai-chat-input-bg, var(--mantine-color-dark-8))
+        );
+    }
+}
+
+.minimalInputWrapper.deepResearchInput .minimalPlaceholder {
+    left: rem(48px);
+}
+
 .minimalTextarea {
     border: none;
     background: transparent;
@@ -396,6 +481,15 @@
         @mixin dark {
             background-color: var(--mantine-color-ldDark-7);
         }
+    }
+}
+
+.submitButton.deepResearchSubmitButton,
+.minimalSubmitButton.deepResearchSubmitButton {
+    background-color: var(--mantine-color-indigo-6) !important;
+
+    &:hover:not(:disabled) {
+        background-color: var(--mantine-color-indigo-7) !important;
     }
 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -485,6 +485,9 @@ export const AgentChatInput = ({
     const showMinimalPlaceholder = isMinimalMode && !hasValue;
     const showDisabledBanner = disabled && disabledReason;
     const isThreadInput = Boolean(threadUuid);
+    const canStartDeepResearch = Boolean(
+        onStartDeepResearch && messageCount === 0,
+    );
     const showSqlModeControl = Boolean(onSqlModeChange && !disabled);
     const activeMessageUuid = threadStream?.isStreaming
         ? threadStream.messageUuid
@@ -502,7 +505,12 @@ export const AgentChatInput = ({
     const handleStartDeepResearch = async () => {
         const ed = editorRef.current;
         const question = ed?.getText().trim() ?? '';
-        if (!question || !onStartDeepResearch || isStartingDeepResearch) {
+        if (
+            !question ||
+            !onStartDeepResearch ||
+            !canStartDeepResearch ||
+            isStartingDeepResearch
+        ) {
             return;
         }
 
@@ -526,7 +534,7 @@ export const AgentChatInput = ({
         if (!ed) return;
         const text = ed.getText().trim();
         if (!text || disabled) return;
-        if (composerMode === 'deep_research' && onStartDeepResearch) {
+        if (composerMode === 'deep_research' && canStartDeepResearch) {
             void handleStartDeepResearch();
             return;
         }
@@ -578,7 +586,13 @@ export const AgentChatInput = ({
         setHasRequestedInterrupt(true);
     };
 
-    const deepResearchControlElement = onStartDeepResearch ? (
+    useEffect(() => {
+        if (!canStartDeepResearch) {
+            setComposerMode('ask');
+        }
+    }, [canStartDeepResearch]);
+
+    const deepResearchControlElement = canStartDeepResearch ? (
         <DeepResearchModeControl
             mode={composerMode}
             onModeChange={setComposerMode}
@@ -589,7 +603,7 @@ export const AgentChatInput = ({
             ? deepResearchControlElement
             : null;
     const deepResearchPreflight =
-        composerMode === 'deep_research' && onStartDeepResearch ? (
+        composerMode === 'deep_research' && canStartDeepResearch ? (
             <DeepResearchPreflight
                 depth={deepResearchDepth}
                 onDepthChange={setDeepResearchDepth}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -595,6 +595,7 @@ export const AgentChatInput = ({
             : null;
 
     const chipRow = useMemo(() => {
+        if (composerMode === 'deep_research') return null;
         if (!emptyStateMode && !postResponseMode) return null;
         if (suggestionsQuery.isError) return null;
         const chips = suggestionsQuery.data?.chips ?? [];
@@ -616,8 +617,10 @@ export const AgentChatInput = ({
         handleChipClick,
         handleImpression,
         isThreadInput,
+        composerMode,
     ]);
     const shouldReserveEmptyStateSuggestions =
+        composerMode !== 'deep_research' &&
         !isThreadInput &&
         emptyStateMode &&
         !chipRow &&

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -16,6 +16,7 @@ import Placeholder from '@tiptap/extension-placeholder';
 import { useEditor, type Editor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { ModelSelector } from '../../../../../components/common/ModelSelector/ModelSelector';
@@ -106,6 +107,7 @@ interface AgentChatInputProps {
     revealAgentSelectorOnFocus?: boolean;
     // Shrinks padding/min-heights for a more compact composer.
     dense?: boolean;
+    deepResearchControlPlacement?: 'composer' | 'page_header';
 }
 
 const extractToolHints = (editor: Editor | null): string[] => {
@@ -151,6 +153,7 @@ export const AgentChatInput = ({
     contentMentionPriorityItems = [],
     revealAgentSelectorOnFocus = false,
     dense = false,
+    deepResearchControlPlacement = 'composer',
 }: AgentChatInputProps) => {
     const user = useUser(true);
     const [value, setValueState] = useState(defaultValue ?? '');
@@ -162,6 +165,8 @@ export const AgentChatInput = ({
     }, [revealAgentSelectorOnFocus]);
     const [composerMode, setComposerMode] = useState<AgentComposerMode>('ask');
     const [preflightRequest, setPreflightRequest] = useState(0);
+    const [deepResearchHeaderTarget, setDeepResearchHeaderTarget] =
+        useState<Element | null>(null);
     const navigate = useNavigate();
     const onSubmitRef = useRef(onSubmit);
     onSubmitRef.current = onSubmit;
@@ -186,6 +191,17 @@ export const AgentChatInput = ({
     // it loads), never submit, so we guard on this in addition to the plugin's
     // `active` flag — which can read stale in the keydown vs async-items race.
     const contentMentionPopupOpenRef = useRef(false);
+
+    useEffect(() => {
+        if (deepResearchControlPlacement !== 'page_header') {
+            setDeepResearchHeaderTarget(null);
+            return;
+        }
+
+        setDeepResearchHeaderTarget(
+            document.querySelector('[data-deep-research-control-target]'),
+        );
+    }, [deepResearchControlPlacement]);
 
     // Hide the chip strip while the user is scrolled away from the input.
     // Reappears as they scroll back toward the bottom of the thread — chips
@@ -540,7 +556,7 @@ export const AgentChatInput = ({
         }
     };
 
-    const deepResearchControl = onStartDeepResearch ? (
+    const deepResearchControlElement = onStartDeepResearch ? (
         <DeepResearchModeControl
             question={value.trim()}
             projectUuid={projectUuid}
@@ -550,6 +566,16 @@ export const AgentChatInput = ({
             preflightRequest={preflightRequest}
         />
     ) : null;
+    const deepResearchControl =
+        deepResearchControlPlacement === 'composer'
+            ? deepResearchControlElement
+            : null;
+    const deepResearchControlPortal =
+        deepResearchControlElement &&
+        deepResearchControlPlacement === 'page_header' &&
+        deepResearchHeaderTarget
+            ? createPortal(deepResearchControlElement, deepResearchHeaderTarget)
+            : null;
 
     const chipRow = useMemo(() => {
         if (!emptyStateMode && !postResponseMode) return null;
@@ -639,6 +665,7 @@ export const AgentChatInput = ({
                 }`}
                 ref={rootRef}
             >
+                {deepResearchControlPortal}
                 {isThreadInput && renderChipRow(styles.threadChipFlow)}
 
                 <Box className={styles.threadInputStack}>
@@ -764,6 +791,7 @@ export const AgentChatInput = ({
             }`}
             data-dense={dense}
         >
+            {deepResearchControlPortal}
             {isThreadInput && renderChipRow(styles.threadChipFlow)}
 
             <Box

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -4,7 +4,15 @@ import {
     type AiPromptContextItem,
     type AiModelOption,
 } from '@lightdash/common';
-import { ActionIcon, Box, Group, Paper, Text, Tooltip } from '@mantine-8/core';
+import {
+    ActionIcon,
+    Badge,
+    Box,
+    Group,
+    Paper,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
 import { RichTextEditor } from '@mantine/tiptap';
 import {
     IconArrowUp,
@@ -698,16 +706,30 @@ export const AgentChatInput = ({
                         pos="relative"
                     >
                         {composerMode === 'deep_research' && (
-                            <Box
-                                className={styles.minimalResearchIndicator}
+                            <Group
+                                gap={4}
+                                wrap="nowrap"
                                 aria-label="Deep research mode"
                             >
-                                <MantineIcon
-                                    icon={IconReportSearch}
-                                    size={15}
-                                    stroke={1.8}
-                                />
-                            </Box>
+                                <Box
+                                    className={styles.minimalResearchIndicator}
+                                >
+                                    <MantineIcon
+                                        icon={IconReportSearch}
+                                        size={15}
+                                        stroke={1.8}
+                                    />
+                                </Box>
+                                <Badge
+                                    size="xs"
+                                    variant="light"
+                                    color="blue"
+                                    tt="none"
+                                    className={styles.minimalResearchBeta}
+                                >
+                                    Beta
+                                </Badge>
+                            </Group>
                         )}
                         <RichTextEditor
                             editor={editor}
@@ -872,6 +894,9 @@ export const AgentChatInput = ({
                         <Text size="xs" fw={600}>
                             Deep research
                         </Text>
+                        <Badge size="xs" variant="light" color="blue" tt="none">
+                            Beta
+                        </Badge>
                     </Group>
                 )}
                 <RichTextEditor

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -22,6 +22,8 @@ import { ModelSelector } from '../../../../../components/common/ModelSelector/Mo
 import useUser from '../../../../../hooks/user/useUser';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
+import { subscribeToDeepResearchComposerPrompt } from '../../deepResearch/deepResearchRegistry';
+import { type StartDeepResearchArgs } from '../../deepResearch/types';
 import { useAgentSuggestions } from '../../hooks/useAgentSuggestions';
 import {
     useCreateAiAgentThreadMessageSteerMutation,
@@ -30,6 +32,10 @@ import {
 import { useAiAgentThreadStreamQuery } from '../../streaming/useAiAgentThreadStreamQuery';
 import { AgentSelector } from '../AgentSelector';
 import { type Agent } from '../AgentSelector/AgentSelectorUtils';
+import {
+    DeepResearchModeControl,
+    type AgentComposerMode,
+} from '../DeepResearch/DeepResearchModeControl';
 import styles from './AgentChatInput.module.css';
 import { AgentSuggestionChips } from './AgentSuggestionChips';
 import {
@@ -71,6 +77,7 @@ type SubmitArgs = {
 
 interface AgentChatInputProps {
     onSubmit: (args: SubmitArgs) => void;
+    onStartDeepResearch?: (args: StartDeepResearchArgs) => Promise<void>;
     loading?: boolean;
     disabled?: boolean;
     disabledReason?: string;
@@ -117,6 +124,7 @@ const extractToolHints = (editor: Editor | null): string[] => {
 
 export const AgentChatInput = ({
     onSubmit,
+    onStartDeepResearch,
     loading = false,
     disabled = false,
     disabledReason,
@@ -152,6 +160,8 @@ export const AgentChatInput = ({
     const handleInputCardMouseDown = useCallback(() => {
         if (revealAgentSelectorOnFocus) setHasClickedInput(true);
     }, [revealAgentSelectorOnFocus]);
+    const [composerMode, setComposerMode] = useState<AgentComposerMode>('ask');
+    const [preflightRequest, setPreflightRequest] = useState(0);
     const navigate = useNavigate();
     const onSubmitRef = useRef(onSubmit);
     onSubmitRef.current = onSubmit;
@@ -339,6 +349,15 @@ export const AgentChatInput = ({
     }, [editor, disabled]);
 
     useEffect(() => {
+        if (!editor || !threadUuid) return undefined;
+        return subscribeToDeepResearchComposerPrompt((detail) => {
+            if (detail.threadUuid !== threadUuid) return;
+            editor.commands.setContent(detail.prompt);
+            editor.commands.focus('end');
+        });
+    }, [editor, threadUuid]);
+
+    useEffect(() => {
         if (hasRequestedInterrupt && !threadStream?.isStreaming) {
             setHasRequestedInterrupt(false);
         }
@@ -454,6 +473,10 @@ export const AgentChatInput = ({
         if (!ed) return;
         const text = ed.getText().trim();
         if (!text || disabled) return;
+        if (composerMode === 'deep_research' && onStartDeepResearch) {
+            setPreflightRequest((request) => request + 1);
+            return;
+        }
         if (canSteer) {
             if (steerMutation.isLoading) return;
             void handleSteer(text);
@@ -501,6 +524,32 @@ export const AgentChatInput = ({
         });
         setHasRequestedInterrupt(true);
     };
+
+    const handleStartDeepResearch = async (
+        depth: StartDeepResearchArgs['depth'],
+    ) => {
+        const ed = editorRef.current;
+        const question = ed?.getText().trim() ?? '';
+        if (!question || !onStartDeepResearch) {
+            return;
+        }
+        await onStartDeepResearch({ question, depth });
+        if (clearOnSubmitRef.current) {
+            ed?.commands.clearContent();
+            setValueState('');
+        }
+    };
+
+    const deepResearchControl = onStartDeepResearch ? (
+        <DeepResearchModeControl
+            question={value.trim()}
+            projectUuid={projectUuid}
+            agentUuid={agentUuid}
+            onStart={handleStartDeepResearch}
+            onModeChange={setComposerMode}
+            preflightRequest={preflightRequest}
+        />
+    ) : null;
 
     const chipRow = useMemo(() => {
         if (!emptyStateMode && !postResponseMode) return null;
@@ -676,10 +725,19 @@ export const AgentChatInput = ({
 
                 {showSqlModeControl && (
                     <Box className={styles.threadBelowControls}>
-                        {renderSqlModeControl({
-                            actionSize: 'sm',
-                            iconSize: 14,
-                        })}
+                        <Group gap="xs">
+                            {deepResearchControl}
+                            {renderSqlModeControl({
+                                actionSize: 'sm',
+                                iconSize: 14,
+                            })}
+                        </Group>
+                    </Box>
+                )}
+
+                {!showSqlModeControl && deepResearchControl && (
+                    <Box className={styles.threadBelowControls}>
+                        {deepResearchControl}
                     </Box>
                 )}
 
@@ -724,6 +782,7 @@ export const AgentChatInput = ({
 
                 <Box className={styles.toolbar}>
                     <Box className={styles.toolbarActions}>
+                        {!isThreadInput && deepResearchControl}
                         {!isThreadInput &&
                             renderSqlModeControl({
                                 actionSize: 30,
@@ -826,12 +885,16 @@ export const AgentChatInput = ({
             </Box>
 
             {isThreadInput
-                ? showSqlModeControl && (
+                ? (showSqlModeControl || deepResearchControl) && (
                       <Box className={styles.threadBelowControls}>
-                          {renderSqlModeControl({
-                              actionSize: 'sm',
-                              iconSize: 14,
-                          })}
+                          <Group gap="xs">
+                              {deepResearchControl}
+                              {showSqlModeControl &&
+                                  renderSqlModeControl({
+                                      actionSize: 'sm',
+                                      iconSize: 14,
+                                  })}
+                          </Group>
                       </Box>
                   )
                 : renderChipRow(

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -9,6 +9,7 @@ import { RichTextEditor } from '@mantine/tiptap';
 import {
     IconArrowUp,
     IconPlayerStop,
+    IconReportSearch,
     IconTerminal2,
 } from '@tabler/icons-react';
 import Mention from '@tiptap/extension-mention';
@@ -24,7 +25,10 @@ import useUser from '../../../../../hooks/user/useUser';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
 import { subscribeToDeepResearchComposerPrompt } from '../../deepResearch/deepResearchRegistry';
-import { type StartDeepResearchArgs } from '../../deepResearch/types';
+import {
+    type DeepResearchDepth,
+    type StartDeepResearchArgs,
+} from '../../deepResearch/types';
 import { useAgentSuggestions } from '../../hooks/useAgentSuggestions';
 import {
     useCreateAiAgentThreadMessageSteerMutation,
@@ -37,6 +41,7 @@ import {
     DeepResearchModeControl,
     type AgentComposerMode,
 } from '../DeepResearch/DeepResearchModeControl';
+import { DeepResearchPreflight } from '../DeepResearch/DeepResearchPreflight';
 import styles from './AgentChatInput.module.css';
 import { AgentSuggestionChips } from './AgentSuggestionChips';
 import {
@@ -164,7 +169,9 @@ export const AgentChatInput = ({
         if (revealAgentSelectorOnFocus) setHasClickedInput(true);
     }, [revealAgentSelectorOnFocus]);
     const [composerMode, setComposerMode] = useState<AgentComposerMode>('ask');
-    const [preflightRequest, setPreflightRequest] = useState(0);
+    const [deepResearchDepth, setDeepResearchDepth] =
+        useState<DeepResearchDepth>('standard');
+    const [isStartingDeepResearch, setIsStartingDeepResearch] = useState(false);
     const [deepResearchHeaderTarget, setDeepResearchHeaderTarget] =
         useState<Element | null>(null);
     const navigate = useNavigate();
@@ -484,13 +491,35 @@ export const AgentChatInput = ({
     const canSteer = canInterrupt && !disabled && !hasRequestedInterrupt;
     canSteerRef.current = canSteer;
 
+    const handleStartDeepResearch = async () => {
+        const ed = editorRef.current;
+        const question = ed?.getText().trim() ?? '';
+        if (!question || !onStartDeepResearch || isStartingDeepResearch) {
+            return;
+        }
+
+        setIsStartingDeepResearch(true);
+        try {
+            await onStartDeepResearch({
+                question,
+                depth: deepResearchDepth,
+            });
+            if (clearOnSubmitRef.current) {
+                ed?.commands.clearContent();
+                setValueState('');
+            }
+        } finally {
+            setIsStartingDeepResearch(false);
+        }
+    };
+
     const handleSubmit = () => {
         const ed = editorRef.current;
         if (!ed) return;
         const text = ed.getText().trim();
         if (!text || disabled) return;
         if (composerMode === 'deep_research' && onStartDeepResearch) {
-            setPreflightRequest((request) => request + 1);
+            void handleStartDeepResearch();
             return;
         }
         if (canSteer) {
@@ -541,35 +570,23 @@ export const AgentChatInput = ({
         setHasRequestedInterrupt(true);
     };
 
-    const handleStartDeepResearch = async (
-        depth: StartDeepResearchArgs['depth'],
-    ) => {
-        const ed = editorRef.current;
-        const question = ed?.getText().trim() ?? '';
-        if (!question || !onStartDeepResearch) {
-            return;
-        }
-        await onStartDeepResearch({ question, depth });
-        if (clearOnSubmitRef.current) {
-            ed?.commands.clearContent();
-            setValueState('');
-        }
-    };
-
     const deepResearchControlElement = onStartDeepResearch ? (
         <DeepResearchModeControl
-            question={value.trim()}
-            projectUuid={projectUuid}
-            agentUuid={agentUuid}
-            onStart={handleStartDeepResearch}
+            mode={composerMode}
             onModeChange={setComposerMode}
-            preflightRequest={preflightRequest}
         />
     ) : null;
     const deepResearchControl =
         deepResearchControlPlacement === 'composer'
             ? deepResearchControlElement
             : null;
+    const deepResearchPreflight =
+        composerMode === 'deep_research' && onStartDeepResearch ? (
+            <DeepResearchPreflight
+                depth={deepResearchDepth}
+                onDepthChange={setDeepResearchDepth}
+            />
+        ) : null;
     const deepResearchControlPortal =
         deepResearchControlElement &&
         deepResearchControlPlacement === 'page_header' &&
@@ -669,7 +686,26 @@ export const AgentChatInput = ({
                 {isThreadInput && renderChipRow(styles.threadChipFlow)}
 
                 <Box className={styles.threadInputStack}>
-                    <Box className={styles.minimalInputWrapper} pos="relative">
+                    <Box
+                        className={`${styles.minimalInputWrapper} ${
+                            composerMode === 'deep_research'
+                                ? styles.deepResearchInput
+                                : ''
+                        }`}
+                        pos="relative"
+                    >
+                        {composerMode === 'deep_research' && (
+                            <Box
+                                className={styles.minimalResearchIndicator}
+                                aria-label="Deep research mode"
+                            >
+                                <MantineIcon
+                                    icon={IconReportSearch}
+                                    size={15}
+                                    stroke={1.8}
+                                />
+                            </Box>
+                        )}
                         <RichTextEditor
                             editor={editor}
                             classNames={{
@@ -733,14 +769,30 @@ export const AgentChatInput = ({
                                 bottom={10}
                                 variant="filled"
                                 size="md"
-                                className={styles.minimalSubmitButton}
+                                className={`${styles.minimalSubmitButton} ${
+                                    composerMode === 'deep_research'
+                                        ? styles.deepResearchSubmitButton
+                                        : ''
+                                }`}
                                 disabled={disabled || !hasValue}
-                                loading={loading}
+                                loading={
+                                    composerMode === 'deep_research'
+                                        ? isStartingDeepResearch
+                                        : loading
+                                }
                                 onClick={handleSubmit}
-                                aria-label="Send message"
+                                aria-label={
+                                    composerMode === 'deep_research'
+                                        ? 'Start research'
+                                        : 'Send message'
+                                }
                             >
                                 <MantineIcon
-                                    icon={IconArrowUp}
+                                    icon={
+                                        composerMode === 'deep_research'
+                                            ? IconReportSearch
+                                            : IconArrowUp
+                                    }
                                     color="ldGray.0"
                                     size={18}
                                     stroke={2}
@@ -748,6 +800,7 @@ export const AgentChatInput = ({
                             </ActionIcon>
                         )}
                     </Box>
+                    {deepResearchPreflight}
                 </Box>
 
                 {showSqlModeControl && (
@@ -795,14 +848,38 @@ export const AgentChatInput = ({
             {isThreadInput && renderChipRow(styles.threadChipFlow)}
 
             <Box
-                className={styles.inputCard}
+                className={`${styles.inputCard} ${
+                    composerMode === 'deep_research'
+                        ? styles.deepResearchInput
+                        : ''
+                }`}
                 onMouseDown={handleInputCardMouseDown}
             >
+                {composerMode === 'deep_research' && (
+                    <Group
+                        gap={6}
+                        className={styles.deepResearchIndicator}
+                        aria-label="Deep research mode"
+                    >
+                        <MantineIcon
+                            icon={IconReportSearch}
+                            size={15}
+                            stroke={1.8}
+                        />
+                        <Text size="xs" fw={600}>
+                            Deep research
+                        </Text>
+                    </Group>
+                )}
                 <RichTextEditor
                     editor={editor}
                     classNames={{
                         root: styles.editorRoot,
-                        content: styles.editorContent,
+                        content: `${styles.editorContent} ${
+                            composerMode === 'deep_research'
+                                ? styles.deepResearchEditorContent
+                                : ''
+                        }`,
                     }}
                 >
                     <RichTextEditor.Content />
@@ -894,14 +971,30 @@ export const AgentChatInput = ({
                             <ActionIcon
                                 variant="filled"
                                 size="lg"
-                                className={styles.submitButton}
+                                className={`${styles.submitButton} ${
+                                    composerMode === 'deep_research'
+                                        ? styles.deepResearchSubmitButton
+                                        : ''
+                                }`}
                                 disabled={disabled || !hasValue}
-                                loading={loading}
+                                loading={
+                                    composerMode === 'deep_research'
+                                        ? isStartingDeepResearch
+                                        : loading
+                                }
                                 onClick={handleSubmit}
-                                aria-label="Send message"
+                                aria-label={
+                                    composerMode === 'deep_research'
+                                        ? 'Start research'
+                                        : 'Send message'
+                                }
                             >
                                 <MantineIcon
-                                    icon={IconArrowUp}
+                                    icon={
+                                        composerMode === 'deep_research'
+                                            ? IconReportSearch
+                                            : IconArrowUp
+                                    }
                                     color="ldGray.0"
                                     size={20}
                                     stroke={2}
@@ -911,6 +1004,8 @@ export const AgentChatInput = ({
                     </Group>
                 </Box>
             </Box>
+
+            {deepResearchPreflight}
 
             {isThreadInput
                 ? (showSqlModeControl || deepResearchControl) && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
@@ -1,55 +1,72 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
 import { renderWithProviders } from '../../../../../testing/testUtils';
+import { type DeepResearchDepth } from '../../deepResearch/types';
 import { DeepResearchModeControl } from './DeepResearchModeControl';
+import { DeepResearchPreflight } from './DeepResearchPreflight';
 
-const renderControl = (onStart = vi.fn().mockResolvedValue(undefined)) => {
-    renderWithProviders(
-        <DeepResearchModeControl
-            question="Why did enterprise retention fall in Q2?"
-            projectUuid="project-1"
-            agentUuid="agent-1"
-            onStart={onStart}
-            preflightRequest={0}
-        />,
+const ModeHarness = () => {
+    const [mode, setMode] = useState<'ask' | 'deep_research'>('ask');
+    const [depth, setDepth] = useState<DeepResearchDepth>('standard');
+
+    return (
+        <>
+            <DeepResearchModeControl mode={mode} onModeChange={setMode} />
+            {mode === 'deep_research' && (
+                <DeepResearchPreflight depth={depth} onDepthChange={setDepth} />
+            )}
+        </>
     );
-    return onStart;
 };
 
 describe('DeepResearchModeControl', () => {
     it('keeps Ask as the unchanged default mode', () => {
-        const onStart = renderControl();
+        renderWithProviders(<ModeHarness />);
 
         expect(
             screen.getByRole('button', { name: 'Deep research' }),
         ).toHaveAttribute('aria-pressed', 'false');
-
-        expect(screen.queryByText('Research depth')).not.toBeInTheDocument();
-        expect(onStart).not.toHaveBeenCalled();
+        expect(
+            screen.queryByRole('region', {
+                name: 'Deep research settings',
+            }),
+        ).not.toBeInTheDocument();
     });
 
-    it('starts Deep Research from the composer preflight', async () => {
+    it('shows inline research settings and toggles back to Ask', async () => {
         const user = userEvent.setup();
-        const onStart = renderControl();
+        renderWithProviders(<ModeHarness />);
 
-        await user.click(screen.getByRole('button', { name: 'Deep research' }));
+        const modeButton = screen.getByRole('button', {
+            name: 'Deep research',
+        });
+        await user.click(modeButton);
 
-        expect(await screen.findByText('Research depth')).toBeInTheDocument();
+        expect(modeButton).toHaveAttribute('aria-pressed', 'true');
+        expect(
+            screen.getByRole('region', { name: 'Deep research settings' }),
+        ).toBeInTheDocument();
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
         expect(screen.getByText('Project data')).toBeInTheDocument();
         expect(screen.getByText('Public web')).toBeInTheDocument();
         expect(
             screen.getByText(/Connected AI Agent sources are not available/),
         ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Start research' }),
+        ).not.toBeInTheDocument();
 
         await user.click(screen.getByText('Quick'));
         expect(screen.getByText('Up to 15 minutes')).toBeInTheDocument();
         expect(screen.getByText('Up to 10 queries')).toBeInTheDocument();
 
-        await user.click(
-            screen.getByRole('button', { name: 'Start research' }),
-        );
-
-        expect(onStart).toHaveBeenCalledWith('quick');
+        await user.click(modeButton);
+        expect(
+            screen.queryByRole('region', {
+                name: 'Deep research settings',
+            }),
+        ).not.toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
@@ -56,8 +56,9 @@ describe('DeepResearchModeControl', () => {
         ).not.toBeInTheDocument();
 
         await user.click(screen.getByText('Quick'));
-        expect(screen.getByText('Up to 15 minutes')).toBeInTheDocument();
-        expect(screen.getByText('Up to 10 queries')).toBeInTheDocument();
+        expect(
+            screen.getByText(/Up to 15 minutes · Up to 10 queries/),
+        ).toBeInTheDocument();
 
         await user.click(modeButton);
         expect(

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
@@ -1,0 +1,53 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { DeepResearchModeControl } from './DeepResearchModeControl';
+
+const renderControl = (onStart = vi.fn().mockResolvedValue(undefined)) => {
+    renderWithProviders(
+        <DeepResearchModeControl
+            question="Why did enterprise retention fall in Q2?"
+            projectUuid="project-1"
+            agentUuid="agent-1"
+            onStart={onStart}
+            preflightRequest={0}
+        />,
+    );
+    return onStart;
+};
+
+describe('DeepResearchModeControl', () => {
+    it('keeps Ask as the unchanged default mode', () => {
+        const onStart = renderControl();
+
+        expect(screen.getByRole('radio', { name: 'Ask' })).toBeChecked();
+
+        expect(screen.queryByText('Research depth')).not.toBeInTheDocument();
+        expect(onStart).not.toHaveBeenCalled();
+    });
+
+    it('starts Deep Research from the composer preflight', async () => {
+        const user = userEvent.setup();
+        const onStart = renderControl();
+
+        await user.click(screen.getByText('Deep research'));
+
+        expect(await screen.findByText('Research depth')).toBeInTheDocument();
+        expect(screen.getByText('Project data')).toBeInTheDocument();
+        expect(screen.getByText('Public web')).toBeInTheDocument();
+        expect(
+            screen.getByText(/Connected AI Agent sources are not available/),
+        ).toBeInTheDocument();
+
+        await user.click(screen.getByText('Quick'));
+        expect(screen.getByText('Up to 15 minutes')).toBeInTheDocument();
+        expect(screen.getByText('Up to 10 queries')).toBeInTheDocument();
+
+        await user.click(
+            screen.getByRole('button', { name: 'Start research' }),
+        );
+
+        expect(onStart).toHaveBeenCalledWith('quick');
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
@@ -55,10 +55,9 @@ describe('DeepResearchModeControl', () => {
             screen.queryByRole('button', { name: 'Start research' }),
         ).not.toBeInTheDocument();
 
-        await user.click(screen.getByText('Quick'));
-        expect(
-            screen.getByText(/Up to 15 minutes · Up to 10 queries/),
-        ).toBeInTheDocument();
+        await user.click(screen.getByText('low'));
+        expect(screen.getByText('Up to 15 minutes')).toBeInTheDocument();
+        expect(screen.getByText('Up to 10 queries')).toBeInTheDocument();
 
         await user.click(modeButton);
         expect(

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
@@ -52,9 +52,6 @@ describe('DeepResearchModeControl', () => {
         expect(screen.getByText('Project data')).toBeInTheDocument();
         expect(screen.getByText('Public web')).toBeInTheDocument();
         expect(
-            screen.getByText(/Connected AI Agent sources are not available/),
-        ).toBeInTheDocument();
-        expect(
             screen.queryByRole('button', { name: 'Start research' }),
         ).not.toBeInTheDocument();
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
@@ -55,7 +55,7 @@ describe('DeepResearchModeControl', () => {
             screen.queryByRole('button', { name: 'Start research' }),
         ).not.toBeInTheDocument();
 
-        await user.click(screen.getByText('low'));
+        await user.click(screen.getByText('Low'));
         expect(screen.getByText('Up to 15 minutes')).toBeInTheDocument();
         expect(screen.getByText('Up to 10 queries')).toBeInTheDocument();
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.test.tsx
@@ -21,7 +21,9 @@ describe('DeepResearchModeControl', () => {
     it('keeps Ask as the unchanged default mode', () => {
         const onStart = renderControl();
 
-        expect(screen.getByRole('radio', { name: 'Ask' })).toBeChecked();
+        expect(
+            screen.getByRole('button', { name: 'Deep research' }),
+        ).toHaveAttribute('aria-pressed', 'false');
 
         expect(screen.queryByText('Research depth')).not.toBeInTheDocument();
         expect(onStart).not.toHaveBeenCalled();
@@ -31,7 +33,7 @@ describe('DeepResearchModeControl', () => {
         const user = userEvent.setup();
         const onStart = renderControl();
 
-        await user.click(screen.getByText('Deep research'));
+        await user.click(screen.getByRole('button', { name: 'Deep research' }));
 
         expect(await screen.findByText('Research depth')).toBeInTheDocument();
         expect(screen.getByText('Project data')).toBeInTheDocument();

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
@@ -1,0 +1,80 @@
+import { SegmentedControl } from '@mantine-8/core';
+import { useEffect, useState } from 'react';
+import { type DeepResearchDepth } from '../../deepResearch/types';
+import { DeepResearchPreflight } from './DeepResearchPreflight';
+
+export type AgentComposerMode = 'ask' | 'deep_research';
+
+type Props = {
+    question: string;
+    projectUuid?: string;
+    agentUuid?: string;
+    onStart: (depth: DeepResearchDepth) => Promise<void>;
+    onModeChange?: (mode: AgentComposerMode) => void;
+    preflightRequest: number;
+};
+
+export const DeepResearchModeControl = ({
+    question,
+    projectUuid,
+    agentUuid,
+    onStart,
+    onModeChange,
+    preflightRequest,
+}: Props) => {
+    const [mode, setMode] = useState<AgentComposerMode>('ask');
+    const [depth, setDepth] = useState<DeepResearchDepth>('standard');
+    const [isPreflightOpen, setIsPreflightOpen] = useState(false);
+    const [isStarting, setIsStarting] = useState(false);
+
+    useEffect(() => {
+        if (mode === 'deep_research' && preflightRequest > 0) {
+            setIsPreflightOpen(true);
+        }
+    }, [mode, preflightRequest]);
+
+    const selectMode = (nextMode: AgentComposerMode) => {
+        setMode(nextMode);
+        onModeChange?.(nextMode);
+        if (nextMode === 'deep_research') {
+            setIsPreflightOpen(true);
+        }
+    };
+
+    const handleStart = async () => {
+        setIsStarting(true);
+        try {
+            await onStart(depth);
+            setIsPreflightOpen(false);
+        } finally {
+            setIsStarting(false);
+        }
+    };
+
+    return (
+        <>
+            <SegmentedControl
+                size="xs"
+                value={mode}
+                onChange={(value) => selectMode(value as AgentComposerMode)}
+                data={[
+                    { label: 'Ask', value: 'ask' },
+                    { label: 'Deep research', value: 'deep_research' },
+                ]}
+                aria-label="Answer mode"
+            />
+
+            <DeepResearchPreflight
+                opened={isPreflightOpen}
+                onClose={() => setIsPreflightOpen(false)}
+                question={question}
+                depth={depth}
+                onDepthChange={setDepth}
+                onStart={() => void handleStart()}
+                isStarting={isStarting}
+                projectUuid={projectUuid}
+                agentUuid={agentUuid}
+            />
+        </>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
@@ -1,92 +1,31 @@
 import { Button } from '@mantine-8/core';
 import { IconReportSearch } from '@tabler/icons-react';
-import { useEffect, useState } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { type DeepResearchDepth } from '../../deepResearch/types';
-import { DeepResearchPreflight } from './DeepResearchPreflight';
 
 export type AgentComposerMode = 'ask' | 'deep_research';
 
 type Props = {
-    question: string;
-    projectUuid?: string;
-    agentUuid?: string;
-    onStart: (depth: DeepResearchDepth) => Promise<void>;
-    onModeChange?: (mode: AgentComposerMode) => void;
-    preflightRequest: number;
+    mode: AgentComposerMode;
+    onModeChange: (mode: AgentComposerMode) => void;
 };
 
-export const DeepResearchModeControl = ({
-    question,
-    projectUuid,
-    agentUuid,
-    onStart,
-    onModeChange,
-    preflightRequest,
-}: Props) => {
-    const [mode, setMode] = useState<AgentComposerMode>('ask');
-    const [depth, setDepth] = useState<DeepResearchDepth>('standard');
-    const [isPreflightOpen, setIsPreflightOpen] = useState(false);
-    const [isStarting, setIsStarting] = useState(false);
-
-    useEffect(() => {
-        if (mode === 'deep_research' && preflightRequest > 0) {
-            setIsPreflightOpen(true);
-        }
-    }, [mode, preflightRequest]);
-
-    const selectMode = (nextMode: AgentComposerMode) => {
-        setMode(nextMode);
-        onModeChange?.(nextMode);
-        if (nextMode === 'deep_research') {
-            setIsPreflightOpen(true);
-        }
-    };
-
+export const DeepResearchModeControl = ({ mode, onModeChange }: Props) => {
     const isDeepResearch = mode === 'deep_research';
 
-    const handleStart = async () => {
-        setIsStarting(true);
-        try {
-            await onStart(depth);
-            setIsPreflightOpen(false);
-        } finally {
-            setIsStarting(false);
-        }
-    };
-
     return (
-        <>
-            <Button
-                size="xs"
-                variant={isDeepResearch ? 'light' : 'default'}
-                color={isDeepResearch ? 'indigo' : 'gray'}
-                leftSection={
-                    <MantineIcon
-                        icon={IconReportSearch}
-                        size={14}
-                        stroke={1.8}
-                    />
-                }
-                onClick={() =>
-                    selectMode(isDeepResearch ? 'ask' : 'deep_research')
-                }
-                aria-pressed={isDeepResearch}
-            >
-                Deep research
-            </Button>
-
-            <DeepResearchPreflight
-                opened={isPreflightOpen}
-                onClose={() => setIsPreflightOpen(false)}
-                question={question}
-                depth={depth}
-                onDepthChange={setDepth}
-                onStart={() => void handleStart()}
-                isStarting={isStarting}
-                projectUuid={projectUuid}
-                agentUuid={agentUuid}
-            />
-        </>
+        <Button
+            size="xs"
+            variant={isDeepResearch ? 'light' : 'default'}
+            color={isDeepResearch ? 'indigo' : 'gray'}
+            leftSection={
+                <MantineIcon icon={IconReportSearch} size={14} stroke={1.8} />
+            }
+            onClick={() =>
+                onModeChange(isDeepResearch ? 'ask' : 'deep_research')
+            }
+            aria-pressed={isDeepResearch}
+        >
+            Deep research
+        </Button>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
@@ -59,7 +59,7 @@ export const DeepResearchModeControl = ({
         <>
             <Button
                 size="xs"
-                variant={isDeepResearch ? 'light' : 'default'}
+                variant={isDeepResearch ? 'light' : 'subtle'}
                 color={isDeepResearch ? 'indigo' : 'gray'}
                 leftSection={
                     <MantineIcon

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
@@ -1,5 +1,7 @@
-import { SegmentedControl } from '@mantine-8/core';
+import { Button } from '@mantine-8/core';
+import { IconReportSearch } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
 import { type DeepResearchDepth } from '../../deepResearch/types';
 import { DeepResearchPreflight } from './DeepResearchPreflight';
 
@@ -41,6 +43,8 @@ export const DeepResearchModeControl = ({
         }
     };
 
+    const isDeepResearch = mode === 'deep_research';
+
     const handleStart = async () => {
         setIsStarting(true);
         try {
@@ -53,16 +57,24 @@ export const DeepResearchModeControl = ({
 
     return (
         <>
-            <SegmentedControl
+            <Button
                 size="xs"
-                value={mode}
-                onChange={(value) => selectMode(value as AgentComposerMode)}
-                data={[
-                    { label: 'Ask', value: 'ask' },
-                    { label: 'Deep research', value: 'deep_research' },
-                ]}
-                aria-label="Answer mode"
-            />
+                variant={isDeepResearch ? 'light' : 'default'}
+                color={isDeepResearch ? 'indigo' : 'gray'}
+                leftSection={
+                    <MantineIcon
+                        icon={IconReportSearch}
+                        size={14}
+                        stroke={1.8}
+                    />
+                }
+                onClick={() =>
+                    selectMode(isDeepResearch ? 'ask' : 'deep_research')
+                }
+                aria-pressed={isDeepResearch}
+            >
+                Deep research
+            </Button>
 
             <DeepResearchPreflight
                 opened={isPreflightOpen}

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
@@ -59,7 +59,7 @@ export const DeepResearchModeControl = ({
         <>
             <Button
                 size="xs"
-                variant={isDeepResearch ? 'light' : 'subtle'}
+                variant={isDeepResearch ? 'light' : 'default'}
                 color={isDeepResearch ? 'indigo' : 'gray'}
                 leftSection={
                     <MantineIcon

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchModeControl.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@mantine-8/core';
+import { Badge, Button, Group } from '@mantine-8/core';
 import { IconReportSearch } from '@tabler/icons-react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 
@@ -15,17 +15,23 @@ export const DeepResearchModeControl = ({ mode, onModeChange }: Props) => {
     return (
         <Button
             size="xs"
-            variant={isDeepResearch ? 'light' : 'default'}
-            color={isDeepResearch ? 'indigo' : 'gray'}
+            variant={isDeepResearch ? 'light' : 'subtle'}
+            color="blue"
             leftSection={
                 <MantineIcon icon={IconReportSearch} size={14} stroke={1.8} />
             }
             onClick={() =>
                 onModeChange(isDeepResearch ? 'ask' : 'deep_research')
             }
+            aria-label="Deep research"
             aria-pressed={isDeepResearch}
         >
-            Deep research
+            <Group gap={5} wrap="nowrap">
+                Deep research
+                <Badge size="xs" variant="light" color="blue" tt="none">
+                    Beta
+                </Badge>
+            </Group>
         </Button>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
@@ -33,7 +33,6 @@
 
     &[data-checked] {
         border-color: var(--mantine-color-indigo-outline);
-        background: var(--mantine-color-indigo-light);
     }
 
     &:focus-visible {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
@@ -42,18 +42,12 @@
 }
 
 .source {
-    min-height: rem(64px);
-    padding: var(--mantine-spacing-xs);
-    border: 1px solid var(--mantine-color-ldGray-3);
-    border-radius: var(--mantine-radius-md);
+    padding: rem(3px) rem(6px);
+    border: 1px solid var(--mantine-color-indigo-2);
+    border-radius: var(--mantine-radius-sm);
 
     @mixin light {
-        background-color: rgba(255, 255, 255, 0.72);
-    }
-
-    @mixin dark {
-        background-color: var(--mantine-color-dark-6);
-        border-color: var(--mantine-color-dark-4);
+        background-color: rgba(255, 255, 255, 0.56);
     }
 
     &[data-available='false'] {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
@@ -45,8 +45,8 @@
     }
 }
 
-.allowancePill {
-    padding: rem(5px) rem(9px);
+.depthAllowance {
+    padding: rem(3px) rem(6px);
     border: 1px solid var(--mantine-color-indigo-2);
     border-radius: var(--mantine-radius-xl);
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
@@ -43,7 +43,7 @@
 }
 
 .source {
-    padding: rem(4px) rem(7px);
+    padding: rem(3px) rem(6px);
     border: 1px solid var(--mantine-color-indigo-2);
     border-radius: var(--mantine-radius-sm);
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
@@ -1,8 +1,8 @@
 .root {
     position: relative;
     z-index: 0;
-    margin-top: rem(-12px);
-    padding: rem(24px) var(--mantine-spacing-md) var(--mantine-spacing-md);
+    margin-top: rem(-28px);
+    padding: rem(40px) var(--mantine-spacing-md) var(--mantine-spacing-md);
     border-radius: 0 0 rem(18px) rem(18px);
 
     @mixin light {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
@@ -1,0 +1,37 @@
+.drawerBody {
+    height: calc(100% - 2rem);
+}
+
+.question {
+    padding: var(--mantine-spacing-sm);
+    border-left: 3px solid var(--mantine-color-indigo-outline);
+    background: light-dark(
+        var(--mantine-color-indigo-light),
+        var(--mantine-color-indigo-light)
+    );
+}
+
+.depthCard {
+    border: 1px solid var(--mantine-color-ldGray-3);
+    cursor: pointer;
+
+    &[data-checked] {
+        border-color: var(--mantine-color-indigo-outline);
+        background: var(--mantine-color-indigo-light);
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--mantine-color-indigo-outline);
+        outline-offset: 2px;
+    }
+}
+
+.source {
+    padding: 0.35rem 0.5rem;
+    border: 1px solid var(--mantine-color-ldGray-3);
+    border-radius: var(--mantine-radius-sm);
+
+    &[data-available='false'] {
+        border-style: dashed;
+    }
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
@@ -45,6 +45,21 @@
     }
 }
 
+.allowancePill {
+    padding: rem(5px) rem(9px);
+    border: 1px solid var(--mantine-color-indigo-2);
+    border-radius: var(--mantine-radius-xl);
+
+    @mixin light {
+        background-color: rgba(255, 255, 255, 0.64);
+    }
+
+    @mixin dark {
+        background-color: var(--mantine-color-dark-6);
+        border-color: var(--mantine-color-indigo-8);
+    }
+}
+
 .source {
     padding: rem(4px) rem(7px);
     border: 1px solid var(--mantine-color-indigo-2);

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
@@ -3,8 +3,6 @@
     z-index: 0;
     margin-top: rem(-12px);
     padding: rem(24px) var(--mantine-spacing-md) var(--mantine-spacing-md);
-    border: 1px solid var(--mantine-color-indigo-2);
-    border-top: 0;
     border-radius: 0 0 rem(18px) rem(18px);
 
     @mixin light {
@@ -17,7 +15,6 @@
             var(--mantine-color-indigo-9) 28%,
             var(--mantine-color-dark-7)
         );
-        border-color: var(--mantine-color-indigo-8);
     }
 }
 
@@ -42,21 +39,6 @@
     &:focus-visible {
         outline: 2px solid var(--mantine-color-indigo-outline);
         outline-offset: 2px;
-    }
-}
-
-.depthAllowance {
-    padding: rem(3px) rem(6px);
-    border: 1px solid var(--mantine-color-indigo-2);
-    border-radius: var(--mantine-radius-xl);
-
-    @mixin light {
-        background-color: rgba(255, 255, 255, 0.64);
-    }
-
-    @mixin dark {
-        background-color: var(--mantine-color-dark-6);
-        border-color: var(--mantine-color-indigo-8);
     }
 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
@@ -1,19 +1,38 @@
-.drawerBody {
-    height: calc(100% - 2rem);
-}
+.root {
+    position: relative;
+    z-index: 0;
+    margin-top: rem(-12px);
+    padding: rem(24px) var(--mantine-spacing-md) var(--mantine-spacing-md);
+    border: 1px solid var(--mantine-color-indigo-2);
+    border-top: 0;
+    border-radius: 0 0 rem(18px) rem(18px);
 
-.question {
-    padding: var(--mantine-spacing-sm);
-    border-left: 3px solid var(--mantine-color-indigo-outline);
-    background: light-dark(
-        var(--mantine-color-indigo-light),
-        var(--mantine-color-indigo-light)
-    );
+    @mixin light {
+        background-color: var(--mantine-color-indigo-0);
+    }
+
+    @mixin dark {
+        background-color: color-mix(
+            in srgb,
+            var(--mantine-color-indigo-9) 28%,
+            var(--mantine-color-dark-7)
+        );
+        border-color: var(--mantine-color-indigo-8);
+    }
 }
 
 .depthCard {
     border: 1px solid var(--mantine-color-ldGray-3);
     cursor: pointer;
+
+    @mixin light {
+        background-color: rgba(255, 255, 255, 0.72);
+    }
+
+    @mixin dark {
+        background-color: var(--mantine-color-dark-6);
+        border-color: var(--mantine-color-dark-4);
+    }
 
     &[data-checked] {
         border-color: var(--mantine-color-indigo-outline);
@@ -27,11 +46,26 @@
 }
 
 .source {
-    padding: 0.35rem 0.5rem;
-    border: 1px solid var(--mantine-color-ldGray-3);
+    padding: rem(4px) rem(7px);
+    border: 1px solid var(--mantine-color-indigo-2);
     border-radius: var(--mantine-radius-sm);
+
+    @mixin light {
+        background-color: rgba(255, 255, 255, 0.56);
+    }
 
     &[data-available='false'] {
         border-style: dashed;
+    }
+}
+
+.warning {
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+}
+
+@media (max-width: 48em) {
+    .root {
+        padding-right: var(--mantine-spacing-sm);
+        padding-left: var(--mantine-spacing-sm);
     }
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
@@ -59,10 +59,6 @@
     }
 }
 
-.warning {
-    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
-}
-
 @media (max-width: 48em) {
     .root {
         padding-right: var(--mantine-spacing-sm);

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.module.css
@@ -42,12 +42,18 @@
 }
 
 .source {
-    padding: rem(3px) rem(6px);
-    border: 1px solid var(--mantine-color-indigo-2);
-    border-radius: var(--mantine-radius-sm);
+    min-height: rem(64px);
+    padding: var(--mantine-spacing-xs);
+    border: 1px solid var(--mantine-color-ldGray-3);
+    border-radius: var(--mantine-radius-md);
 
     @mixin light {
-        background-color: rgba(255, 255, 255, 0.56);
+        background-color: rgba(255, 255, 255, 0.72);
+    }
+
+    @mixin dark {
+        background-color: var(--mantine-color-dark-6);
+        border-color: var(--mantine-color-dark-4);
     }
 
     &[data-available='false'] {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -126,7 +126,7 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                             Evidence sources
                         </Text>
                         <Text size="11px" c="dimmed" lh={1.4}>
-                            Deep Research will search the available sources
+                            Deep research will search the available sources
                             shown below.
                         </Text>
                     </Stack>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -1,5 +1,4 @@
 import {
-    Alert,
     Box,
     Group,
     Radio,
@@ -8,12 +7,7 @@ import {
     Text,
     ThemeIcon,
 } from '@mantine-8/core';
-import {
-    IconAlertTriangle,
-    IconClock,
-    IconDatabase,
-    IconSearch,
-} from '@tabler/icons-react';
+import { IconClock, IconDatabase, IconSearch } from '@tabler/icons-react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { DEEP_RESEARCH_DEPTH_CONFIG } from '../../deepResearch/deepResearchAdapter';
 import {
@@ -29,8 +23,7 @@ const SOURCES: DeepResearchSource[] = [
     {
         name: 'Knowledge and connected integrations',
         isAvailable: false,
-        warning:
-            'Connected AI Agent sources are not available to Deep Research yet and will not be used for this run.',
+        warning: null,
     },
 ];
 
@@ -40,9 +33,6 @@ type Props = {
 };
 
 export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
-    const warnings = SOURCES.flatMap((source) =>
-        source.warning ? [source.warning] : [],
-    );
     const config = DEEP_RESEARCH_DEPTH_CONFIG[depth];
 
     return (
@@ -163,20 +153,6 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                             </Group>
                         ))}
                     </Group>
-                    {warnings.length > 0 && (
-                        <Alert
-                            color="yellow"
-                            variant="light"
-                            icon={<IconAlertTriangle size={15} />}
-                            className={styles.warning}
-                        >
-                            {warnings.map((warning) => (
-                                <Text key={warning} size="xs">
-                                    {warning}
-                                </Text>
-                            ))}
-                        </Alert>
-                    )}
                 </Stack>
             </Stack>
         </Box>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -53,7 +53,11 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                         </Text>
                     </Stack>
                     <Group gap="lg">
-                        <Group gap={6} wrap="nowrap">
+                        <Group
+                            gap={6}
+                            wrap="nowrap"
+                            className={styles.allowancePill}
+                        >
                             <MantineIcon
                                 icon={IconClock}
                                 size={15}
@@ -63,7 +67,11 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                                 {config.duration}
                             </Text>
                         </Group>
-                        <Group gap={6} wrap="nowrap">
+                        <Group
+                            gap={6}
+                            wrap="nowrap"
+                            className={styles.allowancePill}
+                        >
                             <MantineIcon
                                 icon={IconDatabase}
                                 size={15}

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -130,11 +130,12 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                             shown below.
                         </Text>
                     </Stack>
-                    <Group gap="xs">
+                    <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="xs">
                         {SOURCES.map((source) => (
                             <Group
                                 key={source.name}
-                                gap={6}
+                                gap="xs"
+                                wrap="nowrap"
                                 className={styles.source}
                                 data-available={source.isAvailable}
                             >
@@ -164,7 +165,7 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                                 )}
                             </Group>
                         ))}
-                    </Group>
+                    </SimpleGrid>
                 </Stack>
             </Stack>
         </Box>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -22,13 +22,6 @@ const SOURCES: DeepResearchSource[] = [
     { name: 'Public web', isAvailable: true, warning: null },
 ];
 
-const DEPTH_LABELS: Record<DeepResearchDepth, string> = {
-    quick: 'Low',
-    standard: 'Medium',
-    deep: 'High',
-    exhaustive: 'Extra High',
-};
-
 type Props = {
     depth: DeepResearchDepth;
     onDepthChange: (depth: DeepResearchDepth) => void;
@@ -78,7 +71,7 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                                         <Radio.Indicator size="xs" />
                                         <Stack gap={0}>
                                             <Text size="12px" fw={600} lh={1.3}>
-                                                {DEPTH_LABELS[option]}
+                                                {optionConfig.label}
                                             </Text>
                                             <Stack gap={5} mt={6}>
                                                 <Group gap={3} wrap="nowrap">

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -7,7 +7,7 @@ import {
     Text,
     ThemeIcon,
 } from '@mantine-8/core';
-import { IconClock, IconDatabase, IconSearch } from '@tabler/icons-react';
+import { IconDatabase, IconSearch } from '@tabler/icons-react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { DEEP_RESEARCH_DEPTH_CONFIG } from '../../deepResearch/deepResearchAdapter';
 import {
@@ -81,42 +81,11 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                                             >
                                                 {optionConfig.description}
                                             </Text>
-                                            <Group gap={4} mt={4} wrap="wrap">
-                                                <Group
-                                                    gap={4}
-                                                    wrap="nowrap"
-                                                    className={
-                                                        styles.depthAllowance
-                                                    }
-                                                >
-                                                    <MantineIcon
-                                                        icon={IconClock}
-                                                        size={11}
-                                                    />
-                                                    <Text size="9px" fw={600}>
-                                                        {optionConfig.duration}
-                                                    </Text>
-                                                </Group>
-                                                <Group
-                                                    gap={4}
-                                                    wrap="nowrap"
-                                                    className={
-                                                        styles.depthAllowance
-                                                    }
-                                                >
-                                                    <MantineIcon
-                                                        icon={IconDatabase}
-                                                        size={11}
-                                                    />
-                                                    <Text size="9px" fw={600}>
-                                                        Up to{' '}
-                                                        {
-                                                            optionConfig.warehouseQueries
-                                                        }{' '}
-                                                        queries
-                                                    </Text>
-                                                </Group>
-                                            </Group>
+                                            <Text size="10px" c="dimmed" mt={4}>
+                                                {optionConfig.duration} · Up to{' '}
+                                                {optionConfig.warehouseQueries}{' '}
+                                                queries
+                                            </Text>
                                         </Stack>
                                     </Group>
                                 </Radio.Card>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -20,11 +20,6 @@ import styles from './DeepResearchPreflight.module.css';
 const SOURCES: DeepResearchSource[] = [
     { name: 'Project data', isAvailable: true, warning: null },
     { name: 'Public web', isAvailable: true, warning: null },
-    {
-        name: 'Knowledge and connected integrations',
-        isAvailable: false,
-        warning: null,
-    },
 ];
 
 type Props = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -7,7 +7,7 @@ import {
     Text,
     ThemeIcon,
 } from '@mantine-8/core';
-import { IconDatabase, IconSearch } from '@tabler/icons-react';
+import { IconClock, IconDatabase, IconSearch } from '@tabler/icons-react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { DEEP_RESEARCH_DEPTH_CONFIG } from '../../deepResearch/deepResearchAdapter';
 import {
@@ -21,6 +21,13 @@ const SOURCES: DeepResearchSource[] = [
     { name: 'Project data', isAvailable: true, warning: null },
     { name: 'Public web', isAvailable: true, warning: null },
 ];
+
+const DEPTH_LABELS: Record<DeepResearchDepth, string> = {
+    quick: 'low',
+    standard: 'medium',
+    deep: 'high',
+    exhaustive: 'xhigh',
+};
 
 type Props = {
     depth: DeepResearchDepth;
@@ -36,10 +43,10 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
         >
             <Stack gap="md">
                 <Stack gap={2}>
-                    <Text size="sm" fw={600}>
+                    <Text size="13px" fw={600} lh={1.35}>
                         Research depth
                     </Text>
-                    <Text size="xs" c="dimmed">
+                    <Text size="11px" c="dimmed" lh={1.4}>
                         Runs in the background. You can safely leave this page.
                     </Text>
                 </Stack>
@@ -63,17 +70,48 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                                     radius="md"
                                     p="xs"
                                 >
-                                    <Group wrap="nowrap" gap="xs">
-                                        <Radio.Indicator />
+                                    <Group
+                                        wrap="nowrap"
+                                        gap="xs"
+                                        align="center"
+                                    >
+                                        <Radio.Indicator size="xs" />
                                         <Stack gap={0}>
-                                            <Text size="xs" fw={600}>
-                                                {optionConfig.label}
+                                            <Text size="12px" fw={600} lh={1.3}>
+                                                {DEPTH_LABELS[option]}
                                             </Text>
-                                            <Text size="10px" c="dimmed" mt={4}>
-                                                {optionConfig.duration} · Up to{' '}
-                                                {optionConfig.warehouseQueries}{' '}
-                                                queries
-                                            </Text>
+                                            <Group gap="xs" mt={3} wrap="wrap">
+                                                <Group gap={3} wrap="nowrap">
+                                                    <MantineIcon
+                                                        icon={IconClock}
+                                                        size={10}
+                                                    />
+                                                    <Text
+                                                        size="10px"
+                                                        c="dimmed"
+                                                        lh={1.3}
+                                                    >
+                                                        {optionConfig.duration}
+                                                    </Text>
+                                                </Group>
+                                                <Group gap={3} wrap="nowrap">
+                                                    <MantineIcon
+                                                        icon={IconDatabase}
+                                                        size={10}
+                                                    />
+                                                    <Text
+                                                        size="10px"
+                                                        c="dimmed"
+                                                        lh={1.3}
+                                                    >
+                                                        Up to{' '}
+                                                        {
+                                                            optionConfig.warehouseQueries
+                                                        }{' '}
+                                                        queries
+                                                    </Text>
+                                                </Group>
+                                            </Group>
                                         </Stack>
                                     </Group>
                                 </Radio.Card>
@@ -84,10 +122,10 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
 
                 <Stack gap="xs">
                     <Stack gap={2}>
-                        <Text size="sm" fw={600}>
+                        <Text size="13px" fw={600} lh={1.35}>
                             Evidence sources
                         </Text>
-                        <Text size="xs" c="dimmed">
+                        <Text size="11px" c="dimmed" lh={1.4}>
                             Deep Research will search the available sources
                             shown below.
                         </Text>
@@ -105,7 +143,7 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                                     color={
                                         source.isAvailable ? 'indigo' : 'gray'
                                     }
-                                    size="sm"
+                                    size={22}
                                 >
                                     <MantineIcon
                                         icon={
@@ -113,10 +151,12 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                                                 ? IconDatabase
                                                 : IconSearch
                                         }
-                                        size={13}
+                                        size={12}
                                     />
                                 </ThemeIcon>
-                                <Text size="xs">{source.name}</Text>
+                                <Text size="11px" lh={1.35}>
+                                    {source.name}
+                                </Text>
                                 {!source.isAvailable && (
                                     <Text span size="xs" c="dimmed">
                                         unavailable

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -117,9 +117,15 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                 </Radio.Group>
 
                 <Stack gap="xs">
-                    <Text size="xs" fw={600} c="dimmed">
-                        Evidence sources
-                    </Text>
+                    <Stack gap={2}>
+                        <Text size="sm" fw={600}>
+                            Evidence sources
+                        </Text>
+                        <Text size="xs" c="dimmed">
+                            Deep Research will search the available sources
+                            shown below.
+                        </Text>
+                    </Stack>
                     <Group gap="xs">
                         {SOURCES.map((source) => (
                             <Group

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -80,7 +80,7 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                                             <Text size="12px" fw={600} lh={1.3}>
                                                 {DEPTH_LABELS[option]}
                                             </Text>
-                                            <Stack gap={2} mt={6}>
+                                            <Stack gap={5} mt={6}>
                                                 <Group gap={3} wrap="nowrap">
                                                     <MantineIcon
                                                         icon={IconClock}

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -130,12 +130,11 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                             shown below.
                         </Text>
                     </Stack>
-                    <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="xs">
+                    <Group gap="xs">
                         {SOURCES.map((source) => (
                             <Group
                                 key={source.name}
-                                gap="xs"
-                                wrap="nowrap"
+                                gap={6}
                                 className={styles.source}
                                 data-available={source.isAvailable}
                             >
@@ -165,7 +164,7 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                                 )}
                             </Group>
                         ))}
-                    </SimpleGrid>
+                    </Group>
                 </Stack>
             </Stack>
         </Box>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -1,0 +1,237 @@
+import {
+    Alert,
+    Button,
+    Divider,
+    Drawer,
+    Group,
+    Radio,
+    SimpleGrid,
+    Stack,
+    Text,
+    ThemeIcon,
+} from '@mantine-8/core';
+import { useMediaQuery } from '@mantine-8/hooks';
+import {
+    IconAlertTriangle,
+    IconClock,
+    IconDatabase,
+    IconSearch,
+} from '@tabler/icons-react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { DEEP_RESEARCH_DEPTH_CONFIG } from '../../deepResearch/deepResearchAdapter';
+import {
+    DEEP_RESEARCH_DEPTHS,
+    type DeepResearchDepth,
+    type DeepResearchSource,
+} from '../../deepResearch/types';
+import styles from './DeepResearchPreflight.module.css';
+
+const SOURCES: DeepResearchSource[] = [
+    { name: 'Project data', isAvailable: true, warning: null },
+    { name: 'Public web', isAvailable: true, warning: null },
+    {
+        name: 'Knowledge and connected integrations',
+        isAvailable: false,
+        warning:
+            'Connected AI Agent sources are not available to Deep Research yet and will not be used for this run.',
+    },
+];
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    question: string;
+    depth: DeepResearchDepth;
+    onDepthChange: (depth: DeepResearchDepth) => void;
+    onStart: () => void;
+    isStarting: boolean;
+    projectUuid?: string;
+    agentUuid?: string;
+};
+
+export const DeepResearchPreflight = ({
+    opened,
+    onClose,
+    question,
+    depth,
+    onDepthChange,
+    onStart,
+    isStarting,
+    projectUuid: _projectUuid,
+    agentUuid: _agentUuid,
+}: Props) => {
+    const isNarrow = useMediaQuery('(max-width: 48em)');
+    const sources = SOURCES;
+    const warnings = sources.flatMap((source) =>
+        source.warning ? [source.warning] : [],
+    );
+    const config = DEEP_RESEARCH_DEPTH_CONFIG[depth];
+
+    return (
+        <Drawer
+            opened={opened}
+            onClose={onClose}
+            title="Deep research"
+            position={isNarrow ? 'bottom' : 'right'}
+            size={isNarrow ? '92%' : 440}
+            padding="lg"
+            classNames={{ body: styles.drawerBody }}
+        >
+            <Stack gap="lg" h="100%">
+                <Stack gap="xs">
+                    <Text size="sm" c="dimmed">
+                        Research runs in the background. You can leave this page
+                        and return to the report later.
+                    </Text>
+                    <Text size="sm" fw={600}>
+                        Question
+                    </Text>
+                    <Text size="sm" className={styles.question}>
+                        {question || 'Write a question in the composer first.'}
+                    </Text>
+                </Stack>
+
+                <Stack gap="xs">
+                    <Text size="sm" fw={600}>
+                        Research depth
+                    </Text>
+                    <Radio.Group
+                        value={depth}
+                        onChange={(value) =>
+                            onDepthChange(value as DeepResearchDepth)
+                        }
+                        aria-label="Research depth"
+                    >
+                        <SimpleGrid cols={2} spacing="xs">
+                            {DEEP_RESEARCH_DEPTHS.map((option) => {
+                                const optionConfig =
+                                    DEEP_RESEARCH_DEPTH_CONFIG[option];
+                                return (
+                                    <Radio.Card
+                                        key={option}
+                                        value={option}
+                                        className={styles.depthCard}
+                                        radius="md"
+                                        p="sm"
+                                    >
+                                        <Group wrap="nowrap" align="flex-start">
+                                            <Radio.Indicator />
+                                            <Stack gap={2}>
+                                                <Text size="sm" fw={600}>
+                                                    {optionConfig.label}
+                                                </Text>
+                                                <Text size="xs" c="dimmed">
+                                                    {optionConfig.description}
+                                                </Text>
+                                            </Stack>
+                                        </Group>
+                                    </Radio.Card>
+                                );
+                            })}
+                        </SimpleGrid>
+                    </Radio.Group>
+                </Stack>
+
+                <Stack gap="xs">
+                    <Text size="sm" fw={600}>
+                        Included evidence
+                    </Text>
+                    <Group gap="xs">
+                        {sources.map((source) => (
+                            <Group
+                                key={source.name}
+                                gap={6}
+                                className={styles.source}
+                                data-available={source.isAvailable}
+                            >
+                                <ThemeIcon
+                                    variant="light"
+                                    color={
+                                        source.isAvailable ? 'indigo' : 'gray'
+                                    }
+                                    size="sm"
+                                >
+                                    <MantineIcon
+                                        icon={
+                                            source.name === 'Project data'
+                                                ? IconDatabase
+                                                : IconSearch
+                                        }
+                                        size={13}
+                                    />
+                                </ThemeIcon>
+                                <Text size="xs">{source.name}</Text>
+                                {!source.isAvailable && (
+                                    <Text span size="xs" c="dimmed">
+                                        unavailable
+                                    </Text>
+                                )}
+                            </Group>
+                        ))}
+                    </Group>
+                    {warnings.length > 0 && (
+                        <Alert
+                            color="yellow"
+                            variant="light"
+                            icon={<IconAlertTriangle size={16} />}
+                        >
+                            <Stack gap={4}>
+                                {warnings.map((warning) => (
+                                    <Text key={warning} size="xs">
+                                        {warning}
+                                    </Text>
+                                ))}
+                            </Stack>
+                        </Alert>
+                    )}
+                </Stack>
+
+                <Divider />
+
+                <SimpleGrid cols={2} spacing="md">
+                    <Group wrap="nowrap" align="flex-start">
+                        <MantineIcon
+                            icon={IconClock}
+                            size={18}
+                            color="indigo.5"
+                        />
+                        <Stack gap={1}>
+                            <Text size="xs" c="dimmed">
+                                Estimated duration
+                            </Text>
+                            <Text size="sm" fw={600}>
+                                {config.duration}
+                            </Text>
+                        </Stack>
+                    </Group>
+                    <Group wrap="nowrap" align="flex-start">
+                        <MantineIcon
+                            icon={IconDatabase}
+                            size={18}
+                            color="indigo.5"
+                        />
+                        <Stack gap={1}>
+                            <Text size="xs" c="dimmed">
+                                Warehouse allowance
+                            </Text>
+                            <Text size="sm" fw={600}>
+                                Up to {config.warehouseQueries} queries
+                            </Text>
+                        </Stack>
+                    </Group>
+                </SimpleGrid>
+
+                <Button
+                    mt="auto"
+                    fullWidth
+                    leftSection={<IconSearch size={16} />}
+                    disabled={!question.trim()}
+                    loading={isStarting}
+                    onClick={onStart}
+                >
+                    Start research
+                </Button>
+            </Stack>
+        </Drawer>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -1,8 +1,6 @@
 import {
     Alert,
-    Button,
-    Divider,
-    Drawer,
+    Box,
     Group,
     Radio,
     SimpleGrid,
@@ -10,7 +8,6 @@ import {
     Text,
     ThemeIcon,
 } from '@mantine-8/core';
-import { useMediaQuery } from '@mantine-8/hooks';
 import {
     IconAlertTriangle,
     IconClock,
@@ -38,106 +35,103 @@ const SOURCES: DeepResearchSource[] = [
 ];
 
 type Props = {
-    opened: boolean;
-    onClose: () => void;
-    question: string;
     depth: DeepResearchDepth;
     onDepthChange: (depth: DeepResearchDepth) => void;
-    onStart: () => void;
-    isStarting: boolean;
-    projectUuid?: string;
-    agentUuid?: string;
 };
 
-export const DeepResearchPreflight = ({
-    opened,
-    onClose,
-    question,
-    depth,
-    onDepthChange,
-    onStart,
-    isStarting,
-    projectUuid: _projectUuid,
-    agentUuid: _agentUuid,
-}: Props) => {
-    const isNarrow = useMediaQuery('(max-width: 48em)');
-    const sources = SOURCES;
-    const warnings = sources.flatMap((source) =>
+export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
+    const warnings = SOURCES.flatMap((source) =>
         source.warning ? [source.warning] : [],
     );
     const config = DEEP_RESEARCH_DEPTH_CONFIG[depth];
 
     return (
-        <Drawer
-            opened={opened}
-            onClose={onClose}
-            title="Deep research"
-            position={isNarrow ? 'bottom' : 'right'}
-            size={isNarrow ? '92%' : 440}
-            padding="lg"
-            classNames={{ body: styles.drawerBody }}
+        <Box
+            className={styles.root}
+            role="region"
+            aria-label="Deep research settings"
         >
-            <Stack gap="lg" h="100%">
-                <Stack gap="xs">
-                    <Text size="sm" c="dimmed">
-                        Research runs in the background. You can leave this page
-                        and return to the report later.
-                    </Text>
-                    <Text size="sm" fw={600}>
-                        Question
-                    </Text>
-                    <Text size="sm" className={styles.question}>
-                        {question || 'Write a question in the composer first.'}
-                    </Text>
-                </Stack>
+            <Stack gap="md">
+                <Group justify="space-between" align="flex-start" wrap="wrap">
+                    <Stack gap={2}>
+                        <Text size="sm" fw={600}>
+                            Research depth
+                        </Text>
+                        <Text size="xs" c="dimmed">
+                            Runs in the background. You can safely leave this
+                            page.
+                        </Text>
+                    </Stack>
+                    <Group gap="lg">
+                        <Group gap={6} wrap="nowrap">
+                            <MantineIcon
+                                icon={IconClock}
+                                size={15}
+                                color="indigo.5"
+                            />
+                            <Text size="xs" fw={600}>
+                                {config.duration}
+                            </Text>
+                        </Group>
+                        <Group gap={6} wrap="nowrap">
+                            <MantineIcon
+                                icon={IconDatabase}
+                                size={15}
+                                color="indigo.5"
+                            />
+                            <Text size="xs" fw={600}>
+                                Up to {config.warehouseQueries} queries
+                            </Text>
+                        </Group>
+                    </Group>
+                </Group>
+
+                <Radio.Group
+                    value={depth}
+                    onChange={(value) =>
+                        onDepthChange(value as DeepResearchDepth)
+                    }
+                    aria-label="Research depth"
+                >
+                    <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="xs">
+                        {DEEP_RESEARCH_DEPTHS.map((option) => {
+                            const optionConfig =
+                                DEEP_RESEARCH_DEPTH_CONFIG[option];
+                            return (
+                                <Radio.Card
+                                    key={option}
+                                    value={option}
+                                    className={styles.depthCard}
+                                    radius="md"
+                                    p="xs"
+                                >
+                                    <Group wrap="nowrap" gap="xs">
+                                        <Radio.Indicator />
+                                        <Stack gap={0}>
+                                            <Text size="xs" fw={600}>
+                                                {optionConfig.label}
+                                            </Text>
+                                            <Text
+                                                size="10px"
+                                                c="dimmed"
+                                                lineClamp={1}
+                                            >
+                                                {optionConfig.description}
+                                            </Text>
+                                        </Stack>
+                                    </Group>
+                                </Radio.Card>
+                            );
+                        })}
+                    </SimpleGrid>
+                </Radio.Group>
 
                 <Stack gap="xs">
-                    <Text size="sm" fw={600}>
-                        Research depth
-                    </Text>
-                    <Radio.Group
-                        value={depth}
-                        onChange={(value) =>
-                            onDepthChange(value as DeepResearchDepth)
-                        }
-                        aria-label="Research depth"
-                    >
-                        <SimpleGrid cols={2} spacing="xs">
-                            {DEEP_RESEARCH_DEPTHS.map((option) => {
-                                const optionConfig =
-                                    DEEP_RESEARCH_DEPTH_CONFIG[option];
-                                return (
-                                    <Radio.Card
-                                        key={option}
-                                        value={option}
-                                        className={styles.depthCard}
-                                        radius="md"
-                                        p="sm"
-                                    >
-                                        <Group wrap="nowrap" align="flex-start">
-                                            <Radio.Indicator />
-                                            <Stack gap={2}>
-                                                <Text size="sm" fw={600}>
-                                                    {optionConfig.label}
-                                                </Text>
-                                                <Text size="xs" c="dimmed">
-                                                    {optionConfig.description}
-                                                </Text>
-                                            </Stack>
-                                        </Group>
-                                    </Radio.Card>
-                                );
-                            })}
-                        </SimpleGrid>
-                    </Radio.Group>
-                </Stack>
-
-                <Stack gap="xs">
-                    <Text size="sm" fw={600}>
-                        Included evidence
+                    <Text size="xs" fw={600} c="dimmed">
+                        Evidence sources
                     </Text>
                     <Group gap="xs">
-                        {sources.map((source) => (
+                        {SOURCES.map((source) => (
                             <Group
                                 key={source.name}
                                 gap={6}
@@ -173,65 +167,18 @@ export const DeepResearchPreflight = ({
                         <Alert
                             color="yellow"
                             variant="light"
-                            icon={<IconAlertTriangle size={16} />}
+                            icon={<IconAlertTriangle size={15} />}
+                            className={styles.warning}
                         >
-                            <Stack gap={4}>
-                                {warnings.map((warning) => (
-                                    <Text key={warning} size="xs">
-                                        {warning}
-                                    </Text>
-                                ))}
-                            </Stack>
+                            {warnings.map((warning) => (
+                                <Text key={warning} size="xs">
+                                    {warning}
+                                </Text>
+                            ))}
                         </Alert>
                     )}
                 </Stack>
-
-                <Divider />
-
-                <SimpleGrid cols={2} spacing="md">
-                    <Group wrap="nowrap" align="flex-start">
-                        <MantineIcon
-                            icon={IconClock}
-                            size={18}
-                            color="indigo.5"
-                        />
-                        <Stack gap={1}>
-                            <Text size="xs" c="dimmed">
-                                Estimated duration
-                            </Text>
-                            <Text size="sm" fw={600}>
-                                {config.duration}
-                            </Text>
-                        </Stack>
-                    </Group>
-                    <Group wrap="nowrap" align="flex-start">
-                        <MantineIcon
-                            icon={IconDatabase}
-                            size={18}
-                            color="indigo.5"
-                        />
-                        <Stack gap={1}>
-                            <Text size="xs" c="dimmed">
-                                Warehouse allowance
-                            </Text>
-                            <Text size="sm" fw={600}>
-                                Up to {config.warehouseQueries} queries
-                            </Text>
-                        </Stack>
-                    </Group>
-                </SimpleGrid>
-
-                <Button
-                    mt="auto"
-                    fullWidth
-                    leftSection={<IconSearch size={16} />}
-                    disabled={!question.trim()}
-                    loading={isStarting}
-                    onClick={onStart}
-                >
-                    Start research
-                </Button>
             </Stack>
-        </Drawer>
+        </Box>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -23,10 +23,10 @@ const SOURCES: DeepResearchSource[] = [
 ];
 
 const DEPTH_LABELS: Record<DeepResearchDepth, string> = {
-    quick: 'low',
-    standard: 'medium',
-    deep: 'high',
-    exhaustive: 'xhigh',
+    quick: 'Low',
+    standard: 'Medium',
+    deep: 'High',
+    exhaustive: 'Extra High',
 };
 
 type Props = {
@@ -80,7 +80,7 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                                             <Text size="12px" fw={600} lh={1.3}>
                                                 {DEPTH_LABELS[option]}
                                             </Text>
-                                            <Group gap="xs" mt={3} wrap="wrap">
+                                            <Stack gap={2} mt={6}>
                                                 <Group gap={3} wrap="nowrap">
                                                     <MantineIcon
                                                         icon={IconClock}
@@ -111,7 +111,7 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                                                         queries
                                                     </Text>
                                                 </Group>
-                                            </Group>
+                                            </Stack>
                                         </Stack>
                                     </Group>
                                 </Radio.Card>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -69,13 +69,6 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                                             <Text size="xs" fw={600}>
                                                 {optionConfig.label}
                                             </Text>
-                                            <Text
-                                                size="10px"
-                                                c="dimmed"
-                                                lineClamp={1}
-                                            >
-                                                {optionConfig.description}
-                                            </Text>
                                             <Text size="10px" c="dimmed" mt={4}>
                                                 {optionConfig.duration} · Up to{' '}
                                                 {optionConfig.warehouseQueries}{' '}

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchPreflight.tsx
@@ -33,8 +33,6 @@ type Props = {
 };
 
 export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
-    const config = DEEP_RESEARCH_DEPTH_CONFIG[depth];
-
     return (
         <Box
             className={styles.root}
@@ -42,47 +40,14 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
             aria-label="Deep research settings"
         >
             <Stack gap="md">
-                <Group justify="space-between" align="flex-start" wrap="wrap">
-                    <Stack gap={2}>
-                        <Text size="sm" fw={600}>
-                            Research depth
-                        </Text>
-                        <Text size="xs" c="dimmed">
-                            Runs in the background. You can safely leave this
-                            page.
-                        </Text>
-                    </Stack>
-                    <Group gap="lg">
-                        <Group
-                            gap={6}
-                            wrap="nowrap"
-                            className={styles.allowancePill}
-                        >
-                            <MantineIcon
-                                icon={IconClock}
-                                size={15}
-                                color="indigo.5"
-                            />
-                            <Text size="xs" fw={600}>
-                                {config.duration}
-                            </Text>
-                        </Group>
-                        <Group
-                            gap={6}
-                            wrap="nowrap"
-                            className={styles.allowancePill}
-                        >
-                            <MantineIcon
-                                icon={IconDatabase}
-                                size={15}
-                                color="indigo.5"
-                            />
-                            <Text size="xs" fw={600}>
-                                Up to {config.warehouseQueries} queries
-                            </Text>
-                        </Group>
-                    </Group>
-                </Group>
+                <Stack gap={2}>
+                    <Text size="sm" fw={600}>
+                        Research depth
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                        Runs in the background. You can safely leave this page.
+                    </Text>
+                </Stack>
 
                 <Radio.Group
                     value={depth}
@@ -116,6 +81,42 @@ export const DeepResearchPreflight = ({ depth, onDepthChange }: Props) => {
                                             >
                                                 {optionConfig.description}
                                             </Text>
+                                            <Group gap={4} mt={4} wrap="wrap">
+                                                <Group
+                                                    gap={4}
+                                                    wrap="nowrap"
+                                                    className={
+                                                        styles.depthAllowance
+                                                    }
+                                                >
+                                                    <MantineIcon
+                                                        icon={IconClock}
+                                                        size={11}
+                                                    />
+                                                    <Text size="9px" fw={600}>
+                                                        {optionConfig.duration}
+                                                    </Text>
+                                                </Group>
+                                                <Group
+                                                    gap={4}
+                                                    wrap="nowrap"
+                                                    className={
+                                                        styles.depthAllowance
+                                                    }
+                                                >
+                                                    <MantineIcon
+                                                        icon={IconDatabase}
+                                                        size={11}
+                                                    />
+                                                    <Text size="9px" fw={600}>
+                                                        Up to{' '}
+                                                        {
+                                                            optionConfig.warehouseQueries
+                                                        }{' '}
+                                                        queries
+                                                    </Text>
+                                                </Group>
+                                            </Group>
                                         </Stack>
                                     </Group>
                                 </Radio.Card>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
@@ -1,45 +1,96 @@
-.workspace {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 22rem;
-    height: calc(100vh - 3.75rem);
-    overflow: hidden;
-
-    @media (max-width: 62em) {
-        grid-template-columns: minmax(0, 1fr);
-    }
-}
-
 .reportScroll {
-    min-width: 0;
+    height: calc(100vh - 3.75rem);
 }
 
 .report {
-    width: min(100%, 52rem);
+    width: min(100%, 46rem);
     margin-inline: auto;
-    padding: clamp(1.25rem, 4vw, 3.5rem);
+    padding: clamp(1.5rem, 5vw, 4rem) clamp(1.25rem, 4vw, 3rem) 6rem;
+}
+
+.reportHeader {
+    display: grid;
+    gap: var(--mantine-spacing-sm);
+}
+
+.eyebrow {
+    color: var(--mantine-color-indigo-light-color);
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.055em;
+    line-height: 1.35;
+    text-transform: uppercase;
+}
+
+.reportTitle {
+    max-width: 38rem;
+    font-size: clamp(1.45rem, 3vw, 1.85rem);
+    font-weight: 650;
+    letter-spacing: -0.025em;
+    line-height: 1.2;
+}
+
+.executiveAnswer {
+    max-width: 43rem;
+    color: var(--mantine-color-text);
+    font-size: 0.9375rem;
+    line-height: 1.7;
+}
+
+.section {
+    display: grid;
+    gap: var(--mantine-spacing-sm);
+}
+
+.sectionTitle {
+    font-size: 0.9375rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    line-height: 1.35;
+}
+
+.sectionIntro,
+.caption {
+    color: var(--mantine-color-dimmed);
+    font-size: 0.6875rem;
+    line-height: 1.45;
+}
+
+.bodyText {
+    font-size: 0.8125rem;
+    line-height: 1.7;
 }
 
 .finding {
-    border: 1px solid var(--mantine-color-ldGray-3);
-    border-left: 3px solid var(--mantine-color-indigo-outline);
+    display: grid;
+    gap: 0.4rem;
+    padding-block: 1rem;
+    border-top: 1px solid var(--mantine-color-ldGray-3);
+}
+
+.findingTitle,
+.evidenceTitle {
+    font-size: 0.8125rem;
+    font-weight: 650;
+    line-height: 1.45;
 }
 
 .marker {
-    display: inline-grid;
-    width: 1.75rem;
-    height: 1.75rem;
-    padding: 0;
-    place-items: center;
-    border: 1px solid var(--mantine-color-indigo-outline);
-    border-radius: 999px;
+    padding: 0.05rem 0.15rem;
+    border: 0;
+    border-radius: var(--mantine-radius-xs);
     color: var(--mantine-color-indigo-light-color);
-    background: var(--mantine-color-indigo-light);
-    font: 700 var(--mantine-font-size-xs) var(--mantine-font-family-monospace);
+    background: transparent;
+    font: 650 0.6875rem/1.3 var(--mantine-font-family-monospace);
     cursor: pointer;
 
     &[data-selected='true'] {
-        color: var(--mantine-color-white);
-        background: var(--mantine-color-indigo-filled);
+        background: var(--mantine-color-indigo-light);
+    }
+
+    &:hover {
+        text-decoration: underline;
+        text-underline-offset: 2px;
     }
 
     &:focus-visible {
@@ -48,25 +99,79 @@
     }
 }
 
-.evidenceRail {
-    min-width: 0;
+.list {
+    display: grid;
+    gap: 0.4rem;
+    margin: 0;
+    padding-inline-start: 1.1rem;
+}
+
+.evidenceList {
+    display: grid;
+    gap: 0;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.evidenceItem {
+    display: grid;
+    grid-template-columns: 1.5rem minmax(0, 1fr);
+    gap: var(--mantine-spacing-sm);
+    padding-block: 1rem;
+    border-top: 1px solid var(--mantine-color-ldGray-3);
+    scroll-margin-top: 1.5rem;
+
+    &[data-selected='true'] {
+        border-top-color: var(--mantine-color-indigo-outline);
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--mantine-color-indigo-outline);
+        outline-offset: 4px;
+    }
+}
+
+.evidenceNumber {
+    color: var(--mantine-color-indigo-light-color);
+    font: 700 0.6875rem/1.4 var(--mantine-font-family-monospace);
+}
+
+.queryDetails {
+    padding-left: var(--mantine-spacing-sm);
     border-left: 1px solid var(--mantine-color-ldGray-3);
-    background: light-dark(
-        var(--mantine-color-ldGray-0),
-        var(--mantine-color-ldDark-7)
-    );
 }
 
 .reference {
     overflow-wrap: anywhere;
+    color: var(--mantine-color-dimmed);
+    font-size: 0.6875rem;
+    line-height: 1.45;
 }
 
-.actions {
-    position: sticky;
-    bottom: 0;
-    padding-block: var(--mantine-spacing-md);
-    border-top: 1px solid var(--mantine-color-ldGray-3);
-    background: var(--mantine-color-body);
+@media (max-width: 36em) {
+    .report {
+        padding-inline: 1rem;
+    }
+
+    .evidenceItem {
+        grid-template-columns: 1.25rem minmax(0, 1fr);
+    }
+}
+
+@media print {
+    .reportScroll {
+        height: auto;
+    }
+
+    .report {
+        width: 100%;
+        padding: 0;
+    }
+
+    .marker {
+        color: inherit;
+    }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
@@ -1,0 +1,76 @@
+.workspace {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 22rem;
+    height: calc(100vh - 3.75rem);
+    overflow: hidden;
+
+    @media (max-width: 62em) {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+.reportScroll {
+    min-width: 0;
+}
+
+.report {
+    width: min(100%, 52rem);
+    margin-inline: auto;
+    padding: clamp(1.25rem, 4vw, 3.5rem);
+}
+
+.finding {
+    border: 1px solid var(--mantine-color-ldGray-3);
+    border-left: 3px solid var(--mantine-color-indigo-outline);
+}
+
+.marker {
+    display: inline-grid;
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+    place-items: center;
+    border: 1px solid var(--mantine-color-indigo-outline);
+    border-radius: 999px;
+    color: var(--mantine-color-indigo-light-color);
+    background: var(--mantine-color-indigo-light);
+    font: 700 var(--mantine-font-size-xs) var(--mantine-font-family-monospace);
+    cursor: pointer;
+
+    &[data-selected='true'] {
+        color: var(--mantine-color-white);
+        background: var(--mantine-color-indigo-filled);
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--mantine-color-indigo-outline);
+        outline-offset: 2px;
+    }
+}
+
+.evidenceRail {
+    min-width: 0;
+    border-left: 1px solid var(--mantine-color-ldGray-3);
+    background: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-7)
+    );
+}
+
+.reference {
+    overflow-wrap: anywhere;
+}
+
+.actions {
+    position: sticky;
+    bottom: 0;
+    padding-block: var(--mantine-spacing-md);
+    border-top: 1px solid var(--mantine-color-ldGray-3);
+    background: var(--mantine-color-body);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .marker {
+        transition: none;
+    }
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
@@ -1,29 +1,15 @@
-.workspace {
-    display: flex;
-    height: 100%;
-    flex-direction: column;
-    pointer-events: auto;
-    background: light-dark(
-        var(--mantine-color-white),
-        var(--mantine-color-dark-8)
-    );
-}
-
-.workspaceHeader {
-    display: flex;
-    flex-shrink: 0;
-    justify-content: flex-end;
-    padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
+.drawerInner,
+.drawerOverlay {
+    top: var(--drawer-top-offset, 0);
+    height: calc(100% - var(--drawer-top-offset, 0));
 }
 
 .reportScroll {
-    flex: 1;
-    min-height: 0;
+    height: calc(100dvh - var(--navbar-height) - 3.75rem);
 }
 
 .report {
-    width: min(100%, 46rem);
-    margin-inline: auto;
+    width: 100%;
     padding: clamp(1.5rem, 5vw, 4rem) clamp(1.25rem, 4vw, 3rem) 6rem;
 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
@@ -9,8 +9,21 @@
 }
 
 .report {
-    width: 100%;
-    padding: clamp(1.5rem, 5vw, 4rem) clamp(1.25rem, 4vw, 3rem) 6rem;
+    width: min(100%, 46rem);
+    margin-inline: auto;
+    padding: var(--mantine-spacing-lg) clamp(1.25rem, 4vw, 3rem) 6rem;
+}
+
+.visuallyHidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 .reportHeader {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
@@ -1,11 +1,24 @@
-.drawerInner,
-.drawerOverlay {
-    top: var(--drawer-top-offset, 0);
-    height: calc(100% - var(--drawer-top-offset, 0));
+.workspace {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+    pointer-events: auto;
+    background: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-8)
+    );
+}
+
+.workspaceHeader {
+    display: flex;
+    flex-shrink: 0;
+    justify-content: flex-end;
+    padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
 }
 
 .reportScroll {
-    height: calc(100dvh - var(--navbar-height) - 3.75rem);
+    flex: 1;
+    min-height: 0;
 }
 
 .report {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
@@ -1,5 +1,11 @@
+.drawerInner,
+.drawerOverlay {
+    top: var(--drawer-top-offset, 0);
+    height: calc(100% - var(--drawer-top-offset, 0));
+}
+
 .reportScroll {
-    height: calc(100vh - 3.75rem);
+    height: calc(100dvh - var(--navbar-height) - 3.75rem);
 }
 
 .report {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
@@ -33,7 +33,7 @@
 .executiveAnswer {
     max-width: 43rem;
     color: var(--mantine-color-text);
-    font-size: 0.9375rem;
+    font-size: 0.875rem;
     line-height: 1.7;
 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
@@ -4,6 +4,20 @@
     height: calc(100% - var(--drawer-top-offset, 0));
 }
 
+.drawerHeader {
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.drawerTitle {
+    width: 100%;
+}
+
+.reportControls {
+    width: min(100%, 46rem);
+    margin-inline: auto;
+    padding-inline: clamp(1.25rem, 4vw, 3rem);
+}
+
 .reportScroll {
     height: calc(100dvh - var(--navbar-height) - 3.75rem);
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
@@ -65,7 +65,6 @@
     display: grid;
     gap: 0.4rem;
     padding-block: 1rem;
-    border-top: 1px solid var(--mantine-color-ldGray-3);
 }
 
 .findingTitle,
@@ -119,17 +118,17 @@
     grid-template-columns: 1.5rem minmax(0, 1fr);
     gap: var(--mantine-spacing-sm);
     padding-block: 1rem;
-    border-top: 1px solid var(--mantine-color-ldGray-3);
     scroll-margin-top: 1.5rem;
-
-    &[data-selected='true'] {
-        border-top-color: var(--mantine-color-indigo-outline);
-    }
 
     &:focus-visible {
         outline: 2px solid var(--mantine-color-indigo-outline);
         outline-offset: 4px;
     }
+}
+
+.queryDetails {
+    padding-left: var(--mantine-spacing-sm);
+    border-left: 1px solid var(--mantine-color-ldGray-3);
 }
 
 .evidenceNumber {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.module.css
@@ -137,11 +137,6 @@
     font: 700 0.6875rem/1.4 var(--mantine-font-family-monospace);
 }
 
-.queryDetails {
-    padding-left: var(--mantine-spacing-sm);
-    border-left: 1px solid var(--mantine-color-ldGray-3);
-}
-
 .reference {
     overflow-wrap: anywhere;
     color: var(--mantine-color-dimmed);

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
@@ -6,7 +6,7 @@ import { deepResearchRunFixture } from '../../deepResearch/fixtures';
 import { DeepResearchReport } from './DeepResearchReport';
 
 describe('DeepResearchReport', () => {
-    it('shows Lightdash branding and closes from the report header', async () => {
+    it('returns to chat from the report header', async () => {
         const user = userEvent.setup();
         const onClose = vi.fn();
         renderWithProviders(
@@ -17,8 +17,7 @@ describe('DeepResearchReport', () => {
             />,
         );
 
-        expect(screen.getByRole('img', { name: 'Lightdash' })).toBeVisible();
-        await user.click(screen.getByRole('button', { name: 'Close' }));
+        await user.click(screen.getByRole('button', { name: 'Back to chat' }));
         expect(onClose).toHaveBeenCalledOnce();
     });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
@@ -5,17 +5,23 @@ import { renderWithProviders } from '../../../../../testing/testUtils';
 import { deepResearchRunFixture } from '../../deepResearch/fixtures';
 import { DeepResearchReport } from './DeepResearchReport';
 
-describe('DeepResearchReport', () => {
-    it('returns to chat from the report header', async () => {
-        const user = userEvent.setup();
-        const onClose = vi.fn();
-        renderWithProviders(
+const renderReport = (onClose = vi.fn()) =>
+    renderWithProviders(
+        <>
+            <div data-deep-research-report-target />
             <DeepResearchReport
                 run={deepResearchRunFixture}
                 opened
                 onClose={onClose}
-            />,
-        );
+            />
+        </>,
+    );
+
+describe('DeepResearchReport', () => {
+    it('returns to chat from the report header', async () => {
+        const user = userEvent.setup();
+        const onClose = vi.fn();
+        renderReport(onClose);
 
         await user.click(screen.getByRole('button', { name: 'Back to chat' }));
         expect(onClose).toHaveBeenCalledOnce();
@@ -23,13 +29,7 @@ describe('DeepResearchReport', () => {
 
     it('navigates from a claim marker to its supporting query', async () => {
         const user = userEvent.setup();
-        renderWithProviders(
-            <DeepResearchReport
-                run={deepResearchRunFixture}
-                opened
-                onClose={vi.fn()}
-            />,
-        );
+        renderReport();
 
         const marker = screen.getByRole('button', {
             name: /Evidence 1: Enterprise renewal cohort/i,
@@ -56,13 +56,7 @@ describe('DeepResearchReport', () => {
     });
 
     it('supports keyboard navigation between evidence markers', () => {
-        renderWithProviders(
-            <DeepResearchReport
-                run={deepResearchRunFixture}
-                opened
-                onClose={vi.fn()}
-            />,
-        );
+        renderReport();
 
         const firstMarker = screen.getByRole('button', {
             name: /Evidence 1: Enterprise renewal cohort/i,

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
@@ -7,14 +7,11 @@ import { DeepResearchReport } from './DeepResearchReport';
 
 const renderReport = (onClose = vi.fn()) =>
     renderWithProviders(
-        <>
-            <div data-deep-research-report-target />
-            <DeepResearchReport
-                run={deepResearchRunFixture}
-                opened
-                onClose={onClose}
-            />
-        </>,
+        <DeepResearchReport
+            run={deepResearchRunFixture}
+            opened
+            onClose={onClose}
+        />,
     );
 
 describe('DeepResearchReport', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
@@ -6,6 +6,22 @@ import { deepResearchRunFixture } from '../../deepResearch/fixtures';
 import { DeepResearchReport } from './DeepResearchReport';
 
 describe('DeepResearchReport', () => {
+    it('shows Lightdash branding and closes from the report header', async () => {
+        const user = userEvent.setup();
+        const onClose = vi.fn();
+        renderWithProviders(
+            <DeepResearchReport
+                run={deepResearchRunFixture}
+                opened
+                onClose={onClose}
+            />,
+        );
+
+        expect(screen.getByRole('img', { name: 'Lightdash' })).toBeVisible();
+        await user.click(screen.getByRole('button', { name: 'Close' }));
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+
     it('navigates from a claim marker to its supporting query', async () => {
         const user = userEvent.setup();
         renderWithProviders(

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../../testing/testUtils';
@@ -22,13 +22,21 @@ describe('DeepResearchReport', () => {
         await user.click(marker);
 
         expect(marker).toHaveAttribute('aria-pressed', 'true');
-        expect(screen.getByTestId('evidence-detail')).toHaveTextContent(
+        const evidence = screen.getByTestId(
+            'evidence-detail-evidence-retention-query',
+        );
+        await waitFor(() => expect(evidence).toHaveFocus());
+        expect(evidence).toHaveTextContent(
             '7c4b40ba-79f8-4fd2-9c43-223eca8fa76f',
         );
-        expect(screen.getByText(/Renewed ARR/)).toBeInTheDocument();
-        expect(screen.getByText(/Segment is Enterprise/)).toBeInTheDocument();
+        expect(within(evidence).getByText(/Renewed ARR/)).toBeInTheDocument();
         expect(
-            screen.getByRole('link', { name: 'Open in Lightdash' }),
+            within(evidence).getByText(/Segment is Enterprise/),
+        ).toBeInTheDocument();
+        expect(
+            within(evidence).getByRole('link', {
+                name: 'Open in Lightdash',
+            }),
         ).toBeInTheDocument();
     });
 
@@ -52,39 +60,8 @@ describe('DeepResearchReport', () => {
         });
         expect(secondMarker).toHaveFocus();
         expect(secondMarker).toHaveAttribute('aria-pressed', 'true');
-        expect(screen.getByTestId('evidence-detail')).toHaveTextContent(
-            'Q2 enterprise incident review',
-        );
-    });
-
-    it('runs the report actions', async () => {
-        const user = userEvent.setup();
-        const onFollowUp = vi.fn();
-        const onChallenge = vi.fn();
-        const onRerun = vi.fn();
-        renderWithProviders(
-            <DeepResearchReport
-                run={deepResearchRunFixture}
-                opened
-                onClose={vi.fn()}
-                onAskFollowUp={onFollowUp}
-                onChallenge={onChallenge}
-                onRerun={onRerun}
-            />,
-        );
-
-        await user.click(
-            screen.getByRole('button', { name: 'Ask a follow-up' }),
-        );
-        await user.click(
-            screen.getByRole('button', { name: 'Challenge this finding' }),
-        );
-        await user.click(
-            screen.getByRole('button', { name: 'Rerun with more depth' }),
-        );
-
-        expect(onFollowUp).toHaveBeenCalledOnce();
-        expect(onChallenge).toHaveBeenCalledOnce();
-        expect(onRerun).toHaveBeenCalledOnce();
+        expect(
+            screen.getByTestId('evidence-detail-evidence-incident-review'),
+        ).toHaveTextContent('Q2 enterprise incident review');
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { deepResearchRunFixture } from '../../deepResearch/fixtures';
+import { DeepResearchReport } from './DeepResearchReport';
+
+describe('DeepResearchReport', () => {
+    it('navigates from a claim marker to its supporting query', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <DeepResearchReport
+                run={deepResearchRunFixture}
+                opened
+                onClose={vi.fn()}
+            />,
+        );
+
+        const marker = screen.getByRole('button', {
+            name: /Evidence 1: Enterprise renewal cohort/i,
+        });
+        await user.click(marker);
+
+        expect(marker).toHaveAttribute('aria-pressed', 'true');
+        expect(screen.getByTestId('evidence-detail')).toHaveTextContent(
+            '7c4b40ba-79f8-4fd2-9c43-223eca8fa76f',
+        );
+        expect(screen.getByText(/Renewed ARR/)).toBeInTheDocument();
+        expect(screen.getByText(/Segment is Enterprise/)).toBeInTheDocument();
+        expect(
+            screen.getByRole('link', { name: 'Open in Lightdash' }),
+        ).toBeInTheDocument();
+    });
+
+    it('supports keyboard navigation between evidence markers', () => {
+        renderWithProviders(
+            <DeepResearchReport
+                run={deepResearchRunFixture}
+                opened
+                onClose={vi.fn()}
+            />,
+        );
+
+        const firstMarker = screen.getByRole('button', {
+            name: /Evidence 1: Enterprise renewal cohort/i,
+        });
+        firstMarker.focus();
+        fireEvent.keyDown(firstMarker, { key: 'ArrowRight' });
+
+        const secondMarker = screen.getByRole('button', {
+            name: /Evidence 2: Q2 enterprise incident review/i,
+        });
+        expect(secondMarker).toHaveFocus();
+        expect(secondMarker).toHaveAttribute('aria-pressed', 'true');
+        expect(screen.getByTestId('evidence-detail')).toHaveTextContent(
+            'Q2 enterprise incident review',
+        );
+    });
+
+    it('runs the report actions', async () => {
+        const user = userEvent.setup();
+        const onFollowUp = vi.fn();
+        const onChallenge = vi.fn();
+        const onRerun = vi.fn();
+        renderWithProviders(
+            <DeepResearchReport
+                run={deepResearchRunFixture}
+                opened
+                onClose={vi.fn()}
+                onAskFollowUp={onFollowUp}
+                onChallenge={onChallenge}
+                onRerun={onRerun}
+            />,
+        );
+
+        await user.click(
+            screen.getByRole('button', { name: 'Ask a follow-up' }),
+        );
+        await user.click(
+            screen.getByRole('button', { name: 'Challenge this finding' }),
+        );
+        await user.click(
+            screen.getByRole('button', { name: 'Rerun with more depth' }),
+        );
+
+        expect(onFollowUp).toHaveBeenCalledOnce();
+        expect(onChallenge).toHaveBeenCalledOnce();
+        expect(onRerun).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -182,12 +182,12 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
             opened={opened}
             onClose={onClose}
             title={
-                <Group justify="flex-end" w="100%" wrap="nowrap">
+                <Group className={styles.reportControls} wrap="nowrap">
                     <Text className={styles.visuallyHidden}>Deep research</Text>
                     <Button
-                        variant="light"
-                        color="gray"
-                        radius="xl"
+                        variant="filled"
+                        color="indigo"
+                        radius="sm"
                         size="xs"
                         leftSection={<IconArrowLeft size={14} />}
                         onClick={onClose}
@@ -203,6 +203,8 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
             classNames={{
                 inner: styles.drawerInner,
                 overlay: styles.drawerOverlay,
+                header: styles.drawerHeader,
+                title: styles.drawerTitle,
             }}
             __vars={{ '--drawer-top-offset': `${NAVBAR_HEIGHT}px` }}
         >

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -2,7 +2,6 @@ import {
     Badge,
     Box,
     Button,
-    Divider,
     Drawer,
     Group,
     ScrollArea,
@@ -56,7 +55,7 @@ const EvidenceDetail = ({
                 <Text className={styles.bodyText}>{evidence.description}</Text>
             </Stack>
             {evidence.queryUuid && (
-                <Stack gap={4}>
+                <Stack gap={4} className={styles.queryDetails}>
                     <Text className={styles.caption}>Query UUID</Text>
                     <Text ff="monospace" className={styles.reference}>
                         {evidence.queryUuid}
@@ -203,8 +202,6 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                                 {artifact.executiveAnswer}
                             </Text>
                         </Box>
-
-                        <Divider />
 
                         <Box component="section" className={styles.section}>
                             <Title order={2} className={styles.sectionTitle}>
@@ -413,7 +410,6 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                                 className={styles.section}
                                 aria-labelledby="deep-research-evidence-title"
                             >
-                                <Divider mb="xl" />
                                 <Title
                                     order={2}
                                     id="deep-research-evidence-title"

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -185,7 +185,7 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                 <Group className={styles.reportControls} wrap="nowrap">
                     <Text className={styles.visuallyHidden}>Deep research</Text>
                     <Button
-                        variant="light"
+                        variant="subtle"
                         color="gray"
                         radius="xl"
                         size="xs"

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -3,6 +3,7 @@ import {
     Badge,
     Box,
     Button,
+    Drawer,
     Group,
     ScrollArea,
     Stack,
@@ -17,7 +18,7 @@ import {
     useState,
     type KeyboardEvent,
 } from 'react';
-import { createPortal } from 'react-dom';
+import { NAVBAR_HEIGHT } from '../../../../../components/common/Page/constants';
 import {
     type DeepResearchEvidence,
     type DeepResearchRunView,
@@ -132,33 +133,14 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
     >(null);
     const markerRefs = useRef(new Map<string, HTMLButtonElement>());
     const evidenceRefs = useRef(new Map<string, HTMLElement>());
-    const [reportTarget, setReportTarget] = useState<Element | null>(null);
 
     useEffect(() => {
         if (!opened) {
             setSelectedEvidenceUuid(null);
-            setReportTarget(null);
-            return;
         }
-
-        setReportTarget(
-            document.querySelector('[data-deep-research-report-target]'),
-        );
     }, [opened]);
 
-    useEffect(() => {
-        if (!opened) return;
-
-        const handleKeyDown = (event: globalThis.KeyboardEvent) => {
-            if (event.key === 'Escape') {
-                onClose();
-            }
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [onClose, opened]);
-
-    if (!artifact || !opened || !reportTarget) {
+    if (!artifact) {
         return null;
     }
 
@@ -195,24 +177,35 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
         nextMarker.focus();
     };
 
-    return createPortal(
-        <Box
-            className={styles.workspace}
-            role="region"
-            aria-label="Deep research"
+    return (
+        <Drawer
+            opened={opened}
+            onClose={onClose}
+            title={
+                <Group justify="space-between" w="100%" wrap="nowrap">
+                    <Text fw={600}>Deep research</Text>
+                    <Button
+                        variant="light"
+                        color="gray"
+                        radius="xl"
+                        size="xs"
+                        leftSection={<IconArrowLeft size={14} />}
+                        onClick={onClose}
+                    >
+                        Back to chat
+                    </Button>
+                </Group>
+            }
+            withCloseButton={false}
+            position="right"
+            size="100%"
+            padding={0}
+            classNames={{
+                inner: styles.drawerInner,
+                overlay: styles.drawerOverlay,
+            }}
+            __vars={{ '--drawer-top-offset': `${NAVBAR_HEIGHT}px` }}
         >
-            <Box className={styles.workspaceHeader}>
-                <Button
-                    variant="light"
-                    color="gray"
-                    radius="xl"
-                    size="xs"
-                    leftSection={<IconArrowLeft size={14} />}
-                    onClick={onClose}
-                >
-                    Back to chat
-                </Button>
-            </Box>
             <ScrollArea className={styles.reportScroll}>
                 <Box component="article" className={styles.report}>
                     <Stack gap="xl">
@@ -495,7 +488,6 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                     </Stack>
                 </Box>
             </ScrollArea>
-        </Box>,
-        reportTarget,
+        </Drawer>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -10,7 +10,7 @@ import {
     Text,
     Title,
 } from '@mantine-8/core';
-import { IconArrowUpRight, IconX } from '@tabler/icons-react';
+import { IconArrowLeft, IconArrowUpRight } from '@tabler/icons-react';
 import {
     useEffect,
     useMemo,
@@ -18,7 +18,7 @@ import {
     useState,
     type KeyboardEvent,
 } from 'react';
-import LightdashLogo from '../../../../../components/LightdashLogo/LightdashLogo';
+import { NAVBAR_HEIGHT } from '../../../../../components/common/Page/constants';
 import {
     type DeepResearchEvidence,
     type DeepResearchRunView,
@@ -183,18 +183,16 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
             onClose={onClose}
             title={
                 <Group justify="space-between" w="100%" wrap="nowrap">
-                    <Box role="img" aria-label="Lightdash">
-                        <LightdashLogo />
-                    </Box>
+                    <Text fw={600}>Deep research</Text>
                     <Button
                         variant="light"
                         color="gray"
                         radius="xl"
                         size="xs"
-                        leftSection={<IconX size={14} />}
+                        leftSection={<IconArrowLeft size={14} />}
                         onClick={onClose}
                     >
-                        Close
+                        Back to chat
                     </Button>
                 </Group>
             }
@@ -202,6 +200,11 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
             position="right"
             size="100%"
             padding={0}
+            classNames={{
+                inner: styles.drawerInner,
+                overlay: styles.drawerOverlay,
+            }}
+            __vars={{ '--drawer-top-offset': `${NAVBAR_HEIGHT}px` }}
         >
             <ScrollArea className={styles.reportScroll}>
                 <Box component="article" className={styles.report}>

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -185,9 +185,9 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                 <Group className={styles.reportControls} wrap="nowrap">
                     <Text className={styles.visuallyHidden}>Deep research</Text>
                     <Button
-                        variant="filled"
-                        color="indigo"
-                        radius="sm"
+                        variant="light"
+                        color="gray"
+                        radius="xl"
                         size="xs"
                         leftSection={<IconArrowLeft size={14} />}
                         onClick={onClose}

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -56,7 +56,7 @@ const EvidenceDetail = ({
                 <Text className={styles.bodyText}>{evidence.description}</Text>
             </Stack>
             {evidence.queryUuid && (
-                <Stack gap={4} className={styles.queryDetails}>
+                <Stack gap={4}>
                     <Text className={styles.caption}>Query UUID</Text>
                     <Text ff="monospace" className={styles.reference}>
                         {evidence.queryUuid}

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -1,3 +1,4 @@
+import { type AiDeepResearchConfidence } from '@lightdash/common';
 import {
     Badge,
     Box,
@@ -9,7 +10,7 @@ import {
     Text,
     Title,
 } from '@mantine-8/core';
-import { IconArrowUpRight } from '@tabler/icons-react';
+import { IconArrowUpRight, IconX } from '@tabler/icons-react';
 import {
     useEffect,
     useMemo,
@@ -17,11 +18,18 @@ import {
     useState,
     type KeyboardEvent,
 } from 'react';
+import LightdashLogo from '../../../../../components/LightdashLogo/LightdashLogo';
 import {
     type DeepResearchEvidence,
     type DeepResearchRunView,
 } from '../../deepResearch/types';
 import styles from './DeepResearchReport.module.css';
+
+const confidenceColors: Record<AiDeepResearchConfidence, string> = {
+    low: 'red',
+    medium: 'yellow',
+    high: 'green',
+};
 
 const EvidenceDetail = ({
     evidence,
@@ -173,7 +181,24 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
         <Drawer
             opened={opened}
             onClose={onClose}
-            title="Research report"
+            title={
+                <Group justify="space-between" w="100%" wrap="nowrap">
+                    <Box role="img" aria-label="Lightdash">
+                        <LightdashLogo />
+                    </Box>
+                    <Button
+                        variant="light"
+                        color="gray"
+                        radius="xl"
+                        size="xs"
+                        leftSection={<IconX size={14} />}
+                        onClick={onClose}
+                    >
+                        Close
+                    </Button>
+                </Group>
+            }
+            withCloseButton={false}
             position="right"
             size="100%"
             padding={0}
@@ -182,14 +207,16 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                 <Box component="article" className={styles.report}>
                     <Stack gap="xl">
                         <Box component="header" className={styles.reportHeader}>
-                            <Group justify="space-between" align="flex-start">
+                            <Group gap="xs" align="center">
                                 <Text className={styles.eyebrow}>
                                     Deep research report
                                 </Text>
                                 <Badge
                                     size="xs"
                                     variant="light"
-                                    color="indigo"
+                                    color={
+                                        confidenceColors[artifact.confidence]
+                                    }
                                     tt="none"
                                 >
                                     {artifact.confidence} confidence
@@ -215,11 +242,7 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                                             key={finding.uuid}
                                             className={styles.finding}
                                         >
-                                            <Group
-                                                justify="space-between"
-                                                align="baseline"
-                                                gap="md"
-                                            >
+                                            <Group align="center" gap="xs">
                                                 <Title
                                                     order={3}
                                                     className={
@@ -228,12 +251,20 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                                                 >
                                                     {finding.title}
                                                 </Title>
-                                                <Text
-                                                    className={styles.caption}
-                                                    tt="capitalize"
+                                                <Badge
+                                                    size="xs"
+                                                    variant="light"
+                                                    radius="xl"
+                                                    color={
+                                                        confidenceColors[
+                                                            finding.confidence
+                                                        ]
+                                                    }
+                                                    tt="none"
                                                 >
-                                                    {finding.confidence}
-                                                </Text>
+                                                    {finding.confidence}{' '}
+                                                    confidence
+                                                </Badge>
                                             </Group>
                                             <Text className={styles.bodyText}>
                                                 {finding.summary}

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -182,8 +182,8 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
             opened={opened}
             onClose={onClose}
             title={
-                <Group justify="space-between" w="100%" wrap="nowrap">
-                    <Text fw={600}>Deep research</Text>
+                <Group justify="flex-end" w="100%" wrap="nowrap">
+                    <Text className={styles.visuallyHidden}>Deep research</Text>
                     <Button
                         variant="light"
                         color="gray"

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -5,20 +5,12 @@ import {
     Divider,
     Drawer,
     Group,
-    Paper,
     ScrollArea,
     Stack,
     Text,
     Title,
 } from '@mantine-8/core';
-import { useMediaQuery } from '@mantine-8/hooks';
-import {
-    IconArrowUpRight,
-    IconMessageQuestion,
-    IconRefresh,
-    IconScale,
-    IconShare,
-} from '@tabler/icons-react';
+import { IconArrowUpRight } from '@tabler/icons-react';
 import {
     useEffect,
     useMemo,
@@ -32,101 +24,112 @@ import {
 } from '../../deepResearch/types';
 import styles from './DeepResearchReport.module.css';
 
-const EvidenceDetail = ({ evidence }: { evidence: DeepResearchEvidence }) => (
-    <Stack gap="md" data-testid="evidence-detail">
-        <Stack gap={4}>
-            <Text size="xs" c="indigo" fw={700} tt="uppercase">
-                {evidence.sourceLabel}
-            </Text>
-            <Title order={4}>{evidence.title}</Title>
-            <Text size="sm">{evidence.description}</Text>
-        </Stack>
-        {evidence.queryUuid && (
-            <Stack gap="xs">
-                <Text size="xs" c="dimmed">
-                    Query UUID
-                </Text>
-                <Text size="xs" ff="monospace" className={styles.reference}>
-                    {evidence.queryUuid}
-                </Text>
-                {evidence.metrics.length > 0 && (
-                    <Text size="sm">
-                        <Text span fw={600}>
-                            Metrics:{' '}
-                        </Text>
-                        {evidence.metrics.join(', ')}
-                    </Text>
-                )}
-                {evidence.filters.length > 0 && (
-                    <Text size="sm">
-                        <Text span fw={600}>
-                            Filters:{' '}
-                        </Text>
-                        {evidence.filters.join(', ')}
-                    </Text>
-                )}
-                {evidence.dateRange && (
-                    <Text size="sm">
-                        <Text span fw={600}>
-                            Date range:{' '}
-                        </Text>
-                        {evidence.dateRange}
-                    </Text>
-                )}
+const EvidenceDetail = ({
+    evidence,
+    number,
+    isSelected,
+    elementRef,
+}: {
+    evidence: DeepResearchEvidence;
+    number: number;
+    isSelected: boolean;
+    elementRef: (element: HTMLElement | null) => void;
+}) => (
+    <Box
+        component="li"
+        id={`deep-research-evidence-${evidence.uuid}`}
+        className={styles.evidenceItem}
+        data-selected={isSelected}
+        data-testid={`evidence-detail-${evidence.uuid}`}
+        tabIndex={-1}
+        ref={elementRef}
+    >
+        <Text className={styles.evidenceNumber} aria-hidden>
+            {number}
+        </Text>
+        <Stack gap="xs">
+            <Stack gap={2}>
+                <Text className={styles.eyebrow}>{evidence.sourceLabel}</Text>
+                <Title order={4} className={styles.evidenceTitle}>
+                    {evidence.title}
+                </Title>
+                <Text className={styles.bodyText}>{evidence.description}</Text>
             </Stack>
-        )}
-        {evidence.sourceUrl && (
-            <Button
-                component="a"
-                href={evidence.sourceUrl}
-                target="_blank"
-                rel="noreferrer"
-                variant="light"
-                rightSection={<IconArrowUpRight size={14} />}
-            >
-                {evidence.queryUuid ? 'Open in Lightdash' : 'Open source'}
-            </Button>
-        )}
-    </Stack>
+            {evidence.queryUuid && (
+                <Stack gap={4} className={styles.queryDetails}>
+                    <Text className={styles.caption}>Query UUID</Text>
+                    <Text ff="monospace" className={styles.reference}>
+                        {evidence.queryUuid}
+                    </Text>
+                    {evidence.metrics.length > 0 && (
+                        <Text className={styles.caption}>
+                            <Text span fw={600} inherit>
+                                Metrics:{' '}
+                            </Text>
+                            {evidence.metrics.join(', ')}
+                        </Text>
+                    )}
+                    {evidence.filters.length > 0 && (
+                        <Text className={styles.caption}>
+                            <Text span fw={600} inherit>
+                                Filters:{' '}
+                            </Text>
+                            {evidence.filters.join(', ')}
+                        </Text>
+                    )}
+                    {evidence.dateRange && (
+                        <Text className={styles.caption}>
+                            <Text span fw={600} inherit>
+                                Date range:{' '}
+                            </Text>
+                            {evidence.dateRange}
+                        </Text>
+                    )}
+                </Stack>
+            )}
+            {evidence.sourceUrl && (
+                <Button
+                    component="a"
+                    href={evidence.sourceUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    variant="subtle"
+                    size="compact-xs"
+                    w="fit-content"
+                    rightSection={<IconArrowUpRight size={13} />}
+                >
+                    {evidence.queryUuid ? 'Open in Lightdash' : 'Open source'}
+                </Button>
+            )}
+        </Stack>
+    </Box>
 );
 
 type Props = {
     run: DeepResearchRunView;
     opened: boolean;
     onClose: () => void;
-    onAskFollowUp?: () => void;
-    onChallenge?: () => void;
-    onRerun?: () => void;
 };
 
-export const DeepResearchReport = ({
-    run,
-    opened,
-    onClose,
-    onAskFollowUp,
-    onChallenge,
-    onRerun,
-}: Props) => {
-    const isNarrow = useMediaQuery('(max-width: 62em)');
+export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
     const artifact = run.artifact;
-    const allEvidence = useMemo(
-        () => artifact?.findings.flatMap((finding) => finding.evidence) ?? [],
+    const numberedEvidence = useMemo(
+        () =>
+            artifact?.findings
+                .flatMap((finding) => finding.evidence)
+                .map((evidence, index) => ({ evidence, number: index + 1 })) ??
+            [],
         [artifact],
     );
     const [selectedEvidenceUuid, setSelectedEvidenceUuid] = useState<
         string | null
     >(null);
-    const selectedEvidence =
-        allEvidence.find((item) => item.uuid === selectedEvidenceUuid) ?? null;
-    const [isMobileEvidenceOpen, setIsMobileEvidenceOpen] = useState(false);
-    const lastMarkerRef = useRef<HTMLButtonElement | null>(null);
     const markerRefs = useRef(new Map<string, HTMLButtonElement>());
-    const evidenceRailId = `deep-research-evidence-${run.uuid}`;
+    const evidenceRefs = useRef(new Map<string, HTMLElement>());
 
     useEffect(() => {
         if (!opened) {
             setSelectedEvidenceUuid(null);
-            setIsMobileEvidenceOpen(false);
         }
     }, [opened]);
 
@@ -134,20 +137,11 @@ export const DeepResearchReport = ({
         return null;
     }
 
-    const selectEvidence = (
-        evidence: DeepResearchEvidence,
-        marker: HTMLButtonElement,
-    ) => {
-        lastMarkerRef.current = marker;
+    const selectEvidence = (evidence: DeepResearchEvidence) => {
         setSelectedEvidenceUuid(evidence.uuid);
-        if (isNarrow) {
-            setIsMobileEvidenceOpen(true);
-        }
-    };
-
-    const closeMobileEvidence = () => {
-        setIsMobileEvidenceOpen(false);
-        window.requestAnimationFrame(() => lastMarkerRef.current?.focus());
+        window.requestAnimationFrame(() => {
+            evidenceRefs.current.get(evidence.uuid)?.focus();
+        });
     };
 
     const handleMarkerKeyDown = (
@@ -158,39 +152,22 @@ export const DeepResearchReport = ({
             return;
         }
         event.preventDefault();
-        const currentIndex = allEvidence.findIndex(
-            (item) => item.uuid === evidence.uuid,
+        const currentIndex = numberedEvidence.findIndex(
+            (item) => item.evidence.uuid === evidence.uuid,
         );
         const direction = event.key === 'ArrowRight' ? 1 : -1;
         const nextIndex =
-            (currentIndex + direction + allEvidence.length) %
-            allEvidence.length;
-        const nextEvidence = allEvidence[nextIndex];
+            (currentIndex + direction + numberedEvidence.length) %
+            numberedEvidence.length;
+        const nextEvidence = numberedEvidence[nextIndex]?.evidence;
         const nextMarker = nextEvidence
             ? markerRefs.current.get(nextEvidence.uuid)
             : undefined;
         if (!nextEvidence || !nextMarker) {
             return;
         }
-        selectEvidence(nextEvidence, nextMarker);
+        setSelectedEvidenceUuid(nextEvidence.uuid);
         nextMarker.focus();
-    };
-
-    const handleShare = async () => {
-        const shareData = {
-            title: `Deep research: ${run.question}`,
-            text: artifact.executiveAnswer,
-            url: window.location.href,
-        };
-        try {
-            if (navigator.share) {
-                await navigator.share(shareData);
-                return;
-            }
-            await navigator.clipboard?.writeText(window.location.href);
-        } catch {
-            // Cancelling the platform share sheet should leave the report open.
-        }
     };
 
     return (
@@ -202,284 +179,286 @@ export const DeepResearchReport = ({
             size="100%"
             padding={0}
         >
-            <Box className={styles.workspace}>
-                <ScrollArea className={styles.reportScroll}>
-                    <Stack className={styles.report} gap="xl">
-                        <Stack gap="xs">
+            <ScrollArea className={styles.reportScroll}>
+                <Box component="article" className={styles.report}>
+                    <Stack gap="xl">
+                        <Box component="header" className={styles.reportHeader}>
                             <Group justify="space-between" align="flex-start">
-                                <Stack gap={4}>
-                                    <Text
-                                        size="xs"
-                                        c="indigo"
-                                        fw={700}
-                                        tt="uppercase"
-                                    >
-                                        Deep research
-                                    </Text>
-                                    <Title order={2}>{run.question}</Title>
-                                </Stack>
-                                <Badge variant="light" color="indigo">
+                                <Text className={styles.eyebrow}>
+                                    Deep research report
+                                </Text>
+                                <Badge
+                                    size="xs"
+                                    variant="light"
+                                    color="indigo"
+                                    tt="none"
+                                >
                                     {artifact.confidence} confidence
                                 </Badge>
                             </Group>
-                            <Text size="lg" lh={1.6}>
+                            <Title order={1} className={styles.reportTitle}>
+                                {run.question}
+                            </Title>
+                            <Text className={styles.executiveAnswer}>
                                 {artifact.executiveAnswer}
                             </Text>
-                        </Stack>
+                        </Box>
 
                         <Divider />
 
-                        <Stack gap="lg">
-                            <Title order={3}>Key findings</Title>
-                            {artifact.findings.map((finding, findingIndex) => (
-                                <Paper
-                                    key={finding.uuid}
-                                    className={styles.finding}
-                                    p="lg"
-                                    radius="md"
-                                >
-                                    <Stack gap="sm">
-                                        <Group
-                                            justify="space-between"
-                                            align="flex-start"
+                        <Box component="section" className={styles.section}>
+                            <Title order={2} className={styles.sectionTitle}>
+                                Key findings
+                            </Title>
+                            <Stack gap={0}>
+                                {artifact.findings.map(
+                                    (finding, findingIndex) => (
+                                        <Box
+                                            component="section"
+                                            key={finding.uuid}
+                                            className={styles.finding}
                                         >
-                                            <Title order={4}>
-                                                {finding.title}
-                                            </Title>
-                                            <Badge size="sm" variant="outline">
-                                                {finding.confidence}
-                                            </Badge>
-                                        </Group>
-                                        <Text size="sm" lh={1.6}>
-                                            {finding.summary}
-                                        </Text>
-                                        {finding.evidence.length > 0 && (
                                             <Group
-                                                gap="xs"
-                                                aria-label={`Evidence for ${finding.title}`}
+                                                justify="space-between"
+                                                align="baseline"
+                                                gap="md"
                                             >
-                                                {finding.evidence.map(
-                                                    (
-                                                        evidence,
-                                                        evidenceIndex,
-                                                    ) => {
-                                                        const markerNumber =
-                                                            artifact.findings
-                                                                .slice(
-                                                                    0,
-                                                                    findingIndex,
-                                                                )
-                                                                .reduce(
-                                                                    (
-                                                                        count,
-                                                                        item,
-                                                                    ) =>
-                                                                        count +
-                                                                        item
-                                                                            .evidence
-                                                                            .length,
-                                                                    0,
-                                                                ) +
-                                                            evidenceIndex +
-                                                            1;
-                                                        return (
-                                                            <button
-                                                                key={
-                                                                    evidence.uuid
-                                                                }
-                                                                type="button"
-                                                                className={
-                                                                    styles.marker
-                                                                }
-                                                                data-selected={
-                                                                    selectedEvidenceUuid ===
-                                                                    evidence.uuid
-                                                                }
-                                                                aria-label={`Evidence ${markerNumber}: ${evidence.title}`}
-                                                                aria-pressed={
-                                                                    selectedEvidenceUuid ===
-                                                                    evidence.uuid
-                                                                }
-                                                                aria-controls={
-                                                                    evidenceRailId
-                                                                }
-                                                                ref={(
-                                                                    element,
-                                                                ) => {
-                                                                    if (
-                                                                        element
-                                                                    ) {
-                                                                        markerRefs.current.set(
-                                                                            evidence.uuid,
-                                                                            element,
-                                                                        );
-                                                                    } else {
-                                                                        markerRefs.current.delete(
-                                                                            evidence.uuid,
-                                                                        );
-                                                                    }
-                                                                }}
-                                                                onClick={(
-                                                                    event,
-                                                                ) =>
-                                                                    selectEvidence(
-                                                                        evidence,
-                                                                        event.currentTarget,
-                                                                    )
-                                                                }
-                                                                onKeyDown={(
-                                                                    event,
-                                                                ) =>
-                                                                    handleMarkerKeyDown(
-                                                                        event,
-                                                                        evidence,
-                                                                    )
-                                                                }
-                                                            >
-                                                                {markerNumber}
-                                                            </button>
-                                                        );
-                                                    },
-                                                )}
+                                                <Title
+                                                    order={3}
+                                                    className={
+                                                        styles.findingTitle
+                                                    }
+                                                >
+                                                    {finding.title}
+                                                </Title>
+                                                <Text
+                                                    className={styles.caption}
+                                                    tt="capitalize"
+                                                >
+                                                    {finding.confidence}
+                                                </Text>
                                             </Group>
-                                        )}
-                                    </Stack>
-                                </Paper>
-                            ))}
-                        </Stack>
+                                            <Text className={styles.bodyText}>
+                                                {finding.summary}
+                                            </Text>
+                                            {finding.evidence.length > 0 && (
+                                                <Group
+                                                    gap={3}
+                                                    mt="xs"
+                                                    aria-label={`Evidence for ${finding.title}`}
+                                                >
+                                                    {finding.evidence.map(
+                                                        (
+                                                            evidence,
+                                                            evidenceIndex,
+                                                        ) => {
+                                                            const markerNumber =
+                                                                artifact.findings
+                                                                    .slice(
+                                                                        0,
+                                                                        findingIndex,
+                                                                    )
+                                                                    .reduce(
+                                                                        (
+                                                                            count,
+                                                                            item,
+                                                                        ) =>
+                                                                            count +
+                                                                            item
+                                                                                .evidence
+                                                                                .length,
+                                                                        0,
+                                                                    ) +
+                                                                evidenceIndex +
+                                                                1;
+                                                            return (
+                                                                <button
+                                                                    key={
+                                                                        evidence.uuid
+                                                                    }
+                                                                    type="button"
+                                                                    className={
+                                                                        styles.marker
+                                                                    }
+                                                                    data-selected={
+                                                                        selectedEvidenceUuid ===
+                                                                        evidence.uuid
+                                                                    }
+                                                                    aria-label={`Evidence ${markerNumber}: ${evidence.title}`}
+                                                                    aria-pressed={
+                                                                        selectedEvidenceUuid ===
+                                                                        evidence.uuid
+                                                                    }
+                                                                    aria-controls={`deep-research-evidence-${evidence.uuid}`}
+                                                                    ref={(
+                                                                        element,
+                                                                    ) => {
+                                                                        if (
+                                                                            element
+                                                                        ) {
+                                                                            markerRefs.current.set(
+                                                                                evidence.uuid,
+                                                                                element,
+                                                                            );
+                                                                        } else {
+                                                                            markerRefs.current.delete(
+                                                                                evidence.uuid,
+                                                                            );
+                                                                        }
+                                                                    }}
+                                                                    onClick={() =>
+                                                                        selectEvidence(
+                                                                            evidence,
+                                                                        )
+                                                                    }
+                                                                    onKeyDown={(
+                                                                        event,
+                                                                    ) =>
+                                                                        handleMarkerKeyDown(
+                                                                            event,
+                                                                            evidence,
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    [
+                                                                    {
+                                                                        markerNumber
+                                                                    }
+                                                                    ]
+                                                                </button>
+                                                            );
+                                                        },
+                                                    )}
+                                                </Group>
+                                            )}
+                                        </Box>
+                                    ),
+                                )}
+                            </Stack>
+                        </Box>
 
-                        <Stack gap="md">
-                            <Title order={3}>
+                        <Box component="section" className={styles.section}>
+                            <Title order={2} className={styles.sectionTitle}>
                                 Alternative explanations and contradictory
                                 evidence
                             </Title>
                             {artifact.contradictoryEvidence.length ? (
-                                artifact.contradictoryEvidence.map((item) => (
-                                    <Text key={item} size="sm">
-                                        • {item}
-                                    </Text>
-                                ))
+                                <Box component="ul" className={styles.list}>
+                                    {artifact.contradictoryEvidence.map(
+                                        (item) => (
+                                            <Text
+                                                component="li"
+                                                key={item}
+                                                className={styles.bodyText}
+                                            >
+                                                {item}
+                                            </Text>
+                                        ),
+                                    )}
+                                </Box>
                             ) : (
-                                <Text size="sm" c="dimmed">
+                                <Text className={styles.bodyText} c="dimmed">
                                     No material contradictory evidence was
                                     found.
                                 </Text>
                             )}
-                        </Stack>
+                        </Box>
 
-                        <Stack gap="md">
-                            <Title order={3}>Definitions and methodology</Title>
-                            <Text size="sm" lh={1.6}>
+                        <Box component="section" className={styles.section}>
+                            <Title order={2} className={styles.sectionTitle}>
+                                Definitions and methodology
+                            </Title>
+                            <Text className={styles.bodyText}>
                                 {artifact.definitionsAndMethodology}
                             </Text>
-                        </Stack>
+                        </Box>
 
-                        <Stack gap="md">
-                            <Title order={3}>Confidence and limitations</Title>
-                            {artifact.limitations.map((limitation) => (
-                                <Text key={limitation} size="sm">
-                                    • {limitation}
-                                </Text>
-                            ))}
-                        </Stack>
-
-                        <Stack gap="md">
-                            <Title order={3}>Recommended next questions</Title>
-                            {artifact.nextQuestions.map((question) => (
-                                <Text key={question} size="sm">
-                                    • {question}
-                                </Text>
-                            ))}
-                        </Stack>
-
-                        <Group className={styles.actions} gap="xs">
-                            {onAskFollowUp && (
-                                <Button
-                                    variant="light"
-                                    leftSection={
-                                        <IconMessageQuestion size={16} />
-                                    }
-                                    onClick={onAskFollowUp}
-                                >
-                                    Ask a follow-up
-                                </Button>
-                            )}
-                            {onChallenge && (
-                                <Button
-                                    variant="default"
-                                    leftSection={<IconScale size={16} />}
-                                    onClick={onChallenge}
-                                >
-                                    Challenge this finding
-                                </Button>
-                            )}
-                            {onRerun && (
-                                <Button
-                                    variant="default"
-                                    leftSection={<IconRefresh size={16} />}
-                                    onClick={onRerun}
-                                >
-                                    Rerun with more depth
-                                </Button>
-                            )}
-                            <Button
-                                variant="subtle"
-                                leftSection={<IconShare size={16} />}
-                                onClick={() => void handleShare()}
-                            >
-                                Share report
-                            </Button>
-                        </Group>
-                    </Stack>
-                </ScrollArea>
-
-                {!isNarrow && (
-                    <aside
-                        id={evidenceRailId}
-                        className={styles.evidenceRail}
-                        aria-label="Supporting evidence"
-                        aria-live="polite"
-                    >
-                        <ScrollArea h="100%">
-                            <Stack p="lg" gap="lg">
-                                <Stack gap={4}>
-                                    <Text fw={700}>Evidence</Text>
-                                    <Text size="xs" c="dimmed">
-                                        Select a numbered marker to inspect the
-                                        source.
+                        <Box component="section" className={styles.section}>
+                            <Title order={2} className={styles.sectionTitle}>
+                                Confidence and limitations
+                            </Title>
+                            <Box component="ul" className={styles.list}>
+                                {artifact.limitations.map((limitation) => (
+                                    <Text
+                                        component="li"
+                                        key={limitation}
+                                        className={styles.bodyText}
+                                    >
+                                        {limitation}
                                     </Text>
-                                </Stack>
-                                {selectedEvidence ? (
-                                    <EvidenceDetail
-                                        evidence={selectedEvidence}
-                                    />
-                                ) : (
-                                    <Paper variant="dotted" p="md">
-                                        <Text size="sm" c="dimmed">
-                                            No evidence selected.
-                                        </Text>
-                                    </Paper>
-                                )}
-                            </Stack>
-                        </ScrollArea>
-                    </aside>
-                )}
-            </Box>
+                                ))}
+                            </Box>
+                        </Box>
 
-            {isNarrow && (
-                <Drawer
-                    opened={isMobileEvidenceOpen}
-                    onClose={closeMobileEvidence}
-                    title="Supporting evidence"
-                    position="bottom"
-                    size="85%"
-                    trapFocus
-                >
-                    {selectedEvidence && (
-                        <EvidenceDetail evidence={selectedEvidence} />
-                    )}
-                </Drawer>
-            )}
+                        <Box component="section" className={styles.section}>
+                            <Title order={2} className={styles.sectionTitle}>
+                                Recommended next questions
+                            </Title>
+                            <Box component="ul" className={styles.list}>
+                                {artifact.nextQuestions.map((question) => (
+                                    <Text
+                                        component="li"
+                                        key={question}
+                                        className={styles.bodyText}
+                                    >
+                                        {question}
+                                    </Text>
+                                ))}
+                            </Box>
+                        </Box>
+
+                        {numberedEvidence.length > 0 && (
+                            <Box
+                                component="section"
+                                className={styles.section}
+                                aria-labelledby="deep-research-evidence-title"
+                            >
+                                <Divider mb="xl" />
+                                <Title
+                                    order={2}
+                                    id="deep-research-evidence-title"
+                                    className={styles.sectionTitle}
+                                >
+                                    Evidence
+                                </Title>
+                                <Text className={styles.sectionIntro}>
+                                    Sources cited in the findings above.
+                                </Text>
+                                <Box
+                                    component="ol"
+                                    className={styles.evidenceList}
+                                >
+                                    {numberedEvidence.map(
+                                        ({ evidence, number }) => (
+                                            <EvidenceDetail
+                                                key={evidence.uuid}
+                                                evidence={evidence}
+                                                number={number}
+                                                isSelected={
+                                                    selectedEvidenceUuid ===
+                                                    evidence.uuid
+                                                }
+                                                elementRef={(element) => {
+                                                    if (element) {
+                                                        evidenceRefs.current.set(
+                                                            evidence.uuid,
+                                                            element,
+                                                        );
+                                                    } else {
+                                                        evidenceRefs.current.delete(
+                                                            evidence.uuid,
+                                                        );
+                                                    }
+                                                }}
+                                            />
+                                        ),
+                                    )}
+                                </Box>
+                            </Box>
+                        )}
+                    </Stack>
+                </Box>
+            </ScrollArea>
         </Drawer>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -3,7 +3,6 @@ import {
     Badge,
     Box,
     Button,
-    Drawer,
     Group,
     ScrollArea,
     Stack,
@@ -18,7 +17,7 @@ import {
     useState,
     type KeyboardEvent,
 } from 'react';
-import { NAVBAR_HEIGHT } from '../../../../../components/common/Page/constants';
+import { createPortal } from 'react-dom';
 import {
     type DeepResearchEvidence,
     type DeepResearchRunView,
@@ -133,14 +132,33 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
     >(null);
     const markerRefs = useRef(new Map<string, HTMLButtonElement>());
     const evidenceRefs = useRef(new Map<string, HTMLElement>());
+    const [reportTarget, setReportTarget] = useState<Element | null>(null);
 
     useEffect(() => {
         if (!opened) {
             setSelectedEvidenceUuid(null);
+            setReportTarget(null);
+            return;
         }
+
+        setReportTarget(
+            document.querySelector('[data-deep-research-report-target]'),
+        );
     }, [opened]);
 
-    if (!artifact) {
+    useEffect(() => {
+        if (!opened) return;
+
+        const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [onClose, opened]);
+
+    if (!artifact || !opened || !reportTarget) {
         return null;
     }
 
@@ -177,35 +195,24 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
         nextMarker.focus();
     };
 
-    return (
-        <Drawer
-            opened={opened}
-            onClose={onClose}
-            title={
-                <Group justify="space-between" w="100%" wrap="nowrap">
-                    <Text fw={600}>Deep research</Text>
-                    <Button
-                        variant="light"
-                        color="gray"
-                        radius="xl"
-                        size="xs"
-                        leftSection={<IconArrowLeft size={14} />}
-                        onClick={onClose}
-                    >
-                        Back to chat
-                    </Button>
-                </Group>
-            }
-            withCloseButton={false}
-            position="right"
-            size="100%"
-            padding={0}
-            classNames={{
-                inner: styles.drawerInner,
-                overlay: styles.drawerOverlay,
-            }}
-            __vars={{ '--drawer-top-offset': `${NAVBAR_HEIGHT}px` }}
+    return createPortal(
+        <Box
+            className={styles.workspace}
+            role="region"
+            aria-label="Deep research"
         >
+            <Box className={styles.workspaceHeader}>
+                <Button
+                    variant="light"
+                    color="gray"
+                    radius="xl"
+                    size="xs"
+                    leftSection={<IconArrowLeft size={14} />}
+                    onClick={onClose}
+                >
+                    Back to chat
+                </Button>
+            </Box>
             <ScrollArea className={styles.reportScroll}>
                 <Box component="article" className={styles.report}>
                     <Stack gap="xl">
@@ -488,6 +495,7 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                     </Stack>
                 </Box>
             </ScrollArea>
-        </Drawer>
+        </Box>,
+        reportTarget,
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -1,0 +1,485 @@
+import {
+    Badge,
+    Box,
+    Button,
+    Divider,
+    Drawer,
+    Group,
+    Paper,
+    ScrollArea,
+    Stack,
+    Text,
+    Title,
+} from '@mantine-8/core';
+import { useMediaQuery } from '@mantine-8/hooks';
+import {
+    IconArrowUpRight,
+    IconMessageQuestion,
+    IconRefresh,
+    IconScale,
+    IconShare,
+} from '@tabler/icons-react';
+import {
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type KeyboardEvent,
+} from 'react';
+import {
+    type DeepResearchEvidence,
+    type DeepResearchRunView,
+} from '../../deepResearch/types';
+import styles from './DeepResearchReport.module.css';
+
+const EvidenceDetail = ({ evidence }: { evidence: DeepResearchEvidence }) => (
+    <Stack gap="md" data-testid="evidence-detail">
+        <Stack gap={4}>
+            <Text size="xs" c="indigo" fw={700} tt="uppercase">
+                {evidence.sourceLabel}
+            </Text>
+            <Title order={4}>{evidence.title}</Title>
+            <Text size="sm">{evidence.description}</Text>
+        </Stack>
+        {evidence.queryUuid && (
+            <Stack gap="xs">
+                <Text size="xs" c="dimmed">
+                    Query UUID
+                </Text>
+                <Text size="xs" ff="monospace" className={styles.reference}>
+                    {evidence.queryUuid}
+                </Text>
+                {evidence.metrics.length > 0 && (
+                    <Text size="sm">
+                        <Text span fw={600}>
+                            Metrics:{' '}
+                        </Text>
+                        {evidence.metrics.join(', ')}
+                    </Text>
+                )}
+                {evidence.filters.length > 0 && (
+                    <Text size="sm">
+                        <Text span fw={600}>
+                            Filters:{' '}
+                        </Text>
+                        {evidence.filters.join(', ')}
+                    </Text>
+                )}
+                {evidence.dateRange && (
+                    <Text size="sm">
+                        <Text span fw={600}>
+                            Date range:{' '}
+                        </Text>
+                        {evidence.dateRange}
+                    </Text>
+                )}
+            </Stack>
+        )}
+        {evidence.sourceUrl && (
+            <Button
+                component="a"
+                href={evidence.sourceUrl}
+                target="_blank"
+                rel="noreferrer"
+                variant="light"
+                rightSection={<IconArrowUpRight size={14} />}
+            >
+                {evidence.queryUuid ? 'Open in Lightdash' : 'Open source'}
+            </Button>
+        )}
+    </Stack>
+);
+
+type Props = {
+    run: DeepResearchRunView;
+    opened: boolean;
+    onClose: () => void;
+    onAskFollowUp?: () => void;
+    onChallenge?: () => void;
+    onRerun?: () => void;
+};
+
+export const DeepResearchReport = ({
+    run,
+    opened,
+    onClose,
+    onAskFollowUp,
+    onChallenge,
+    onRerun,
+}: Props) => {
+    const isNarrow = useMediaQuery('(max-width: 62em)');
+    const artifact = run.artifact;
+    const allEvidence = useMemo(
+        () => artifact?.findings.flatMap((finding) => finding.evidence) ?? [],
+        [artifact],
+    );
+    const [selectedEvidenceUuid, setSelectedEvidenceUuid] = useState<
+        string | null
+    >(null);
+    const selectedEvidence =
+        allEvidence.find((item) => item.uuid === selectedEvidenceUuid) ?? null;
+    const [isMobileEvidenceOpen, setIsMobileEvidenceOpen] = useState(false);
+    const lastMarkerRef = useRef<HTMLButtonElement | null>(null);
+    const markerRefs = useRef(new Map<string, HTMLButtonElement>());
+    const evidenceRailId = `deep-research-evidence-${run.uuid}`;
+
+    useEffect(() => {
+        if (!opened) {
+            setSelectedEvidenceUuid(null);
+            setIsMobileEvidenceOpen(false);
+        }
+    }, [opened]);
+
+    if (!artifact) {
+        return null;
+    }
+
+    const selectEvidence = (
+        evidence: DeepResearchEvidence,
+        marker: HTMLButtonElement,
+    ) => {
+        lastMarkerRef.current = marker;
+        setSelectedEvidenceUuid(evidence.uuid);
+        if (isNarrow) {
+            setIsMobileEvidenceOpen(true);
+        }
+    };
+
+    const closeMobileEvidence = () => {
+        setIsMobileEvidenceOpen(false);
+        window.requestAnimationFrame(() => lastMarkerRef.current?.focus());
+    };
+
+    const handleMarkerKeyDown = (
+        event: KeyboardEvent<HTMLButtonElement>,
+        evidence: DeepResearchEvidence,
+    ) => {
+        if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
+            return;
+        }
+        event.preventDefault();
+        const currentIndex = allEvidence.findIndex(
+            (item) => item.uuid === evidence.uuid,
+        );
+        const direction = event.key === 'ArrowRight' ? 1 : -1;
+        const nextIndex =
+            (currentIndex + direction + allEvidence.length) %
+            allEvidence.length;
+        const nextEvidence = allEvidence[nextIndex];
+        const nextMarker = nextEvidence
+            ? markerRefs.current.get(nextEvidence.uuid)
+            : undefined;
+        if (!nextEvidence || !nextMarker) {
+            return;
+        }
+        selectEvidence(nextEvidence, nextMarker);
+        nextMarker.focus();
+    };
+
+    const handleShare = async () => {
+        const shareData = {
+            title: `Deep research: ${run.question}`,
+            text: artifact.executiveAnswer,
+            url: window.location.href,
+        };
+        try {
+            if (navigator.share) {
+                await navigator.share(shareData);
+                return;
+            }
+            await navigator.clipboard?.writeText(window.location.href);
+        } catch {
+            // Cancelling the platform share sheet should leave the report open.
+        }
+    };
+
+    return (
+        <Drawer
+            opened={opened}
+            onClose={onClose}
+            title="Research report"
+            position="right"
+            size="100%"
+            padding={0}
+        >
+            <Box className={styles.workspace}>
+                <ScrollArea className={styles.reportScroll}>
+                    <Stack className={styles.report} gap="xl">
+                        <Stack gap="xs">
+                            <Group justify="space-between" align="flex-start">
+                                <Stack gap={4}>
+                                    <Text
+                                        size="xs"
+                                        c="indigo"
+                                        fw={700}
+                                        tt="uppercase"
+                                    >
+                                        Deep research
+                                    </Text>
+                                    <Title order={2}>{run.question}</Title>
+                                </Stack>
+                                <Badge variant="light" color="indigo">
+                                    {artifact.confidence} confidence
+                                </Badge>
+                            </Group>
+                            <Text size="lg" lh={1.6}>
+                                {artifact.executiveAnswer}
+                            </Text>
+                        </Stack>
+
+                        <Divider />
+
+                        <Stack gap="lg">
+                            <Title order={3}>Key findings</Title>
+                            {artifact.findings.map((finding, findingIndex) => (
+                                <Paper
+                                    key={finding.uuid}
+                                    className={styles.finding}
+                                    p="lg"
+                                    radius="md"
+                                >
+                                    <Stack gap="sm">
+                                        <Group
+                                            justify="space-between"
+                                            align="flex-start"
+                                        >
+                                            <Title order={4}>
+                                                {finding.title}
+                                            </Title>
+                                            <Badge size="sm" variant="outline">
+                                                {finding.confidence}
+                                            </Badge>
+                                        </Group>
+                                        <Text size="sm" lh={1.6}>
+                                            {finding.summary}
+                                        </Text>
+                                        {finding.evidence.length > 0 && (
+                                            <Group
+                                                gap="xs"
+                                                aria-label={`Evidence for ${finding.title}`}
+                                            >
+                                                {finding.evidence.map(
+                                                    (
+                                                        evidence,
+                                                        evidenceIndex,
+                                                    ) => {
+                                                        const markerNumber =
+                                                            artifact.findings
+                                                                .slice(
+                                                                    0,
+                                                                    findingIndex,
+                                                                )
+                                                                .reduce(
+                                                                    (
+                                                                        count,
+                                                                        item,
+                                                                    ) =>
+                                                                        count +
+                                                                        item
+                                                                            .evidence
+                                                                            .length,
+                                                                    0,
+                                                                ) +
+                                                            evidenceIndex +
+                                                            1;
+                                                        return (
+                                                            <button
+                                                                key={
+                                                                    evidence.uuid
+                                                                }
+                                                                type="button"
+                                                                className={
+                                                                    styles.marker
+                                                                }
+                                                                data-selected={
+                                                                    selectedEvidenceUuid ===
+                                                                    evidence.uuid
+                                                                }
+                                                                aria-label={`Evidence ${markerNumber}: ${evidence.title}`}
+                                                                aria-pressed={
+                                                                    selectedEvidenceUuid ===
+                                                                    evidence.uuid
+                                                                }
+                                                                aria-controls={
+                                                                    evidenceRailId
+                                                                }
+                                                                ref={(
+                                                                    element,
+                                                                ) => {
+                                                                    if (
+                                                                        element
+                                                                    ) {
+                                                                        markerRefs.current.set(
+                                                                            evidence.uuid,
+                                                                            element,
+                                                                        );
+                                                                    } else {
+                                                                        markerRefs.current.delete(
+                                                                            evidence.uuid,
+                                                                        );
+                                                                    }
+                                                                }}
+                                                                onClick={(
+                                                                    event,
+                                                                ) =>
+                                                                    selectEvidence(
+                                                                        evidence,
+                                                                        event.currentTarget,
+                                                                    )
+                                                                }
+                                                                onKeyDown={(
+                                                                    event,
+                                                                ) =>
+                                                                    handleMarkerKeyDown(
+                                                                        event,
+                                                                        evidence,
+                                                                    )
+                                                                }
+                                                            >
+                                                                {markerNumber}
+                                                            </button>
+                                                        );
+                                                    },
+                                                )}
+                                            </Group>
+                                        )}
+                                    </Stack>
+                                </Paper>
+                            ))}
+                        </Stack>
+
+                        <Stack gap="md">
+                            <Title order={3}>
+                                Alternative explanations and contradictory
+                                evidence
+                            </Title>
+                            {artifact.contradictoryEvidence.length ? (
+                                artifact.contradictoryEvidence.map((item) => (
+                                    <Text key={item} size="sm">
+                                        • {item}
+                                    </Text>
+                                ))
+                            ) : (
+                                <Text size="sm" c="dimmed">
+                                    No material contradictory evidence was
+                                    found.
+                                </Text>
+                            )}
+                        </Stack>
+
+                        <Stack gap="md">
+                            <Title order={3}>Definitions and methodology</Title>
+                            <Text size="sm" lh={1.6}>
+                                {artifact.definitionsAndMethodology}
+                            </Text>
+                        </Stack>
+
+                        <Stack gap="md">
+                            <Title order={3}>Confidence and limitations</Title>
+                            {artifact.limitations.map((limitation) => (
+                                <Text key={limitation} size="sm">
+                                    • {limitation}
+                                </Text>
+                            ))}
+                        </Stack>
+
+                        <Stack gap="md">
+                            <Title order={3}>Recommended next questions</Title>
+                            {artifact.nextQuestions.map((question) => (
+                                <Text key={question} size="sm">
+                                    • {question}
+                                </Text>
+                            ))}
+                        </Stack>
+
+                        <Group className={styles.actions} gap="xs">
+                            {onAskFollowUp && (
+                                <Button
+                                    variant="light"
+                                    leftSection={
+                                        <IconMessageQuestion size={16} />
+                                    }
+                                    onClick={onAskFollowUp}
+                                >
+                                    Ask a follow-up
+                                </Button>
+                            )}
+                            {onChallenge && (
+                                <Button
+                                    variant="default"
+                                    leftSection={<IconScale size={16} />}
+                                    onClick={onChallenge}
+                                >
+                                    Challenge this finding
+                                </Button>
+                            )}
+                            {onRerun && (
+                                <Button
+                                    variant="default"
+                                    leftSection={<IconRefresh size={16} />}
+                                    onClick={onRerun}
+                                >
+                                    Rerun with more depth
+                                </Button>
+                            )}
+                            <Button
+                                variant="subtle"
+                                leftSection={<IconShare size={16} />}
+                                onClick={() => void handleShare()}
+                            >
+                                Share report
+                            </Button>
+                        </Group>
+                    </Stack>
+                </ScrollArea>
+
+                {!isNarrow && (
+                    <aside
+                        id={evidenceRailId}
+                        className={styles.evidenceRail}
+                        aria-label="Supporting evidence"
+                        aria-live="polite"
+                    >
+                        <ScrollArea h="100%">
+                            <Stack p="lg" gap="lg">
+                                <Stack gap={4}>
+                                    <Text fw={700}>Evidence</Text>
+                                    <Text size="xs" c="dimmed">
+                                        Select a numbered marker to inspect the
+                                        source.
+                                    </Text>
+                                </Stack>
+                                {selectedEvidence ? (
+                                    <EvidenceDetail
+                                        evidence={selectedEvidence}
+                                    />
+                                ) : (
+                                    <Paper variant="dotted" p="md">
+                                        <Text size="sm" c="dimmed">
+                                            No evidence selected.
+                                        </Text>
+                                    </Paper>
+                                )}
+                            </Stack>
+                        </ScrollArea>
+                    </aside>
+                )}
+            </Box>
+
+            {isNarrow && (
+                <Drawer
+                    opened={isMobileEvidenceOpen}
+                    onClose={closeMobileEvidence}
+                    title="Supporting evidence"
+                    position="bottom"
+                    size="85%"
+                    trapFocus
+                >
+                    {selectedEvidence && (
+                        <EvidenceDetail evidence={selectedEvidence} />
+                    )}
+                </Drawer>
+            )}
+        </Drawer>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -254,7 +254,6 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                                                 <Badge
                                                     size="xs"
                                                     variant="light"
-                                                    radius="xl"
                                                     color={
                                                         confidenceColors[
                                                             finding.confidence

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.tsx
@@ -209,7 +209,7 @@ export const DeepResearchReport = ({ run, opened, onClose }: Props) => {
                         <Box component="header" className={styles.reportHeader}>
                             <Group gap="xs" align="center">
                                 <Text className={styles.eyebrow}>
-                                    Deep research report
+                                    Deep research
                                 </Text>
                                 <Badge
                                     size="xs"

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.module.css
@@ -1,0 +1,24 @@
+.card {
+    border: 1px solid var(--mantine-color-ldGray-3);
+    border-top: 3px solid var(--mantine-color-indigo-outline);
+}
+
+.answer {
+    border-left: 3px solid var(--mantine-color-indigo-outline);
+    background: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-6)
+    );
+}
+
+.liveRegion {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.module.css
@@ -3,7 +3,6 @@
 }
 
 .answer {
-    border-left: 3px solid var(--mantine-color-indigo-outline);
     background: light-dark(
         var(--mantine-color-ldGray-0),
         var(--mantine-color-ldDark-6)

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.module.css
@@ -3,6 +3,7 @@
 }
 
 .answer {
+    border-left: 3px solid var(--mantine-color-indigo-outline);
     background: light-dark(
         var(--mantine-color-ldGray-0),
         var(--mantine-color-ldDark-6)

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.module.css
@@ -1,6 +1,5 @@
 .card {
     border: 1px solid var(--mantine-color-ldGray-3);
-    border-top: 3px solid var(--mantine-color-indigo-outline);
 }
 
 .answer {

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
@@ -39,6 +39,7 @@ describe('DeepResearchRunCard', () => {
             );
 
             expect(screen.getByText(label)).toBeInTheDocument();
+            expect(screen.getByText('Medium')).toBeInTheDocument();
             expect(screen.getByText(/leave this page/i)).toBeInTheDocument();
             expect(screen.queryByText(/%/)).not.toBeInTheDocument();
             expect(

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
@@ -1,0 +1,186 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { deepResearchRunFixture } from '../../deepResearch/fixtures';
+import { DeepResearchRunCard } from './DeepResearchRunCard';
+
+const cancelRun = vi.fn();
+
+vi.mock('../../hooks/useDeepResearch', () => ({
+    useCancelDeepResearchMutation: () => ({
+        mutate: cancelRun,
+        isLoading: false,
+    }),
+}));
+
+describe('DeepResearchRunCard', () => {
+    beforeEach(() => {
+        cancelRun.mockClear();
+    });
+
+    it.each([
+        ['queued', 'Queued'],
+        ['running', 'Running'],
+    ] as const)(
+        'renders the %s active state without fake progress',
+        (status, label) => {
+            renderWithProviders(
+                <DeepResearchRunCard
+                    run={{
+                        ...deepResearchRunFixture,
+                        status,
+                        artifact: null,
+                        findingCount: 0,
+                        completedAt: null,
+                    }}
+                    projectUuid="project-1"
+                />,
+            );
+
+            expect(screen.getByText(label)).toBeInTheDocument();
+            expect(screen.getByText(/leave this page/i)).toBeInTheDocument();
+            expect(screen.queryByText(/%/)).not.toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: 'Stop research' }),
+            ).toBeInTheDocument();
+        },
+    );
+
+    it('cancels an active run and exposes safe activity', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <DeepResearchRunCard
+                run={{
+                    ...deepResearchRunFixture,
+                    status: 'running',
+                    artifact: null,
+                    completedAt: null,
+                }}
+                projectUuid="project-1"
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'View activity' }));
+        expect(
+            screen.getByText('Executed a warehouse query'),
+        ).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Stop research' }));
+        expect(cancelRun).toHaveBeenCalledOnce();
+    });
+
+    it.each([
+        ['completed', 'Completed'],
+        ['cancelled', 'Cancelled'],
+        ['failed', 'Failed'],
+    ] as const)(
+        'renders the %s terminal state without a stop action',
+        (status, label) => {
+            renderWithProviders(
+                <DeepResearchRunCard
+                    run={{
+                        ...deepResearchRunFixture,
+                        status,
+                        artifact:
+                            status === 'cancelled'
+                                ? null
+                                : deepResearchRunFixture.artifact,
+                        errorMessage:
+                            status === 'failed'
+                                ? 'The warehouse timed out.'
+                                : null,
+                    }}
+                    projectUuid="project-1"
+                />,
+            );
+
+            expect(screen.getByText(label)).toBeInTheDocument();
+            expect(
+                screen.queryByRole('button', { name: 'Stop research' }),
+            ).not.toBeInTheDocument();
+        },
+    );
+
+    it('preserves partial findings and offers the report', () => {
+        renderWithProviders(
+            <DeepResearchRunCard
+                run={{
+                    ...deepResearchRunFixture,
+                    status: 'partially_completed',
+                }}
+                projectUuid="project-1"
+            />,
+        );
+
+        expect(screen.getByText('Partially completed')).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                /findings and completed queries have been preserved/i,
+            ),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Executive answer')).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Open full report' }),
+        ).toBeInTheDocument();
+    });
+
+    it('offers reconnection and continue-without-source recovery', async () => {
+        const user = userEvent.setup();
+        const onReconnect = vi.fn();
+        const onContinue = vi.fn();
+        renderWithProviders(
+            <DeepResearchRunCard
+                run={{
+                    ...deepResearchRunFixture,
+                    status: 'waiting_for_reconnection',
+                    actionRequired: {
+                        type: 'reconnect',
+                        integrationName: 'GitHub',
+                        message:
+                            'The GitHub connection expired after repository review.',
+                    },
+                }}
+                projectUuid="project-1"
+                onReconnect={onReconnect}
+                onContinueWithoutSource={onContinue}
+            />,
+        );
+
+        await user.click(
+            screen.getByRole('button', { name: 'Reconnect GitHub' }),
+        );
+        await user.click(
+            screen.getByRole('button', { name: 'Continue without GitHub' }),
+        );
+
+        expect(onReconnect).toHaveBeenCalledWith('GitHub');
+        expect(onContinue).toHaveBeenCalledWith('GitHub');
+    });
+
+    it('offers a permission action without discarding findings', async () => {
+        const user = userEvent.setup();
+        const onReviewPermissions = vi.fn();
+        renderWithProviders(
+            <DeepResearchRunCard
+                run={{
+                    ...deepResearchRunFixture,
+                    status: 'waiting_for_permission',
+                    actionRequired: {
+                        type: 'permission',
+                        message:
+                            'Approval is required before the warehouse query can run.',
+                    },
+                }}
+                projectUuid="project-1"
+                onReconnect={onReviewPermissions}
+            />,
+        );
+
+        expect(screen.getByText('Executive answer')).toBeInTheDocument();
+        await user.click(
+            screen.getByRole('button', { name: 'Review permissions' }),
+        );
+        expect(onReviewPermissions).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.test.tsx
@@ -99,6 +99,9 @@ describe('DeepResearchRunCard', () => {
             expect(
                 screen.queryByRole('button', { name: 'Stop research' }),
             ).not.toBeInTheDocument();
+            expect(
+                screen.getByText('This run is saved in this thread.'),
+            ).toBeInTheDocument();
         },
     );
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
@@ -24,7 +24,10 @@ import {
 import { useEffect, useState } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { formatDuration } from '../../../../../utils/formatters';
-import { isDeepResearchRunTerminal } from '../../deepResearch/deepResearchAdapter';
+import {
+    DEEP_RESEARCH_DEPTH_CONFIG,
+    isDeepResearchRunTerminal,
+} from '../../deepResearch/deepResearchAdapter';
 import { type DeepResearchRunView } from '../../deepResearch/types';
 import { useCancelDeepResearchMutation } from '../../hooks/useDeepResearch';
 import { DeepResearchReport } from './DeepResearchReport';
@@ -103,9 +106,27 @@ export const DeepResearchRunCard = ({
                             <MantineIcon icon={IconReportSearch} size={18} />
                         </ThemeIcon>
                         <Stack gap={3}>
-                            <Text size="xs" c="indigo" fw={700} tt="uppercase">
-                                Deep research
-                            </Text>
+                            <Group gap="xs">
+                                <Text
+                                    size="xs"
+                                    c="indigo"
+                                    fw={700}
+                                    tt="uppercase"
+                                >
+                                    Deep research
+                                </Text>
+                                <Badge
+                                    size="xs"
+                                    variant="light"
+                                    color="gray"
+                                    tt="none"
+                                >
+                                    {
+                                        DEEP_RESEARCH_DEPTH_CONFIG[run.depth]
+                                            .label
+                                    }
+                                </Badge>
+                            </Group>
                             <Text fw={600}>{run.question}</Text>
                         </Stack>
                     </Group>
@@ -121,6 +142,8 @@ export const DeepResearchRunCard = ({
                 <Text className={styles.liveRegion} aria-live="polite">
                     Research status changed to {status.label}
                 </Text>
+
+                <Divider />
 
                 {run.phase && !isTerminal && (
                     <Group gap="xs" wrap="nowrap">

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
@@ -109,7 +109,11 @@ export const DeepResearchRunCard = ({
                             <Text fw={600}>{run.question}</Text>
                         </Stack>
                     </Group>
-                    <Badge color={status.color} variant="light">
+                    <Badge
+                        color={status.color}
+                        variant="light"
+                        style={{ flexShrink: 0 }}
+                    >
                         {status.label}
                     </Badge>
                 </Group>
@@ -301,7 +305,9 @@ export const DeepResearchRunCard = ({
                 <Divider />
                 <Group justify="space-between" align="center">
                     <Text size="xs" c="dimmed">
-                        You can leave this page while research continues.
+                        {isTerminal
+                            ? 'This run is saved in this thread.'
+                            : 'You can leave this page while research continues.'}
                     </Text>
                     {!isTerminal && (
                         <Button

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
@@ -62,9 +62,6 @@ type Props = {
     projectUuid: string;
     onReconnect?: (integrationName?: string) => void;
     onContinueWithoutSource?: (integrationName?: string) => void;
-    onAskFollowUp?: () => void;
-    onChallenge?: () => void;
-    onRerun?: () => void;
 };
 
 export const DeepResearchRunCard = ({
@@ -72,9 +69,6 @@ export const DeepResearchRunCard = ({
     projectUuid,
     onReconnect,
     onContinueWithoutSource,
-    onAskFollowUp,
-    onChallenge,
-    onRerun,
 }: Props) => {
     const status = STATUS_CONFIG[run.status];
     const cancelMutation = useCancelDeepResearchMutation(projectUuid, run.uuid);
@@ -351,9 +345,6 @@ export const DeepResearchRunCard = ({
                 run={run}
                 opened={isReportOpen}
                 onClose={() => setIsReportOpen(false)}
-                onAskFollowUp={onAskFollowUp}
-                onChallenge={onChallenge}
-                onRerun={onRerun}
             />
         </Paper>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
@@ -1,0 +1,331 @@
+import {
+    Alert,
+    Badge,
+    Button,
+    Collapse,
+    Divider,
+    Group,
+    Paper,
+    SimpleGrid,
+    Stack,
+    Text,
+    ThemeIcon,
+    Timeline,
+} from '@mantine-8/core';
+import {
+    IconAlertCircle,
+    IconCheck,
+    IconClock,
+    IconFileSearch,
+    IconPlayerStop,
+    IconPlugConnected,
+    IconReportSearch,
+} from '@tabler/icons-react';
+import { useEffect, useState } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { formatDuration } from '../../../../../utils/formatters';
+import { isDeepResearchRunTerminal } from '../../deepResearch/deepResearchAdapter';
+import { type DeepResearchRunView } from '../../deepResearch/types';
+import { useCancelDeepResearchMutation } from '../../hooks/useDeepResearch';
+import { DeepResearchReport } from './DeepResearchReport';
+import styles from './DeepResearchRunCard.module.css';
+
+const STATUS_CONFIG: Record<
+    DeepResearchRunView['status'],
+    { label: string; color: string }
+> = {
+    queued: { label: 'Queued', color: 'gray' },
+    running: { label: 'Running', color: 'indigo' },
+    waiting_for_permission: {
+        label: 'Waiting for permission',
+        color: 'yellow',
+    },
+    waiting_for_reconnection: {
+        label: 'Waiting for reconnection',
+        color: 'yellow',
+    },
+    completed: { label: 'Completed', color: 'green' },
+    partially_completed: { label: 'Partially completed', color: 'yellow' },
+    failed: { label: 'Failed', color: 'red' },
+    cancelled: { label: 'Cancelled', color: 'gray' },
+};
+
+const getElapsedLabel = (elapsedMs: number) => {
+    return formatDuration(Math.max(0, elapsedMs));
+};
+
+type Props = {
+    run: DeepResearchRunView;
+    projectUuid: string;
+    onReconnect?: (integrationName?: string) => void;
+    onContinueWithoutSource?: (integrationName?: string) => void;
+    onAskFollowUp?: () => void;
+    onChallenge?: () => void;
+    onRerun?: () => void;
+};
+
+export const DeepResearchRunCard = ({
+    run,
+    projectUuid,
+    onReconnect,
+    onContinueWithoutSource,
+    onAskFollowUp,
+    onChallenge,
+    onRerun,
+}: Props) => {
+    const status = STATUS_CONFIG[run.status];
+    const cancelMutation = useCancelDeepResearchMutation(projectUuid, run.uuid);
+    const [isActivityOpen, setIsActivityOpen] = useState(false);
+    const [isReportOpen, setIsReportOpen] = useState(false);
+    const [announcedStatus, setAnnouncedStatus] = useState(run.status);
+
+    useEffect(() => {
+        if (announcedStatus !== run.status) {
+            setAnnouncedStatus(run.status);
+        }
+    }, [announcedStatus, run.status]);
+
+    const hasReport = !!run.artifact;
+    const isTerminal = isDeepResearchRunTerminal(run.status);
+    const isActionRequired = !!run.actionRequired;
+
+    return (
+        <Paper
+            className={styles.card}
+            p="lg"
+            radius="md"
+            aria-label="Deep research run"
+        >
+            <Stack gap="md">
+                <Group justify="space-between" align="flex-start" wrap="nowrap">
+                    <Group align="flex-start" wrap="nowrap">
+                        <ThemeIcon color="indigo" variant="light" radius="md">
+                            <MantineIcon icon={IconReportSearch} size={18} />
+                        </ThemeIcon>
+                        <Stack gap={3}>
+                            <Text size="xs" c="indigo" fw={700} tt="uppercase">
+                                Deep research
+                            </Text>
+                            <Text fw={600}>{run.question}</Text>
+                        </Stack>
+                    </Group>
+                    <Badge color={status.color} variant="light">
+                        {status.label}
+                    </Badge>
+                </Group>
+
+                <Text className={styles.liveRegion} aria-live="polite">
+                    Research status changed to {status.label}
+                </Text>
+
+                {run.phase && !isTerminal && (
+                    <Group gap="xs" wrap="nowrap">
+                        <ThemeIcon size="sm" color="indigo" variant="light">
+                            <MantineIcon icon={IconFileSearch} size={13} />
+                        </ThemeIcon>
+                        <Text size="sm" fw={600}>
+                            {run.phase}
+                        </Text>
+                    </Group>
+                )}
+
+                <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="sm">
+                    <Stack gap={2}>
+                        <Text size="xs" c="dimmed">
+                            Elapsed
+                        </Text>
+                        <Group gap={5}>
+                            <IconClock size={13} />
+                            <Text size="sm" ff="monospace">
+                                {getElapsedLabel(run.elapsedMs)}
+                            </Text>
+                        </Group>
+                    </Stack>
+                    <Stack gap={2}>
+                        <Text size="xs" c="dimmed">
+                            Sources
+                        </Text>
+                        <Text size="sm" fw={600}>
+                            {run.sourceCount ?? '—'}
+                        </Text>
+                    </Stack>
+                    <Stack gap={2}>
+                        <Text size="xs" c="dimmed">
+                            Queries
+                        </Text>
+                        <Text size="sm" fw={600}>
+                            {run.queryCount}
+                        </Text>
+                    </Stack>
+                    <Stack gap={2}>
+                        <Text size="xs" c="dimmed">
+                            Findings
+                        </Text>
+                        <Text size="sm" fw={600}>
+                            {run.findingCount}
+                        </Text>
+                    </Stack>
+                </SimpleGrid>
+
+                {isActionRequired &&
+                    run.actionRequired &&
+                    (onReconnect || onContinueWithoutSource) && (
+                        <Alert
+                            color="yellow"
+                            icon={<IconPlugConnected size={16} />}
+                        >
+                            <Stack gap="sm">
+                                <Text size="sm">
+                                    {run.actionRequired.message}
+                                </Text>
+                                <Group gap="xs">
+                                    {onReconnect && (
+                                        <Button
+                                            size="xs"
+                                            onClick={() =>
+                                                onReconnect?.(
+                                                    run.actionRequired
+                                                        ?.integrationName,
+                                                )
+                                            }
+                                        >
+                                            {run.actionRequired.type ===
+                                            'permission'
+                                                ? 'Review permissions'
+                                                : `Reconnect ${run.actionRequired.integrationName ?? 'source'}`}
+                                        </Button>
+                                    )}
+                                    {onContinueWithoutSource && (
+                                        <Button
+                                            size="xs"
+                                            variant="default"
+                                            onClick={() =>
+                                                onContinueWithoutSource?.(
+                                                    run.actionRequired
+                                                        ?.integrationName,
+                                                )
+                                            }
+                                        >
+                                            Continue without{' '}
+                                            {run.actionRequired
+                                                .integrationName ?? 'source'}
+                                        </Button>
+                                    )}
+                                </Group>
+                            </Stack>
+                        </Alert>
+                    )}
+
+                {run.status === 'failed' && (
+                    <Alert color="red" icon={<IconAlertCircle size={16} />}>
+                        <Text size="sm">
+                            {run.errorMessage ??
+                                'The investigation stopped before a report could be completed.'}
+                        </Text>
+                        <Text size="sm" mt="xs">
+                            Completed queries and partial findings remain
+                            available below. You can rerun the question after
+                            resolving the issue.
+                        </Text>
+                    </Alert>
+                )}
+
+                {run.status === 'partially_completed' && (
+                    <Alert color="yellow" icon={<IconAlertCircle size={16} />}>
+                        The report is incomplete, but all validated findings and
+                        completed queries have been preserved.
+                    </Alert>
+                )}
+
+                {hasReport && (
+                    <Paper className={styles.answer} p="md" radius="sm">
+                        <Stack gap="xs">
+                            <Group gap="xs">
+                                <MantineIcon
+                                    icon={IconCheck}
+                                    size={16}
+                                    color="green.6"
+                                />
+                                <Text size="sm" fw={700}>
+                                    Executive answer
+                                </Text>
+                            </Group>
+                            <Text size="sm" lineClamp={5}>
+                                {run.artifact?.executiveAnswer}
+                            </Text>
+                            <Button
+                                variant="light"
+                                size="xs"
+                                w="fit-content"
+                                onClick={() => setIsReportOpen(true)}
+                            >
+                                Open full report
+                            </Button>
+                        </Stack>
+                    </Paper>
+                )}
+
+                {run.latestEvents.length > 0 && (
+                    <>
+                        <Button
+                            variant="subtle"
+                            size="xs"
+                            w="fit-content"
+                            onClick={() => setIsActivityOpen((open) => !open)}
+                            aria-expanded={isActivityOpen}
+                        >
+                            {isActivityOpen ? 'Hide activity' : 'View activity'}
+                        </Button>
+                        <Collapse in={isActivityOpen}>
+                            <Timeline bulletSize={16} lineWidth={1}>
+                                {run.latestEvents.map((event) => (
+                                    <Timeline.Item
+                                        key={event.uuid}
+                                        title={event.label}
+                                    >
+                                        <Text size="xs" c="dimmed">
+                                            {new Date(
+                                                event.createdAt,
+                                            ).toLocaleTimeString([], {
+                                                hour: '2-digit',
+                                                minute: '2-digit',
+                                            })}
+                                        </Text>
+                                    </Timeline.Item>
+                                ))}
+                            </Timeline>
+                        </Collapse>
+                    </>
+                )}
+
+                <Divider />
+                <Group justify="space-between" align="center">
+                    <Text size="xs" c="dimmed">
+                        You can leave this page while research continues.
+                    </Text>
+                    {!isTerminal && (
+                        <Button
+                            variant="subtle"
+                            color="red"
+                            size="xs"
+                            leftSection={<IconPlayerStop size={14} />}
+                            loading={cancelMutation.isLoading}
+                            onClick={() => cancelMutation.mutate()}
+                        >
+                            Stop research
+                        </Button>
+                    )}
+                </Group>
+            </Stack>
+
+            <DeepResearchReport
+                run={run}
+                opened={isReportOpen}
+                onClose={() => setIsReportOpen(false)}
+                onAskFollowUp={onAskFollowUp}
+                onChallenge={onChallenge}
+                onRerun={onRerun}
+            />
+        </Paper>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchRunCard.tsx
@@ -3,7 +3,6 @@ import {
     Badge,
     Button,
     Collapse,
-    Divider,
     Group,
     Paper,
     SimpleGrid,
@@ -136,8 +135,6 @@ export const DeepResearchRunCard = ({
                 <Text className={styles.liveRegion} aria-live="polite">
                     Research status changed to {status.label}
                 </Text>
-
-                <Divider />
 
                 {run.phase && !isTerminal && (
                     <Group gap="xs" wrap="nowrap">
@@ -319,7 +316,6 @@ export const DeepResearchRunCard = ({
                     </>
                 )}
 
-                <Divider />
                 <Group justify="space-between" align="center">
                     <Text size="xs" c="dimmed">
                         {isTerminal

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.tsx
@@ -1,25 +1,12 @@
 import { Alert, Button, Paper, Skeleton, Stack, Text } from '@mantine-8/core';
 import useUser from '../../../../../hooks/user/useUser';
-import {
-    requestDeepResearchComposerPrompt,
-    useDeepResearchRunsForThread,
-} from '../../deepResearch/deepResearchRegistry';
+import { useDeepResearchRunsForThread } from '../../deepResearch/deepResearchRegistry';
 import { type DeepResearchRunRegistration } from '../../deepResearch/types';
 import {
     useContinueDeepResearchMutation,
     useDeepResearchRun,
 } from '../../hooks/useDeepResearch';
 import { DeepResearchRunCard } from './DeepResearchRunCard';
-
-const NEXT_DEPTH: Record<
-    DeepResearchRunRegistration['depth'],
-    DeepResearchRunRegistration['depth']
-> = {
-    quick: 'standard',
-    standard: 'deep',
-    deep: 'exhaustive',
-    exhaustive: 'exhaustive',
-};
 
 const DeepResearchThreadRun = ({
     registration,
@@ -108,24 +95,6 @@ const DeepResearchThreadRun = ({
         <DeepResearchRunCard
             run={runQuery.data}
             projectUuid={registration.projectUuid}
-            onAskFollowUp={() =>
-                requestDeepResearchComposerPrompt(
-                    registration.threadUuid,
-                    `Follow up on the research about “${registration.question}”: `,
-                )
-            }
-            onChallenge={() =>
-                requestDeepResearchComposerPrompt(
-                    registration.threadUuid,
-                    `Challenge the research findings about “${registration.question}”. Look for contradictory evidence and test the weakest assumption: `,
-                )
-            }
-            onRerun={() =>
-                continueMutation.mutate({
-                    question: registration.question,
-                    depth: NEXT_DEPTH[registration.depth],
-                })
-            }
         />
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.tsx
@@ -1,0 +1,159 @@
+import { Alert, Button, Paper, Skeleton, Stack, Text } from '@mantine-8/core';
+import useUser from '../../../../../hooks/user/useUser';
+import {
+    requestDeepResearchComposerPrompt,
+    useDeepResearchRunsForThread,
+} from '../../deepResearch/deepResearchRegistry';
+import { type DeepResearchRunRegistration } from '../../deepResearch/types';
+import {
+    useContinueDeepResearchMutation,
+    useDeepResearchRun,
+} from '../../hooks/useDeepResearch';
+import { DeepResearchRunCard } from './DeepResearchRunCard';
+
+const NEXT_DEPTH: Record<
+    DeepResearchRunRegistration['depth'],
+    DeepResearchRunRegistration['depth']
+> = {
+    quick: 'standard',
+    standard: 'deep',
+    deep: 'exhaustive',
+    exhaustive: 'exhaustive',
+};
+
+const DeepResearchThreadRun = ({
+    registration,
+}: {
+    registration: DeepResearchRunRegistration;
+}) => {
+    const runQuery = useDeepResearchRun(registration);
+    const continueMutation = useContinueDeepResearchMutation({
+        projectUuid: registration.projectUuid,
+        threadUuid: registration.threadUuid,
+    });
+
+    if (registration.state !== 'started') {
+        const failed = registration.state === 'start_failed';
+        return (
+            <Paper p="lg" radius="md" withBorder aria-label="Deep research run">
+                <Stack gap="xs">
+                    <Text size="xs" c="indigo" fw={700} tt="uppercase">
+                        Deep research
+                    </Text>
+                    <Text fw={600}>{registration.question}</Text>
+                    {failed ? (
+                        <Alert color="red" title="Research did not start">
+                            {registration.errorMessage ??
+                                'The run could not be created. Your question is preserved in this thread; try again when the service is available.'}
+                        </Alert>
+                    ) : (
+                        <Text size="sm" c="dimmed" aria-live="polite">
+                            Starting research… The run card is saved in this
+                            thread.
+                        </Text>
+                    )}
+                    {failed && (
+                        <Button
+                            size="xs"
+                            w="fit-content"
+                            loading={continueMutation.isLoading}
+                            onClick={() =>
+                                continueMutation.mutate({
+                                    question: registration.question,
+                                    depth: registration.depth,
+                                })
+                            }
+                        >
+                            Try again
+                        </Button>
+                    )}
+                </Stack>
+            </Paper>
+        );
+    }
+    if (runQuery.isLoading) {
+        return <Skeleton h={190} radius="md" />;
+    }
+    if (runQuery.isError || runQuery.eventsQuery.isError) {
+        return (
+            <Paper p="lg" radius="md" withBorder aria-label="Deep research run">
+                <Stack gap="sm">
+                    <Text size="xs" c="indigo" fw={700} tt="uppercase">
+                        Deep research
+                    </Text>
+                    <Text fw={600}>{registration.question}</Text>
+                    <Alert color="yellow" title="Could not refresh this run">
+                        The durable run is still saved. Check your connection
+                        and try loading its latest state again.
+                    </Alert>
+                    <Button
+                        size="xs"
+                        variant="default"
+                        w="fit-content"
+                        onClick={() => {
+                            void runQuery.refetch();
+                            void runQuery.eventsQuery.refetch();
+                        }}
+                    >
+                        Try again
+                    </Button>
+                </Stack>
+            </Paper>
+        );
+    }
+    if (!runQuery.data) {
+        return null;
+    }
+    return (
+        <DeepResearchRunCard
+            run={runQuery.data}
+            projectUuid={registration.projectUuid}
+            onAskFollowUp={() =>
+                requestDeepResearchComposerPrompt(
+                    registration.threadUuid,
+                    `Follow up on the research about “${registration.question}”: `,
+                )
+            }
+            onChallenge={() =>
+                requestDeepResearchComposerPrompt(
+                    registration.threadUuid,
+                    `Challenge the research findings about “${registration.question}”. Look for contradictory evidence and test the weakest assumption: `,
+                )
+            }
+            onRerun={() =>
+                continueMutation.mutate({
+                    question: registration.question,
+                    depth: NEXT_DEPTH[registration.depth],
+                })
+            }
+        />
+    );
+};
+
+export const DeepResearchThreadRuns = ({
+    projectUuid,
+    threadUuid,
+}: {
+    projectUuid: string;
+    threadUuid: string;
+}) => {
+    const user = useUser(true);
+    const registrations = useDeepResearchRunsForThread(
+        projectUuid,
+        threadUuid,
+        user.data?.userUuid,
+    );
+    if (!registrations.length) {
+        return null;
+    }
+    return (
+        <Stack gap="md">
+            {registrations.map((registration) => (
+                <DeepResearchThreadRun
+                    key={registration.runUuid}
+                    registration={registration}
+                />
+            ))}
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -1,4 +1,5 @@
 import {
+    FeatureFlags,
     type AiAgentSummary,
     type AiPromptContext,
     type AiPromptContextInput,
@@ -23,9 +24,15 @@ import {
 } from 'react';
 import { createPath, useLocation, useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
+import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../../providers/App/useApp';
+import { type StartDeepResearchArgs } from '../../deepResearch/types';
 import { useAiAgentSqlModeAvailable } from '../../hooks/useAiAgentSqlModeAvailable';
 import { useDashboardPageContextCuration } from '../../hooks/useDashboardPageContextCuration';
+import {
+    useStartDeepResearchForThreadMutation,
+    useStartDeepResearchMutation,
+} from '../../hooks/useDeepResearch';
 import { usePendingThreadRefetch } from '../../hooks/usePendingThreadRefetch';
 import { usePinnedContext } from '../../hooks/usePinnedContext';
 import {
@@ -131,6 +138,7 @@ const NewThreadPanel: FC<{
     const { addItem: addDockItem } = useLauncherDock(projectUuid);
     const isAuto = isLauncherAutoAgent(agent);
     const concreteAgent = getConcreteLauncherAgent(agent);
+    const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
 
     const {
         contextInput,
@@ -205,6 +213,36 @@ const NewThreadPanel: FC<{
             },
             onToolResult: handleToolResult,
         });
+    const startDeepResearch =
+        useStartDeepResearchForThreadMutation(projectUuid);
+
+    const handleStartDeepResearch = useCallback(
+        async ({ question, depth }: StartDeepResearchArgs) => {
+            if (!concreteAgent || !isPinnedContextReady) {
+                return;
+            }
+            const thread = await createAgentThread({
+                agentUuid: concreteAgent.uuid,
+                prompt: question,
+                context: contextInputWithPageContext,
+                optimisticContext: previewItemsWithPageContext,
+                skipAgentResponse: true,
+            });
+            await startDeepResearch.mutateAsync({
+                question,
+                depth,
+                threadUuid: thread.uuid,
+            });
+        },
+        [
+            concreteAgent,
+            contextInputWithPageContext,
+            createAgentThread,
+            isPinnedContextReady,
+            previewItemsWithPageContext,
+            startDeepResearch,
+        ],
+    );
 
     const createThreadForAgent = useCallback(
         async ({
@@ -327,6 +365,11 @@ const NewThreadPanel: FC<{
                     key={composerSeed ?? 'composer'}
                     defaultValue={composerSeed ?? undefined}
                     onSubmit={handleSubmit}
+                    onStartDeepResearch={
+                        concreteAgent && deepResearchFlag.data?.enabled
+                            ? handleStartDeepResearch
+                            : undefined
+                    }
                     loading={isLocked}
                     disabled={!isPinnedContextReady || isPickingAgent}
                     placeholder={`Ask ${displayName} anything...`}
@@ -394,6 +437,7 @@ const ExistingThreadPanel: FC<{
     style?: CSSProperties;
 }> = ({ projectUuid, agent, agents, threadId, style }) => {
     const { user } = useApp();
+    const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
     const navigate = useNavigate();
     const location = useLocation();
     const {
@@ -426,6 +470,10 @@ const ExistingThreadPanel: FC<{
         isLoading: isCreatingMessage,
     } = useCreateAgentThreadMessageMutation(projectUuid, agent.uuid, threadId, {
         onToolResult: handleToolResult,
+    });
+    const startDeepResearch = useStartDeepResearchMutation({
+        projectUuid,
+        threadUuid: threadId,
     });
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
@@ -480,6 +528,17 @@ const ExistingThreadPanel: FC<{
         }).then(() => {
             recordSubmittedContext(curatedContext.context);
         });
+    };
+
+    const handleStartDeepResearch = async ({
+        question,
+        depth,
+    }: Parameters<typeof startDeepResearch.mutateAsync>[0]) => {
+        await createAgentThreadMessage({
+            prompt: question,
+            skipAgentResponse: true,
+        });
+        await startDeepResearch.mutateAsync({ question, depth });
     };
 
     const headerTitle =
@@ -542,6 +601,11 @@ const ExistingThreadPanel: FC<{
                         disabledReason="This thread is read-only. To continue the conversation, reply in Slack."
                         loading={isCreatingMessage || isStreaming || isPending}
                         onSubmit={handleSubmit}
+                        onStartDeepResearch={
+                            deepResearchFlag.data?.enabled
+                                ? handleStartDeepResearch
+                                : undefined
+                        }
                         placeholder={`Ask ${agent.name} anything...`}
                         messageCount={thread.messages?.length || 0}
                         projectUuid={projectUuid}

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchAdapter.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchAdapter.test.ts
@@ -14,6 +14,35 @@ const registration: DeepResearchRunRegistration = {
 };
 
 describe('adaptDeepResearchRun', () => {
+    it('uses the client registration time for an active run', () => {
+        const view = adaptDeepResearchRun({
+            registration,
+            events: [],
+            now: Date.parse('2026-07-15T09:00:08.000Z'),
+            run: {
+                aiDeepResearchRunUuid: 'run-1',
+                projectUuid: 'project-1',
+                status: 'running',
+                result: null,
+                budget: {
+                    maxRuntimeMs: 1_800_000,
+                    maxTokens: 10_000,
+                    maxToolCalls: 25,
+                    maxWarehouseQueries: 25,
+                    maxResultRows: 10_000,
+                },
+                errorMessage: null,
+                cancellationRequestedAt: null,
+                createdAt: '2026-07-15T08:00:00.000Z',
+                updatedAt: '2026-07-15T08:00:08.000Z',
+                startedAt: '2026-07-15T08:00:01.000Z',
+                completedAt: null,
+            },
+        });
+
+        expect(view.elapsedMs).toBe(8_000);
+    });
+
     it('drops unsafe model-produced evidence links', () => {
         const view = adaptDeepResearchRun({
             registration,

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchAdapter.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchAdapter.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { adaptDeepResearchRun } from './deepResearchAdapter';
+import { type DeepResearchRunRegistration } from './types';
+
+const registration: DeepResearchRunRegistration = {
+    runUuid: 'run-1',
+    projectUuid: 'project-1',
+    threadUuid: 'thread-1',
+    userUuid: 'user-1',
+    question: 'Why did enterprise retention fall?',
+    depth: 'standard',
+    createdAt: '2026-07-15T09:00:00.000Z',
+    state: 'started',
+};
+
+describe('adaptDeepResearchRun', () => {
+    it('drops unsafe model-produced evidence links', () => {
+        const view = adaptDeepResearchRun({
+            registration,
+            events: [],
+            now: Date.parse('2026-07-15T09:05:00.000Z'),
+            run: {
+                aiDeepResearchRunUuid: 'run-1',
+                projectUuid: 'project-1',
+                status: 'completed',
+                result: {
+                    summary: 'A small renewal cohort caused the movement.',
+                    findings: [
+                        {
+                            title: 'Renewal cohort',
+                            summary: 'Three accounts drove most of the change.',
+                            confidence: 'high',
+                            evidence: [
+                                {
+                                    title: 'Unsafe source',
+                                    description: 'Untrusted model output.',
+                                    sourceType: 'web',
+                                    sourceLabel: 'External source',
+                                    sourceUrl: 'javascript:alert(1)',
+                                },
+                            ],
+                        },
+                    ],
+                    caveats: [],
+                    scope: 'Enterprise renewals in Q2.',
+                    unresolvedQuestions: [],
+                    nextSteps: [],
+                },
+                budget: {
+                    maxRuntimeMs: 1_800_000,
+                    maxTokens: 10_000,
+                    maxToolCalls: 25,
+                    maxWarehouseQueries: 25,
+                    maxResultRows: 10_000,
+                },
+                errorMessage: null,
+                cancellationRequestedAt: null,
+                createdAt: '2026-07-15T09:00:00.000Z',
+                updatedAt: '2026-07-15T09:05:00.000Z',
+                startedAt: '2026-07-15T09:00:01.000Z',
+                completedAt: '2026-07-15T09:05:00.000Z',
+            },
+        });
+
+        expect(view.artifact?.findings[0].evidence[0].sourceUrl).toBeNull();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchAdapter.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchAdapter.ts
@@ -27,14 +27,14 @@ export const DEEP_RESEARCH_DEPTH_CONFIG: Record<
     }
 > = {
     quick: {
-        label: 'Quick',
+        label: 'Low',
         effort: 'low',
         duration: 'Up to 15 minutes',
         warehouseQueries: 10,
         description: 'A focused check of the strongest available evidence.',
     },
     standard: {
-        label: 'Standard',
+        label: 'Medium',
         effort: 'medium',
         duration: 'Up to 30 minutes',
         warehouseQueries: 25,
@@ -42,14 +42,14 @@ export const DEEP_RESEARCH_DEPTH_CONFIG: Record<
             'A balanced investigation with validation and alternatives.',
     },
     deep: {
-        label: 'Deep',
+        label: 'High',
         effort: 'high',
         duration: 'Up to 45 minutes',
         warehouseQueries: 50,
         description: 'A broad investigation with more competing explanations.',
     },
     exhaustive: {
-        label: 'Exhaustive',
+        label: 'Extra High',
         effort: 'xhigh',
         duration: 'Up to 55 minutes',
         warehouseQueries: 100,
@@ -236,8 +236,10 @@ export const adaptDeepResearchRun = ({
     const queryCount = progressEvents.filter(
         (event) => event.payload.progress.activity === 'warehouse_query',
     ).length;
+    const startTime = run.completedAt
+        ? new Date(run.startedAt ?? run.createdAt).getTime()
+        : new Date(registration.createdAt).getTime();
     const endTime = run.completedAt ? new Date(run.completedAt).getTime() : now;
-    const startTime = new Date(run.startedAt ?? run.createdAt).getTime();
 
     return {
         uuid: run.aiDeepResearchRunUuid,

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchAdapter.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchAdapter.ts
@@ -1,0 +1,271 @@
+import {
+    assertUnreachable,
+    type AiDeepResearchActivity,
+    type AiDeepResearchEvidence,
+    type AiDeepResearchEffort,
+    type AiDeepResearchEvent,
+    type AiDeepResearchPhase,
+    type AiDeepResearchRun,
+} from '@lightdash/common';
+import {
+    type DeepResearchArtifact,
+    type DeepResearchDepth,
+    type DeepResearchEvidence,
+    type DeepResearchRunRegistration,
+    type DeepResearchRunStatus,
+    type DeepResearchRunView,
+} from './types';
+
+export const DEEP_RESEARCH_DEPTH_CONFIG: Record<
+    DeepResearchDepth,
+    {
+        label: string;
+        effort: AiDeepResearchEffort;
+        duration: string;
+        warehouseQueries: number;
+        description: string;
+    }
+> = {
+    quick: {
+        label: 'Quick',
+        effort: 'low',
+        duration: 'Up to 15 minutes',
+        warehouseQueries: 10,
+        description: 'A focused check of the strongest available evidence.',
+    },
+    standard: {
+        label: 'Standard',
+        effort: 'medium',
+        duration: 'Up to 30 minutes',
+        warehouseQueries: 25,
+        description:
+            'A balanced investigation with validation and alternatives.',
+    },
+    deep: {
+        label: 'Deep',
+        effort: 'high',
+        duration: 'Up to 45 minutes',
+        warehouseQueries: 50,
+        description: 'A broad investigation with more competing explanations.',
+    },
+    exhaustive: {
+        label: 'Exhaustive',
+        effort: 'xhigh',
+        duration: 'Up to 55 minutes',
+        warehouseQueries: 100,
+        description: 'The widest evidence review for high-stakes questions.',
+    },
+};
+
+const QUERY_UUID_PATTERN = /[0-9a-f]{8}-[0-9a-f-]{27,36}/i;
+
+const getSafeEvidenceUrl = (value: string | null): string | null => {
+    if (!value) return null;
+    if (value.startsWith('/') && !value.startsWith('//')) return value;
+    try {
+        const url = new URL(value);
+        return url.protocol === 'https:' ? url.toString() : null;
+    } catch {
+        return null;
+    }
+};
+
+const getEvidenceSourceType = (
+    sourceType: 'lightdash' | 'warehouse' | 'web',
+    sourceLabel: string,
+): DeepResearchEvidence['sourceType'] => {
+    if (/github|repository|pull request/i.test(sourceLabel)) {
+        return 'repository';
+    }
+    if (/document|knowledge|notion/i.test(sourceLabel)) {
+        return 'document';
+    }
+    return sourceType;
+};
+
+const getEvidence = (
+    evidence: AiDeepResearchEvidence,
+    findingIndex: number,
+    evidenceIndex: number,
+): DeepResearchEvidence => {
+    const sourceUrl = getSafeEvidenceUrl(evidence.sourceUrl);
+    const sourceType = getEvidenceSourceType(
+        evidence.sourceType,
+        evidence.sourceLabel,
+    );
+    return {
+        uuid: `evidence-${findingIndex + 1}-${evidenceIndex + 1}`,
+        title: evidence.title,
+        description: evidence.description,
+        sourceType,
+        sourceLabel: evidence.sourceLabel,
+        sourceUrl,
+        queryUuid:
+            sourceUrl &&
+            (evidence.sourceType === 'lightdash' ||
+                evidence.sourceType === 'warehouse')
+                ? (sourceUrl.match(QUERY_UUID_PATTERN)?.[0] ?? null)
+                : null,
+        metrics: [],
+        filters: [],
+        dateRange: null,
+    };
+};
+
+const getArtifact = (run: AiDeepResearchRun): DeepResearchArtifact | null => {
+    if (!run.result) {
+        return null;
+    }
+
+    const findingConfidences = run.result.findings.map(
+        (finding) => finding.confidence,
+    );
+    const confidence = findingConfidences.includes('low')
+        ? 'low'
+        : findingConfidences.includes('medium')
+          ? 'medium'
+          : 'high';
+
+    return {
+        executiveAnswer: run.result.summary,
+        findings: run.result.findings.map((finding, findingIndex) => ({
+            uuid: `finding-${findingIndex + 1}`,
+            title: finding.title,
+            summary: finding.summary,
+            confidence: finding.confidence,
+            evidence: finding.evidence.map((evidence, evidenceIndex) =>
+                getEvidence(evidence, findingIndex, evidenceIndex),
+            ),
+        })),
+        contradictoryEvidence: run.result.caveats,
+        definitionsAndMethodology: run.result.scope,
+        confidence,
+        limitations: run.result.caveats,
+        nextQuestions: run.result.unresolvedQuestions.length
+            ? run.result.unresolvedQuestions
+            : run.result.nextSteps,
+    };
+};
+
+const getActivityLabel = (activity: AiDeepResearchActivity | null): string => {
+    switch (activity) {
+        case 'lightdash_metadata':
+            return 'Reviewed project data and metric definitions';
+        case 'warehouse_query':
+            return 'Executed a warehouse query';
+        case 'web_search':
+            return 'Searched public evidence sources';
+        case 'web_fetch':
+            return 'Reviewed a source document';
+        case 'reporting':
+            return 'Prepared the evidence-backed report';
+        case null:
+            return 'Updated the investigation';
+        default:
+            return assertUnreachable(activity, 'Unknown research activity');
+    }
+};
+
+const getEventLabel = (event: AiDeepResearchEvent): string => {
+    switch (event.eventType) {
+        case 'status_changed':
+            return `Research ${event.payload.status.replaceAll('_', ' ')}`;
+        case 'cancellation_requested':
+            return 'Cancellation requested';
+        case 'progress':
+            return getActivityLabel(event.payload.progress.activity);
+        default:
+            return assertUnreachable(event, 'Unknown research event');
+    }
+};
+
+const getPhaseLabel = (
+    phase: AiDeepResearchPhase | null,
+    activity: AiDeepResearchActivity | null,
+): string | null => {
+    switch (phase) {
+        case 'planning':
+            return 'Planning the investigation';
+        case 'investigating':
+            return activity === 'warehouse_query'
+                ? 'Testing explanations'
+                : 'Gathering context';
+        case 'validating':
+            return activity === 'web_fetch'
+                ? 'Reviewing evidence'
+                : 'Validating findings';
+        case 'synthesizing':
+            return 'Writing the report';
+        case null:
+            return null;
+        default:
+            return assertUnreachable(phase, 'Unknown research phase');
+    }
+};
+
+export const isDeepResearchRunTerminal = (
+    status: DeepResearchRunStatus,
+): boolean =>
+    [
+        'completed',
+        'partially_completed',
+        'failed',
+        'cancelled',
+        'waiting_for_permission',
+        'waiting_for_reconnection',
+    ].includes(status);
+
+export const adaptDeepResearchRun = ({
+    run,
+    events,
+    registration,
+    now = Date.now(),
+}: {
+    run: AiDeepResearchRun;
+    events: AiDeepResearchEvent[];
+    registration: DeepResearchRunRegistration;
+    now?: number;
+}): DeepResearchRunView => {
+    const progressEvents = events.filter(
+        (
+            event,
+        ): event is Extract<AiDeepResearchEvent, { eventType: 'progress' }> =>
+            event.eventType === 'progress',
+    );
+    const latestProgress = progressEvents.at(-1)?.payload.progress;
+    const queryCount = progressEvents.filter(
+        (event) => event.payload.progress.activity === 'warehouse_query',
+    ).length;
+    const endTime = run.completedAt ? new Date(run.completedAt).getTime() : now;
+    const startTime = new Date(run.startedAt ?? run.createdAt).getTime();
+
+    return {
+        uuid: run.aiDeepResearchRunUuid,
+        threadUuid: registration.threadUuid,
+        question: registration.question,
+        depth: registration.depth,
+        status: run.status,
+        phase: getPhaseLabel(
+            latestProgress?.phase ?? null,
+            latestProgress?.activity ?? null,
+        ),
+        startedAt: run.startedAt,
+        completedAt: run.completedAt,
+        elapsedMs: Math.max(0, endTime - startTime),
+        sourceCount: null,
+        queryCount,
+        findingCount: run.result?.findings.length ?? 0,
+        actionRequired: null,
+        latestEvents: events
+            .slice(-4)
+            .reverse()
+            .map((event) => ({
+                uuid: event.aiDeepResearchEventUuid,
+                type: event.eventType,
+                label: getEventLabel(event),
+                createdAt: event.createdAt,
+            })),
+        artifact: getArtifact(run),
+        errorMessage: run.errorMessage,
+    };
+};

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchRegistry.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchRegistry.ts
@@ -104,15 +104,6 @@ export const useDeepResearchRunsForThread = (
 
 const COMPOSER_EVENT = 'lightdash:deep-research-composer-prompt';
 
-export const requestDeepResearchComposerPrompt = (
-    threadUuid: string,
-    prompt: string,
-) => {
-    window.dispatchEvent(
-        new CustomEvent(COMPOSER_EVENT, { detail: { threadUuid, prompt } }),
-    );
-};
-
 export const subscribeToDeepResearchComposerPrompt = (
     listener: (detail: { threadUuid: string; prompt: string }) => void,
 ) => {

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchRegistry.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/deepResearchRegistry.ts
@@ -1,0 +1,130 @@
+import { useSyncExternalStore } from 'react';
+import { type DeepResearchRunRegistration } from './types';
+
+const STORAGE_KEY = 'lightdash.deep-research-runs.v1';
+const REGISTRY_EVENT = 'lightdash:deep-research-runs-changed';
+
+const readRegistry = (): DeepResearchRunRegistration[] => {
+    if (typeof window === 'undefined') {
+        return [];
+    }
+    try {
+        const value: unknown = JSON.parse(
+            window.localStorage.getItem(STORAGE_KEY) ?? '[]',
+        );
+        return Array.isArray(value)
+            ? value.filter(
+                  (item): item is DeepResearchRunRegistration =>
+                      typeof item === 'object' &&
+                      item !== null &&
+                      'runUuid' in item &&
+                      typeof item.runUuid === 'string' &&
+                      'userUuid' in item &&
+                      typeof item.userUuid === 'string' &&
+                      'threadUuid' in item &&
+                      typeof item.threadUuid === 'string',
+              )
+            : [];
+    } catch {
+        return [];
+    }
+};
+
+let snapshot = readRegistry();
+const EMPTY_REGISTRY: DeepResearchRunRegistration[] = [];
+
+const emitChange = (registrations: DeepResearchRunRegistration[]) => {
+    snapshot = registrations;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(registrations));
+    window.dispatchEvent(new Event(REGISTRY_EVENT));
+};
+
+export const registerDeepResearchRun = (
+    registration: DeepResearchRunRegistration,
+) => {
+    const registrations = readRegistry().filter(
+        (item) => item.runUuid !== registration.runUuid,
+    );
+    emitChange([...registrations, registration]);
+};
+
+export const replaceDeepResearchRun = (
+    previousRunUuid: string,
+    registration: DeepResearchRunRegistration,
+) => {
+    const registrations = readRegistry().filter(
+        (item) => item.runUuid !== previousRunUuid,
+    );
+    emitChange([...registrations, registration]);
+};
+
+export const updateDeepResearchRun = (
+    runUuid: string,
+    updates: Partial<DeepResearchRunRegistration>,
+) => {
+    emitChange(
+        readRegistry().map((registration) =>
+            registration.runUuid === runUuid
+                ? { ...registration, ...updates }
+                : registration,
+        ),
+    );
+};
+
+const subscribe = (onStoreChange: () => void) => {
+    const handleChange = () => {
+        snapshot = readRegistry();
+        onStoreChange();
+    };
+    window.addEventListener(REGISTRY_EVENT, handleChange);
+    window.addEventListener('storage', handleChange);
+    return () => {
+        window.removeEventListener(REGISTRY_EVENT, handleChange);
+        window.removeEventListener('storage', handleChange);
+    };
+};
+
+export const useDeepResearchRunsForThread = (
+    projectUuid: string,
+    threadUuid: string,
+    userUuid: string | undefined,
+) => {
+    const registrations = useSyncExternalStore(
+        subscribe,
+        () => snapshot,
+        () => EMPTY_REGISTRY,
+    );
+    return registrations.filter(
+        (registration) =>
+            registration.projectUuid === projectUuid &&
+            registration.threadUuid === threadUuid &&
+            registration.userUuid === userUuid,
+    );
+};
+
+const COMPOSER_EVENT = 'lightdash:deep-research-composer-prompt';
+
+export const requestDeepResearchComposerPrompt = (
+    threadUuid: string,
+    prompt: string,
+) => {
+    window.dispatchEvent(
+        new CustomEvent(COMPOSER_EVENT, { detail: { threadUuid, prompt } }),
+    );
+};
+
+export const subscribeToDeepResearchComposerPrompt = (
+    listener: (detail: { threadUuid: string; prompt: string }) => void,
+) => {
+    const handleEvent = (event: Event) => {
+        const detail = (
+            event as CustomEvent<{
+                threadUuid: string;
+                prompt: string;
+            }>
+        ).detail;
+        if (detail) listener(detail);
+    };
+    window.addEventListener(COMPOSER_EVENT, handleEvent);
+    return () => window.removeEventListener(COMPOSER_EVENT, handleEvent);
+};

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/fixtures.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/fixtures.ts
@@ -1,0 +1,118 @@
+import { type DeepResearchRunView } from './types';
+
+export const deepResearchRunFixture: DeepResearchRunView = {
+    uuid: 'run-quarterly-retention',
+    threadUuid: 'thread-quarterly-retention',
+    question:
+        'Why did enterprise retention fall in Q2 despite higher product adoption?',
+    depth: 'standard',
+    status: 'completed',
+    phase: 'Writing the report',
+    startedAt: '2026-07-15T09:00:00.000Z',
+    completedAt: '2026-07-15T09:18:00.000Z',
+    elapsedMs: 1_080_000,
+    sourceCount: 4,
+    queryCount: 7,
+    findingCount: 2,
+    actionRequired: null,
+    latestEvents: [
+        {
+            uuid: 'event-report',
+            type: 'progress',
+            label: 'Prepared the evidence-backed report',
+            createdAt: '2026-07-15T09:18:00.000Z',
+        },
+        {
+            uuid: 'event-query',
+            type: 'progress',
+            label: 'Executed a warehouse query',
+            createdAt: '2026-07-15T09:12:00.000Z',
+        },
+    ],
+    artifact: {
+        executiveAnswer:
+            'Retention fell because three large customers reached renewal with unresolved reliability incidents. Adoption increased among retained accounts, but it did not offset the revenue concentration of those churns.',
+        findings: [
+            {
+                uuid: 'finding-renewals',
+                title: 'Churn was concentrated in three incident-affected renewals',
+                summary:
+                    'Three enterprise accounts represented 71% of Q2 churned ARR. Each recorded multiple severity-one incidents in the 60 days before renewal.',
+                confidence: 'high',
+                evidence: [
+                    {
+                        uuid: 'evidence-retention-query',
+                        title: 'Enterprise renewal cohort by incident exposure',
+                        description:
+                            'The renewal cohort query joins contracted ARR, renewal outcome, and production incident exposure for Q2.',
+                        sourceType: 'lightdash',
+                        sourceLabel: 'Project data',
+                        sourceUrl:
+                            '/projects/project-1/queries/7c4b40ba-79f8-4fd2-9c43-223eca8fa76f',
+                        queryUuid: '7c4b40ba-79f8-4fd2-9c43-223eca8fa76f',
+                        metrics: [
+                            'Renewed ARR',
+                            'Churned ARR',
+                            'Incident count',
+                        ],
+                        filters: [
+                            'Segment is Enterprise',
+                            'Renewal quarter is 2026 Q2',
+                        ],
+                        dateRange: '1 April–30 June 2026',
+                    },
+                    {
+                        uuid: 'evidence-incident-review',
+                        title: 'Q2 enterprise incident review',
+                        description:
+                            'The support review identifies repeated export failures and delayed incident follow-up for the affected accounts.',
+                        sourceType: 'document',
+                        sourceLabel: 'Knowledge',
+                        sourceUrl: null,
+                        queryUuid: null,
+                        metrics: [],
+                        filters: [],
+                        dateRange: null,
+                    },
+                ],
+            },
+            {
+                uuid: 'finding-adoption',
+                title: 'Adoption gains occurred mostly in accounts that already renewed',
+                summary:
+                    'Weekly active seats rose 14%, but the increase was strongest among healthy retained accounts and is not evidence that at-risk renewals recovered.',
+                confidence: 'medium',
+                evidence: [
+                    {
+                        uuid: 'evidence-adoption-query',
+                        title: 'Seat adoption by renewal outcome',
+                        description:
+                            'Usage is segmented by renewal outcome to avoid conflating retained-account expansion with churn prevention.',
+                        sourceType: 'warehouse',
+                        sourceLabel: 'Warehouse query',
+                        sourceUrl: null,
+                        queryUuid: 'aab39aec-c169-40ed-83aa-86cd8da1a7dd',
+                        metrics: ['Weekly active seats'],
+                        filters: ['Segment is Enterprise'],
+                        dateRange: '1 January–30 June 2026',
+                    },
+                ],
+            },
+        ],
+        contradictoryEvidence: [
+            'One churned customer had high adoption and no recorded severity-one incident, suggesting procurement pressure was also involved.',
+        ],
+        definitionsAndMethodology:
+            'Enterprise means accounts with at least £100k contracted ARR. Retention is measured on renewable ARR. The analysis compared Q2 renewal cohorts, incident records, usage, and support reviews.',
+        confidence: 'high',
+        limitations: [
+            'Support sentiment is incomplete for one churned account.',
+            'The analysis establishes a strong association, not a controlled causal estimate.',
+        ],
+        nextQuestions: [
+            'Which open reliability issues affect enterprise accounts renewing in Q3?',
+            'Would excluding incident-affected accounts change the adoption-retention relationship?',
+        ],
+    },
+    errorMessage: null,
+};

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/types.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/types.ts
@@ -1,0 +1,102 @@
+import { type AiDeepResearchConfidence } from '@lightdash/common';
+
+export const DEEP_RESEARCH_DEPTHS = [
+    'quick',
+    'standard',
+    'deep',
+    'exhaustive',
+] as const;
+
+export type DeepResearchDepth = (typeof DEEP_RESEARCH_DEPTHS)[number];
+
+export type DeepResearchRunStatus =
+    | 'queued'
+    | 'running'
+    | 'waiting_for_permission'
+    | 'waiting_for_reconnection'
+    | 'completed'
+    | 'partially_completed'
+    | 'failed'
+    | 'cancelled';
+
+export type DeepResearchSource = {
+    name: string;
+    isAvailable: boolean;
+    warning: string | null;
+};
+
+export type DeepResearchEvidence = {
+    uuid: string;
+    title: string;
+    description: string;
+    sourceType: 'lightdash' | 'warehouse' | 'repository' | 'document' | 'web';
+    sourceLabel: string;
+    sourceUrl: string | null;
+    queryUuid: string | null;
+    metrics: string[];
+    filters: string[];
+    dateRange: string | null;
+};
+
+export type DeepResearchFinding = {
+    uuid: string;
+    title: string;
+    summary: string;
+    confidence: AiDeepResearchConfidence;
+    evidence: DeepResearchEvidence[];
+};
+
+export type DeepResearchArtifact = {
+    executiveAnswer: string;
+    findings: DeepResearchFinding[];
+    contradictoryEvidence: string[];
+    definitionsAndMethodology: string;
+    confidence: AiDeepResearchConfidence;
+    limitations: string[];
+    nextQuestions: string[];
+};
+
+export type DeepResearchRunView = {
+    uuid: string;
+    threadUuid: string;
+    question: string;
+    depth: DeepResearchDepth;
+    status: DeepResearchRunStatus;
+    phase: string | null;
+    startedAt: string | null;
+    completedAt: string | null;
+    elapsedMs: number;
+    sourceCount: number | null;
+    queryCount: number;
+    findingCount: number;
+    actionRequired: null | {
+        type: string;
+        integrationName?: string;
+        message: string;
+    };
+    latestEvents: Array<{
+        uuid: string;
+        type: string;
+        label: string;
+        createdAt: string;
+    }>;
+    artifact: DeepResearchArtifact | null;
+    errorMessage: string | null;
+};
+
+export type DeepResearchRunRegistration = {
+    runUuid: string;
+    projectUuid: string;
+    threadUuid: string;
+    userUuid: string;
+    question: string;
+    depth: DeepResearchDepth;
+    createdAt: string;
+    state: 'starting' | 'started' | 'start_failed';
+    errorMessage?: string;
+};
+
+export type StartDeepResearchArgs = {
+    question: string;
+    depth: DeepResearchDepth;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
@@ -1,0 +1,161 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type DeepResearchRunRegistration } from '../deepResearch/types';
+import { useDeepResearchRun } from './useDeepResearch';
+
+const lightdashApiMock = vi.fn();
+
+vi.mock('../../../../api', () => ({
+    lightdashApi: (args: unknown) => lightdashApiMock(args),
+}));
+
+const registration: DeepResearchRunRegistration = {
+    runUuid: 'run-1',
+    projectUuid: 'project-1',
+    threadUuid: 'thread-1',
+    userUuid: 'user-1',
+    question: 'Why did enterprise retention fall in Q2?',
+    depth: 'standard',
+    createdAt: '2026-07-15T09:00:00.000Z',
+    state: 'started',
+};
+
+const getRun = (status: 'running' | 'completed') => ({
+    aiDeepResearchRunUuid: 'run-1',
+    projectUuid: 'project-1',
+    status,
+    result:
+        status === 'completed'
+            ? {
+                  summary:
+                      'Three incident-affected renewals drove the decline.',
+                  findings: [],
+                  caveats: [],
+                  scope: 'Q2 enterprise renewal cohort.',
+                  unresolvedQuestions: [],
+                  nextSteps: [],
+              }
+            : null,
+    budget: {
+        maxRuntimeMs: 1_800_000,
+        maxTokens: 10_000,
+        maxToolCalls: 25,
+        maxWarehouseQueries: 25,
+        maxResultRows: 10_000,
+    },
+    errorMessage: null,
+    cancellationRequestedAt: null,
+    createdAt: '2026-07-15T09:00:00.000Z',
+    updatedAt: '2026-07-15T09:05:00.000Z',
+    startedAt: '2026-07-15T09:00:02.000Z',
+    completedAt: status === 'completed' ? '2026-07-15T09:05:00.000Z' : null,
+});
+
+const getWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, cacheTime: 0 } },
+    });
+    return ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+};
+
+describe('useDeepResearchRun', () => {
+    beforeEach(() => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        let runReads = 0;
+        lightdashApiMock.mockImplementation(({ url }: { url: string }) => {
+            if (url.includes('/events')) {
+                return Promise.resolve({ events: [], nextCursor: null });
+            }
+            runReads += 1;
+            return Promise.resolve(
+                getRun(runReads === 1 ? 'running' : 'completed'),
+            );
+        });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        lightdashApiMock.mockReset();
+    });
+
+    it('stops polling after a terminal state and cleans up on unmount', async () => {
+        const wrapper = getWrapper();
+        const { result, unmount } = renderHook(
+            () => useDeepResearchRun(registration),
+            { wrapper },
+        );
+
+        await waitFor(() =>
+            expect(result.current.data?.status).toBe('running'),
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(2_100);
+        });
+        await waitFor(() =>
+            expect(result.current.data?.status).toBe('completed'),
+        );
+
+        const callsAtCompletion = lightdashApiMock.mock.calls.length;
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(5_000);
+        });
+        expect(lightdashApiMock).toHaveBeenCalledTimes(callsAtCompletion);
+
+        unmount();
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(5_000);
+        });
+        expect(lightdashApiMock).toHaveBeenCalledTimes(callsAtCompletion);
+    });
+
+    it('loads every event page before calculating activity counts', async () => {
+        lightdashApiMock.mockImplementation(({ url }: { url: string }) => {
+            if (url.includes('/events') && !url.includes('cursor=')) {
+                return Promise.resolve({
+                    events: [],
+                    nextCursor: 'next page',
+                });
+            }
+            if (url.includes('cursor=next%20page')) {
+                return Promise.resolve({
+                    events: [
+                        {
+                            aiDeepResearchEventUuid: 'event-101',
+                            aiDeepResearchRunUuid: 'run-1',
+                            eventType: 'progress',
+                            payload: {
+                                progress: {
+                                    phase: 'investigating',
+                                    activity: 'warehouse_query',
+                                    current: null,
+                                    total: null,
+                                },
+                            },
+                            createdAt: '2026-07-15T09:01:00.000Z',
+                        },
+                    ],
+                    nextCursor: null,
+                });
+            }
+            return Promise.resolve(getRun('completed'));
+        });
+
+        const { result } = renderHook(() => useDeepResearchRun(registration), {
+            wrapper: getWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.data?.queryCount).toBe(1));
+        expect(
+            lightdashApiMock.mock.calls.filter(([args]) =>
+                (args as { url: string }).url.includes('/events'),
+            ),
+        ).toHaveLength(2);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.test.tsx
@@ -119,7 +119,13 @@ describe('useDeepResearchRun', () => {
         lightdashApiMock.mockImplementation(({ url }: { url: string }) => {
             if (url.includes('/events') && !url.includes('cursor=')) {
                 return Promise.resolve({
-                    events: [],
+                    events: Array.from({ length: 100 }, (_, index) => ({
+                        aiDeepResearchEventUuid: `event-${index}`,
+                        aiDeepResearchRunUuid: 'run-1',
+                        eventType: 'status_changed',
+                        payload: { status: 'running' },
+                        createdAt: '2026-07-15T09:00:30.000Z',
+                    })),
                     nextCursor: 'next page',
                 });
             }
@@ -152,6 +158,43 @@ describe('useDeepResearchRun', () => {
         });
 
         await waitFor(() => expect(result.current.data?.queryCount).toBe(1));
+        expect(
+            lightdashApiMock.mock.calls.filter(([args]) =>
+                (args as { url: string }).url.includes('/events'),
+            ),
+        ).toHaveLength(2);
+    });
+
+    it('stops paging when the backend returns a reusable unchanged cursor', async () => {
+        lightdashApiMock.mockImplementation(({ url }: { url: string }) => {
+            if (url.includes('/events') && !url.includes('cursor=')) {
+                return Promise.resolve({
+                    events: Array.from({ length: 100 }, (_, index) => ({
+                        aiDeepResearchEventUuid: `event-${index}`,
+                        aiDeepResearchRunUuid: 'run-1',
+                        eventType: 'status_changed',
+                        payload: { status: 'running' },
+                        createdAt: '2026-07-15T09:00:30.000Z',
+                    })),
+                    nextCursor: 'stable cursor',
+                });
+            }
+            if (url.includes('cursor=stable%20cursor')) {
+                return Promise.resolve({
+                    events: [],
+                    nextCursor: 'stable cursor',
+                });
+            }
+            return Promise.resolve(getRun('completed'));
+        });
+
+        const { result } = renderHook(() => useDeepResearchRun(registration), {
+            wrapper: getWrapper(),
+        });
+
+        await waitFor(() =>
+            expect(result.current.data?.status).toBe('completed'),
+        );
         expect(
             lightdashApiMock.mock.calls.filter(([args]) =>
                 (args as { url: string }).url.includes('/events'),

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
@@ -28,6 +28,7 @@ import {
 
 const DEEP_RESEARCH_QUERY_KEY = 'deepResearch';
 const DEEP_RESEARCH_POLL_INTERVAL_MS = 2_000;
+const DEEP_RESEARCH_EVENT_PAGE_SIZE = 100;
 
 const getBaseUrl = (projectUuid: string) =>
     `/ee/projects/${projectUuid}/ai-deep-research`;
@@ -58,7 +59,7 @@ const getDeepResearchEventsPage = (
 ) =>
     lightdashApi<AnyType>({
         version: 'v1',
-        url: `${getBaseUrl(projectUuid)}/${runUuid}/events?limit=100${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`,
+        url: `${getBaseUrl(projectUuid)}/${runUuid}/events?limit=${DEEP_RESEARCH_EVENT_PAGE_SIZE}${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`,
         method: 'GET',
         body: undefined,
     }) as Promise<ApiAiDeepResearchEventsResponse['results']>;
@@ -69,15 +70,23 @@ const getDeepResearchEvents = async (
 ): Promise<AiDeepResearchEventsPage> => {
     const events: AiDeepResearchEventsPage['events'] = [];
     let cursor: string | undefined;
-    do {
+    while (true) {
         const page = await getDeepResearchEventsPage(
             projectUuid,
             runUuid,
             cursor,
         );
         events.push(...page.events);
-        cursor = page.nextCursor ?? undefined;
-    } while (cursor);
+        const nextCursor = page.nextCursor ?? undefined;
+        if (
+            !nextCursor ||
+            nextCursor === cursor ||
+            page.events.length < DEEP_RESEARCH_EVENT_PAGE_SIZE
+        ) {
+            break;
+        }
+        cursor = nextCursor;
+    }
     return { events, nextCursor: null };
 };
 

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
@@ -111,10 +111,11 @@ export const useStartDeepResearchMutation = ({
         AiDeepResearchRun,
         ApiError,
         StartDeepResearchArgs,
-        { optimisticRunUuid: string }
+        { optimisticRunUuid: string; createdAt: string }
     >({
         onMutate: (variables) => {
             const optimisticRunUuid = `starting-${crypto.randomUUID()}`;
+            const createdAt = new Date().toISOString();
             registerDeepResearchRun({
                 runUuid: optimisticRunUuid,
                 projectUuid,
@@ -122,10 +123,10 @@ export const useStartDeepResearchMutation = ({
                 userUuid: user.data?.userUuid ?? '',
                 question: variables.question,
                 depth: variables.depth,
-                createdAt: new Date().toISOString(),
+                createdAt,
                 state: 'starting',
             });
-            return { optimisticRunUuid };
+            return { optimisticRunUuid, createdAt };
         },
         mutationFn: ({ question, depth }) =>
             startDeepResearch(projectUuid, {
@@ -140,7 +141,7 @@ export const useStartDeepResearchMutation = ({
                 userUuid: user.data?.userUuid ?? '',
                 question: variables.question,
                 depth: variables.depth,
-                createdAt: run.createdAt,
+                createdAt: context?.createdAt ?? new Date().toISOString(),
                 state: 'started',
             });
         },
@@ -166,10 +167,11 @@ export const useStartDeepResearchForThreadMutation = (projectUuid: string) => {
         AiDeepResearchRun,
         ApiError,
         StartDeepResearchArgs & { threadUuid: string },
-        { optimisticRunUuid: string }
+        { optimisticRunUuid: string; createdAt: string }
     >({
         onMutate: (variables) => {
             const optimisticRunUuid = `starting-${crypto.randomUUID()}`;
+            const createdAt = new Date().toISOString();
             registerDeepResearchRun({
                 runUuid: optimisticRunUuid,
                 projectUuid,
@@ -177,10 +179,10 @@ export const useStartDeepResearchForThreadMutation = (projectUuid: string) => {
                 userUuid: user.data?.userUuid ?? '',
                 question: variables.question,
                 depth: variables.depth,
-                createdAt: new Date().toISOString(),
+                createdAt,
                 state: 'starting',
             });
-            return { optimisticRunUuid };
+            return { optimisticRunUuid, createdAt };
         },
         mutationFn: ({ question, depth }) =>
             startDeepResearch(projectUuid, {
@@ -195,7 +197,7 @@ export const useStartDeepResearchForThreadMutation = (projectUuid: string) => {
                 userUuid: user.data?.userUuid ?? '',
                 question: variables.question,
                 depth: variables.depth,
-                createdAt: run.createdAt,
+                createdAt: context?.createdAt ?? new Date().toISOString(),
                 state: 'started',
             });
         },

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
@@ -1,0 +1,286 @@
+import {
+    type AnyType,
+    type AiDeepResearchEventsPage,
+    type AiDeepResearchRequestBody,
+    type AiDeepResearchRun,
+    type ApiAiDeepResearchEventsResponse,
+    type ApiAiDeepResearchRunResponse,
+    type ApiError,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+import useToaster from '../../../../hooks/toaster/useToaster';
+import useUser from '../../../../hooks/user/useUser';
+import {
+    adaptDeepResearchRun,
+    DEEP_RESEARCH_DEPTH_CONFIG,
+    isDeepResearchRunTerminal,
+} from '../deepResearch/deepResearchAdapter';
+import {
+    registerDeepResearchRun,
+    replaceDeepResearchRun,
+    updateDeepResearchRun,
+} from '../deepResearch/deepResearchRegistry';
+import {
+    type DeepResearchRunRegistration,
+    type StartDeepResearchArgs,
+} from '../deepResearch/types';
+
+const DEEP_RESEARCH_QUERY_KEY = 'deepResearch';
+const DEEP_RESEARCH_POLL_INTERVAL_MS = 2_000;
+
+const getBaseUrl = (projectUuid: string) =>
+    `/ee/projects/${projectUuid}/ai-deep-research`;
+
+const startDeepResearch = (
+    projectUuid: string,
+    data: AiDeepResearchRequestBody,
+) =>
+    lightdashApi<AnyType>({
+        version: 'v1',
+        url: getBaseUrl(projectUuid),
+        method: 'POST',
+        body: JSON.stringify(data),
+    }) as Promise<ApiAiDeepResearchRunResponse['results']>;
+
+const getDeepResearchRun = (projectUuid: string, runUuid: string) =>
+    lightdashApi<AnyType>({
+        version: 'v1',
+        url: `${getBaseUrl(projectUuid)}/${runUuid}`,
+        method: 'GET',
+        body: undefined,
+    }) as Promise<ApiAiDeepResearchRunResponse['results']>;
+
+const getDeepResearchEventsPage = (
+    projectUuid: string,
+    runUuid: string,
+    cursor?: string,
+) =>
+    lightdashApi<AnyType>({
+        version: 'v1',
+        url: `${getBaseUrl(projectUuid)}/${runUuid}/events?limit=100${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`,
+        method: 'GET',
+        body: undefined,
+    }) as Promise<ApiAiDeepResearchEventsResponse['results']>;
+
+const getDeepResearchEvents = async (
+    projectUuid: string,
+    runUuid: string,
+): Promise<AiDeepResearchEventsPage> => {
+    const events: AiDeepResearchEventsPage['events'] = [];
+    let cursor: string | undefined;
+    do {
+        const page = await getDeepResearchEventsPage(
+            projectUuid,
+            runUuid,
+            cursor,
+        );
+        events.push(...page.events);
+        cursor = page.nextCursor ?? undefined;
+    } while (cursor);
+    return { events, nextCursor: null };
+};
+
+const cancelDeepResearch = (projectUuid: string, runUuid: string) =>
+    lightdashApi<AnyType>({
+        version: 'v1',
+        url: `${getBaseUrl(projectUuid)}/${runUuid}/cancel`,
+        method: 'POST',
+        body: JSON.stringify({}),
+    }) as Promise<ApiAiDeepResearchRunResponse['results']>;
+
+export const useStartDeepResearchMutation = ({
+    projectUuid,
+    threadUuid,
+}: {
+    projectUuid: string;
+    threadUuid: string;
+}) => {
+    const { showToastApiError } = useToaster();
+    const user = useUser(true);
+    return useMutation<
+        AiDeepResearchRun,
+        ApiError,
+        StartDeepResearchArgs,
+        { optimisticRunUuid: string }
+    >({
+        onMutate: (variables) => {
+            const optimisticRunUuid = `starting-${crypto.randomUUID()}`;
+            registerDeepResearchRun({
+                runUuid: optimisticRunUuid,
+                projectUuid,
+                threadUuid,
+                userUuid: user.data?.userUuid ?? '',
+                question: variables.question,
+                depth: variables.depth,
+                createdAt: new Date().toISOString(),
+                state: 'starting',
+            });
+            return { optimisticRunUuid };
+        },
+        mutationFn: ({ question, depth }) =>
+            startDeepResearch(projectUuid, {
+                prompt: question,
+                effort: DEEP_RESEARCH_DEPTH_CONFIG[depth].effort,
+            }),
+        onSuccess: (run, variables, context) => {
+            replaceDeepResearchRun(context?.optimisticRunUuid ?? '', {
+                runUuid: run.aiDeepResearchRunUuid,
+                projectUuid,
+                threadUuid,
+                userUuid: user.data?.userUuid ?? '',
+                question: variables.question,
+                depth: variables.depth,
+                createdAt: run.createdAt,
+                state: 'started',
+            });
+        },
+        onError: ({ error }, _variables, context) => {
+            if (context) {
+                updateDeepResearchRun(context.optimisticRunUuid, {
+                    state: 'start_failed',
+                    errorMessage: error.message,
+                });
+            }
+            showToastApiError({
+                title: 'Could not start research',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useStartDeepResearchForThreadMutation = (projectUuid: string) => {
+    const { showToastApiError } = useToaster();
+    const user = useUser(true);
+    return useMutation<
+        AiDeepResearchRun,
+        ApiError,
+        StartDeepResearchArgs & { threadUuid: string },
+        { optimisticRunUuid: string }
+    >({
+        onMutate: (variables) => {
+            const optimisticRunUuid = `starting-${crypto.randomUUID()}`;
+            registerDeepResearchRun({
+                runUuid: optimisticRunUuid,
+                projectUuid,
+                threadUuid: variables.threadUuid,
+                userUuid: user.data?.userUuid ?? '',
+                question: variables.question,
+                depth: variables.depth,
+                createdAt: new Date().toISOString(),
+                state: 'starting',
+            });
+            return { optimisticRunUuid };
+        },
+        mutationFn: ({ question, depth }) =>
+            startDeepResearch(projectUuid, {
+                prompt: question,
+                effort: DEEP_RESEARCH_DEPTH_CONFIG[depth].effort,
+            }),
+        onSuccess: (run, variables, context) => {
+            replaceDeepResearchRun(context?.optimisticRunUuid ?? '', {
+                runUuid: run.aiDeepResearchRunUuid,
+                projectUuid,
+                threadUuid: variables.threadUuid,
+                userUuid: user.data?.userUuid ?? '',
+                question: variables.question,
+                depth: variables.depth,
+                createdAt: run.createdAt,
+                state: 'started',
+            });
+        },
+        onError: ({ error }, _variables, context) => {
+            if (context) {
+                updateDeepResearchRun(context.optimisticRunUuid, {
+                    state: 'start_failed',
+                    errorMessage: error.message,
+                });
+            }
+            showToastApiError({
+                title: 'Could not start research',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useDeepResearchRun = (
+    registration: DeepResearchRunRegistration,
+) => {
+    const runQuery = useQuery<AiDeepResearchRun, ApiError>({
+        queryKey: [
+            DEEP_RESEARCH_QUERY_KEY,
+            registration.projectUuid,
+            registration.runUuid,
+        ],
+        queryFn: () =>
+            getDeepResearchRun(registration.projectUuid, registration.runUuid),
+        enabled: registration.state === 'started',
+        refetchInterval: (run) =>
+            run && isDeepResearchRunTerminal(run.status)
+                ? false
+                : DEEP_RESEARCH_POLL_INTERVAL_MS,
+    });
+    const isRunActive = runQuery.data
+        ? !isDeepResearchRunTerminal(runQuery.data.status)
+        : true;
+    const eventsQuery = useQuery<AiDeepResearchEventsPage, ApiError>({
+        queryKey: [
+            DEEP_RESEARCH_QUERY_KEY,
+            registration.projectUuid,
+            registration.runUuid,
+            'events',
+        ],
+        queryFn: () =>
+            getDeepResearchEvents(
+                registration.projectUuid,
+                registration.runUuid,
+            ),
+        enabled: registration.state === 'started',
+        refetchInterval: isRunActive ? DEEP_RESEARCH_POLL_INTERVAL_MS : false,
+    });
+
+    return {
+        ...runQuery,
+        data: runQuery.data
+            ? adaptDeepResearchRun({
+                  run: runQuery.data,
+                  events: eventsQuery.data?.events ?? [],
+                  registration,
+              })
+            : undefined,
+        eventsQuery,
+    };
+};
+
+export const useCancelDeepResearchMutation = (
+    projectUuid: string,
+    runUuid: string,
+) => {
+    const queryClient = useQueryClient();
+    const { showToastApiError } = useToaster();
+    return useMutation<AiDeepResearchRun, ApiError>({
+        mutationFn: () => cancelDeepResearch(projectUuid, runUuid),
+        onSuccess: (run) => {
+            queryClient.setQueryData(
+                [DEEP_RESEARCH_QUERY_KEY, projectUuid, runUuid],
+                run,
+            );
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Could not stop research',
+                apiError: error,
+            });
+        },
+    });
+};
+
+export const useContinueDeepResearchMutation = ({
+    projectUuid,
+    threadUuid,
+}: {
+    projectUuid: string;
+    threadUuid: string;
+}) => useStartDeepResearchMutation({ projectUuid, threadUuid });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -729,22 +729,29 @@ const createOptimisticMessages = (
     agent: AiAgent,
     context: AiPromptContext = [],
     hidden = false,
+    includeAssistantResponse = true,
 ) => {
-    return [
-        {
-            role: 'user' as const,
-            uuid: promptUuid,
-            threadUuid,
-            message: prompt,
-            createdAt: new Date().toISOString(),
-            user: {
-                name: getOptimisticUserName(user),
-                uuid: user?.userUuid ?? 'unknown',
-            },
-            context,
-            steers: [],
-            hidden,
+    const userMessage = {
+        role: 'user' as const,
+        uuid: promptUuid,
+        threadUuid,
+        message: prompt,
+        createdAt: new Date().toISOString(),
+        user: {
+            name: getOptimisticUserName(user),
+            uuid: user?.userUuid ?? 'unknown',
         },
+        context,
+        steers: [],
+        hidden,
+    };
+
+    if (!includeAssistantResponse) {
+        return [userMessage];
+    }
+
+    return [
+        userMessage,
         {
             role: 'assistant' as const,
             status: 'pending' as const,
@@ -885,6 +892,7 @@ export const useCreateAgentThreadMutation = (
             optimisticContext?: AiPromptContext;
             enableSqlMode?: boolean;
             toolHints?: string[];
+            skipAgentResponse?: boolean;
         }
     >({
         mutationFn: ({
@@ -892,6 +900,7 @@ export const useCreateAgentThreadMutation = (
             optimisticContext: _optimisticContext,
             enableSqlMode: _enableSqlMode,
             toolHints: _toolHints,
+            skipAgentResponse: _skipAgentResponse,
             ...data
         }) => createAgentThread(projectUuid, agentUuid, data),
         onSuccess: async (thread, variables) => {
@@ -944,6 +953,8 @@ export const useCreateAgentThreadMutation = (
                             // post-stream refetch to fill them in.
                             variables.optimisticContext ??
                                 variables.context?.map(toOptimisticContextItem),
+                            false,
+                            !variables.skipAgentResponse,
                         ),
                         createdAt: new Date().toISOString(),
                         user: {
@@ -954,67 +965,69 @@ export const useCreateAgentThreadMutation = (
                 },
             );
 
-            void streamMessage({
-                projectUuid,
-                agentUuid: thread.agentUuid,
-                threadUuid: thread.uuid,
-                messageUuid: thread.firstMessage.uuid,
-                enableSqlMode: variables.enableSqlMode,
-                toolHints: variables.toolHints,
-                onFinish: () =>
-                    queryClient.invalidateQueries({
-                        queryKey: [
-                            AI_AGENTS_KEY,
-                            projectUuid,
-                            agentUuid,
-                            'threads',
-                            thread.uuid,
-                        ],
-                    }),
-                onError: (errorMessage) => {
-                    queryClient.setQueryData(
-                        [
-                            AI_AGENTS_KEY,
-                            projectUuid,
-                            agentUuid,
-                            'threads',
-                            thread.uuid,
-                        ],
-                        (
-                            currentData:
-                                | ApiAiAgentThreadResponse['results']
-                                | undefined,
-                        ) =>
-                            markOptimisticAssistantMessageAsErrored(
-                                currentData,
-                                thread.firstMessage.uuid,
-                                errorMessage,
-                            ),
-                    );
+            if (!variables.skipAgentResponse) {
+                void streamMessage({
+                    projectUuid,
+                    agentUuid: thread.agentUuid,
+                    threadUuid: thread.uuid,
+                    messageUuid: thread.firstMessage.uuid,
+                    enableSqlMode: variables.enableSqlMode,
+                    toolHints: variables.toolHints,
+                    onFinish: () =>
+                        queryClient.invalidateQueries({
+                            queryKey: [
+                                AI_AGENTS_KEY,
+                                projectUuid,
+                                agentUuid,
+                                'threads',
+                                thread.uuid,
+                            ],
+                        }),
+                    onError: (errorMessage) => {
+                        queryClient.setQueryData(
+                            [
+                                AI_AGENTS_KEY,
+                                projectUuid,
+                                agentUuid,
+                                'threads',
+                                thread.uuid,
+                            ],
+                            (
+                                currentData:
+                                    | ApiAiAgentThreadResponse['results']
+                                    | undefined,
+                            ) =>
+                                markOptimisticAssistantMessageAsErrored(
+                                    currentData,
+                                    thread.firstMessage.uuid,
+                                    errorMessage,
+                                ),
+                        );
 
-                    void queryClient.invalidateQueries({
-                        queryKey: [
-                            AI_AGENTS_KEY,
-                            projectUuid,
-                            agentUuid,
-                            'threads',
-                            thread.uuid,
-                        ],
-                    });
-                },
-                refetchThread: () =>
-                    queryClient.invalidateQueries({
-                        queryKey: [
-                            AI_AGENTS_KEY,
-                            projectUuid,
-                            agentUuid,
-                            'threads',
-                            thread.uuid,
-                        ],
-                    }),
-                onToolCall: options?.onToolCall,
-                onToolResult: options?.onToolResult,
-            });
+                        void queryClient.invalidateQueries({
+                            queryKey: [
+                                AI_AGENTS_KEY,
+                                projectUuid,
+                                agentUuid,
+                                'threads',
+                                thread.uuid,
+                            ],
+                        });
+                    },
+                    refetchThread: () =>
+                        queryClient.invalidateQueries({
+                            queryKey: [
+                                AI_AGENTS_KEY,
+                                projectUuid,
+                                agentUuid,
+                                'threads',
+                                thread.uuid,
+                            ],
+                        }),
+                    onToolCall: options?.onToolCall,
+                    onToolResult: options?.onToolResult,
+                });
+            }
 
             options?.onCreated?.(thread);
 
@@ -1080,6 +1093,7 @@ export const useCreateAgentThreadMessageMutation = (
             enableSqlMode?: boolean;
             autoApproveSql?: boolean;
             toolHints?: string[];
+            skipAgentResponse?: boolean;
         },
         { messageUuid: string }
     >({
@@ -1088,6 +1102,7 @@ export const useCreateAgentThreadMessageMutation = (
             enableSqlMode: _enableSqlMode,
             autoApproveSql: _autoApproveSql,
             toolHints: _toolHints,
+            skipAgentResponse: _skipAgentResponse,
             ...data
         }) =>
             agentUuid && threadUuid
@@ -1126,6 +1141,7 @@ export const useCreateAgentThreadMessageMutation = (
                                 data.optimisticContext ??
                                     data.context?.map(toOptimisticContextItem),
                                 data.hidden,
+                                !data.skipAgentResponse,
                             ),
                         ],
                     };
@@ -1159,6 +1175,10 @@ export const useCreateAgentThreadMessageMutation = (
                     };
                 },
             );
+
+            if (vars.skipAgentResponse) {
+                return;
+            }
 
             void streamMessage({
                 projectUuid,

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -355,6 +355,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                                 ? handleStartDeepResearch
                                 : undefined
                         }
+                        deepResearchControlPlacement="page_header"
                         placeholder={`Ask ${agent.name} anything about your data...`}
                         messageCount={thread.messages?.length || 0}
                         projectUuid={projectUuid}

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -1,7 +1,9 @@
 import { subject } from '@casl/ability';
+import { FeatureFlags } from '@lightdash/common';
 import { Box, Center, Flex, Loader } from '@mantine-8/core';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useOutletContext, useParams, useSearchParams } from 'react-router';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import { ReviewVerificationPanel } from '../../features/aiCopilot/components/Admin/ReviewVerificationPanel';
 import { AgentChatDisplay } from '../../features/aiCopilot/components/ChatElements/AgentChatDisplay';
@@ -22,6 +24,7 @@ import {
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
 import { useAiAgentThreadArtifact } from '../../features/aiCopilot/hooks/useAiAgentThreadArtifact';
+import { useStartDeepResearchMutation } from '../../features/aiCopilot/hooks/useDeepResearch';
 import { useModelOptions } from '../../features/aiCopilot/hooks/useModelOptions';
 import { usePendingThreadRefetch } from '../../features/aiCopilot/hooks/usePendingThreadRefetch';
 import { usePinnedContext } from '../../features/aiCopilot/hooks/usePinnedContext';
@@ -165,6 +168,11 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
     const updateReviewItemStatus = useUpdateAiAgentReviewItemStatus();
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
+    const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
+    const startDeepResearch = useStartDeepResearchMutation({
+        projectUuid: projectUuid!,
+        threadUuid: threadUuid!,
+    });
     const sqlMode = useAiAgentStoreSelector(
         selectThreadSqlMode(threadUuid ?? ''),
     );
@@ -279,6 +287,19 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
             toolHints,
         });
     };
+    const handleStartDeepResearch = async ({
+        question,
+        depth,
+    }: Parameters<typeof startDeepResearch.mutateAsync>[0]) => {
+        await createAgentThreadMessage({
+            prompt: question,
+            modelConfig: threadModelConfig ?? undefined,
+            context: pageContextInput,
+            optimisticContext: pagePreviewItems,
+            skipAgentResponse: true,
+        });
+        await startDeepResearch.mutateAsync({ question, depth });
+    };
     const isBusy = Boolean(isCreatingMessage || isStreaming || isPending);
     const retryPrompt = reviewItem?.remediation?.retryPrompt ?? null;
     const handleRetryOriginalQuestion = () => {
@@ -329,6 +350,11 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                         disabledReason={inputDisabledReason}
                         loading={isBusy}
                         onSubmit={handleSubmit}
+                        onStartDeepResearch={
+                            deepResearchFlag.data?.enabled
+                                ? handleStartDeepResearch
+                                : undefined
+                        }
                         placeholder={`Ask ${agent.name} anything about your data...`}
                         messageCount={thread.messages?.length || 0}
                         projectUuid={projectUuid}

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -1,3 +1,4 @@
+import { FeatureFlags } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
@@ -15,6 +16,7 @@ import { useCallback, useRef, useState, type FC } from 'react';
 import { useOutletContext, useParams, useSearchParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { AiAgentNewThreadMcpConnections } from '../../features/aiCopilot/components/AiAgentNewThreadMcpConnections';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
 import {
@@ -27,10 +29,12 @@ import { DefaultAgentButton } from '../../features/aiCopilot/components/DefaultA
 import { usePendingPrompt } from '../../features/aiCopilot/components/PendingPromptContext/PendingPromptContext';
 import { PinnedContextCard } from '../../features/aiCopilot/components/PinnedContextCard/PinnedContextCard';
 import { SuggestedQuestions } from '../../features/aiCopilot/components/SuggestedQuestions/SuggestedQuestions';
+import { type StartDeepResearchArgs } from '../../features/aiCopilot/deepResearch/types';
 import { isEmbedAiAgentRoute } from '../../features/aiCopilot/hooks/aiAgentRouting';
 import { emitEmbedAiAgentThreadChange } from '../../features/aiCopilot/hooks/embedAiAgentThreadChange';
 import { useAiAgentModelSelection } from '../../features/aiCopilot/hooks/useAiAgentModelSelection';
 import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
+import { useStartDeepResearchForThreadMutation } from '../../features/aiCopilot/hooks/useDeepResearch';
 import { usePinnedContext } from '../../features/aiCopilot/hooks/usePinnedContext';
 import {
     useCreateAgentThreadMutation,
@@ -62,6 +66,7 @@ const AiAgentNewThreadPage: FC = () => {
     });
 
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
+    const deepResearchFlag = useServerFeatureFlag(FeatureFlags.AiDeepResearch);
     const [sqlMode, setSqlMode] = useState(true);
     const dispatch = useAiAgentStoreDispatch();
     const { agent, agents, navigateFromAgentChat } =
@@ -118,6 +123,9 @@ const AiAgentNewThreadPage: FC = () => {
     const { data: verifiedQuestions } = useVerifiedQuestions(
         projectUuid,
         agentUuid,
+    );
+    const startDeepResearch = useStartDeepResearchForThreadMutation(
+        projectUuid!,
     );
 
     const {
@@ -188,6 +196,38 @@ const AiAgentNewThreadPage: FC = () => {
             sqlMode,
             modelConfig,
             isPinnedContextReady,
+        ],
+    );
+
+    const onStartDeepResearch = useCallback(
+        async ({ question, depth }: StartDeepResearchArgs) => {
+            if (!agentUuid || !isPinnedContextReady) {
+                return;
+            }
+            setPendingPrompt('');
+            const thread = await createAgentThread({
+                agentUuid,
+                prompt: question,
+                context: contextInput,
+                optimisticContext: previewItems,
+                modelConfig,
+                skipAgentResponse: true,
+            });
+            await startDeepResearch.mutateAsync({
+                question,
+                depth,
+                threadUuid: thread.uuid,
+            });
+        },
+        [
+            agentUuid,
+            contextInput,
+            createAgentThread,
+            isPinnedContextReady,
+            modelConfig,
+            previewItems,
+            setPendingPrompt,
+            startDeepResearch,
         ],
     );
 
@@ -311,6 +351,11 @@ const AiAgentNewThreadPage: FC = () => {
                     <AgentChatInput
                         key={composerSeedKey}
                         onSubmit={onSubmit}
+                        onStartDeepResearch={
+                            deepResearchFlag.data?.enabled
+                                ? onStartDeepResearch
+                                : undefined
+                        }
                         loading={isCreatingThread}
                         disabled={!isPinnedContextReady}
                         placeholder={`Ask ${agent.name} anything about your data...`}

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -356,6 +356,7 @@ const AiAgentNewThreadPage: FC = () => {
                                 ? onStartDeepResearch
                                 : undefined
                         }
+                        deepResearchControlPlacement="page_header"
                         loading={isCreatingThread}
                         disabled={!isPinnedContextReady}
                         placeholder={`Ask ${agent.name} anything about your data...`}


### PR DESCRIPTION

Closes: No linked issue

## Summary

Adds the first Deep Research frontend slice to the existing AI Agent composer and thread. Analytics users can configure a background investigation, leave a durable run card in context, follow backend-owned phases, and inspect a report through numbered evidence markers without changing normal Ask behavior.

### Composer and active runs

- Adds a compact Ask/Deep research control and a responsive preflight with Quick, Standard, Deep, and Exhaustive tiers.
- Shows only evidence sources supported by the current service, along with duration and warehouse-query allowances.
- Persists the user question without starting a normal agent response, registers a run card immediately, polls durable state, supports cancellation, and preserves start or refresh failures in-thread.

### Reports and evidence

- Expands completed and partial runs into a readable report with executive answer, findings, alternatives, methodology, limitations, and next questions.
- Connects numbered claim markers to an accessible desktop evidence rail or mobile bottom drawer with query references and safe source links.
- Wires follow-up, challenge, deeper rerun, share, activity, and cancellation actions while omitting controls that lack a backend-supported operation.

## UI flow

```text
AI Agent composer
  Ask ──────────────────────────────> existing response flow
  Deep research -> preflight -> durable thread card -> full report
                                      │                    │
                                      └─ safe activity     └─ evidence rail
```

Screenshot capture is pending because the local browser integration had no available browser session.

## Regression analysis

- Existing AI Agent call sites receive optional props, and Ask remains the default mode with its existing submit behavior.
- The feature is gated by the existing `ai-deep-research` flag and reuses current thread creation and message APIs.
- Transport and backend-shape assumptions stay in focused hooks and one adapter; presentation components do not inspect raw events or model reasoning.
- The current same-browser registry is user-scoped; cross-device restoration remains dependent on a future thread-linked backend listing contract.

## Local end-to-end result

A Quick run was created successfully through the real Paris UI and persisted as `queued → running → failed`. Chrome verification exposed and fixed an event cursor loop: the backend returns an unchanged reusable cursor when no new events exist, which previously caused thousands of requests. After the fix, the browser observed one start request, two status reads, and two event reads, followed by no terminal-state polling for eight seconds. The failed card preserves the question and shows sanitized recovery copy. The external research service still rejects the generated Lightdash evidence endpoint because the local `SITE_URL` uses `localhost`; completing the report path requires a public HTTPS development endpoint.

## Test plan

- [x] Run focused Deep Research component, adapter, polling, pagination, and keyboard tests: 17 passed.
- [x] Run frontend fast typecheck and targeted lint/format checks.
- [x] Verify normal Ask behavior remains the default and `skipAgentResponse` stays opt-in.
- [x] Verify the desktop preflight, immediate run card, terminal failure card, request cleanup, and console behavior in Chrome.
- [ ] Verify mobile evidence layouts and the completed report against a public HTTPS development endpoint.
- [ ] Complete a real report run with `SITE_URL` configured to a public HTTPS endpoint.
