### PR TITLE
feat(frontend): homepage Text block — Tiptap slash-command markdown editor

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -134,6 +134,7 @@
         "streamdown": "2.5.0",
         "styled-components": "5.3.3",
         "tippy.js": "6.3.7",
+        "tiptap-markdown": "0.8.10",
         "topojson-client": "3.1.0",
         "type-fest": "4.32.0",
         "unique-names-generator": "4.7.1",

--- a/packages/frontend/src/components/common/PolymorphicGroupButton.module.css
+++ b/packages/frontend/src/components/common/PolymorphicGroupButton.module.css
@@ -1,0 +1,8 @@
+.reset {
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+    background: none;
+    border: none;
+    text-align: inherit;
+}

--- a/packages/frontend/src/components/common/PolymorphicGroupButton.tsx
+++ b/packages/frontend/src/components/common/PolymorphicGroupButton.tsx
@@ -4,6 +4,7 @@ import {
     type GroupProps,
 } from '@mantine-8/core';
 import { forwardRef, type Ref } from 'react';
+import classes from './PolymorphicGroupButton.module.css';
 
 /**
  * A polymorphic component that renders a group button.
@@ -14,8 +15,12 @@ export const PolymorphicGroupButton = createPolymorphicComponent<
     GroupProps
 >(
     forwardRef<HTMLDivElement, GroupProps>(
-        (props: GroupProps, ref: Ref<HTMLDivElement>) => (
-            <Group ref={ref} {...props} style={{ cursor: 'pointer' }} />
+        ({ className, ...props }: GroupProps, ref: Ref<HTMLDivElement>) => (
+            <Group
+                ref={ref}
+                {...props}
+                className={`${classes.reset} ${className ?? ''}`}
+            />
         ),
     ),
 );

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MarkdownBlock.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MarkdownBlock.module.css
@@ -1,40 +1,8 @@
-.preview :global(.wmde-markdown) {
-    background-color: transparent;
-    font-family: var(--mantine-font-family);
-    font-size: 14px;
-    color: var(--mantine-color-ldGray-8);
-    padding: 0;
-}
-
-.preview :global(.wmde-markdown) :global(p:first-child) {
-    margin-top: 0;
-}
-
-.preview :global(.wmde-markdown) :global(p:last-child) {
-    margin-bottom: 0;
-}
-
 .editorWrap {
     border: 1px solid var(--mantine-color-ldGray-2);
     border-radius: 10px;
     background: light-dark(#fff, var(--mantine-color-dark-6));
     padding: 16px;
-}
-
-.editorTextarea {
-    width: 100%;
-    border: none;
-    background: transparent;
-    font-size: 14px;
-    line-height: 1.55;
-    color: var(--mantine-color-ldGray-8);
-    font-family: var(--mantine-font-family);
-    resize: vertical;
-    padding: 0;
-}
-
-.editorTextarea:focus {
-    outline: none;
 }
 
 .editorHint {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MarkdownBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MarkdownBlock.tsx
@@ -1,19 +1,15 @@
-import { Text, Textarea, useMantineColorScheme } from '@mantine-8/core';
-import MarkdownPreview from '@uiw/react-markdown-preview';
+import { Text } from '@mantine-8/core';
 import { type FC } from 'react';
-import rehypeExternalLinks from 'rehype-external-links';
+import { AiMarkdown } from '../../../../components/common/AiMarkdown/AiMarkdown';
 import classes from './MarkdownBlock.module.css';
+import { TiptapMarkdownEditor } from './markdownEditor/TiptapMarkdownEditor';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 export const MarkdownBlockView: FC<BlockComponentProps> = ({ block }) => {
-    const { colorScheme } = useMantineColorScheme();
     if (block.type !== 'markdown') return null;
     return (
-        <div className={classes.preview} data-color-mode={colorScheme}>
-            <MarkdownPreview
-                source={block.config.content}
-                rehypePlugins={[[rehypeExternalLinks, { target: '_blank' }]]}
-            />
+        <div className={classes.preview}>
+            <AiMarkdown>{block.config.content}</AiMarkdown>
         </div>
     );
 };
@@ -25,22 +21,18 @@ export const MarkdownBlockBuild: FC<BuildComponentProps> = ({
     if (block.type !== 'markdown') return null;
     return (
         <div className={classes.editorWrap}>
-            <Textarea
-                aria-label="Markdown content"
-                variant="unstyled"
-                autosize
-                minRows={4}
-                maxRows={16}
-                value={block.config.content}
-                onChange={(e) =>
+            <TiptapMarkdownEditor
+                content={block.config.content}
+                onChange={(markdown) =>
                     onChange({
                         ...block,
-                        config: { content: e.currentTarget.value },
+                        config: { content: markdown },
                     })
                 }
-                classNames={{ input: classes.editorTextarea }}
             />
-            <Text className={classes.editorHint}>Markdown supported</Text>
+            <Text className={classes.editorHint}>
+                Type &quot;/&quot; for commands
+            </Text>
         </div>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/SlashCommandExtension.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/SlashCommandExtension.ts
@@ -1,0 +1,35 @@
+import { PluginKey } from '@tiptap/pm/state';
+import { Extension } from '@tiptap/react';
+import Suggestion from '@tiptap/suggestion';
+import { generateSuggestion } from '../../../../../components/common/SuggestionList/generateSuggestion';
+import {
+    SLASH_COMMAND_ITEMS,
+    type SlashCommandItem,
+} from './slashCommandItems';
+import { renderSlashCommandItem } from './SlashCommandMenuItem';
+
+const slashCommandPluginKey = new PluginKey('homepageMarkdownSlashCommand');
+
+export const SlashCommand = Extension.create({
+    name: 'slashCommand',
+
+    addProseMirrorPlugins() {
+        return [
+            Suggestion<SlashCommandItem>({
+                editor: this.editor,
+                char: '/',
+                startOfLine: false,
+                pluginKey: slashCommandPluginKey,
+                ...generateSuggestion<SlashCommandItem>({
+                    items: SLASH_COMMAND_ITEMS,
+                    command: ({ editor, range, props }) => {
+                        const item = props as SlashCommandItem;
+                        item.run(editor, range);
+                    },
+                    renderItem: renderSlashCommandItem,
+                    emptyMessage: 'No matching block type',
+                }),
+            }),
+        ];
+    },
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/SlashCommandMenuItem.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/SlashCommandMenuItem.module.css
@@ -1,0 +1,36 @@
+.iconSquare {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 26px;
+    height: 26px;
+    border-radius: 6px;
+    background-color: var(--mantine-color-ldGray-1);
+    color: var(--mantine-color-ldGray-6);
+
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-4);
+        color: var(--mantine-color-ldGray-6);
+    }
+}
+
+.text {
+    min-width: 0;
+    flex: 1;
+}
+
+.label {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--mantine-color-ldDark-9);
+
+    @mixin dark {
+        color: var(--mantine-color-ldGray-8);
+    }
+}
+
+.description {
+    font-size: 11.5px;
+    color: var(--mantine-color-ldGray-5);
+}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/SlashCommandMenuItem.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/SlashCommandMenuItem.tsx
@@ -1,0 +1,30 @@
+import { Group, Stack, Text } from '@mantine-8/core';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { PolymorphicGroupButton } from '../../../../../components/common/PolymorphicGroupButton';
+import suggestionStyles from '../../../../../components/common/SuggestionList/SuggestionList.module.css';
+import { type SlashCommandItem } from './slashCommandItems';
+import classes from './SlashCommandMenuItem.module.css';
+
+export const renderSlashCommandItem = (
+    item: SlashCommandItem,
+    isSelected: boolean,
+    onClick: () => void,
+) => (
+    <PolymorphicGroupButton
+        onClick={onClick}
+        className={suggestionStyles.suggestionItem}
+        data-selected={isSelected}
+    >
+        <Group wrap="nowrap" gap="xs">
+            <div className={classes.iconSquare}>
+                <MantineIcon icon={item.icon} size={14} />
+            </div>
+            <Stack gap={0} className={classes.text}>
+                <Text className={classes.label}>{item.label}</Text>
+                <Text className={classes.description} truncate>
+                    {item.description}
+                </Text>
+            </Stack>
+        </Group>
+    </PolymorphicGroupButton>
+);

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/TiptapMarkdownEditor.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/TiptapMarkdownEditor.module.css
@@ -1,0 +1,89 @@
+.editorContent {
+    font-size: 14px;
+    line-height: 1.55;
+    color: var(--mantine-color-ldGray-8);
+    font-family: var(--mantine-font-family);
+}
+
+.editorContent :global(.ProseMirror) {
+    outline: none;
+}
+
+.editorContent :global(.ProseMirror) :global(p) {
+    margin: 0 0 8px;
+}
+
+.editorContent :global(.ProseMirror) :global(p:last-child) {
+    margin-bottom: 0;
+}
+
+.editorContent :global(.ProseMirror) :global(h1),
+.editorContent :global(.ProseMirror) :global(h2),
+.editorContent :global(.ProseMirror) :global(h3) {
+    margin: 12px 0 6px;
+    font-weight: 600;
+    color: var(--mantine-color-ldDark-9);
+
+    @mixin dark {
+        color: var(--mantine-color-ldGray-9);
+    }
+}
+
+.editorContent :global(.ProseMirror) :global(h1) {
+    font-size: 20px;
+}
+
+.editorContent :global(.ProseMirror) :global(h2) {
+    font-size: 17px;
+}
+
+.editorContent :global(.ProseMirror) :global(h3) {
+    font-size: 15px;
+}
+
+.editorContent :global(.ProseMirror) :global(ul),
+.editorContent :global(.ProseMirror) :global(ol) {
+    margin: 0 0 8px;
+    padding-left: 20px;
+}
+
+.editorContent :global(.ProseMirror) :global(blockquote) {
+    margin: 0 0 8px;
+    padding-left: 12px;
+    border-left: 3px solid var(--mantine-color-ldGray-3);
+    color: var(--mantine-color-ldGray-6);
+}
+
+.editorContent :global(.ProseMirror) :global(pre) {
+    margin: 0 0 8px;
+    padding: 10px 12px;
+    border-radius: 6px;
+    background-color: var(--mantine-color-ldGray-1);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 12.5px;
+    overflow-x: auto;
+
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.editorContent :global(.ProseMirror) :global(code) {
+    font-family: var(--mantine-font-family-monospace);
+}
+
+.editorContent :global(.ProseMirror) :global(hr) {
+    margin: 12px 0;
+    border: none;
+    border-top: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.editorContent
+    :global(.ProseMirror)
+    :global(.is-editor-empty:first-child::before) {
+    content: attr(data-placeholder);
+    float: left;
+    height: 0;
+    color: var(--mantine-color-ldGray-4);
+    pointer-events: none;
+}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/TiptapMarkdownEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/TiptapMarkdownEditor.tsx
@@ -1,0 +1,38 @@
+import Placeholder from '@tiptap/extension-placeholder';
+import { EditorContent, useEditor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import { type FC } from 'react';
+import { Markdown, type MarkdownStorage } from 'tiptap-markdown';
+import { SlashCommand } from './SlashCommandExtension';
+import classes from './TiptapMarkdownEditor.module.css';
+
+type Props = {
+    content: string;
+    onChange: (markdown: string) => void;
+};
+
+export const TiptapMarkdownEditor: FC<Props> = ({ content, onChange }) => {
+    const editor = useEditor({
+        extensions: [
+            StarterKit,
+            Markdown.configure({
+                html: false,
+                transformPastedText: true,
+                transformCopiedText: true,
+            }),
+            Placeholder.configure({
+                placeholder: "Write something, or type '/' for commands…",
+            }),
+            SlashCommand,
+        ],
+        content,
+        onUpdate: ({ editor: updatedEditor }) => {
+            const { markdown } = updatedEditor.storage as {
+                markdown: MarkdownStorage;
+            };
+            onChange(markdown.getMarkdown());
+        },
+    });
+
+    return <EditorContent editor={editor} className={classes.editorContent} />;
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/slashCommandItems.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/slashCommandItems.tsx
@@ -1,0 +1,110 @@
+import {
+    IconBlockquote,
+    IconCode,
+    IconH1,
+    IconH2,
+    IconH3,
+    IconList,
+    IconListNumbers,
+    IconMinus,
+    IconPilcrow,
+    type Icon as TablerIcon,
+} from '@tabler/icons-react';
+import { type Editor, type Range } from '@tiptap/react';
+import { type SuggestionItem } from '../../../../../components/common/SuggestionList/SuggestionList';
+
+export type SlashCommandItem = SuggestionItem & {
+    description: string;
+    icon: TablerIcon;
+    run: (editor: Editor, range: Range) => void;
+};
+
+export const SLASH_COMMAND_ITEMS: SlashCommandItem[] = [
+    {
+        id: 'text',
+        label: 'Text',
+        description: 'Plain paragraph',
+        icon: IconPilcrow,
+        run: (editor, range) =>
+            editor.chain().focus().deleteRange(range).setParagraph().run(),
+    },
+    {
+        id: 'heading1',
+        label: 'Heading 1',
+        description: 'Big section heading',
+        icon: IconH1,
+        run: (editor, range) =>
+            editor
+                .chain()
+                .focus()
+                .deleteRange(range)
+                .setNode('heading', { level: 1 })
+                .run(),
+    },
+    {
+        id: 'heading2',
+        label: 'Heading 2',
+        description: 'Medium section heading',
+        icon: IconH2,
+        run: (editor, range) =>
+            editor
+                .chain()
+                .focus()
+                .deleteRange(range)
+                .setNode('heading', { level: 2 })
+                .run(),
+    },
+    {
+        id: 'heading3',
+        label: 'Heading 3',
+        description: 'Small section heading',
+        icon: IconH3,
+        run: (editor, range) =>
+            editor
+                .chain()
+                .focus()
+                .deleteRange(range)
+                .setNode('heading', { level: 3 })
+                .run(),
+    },
+    {
+        id: 'bulletList',
+        label: 'Bulleted list',
+        description: 'Simple unordered list',
+        icon: IconList,
+        run: (editor, range) =>
+            editor.chain().focus().deleteRange(range).toggleBulletList().run(),
+    },
+    {
+        id: 'orderedList',
+        label: 'Numbered list',
+        description: 'Ordered list with numbers',
+        icon: IconListNumbers,
+        run: (editor, range) =>
+            editor.chain().focus().deleteRange(range).toggleOrderedList().run(),
+    },
+    {
+        id: 'blockquote',
+        label: 'Quote',
+        description: 'Indented callout text',
+        icon: IconBlockquote,
+        run: (editor, range) =>
+            editor.chain().focus().deleteRange(range).toggleBlockquote().run(),
+    },
+    {
+        id: 'codeBlock',
+        label: 'Code block',
+        description: 'Monospaced code snippet',
+        icon: IconCode,
+        run: (editor, range) =>
+            editor.chain().focus().deleteRange(range).toggleCodeBlock().run(),
+    },
+    {
+        id: 'divider',
+        label: 'Divider',
+        description: 'Horizontal rule',
+        icon: IconMinus,
+        run: (editor, range) =>
+            editor.chain().focus().deleteRange(range).setHorizontalRule().run(),
+    },
+];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1389,6 +1389,9 @@ importers:
       tippy.js:
         specifier: 6.3.7
         version: 6.3.7
+      tiptap-markdown:
+        specifier: 0.8.10
+        version: 0.8.10(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
       topojson-client:
         specifier: 3.1.0
         version: 3.1.0
@@ -7446,11 +7449,17 @@ packages:
   '@types/leaflet@1.9.21':
     resolution: {integrity: sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==}
 
+  '@types/linkify-it@3.0.5':
+    resolution: {integrity: sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==}
+
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
 
   '@types/lodash@4.14.202':
     resolution: {integrity: sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==}
+
+  '@types/markdown-it@13.0.9':
+    resolution: {integrity: sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==}
 
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
@@ -7460,6 +7469,9 @@ packages:
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@1.0.5':
+    resolution: {integrity: sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==}
 
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
@@ -12341,8 +12353,8 @@ packages:
   lines-and-columns@1.1.6:
     resolution: {integrity: sha512-8ZmlJFVK9iCmtLz19HpSsR8HaAMWBT284VMNednLwlIMDP2hJDCIhUp0IZ2xUcZ+Ob6BM0VvCSJwzASDM45NLQ==}
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
@@ -12584,8 +12596,11 @@ packages:
       '@mantine/form': '>=7.0.0'
       zod: '>=3.0.0'
 
-  markdown-it@14.0.0:
-    resolution: {integrity: sha512-seFjF0FIcPt4P9U39Bq1JYblX0KZCjDLFFQPHpL5AzHpqPEKtosxmdq/LTVZnjfH7tjt9BxStm+wXcDBNuYmzw==}
+  markdown-it-task-lists@2.1.1:
+    resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
+
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
     hasBin: true
 
   markdown-table@2.0.0:
@@ -15926,6 +15941,11 @@ packages:
   tippy.js@6.3.7:
     resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
 
+  tiptap-markdown@0.8.10:
+    resolution: {integrity: sha512-iDVkR2BjAqkTDtFX0h94yVvE2AihCXlF0Q7RIXSJPRSR5I0PA1TMuAg6FHFpmqTn4tPxJ0by0CK7PUMlnFLGEQ==}
+    peerDependencies:
+      '@tiptap/core': ^2.0.3
+
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
@@ -16206,8 +16226,8 @@ packages:
   ua-parser-js@1.0.35:
     resolution: {integrity: sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==}
 
-  uc.micro@2.0.0:
-    resolution: {integrity: sha512-DffL94LsNOccVn4hyfRe5rdKa273swqeA5DJpMOeFmEn1wCDc7nAbbB0gXlgBCL7TNzeTv6G7XVWzan7iJtfig==}
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
@@ -17308,7 +17328,7 @@ snapshots:
   '@apm-js-collab/tracing-hooks@0.3.1':
     dependencies:
       '@apm-js-collab/code-transformer': 0.8.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -18658,7 +18678,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -18730,7 +18750,7 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -19419,7 +19439,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.27.2
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19443,7 +19463,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19978,7 +19998,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.15.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -20340,7 +20360,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -20653,7 +20673,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22167,7 +22187,7 @@ snapshots:
 
   '@pm2/pm2-version-check@1.0.4':
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23952,7 +23972,7 @@ snapshots:
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
@@ -24365,9 +24385,16 @@ snapshots:
     dependencies:
       '@types/geojson': 7946.0.16
 
+  '@types/linkify-it@3.0.5': {}
+
   '@types/linkify-it@5.0.0': {}
 
   '@types/lodash@4.14.202': {}
+
+  '@types/markdown-it@13.0.9':
+    dependencies:
+      '@types/linkify-it': 3.0.5
+      '@types/mdurl': 1.0.5
 
   '@types/markdown-it@14.1.2':
     dependencies:
@@ -24381,6 +24408,8 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mdurl@1.0.5': {}
 
   '@types/mdurl@2.0.0': {}
 
@@ -24687,7 +24716,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.1'
@@ -24700,7 +24729,7 @@ snapshots:
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/typescript-estree': 8.43.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/visitor-keys': 8.43.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
       typescript: '@typescript/typescript6@6.0.1'
     transitivePeerDependencies:
@@ -24710,7 +24739,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.63.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/types': 8.63.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: '@typescript/typescript6@6.0.1'
     transitivePeerDependencies:
       - supports-color
@@ -24719,7 +24748,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.63.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/types': 8.63.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: '@typescript/typescript6@6.0.1'
     transitivePeerDependencies:
       - supports-color
@@ -24728,7 +24757,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.63.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/types': 8.63.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: '@typescript/typescript6@6.0.1'
     transitivePeerDependencies:
       - supports-color
@@ -24737,7 +24766,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.63.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -24787,7 +24816,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/utils': 7.18.0(@typescript/typescript6@6.0.1)(eslint@8.57.1)
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
       ts-api-utils: 1.4.3(@typescript/typescript6@6.0.1)
     optionalDependencies:
@@ -24800,7 +24829,7 @@ snapshots:
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/typescript-estree': 8.43.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/utils': 8.43.0(@typescript/typescript6@6.0.1)(eslint@8.57.1)
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
       ts-api-utils: 2.5.0(@typescript/typescript6@6.0.1)
       typescript: '@typescript/typescript6@6.0.1'
@@ -24821,7 +24850,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.8.5
@@ -24835,7 +24864,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -24852,7 +24881,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.43.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/visitor-keys': 8.43.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -24868,7 +24897,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.56.1(@typescript/typescript6@6.0.1)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.15
@@ -24883,7 +24912,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.63.0(@typescript/typescript6@6.0.1)
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/visitor-keys': 8.63.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.15
@@ -24898,7 +24927,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/visitor-keys': 8.63.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.15
@@ -25389,7 +25418,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -25965,7 +25994,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.0
       iconv-lite: 0.7.0
       on-finished: 2.4.1
@@ -26794,7 +26823,7 @@ snapshots:
       '@actions/core': 2.0.3
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       fast-shuffle: 6.1.0
       find-cypress-specs: 1.54.11(@babel/core@7.28.4)
       globby: 11.1.0
@@ -27300,7 +27329,7 @@ snapshots:
 
   docker-modem@5.0.7:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       readable-stream: 3.6.2
       split-ca: 1.0.1
       ssh2: 1.17.0
@@ -27817,7 +27846,7 @@ snapshots:
       '@es-joy/resolve.exports': 1.2.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.5
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint: 8.57.1
       espree: 11.1.0
@@ -27935,7 +27964,7 @@ snapshots:
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -28161,7 +28190,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -28364,7 +28393,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -28378,7 +28407,7 @@ snapshots:
       '@actions/core': 2.0.3
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       find-test-names: 1.29.19(@babel/core@7.28.4)
       minimatch: 10.2.5
       pluralize: 8.0.0
@@ -28402,7 +28431,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.4)
       acorn-walk: 8.2.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       simple-bin-help: 1.8.0
       tinyglobby: 0.2.15
     transitivePeerDependencies:
@@ -28703,7 +28732,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 11.3.2
     transitivePeerDependencies:
       - supports-color
@@ -29243,14 +29272,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -29263,14 +29292,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -29444,7 +29473,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -30170,9 +30199,9 @@ snapshots:
 
   lines-and-columns@1.1.6: {}
 
-  linkify-it@5.0.0:
+  linkify-it@5.0.2:
     dependencies:
-      uc.micro: 2.0.0
+      uc.micro: 2.1.0
 
   linkifyjs@4.3.2: {}
 
@@ -30419,14 +30448,16 @@ snapshots:
       '@mantine/form': 7.5.2(react@19.2.0)
       zod: 3.25.55
 
-  markdown-it@14.0.0:
+  markdown-it-task-lists@2.1.1: {}
+
+  markdown-it@14.3.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.0
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
-      uc.micro: 2.0.0
+      uc.micro: 2.1.0
 
   markdown-table@2.0.0:
     dependencies:
@@ -30939,7 +30970,7 @@ snapshots:
 
   micromark@2.11.4:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -30947,7 +30978,7 @@ snapshots:
   micromark@4.0.1:
     dependencies:
       '@types/debug': 4.1.7
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.2
@@ -31294,7 +31325,7 @@ snapshots:
 
   nock@13.5.1:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -31755,7 +31786,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -31768,7 +31799,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -32069,7 +32100,7 @@ snapshots:
   pm2-sysmonit@1.2.8:
     dependencies:
       async: 3.2.6
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       pidusage: 2.0.21
       systeminformation: 5.31.6
       tx2: 1.0.5
@@ -32091,7 +32122,7 @@ snapshots:
       commander: 2.15.1
       croner: 4.1.97
       dayjs: 1.11.15
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eventemitter2: 6.4.9
       fast-json-patch: 3.1.1
       js-yaml: 4.1.1
@@ -32535,7 +32566,7 @@ snapshots:
   prosemirror-markdown@1.13.4:
     dependencies:
       '@types/markdown-it': 14.1.2
-      markdown-it: 14.0.0
+      markdown-it: 14.3.0
       prosemirror-model: 1.25.6
 
   prosemirror-menu@1.2.4:
@@ -32619,7 +32650,7 @@ snapshots:
   proxy-agent@6.4.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -32632,7 +32663,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -33341,7 +33372,7 @@ snapshots:
 
   require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -33349,7 +33380,7 @@ snapshots:
 
   require-in-the-middle@8.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -33474,7 +33505,7 @@ snapshots:
 
   rollup-plugin-esbuild@6.2.1(esbuild@0.27.7)(rollup@4.60.2):
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       esbuild: 0.27.7
       get-tsconfig: 4.10.1
@@ -33553,7 +33584,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -33702,7 +33733,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -33912,7 +33943,7 @@ snapshots:
       '@kwsites/promise-deferred': 1.1.1
       '@simple-git/args-pathspec': 1.0.3
       '@simple-git/argv-parser': 1.1.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -34031,7 +34062,7 @@ snapshots:
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.7.3
     transitivePeerDependencies:
       - supports-color
@@ -34039,7 +34070,7 @@ snapshots:
   socks-proxy-agent@8.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.7.3
     transitivePeerDependencies:
       - supports-color
@@ -34047,7 +34078,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
@@ -34092,7 +34123,7 @@ snapshots:
   spec-change@1.11.21:
     dependencies:
       arg: 5.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       deep-equal: 2.2.3
       dependency-tree: 11.4.0
       lazy-ass: 2.0.3
@@ -34660,6 +34691,14 @@ snapshots:
     dependencies:
       '@popperjs/core': 2.11.8
 
+  tiptap-markdown@0.8.10(@tiptap/core@2.27.2(@tiptap/pm@2.27.2)):
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@types/markdown-it': 13.0.9
+      markdown-it: 14.3.0
+      markdown-it-task-lists: 2.1.1
+      prosemirror-markdown: 1.13.4
+
   tldts-core@6.1.86: {}
 
   tldts@6.1.86:
@@ -34951,7 +34990,7 @@ snapshots:
 
   ua-parser-js@1.0.35: {}
 
-  uc.micro@2.0.0: {}
+  uc.micro@2.1.0: {}
 
   ufo@1.6.1: {}
 
@@ -35563,7 +35602,7 @@ snapshots:
       '@volar/typescript': 2.4.23
       '@vue/language-core': 2.2.0(@typescript/typescript6@6.0.1)
       compare-versions: 6.1.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21


### PR DESCRIPTION
Part 1 of 3 in the homepage-builder round-3 polish stack (split from #25621).

## Summary

Replaces the Text/banner block's plain `Textarea` with a Tiptap WYSIWYG editor plus a Linear/Notion-style `/` slash-command menu (Text, Heading 1-3, bulleted/numbered list, quote, code block, divider). Markdown stays the storage format — `tiptap-markdown` serializes the ProseMirror doc back to markdown on every change — and the read view renders through the shared Streamdown-based `AiMarkdown` for nicer typography.

Also fixes `PolymorphicGroupButton`: it renders a raw `<button>` that didn't inherit the page font. The reset now lives in a CSS class instead of an inline style, so it no longer out-specificity's the suggestion-list hover/keyboard-selected highlight (which an earlier inline-style version had silently broken across every suggestion list in the app).

## Test plan

- [x] `pnpm -F frontend typecheck:fast` (branch compiles independently)
- [x] `pnpm -F frontend run linter` + `oxfmt` on touched files
- [x] Verified live: slash menu opens on `/`, keyboard up/down highlights, node transforms apply; markdown persists and re-renders via Streamdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ