### PR TITLE
feat(frontend): @-mention charts and dashboards in homepage announcements

### DIFF
--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -45,6 +45,9 @@ export type HomepageResourcesBlock = {
 };
 
 export type HomepageAnnouncementItem = {
+    /** Markdown — @-mentioned charts/dashboards are plain markdown links
+     * (`[label](/projects/.../saved/:uuid/view)`), rendered as rich chips by
+     * `rehypeAiAgentContentLinks`. */
     text: string;
     date: string;
     author: string;

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AnnouncementsBlock.tsx
@@ -1,24 +1,32 @@
 import { type HomepageAnnouncementItem } from '@lightdash/common';
-import { ActionIcon, Group, Stack, Textarea } from '@mantine-8/core';
-import { IconSend, IconSpeakerphone, IconX } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import { ActionIcon, Stack } from '@mantine-8/core';
+import { IconSpeakerphone, IconX } from '@tabler/icons-react';
+import { type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { useTimeAgo } from '../../../../hooks/useTimeAgo';
 import useApp from '../../../../providers/App/useApp';
+import { AnnouncementComposer } from './announcements/AnnouncementComposer';
+import { AnnouncementContent } from './announcements/AnnouncementContent';
 import { BlockHeader } from './BlockShell';
 import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const AnnouncementRow: FC<{
     item: HomepageAnnouncementItem;
+    projectUuid: string;
     onRemove?: () => void;
-}> = ({ item, onRemove }) => {
+}> = ({ item, projectUuid, onRemove }) => {
     const timeAgo = useTimeAgo(item.date);
     return (
         <div className={`${classes.listRow} ${classes.listRowTop}`}>
             <span className={classes.announcementDot} />
             <div className={classes.flexFill}>
-                <div className={classes.announcementText}>{item.text}</div>
+                <div className={classes.announcementText}>
+                    <AnnouncementContent
+                        projectUuid={projectUuid}
+                        text={item.text}
+                    />
+                </div>
                 <div
                     className={`${classes.rowAside} ${classes.rowAsideSpaced}`}
                 >
@@ -28,7 +36,7 @@ const AnnouncementRow: FC<{
             {onRemove && (
                 <ActionIcon
                     variant="subtle"
-                    color="gray"
+                    color="ldGray.6"
                     size="sm"
                     aria-label="Remove announcement"
                     onClick={onRemove}
@@ -40,22 +48,22 @@ const AnnouncementRow: FC<{
     );
 };
 
-export const AnnouncementsBlockView: FC<BlockComponentProps> = ({ block }) => {
+export const AnnouncementsBlockView: FC<BlockComponentProps> = ({
+    block,
+    projectUuid,
+}) => {
     if (block.type !== 'announcements' || block.config.items.length === 0) {
         return null;
     }
     return (
         <Stack gap={0}>
-            <BlockHeader
-                icon={IconSpeakerphone}
-                iconColor="#7262FF"
-                title={block.config.title}
-            />
+            <BlockHeader icon={IconSpeakerphone} title={block.config.title} />
             <div className={classes.listCard}>
                 {block.config.items.map((item) => (
                     <AnnouncementRow
                         key={`${item.date}-${item.author}`}
                         item={item}
+                        projectUuid={projectUuid}
                     />
                 ))}
             </div>
@@ -65,15 +73,13 @@ export const AnnouncementsBlockView: FC<BlockComponentProps> = ({ block }) => {
 
 export const AnnouncementsBlockBuild: FC<BuildComponentProps> = ({
     block,
+    projectUuid,
     onChange,
 }) => {
     const { user } = useApp();
-    const [text, setText] = useState('');
     if (block.type !== 'announcements') return null;
 
-    const postAnnouncement = () => {
-        const trimmed = text.trim();
-        if (!trimmed) return;
+    const postAnnouncement = (text: string) => {
         const author = [user.data?.firstName, user.data?.lastName]
             .filter(Boolean)
             .join(' ');
@@ -83,7 +89,7 @@ export const AnnouncementsBlockBuild: FC<BuildComponentProps> = ({
                 ...block.config,
                 items: [
                     {
-                        text: trimmed,
+                        text,
                         date: new Date().toISOString(),
                         author,
                     },
@@ -91,21 +97,17 @@ export const AnnouncementsBlockBuild: FC<BuildComponentProps> = ({
                 ],
             },
         });
-        setText('');
     };
 
     return (
         <Stack gap={0}>
-            <BlockHeader
-                icon={IconSpeakerphone}
-                iconColor="#7262FF"
-                title={block.config.title}
-            />
+            <BlockHeader icon={IconSpeakerphone} title={block.config.title} />
             <div className={`${classes.listCard} ${classes.listCardSpaced}`}>
                 {block.config.items.map((item, index) => (
                     <AnnouncementRow
                         key={`${item.date}-${item.author}`}
                         item={item}
+                        projectUuid={projectUuid}
                         onRemove={() =>
                             onChange({
                                 ...block,
@@ -120,27 +122,10 @@ export const AnnouncementsBlockBuild: FC<BuildComponentProps> = ({
                     />
                 ))}
             </div>
-            <Group gap="xs" align="flex-end">
-                <Textarea
-                    aria-label="New announcement"
-                    size="xs"
-                    flex={1}
-                    autosize
-                    minRows={1}
-                    maxRows={4}
-                    placeholder="Post an announcement to this audience…"
-                    value={text}
-                    onChange={(e) => setText(e.currentTarget.value)}
-                />
-                <ActionIcon
-                    variant="default"
-                    size="lg"
-                    aria-label="Post announcement"
-                    onClick={postAnnouncement}
-                >
-                    <MantineIcon icon={IconSend} />
-                </ActionIcon>
-            </Group>
+            <AnnouncementComposer
+                projectUuid={projectUuid}
+                onPost={postAnnouncement}
+            />
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementComposer.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementComposer.module.css
@@ -1,0 +1,36 @@
+.composer {
+    display: flex;
+    align-items: flex-end;
+    gap: var(--mantine-spacing-xs);
+}
+
+.editorContent {
+    flex: 1;
+    min-width: 0;
+    min-height: 30px;
+    max-height: 110px;
+    overflow-y: auto;
+    padding: 6px 10px;
+    border-radius: var(--mantine-radius-sm);
+    border: 1px solid var(--mantine-color-ldGray-3);
+    font-size: var(--mantine-font-size-xs);
+    background: var(--mantine-color-body);
+}
+
+.editorContent :global(.ProseMirror) {
+    outline: none;
+}
+
+.editorContent :global(.ProseMirror) :global(p) {
+    margin: 0;
+}
+
+.editorContent
+    :global(.ProseMirror)
+    :global(.is-editor-empty:first-child::before) {
+    content: attr(data-placeholder);
+    float: left;
+    height: 0;
+    color: var(--mantine-color-ldGray-4);
+    pointer-events: none;
+}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementComposer.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementComposer.tsx
@@ -1,0 +1,42 @@
+import { ActionIcon } from '@mantine-8/core';
+import { IconSend } from '@tabler/icons-react';
+import { EditorContent, useEditor } from '@tiptap/react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import classes from './AnnouncementComposer.module.css';
+import { createAnnouncementExtensions } from './announcementExtensions';
+import { serializeAnnouncementMarkdown } from './serializeAnnouncementMarkdown';
+
+type Props = {
+    projectUuid: string;
+    onPost: (markdown: string) => void;
+};
+
+export const AnnouncementComposer: FC<Props> = ({ projectUuid, onPost }) => {
+    const editor = useEditor({
+        extensions: createAnnouncementExtensions(() => projectUuid),
+    });
+
+    const handlePost = () => {
+        if (!editor) return;
+        const markdown = serializeAnnouncementMarkdown(editor, projectUuid);
+        if (!markdown) return;
+        onPost(markdown);
+        editor.commands.clearContent();
+    };
+
+    return (
+        <div className={classes.composer}>
+            <EditorContent editor={editor} className={classes.editorContent} />
+            <ActionIcon
+                variant="subtle"
+                size="lg"
+                color="ldGray.6"
+                aria-label="Post announcement"
+                onClick={handlePost}
+            >
+                <MantineIcon icon={IconSend} />
+            </ActionIcon>
+        </div>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementContent.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementContent.tsx
@@ -1,0 +1,60 @@
+import { ContentType } from '@lightdash/common';
+import { type FC } from 'react';
+import { AiMarkdown } from '../../../../../components/common/AiMarkdown/AiMarkdown';
+import { rehypeAiAgentContentLinks } from '../../../aiCopilot/components/ChatElements/rehypeContentLinks';
+import { AnnouncementMentionChip } from './AnnouncementMentionChip';
+
+type Props = {
+    projectUuid: string;
+    text: string;
+};
+
+export const AnnouncementContent: FC<Props> = ({ projectUuid, text }) => (
+    <AiMarkdown
+        rehypePlugins={[rehypeAiAgentContentLinks]}
+        components={{
+            a: ({ children, ...props }) => {
+                const rest = props as Record<string, unknown>;
+                const contentType = rest['data-content-type'];
+                const chartUuid = rest['data-chart-uuid'];
+                const dashboardUuid = rest['data-dashboard-uuid'];
+                const label =
+                    typeof children === 'string' ? children : String(children);
+
+                if (
+                    contentType === 'chart-link' &&
+                    typeof chartUuid === 'string'
+                ) {
+                    return (
+                        <AnnouncementMentionChip
+                            projectUuid={projectUuid}
+                            contentType={ContentType.CHART}
+                            uuid={chartUuid}
+                            label={label}
+                        />
+                    );
+                }
+                if (
+                    contentType === 'dashboard-link' &&
+                    typeof dashboardUuid === 'string'
+                ) {
+                    return (
+                        <AnnouncementMentionChip
+                            projectUuid={projectUuid}
+                            contentType={ContentType.DASHBOARD}
+                            uuid={dashboardUuid}
+                            label={label}
+                        />
+                    );
+                }
+                return (
+                    <a {...props} target="_blank" rel="noreferrer">
+                        {children}
+                    </a>
+                );
+            },
+        }}
+    >
+        {text}
+    </AiMarkdown>
+);

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementMentionChip.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementMentionChip.module.css
@@ -1,0 +1,4 @@
+.chip,
+.chip:hover {
+    text-decoration: none;
+}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementMentionChip.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/AnnouncementMentionChip.tsx
@@ -1,0 +1,64 @@
+import { ContentType, type ChartKind } from '@lightdash/common';
+import { IconLayoutDashboard } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
+import TruncatedText from '../../../../../components/common/TruncatedText';
+import styles from '../../../aiCopilot/components/ChatElements/AgentChatInput.module.css';
+import chipClasses from './AnnouncementMentionChip.module.css';
+
+type Props = {
+    projectUuid: string;
+    contentType: ContentType.CHART | ContentType.DASHBOARD;
+    uuid: string;
+    label: string;
+    chartKind?: ChartKind | null;
+};
+
+export const AnnouncementMentionChip: FC<Props> = ({
+    projectUuid,
+    contentType,
+    uuid,
+    label,
+    chartKind,
+}) => {
+    const isDashboard = contentType === ContentType.DASHBOARD;
+    const Icon = isDashboard
+        ? IconLayoutDashboard
+        : getChartIcon(chartKind ?? undefined);
+    const url = isDashboard
+        ? `/projects/${projectUuid}/dashboards/${uuid}/view`
+        : `/projects/${projectUuid}/saved/${uuid}/view`;
+
+    return (
+        <Link
+            to={url}
+            className={`${styles.contentMention} ${chipClasses.chip}`}
+            data-content-type={contentType}
+            data-content-link="true"
+        >
+            <span
+                className={styles.contentMentionIcon}
+                data-rendered-icon="true"
+            >
+                <MantineIcon
+                    icon={Icon}
+                    size={12}
+                    color={isDashboard ? 'green.7' : 'blue.7'}
+                    stroke={1.8}
+                />
+            </span>
+            <TruncatedText
+                className={styles.contentMentionLabel}
+                fz="inherit"
+                fw="inherit"
+                inline
+                maxWidth={260}
+                style={{ flex: 1, minWidth: 0 }}
+            >
+                {label}
+            </TruncatedText>
+        </Link>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/announcementExtensions.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/announcementExtensions.ts
@@ -1,0 +1,24 @@
+import Placeholder from '@tiptap/extension-placeholder';
+import StarterKit from '@tiptap/starter-kit';
+import { createContentMentionExtension } from '../../../aiCopilot/components/ChatElements/contentMentions';
+
+export const createAnnouncementExtensions = (
+    getProjectUuid: () => string | undefined,
+) => [
+    StarterKit.configure({
+        heading: false,
+        bulletList: false,
+        orderedList: false,
+        blockquote: false,
+        codeBlock: false,
+        horizontalRule: false,
+    }),
+    Placeholder.configure({
+        placeholder:
+            'Post an announcement to this audience — type @ to mention a chart or dashboard…',
+    }),
+    createContentMentionExtension({
+        getProjectUuid,
+        getPriorityItems: () => [],
+    }),
+];

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/serializeAnnouncementMarkdown.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/serializeAnnouncementMarkdown.ts
@@ -1,0 +1,70 @@
+import { ContentType } from '@lightdash/common';
+import { type Editor } from '@tiptap/react';
+
+// Must match `CONTENT_MENTION_NAME` in
+// ee/features/aiCopilot/components/ChatElements/contentMentions.tsx — not
+// exported from there, so kept in sync manually.
+const CONTENT_MENTION_NODE_TYPE = 'contentMention';
+
+// Escapes markdown syntax characters so plain typed text (e.g. "Q1 * Q2",
+// "50% off!") isn't reinterpreted as emphasis/headings/etc when re-parsed by
+// the read-view's markdown renderer.
+const escapeMarkdown = (text: string) =>
+    text.replace(/([\\`*_{}[\]()#+!])/g, '\\$1');
+
+const mentionUrl = (
+    projectUuid: string,
+    contentType: ContentType,
+    uuid: string,
+): string =>
+    contentType === ContentType.DASHBOARD
+        ? `/projects/${projectUuid}/dashboards/${uuid}/view`
+        : `/projects/${projectUuid}/saved/${uuid}/view`;
+
+/** Serializes the composer's doc to markdown, turning @-mentioned content
+ * into plain markdown links that `rehypeAiAgentContentLinks` renders as rich
+ * chips on read. */
+export const serializeAnnouncementMarkdown = (
+    editor: Editor,
+    projectUuid: string,
+): string => {
+    const paragraphs: string[] = [];
+    editor.state.doc.forEach((paragraph) => {
+        const parts: string[] = [];
+        paragraph.forEach((child) => {
+            if (child.type.name === CONTENT_MENTION_NODE_TYPE) {
+                const attrs = child.attrs as {
+                    contentType?: ContentType;
+                    uuid?: string;
+                    label?: string;
+                };
+                if (
+                    attrs.uuid &&
+                    (attrs.contentType === ContentType.CHART ||
+                        attrs.contentType === ContentType.DASHBOARD)
+                ) {
+                    const label = escapeMarkdown(attrs.label ?? '');
+                    const url = mentionUrl(
+                        projectUuid,
+                        attrs.contentType,
+                        attrs.uuid,
+                    );
+                    parts.push(`[${label}](${url})`);
+                }
+                return;
+            }
+            if (child.isText) {
+                let text = escapeMarkdown(child.text ?? '');
+                child.marks.forEach((mark) => {
+                    if (mark.type.name === 'bold') text = `**${text}**`;
+                    else if (mark.type.name === 'italic') text = `_${text}_`;
+                    else if (mark.type.name === 'code') text = `\`${text}\``;
+                    else if (mark.type.name === 'strike') text = `~~${text}~~`;
+                });
+                parts.push(text);
+            }
+        });
+        paragraphs.push(parts.join(''));
+    });
+    return paragraphs.join('\n\n').trim();
+};


### PR DESCRIPTION
Part 2 of 3 in the homepage-builder round-3 polish stack (split from #25621). Stacked on #25624.

## Summary

Posting a homepage announcement now supports `@`-mentioning a chart or dashboard. The composer reuses the AI chat's Tiptap content-mention infrastructure (same search + pill rendering). Storage stays plain markdown — mentions serialize as ordinary markdown links, and the existing `rehypeAiAgentContentLinks` plugin auto-detects and renders them as rich clickable chips in the posted announcement. Older plain-text announcements still render unchanged.

## Test plan

- [x] `pnpm -F frontend typecheck:fast` (branch compiles independently)
- [x] `pnpm -F frontend run linter` + `oxfmt` on touched files
- [x] Verified live: `@`-search returns charts/dashboards, selecting inserts a chip in the composer, the posted announcement renders a real clickable link/chip (dark text, no underline, correct content icon), markdown-special chars in plain text escape correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ