### PR TITLE
feat(metricflow): expose only semantic-model-declared dimensions

### DIFF
--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -166,9 +166,10 @@ const applyMetricFlow = (
         });
         columnsByModel = dimensionTranslation.columnsByModel;
 
-        [...metricTranslation.warnings, ...dimensionTranslation.warnings].forEach(
-            (warning) => GlobalState.debug(`> ${warning}`),
-        );
+        [
+            ...metricTranslation.warnings,
+            ...dimensionTranslation.warnings,
+        ].forEach((warning) => GlobalState.debug(`> ${warning}`));
 
         const { translatedCount, skippedCount } = metricTranslation;
         if (translatedCount > 0) {

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -17,6 +17,7 @@ import {
     LightdashProjectConfig,
     ParseError,
     preAggregatePostProcessor,
+    translateMetricFlowDimensions,
     translateMetricFlowMetrics,
     WarehouseCatalog,
 } from '@lightdash/common';
@@ -115,12 +116,19 @@ const getExploresFromLightdashYmlProject = async (
 
 /**
  * Translate dbt MetricFlow definitions (`semantic_models` + `metrics`) from the
- * manifest into Lightdash metrics and merge them into each model's meta so they
- * compile through the normal explore pipeline. YAML-defined metrics take
- * priority over translated ones on name collision. No-op when the manifest has
- * no semantic models.
+ * manifest into Lightdash fields and merge them into each model so they compile
+ * through the normal explore pipeline:
+ *
+ * - `metrics` (+ `create_metric` measures) become model metrics; YAML-defined
+ *   metrics win over translated ones on name collision.
+ * - For models targeted by a semantic model, columns are replaced with the
+ *   semantic model's declared `dimensions:` (plus the primary entity key as a
+ *   hidden dimension) so only the curated interface is exposed instead of every
+ *   warehouse column. Models without a semantic model keep all their columns.
+ *
+ * No-op when the manifest has no semantic models.
  */
-const applyMetricFlowMetrics = (
+const applyMetricFlow = (
     models: DbtModelNode[],
     manifest: DbtManifest,
 ): DbtModelNode[] => {
@@ -135,59 +143,85 @@ const applyMetricFlowMetrics = (
 
     // MetricFlow translation is best-effort: a malformed manifest must never
     // abort the compile/deploy, so degrade to "no translated metrics".
-    let translation: ReturnType<typeof translateMetricFlowMetrics>;
+    let metricsByModel: ReturnType<
+        typeof translateMetricFlowMetrics
+    >['metricsByModel'] = {};
+    let columnsByModel: ReturnType<
+        typeof translateMetricFlowDimensions
+    >['columnsByModel'] = {};
     try {
-        translation = translateMetricFlowMetrics({
+        const metricTranslation = translateMetricFlowMetrics({
             semanticModels,
             metrics: manifest.metrics ?? {},
             modelNamesByUniqueId,
         });
-    } catch (e) {
-        console.error(
-            styles.warning(
-                `> Failed to translate MetricFlow metrics, continuing without them: ${getErrorMessage(
-                    e,
-                )}`,
+        metricsByModel = metricTranslation.metricsByModel;
+
+        const dimensionTranslation = translateMetricFlowDimensions({
+            semanticModels,
+            modelNamesByUniqueId,
+            columnsByModel: Object.fromEntries(
+                models.map((model) => [model.name, model.columns]),
             ),
+        });
+        columnsByModel = dimensionTranslation.columnsByModel;
+
+        [...metricTranslation.warnings, ...dimensionTranslation.warnings].forEach(
+            (warning) => GlobalState.debug(`> ${warning}`),
         );
-        return models;
-    }
-    const { metricsByModel, warnings, translatedCount, skippedCount } =
-        translation;
 
-    warnings.forEach((warning) => GlobalState.debug(`> ${warning}`));
-
-    if (translatedCount === 0) {
-        if (skippedCount > 0) {
+        const { translatedCount, skippedCount } = metricTranslation;
+        if (translatedCount > 0) {
+            const skippedSuffix =
+                skippedCount > 0
+                    ? ` (skipped ${skippedCount} unsupported, run with --verbose for details)`
+                    : '';
+            console.error(
+                styles.info(
+                    `> Translated ${translatedCount} MetricFlow metric(s) into Lightdash metrics${skippedSuffix}`,
+                ),
+            );
+        } else if (skippedCount > 0) {
             console.error(
                 styles.warning(
                     `> Skipped ${skippedCount} unsupported MetricFlow metric(s). Run with --verbose for details.`,
                 ),
             );
         }
+
+        const modelsWithDimensions = Object.keys(columnsByModel).length;
+        if (modelsWithDimensions > 0) {
+            console.error(
+                styles.info(
+                    `> Restricted ${modelsWithDimensions} model(s) to their semantic model's declared dimensions`,
+                ),
+            );
+        }
+    } catch (e) {
+        console.error(
+            styles.warning(
+                `> Failed to translate MetricFlow definitions, continuing without them: ${getErrorMessage(
+                    e,
+                )}`,
+            ),
+        );
         return models;
     }
 
-    const skippedSuffix =
-        skippedCount > 0
-            ? ` (skipped ${skippedCount} unsupported, run with --verbose for details)`
-            : '';
-    console.error(
-        styles.info(
-            `> Translated ${translatedCount} MetricFlow metric(s) into Lightdash metrics${skippedSuffix}`,
-        ),
-    );
-
     return models.map((model) => {
         const modelMetrics = metricsByModel[model.name];
-        if (!modelMetrics) {
+        const modelColumns = columnsByModel[model.name];
+        if (!modelMetrics && !modelColumns) {
             return model;
         }
         return {
             ...model,
+            ...(modelColumns ? { columns: modelColumns } : {}),
             meta: {
                 ...model.meta,
-                metrics: { ...modelMetrics, ...model.meta.metrics },
+                ...(modelMetrics
+                    ? { metrics: { ...modelMetrics, ...model.meta.metrics } }
+                    : {}),
             },
         };
     });
@@ -397,7 +431,7 @@ export const compile = async (options: CompileHandlerOptions) => {
             GlobalState.debug('> Skipping warehouse catalog');
         }
 
-        const validModelsWithTypes = applyMetricFlowMetrics(
+        const validModelsWithTypes = applyMetricFlow(
             attachTypesToModels(validModels, catalog, false),
             manifest,
         );

--- a/packages/common/src/dbt/metricFlow.test.ts
+++ b/packages/common/src/dbt/metricFlow.test.ts
@@ -8,9 +8,12 @@ import {
     type DbtSemanticModel,
 } from '../types/dbtSemanticLayer';
 import { type Explore } from '../types/explore';
-import { FieldType, MetricType } from '../types/field';
+import { DimensionType, FieldType, MetricType } from '../types/field';
 import { DEFAULT_SPOTLIGHT_CONFIG } from '../types/lightdashProjectConfig';
-import { translateMetricFlowMetrics } from './metricFlow';
+import {
+    translateMetricFlowDimensions,
+    translateMetricFlowMetrics,
+} from './metricFlow';
 
 const ordersSemanticModel: DbtSemanticModel = {
     name: 'orders',
@@ -1189,5 +1192,327 @@ describe('translateMetricFlowMetrics', () => {
                 group_label: 'Claim Metrics',
             });
         });
+    });
+});
+
+describe('translateMetricFlowDimensions', () => {
+    const columnsByModel = {
+        orders: {
+            order_id: { name: 'order_id', data_type: DimensionType.NUMBER },
+            status: { name: 'status', data_type: DimensionType.STRING },
+            ordered_at: {
+                name: 'ordered_at',
+                data_type: DimensionType.TIMESTAMP,
+            },
+            customer_id: {
+                name: 'customer_id',
+                data_type: DimensionType.NUMBER,
+            },
+            // A wide-mart column that is NOT declared on the semantic model.
+            internal_note: {
+                name: 'internal_note',
+                data_type: DimensionType.STRING,
+            },
+        },
+    };
+
+    it('exposes only declared dimensions plus the primary entity key', () => {
+        const { columnsByModel: result } = translateMetricFlowDimensions({
+            semanticModels: {
+                [ordersSemanticModel.unique_id]: ordersSemanticModel,
+            },
+            modelNamesByUniqueId,
+            columnsByModel,
+        });
+
+        expect(Object.keys(result.orders).sort()).toEqual([
+            'order',
+            'ordered_at',
+            'status',
+        ]);
+        // internal_note (undeclared) is dropped.
+        expect(result.orders.internal_note).toBeUndefined();
+    });
+
+    it('qualifies a bare expr as ${TABLE}.col and defaults categorical type', () => {
+        const { columnsByModel: result } = translateMetricFlowDimensions({
+            semanticModels: {
+                sm: {
+                    ...ordersSemanticModel,
+                    entities: [],
+                    dimensions: [{ name: 'status', type: 'categorical' }],
+                },
+            },
+            modelNamesByUniqueId,
+            columnsByModel,
+        });
+        expect(result.orders.status).toEqual({
+            name: 'status',
+            data_type: DimensionType.STRING,
+            meta: {
+                dimension: {
+                    name: 'status',
+                    type: DimensionType.STRING,
+                    sql: '${TABLE}.status',
+                },
+            },
+        });
+    });
+
+    it('passes a complex expr through verbatim', () => {
+        const { columnsByModel: result } = translateMetricFlowDimensions({
+            semanticModels: {
+                sm: {
+                    ...ordersSemanticModel,
+                    entities: [],
+                    dimensions: [
+                        {
+                            name: 'is_completed',
+                            type: 'categorical',
+                            expr: "status = 'completed'",
+                        },
+                    ],
+                },
+            },
+            modelNamesByUniqueId,
+            columnsByModel,
+        });
+        expect(result.orders.is_completed.meta?.dimension?.sql).toBe(
+            "status = 'completed'",
+        );
+    });
+
+    it('maps time granularity to date vs timestamp and carries label/description', () => {
+        const { columnsByModel: result } = translateMetricFlowDimensions({
+            semanticModels: {
+                sm: {
+                    ...ordersSemanticModel,
+                    entities: [],
+                    dimensions: [
+                        {
+                            name: 'ordered_date',
+                            type: 'time',
+                            expr: 'ordered_at',
+                            label: 'Ordered date',
+                            description: 'When the order was placed',
+                            type_params: { time_granularity: 'day' },
+                        },
+                        {
+                            name: 'created_ts',
+                            type: 'time',
+                            expr: 'created_at',
+                            type_params: { time_granularity: 'second' },
+                        },
+                    ],
+                },
+            },
+            modelNamesByUniqueId,
+            columnsByModel,
+        });
+        expect(result.orders.ordered_date.meta?.dimension).toEqual({
+            name: 'ordered_date',
+            type: DimensionType.DATE,
+            sql: '${TABLE}.ordered_at',
+            label: 'Ordered date',
+            description: 'When the order was placed',
+        });
+        expect(result.orders.created_ts.meta?.dimension?.type).toBe(
+            DimensionType.TIMESTAMP,
+        );
+    });
+
+    it('carries config.meta group_label and hidden onto the dimension', () => {
+        const { columnsByModel: result } = translateMetricFlowDimensions({
+            semanticModels: {
+                sm: {
+                    ...ordersSemanticModel,
+                    entities: [],
+                    dimensions: [
+                        {
+                            name: 'status',
+                            type: 'categorical',
+                            config: {
+                                meta: {
+                                    group_label: 'Claim',
+                                    hidden: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+            modelNamesByUniqueId,
+            columnsByModel,
+        });
+        expect(result.orders.status.meta?.dimension?.group_label).toBe('Claim');
+        expect(result.orders.status.meta?.dimension?.hidden).toBe(true);
+    });
+
+    it('preserves the categorical type of a numeric backing column', () => {
+        const { columnsByModel: result } = translateMetricFlowDimensions({
+            semanticModels: {
+                sm: {
+                    ...ordersSemanticModel,
+                    entities: [],
+                    dimensions: [
+                        {
+                            name: 'customer_id',
+                            type: 'categorical',
+                            expr: 'customer_id',
+                        },
+                    ],
+                },
+            },
+            modelNamesByUniqueId,
+            columnsByModel,
+        });
+        expect(result.orders.customer_id.meta?.dimension?.type).toBe(
+            DimensionType.NUMBER,
+        );
+    });
+
+    it('exposes the primary entity key as a hidden dimension', () => {
+        const { columnsByModel: result } = translateMetricFlowDimensions({
+            semanticModels: {
+                sm: {
+                    ...ordersSemanticModel,
+                    dimensions: [],
+                },
+            },
+            modelNamesByUniqueId,
+            columnsByModel,
+        });
+        expect(result.orders.order.meta?.dimension).toEqual({
+            name: 'order',
+            type: DimensionType.NUMBER,
+            sql: '${TABLE}.order_id',
+            hidden: true,
+        });
+    });
+
+    it('does not add the entity key when a declared dimension already claims its name', () => {
+        const { columnsByModel: result } = translateMetricFlowDimensions({
+            semanticModels: {
+                sm: {
+                    ...ordersSemanticModel,
+                    entities: [
+                        { name: 'status', type: 'primary', expr: 'status_id' },
+                    ],
+                    dimensions: [{ name: 'status', type: 'categorical' }],
+                },
+            },
+            modelNamesByUniqueId,
+            columnsByModel,
+        });
+        // The declared dimension wins: sql is the dimension's, not the entity's.
+        expect(result.orders.status.meta?.dimension?.sql).toBe(
+            '${TABLE}.status',
+        );
+        expect(result.orders.status.meta?.dimension?.hidden).toBeUndefined();
+    });
+
+    it('lets hand-authored YAML dimension config win per-field on collision', () => {
+        const { columnsByModel: result } = translateMetricFlowDimensions({
+            semanticModels: {
+                sm: {
+                    ...ordersSemanticModel,
+                    entities: [],
+                    dimensions: [{ name: 'status', type: 'categorical' }],
+                },
+            },
+            modelNamesByUniqueId,
+            columnsByModel: {
+                orders: {
+                    status: {
+                        name: 'status',
+                        data_type: DimensionType.STRING,
+                        meta: {
+                            dimension: {
+                                label: 'Order status',
+                                group_label: 'YAML group',
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        expect(result.orders.status.meta?.dimension?.label).toBe(
+            'Order status',
+        );
+        expect(result.orders.status.meta?.dimension?.group_label).toBe(
+            'YAML group',
+        );
+        // Non-colliding fields still come from the semantic model.
+        expect(result.orders.status.meta?.dimension?.sql).toBe(
+            '${TABLE}.status',
+        );
+    });
+
+    it('keeps undeclared columns that carry explicit Lightdash config', () => {
+        const { columnsByModel: result } = translateMetricFlowDimensions({
+            semanticModels: {
+                sm: {
+                    ...ordersSemanticModel,
+                    entities: [],
+                    dimensions: [{ name: 'status', type: 'categorical' }],
+                },
+            },
+            modelNamesByUniqueId,
+            columnsByModel: {
+                orders: {
+                    status: { name: 'status', data_type: DimensionType.STRING },
+                    audited_by: {
+                        name: 'audited_by',
+                        data_type: DimensionType.STRING,
+                        meta: {
+                            dimension: { label: 'Audited by' },
+                        },
+                    },
+                    plain_column: {
+                        name: 'plain_column',
+                        data_type: DimensionType.STRING,
+                    },
+                },
+            },
+        });
+        // Hand-authored column survives; the plain undeclared column does not.
+        expect(result.orders.audited_by).toBeDefined();
+        expect(result.orders.plain_column).toBeUndefined();
+    });
+
+    it('skips models whose semantic model does not resolve, leaving columns untouched', () => {
+        const { columnsByModel: result, warnings } =
+            translateMetricFlowDimensions({
+                semanticModels: {
+                    sm: {
+                        ...ordersSemanticModel,
+                        depends_on: { nodes: [] },
+                    },
+                },
+                modelNamesByUniqueId,
+                columnsByModel,
+            });
+        expect(result.orders).toBeUndefined();
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toContain('Could not resolve the dbt model');
+    });
+
+    it('is a no-op for models not targeted by any semantic model', () => {
+        const { columnsByModel: result } = translateMetricFlowDimensions({
+            semanticModels: {
+                [ordersSemanticModel.unique_id]: ordersSemanticModel,
+            },
+            modelNamesByUniqueId,
+            columnsByModel: {
+                orders: columnsByModel.orders,
+                other_model: {
+                    some_column: {
+                        name: 'some_column',
+                        data_type: DimensionType.STRING,
+                    },
+                },
+            },
+        });
+        expect(result.other_model).toBeUndefined();
     });
 });

--- a/packages/common/src/dbt/metricFlow.ts
+++ b/packages/common/src/dbt/metricFlow.ts
@@ -862,11 +862,11 @@ const hasLightdashColumnConfig = (column: DbtModelColumn): boolean => {
     const configMeta = column.config?.meta ?? {};
     return Boolean(
         meta.dimension ||
-            meta.additional_dimensions ||
-            meta.metrics ||
-            configMeta.dimension ||
-            configMeta.additional_dimensions ||
-            configMeta.metrics,
+        meta.additional_dimensions ||
+        meta.metrics ||
+        configMeta.dimension ||
+        configMeta.additional_dimensions ||
+        configMeta.metrics,
     );
 };
 
@@ -928,10 +928,7 @@ export const translateMetricFlowDimensions = ({
     };
 
     Object.values(semanticModels).forEach((semanticModel) => {
-        const modelName = resolveModelName(
-            semanticModel,
-            modelNamesByUniqueId,
-        );
+        const modelName = resolveModelName(semanticModel, modelNamesByUniqueId);
         if (!modelName) {
             warnings.push(
                 `Could not resolve the dbt model for semantic model "${semanticModel.name}"; keeping all columns as dimensions.`,
@@ -974,9 +971,7 @@ export const translateMetricFlowDimensions = ({
                         name,
                         type,
                         sql: dimensionSql(expr),
-                        ...(overrides.label
-                            ? { label: overrides.label }
-                            : {}),
+                        ...(overrides.label ? { label: overrides.label } : {}),
                         ...(overrides.description
                             ? { description: overrides.description }
                             : {}),
@@ -999,8 +994,8 @@ export const translateMetricFlowDimensions = ({
                     ? timeGranularityToDimensionType(
                           dimension.type_params?.time_granularity,
                       )
-                    : lookupColumnType(originalColumns, expr) ??
-                      DimensionType.STRING;
+                    : (lookupColumnType(originalColumns, expr) ??
+                      DimensionType.STRING);
             columns[dimension.name] = buildColumn(dimension.name, expr, type, {
                 label: dimension.label,
                 description: dimension.description,

--- a/packages/common/src/dbt/metricFlow.ts
+++ b/packages/common/src/dbt/metricFlow.ts
@@ -1,14 +1,19 @@
 import { type AnyType } from '../types/any';
-import { type DbtModelLightdashMetric } from '../types/dbt';
+import {
+    type DbtModelColumn,
+    type DbtModelLightdashMetric,
+} from '../types/dbt';
 import {
     MetricFlowAggregation,
+    type DbtSemanticDimension,
+    type DbtSemanticEntity,
     type DbtSemanticFilter,
     type DbtSemanticMeasure,
     type DbtSemanticMetric,
     type DbtSemanticMetricInput,
     type DbtSemanticModel,
 } from '../types/dbtSemanticLayer';
-import { MetricType } from '../types/field';
+import { DimensionType, MetricType } from '../types/field';
 
 /**
  * Translation for dbt's MetricFlow semantic layer as it appears in the dbt
@@ -814,4 +819,221 @@ export const translateMetricFlowMetrics = ({
     });
 
     return { metricsByModel, warnings, translatedCount, skippedCount };
+};
+
+/**
+ * MetricFlow `time` dimensions carry a base grain (`type_params.time_granularity`).
+ * Sub-day grains map to a timestamp dimension (so Lightdash offers hour/minute
+ * intervals and applies timezone conversion); day and coarser map to a date
+ * dimension. An unknown/absent grain defaults to date, which is the safer
+ * choice — it skips timezone conversion that would be wrong for a date column.
+ */
+const SUB_DAY_GRANULARITIES = new Set([
+    'nanosecond',
+    'microsecond',
+    'millisecond',
+    'second',
+    'minute',
+    'hour',
+]);
+const timeGranularityToDimensionType = (
+    granularity: string | null | undefined,
+): DimensionType =>
+    granularity && SUB_DAY_GRANULARITIES.has(granularity.toLowerCase())
+        ? DimensionType.TIMESTAMP
+        : DimensionType.DATE;
+
+/**
+ * SQL for a semantic-model dimension/entity expr: a bare column reference is
+ * qualified with `${TABLE}` so it resolves unambiguously; anything more complex
+ * is passed through verbatim. Mirrors `measureSql`.
+ */
+const dimensionSql = (expr: string): string =>
+    SIMPLE_COLUMN_REGEX.test(expr) ? `\${TABLE}.${expr}` : expr;
+
+/**
+ * A dbt column carries explicit Lightdash config when it has a `dimension`,
+ * `additional_dimensions` or column-level `metrics` block (under `meta` or
+ * `config.meta`). Such columns are hand-authored, so they survive the switch to
+ * semantic-model-declared dimensions even when the semantic model omits them.
+ */
+const hasLightdashColumnConfig = (column: DbtModelColumn): boolean => {
+    const meta = column.meta ?? {};
+    const configMeta = column.config?.meta ?? {};
+    return Boolean(
+        meta.dimension ||
+            meta.additional_dimensions ||
+            meta.metrics ||
+            configMeta.dimension ||
+            configMeta.additional_dimensions ||
+            configMeta.metrics,
+    );
+};
+
+export type TranslateMetricFlowDimensionsArgs = {
+    /** `manifest.semantic_models` */
+    semanticModels: Record<string, DbtSemanticModel>;
+    /** dbt model `unique_id` -> Lightdash table name, for models being deployed. */
+    modelNamesByUniqueId: Record<string, string>;
+    /** table name -> dbt columns (with warehouse types attached). */
+    columnsByModel: Record<string, Record<string, DbtModelColumn>>;
+};
+
+export type TranslateMetricFlowDimensionsResult = {
+    /**
+     * table name -> replacement columns, only for models targeted by a semantic
+     * model. Models absent from this map keep their original columns.
+     */
+    columnsByModel: Record<string, Record<string, DbtModelColumn>>;
+    warnings: string[];
+    translatedCount: number;
+};
+
+/**
+ * Build the replacement dimension columns for models targeted by a MetricFlow
+ * semantic model. The semantic model is the curated interface, so instead of
+ * turning every warehouse column into a dimension we expose only what the
+ * semantic model declares:
+ *
+ * - each `dimensions:` entry (name + expr -> sql, categorical/time -> type,
+ *   label/description, and `config.meta` group_label/hidden), and
+ * - the primary entity's key as a hidden dimension (a usable key for the mart),
+ *   unless a declared dimension already covers that name.
+ *
+ * Hand-authored dbt columns carrying explicit Lightdash config (`meta.dimension`
+ * etc.) are preserved and win per-field on a name collision, mirroring how
+ * YAML-defined metrics take priority over translated ones.
+ */
+export const translateMetricFlowDimensions = ({
+    semanticModels,
+    modelNamesByUniqueId,
+    columnsByModel,
+}: TranslateMetricFlowDimensionsArgs): TranslateMetricFlowDimensionsResult => {
+    const warnings: string[] = [];
+    const result: Record<string, Record<string, DbtModelColumn>> = {};
+    let translatedCount = 0;
+
+    // Resolve the warehouse type of a semantic dimension/entity when its expr is
+    // a bare column present in the original model columns; used so categorical
+    // dimensions keep their real type (e.g. a numeric id) instead of defaulting
+    // to string. Complex exprs have no single backing column, so return null.
+    const lookupColumnType = (
+        originalColumns: Record<string, DbtModelColumn>,
+        expr: string,
+    ): DimensionType | null => {
+        if (!SIMPLE_COLUMN_REGEX.test(expr)) {
+            return null;
+        }
+        return originalColumns[expr]?.data_type ?? null;
+    };
+
+    Object.values(semanticModels).forEach((semanticModel) => {
+        const modelName = resolveModelName(
+            semanticModel,
+            modelNamesByUniqueId,
+        );
+        if (!modelName) {
+            warnings.push(
+                `Could not resolve the dbt model for semantic model "${semanticModel.name}"; keeping all columns as dimensions.`,
+            );
+            return;
+        }
+
+        const originalColumns = columnsByModel[modelName] ?? {};
+        const dimensions = Array.isArray(semanticModel.dimensions)
+            ? semanticModel.dimensions
+            : [];
+        const entities = Array.isArray(semanticModel.entities)
+            ? semanticModel.entities
+            : [];
+
+        const columns: Record<string, DbtModelColumn> = {};
+
+        const buildColumn = (
+            name: string,
+            expr: string,
+            type: DimensionType,
+            overrides: {
+                label?: string | null;
+                description?: string | null;
+                hidden?: boolean | null;
+                groupLabel?: string | null;
+            },
+        ): DbtModelColumn => {
+            // Merge with any hand-authored YAML dimension config, YAML winning.
+            const original = originalColumns[name];
+            const yamlDimension =
+                original?.config?.meta?.dimension ??
+                original?.meta?.dimension ??
+                {};
+            return {
+                name,
+                data_type: type,
+                meta: {
+                    dimension: {
+                        name,
+                        type,
+                        sql: dimensionSql(expr),
+                        ...(overrides.label
+                            ? { label: overrides.label }
+                            : {}),
+                        ...(overrides.description
+                            ? { description: overrides.description }
+                            : {}),
+                        ...(overrides.hidden != null
+                            ? { hidden: overrides.hidden }
+                            : {}),
+                        ...(overrides.groupLabel
+                            ? { group_label: overrides.groupLabel }
+                            : {}),
+                        ...yamlDimension,
+                    },
+                },
+            };
+        };
+
+        dimensions.forEach((dimension: DbtSemanticDimension) => {
+            const expr = dimension.expr ?? dimension.name;
+            const type =
+                dimension.type === 'time'
+                    ? timeGranularityToDimensionType(
+                          dimension.type_params?.time_granularity,
+                      )
+                    : lookupColumnType(originalColumns, expr) ??
+                      DimensionType.STRING;
+            columns[dimension.name] = buildColumn(dimension.name, expr, type, {
+                label: dimension.label,
+                description: dimension.description,
+                hidden: dimension.config?.meta?.hidden,
+                groupLabel: dimension.config?.meta?.group_label,
+            });
+        });
+
+        // Expose the primary entity key as a hidden dimension, unless a declared
+        // dimension already claims that name.
+        const primaryEntity = entities.find(
+            (entity: DbtSemanticEntity) => entity.type === 'primary',
+        );
+        if (primaryEntity && !columns[primaryEntity.name]) {
+            const expr = primaryEntity.expr ?? primaryEntity.name;
+            columns[primaryEntity.name] = buildColumn(
+                primaryEntity.name,
+                expr,
+                lookupColumnType(originalColumns, expr) ?? DimensionType.STRING,
+                { hidden: true },
+            );
+        }
+
+        // Never silently drop hand-authored columns carrying Lightdash config.
+        Object.entries(originalColumns).forEach(([columnName, column]) => {
+            if (!columns[columnName] && hasLightdashColumnConfig(column)) {
+                columns[columnName] = column;
+            }
+        });
+
+        result[modelName] = columns;
+        translatedCount += Object.keys(columns).length;
+    });
+
+    return { columnsByModel: result, warnings, translatedCount };
 };

--- a/packages/common/src/types/dbtSemanticLayer.ts
+++ b/packages/common/src/types/dbtSemanticLayer.ts
@@ -58,10 +58,18 @@ export type DbtSemanticEntity = {
     expr?: string | null;
 };
 
+export type DbtSemanticDimensionTypeParams = {
+    /** MetricFlow base grain of a `time` dimension (e.g. "day", "month"). */
+    time_granularity?: string | null;
+};
+
 export type DbtSemanticDimension = {
     name: string;
     type: 'categorical' | 'time';
     expr?: string | null;
+    label?: string | null;
+    description?: string | null;
+    type_params?: DbtSemanticDimensionTypeParams | null;
     config?: DbtSemanticConfig | null;
 };
 


### PR DESCRIPTION
When a dbt model is the target of a MetricFlow semantic model, dimensions are now generated from the semantic model's `dimensions:` list only, instead of turning every warehouse column into a Lightdash dimension.

Models **without** a semantic model keep the current all-columns behavior.

Per the issue discussion this is **default-on** — MetricFlow shipped very recently, so the breaking change is acceptable rather than gating it behind an opt-in flag.

### Mapping
- `name` + `expr` → dimension (bare column exprs qualified `${TABLE}.col`, complex exprs passed through verbatim)
- `type: categorical` / `type: time` → dimension type; time dims get Lightdash time intervals with the base grain from `type_params.time_granularity` (sub-day → timestamp, day+ → date)
- `label`, `description` carried over
- `config.meta` `group_label` / `hidden` carried where they map
- The **primary entity** key is exposed as a hidden dimension, unless a declared dimension already claims its name
- Hand-authored dbt columns carrying explicit Lightdash config (`meta.dimension`, column-level `metrics`, etc.) are preserved and win per-field on collision — mirroring how YAML-defined metrics take priority over translated ones

Filter resolution in `resolveDimensionSql` is unchanged (it already read semantic-model dimensions).

### Changes
- `translateMetricFlowDimensions` in `metricFlow.ts` builds the replacement dimension columns per model
- `compile.ts` applies both metrics and the new dimension columns (`applyMetricFlow`)
- Extended `DbtSemanticDimension` with `label`, `description`, `type_params.time_granularity`
- Unit tests covering expr qualification, type mapping, meta carry-over, primary-entity key, YAML collision, and preservation of hand-authored columns
