### PR TITLE
feat(frontend): homepage design polish, hero centering & block limits

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.module.css
@@ -1,25 +1,3 @@
-.page {
-    display: flex;
-    flex-direction: column;
-    padding: 0 24px 64px;
-}
-
-.heroSection {
-    min-height: calc(100vh - var(--navbar-height) - 72px);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-}
-
-.hero {
-    width: 100%;
-    max-width: 720px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-}
-
 .welcome {
     width: 100%;
     max-width: 1040px;

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneHomepage.tsx
@@ -12,6 +12,7 @@ import { AskAiHero } from './blocks/AskAiHeroBlock';
 import { getDefaultQuickActions } from './blocks/quickActionDefaults';
 import { QuickActionCards } from './blocks/QuickActionsBlock';
 import classes from './DayOneHomepage.module.css';
+import layout from './homepageLayout.module.css';
 
 type Props = {
     projectUuid: string;
@@ -32,10 +33,10 @@ export const DayOneHomepage: FC<Props> = ({
     const isAiEnabled = useAiAgentButtonVisibility();
 
     return (
-        <div className={classes.page}>
-            <div className={classes.heroSection}>
+        <div className={layout.page}>
+            <div className={layout.heroSection}>
                 {isAiEnabled ? (
-                    <div className={classes.hero}>
+                    <div className={layout.hero}>
                         <AskAiHero projectUuid={projectUuid} showGreeting />
                     </div>
                 ) : (

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -285,7 +285,7 @@ const BlockCard: FC<BlockCardProps> = ({
                     aria-label={`Drag ${definition.label} block`}
                 >
                     <span className={classes.blockHandle}>
-                        <MantineIcon icon={IconGripVertical} color="gray" />
+                        <MantineIcon icon={IconGripVertical} color="ldGray.6" />
                     </span>
                     <span className={classes.blockTypeLabel}>
                         {definition.label}
@@ -295,7 +295,7 @@ const BlockCard: FC<BlockCardProps> = ({
                     <Tooltip label="Move up">
                         <ActionIcon
                             variant="subtle"
-                            color="gray"
+                            color="ldGray.6"
                             disabled={!canUp}
                             onClick={onUp}
                         >
@@ -305,7 +305,7 @@ const BlockCard: FC<BlockCardProps> = ({
                     <Tooltip label="Move down">
                         <ActionIcon
                             variant="subtle"
-                            color="gray"
+                            color="ldGray.6"
                             disabled={!canDown}
                             onClick={onDown}
                         >
@@ -315,7 +315,7 @@ const BlockCard: FC<BlockCardProps> = ({
                     <Tooltip label="Duplicate">
                         <ActionIcon
                             variant="subtle"
-                            color="gray"
+                            color="ldGray.6"
                             onClick={onDuplicate}
                         >
                             <MantineIcon icon={IconCopy} />
@@ -375,9 +375,6 @@ export const HomepageEditor: FC<Props> = ({
     const [isViewAsModalOpen, setIsViewAsModalOpen] = useState(false);
 
     const isAiEnabled = useAiAgentButtonVisibility();
-    const availableBlocks = blockLibrary.filter(
-        (definition) => !definition.requiresAi || isAiEnabled,
-    );
 
     const [draft, setDraft] = useState<HomepageConfig>(homepage.draftConfig);
     const [isPreviewing, setIsPreviewing] = useState(false);
@@ -392,6 +389,16 @@ export const HomepageEditor: FC<Props> = ({
     const preDragDraftRef = useRef<HomepageConfig | null>(null);
     // Instance created for a library drag, once it first enters the canvas
     const pendingNewBlockRef = useRef<HomepageBlock | null>(null);
+
+    // Singleton blocks (e.g. metrics) drop out of the library once placed.
+    const usedSingletonTypes = new Set(
+        draft.rows.flatMap((row) => row.blocks).map((block) => block.type),
+    );
+    const availableBlocks = blockLibrary.filter(
+        (definition) =>
+            (!definition.requiresAi || isAiEnabled) &&
+            !(definition.singleton && usedSingletonTypes.has(definition.type)),
+    );
 
     const { mutate: saveDraft } = updateMutation;
     useEffect(() => {
@@ -452,6 +459,14 @@ export const HomepageEditor: FC<Props> = ({
         useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     );
 
+    // A block being hovered is split into zones: the top/bottom bands reorder
+    // the dragged block into its own row above/below (the common case), the
+    // narrow left/right edges split it into the same row side-by-side, and
+    // the center defaults to reordering above — so merely passing over a
+    // block on the way elsewhere doesn't accidentally split it.
+    const ROW_ZONE_FRACTION = 0.3;
+    const CELL_EDGE_FRACTION = 0.15;
+
     // Where would the dragged block land, given what the pointer is over?
     const computeTarget = (
         config: HomepageConfig,
@@ -467,15 +482,37 @@ export const HomepageEditor: FC<Props> = ({
         const location = locateBlock(config, overId);
         if (!location) return null;
         const activeRect = event.active.rect.current.translated;
-        const activeCenter = activeRect
+        const activeCenterX = activeRect
             ? activeRect.left + activeRect.width / 2
             : over.rect.left;
-        const isAfter = activeCenter > over.rect.left + over.rect.width / 2;
-        return {
-            kind: 'cell',
-            rowIndex: location.rowIndex,
-            blockIndex: location.blockIndex + (isAfter ? 1 : 0),
-        };
+        const activeCenterY = activeRect
+            ? activeRect.top + activeRect.height / 2
+            : over.rect.top;
+        const relY = (activeCenterY - over.rect.top) / over.rect.height;
+
+        if (relY < ROW_ZONE_FRACTION) {
+            return { kind: 'row', rowIndex: location.rowIndex };
+        }
+        if (relY > 1 - ROW_ZONE_FRACTION) {
+            return { kind: 'row', rowIndex: location.rowIndex + 1 };
+        }
+
+        const relX = (activeCenterX - over.rect.left) / over.rect.width;
+        if (relX < CELL_EDGE_FRACTION) {
+            return {
+                kind: 'cell',
+                rowIndex: location.rowIndex,
+                blockIndex: location.blockIndex,
+            };
+        }
+        if (relX > 1 - CELL_EDGE_FRACTION) {
+            return {
+                kind: 'cell',
+                rowIndex: location.rowIndex,
+                blockIndex: location.blockIndex + 1,
+            };
+        }
+        return { kind: 'row', rowIndex: location.rowIndex };
     };
 
     // Live-preview move: relocate the block in the draft as the drag hovers,
@@ -636,7 +673,7 @@ export const HomepageEditor: FC<Props> = ({
                                         homepage.homepageUuid ? (
                                             <MantineIcon
                                                 icon={IconCheck}
-                                                color="blue"
+                                                color="ldGray.7"
                                             />
                                         ) : undefined
                                     }

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
@@ -365,7 +365,7 @@ const PublishModalBody: FC<BodyProps> = ({
                                                 </Box>
                                                 <ActionIcon
                                                     variant="subtle"
-                                                    color="gray"
+                                                    color="ldGray.6"
                                                     size="sm"
                                                     disabled={index === 0}
                                                     aria-label={`Move ${assignment.groupName} up`}
@@ -383,7 +383,7 @@ const PublishModalBody: FC<BodyProps> = ({
                                                 </ActionIcon>
                                                 <ActionIcon
                                                     variant="subtle"
-                                                    color="gray"
+                                                    color="ldGray.6"
                                                     size="sm"
                                                     disabled={
                                                         index ===

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -1,7 +1,12 @@
-import { type HomepageBlock, type HomepageConfig } from '@lightdash/common';
+import {
+    type HomepageBlock,
+    type HomepageConfig,
+    type HomepageRow,
+} from '@lightdash/common';
 import { Box, Group, Paper, Stack, Text } from '@mantine-8/core';
-import { type FC } from 'react';
+import { type FC, type ReactNode } from 'react';
 import { getBlockDefinition } from './blocks/registry';
+import layout from './homepageLayout.module.css';
 import classes from './PublishedHomepage.module.css';
 
 const PERSONAL_BLOCK_TYPES: HomepageBlock['type'][] = ['favorites', 'recent'];
@@ -9,6 +14,9 @@ const PERSONAL_BLOCK_TYPES: HomepageBlock['type'][] = ['favorites', 'recent'];
 // Composer-style blocks read better narrow and centered, like day-0's own
 // hero, instead of stretching to the full row width other blocks use.
 const NARROW_BLOCK_TYPES: HomepageBlock['type'][] = ['ask-ai-hero'];
+
+// A leading hero block gets the vertically-centred day-0 treatment.
+const HERO_BLOCK_TYPES: HomepageBlock['type'][] = ['ask-ai-hero'];
 
 // Unknown block types render nothing so newer configs degrade gracefully
 const BlockRenderer: FC<{
@@ -42,20 +50,13 @@ const BlockRenderer: FC<{
     );
 };
 
-type Props = {
-    config: HomepageConfig;
+const HomepageRows: FC<{
+    rows: HomepageRow[];
     projectUuid: string;
-    /** Render personal blocks as placeholders (admin view-as preview) */
-    personalPlaceholders?: boolean;
-};
-
-export const PublishedHomepage: FC<Props> = ({
-    config,
-    projectUuid,
-    personalPlaceholders = false,
-}) => (
-    <Stack gap={28} className={classes.container}>
-        {config.rows.map((row) => (
+    personalPlaceholders: boolean;
+}> = ({ rows, projectUuid, personalPlaceholders }) => (
+    <Stack gap={28}>
+        {rows.map((row) => (
             <Group key={row.id} gap={14} align="stretch" wrap="nowrap">
                 {row.blocks.map((block) => (
                     <Box key={block.id} flex={1} miw={0}>
@@ -70,3 +71,71 @@ export const PublishedHomepage: FC<Props> = ({
         ))}
     </Stack>
 );
+
+type Props = {
+    config: HomepageConfig;
+    projectUuid: string;
+    /** Render personal blocks as placeholders (admin view-as preview) */
+    personalPlaceholders?: boolean;
+    /** Content rendered below the centred hero, above the remaining rows
+     * (e.g. the personal favorites strip). */
+    secondaryTop?: ReactNode;
+};
+
+export const PublishedHomepage: FC<Props> = ({
+    config,
+    projectUuid,
+    personalPlaceholders = false,
+    secondaryTop = null,
+}) => {
+    const [firstRow, ...restRows] = config.rows;
+    const leadingHero =
+        firstRow &&
+        firstRow.blocks.length === 1 &&
+        HERO_BLOCK_TYPES.includes(firstRow.blocks[0].type)
+            ? firstRow.blocks[0]
+            : null;
+
+    if (leadingHero) {
+        return (
+            <div className={layout.page}>
+                <div className={layout.heroSection}>
+                    <div className={layout.hero}>
+                        <BlockRenderer
+                            block={leadingHero}
+                            projectUuid={projectUuid}
+                            personalPlaceholders={personalPlaceholders}
+                        />
+                    </div>
+                </div>
+                {(secondaryTop || restRows.length > 0) && (
+                    <div className={layout.secondary}>
+                        <Stack gap={28}>
+                            {secondaryTop}
+                            <HomepageRows
+                                rows={restRows}
+                                projectUuid={projectUuid}
+                                personalPlaceholders={personalPlaceholders}
+                            />
+                        </Stack>
+                    </div>
+                )}
+            </div>
+        );
+    }
+
+    return (
+        <div className={layout.page}>
+            <div className={layout.secondary}>
+                <Stack gap={28}>
+                    {secondaryTop}
+                    <HomepageRows
+                        rows={config.rows}
+                        projectUuid={projectUuid}
+                        personalPlaceholders={personalPlaceholders}
+                    />
+                </Stack>
+            </div>
+        </div>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -101,7 +101,7 @@ const CollectionPickerModal: FC<{
                                     {content.space?.name}
                                 </Text>
                             </Box>
-                            <MantineIcon icon={IconPlus} color="gray" />
+                            <MantineIcon icon={IconPlus} color="ldGray.6" />
                         </Group>
                     ))}
                     {results.length === 0 && !isFetching && (

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
@@ -69,7 +69,7 @@ const CardActions: FC<Pick<Props, 'content' | 'onRemove' | 'star'>> = ({
         {star && (
             <ActionIcon
                 variant="subtle"
-                color={star.isFavorite ? 'yellow' : 'gray'}
+                color={star.isFavorite ? 'yellow' : 'ldGray.6'}
                 size="sm"
                 aria-label={
                     star.isFavorite
@@ -89,7 +89,7 @@ const CardActions: FC<Pick<Props, 'content' | 'onRemove' | 'star'>> = ({
         {onRemove && (
             <ActionIcon
                 variant="subtle"
-                color="gray"
+                color="ldGray.6"
                 size="sm"
                 aria-label={`Remove ${content.name} from collection`}
                 onClick={(e) => {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
@@ -18,8 +18,6 @@ import { BlockHeader } from './BlockShell';
 import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
-const STAR_COLOR = 'light-dark(#de7f0b, #e08a20)';
-
 const FAVORITE_ICONS: Partial<Record<ResourceViewItemType, Icon>> = {
     [ResourceViewItemType.CHART]: IconChartBar,
     [ResourceViewItemType.DASHBOARD]: IconLayoutDashboard,
@@ -78,7 +76,7 @@ const FavoritePills: FC<{
                         <MantineIcon
                             icon={IconStarFilled}
                             size={13}
-                            color={STAR_COLOR}
+                            color="ldGray.7"
                             className={classes.clickable}
                             aria-label={`Remove ${item.data.name} from favorites`}
                             onClick={(e) => handleUnfavorite(e, item)}
@@ -87,7 +85,7 @@ const FavoritePills: FC<{
                         <MantineIcon
                             icon={IconStarFilled}
                             size={13}
-                            color={STAR_COLOR}
+                            color="ldGray.7"
                         />
                     )}
                 </Link>
@@ -102,7 +100,6 @@ export const PersonalFavoritesStrip: FC<{ projectUuid: string }> = ({
     <Stack gap={0}>
         <BlockHeader
             icon={IconStar}
-            iconColor={STAR_COLOR}
             title="My favorites"
             pill="Only you see this"
             mb={10}
@@ -124,7 +121,6 @@ export const FavoritesBlockView: FC<BlockComponentProps> = ({
         <Stack gap={0}>
             <BlockHeader
                 icon={IconStar}
-                iconColor={STAR_COLOR}
                 title={block.config.title}
                 pill="Only you see this"
             />
@@ -146,7 +142,6 @@ export const FavoritesBlockBuild: FC<BuildComponentProps> = ({
         <Stack gap={0}>
             <BlockHeader
                 icon={IconStar}
-                iconColor={STAR_COLOR}
                 title={block.config.title}
                 pill="Personal per viewer"
             />

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/HeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/HeroBlock.tsx
@@ -1,64 +1,23 @@
-import { subject } from '@casl/ability';
-import {
-    Box,
-    Button,
-    Code,
-    Group,
-    Stack,
-    Text,
-    TextInput,
-} from '@mantine-8/core';
-import { IconSquareRoundedPlus } from '@tabler/icons-react';
+import { Box, Code, Stack, Text, TextInput } from '@mantine-8/core';
 import { type FC } from 'react';
-import { Link } from 'react-router';
-import MantineIcon from '../../../../components/common/MantineIcon';
-import { Can } from '../../../../providers/Ability';
 import useApp from '../../../../providers/App/useApp';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const resolveTokens = (text: string, firstName: string | undefined): string =>
     text.replaceAll('{name}', firstName ?? 'there');
 
-export const HeroBlockView: FC<BlockComponentProps> = ({
-    block,
-    projectUuid,
-}) => {
+export const HeroBlockView: FC<BlockComponentProps> = ({ block }) => {
     const { user } = useApp();
     if (block.type !== 'hero') return null;
     return (
-        <Group justify="space-between" align="flex-end" gap="md" wrap="nowrap">
-            <Box>
-                <Text
-                    component="h1"
-                    fz={28}
-                    fw={600}
-                    lts="-0.02em"
-                    m={0}
-                    lh={1.2}
-                >
-                    {resolveTokens(block.config.title, user.data?.firstName)}
-                </Text>
-                <Text fz={15} c="dimmed" mt={5}>
-                    {resolveTokens(block.config.subtitle, user.data?.firstName)}
-                </Text>
-            </Box>
-            <Can
-                I="manage"
-                this={subject('Explore', {
-                    organizationUuid: user.data?.organizationUuid,
-                    projectUuid,
-                })}
-            >
-                <Button
-                    component={Link}
-                    to={`/projects/${projectUuid}/tables`}
-                    leftSection={<MantineIcon icon={IconSquareRoundedPlus} />}
-                    flex="0 0 auto"
-                >
-                    New
-                </Button>
-            </Can>
-        </Group>
+        <Box>
+            <Text component="h1" fz={28} fw={600} lts="-0.02em" m={0} lh={1.2}>
+                {resolveTokens(block.config.title, user.data?.firstName)}
+            </Text>
+            <Text fz={15} c="dimmed" mt={5}>
+                {resolveTokens(block.config.subtitle, user.data?.firstName)}
+            </Text>
+        </Box>
     );
 };
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
@@ -37,6 +37,8 @@ import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const KPI_TIME_FRAME = TimeFrames.MONTH;
 
+const MAX_METRICS = 4;
+
 const MetricKpiCard: FC<{
     metricRef: HomepageMetricRef;
     projectUuid: string;
@@ -134,8 +136,9 @@ const MetricsPickerModal: FC<{
     onClose: () => void;
     projectUuid: string;
     selected: HomepageMetricRef[];
+    atLimit: boolean;
     onAdd: (metricRef: HomepageMetricRef) => void;
-}> = ({ opened, onClose, projectUuid, selected, onAdd }) => {
+}> = ({ opened, onClose, projectUuid, selected, atLimit, onAdd }) => {
     const [search, setSearch] = useState('');
     const [debouncedSearch] = useDebouncedValue(search, 300);
     const { data, isFetching } = useMetricsCatalog({
@@ -167,36 +170,44 @@ const MetricsPickerModal: FC<{
                     value={search}
                     onChange={(e) => setSearch(e.currentTarget.value)}
                     rightSection={isFetching ? <Loader size="xs" /> : null}
+                    disabled={atLimit}
                 />
+                {atLimit && (
+                    <Text size="xs" c="dimmed">
+                        You can show up to {MAX_METRICS} metrics. Remove one to
+                        add another.
+                    </Text>
+                )}
                 <Stack gap={4} mah={360} className={classes.pickerScrollList}>
-                    {results.map((metric) => (
-                        <Group
-                            key={metric.catalogSearchUuid}
-                            gap="sm"
-                            wrap="nowrap"
-                            p="xs"
-                            className={classes.pickerRow}
-                            onClick={() =>
-                                onAdd({
-                                    tableName: metric.tableName,
-                                    metricName: metric.name,
-                                    label: metric.label ?? metric.name,
-                                })
-                            }
-                        >
-                            <MantineIcon icon={IconHash} color="gray" />
-                            <Box flex={1} miw={0}>
-                                <Text size="sm" fw={500} truncate>
-                                    {metric.label ?? metric.name}
-                                </Text>
-                                <Text size="xs" c="dimmed">
-                                    {metric.tableLabel ?? metric.tableName}
-                                </Text>
-                            </Box>
-                            <MantineIcon icon={IconPlus} color="gray" />
-                        </Group>
-                    ))}
-                    {results.length === 0 && !isFetching && (
+                    {!atLimit &&
+                        results.map((metric) => (
+                            <Group
+                                key={metric.catalogSearchUuid}
+                                gap="sm"
+                                wrap="nowrap"
+                                p="xs"
+                                className={classes.pickerRow}
+                                onClick={() =>
+                                    onAdd({
+                                        tableName: metric.tableName,
+                                        metricName: metric.name,
+                                        label: metric.label ?? metric.name,
+                                    })
+                                }
+                            >
+                                <MantineIcon icon={IconHash} color="ldGray.6" />
+                                <Box flex={1} miw={0}>
+                                    <Text size="sm" fw={500} truncate>
+                                        {metric.label ?? metric.name}
+                                    </Text>
+                                    <Text size="xs" c="dimmed">
+                                        {metric.tableLabel ?? metric.tableName}
+                                    </Text>
+                                </Box>
+                                <MantineIcon icon={IconPlus} color="ldGray.6" />
+                            </Group>
+                        ))}
+                    {!atLimit && results.length === 0 && !isFetching && (
                         <Text size="sm" c="dimmed" p="sm">
                             No matching metrics.
                         </Text>
@@ -216,11 +227,7 @@ export const MetricsBlockView: FC<BlockComponentProps> = ({
     }
     return (
         <Stack gap={0}>
-            <BlockHeader
-                icon={IconChartDots}
-                iconColor="light-dark(#de7f0b, #e08a20)"
-                title={block.config.title}
-            />
+            <BlockHeader icon={IconChartDots} title={block.config.title} />
             <SimpleGrid cols={{ base: 1, sm: 2, md: 4 }} spacing={12}>
                 {block.config.items.map((metricRef) => (
                     <MetricKpiCard
@@ -241,6 +248,8 @@ export const MetricsBlockBuild: FC<BuildComponentProps> = ({
 }) => {
     const [isPickerOpen, setIsPickerOpen] = useState(false);
     if (block.type !== 'metrics') return null;
+
+    const atLimit = block.config.items.length >= MAX_METRICS;
 
     return (
         <Stack gap="xs">
@@ -277,7 +286,7 @@ export const MetricsBlockBuild: FC<BuildComponentProps> = ({
                             </Box>
                             <ActionIcon
                                 variant="subtle"
-                                color="gray"
+                                color="ldGray.6"
                                 size="sm"
                                 aria-label={`Remove metric ${metricRef.label}`}
                                 onClick={() =>
@@ -306,25 +315,30 @@ export const MetricsBlockBuild: FC<BuildComponentProps> = ({
                 variant="default"
                 size="xs"
                 w="fit-content"
+                disabled={atLimit}
                 leftSection={<MantineIcon icon={IconHash} />}
                 onClick={() => setIsPickerOpen(true)}
             >
-                Choose metrics from catalog…
+                {atLimit
+                    ? `Metric limit reached (${MAX_METRICS})`
+                    : 'Choose metrics from catalog…'}
             </Button>
             <MetricsPickerModal
                 opened={isPickerOpen}
                 onClose={() => setIsPickerOpen(false)}
                 projectUuid={projectUuid}
                 selected={block.config.items}
-                onAdd={(metricRef) =>
+                atLimit={atLimit}
+                onAdd={(metricRef) => {
+                    if (block.config.items.length >= MAX_METRICS) return;
                     onChange({
                         ...block,
                         config: {
                             ...block.config,
                             items: [...block.config.items, metricRef],
                         },
-                    })
-                }
+                    });
+                }}
             />
         </Stack>
     );

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
@@ -7,7 +7,6 @@ import {
     Group,
     Loader,
     Menu,
-    SimpleGrid,
     Stack,
     Text,
     TextInput,
@@ -32,7 +31,6 @@ import { useInfiniteContent } from '../../../../hooks/useContent';
 import useTracking from '../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../types/Events';
 import { useAiAgentButtonVisibility } from '../../aiCopilot/hooks/useAiAgentsButtonVisibility';
-import { IconSquare } from './BlockShell';
 import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
@@ -100,7 +98,7 @@ export const QuickActionCards: FC<{
     );
     if (visibleActions.length === 0) return null;
     return (
-        <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm">
+        <Group gap={8}>
             {visibleActions.map((action, index) => {
                 const presentation = actionPresentation(action, projectUuid);
                 return (
@@ -110,6 +108,7 @@ export const QuickActionCards: FC<{
                         to={presentation.url}
                         underline="never"
                         c="inherit"
+                        className={classes.quickActionChip}
                         onClick={() =>
                             track({
                                 name: EventName.HOMEPAGE_QUICK_ACTION_CLICKED,
@@ -117,23 +116,16 @@ export const QuickActionCards: FC<{
                             })
                         }
                     >
-                        <Box
-                            className={`${classes.hoverCard} ${classes.clickable}`}
-                            p={18}
-                            h="100%"
-                        >
-                            <IconSquare icon={presentation.icon} size="lg" />
-                            <Text fw={600} fz={15} mt={13} mb={3}>
-                                {presentation.title}
-                            </Text>
-                            <Text fz={13} c="dimmed" lh={1.45}>
-                                {presentation.description}
-                            </Text>
-                        </Box>
+                        <MantineIcon
+                            icon={presentation.icon}
+                            size={14}
+                            color="ldGray.6"
+                        />
+                        {presentation.title}
                     </Anchor>
                 );
             })}
-        </SimpleGrid>
+        </Group>
     );
 };
 
@@ -181,12 +173,12 @@ const DashboardPickerModal: FC<{
                         >
                             <MantineIcon
                                 icon={IconLayoutDashboard}
-                                color="gray"
+                                color="ldGray.6"
                             />
                             <Text size="sm" fw={500} flex={1} truncate>
                                 {content.name}
                             </Text>
-                            <MantineIcon icon={IconPlus} color="gray" />
+                            <MantineIcon icon={IconPlus} color="ldGray.6" />
                         </Group>
                     ))}
                 </Stack>
@@ -251,14 +243,14 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
                         >
                             <MantineIcon
                                 icon={presentation.icon}
-                                color="gray"
+                                color="ldGray.6"
                             />
                             <Text size="sm" fw={500} flex={1}>
                                 {presentation.title}
                             </Text>
                             <ActionIcon
                                 variant="subtle"
-                                color="gray"
+                                color="ldGray.6"
                                 size="sm"
                                 disabled={index === 0}
                                 aria-label={`Move ${presentation.title} earlier`}
@@ -268,7 +260,7 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
                             </ActionIcon>
                             <ActionIcon
                                 variant="subtle"
-                                color="gray"
+                                color="ldGray.6"
                                 size="sm"
                                 disabled={
                                     index === block.config.actions.length - 1
@@ -280,7 +272,7 @@ export const QuickActionsBlockBuild: FC<BuildComponentProps> = ({
                             </ActionIcon>
                             <ActionIcon
                                 variant="subtle"
-                                color="gray"
+                                color="ldGray.6"
                                 size="sm"
                                 aria-label={`Remove ${presentation.title}`}
                                 onClick={() =>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecentBlock.tsx
@@ -27,6 +27,8 @@ const getRecentlyViewed = async (projectUuid: string) =>
         body: undefined,
     });
 
+const MAX_RECENT_ITEMS = 4;
+
 const useRecentlyViewed = (projectUuid: string) =>
     useQuery<HomepageRecentlyViewedItem[], ApiError>({
         queryKey: ['homepage_recently_viewed', projectUuid],
@@ -72,7 +74,9 @@ const RecentRow: FC<{
 
 const RecentList: FC<{ projectUuid: string }> = ({ projectUuid }) => {
     const { data: recents, isInitialLoading } = useRecentlyViewed(projectUuid);
-    const uuids = (recents ?? []).map((item) => item.uuid);
+    const uuids = (recents ?? [])
+        .slice(0, MAX_RECENT_ITEMS)
+        .map((item) => item.uuid);
     const { data: contents, isInitialLoading: isResolving } =
         useCollectionContent(projectUuid, uuids);
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -45,7 +45,7 @@ const ResourceRow: FC<{
             {onRemove ? (
                 <ActionIcon
                     variant="subtle"
-                    color="gray"
+                    color="ldGray.6"
                     size="sm"
                     aria-label={`Remove resource ${item.title}`}
                     onClick={onRemove}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -161,7 +161,7 @@ a .hoverCard:hover,
     width: 7px;
     height: 7px;
     border-radius: 50%;
-    background: #7262ff;
+    background: var(--mantine-color-ldGray-4);
     margin-top: 6px;
     flex-shrink: 0;
 }
@@ -265,4 +265,28 @@ a .hoverCard:hover,
     background: var(--mantine-color-ldGray-1);
     border-radius: 5px;
     padding: 2px 7px;
+}
+
+.quickActionChip {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 6px 12px;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    color: inherit;
+    text-decoration: none;
+    background: light-dark(#fff, var(--mantine-color-dark-6));
+    border: 1px solid var(--mantine-color-ldGray-2);
+    transition:
+        background 0.15s ease,
+        border-color 0.15s ease;
+}
+
+.quickActionChip:hover {
+    text-decoration: none;
+    color: inherit;
+    background: var(--mantine-color-ldGray-0);
+    border-color: var(--mantine-color-ldGray-3);
 }

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
@@ -39,6 +39,8 @@ export type BlockDefinition = {
     description: string;
     icon: Icon;
     requiresAi?: boolean;
+    /** Can only be added once per homepage. */
+    singleton?: boolean;
     create: () => HomepageBlock;
     View: FC<BlockComponentProps>;
     Build: FC<BuildComponentProps>;
@@ -94,6 +96,7 @@ export const blockLibrary: BlockDefinition[] = [
         label: 'Metrics',
         description: 'KPI cards from the metrics catalog, with deltas.',
         icon: IconChartDots,
+        singleton: true,
         create: () => ({
             id: uuidv4(),
             type: 'metrics',

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -1,0 +1,32 @@
+/* Shared homepage layout — used by both the day-0 homepage and the published
+ * homepage so their hero (greeting + Ask AI) sits identically: vertically
+ * centred in the viewport, constrained, with everything else in a secondary
+ * section below. */
+
+.page {
+    display: flex;
+    flex-direction: column;
+    padding: 32px 24px 64px;
+}
+
+.heroSection {
+    min-height: calc(100vh - var(--navbar-height) - 72px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.hero {
+    width: 100%;
+    max-width: 720px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.secondary {
+    width: 100%;
+    max-width: 1160px;
+    margin: 0 auto;
+}

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import { DbtProjectType, ProjectType } from '@lightdash/common';
-import { Box, Stack } from '@mantine-8/core';
+import { Stack } from '@mantine-8/core';
 import { type FC } from 'react';
 import { Navigate, useParams } from 'react-router';
 import { useUnmount } from 'react-use';
@@ -22,7 +22,6 @@ import {
     useResolvedHomepage,
 } from '../ee/features/homepageBuilder/hooks/useProjectHomepage';
 import { PublishedHomepage } from '../ee/features/homepageBuilder/PublishedHomepage';
-import publishedHomepageClasses from '../ee/features/homepageBuilder/PublishedHomepage.module.css';
 import { ManagedAgentHomeCard } from '../ee/features/managedAgent/ManagedAgentHomeCard';
 import { useFavorites } from '../hooks/favorites/useFavorites';
 import { usePinnedItems } from '../hooks/pinning/usePinnedItems';
@@ -109,25 +108,23 @@ const Home: FC = () => {
             row.blocks.some((block) => block.type === 'favorites'),
         );
         return (
-            <Page withPaddedContent withFooter>
+            <Page withFooter noContentPadding>
                 <AdminHomepageControls
                     projectUuid={project.data.projectUuid}
                     organizationUuid={project.data.organizationUuid}
                     showNewHomepage
                 />
-                <Stack gap="md" pt={40} pb={64}>
-                    {homepage.allowPersonal && !hasFavoritesBlock && (
-                        <Box className={publishedHomepageClasses.container}>
+                <PublishedHomepage
+                    config={homepage.config}
+                    projectUuid={project.data.projectUuid}
+                    secondaryTop={
+                        homepage.allowPersonal && !hasFavoritesBlock ? (
                             <PersonalFavoritesStrip
                                 projectUuid={project.data.projectUuid}
                             />
-                        </Box>
-                    )}
-                    <PublishedHomepage
-                        config={homepage.config}
-                        projectUuid={project.data.projectUuid}
-                    />
-                </Stack>
+                        ) : null
+                    }
+                />
             </Page>
         );
     }


### PR DESCRIPTION
Part 3 of 3 in the homepage-builder round-3 polish stack (split from #25621). Stacked on #25625. This bundles the design/layout/constraint changes that share files (HomepageEditor, MetricsBlock, blockStyles), which is why they aren't split further.

## Summary

**Design**
- Neutral `ldGray` icon palette across the builder; color reserved for real status (destructive red, success green, favorites/metric-deltas). Drops decorative violet/amber accents.
- Favorites goes fully monochrome and loses its floating white wrapper.
- Quick actions becomes compact inline chips instead of a 3-box card grid / full-width list.
- The Greeting block drops a stray hardcoded "New" CTA button (Quick actions already covers CTAs).

**Layout**
- The Ask-AI hero is now vertically centred like the day-0 homepage, via a shared `homepageLayout` module both use; the personal favorites strip moves below the hero.

**Block limits & DnD**
- Metrics is add-once (singleton) and capped at 4 metrics; recently-viewed capped at 4 items.
- Drag-and-drop hover is zone-based — top/bottom bands reorder into a new row, narrow edges split side-by-side, center defaults to reorder — instead of always splitting.

## Test plan

- [x] `pnpm -F frontend typecheck:fast` (tip is byte-identical to the pre-split branch), `linter`, `oxfmt`
- [x] Verified live: centered hero + favorites-below, monochrome favorites, compact quick-action chips w/ hover, no Greeting CTA, metrics singleton + 4-cap, recent 4-cap, drag-to-reorder vs edge-split

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ