### PR TITLE
feat(frontend): Linear-style slash-command markdown editor + subtler icon palette

### DIFF
--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -45,6 +45,9 @@ export type HomepageResourcesBlock = {
 };
 
 export type HomepageAnnouncementItem = {
+    /** Markdown — @-mentioned charts/dashboards are plain markdown links
+     * (`[label](/projects/.../saved/:uuid/view)`), rendered as rich chips by
+     * `rehypeAiAgentContentLinks`. */
     text: string;
     date: string;
     author: string;

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -134,6 +134,7 @@
         "streamdown": "2.5.0",
         "styled-components": "5.3.3",
         "tippy.js": "6.3.7",
+        "tiptap-markdown": "0.8.10",
         "topojson-client": "3.1.0",
         "type-fest": "4.32.0",
         "unique-names-generator": "4.7.1",

--- a/packages/frontend/src/components/common/PolymorphicGroupButton.module.css
+++ b/packages/frontend/src/components/common/PolymorphicGroupButton.module.css
@@ -1,0 +1,8 @@
+.reset {
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+    background: none;
+    border: none;
+    text-align: inherit;
+}

--- a/packages/frontend/src/components/common/PolymorphicGroupButton.tsx
+++ b/packages/frontend/src/components/common/PolymorphicGroupButton.tsx
@@ -4,6 +4,7 @@ import {
     type GroupProps,
 } from '@mantine-8/core';
 import { forwardRef, type Ref } from 'react';
+import classes from './PolymorphicGroupButton.module.css';
 
 /**
  * A polymorphic component that renders a group button.
@@ -14,8 +15,12 @@ export const PolymorphicGroupButton = createPolymorphicComponent<
     GroupProps
 >(
     forwardRef<HTMLDivElement, GroupProps>(
-        (props: GroupProps, ref: Ref<HTMLDivElement>) => (
-            <Group ref={ref} {...props} style={{ cursor: 'pointer' }} />
+        ({ className, ...props }: GroupProps, ref: Ref<HTMLDivElement>) => (
+            <Group
+                ref={ref}
+                {...props}
+                className={`${classes.reset} ${className ?? ''}`}
+            />
         ),
     ),
 );

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.module.css
@@ -1,25 +1,3 @@
-.page {
-    display: flex;
-    flex-direction: column;
-    padding: 0 24px 64px;
-}
-
-.heroSection {
-    min-height: calc(100vh - var(--navbar-height) - 72px);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-}
-
-.hero {
-    width: 100%;
-    max-width: 720px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-}
-
 .welcome {
     width: 100%;
     max-width: 1040px;

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
@@ -12,6 +12,7 @@ import { AskAiHero } from './blocks/AskAiHeroBlock';
 import { getDefaultQuickActions } from './blocks/quickActionDefaults';
 import { QuickActionCards } from './blocks/QuickActionsBlock';
 import classes from './DayOneHomepage.module.css';
+import layout from './homepageLayout.module.css';
 
 type Props = {
     projectUuid: string;
@@ -32,10 +33,10 @@ export const DayOneHomepage: FC<Props> = ({
     const isAiEnabled = useAiAgentButtonVisibility();
 
     return (
-        <div className={classes.page}>
-            <div className={classes.heroSection}>
+        <div className={layout.page}>
+            <div className={layout.heroSection}>
                 {isAiEnabled ? (
-                    <div className={classes.hero}>
+                    <div className={layout.hero}>
                         <AskAiHero projectUuid={projectUuid} showGreeting />
                     </div>
                 ) : (

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -285,7 +285,7 @@ const BlockCard: FC<BlockCardProps> = ({
                     aria-label={`Drag ${definition.label} block`}
                 >
                     <span className={classes.blockHandle}>
-                        <MantineIcon icon={IconGripVertical} color="gray" />
+                        <MantineIcon icon={IconGripVertical} color="ldGray.6" />
                     </span>
                     <span className={classes.blockTypeLabel}>
                         {definition.label}
@@ -295,7 +295,7 @@ const BlockCard: FC<BlockCardProps> = ({
                     <Tooltip label="Move up">
                         <ActionIcon
                             variant="subtle"
-                            color="gray"
+                            color="ldGray.6"
                             disabled={!canUp}
                             onClick={onUp}
                         >
@@ -305,7 +305,7 @@ const BlockCard: FC<BlockCardProps> = ({
                     <Tooltip label="Move down">
                         <ActionIcon
                             variant="subtle"
-                            color="gray"
+                            color="ldGray.6"
                             disabled={!canDown}
                             onClick={onDown}
                         >
@@ -315,7 +315,7 @@ const BlockCard: FC<BlockCardProps> = ({
                     <Tooltip label="Duplicate">
                         <ActionIcon
                             variant="subtle"
-                            color="gray"
+                            color="ldGray.6"
                             onClick={onDuplicate}
                         >
                             <MantineIcon icon={IconCopy} />
@@ -375,9 +375,6 @@ export const HomepageEditor: FC<Props> = ({
     const [isViewAsModalOpen, setIsViewAsModalOpen] = useState(false);
 
     const isAiEnabled = useAiAgentButtonVisibility();
-    const availableBlocks = blockLibrary.filter(
-        (definition) => !definition.requiresAi || isAiEnabled,
-    );
 
     const [draft, setDraft] = useState<HomepageConfig>(homepage.draftConfig);
     const [isPreviewing, setIsPreviewing] = useState(false);
@@ -392,6 +389,16 @@ export const HomepageEditor: FC<Props> = ({
     const preDragDraftRef = useRef<HomepageConfig | null>(null);
     // Instance created for a library drag, once it first enters the canvas
     const pendingNewBlockRef = useRef<HomepageBlock | null>(null);
+
+    // Singleton blocks (e.g. metrics) drop out of the library once placed.
+    const usedSingletonTypes = new Set(
+        draft.rows.flatMap((row) => row.blocks).map((block) => block.type),
+    );
+    const availableBlocks = blockLibrary.filter(
+        (definition) =>
+            (!definition.requiresAi || isAiEnabled) &&
+            !(definition.singleton && usedSingletonTypes.has(definition.type)),
+    );
 
     const { mutate: saveDraft } = updateMutation;
     useEffect(() => {
@@ -452,6 +459,14 @@ export const HomepageEditor: FC<Props> = ({
         useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     );
 
+    // A block being hovered is split into zones: the top/bottom bands reorder
+    // the dragged block into its own row above/below (the common case), the
+    // narrow left/right edges split it into the same row side-by-side, and
+    // the center defaults to reordering above — so merely passing over a
+    // block on the way elsewhere doesn't accidentally split it.
+    const ROW_ZONE_FRACTION = 0.3;
+    const CELL_EDGE_FRACTION = 0.15;
+
     // Where would the dragged block land, given what the pointer is over?
     const computeTarget = (
         config: HomepageConfig,
@@ -467,15 +482,37 @@ export const HomepageEditor: FC<Props> = ({
         const location = locateBlock(config, overId);
         if (!location) return null;
         const activeRect = event.active.rect.current.translated;
-        const activeCenter = activeRect
+        const activeCenterX = activeRect
             ? activeRect.left + activeRect.width / 2
             : over.rect.left;
-        const isAfter = activeCenter > over.rect.left + over.rect.width / 2;
-        return {
-            kind: 'cell',
-            rowIndex: location.rowIndex,
-            blockIndex: location.blockIndex + (isAfter ? 1 : 0),
-        };
+        const activeCenterY = activeRect
+            ? activeRect.top + activeRect.height / 2
+            : over.rect.top;
+        const relY = (activeCenterY - over.rect.top) / over.rect.height;
+
+        if (relY < ROW_ZONE_FRACTION) {
+            return { kind: 'row', rowIndex: location.rowIndex };
+        }
+        if (relY > 1 - ROW_ZONE_FRACTION) {
+            return { kind: 'row', rowIndex: location.rowIndex + 1 };
+        }
+
+        const relX = (activeCenterX - over.rect.left) / over.rect.width;
+        if (relX < CELL_EDGE_FRACTION) {
+            return {
+                kind: 'cell',
+                rowIndex: location.rowIndex,
+                blockIndex: location.blockIndex,
+            };
+        }
+        if (relX > 1 - CELL_EDGE_FRACTION) {
+            return {
+                kind: 'cell',
+                rowIndex: location.rowIndex,
+                blockIndex: location.blockIndex + 1,
+            };
+        }
+        return { kind: 'row', rowIndex: location.rowIndex };
     };
 
     // Live-preview move: relocate the block in the draft as the drag hovers,
@@ -636,7 +673,7 @@ export const HomepageEditor: FC<Props> = ({
                                         homepage.homepageUuid ? (
                                             <MantineIcon
                                                 icon={IconCheck}
-                                                color="blue"
+                                                color="ldGray.7"
                                             />
                                         ) : undefined
                                     }

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
@@ -365,7 +365,7 @@ const PublishModalBody: FC<BodyProps> = ({
                                                 </Box>
                                                 <ActionIcon
                                                     variant="subtle"
-                                                    color="gray"
+                                                    color="ldGray.6"
                                                     size="sm"
                                                     disabled={index === 0}
                                                     aria-label={`Move ${assignment.groupName} up`}
@@ -383,7 +383,7 @@ const PublishModalBody: FC<BodyProps> = ({
                                                 </ActionIcon>
                                                 <ActionIcon
                                                     variant="subtle"
-                                                    color="gray"
+                                                    color="ldGray.6"
                                                     size="sm"
                                                     disabled={
                                                         index ===

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -1,7 +1,12 @@
-import { type HomepageBlock, type HomepageConfig } from '@lightdash/common';
+import {
+    type HomepageBlock,
+    type HomepageConfig,
+    type HomepageRow,
+} from '@lightdash/common';
 import { Box, Group, Paper, Stack, Text } from '@mantine-8/core';
-import { type FC } from 'react';
+import { type FC, type ReactNode } from 'react';
 import { getBlockDefinition } from './blocks/registry';
+import layout from './homepageLayout.module.css';
 import classes from './PublishedHomepage.module.css';
 
 const PERSONAL_BLOCK_TYPES: HomepageBlock['type'][] = ['favorites', 'recent'];
@@ -9,6 +14,9 @@ const PERSONAL_BLOCK_TYPES: HomepageBlock['type'][] = ['favorites', 'recent'];
 // Composer-style blocks read better narrow and centered, like day-0's own
 // hero, instead of stretching to the full row width other blocks use.
 const NARROW_BLOCK_TYPES: HomepageBlock['type'][] = ['ask-ai-hero'];
+
+// A leading hero block gets the vertically-centred day-0 treatment.
+const HERO_BLOCK_TYPES: HomepageBlock['type'][] = ['ask-ai-hero'];
 
 // Unknown block types render nothing so newer configs degrade gracefully
 const BlockRenderer: FC<{
@@ -42,20 +50,13 @@ const BlockRenderer: FC<{
     );
 };
 
-type Props = {
-    config: HomepageConfig;
+const HomepageRows: FC<{
+    rows: HomepageRow[];
     projectUuid: string;
-    /** Render personal blocks as placeholders (admin view-as preview) */
-    personalPlaceholders?: boolean;
-};
-
-export const PublishedHomepage: FC<Props> = ({
-    config,
-    projectUuid,
-    personalPlaceholders = false,
-}) => (
-    <Stack gap={28} className={classes.container}>
-        {config.rows.map((row) => (
+    personalPlaceholders: boolean;
+}> = ({ rows, projectUuid, personalPlaceholders }) => (
+    <Stack gap={28}>
+        {rows.map((row) => (
             <Group key={row.id} gap={14} align="stretch" wrap="nowrap">
                 {row.blocks.map((block) => (
                     <Box key={block.id} flex={1} miw={0}>
@@ -70,3 +71,71 @@ export const PublishedHomepage: FC<Props> = ({
         ))}
     </Stack>
 );
+
+type Props = {
+    config: HomepageConfig;
+    projectUuid: string;
+    /** Render personal blocks as placeholders (admin view-as preview) */
+    personalPlaceholders?: boolean;
+    /** Content rendered below the centred hero, above the remaining rows
+     * (e.g. the personal favorites strip). */
+    secondaryTop?: ReactNode;
+};
+
+export const PublishedHomepage: FC<Props> = ({
+    config,
+    projectUuid,
+    personalPlaceholders = false,
+    secondaryTop = null,
+}) => {
+    const [firstRow, ...restRows] = config.rows;
+    const leadingHero =
+        firstRow &&
+        firstRow.blocks.length === 1 &&
+        HERO_BLOCK_TYPES.includes(firstRow.blocks[0].type)
+            ? firstRow.blocks[0]
+            : null;
+
+    if (leadingHero) {
+        return (
+            <div className={layout.page}>
+                <div className={layout.heroSection}>
+                    <div className={layout.hero}>
+                        <BlockRenderer
+                            block={leadingHero}
+                            projectUuid={projectUuid}
+                            personalPlaceholders={personalPlaceholders}
+                        />
+                    </div>
+                </div>
+                {(secondaryTop || restRows.length > 0) && (
+                    <div className={layout.secondary}>
+                        <Stack gap={28}>
+                            {secondaryTop}
+                            <HomepageRows
+                                rows={restRows}
+                                projectUuid={projectUuid}
+                                personalPlaceholders={personalPlaceholders}
+                            />
+                        </Stack>
+                    </div>
+                )}
+            </div>
+        );
+    }
+
+    return (
+        <div className={layout.page}>
+            <div className={layout.secondary}>
+                <Stack gap={28}>
+                    {secondaryTop}
+                    <HomepageRows
+                        rows={config.rows}
+                        projectUuid={projectUuid}
+                        personalPlaceholders={personalPlaceholders}
+                    />
+                </Stack>
+            </div>
+        </div>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
@@ -1,24 +1,32 @@
 import { type HomepageAnnouncementItem } from '@lightdash/common';
-import { ActionIcon, Group, Stack, Textarea } from '@mantine-8/core';
-import { IconSend, IconSpeakerphone, IconX } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import { ActionIcon, Stack } from '@mantine-8/core';
+import { IconSpeakerphone, IconX } from '@tabler/icons-react';
+import { type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { useTimeAgo } from '../../../../hooks/useTimeAgo';
 import useApp from '../../../../providers/App/useApp';
+import { AnnouncementComposer } from './announcements/AnnouncementComposer';
+import { AnnouncementContent } from './announcements/AnnouncementContent';
 import { BlockHeader } from './BlockShell';
 import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const AnnouncementRow: FC<{
     item: HomepageAnnouncementItem;
+    projectUuid: string;
     onRemove?: () => void;
-}> = ({ item, onRemove }) => {
+}> = ({ item, projectUuid, onRemove }) => {
     const timeAgo = useTimeAgo(item.date);
     return (
         <div className={`${classes.listRow} ${classes.listRowTop}`}>
             <span className={classes.announcementDot} />
             <div className={classes.flexFill}>
-                <div className={classes.announcementText}>{item.text}</div>
+                <div className={classes.announcementText}>
+                    <AnnouncementContent
+                        projectUuid={projectUuid}
+                        text={item.text}
+                    />
+                </div>
                 <div
                     className={`${classes.rowAside} ${classes.rowAsideSpaced}`}
                 >
@@ -28,7 +36,7 @@ const AnnouncementRow: FC<{
             {onRemove && (
                 <ActionIcon
                     variant="subtle"
-                    color="gray"
+                    color="ldGray.6"
                     size="sm"
                     aria-label="Remove announcement"
                     onClick={onRemove}
@@ -40,22 +48,22 @@ const AnnouncementRow: FC<{
     );
 };
 
-export const AnnouncementsBlockView: FC<BlockComponentProps> = ({ block }) => {
+export const AnnouncementsBlockView: FC<BlockComponentProps> = ({
+    block,
+    projectUuid,
+}) => {
     if (block.type !== 'announcements' || block.config.items.length === 0) {
         return null;
     }
     return (
         <Stack gap={0}>
-            <BlockHeader
-                icon={IconSpeakerphone}
-                iconColor="#7262FF"
-                title={block.config.title}
-            />
+            <BlockHeader icon={IconSpeakerphone} title={block.config.title} />
             <div className={classes.listCard}>
                 {block.config.items.map((item) => (
                     <AnnouncementRow
                         key={`${item.date}-${item.author}`}
                         item={item}
+                        projectUuid={projectUuid}
                     />
                 ))}
             </div>
@@ -65,15 +73,13 @@ export const AnnouncementsBlockView: FC<BlockComponentProps> = ({ block }) => {
 
 export const AnnouncementsBlockBuild: FC<BuildComponentProps> = ({
     block,
+    projectUuid,
     onChange,
 }) => {
     const { user } = useApp();
-    const [text, setText] = useState('');
     if (block.type !== 'announcements') return null;
 
-    const postAnnouncement = () => {
-        const trimmed = text.trim();
-        if (!trimmed) return;
+    const postAnnouncement = (text: string) => {
         const author = [user.data?.firstName, user.data?.lastName]
             .filter(Boolean)
             .join(' ');
@@ -83,7 +89,7 @@ export const AnnouncementsBlockBuild: FC<BuildComponentProps> = ({
                 ...block.config,
                 items: [
                     {
-                        text: trimmed,
+                        text,
                         date: new Date().toISOString(),
                         author,
                     },
@@ -91,21 +97,17 @@ export const AnnouncementsBlockBuild: FC<BuildComponentProps> = ({
                 ],
             },
         });
-        setText('');
     };
 
     return (
         <Stack gap={0}>
-            <BlockHeader
-                icon={IconSpeakerphone}
-                iconColor="#7262FF"
-                title={block.config.title}
-            />
+            <BlockHeader icon={IconSpeakerphone} title={block.config.title} />
             <div className={`${classes.listCard} ${classes.listCardSpaced}`}>
                 {block.config.items.map((item, index) => (
                     <AnnouncementRow
                         key={`${item.date}-${item.author}`}
                         item={item}
+                        projectUuid={projectUuid}
                         onRemove={() =>
                             onChange({
                                 ...block,
@@ -120,27 +122,10 @@ export const AnnouncementsBlockBuild: FC<BuildComponentProps> = ({
                     />
                 ))}
             </div>
-            <Group gap="xs" align="flex-end">
-                <Textarea
-                    aria-label="New announcement"
-                    size="xs"
-                    flex={1}
-                    autosize
-                    minRows={1}
-                    maxRows={4}
-                    placeholder="Post an announcement to this audience…"
-                    value={text}
-                    onChange={(e) => setText(e.currentTarget.value)}
-                />
-                <ActionIcon
-                    variant="default"
-                    size="lg"
-                    aria-label="Post announcement"
-                    onClick={postAnnouncement}
-                >
-                    <MantineIcon icon={IconSend} />
-                </ActionIcon>
-            </Group>
+            <AnnouncementComposer
+                projectUuid={projectUuid}
+                onPost={postAnnouncement}
+            />
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -101,7 +101,7 @@ const CollectionPickerModal: FC<{
                                     {content.space?.name}
                                 </Text>
                             </Box>
-                            <MantineIcon icon={IconPlus} color="gray" />
+                            <MantineIcon icon={IconPlus} color="ldGray.6" />
                         </Group>
                     ))}
                     {results.length === 0 && !isFetching && (

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
@@ -69,7 +69,7 @@ const CardActions: FC<Pick<Props, 'content' | 'onRemove' | 'star'>> = ({
         {star && (
             <ActionIcon
                 variant="subtle"
-                color={star.isFavorite ? 'yellow' : 'gray'}
+                color={star.isFavorite ? 'yellow' : 'ldGray.6'}
                 size="sm"
                 aria-label={
                     star.isFavorite
@@ -89,7 +89,7 @@ const CardActions: FC<Pick<Props, 'content' | 'onRemove' | 'star'>> = ({
         {onRemove && (
             <ActionIcon
                 variant="subtle"
-                color="gray"
+                color="ldGray.6"
                 size="sm"
                 aria-label={`Remove ${content.name} from collection`}
                 onClick={(e) => {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
@@ -18,8 +18,6 @@ import { BlockHeader } from './BlockShell';
 import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
-const STAR_COLOR = 'light-dark(#de7f0b, #e08a20)';
-
 const FAVORITE_ICONS: Partial<Record<ResourceViewItemType, Icon>> = {
     [ResourceViewItemType.CHART]: IconChartBar,
     [ResourceViewItemType.DASHBOARD]: IconLayoutDashboard,
@@ -78,7 +76,7 @@ const FavoritePills: FC<{
                         <MantineIcon
                             icon={IconStarFilled}
                             size={13}
-                            color={STAR_COLOR}
+                            color="ldGray.7"
                             className={classes.clickable}
                             aria-label={`Remove ${item.data.name} from favorites`}
                             onClick={(e) => handleUnfavorite(e, item)}
@@ -87,7 +85,7 @@ const FavoritePills: FC<{
                         <MantineIcon
                             icon={IconStarFilled}
                             size={13}
-                            color={STAR_COLOR}
+                            color="ldGray.7"
                         />
                     )}
                 </Link>
@@ -102,7 +100,6 @@ export const PersonalFavoritesStrip: FC<{ projectUuid: string }> = ({
     <Stack gap={0}>
         <BlockHeader
             icon={IconStar}
-            iconColor={STAR_COLOR}
             title="My favorites"
             pill="Only you see this"
             mb={10}
@@ -124,7 +121,6 @@ export const FavoritesBlockView: FC<BlockComponentProps> = ({
         <Stack gap={0}>
             <BlockHeader
                 icon={IconStar}
-                iconColor={STAR_COLOR}
                 title={block.config.title}
                 pill="Only you see this"
             />
@@ -146,7 +142,6 @@ export const FavoritesBlockBuild: FC<BuildComponentProps> = ({
         <Stack gap={0}>
             <BlockHeader
                 icon={IconStar}
-                iconColor={STAR_COLOR}
                 title={block.config.title}
                 pill="Personal per viewer"
             />

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/HeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/HeroBlock.tsx
@@ -1,64 +1,23 @@
-import { subject } from '@casl/ability';
-import {
-    Box,
-    Button,
-    Code,
-    Group,
-    Stack,
-    Text,
-    TextInput,
-} from '@mantine-8/core';
-import { IconSquareRoundedPlus } from '@tabler/icons-react';
+import { Box, Code, Stack, Text, TextInput } from '@mantine-8/core';
 import { type FC } from 'react';
-import { Link } from 'react-router';
-import MantineIcon from '../../../../components/common/MantineIcon';
-import { Can } from '../../../../providers/Ability';
 import useApp from '../../../../providers/App/useApp';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const resolveTokens = (text: string, firstName: string | undefined): string =>
     text.replaceAll('{name}', firstName ?? 'there');
 
-export const HeroBlockView: FC<BlockComponentProps> = ({
-    block,
-    projectUuid,
-}) => {
+export const HeroBlockView: FC<BlockComponentProps> = ({ block }) => {
     const { user } = useApp();
     if (block.type !== 'hero') return null;
     return (
-        <Group justify="space-between" align="flex-end" gap="md" wrap="nowrap">
-            <Box>
-                <Text
-                    component="h1"
-                    fz={28}
-                    fw={600}
-                    lts="-0.02em"
-                    m={0}
-                    lh={1.2}
-                >
-                    {resolveTokens(block.config.title, user.data?.firstName)}
-                </Text>
-                <Text fz={15} c="dimmed" mt={5}>
-                    {resolveTokens(block.config.subtitle, user.data?.firstName)}
-                </Text>
-            </Box>
-            <Can
-                I="manage"
-                this={subject('Explore', {
-                    organizationUuid: user.data?.organizationUuid,
-                    projectUuid,
-                })}
-            >
-                <Button
-                    component={Link}
-                    to={`/projects/${projectUuid}/tables`}
-                    leftSection={<MantineIcon icon={IconSquareRoundedPlus} />}
-                    flex="0 0 auto"
-                >
-                    New
-                </Button>
-            </Can>
-        </Group>
+        <Box>
+            <Text component="h1" fz={28} fw={600} lts="-0.02em" m={0} lh={1.2}>
+                {resolveTokens(block.config.title, user.data?.firstName)}
+            </Text>
+            <Text fz={15} c="dimmed" mt={5}>
+                {resolveTokens(block.config.subtitle, user.data?.firstName)}
+            </Text>
+        </Box>
     );
 };
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MarkdownBlock.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MarkdownBlock.module.css
@@ -1,40 +1,8 @@
-.preview :global(.wmde-markdown) {
-    background-color: transparent;
-    font-family: var(--mantine-font-family);
-    font-size: 14px;
-    color: var(--mantine-color-ldGray-8);
-    padding: 0;
-}
-
-.preview :global(.wmde-markdown) :global(p:first-child) {
-    margin-top: 0;
-}
-
-.preview :global(.wmde-markdown) :global(p:last-child) {
-    margin-bottom: 0;
-}
-
 .editorWrap {
     border: 1px solid var(--mantine-color-ldGray-2);
     border-radius: 10px;
     background: light-dark(#fff, var(--mantine-color-dark-6));
     padding: 16px;
-}
-
-.editorTextarea {
-    width: 100%;
-    border: none;
-    background: transparent;
-    font-size: 14px;
-    line-height: 1.55;
-    color: var(--mantine-color-ldGray-8);
-    font-family: var(--mantine-font-family);
-    resize: vertical;
-    padding: 0;
-}
-
-.editorTextarea:focus {
-    outline: none;
 }
 
 .editorHint {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MarkdownBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MarkdownBlock.tsx
@@ -1,19 +1,15 @@
-import { Text, Textarea, useMantineColorScheme } from '@mantine-8/core';
-import MarkdownPreview from '@uiw/react-markdown-preview';
+import { Text } from '@mantine-8/core';
 import { type FC } from 'react';
-import rehypeExternalLinks from 'rehype-external-links';
+import { AiMarkdown } from '../../../../components/common/AiMarkdown/AiMarkdown';
 import classes from './MarkdownBlock.module.css';
+import { TiptapMarkdownEditor } from './markdownEditor/TiptapMarkdownEditor';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 export const MarkdownBlockView: FC<BlockComponentProps> = ({ block }) => {
-    const { colorScheme } = useMantineColorScheme();
     if (block.type !== 'markdown') return null;
     return (
-        <div className={classes.preview} data-color-mode={colorScheme}>
-            <MarkdownPreview
-                source={block.config.content}
-                rehypePlugins={[[rehypeExternalLinks, { target: '_blank' }]]}
-            />
+        <div className={classes.preview}>
+            <AiMarkdown>{block.config.content}</AiMarkdown>
         </div>
     );
 };
@@ -25,22 +21,18 @@ export const MarkdownBlockBuild: FC<BuildComponentProps> = ({
     if (block.type !== 'markdown') return null;
     return (
         <div className={classes.editorWrap}>
-            <Textarea
-                aria-label="Markdown content"
-                variant="unstyled"
-                autosize
-                minRows={4}
-                maxRows={16}
-                value={block.config.content}
-                onChange={(e) =>
+            <TiptapMarkdownEditor
+                content={block.config.content}
+                onChange={(markdown) =>
                     onChange({
                         ...block,
-                        config: { content: e.currentTarget.value },
+                        config: { content: markdown },
                     })
                 }
-                classNames={{ input: classes.editorTextarea }}
             />
-            <Text className={classes.editorHint}>Markdown supported</Text>
+            <Text className={classes.editorHint}>
+                Type &quot;/&quot; for commands
+            </Text>
         </div>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
@@ -37,6 +37,8 @@ import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const KPI_TIME_FRAME = TimeFrames.MONTH;
 
+const MAX_METRICS = 4;
+
 const MetricKpiCard: FC<{
     metricRef: HomepageMetricRef;
     projectUuid: string;
@@ -134,8 +136,9 @@ const MetricsPickerModal: FC<{
     onClose: () => void;
     projectUuid: string;
     selected: HomepageMetricRef[];
+    atLimit: boolean;
     onAdd: (metricRef: HomepageMetricRef) => void;
-}> = ({ opened, onClose, projectUuid, selected, onAdd }) => {
+}> = ({ opened, onClose, projectUuid, selected, atLimit, onAdd }) => {
     const [search, setSearch] = useState('');
     const [debouncedSearch] = useDebouncedValue(search, 300);
     const { data, isFetching } = useMetricsCatalog({
@@ -167,36 +170,44 @@ const MetricsPickerModal: FC<{
                     value={search}
                     onChange={(e) => setSearch(e.currentTarget.value)}
                     rightSection={isFetching ? <Loader size="xs" /> : null}
+                    disabled={atLimit}
                 />
+                {atLimit && (
+                    <Text size="xs" c="dimmed">
+                        You can show up to {MAX_METRICS} metrics. Remove one to
+                        add another.
+                    </Text>
+                )}
                 <Stack gap={4} mah={360} className={classes.pickerScrollList}>
-                    {results.map((metric) => (
-                        <Group
-                            key={metric.catalogSearchUuid}
-                            gap="sm"
-                            wrap="nowrap"
-                            p="xs"
-                            className={classes.pickerRow}
-                            onClick={() =>
-                                onAdd({
-                                    tableName: metric.tableName,
-                                    metricName: metric.name,
-                                    label: metric.label ?? metric.name,
-                                })
-                            }
-                        >
-                            <MantineIcon icon={IconHash} color="gray" />
-                            <Box flex={1} miw={0}>
-                                <Text size="sm" fw={500} truncate>
-                                    {metric.label ?? metric.name}
-                                </Text>
-                                <Text size="xs" c="dimmed">
-                                    {metric.tableLabel ?? metric.tableName}
-                                </Text>
-                            </Box>
-                            <MantineIcon icon={IconPlus} color="gray" />
-                        </Group>
-                    ))}
-                    {results.length === 0 && !isFetching && (
+                    {!atLimit &&
+                        results.map((metric) => (
+                            <Group
+                                key={metric.catalogSearchUuid}
+                                gap="sm"
+                                wrap="nowrap"
+                                p="xs"
+                                className={classes.pickerRow}
+                                onClick={() =>
+                                    onAdd({
+                                        tableName: metric.tableName,
+                                        metricName: metric.name,
+                                        label: metric.label ?? metric.name,
+                                    })
+                                }
+                            >
+                                <MantineIcon icon={IconHash} color="ldGray.6" />
+                                <Box flex={1} miw={0}>
+                                    <Text size="sm" fw={500} truncate>
+                                        {metric.label ?? metric.name}
+                                    </Text>
+                                    <Text size="xs" c="dimmed">
+                                        {metric.tableLabel ?? metric.tableName}
+                                    </Text>
+                                </Box>
+                                <MantineIcon icon={IconPlus} color="ldGray.6" />
+                            </Group>
+                        ))}
+                    {!atLimit && results.length === 0 && !isFetching && (
                         <Text size="sm" c="dimmed" p="sm">
                             No matching metrics.
                         </Text>
@@ -216,11 +227,7 @@ export const MetricsBlockView: FC<BlockComponentProps> = ({
     }
     return (
         <Stack gap={0}>
-            <BlockHeader
-                icon={IconChartDots}
-                iconColor="light-dark(#de7f0b, #e08a20)"
-                title={block.config.title}
-            />
+            <BlockHeader icon={IconChartDots} title={block.config.title} />
             <SimpleGrid cols={{ base: 1, sm: 2, md: 4 }} spacing={12}>
                 {block.config.items.map((metricRef) => (
                     <MetricKpiCard
@@ -241,6 +248,8 @@ export const MetricsBlockBuild: FC<BuildComponentProps> = ({
 }) => {
     const [isPickerOpen, setIsPickerOpen] = useState(false);
     if (block.type !== 'metrics') return null;
+
+    const atLimit = block.config.items.length >= MAX_METRICS;
 
     return (
         <Stack gap="xs">
@@ -277,7 +286,7 @@ export const MetricsBlockBuild: FC<BuildComponentProps> = ({
                             </Box>
                             <ActionIcon
                                 variant="subtle"
-                                color="gray"
+                                color="ldGray.6"
                                 size="sm"
                                 aria-label={`Remove metric ${metricRef.label}`}
                                 onClick={() =>
@@ -306,25 +315,30 @@ export const MetricsBlockBuild: FC<BuildComponentProps> = ({
                 variant="default"
                 size="xs"
                 w="fit-content"
+                disabled={atLimit}
                 leftSection={<MantineIcon icon={IconHash} />}
                 onClick={() => setIsPickerOpen(true)}
             >
-                Choose metrics from catalog…
+                {atLimit
+                    ? `Metric limit reached (${MAX_METRICS})`
+                    : 'Choose metrics from catalog…'}
             </Button>
             <MetricsPickerModal
                 opened={isPickerOpen}
                 onClose={() => setIsPickerOpen(false)}
                 projectUuid={projectUuid}
                 selected={block.config.items}
-                onAdd={(metricRef) =>
+                atLimit={atLimit}
+                onAdd={(metricRef) => {
+                    if (block.config.items.length >= MAX_METRICS) return;
                     onChange({
                         ...block,
                         config: {
                             ...block.config,
                             items: [...block.config.items, metricRef],
                         },
-                    })
-                }
+                    });
+                }}
             />
         </Stack>
     );

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
@@ -7,7 +7,6 @@ import {
     Group,
     Loader,
     Menu,
-    SimpleGrid,
     Stack,
     Text,
     TextInput,
@@ -32,7 +31,6 @@ import { useInfiniteContent } from '../../../../hooks/useContent';
 import useTracking from '../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../types/Events';
 import { useAiAgentButtonVisibility } from '../../aiCopilot/hooks/useAiAgentsButtonVisibility';
-import { IconSquare } from './BlockShell';
 import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
@@ -100,7 +98,7 @@ export const QuickActionCards: FC<{
     );
     if (visibleActions.length === 0) return null;
     return (
-        <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+        <Group gap={8}>
             {visibleActions.map((action, index) => {
                 const presentation = actionPresentation(action, projectUuid);
                 return (
@@ -110,6 +108,7 @@ export const QuickActionCards: FC<{
                         to={presentation.url}
                         underline="never"
                         c="inherit"
+                        className={classes.quickActionChip}
                         onClick={() =>
                             track({
                                 name: EventName.HOMEPAGE_QUICK_ACTION_CLICKED,
@@ -117,23 +116,16 @@ export const QuickActionCards: FC<{
                             })
                         }
                     >
-                        <Box
-                            className={`${classes.hoverCard} ${classes.clickable}`}
-                            p={18}
-                            h="100%"
-                        >
-                            <IconSquare icon={presentation.icon} size="lg" />
-                            <Text fw={600} fz={15} mt={13} mb={3}>
-                                {presentation.title}
-                            </Text>
-                            <Text fz={13} c="dimmed" lh={1.45}>
-                                {presentation.description}
-                            </Text>
-                        </Box>
+                        <MantineIcon
+                            icon={presentation.icon}
+                            size={14}
+                            color="ldGray.6"
+                        />
+                        {presentation.title}
                     </Anchor>
                 );
             })}
-        </SimpleGrid>
+        </Group>
     );
 };
 
@@ -181,12 +173,12 @@ const DashboardPickerModal: FC<{
                         >
                             <MantineIcon
                                 icon={IconLayoutDashboard}
-                                color="gray"
+                                color="ldGray.6"
                             />
                             <Text size="sm" fw={500} flex={1} truncate>
                                 {content.name}
                             </Text>
-                            <MantineIcon icon={IconPlus} color="gray" />
+                            <MantineIcon icon={IconPlus} color="ldGray.6" />
                         </Group>
                     ))}
                 </Stack>
@@ -251,14 +243,14 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
                         >
                             <MantineIcon
                                 icon={presentation.icon}
-                                color="gray"
+                                color="ldGray.6"
                             />
                             <Text size="sm" fw={500} flex={1}>
                                 {presentation.title}
                             </Text>
                             <ActionIcon
                                 variant="subtle"
-                                color="gray"
+                                color="ldGray.6"
                                 size="sm"
                                 disabled={index === 0}
                                 aria-label={`Move ${presentation.title} earlier`}
@@ -268,7 +260,7 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
                             </ActionIcon>
                             <ActionIcon
                                 variant="subtle"
-                                color="gray"
+                                color="ldGray.6"
                                 size="sm"
                                 disabled={
                                     index === block.config.actions.length - 1
@@ -280,7 +272,7 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
                             </ActionIcon>
                             <ActionIcon
                                 variant="subtle"
-                                color="gray"
+                                color="ldGray.6"
                                 size="sm"
                                 aria-label={`Remove ${presentation.title}`}
                                 onClick={() =>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
@@ -27,6 +27,8 @@ const getRecentlyViewed = async (projectUuid: string) =>
         body: undefined,
     });
 
+const MAX_RECENT_ITEMS = 4;
+
 const useRecentlyViewed = (projectUuid: string) =>
     useQuery<HomepageRecentlyViewedItem[], ApiError>({
         queryKey: ['homepage_recently_viewed', projectUuid],
@@ -72,7 +74,9 @@ const RecentRow: FC<{
 
 const RecentList: FC<{ projectUuid: string }> = ({ projectUuid }) => {
     const { data: recents, isInitialLoading } = useRecentlyViewed(projectUuid);
-    const uuids = (recents ?? []).map((item) => item.uuid);
+    const uuids = (recents ?? [])
+        .slice(0, MAX_RECENT_ITEMS)
+        .map((item) => item.uuid);
     const { data: contents, isInitialLoading: isResolving } =
         useCollectionContent(projectUuid, uuids);
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -45,7 +45,7 @@ const ResourceRow: FC<{
             {onRemove ? (
                 <ActionIcon
                     variant="subtle"
-                    color="gray"
+                    color="ldGray.6"
                     size="sm"
                     aria-label={`Remove resource ${item.title}`}
                     onClick={onRemove}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementComposer.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementComposer.module.css
@@ -1,0 +1,36 @@
+.composer {
+    display: flex;
+    align-items: flex-end;
+    gap: var(--mantine-spacing-xs);
+}
+
+.editorContent {
+    flex: 1;
+    min-width: 0;
+    min-height: 30px;
+    max-height: 110px;
+    overflow-y: auto;
+    padding: 6px 10px;
+    border-radius: var(--mantine-radius-sm);
+    border: 1px solid var(--mantine-color-ldGray-3);
+    font-size: var(--mantine-font-size-xs);
+    background: var(--mantine-color-body);
+}
+
+.editorContent :global(.ProseMirror) {
+    outline: none;
+}
+
+.editorContent :global(.ProseMirror) :global(p) {
+    margin: 0;
+}
+
+.editorContent
+    :global(.ProseMirror)
+    :global(.is-editor-empty:first-child::before) {
+    content: attr(data-placeholder);
+    float: left;
+    height: 0;
+    color: var(--mantine-color-ldGray-4);
+    pointer-events: none;
+}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementComposer.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementComposer.tsx
@@ -1,0 +1,42 @@
+import { ActionIcon } from '@mantine-8/core';
+import { IconSend } from '@tabler/icons-react';
+import { EditorContent, useEditor } from '@tiptap/react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import classes from './AnnouncementComposer.module.css';
+import { createAnnouncementExtensions } from './announcementExtensions';
+import { serializeAnnouncementMarkdown } from './serializeAnnouncementMarkdown';
+
+type Props = {
+    projectUuid: string;
+    onPost: (markdown: string) => void;
+};
+
+export const AnnouncementComposer: FC<Props> = ({ projectUuid, onPost }) => {
+    const editor = useEditor({
+        extensions: createAnnouncementExtensions(() => projectUuid),
+    });
+
+    const handlePost = () => {
+        if (!editor) return;
+        const markdown = serializeAnnouncementMarkdown(editor, projectUuid);
+        if (!markdown) return;
+        onPost(markdown);
+        editor.commands.clearContent();
+    };
+
+    return (
+        <div className={classes.composer}>
+            <EditorContent editor={editor} className={classes.editorContent} />
+            <ActionIcon
+                variant="subtle"
+                size="lg"
+                color="ldGray.6"
+                aria-label="Post announcement"
+                onClick={handlePost}
+            >
+                <MantineIcon icon={IconSend} />
+            </ActionIcon>
+        </div>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementContent.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementContent.tsx
@@ -1,0 +1,60 @@
+import { ContentType } from '@lightdash/common';
+import { type FC } from 'react';
+import { AiMarkdown } from '../../../../../components/common/AiMarkdown/AiMarkdown';
+import { rehypeAiAgentContentLinks } from '../../../aiCopilot/components/ChatElements/rehypeContentLinks';
+import { AnnouncementMentionChip } from './AnnouncementMentionChip';
+
+type Props = {
+    projectUuid: string;
+    text: string;
+};
+
+export const AnnouncementContent: FC<Props> = ({ projectUuid, text }) => (
+    <AiMarkdown
+        rehypePlugins={[rehypeAiAgentContentLinks]}
+        components={{
+            a: ({ children, ...props }) => {
+                const rest = props as Record<string, unknown>;
+                const contentType = rest['data-content-type'];
+                const chartUuid = rest['data-chart-uuid'];
+                const dashboardUuid = rest['data-dashboard-uuid'];
+                const label =
+                    typeof children === 'string' ? children : String(children);
+
+                if (
+                    contentType === 'chart-link' &&
+                    typeof chartUuid === 'string'
+                ) {
+                    return (
+                        <AnnouncementMentionChip
+                            projectUuid={projectUuid}
+                            contentType={ContentType.CHART}
+                            uuid={chartUuid}
+                            label={label}
+                        />
+                    );
+                }
+                if (
+                    contentType === 'dashboard-link' &&
+                    typeof dashboardUuid === 'string'
+                ) {
+                    return (
+                        <AnnouncementMentionChip
+                            projectUuid={projectUuid}
+                            contentType={ContentType.DASHBOARD}
+                            uuid={dashboardUuid}
+                            label={label}
+                        />
+                    );
+                }
+                return (
+                    <a {...props} target="_blank" rel="noreferrer">
+                        {children}
+                    </a>
+                );
+            },
+        }}
+    >
+        {text}
+    </AiMarkdown>
+);

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementMentionChip.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementMentionChip.module.css
@@ -1,0 +1,4 @@
+.chip,
+.chip:hover {
+    text-decoration: none;
+}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementMentionChip.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementMentionChip.tsx
@@ -1,0 +1,64 @@
+import { ContentType, type ChartKind } from '@lightdash/common';
+import { IconLayoutDashboard } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
+import TruncatedText from '../../../../../components/common/TruncatedText';
+import styles from '../../../aiCopilot/components/ChatElements/AgentChatInput.module.css';
+import chipClasses from './AnnouncementMentionChip.module.css';
+
+type Props = {
+    projectUuid: string;
+    contentType: ContentType.CHART | ContentType.DASHBOARD;
+    uuid: string;
+    label: string;
+    chartKind?: ChartKind | null;
+};
+
+export const AnnouncementMentionChip: FC<Props> = ({
+    projectUuid,
+    contentType,
+    uuid,
+    label,
+    chartKind,
+}) => {
+    const isDashboard = contentType === ContentType.DASHBOARD;
+    const Icon = isDashboard
+        ? IconLayoutDashboard
+        : getChartIcon(chartKind ?? undefined);
+    const url = isDashboard
+        ? `/projects/${projectUuid}/dashboards/${uuid}/view`
+        : `/projects/${projectUuid}/saved/${uuid}/view`;
+
+    return (
+        <Link
+            to={url}
+            className={`${styles.contentMention} ${chipClasses.chip}`}
+            data-content-type={contentType}
+            data-content-link="true"
+        >
+            <span
+                className={styles.contentMentionIcon}
+                data-rendered-icon="true"
+            >
+                <MantineIcon
+                    icon={Icon}
+                    size={12}
+                    color={isDashboard ? 'green.7' : 'blue.7'}
+                    stroke={1.8}
+                />
+            </span>
+            <TruncatedText
+                className={styles.contentMentionLabel}
+                fz="inherit"
+                fw="inherit"
+                inline
+                maxWidth={260}
+                style={{ flex: 1, minWidth: 0 }}
+            >
+                {label}
+            </TruncatedText>
+        </Link>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/announcementExtensions.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/announcementExtensions.ts
@@ -1,0 +1,24 @@
+import Placeholder from '@tiptap/extension-placeholder';
+import StarterKit from '@tiptap/starter-kit';
+import { createContentMentionExtension } from '../../../aiCopilot/components/ChatElements/contentMentions';
+
+export const createAnnouncementExtensions = (
+    getProjectUuid: () => string | undefined,
+) => [
+    StarterKit.configure({
+        heading: false,
+        bulletList: false,
+        orderedList: false,
+        blockquote: false,
+        codeBlock: false,
+        horizontalRule: false,
+    }),
+    Placeholder.configure({
+        placeholder:
+            'Post an announcement to this audience — type @ to mention a chart or dashboard…',
+    }),
+    createContentMentionExtension({
+        getProjectUuid,
+        getPriorityItems: () => [],
+    }),
+];

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/serializeAnnouncementMarkdown.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/serializeAnnouncementMarkdown.ts
@@ -1,0 +1,70 @@
+import { ContentType } from '@lightdash/common';
+import { type Editor } from '@tiptap/react';
+
+// Must match `CONTENT_MENTION_NAME` in
+// ee/features/aiCopilot/components/ChatElements/contentMentions.tsx — not
+// exported from there, so kept in sync manually.
+const CONTENT_MENTION_NODE_TYPE = 'contentMention';
+
+// Escapes markdown syntax characters so plain typed text (e.g. "Q1 * Q2",
+// "50% off!") isn't reinterpreted as emphasis/headings/etc when re-parsed by
+// the read-view's markdown renderer.
+const escapeMarkdown = (text: string) =>
+    text.replace(/([\\`*_{}[\]()#+!])/g, '\\$1');
+
+const mentionUrl = (
+    projectUuid: string,
+    contentType: ContentType,
+    uuid: string,
+): string =>
+    contentType === ContentType.DASHBOARD
+        ? `/projects/${projectUuid}/dashboards/${uuid}/view`
+        : `/projects/${projectUuid}/saved/${uuid}/view`;
+
+/** Serializes the composer's doc to markdown, turning @-mentioned content
+ * into plain markdown links that `rehypeAiAgentContentLinks` renders as rich
+ * chips on read. */
+export const serializeAnnouncementMarkdown = (
+    editor: Editor,
+    projectUuid: string,
+): string => {
+    const paragraphs: string[] = [];
+    editor.state.doc.forEach((paragraph) => {
+        const parts: string[] = [];
+        paragraph.forEach((child) => {
+            if (child.type.name === CONTENT_MENTION_NODE_TYPE) {
+                const attrs = child.attrs as {
+                    contentType?: ContentType;
+                    uuid?: string;
+                    label?: string;
+                };
+                if (
+                    attrs.uuid &&
+                    (attrs.contentType === ContentType.CHART ||
+                        attrs.contentType === ContentType.DASHBOARD)
+                ) {
+                    const label = escapeMarkdown(attrs.label ?? '');
+                    const url = mentionUrl(
+                        projectUuid,
+                        attrs.contentType,
+                        attrs.uuid,
+                    );
+                    parts.push(`[${label}](${url})`);
+                }
+                return;
+            }
+            if (child.isText) {
+                let text = escapeMarkdown(child.text ?? '');
+                child.marks.forEach((mark) => {
+                    if (mark.type.name === 'bold') text = `**${text}**`;
+                    else if (mark.type.name === 'italic') text = `_${text}_`;
+                    else if (mark.type.name === 'code') text = `\`${text}\``;
+                    else if (mark.type.name === 'strike') text = `~~${text}~~`;
+                });
+                parts.push(text);
+            }
+        });
+        paragraphs.push(parts.join(''));
+    });
+    return paragraphs.join('\n\n').trim();
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -161,7 +161,7 @@ a .hoverCard:hover,
     width: 7px;
     height: 7px;
     border-radius: 50%;
-    background: #7262ff;
+    background: var(--mantine-color-ldGray-4);
     margin-top: 6px;
     flex-shrink: 0;
 }
@@ -265,4 +265,28 @@ a .hoverCard:hover,
     background: var(--mantine-color-ldGray-1);
     border-radius: 5px;
     padding: 2px 7px;
+}
+
+.quickActionChip {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 6px 12px;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    color: inherit;
+    text-decoration: none;
+    background: light-dark(#fff, var(--mantine-color-dark-6));
+    border: 1px solid var(--mantine-color-ldGray-2);
+    transition:
+        background 0.15s ease,
+        border-color 0.15s ease;
+}
+
+.quickActionChip:hover {
+    text-decoration: none;
+    color: inherit;
+    background: var(--mantine-color-ldGray-0);
+    border-color: var(--mantine-color-ldGray-3);
 }

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/SlashCommandExtension.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/SlashCommandExtension.ts
@@ -1,0 +1,35 @@
+import { PluginKey } from '@tiptap/pm/state';
+import { Extension } from '@tiptap/react';
+import Suggestion from '@tiptap/suggestion';
+import { generateSuggestion } from '../../../../../components/common/SuggestionList/generateSuggestion';
+import {
+    SLASH_COMMAND_ITEMS,
+    type SlashCommandItem,
+} from './slashCommandItems';
+import { renderSlashCommandItem } from './SlashCommandMenuItem';
+
+const slashCommandPluginKey = new PluginKey('homepageMarkdownSlashCommand');
+
+export const SlashCommand = Extension.create({
+    name: 'slashCommand',
+
+    addProseMirrorPlugins() {
+        return [
+            Suggestion<SlashCommandItem>({
+                editor: this.editor,
+                char: '/',
+                startOfLine: false,
+                pluginKey: slashCommandPluginKey,
+                ...generateSuggestion<SlashCommandItem>({
+                    items: SLASH_COMMAND_ITEMS,
+                    command: ({ editor, range, props }) => {
+                        const item = props as SlashCommandItem;
+                        item.run(editor, range);
+                    },
+                    renderItem: renderSlashCommandItem,
+                    emptyMessage: 'No matching block type',
+                }),
+            }),
+        ];
+    },
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/SlashCommandMenuItem.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/SlashCommandMenuItem.module.css
@@ -1,0 +1,36 @@
+.iconSquare {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 26px;
+    height: 26px;
+    border-radius: 6px;
+    background-color: var(--mantine-color-ldGray-1);
+    color: var(--mantine-color-ldGray-6);
+
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-4);
+        color: var(--mantine-color-ldGray-6);
+    }
+}
+
+.text {
+    min-width: 0;
+    flex: 1;
+}
+
+.label {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--mantine-color-ldDark-9);
+
+    @mixin dark {
+        color: var(--mantine-color-ldGray-8);
+    }
+}
+
+.description {
+    font-size: 11.5px;
+    color: var(--mantine-color-ldGray-5);
+}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/SlashCommandMenuItem.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/SlashCommandMenuItem.tsx
@@ -1,0 +1,30 @@
+import { Group, Stack, Text } from '@mantine-8/core';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { PolymorphicGroupButton } from '../../../../../components/common/PolymorphicGroupButton';
+import suggestionStyles from '../../../../../components/common/SuggestionList/SuggestionList.module.css';
+import { type SlashCommandItem } from './slashCommandItems';
+import classes from './SlashCommandMenuItem.module.css';
+
+export const renderSlashCommandItem = (
+    item: SlashCommandItem,
+    isSelected: boolean,
+    onClick: () => void,
+) => (
+    <PolymorphicGroupButton
+        onClick={onClick}
+        className={suggestionStyles.suggestionItem}
+        data-selected={isSelected}
+    >
+        <Group wrap="nowrap" gap="xs">
+            <div className={classes.iconSquare}>
+                <MantineIcon icon={item.icon} size={14} />
+            </div>
+            <Stack gap={0} className={classes.text}>
+                <Text className={classes.label}>{item.label}</Text>
+                <Text className={classes.description} truncate>
+                    {item.description}
+                </Text>
+            </Stack>
+        </Group>
+    </PolymorphicGroupButton>
+);

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/TiptapMarkdownEditor.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/TiptapMarkdownEditor.module.css
@@ -1,0 +1,89 @@
+.editorContent {
+    font-size: 14px;
+    line-height: 1.55;
+    color: var(--mantine-color-ldGray-8);
+    font-family: var(--mantine-font-family);
+}
+
+.editorContent :global(.ProseMirror) {
+    outline: none;
+}
+
+.editorContent :global(.ProseMirror) :global(p) {
+    margin: 0 0 8px;
+}
+
+.editorContent :global(.ProseMirror) :global(p:last-child) {
+    margin-bottom: 0;
+}
+
+.editorContent :global(.ProseMirror) :global(h1),
+.editorContent :global(.ProseMirror) :global(h2),
+.editorContent :global(.ProseMirror) :global(h3) {
+    margin: 12px 0 6px;
+    font-weight: 600;
+    color: var(--mantine-color-ldDark-9);
+
+    @mixin dark {
+        color: var(--mantine-color-ldGray-9);
+    }
+}
+
+.editorContent :global(.ProseMirror) :global(h1) {
+    font-size: 20px;
+}
+
+.editorContent :global(.ProseMirror) :global(h2) {
+    font-size: 17px;
+}
+
+.editorContent :global(.ProseMirror) :global(h3) {
+    font-size: 15px;
+}
+
+.editorContent :global(.ProseMirror) :global(ul),
+.editorContent :global(.ProseMirror) :global(ol) {
+    margin: 0 0 8px;
+    padding-left: 20px;
+}
+
+.editorContent :global(.ProseMirror) :global(blockquote) {
+    margin: 0 0 8px;
+    padding-left: 12px;
+    border-left: 3px solid var(--mantine-color-ldGray-3);
+    color: var(--mantine-color-ldGray-6);
+}
+
+.editorContent :global(.ProseMirror) :global(pre) {
+    margin: 0 0 8px;
+    padding: 10px 12px;
+    border-radius: 6px;
+    background-color: var(--mantine-color-ldGray-1);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 12.5px;
+    overflow-x: auto;
+
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.editorContent :global(.ProseMirror) :global(code) {
+    font-family: var(--mantine-font-family-monospace);
+}
+
+.editorContent :global(.ProseMirror) :global(hr) {
+    margin: 12px 0;
+    border: none;
+    border-top: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.editorContent
+    :global(.ProseMirror)
+    :global(.is-editor-empty:first-child::before) {
+    content: attr(data-placeholder);
+    float: left;
+    height: 0;
+    color: var(--mantine-color-ldGray-4);
+    pointer-events: none;
+}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/TiptapMarkdownEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/TiptapMarkdownEditor.tsx
@@ -1,0 +1,38 @@
+import Placeholder from '@tiptap/extension-placeholder';
+import { EditorContent, useEditor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import { type FC } from 'react';
+import { Markdown, type MarkdownStorage } from 'tiptap-markdown';
+import { SlashCommand } from './SlashCommandExtension';
+import classes from './TiptapMarkdownEditor.module.css';
+
+type Props = {
+    content: string;
+    onChange: (markdown: string) => void;
+};
+
+export const TiptapMarkdownEditor: FC<Props> = ({ content, onChange }) => {
+    const editor = useEditor({
+        extensions: [
+            StarterKit,
+            Markdown.configure({
+                html: false,
+                transformPastedText: true,
+                transformCopiedText: true,
+            }),
+            Placeholder.configure({
+                placeholder: "Write something, or type '/' for commands…",
+            }),
+            SlashCommand,
+        ],
+        content,
+        onUpdate: ({ editor: updatedEditor }) => {
+            const { markdown } = updatedEditor.storage as {
+                markdown: MarkdownStorage;
+            };
+            onChange(markdown.getMarkdown());
+        },
+    });
+
+    return <EditorContent editor={editor} className={classes.editorContent} />;
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/slashCommandItems.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/slashCommandItems.tsx
@@ -1,0 +1,110 @@
+import {
+    IconBlockquote,
+    IconCode,
+    IconH1,
+    IconH2,
+    IconH3,
+    IconList,
+    IconListNumbers,
+    IconMinus,
+    IconPilcrow,
+    type Icon as TablerIcon,
+} from '@tabler/icons-react';
+import { type Editor, type Range } from '@tiptap/react';
+import { type SuggestionItem } from '../../../../../components/common/SuggestionList/SuggestionList';
+
+export type SlashCommandItem = SuggestionItem & {
+    description: string;
+    icon: TablerIcon;
+    run: (editor: Editor, range: Range) => void;
+};
+
+export const SLASH_COMMAND_ITEMS: SlashCommandItem[] = [
+    {
+        id: 'text',
+        label: 'Text',
+        description: 'Plain paragraph',
+        icon: IconPilcrow,
+        run: (editor, range) =>
+            editor.chain().focus().deleteRange(range).setParagraph().run(),
+    },
+    {
+        id: 'heading1',
+        label: 'Heading 1',
+        description: 'Big section heading',
+        icon: IconH1,
+        run: (editor, range) =>
+            editor
+                .chain()
+                .focus()
+                .deleteRange(range)
+                .setNode('heading', { level: 1 })
+                .run(),
+    },
+    {
+        id: 'heading2',
+        label: 'Heading 2',
+        description: 'Medium section heading',
+        icon: IconH2,
+        run: (editor, range) =>
+            editor
+                .chain()
+                .focus()
+                .deleteRange(range)
+                .setNode('heading', { level: 2 })
+                .run(),
+    },
+    {
+        id: 'heading3',
+        label: 'Heading 3',
+        description: 'Small section heading',
+        icon: IconH3,
+        run: (editor, range) =>
+            editor
+                .chain()
+                .focus()
+                .deleteRange(range)
+                .setNode('heading', { level: 3 })
+                .run(),
+    },
+    {
+        id: 'bulletList',
+        label: 'Bulleted list',
+        description: 'Simple unordered list',
+        icon: IconList,
+        run: (editor, range) =>
+            editor.chain().focus().deleteRange(range).toggleBulletList().run(),
+    },
+    {
+        id: 'orderedList',
+        label: 'Numbered list',
+        description: 'Ordered list with numbers',
+        icon: IconListNumbers,
+        run: (editor, range) =>
+            editor.chain().focus().deleteRange(range).toggleOrderedList().run(),
+    },
+    {
+        id: 'blockquote',
+        label: 'Quote',
+        description: 'Indented callout text',
+        icon: IconBlockquote,
+        run: (editor, range) =>
+            editor.chain().focus().deleteRange(range).toggleBlockquote().run(),
+    },
+    {
+        id: 'codeBlock',
+        label: 'Code block',
+        description: 'Monospaced code snippet',
+        icon: IconCode,
+        run: (editor, range) =>
+            editor.chain().focus().deleteRange(range).toggleCodeBlock().run(),
+    },
+    {
+        id: 'divider',
+        label: 'Divider',
+        description: 'Horizontal rule',
+        icon: IconMinus,
+        run: (editor, range) =>
+            editor.chain().focus().deleteRange(range).setHorizontalRule().run(),
+    },
+];

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
@@ -39,6 +39,8 @@ export type BlockDefinition = {
     description: string;
     icon: Icon;
     requiresAi?: boolean;
+    /** Can only be added once per homepage. */
+    singleton?: boolean;
     create: () => HomepageBlock;
     View: FC<BlockComponentProps>;
     Build: FC<BuildComponentProps>;
@@ -94,6 +96,7 @@ export const blockLibrary: BlockDefinition[] = [
         label: 'Metrics',
         description: 'KPI cards from the metrics catalog, with deltas.',
         icon: IconChartDots,
+        singleton: true,
         create: () => ({
             id: uuidv4(),
             type: 'metrics',

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -1,0 +1,32 @@
+/* Shared homepage layout — used by both the day-0 homepage and the published
+ * homepage so their hero (greeting + Ask AI) sits identically: vertically
+ * centred in the viewport, constrained, with everything else in a secondary
+ * section below. */
+
+.page {
+    display: flex;
+    flex-direction: column;
+    padding: 32px 24px 64px;
+}
+
+.heroSection {
+    min-height: calc(100vh - var(--navbar-height) - 72px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.hero {
+    width: 100%;
+    max-width: 720px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.secondary {
+    width: 100%;
+    max-width: 1160px;
+    margin: 0 auto;
+}

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import { DbtProjectType, ProjectType } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Stack } from '@mantine-8/core';
 import { type FC } from 'react';
 import { Navigate, useParams } from 'react-router';
 import { useUnmount } from 'react-use';
@@ -22,7 +22,6 @@ import {
     useResolvedHomepage,
 } from '../ee/features/homepageBuilder/hooks/useProjectHomepage';
 import { PublishedHomepage } from '../ee/features/homepageBuilder/PublishedHomepage';
-import publishedHomepageClasses from '../ee/features/homepageBuilder/PublishedHomepage.module.css';
 import { ManagedAgentHomeCard } from '../ee/features/managedAgent/ManagedAgentHomeCard';
 import { useFavorites } from '../hooks/favorites/useFavorites';
 import { usePinnedItems } from '../hooks/pinning/usePinnedItems';
@@ -109,25 +108,23 @@ const Home: FC = () => {
             row.blocks.some((block) => block.type === 'favorites'),
         );
         return (
-            <Page withPaddedContent withFooter>
+            <Page withFooter noContentPadding>
                 <AdminHomepageControls
                     projectUuid={project.data.projectUuid}
                     organizationUuid={project.data.organizationUuid}
                     showNewHomepage
                 />
-                <Stack gap="md" pt={40} pb={64}>
-                    {homepage.allowPersonal && !hasFavoritesBlock && (
-                        <Box className={publishedHomepageClasses.container}>
+                <PublishedHomepage
+                    config={homepage.config}
+                    projectUuid={project.data.projectUuid}
+                    secondaryTop={
+                        homepage.allowPersonal && !hasFavoritesBlock ? (
                             <PersonalFavoritesStrip
                                 projectUuid={project.data.projectUuid}
                             />
-                        </Box>
-                    )}
-                    <PublishedHomepage
-                        config={homepage.config}
-                        projectUuid={project.data.projectUuid}
-                    />
-                </Stack>
+                        ) : null
+                    }
+                />
             </Page>
         );
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1389,6 +1389,9 @@ importers:
       tippy.js:
         specifier: 6.3.7
         version: 6.3.7
+      tiptap-markdown:
+        specifier: 0.8.10
+        version: 0.8.10(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
       topojson-client:
         specifier: 3.1.0
         version: 3.1.0
@@ -7446,11 +7449,17 @@ packages:
   '@types/leaflet@1.9.21':
     resolution: {integrity: sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==}
 
+  '@types/linkify-it@3.0.5':
+    resolution: {integrity: sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==}
+
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
 
   '@types/lodash@4.14.202':
     resolution: {integrity: sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==}
+
+  '@types/markdown-it@13.0.9':
+    resolution: {integrity: sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==}
 
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
@@ -7460,6 +7469,9 @@ packages:
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@1.0.5':
+    resolution: {integrity: sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==}
 
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
@@ -12341,8 +12353,8 @@ packages:
   lines-and-columns@1.1.6:
     resolution: {integrity: sha512-8ZmlJFVK9iCmtLz19HpSsR8HaAMWBT284VMNednLwlIMDP2hJDCIhUp0IZ2xUcZ+Ob6BM0VvCSJwzASDM45NLQ==}
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
@@ -12584,8 +12596,11 @@ packages:
       '@mantine/form': '>=7.0.0'
       zod: '>=3.0.0'
 
-  markdown-it@14.0.0:
-    resolution: {integrity: sha512-seFjF0FIcPt4P9U39Bq1JYblX0KZCjDLFFQPHpL5AzHpqPEKtosxmdq/LTVZnjfH7tjt9BxStm+wXcDBNuYmzw==}
+  markdown-it-task-lists@2.1.1:
+    resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
+
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
     hasBin: true
 
   markdown-table@2.0.0:
@@ -15926,6 +15941,11 @@ packages:
   tippy.js@6.3.7:
     resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
 
+  tiptap-markdown@0.8.10:
+    resolution: {integrity: sha512-iDVkR2BjAqkTDtFX0h94yVvE2AihCXlF0Q7RIXSJPRSR5I0PA1TMuAg6FHFpmqTn4tPxJ0by0CK7PUMlnFLGEQ==}
+    peerDependencies:
+      '@tiptap/core': ^2.0.3
+
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
@@ -16206,8 +16226,8 @@ packages:
   ua-parser-js@1.0.35:
     resolution: {integrity: sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==}
 
-  uc.micro@2.0.0:
-    resolution: {integrity: sha512-DffL94LsNOccVn4hyfRe5rdKa273swqeA5DJpMOeFmEn1wCDc7nAbbB0gXlgBCL7TNzeTv6G7XVWzan7iJtfig==}
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
@@ -17308,7 +17328,7 @@ snapshots:
   '@apm-js-collab/tracing-hooks@0.3.1':
     dependencies:
       '@apm-js-collab/code-transformer': 0.8.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -18658,7 +18678,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -18730,7 +18750,7 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -19419,7 +19439,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.27.2
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19443,7 +19463,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19978,7 +19998,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.15.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -20340,7 +20360,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -20653,7 +20673,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22167,7 +22187,7 @@ snapshots:
 
   '@pm2/pm2-version-check@1.0.4':
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23952,7 +23972,7 @@ snapshots:
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
@@ -24365,9 +24385,16 @@ snapshots:
     dependencies:
       '@types/geojson': 7946.0.16
 
+  '@types/linkify-it@3.0.5': {}
+
   '@types/linkify-it@5.0.0': {}
 
   '@types/lodash@4.14.202': {}
+
+  '@types/markdown-it@13.0.9':
+    dependencies:
+      '@types/linkify-it': 3.0.5
+      '@types/mdurl': 1.0.5
 
   '@types/markdown-it@14.1.2':
     dependencies:
@@ -24381,6 +24408,8 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mdurl@1.0.5': {}
 
   '@types/mdurl@2.0.0': {}
 
@@ -24687,7 +24716,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.1'
@@ -24700,7 +24729,7 @@ snapshots:
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/typescript-estree': 8.43.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/visitor-keys': 8.43.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
       typescript: '@typescript/typescript6@6.0.1'
     transitivePeerDependencies:
@@ -24710,7 +24739,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.63.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/types': 8.63.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: '@typescript/typescript6@6.0.1'
     transitivePeerDependencies:
       - supports-color
@@ -24719,7 +24748,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.63.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/types': 8.63.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: '@typescript/typescript6@6.0.1'
     transitivePeerDependencies:
       - supports-color
@@ -24728,7 +24757,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.63.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/types': 8.63.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: '@typescript/typescript6@6.0.1'
     transitivePeerDependencies:
       - supports-color
@@ -24737,7 +24766,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.63.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -24787,7 +24816,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/utils': 7.18.0(@typescript/typescript6@6.0.1)(eslint@8.57.1)
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
       ts-api-utils: 1.4.3(@typescript/typescript6@6.0.1)
     optionalDependencies:
@@ -24800,7 +24829,7 @@ snapshots:
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/typescript-estree': 8.43.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/utils': 8.43.0(@typescript/typescript6@6.0.1)(eslint@8.57.1)
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
       ts-api-utils: 2.5.0(@typescript/typescript6@6.0.1)
       typescript: '@typescript/typescript6@6.0.1'
@@ -24821,7 +24850,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.8.5
@@ -24835,7 +24864,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -24852,7 +24881,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.43.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/visitor-keys': 8.43.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -24868,7 +24897,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.56.1(@typescript/typescript6@6.0.1)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.15
@@ -24883,7 +24912,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.63.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/visitor-keys': 8.63.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.15
@@ -24898,7 +24927,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/visitor-keys': 8.63.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.15
@@ -25389,7 +25418,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -25965,7 +25994,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.0
       iconv-lite: 0.7.0
       on-finished: 2.4.1
@@ -26794,7 +26823,7 @@ snapshots:
       '@actions/core': 2.0.3
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       fast-shuffle: 6.1.0
       find-cypress-specs: 1.54.11(@babel/core@7.28.4)
       globby: 11.1.0
@@ -27300,7 +27329,7 @@ snapshots:
 
   docker-modem@5.0.7:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       readable-stream: 3.6.2
       split-ca: 1.0.1
       ssh2: 1.17.0
@@ -27817,7 +27846,7 @@ snapshots:
       '@es-joy/resolve.exports': 1.2.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.5
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint: 8.57.1
       espree: 11.1.0
@@ -27935,7 +27964,7 @@ snapshots:
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -28161,7 +28190,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -28364,7 +28393,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -28378,7 +28407,7 @@ snapshots:
       '@actions/core': 2.0.3
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       find-test-names: 1.29.19(@babel/core@7.28.4)
       minimatch: 10.2.5
       pluralize: 8.0.0
@@ -28402,7 +28431,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.4)
       acorn-walk: 8.2.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       simple-bin-help: 1.8.0
       tinyglobby: 0.2.15
     transitivePeerDependencies:
@@ -28703,7 +28732,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 11.3.2
     transitivePeerDependencies:
       - supports-color
@@ -29243,14 +29272,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -29263,14 +29292,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -29444,7 +29473,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -30170,9 +30199,9 @@ snapshots:
 
   lines-and-columns@1.1.6: {}
 
-  linkify-it@5.0.0:
+  linkify-it@5.0.2:
     dependencies:
-      uc.micro: 2.0.0
+      uc.micro: 2.1.0
 
   linkifyjs@4.3.2: {}
 
@@ -30419,14 +30448,16 @@ snapshots:
       '@mantine/form': 7.5.2(react@19.2.0)
       zod: 3.25.55
 
-  markdown-it@14.0.0:
+  markdown-it-task-lists@2.1.1: {}
+
+  markdown-it@14.3.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.0
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
-      uc.micro: 2.0.0
+      uc.micro: 2.1.0
 
   markdown-table@2.0.0:
     dependencies:
@@ -30939,7 +30970,7 @@ snapshots:
 
   micromark@2.11.4:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -30947,7 +30978,7 @@ snapshots:
   micromark@4.0.1:
     dependencies:
       '@types/debug': 4.1.7
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.2
@@ -31294,7 +31325,7 @@ snapshots:
 
   nock@13.5.1:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -31755,7 +31786,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -31768,7 +31799,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -32069,7 +32100,7 @@ snapshots:
   pm2-sysmonit@1.2.8:
     dependencies:
       async: 3.2.6
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       pidusage: 2.0.21
       systeminformation: 5.31.6
       tx2: 1.0.5
@@ -32091,7 +32122,7 @@ snapshots:
       commander: 2.15.1
       croner: 4.1.97
       dayjs: 1.11.15
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eventemitter2: 6.4.9
       fast-json-patch: 3.1.1
       js-yaml: 4.1.1
@@ -32535,7 +32566,7 @@ snapshots:
   prosemirror-markdown@1.13.4:
     dependencies:
       '@types/markdown-it': 14.1.2
-      markdown-it: 14.0.0
+      markdown-it: 14.3.0
       prosemirror-model: 1.25.6
 
   prosemirror-menu@1.2.4:
@@ -32619,7 +32650,7 @@ snapshots:
   proxy-agent@6.4.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -32632,7 +32663,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -33341,7 +33372,7 @@ snapshots:
 
   require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -33349,7 +33380,7 @@ snapshots:
 
   require-in-the-middle@8.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -33474,7 +33505,7 @@ snapshots:
 
   rollup-plugin-esbuild@6.2.1(esbuild@0.27.7)(rollup@4.60.2):
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       esbuild: 0.27.7
       get-tsconfig: 4.10.1
@@ -33553,7 +33584,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -33702,7 +33733,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -33912,7 +33943,7 @@ snapshots:
       '@kwsites/promise-deferred': 1.1.1
       '@simple-git/args-pathspec': 1.0.3
       '@simple-git/argv-parser': 1.1.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -34031,7 +34062,7 @@ snapshots:
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.7.3
     transitivePeerDependencies:
       - supports-color
@@ -34039,7 +34070,7 @@ snapshots:
   socks-proxy-agent@8.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.7.3
     transitivePeerDependencies:
       - supports-color
@@ -34047,7 +34078,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
@@ -34092,7 +34123,7 @@ snapshots:
   spec-change@1.11.21:
     dependencies:
       arg: 5.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       deep-equal: 2.2.3
       dependency-tree: 11.4.0
       lazy-ass: 2.0.3
@@ -34660,6 +34691,14 @@ snapshots:
     dependencies:
       '@popperjs/core': 2.11.8
 
+  tiptap-markdown@0.8.10(@tiptap/core@2.27.2(@tiptap/pm@2.27.2)):
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@types/markdown-it': 13.0.9
+      markdown-it: 14.3.0
+      markdown-it-task-lists: 2.1.1
+      prosemirror-markdown: 1.13.4
+
   tldts-core@6.1.86: {}
 
   tldts@6.1.86:
@@ -34951,7 +34990,7 @@ snapshots:
 
   ua-parser-js@1.0.35: {}
 
-  uc.micro@2.0.0: {}
+  uc.micro@2.1.0: {}
 
   ufo@1.6.1: {}
 
@@ -35563,7 +35602,7 @@ snapshots:
       '@volar/typescript': 2.4.23
       '@vue/language-core': 2.2.0(@typescript/typescript6@6.0.1)
       compare-versions: 6.1.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21


### PR DESCRIPTION
## Summary

- **Markdown editor**: upgrades the Homepage Builder's Text/banner block from a plain `Textarea` to a Tiptap WYSIWYG editor with a Linear/Notion-style `/` slash command menu (Text, Heading 1-3, Bulleted/Numbered list, Quote, Code block, Divider). Markdown stays the storage format — `tiptap-markdown` serializes the ProseMirror doc back to markdown on every change.
- **Icon palette**: tones down icon usage across the Homepage Builder to a single neutral `ldGray` default, reserving color for real status (destructive = red, success = green, favorites = monochrome now too, metric deltas = teal/red).
- **Announcements @-mentions**: posting an announcement supports `@`-mentioning a chart or dashboard. Storage stays plain markdown — mentions serialize as ordinary markdown links, and the existing `rehypeAiAgentContentLinks` plugin (already used by the AI chat surface) auto-detects and renders them as rich clickable chips, both while composing (via the same Tiptap content-mention infra as chat) and in the posted announcement.
- **Drag-and-drop fix**: dropping a block onto another previously always split them side-by-side in the same row, with no easy way to reorder except hitting a thin gap strip between rows. Hovering is now zone-based — top/bottom bands of a block reorder into a new row above/below (the common case), narrow left/right edges split side-by-side, center defaults to reorder.
- **Hero/Greeting cleanup**: removes a hardcoded "New" CTA button baked into the Greeting block (unrelated to its job of showing personalized title/subtitle text) — Quick actions already covers CTAs.
- **Favorites redesign**: wraps the personal favorites strip in the same card chrome as every other homepage section instead of floating loose at the top of the page, and drops the amber star accent in favor of the same neutral palette as everything else.
- **Quick actions redesign**: replaces the 3-box card grid with a compact vertical list (same row style as Announcements), smaller and quieter — no shadow/lift on hover, just a subtle background tint and a chevron that reveals on hover.
- Fixes `PolymorphicGroupButton` (used by every suggestion-list row, including mentions and the slash menu): it renders a raw `<button>` that doesn't inherit page font by default (fixed via a CSS class reset instead of inline style — an earlier inline-style version of this fix had accidentally broken the hover/keyboard-selected highlight on every suggestion list in the app by out-specificity-ing the highlight CSS).

## Test plan

- [x] `pnpm -F frontend typecheck:fast`, `pnpm -F frontend run linter`, `oxfmt` on all touched files
- [x] Verified live in the browser via Chrome DevTools MCP:
  - Slash-command menu renders, applies node transforms, keyboard up/down visibly highlights the selected item
  - `@`-mentioning a chart in Announcements shows live search results; the posted announcement renders the chart as a real clickable link/chip (verified target URL); escaping of markdown-special characters in plain text confirmed (`!` renders literally)
  - Dropping a block onto another's center reorders into a new row instead of splitting side-by-side
  - Favorites strip has card chrome and is fully monochrome; Quick actions renders as a compact list with working hover/chevron affordance and correct navigation links
  - Greeting block no longer shows the stray CTA button