### PR TITLE
chore: remove dead permission deny rules from claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,10 +2,7 @@
   "permissions": {
     "deny": [
       "Read(packages/formula-tests/**)",
-      "Edit(packages/formula-tests/**)",
-      "Write(packages/formula-tests/**)",
-      "Glob(packages/formula-tests/**)",
-      "Grep(packages/formula-tests/**)"
+      "Edit(packages/formula-tests/**)"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Claude Code was emitting warnings on startup because `.claude/settings.json` contained permission deny rules that the file permission system never matches:

```
Permission deny rule (.claude/settings.json): Write(packages/formula-tests/**) is not matched by file permission checks — only Edit(path) rules are.
Permission deny rule (.claude/settings.json): Glob(packages/formula-tests/**) is not matched by file permission checks — only Read(path) rules are.
```

Claude Code's file permission checks only recognize two rule families: `Read(path)` (covers all file-reading tools: Read, Glob, Grep) and `Edit(path)` (covers all file-editing tools: Edit, Write, NotebookEdit). The `Write(...)`, `Glob(...)`, and `Grep(...)` rules were dead — silently ignored.

This removes the three dead rules. The remaining `Read` + `Edit` rules already fully block reading and editing of `packages/formula-tests/` (the black-box formula test package), so there is no change in enforcement — just no more startup warnings.

No Linear ticket — internal dev-tooling cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)