### PR TITLE
feat: round-trip space access in .space.yml

### DIFF
--- a/docs/content-as-code.md
+++ b/docs/content-as-code.md
@@ -17,12 +17,12 @@ validation against current server capabilities.
 
 ## Responsibility boundary
 
-| Layer | Responsibilities |
-|---|---|
-| Common | Defines the portable resource and API response types used by the CLI and backend. |
-| Backend controller | Exposes authenticated `/code` endpoints and generated OpenAPI contracts. |
-| Backend service | Loads resources, builds the portable representation, validates uploads, resolves identity, calculates changes, and persists them. |
-| CLI | Selects the project or organization, reads and writes files, chooses deterministic filenames, calls the `/code` API, and presents progress and per-file failures. |
+| Layer              | Responsibilities                                                                                                                                                  |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Common             | Defines the portable resource and API response types used by the CLI and backend.                                                                                 |
+| Backend controller | Exposes authenticated `/code` endpoints and generated OpenAPI contracts.                                                                                          |
+| Backend service    | Loads resources, builds the portable representation, validates uploads, resolves identity, calculates changes, and persists them.                                 |
+| CLI                | Selects the project or organization, reads and writes files, chooses deterministic filenames, calls the `/code` API, and presents progress and per-file failures. |
 
 The CLI should not contain lists of valid domain values, compare uploaded
 resources with database resources, or coordinate lower-level create and update
@@ -132,6 +132,95 @@ lightdash/
 
 The CLI success message refers to the shared `lightdash/` parent because future
 organization resources will use the same root.
+
+## Spaces and access
+
+Project space definitions use `.space.yml` files. New flat downloads place them
+under `lightdash/spaces/`:
+
+```text
+lightdash/
+  spaces/
+    finance.space.yml
+```
+
+Use `--root-spaces` to write new flat space files at the `lightdash/` root for
+the legacy layout. With `--nested`, each definition stays in its per-space
+folder alongside that space's `charts/` and `dashboards/` directories.
+Existing files are always updated in their current location, so downloading
+does not duplicate or automatically move root, `spaces/`, or nested files.
+Upload discovers all of these layouts recursively.
+
+Each space file contains:
+
+```yaml
+contentType: space
+version: 1
+spaceName: Finance
+slug: company/finance
+access:
+  inheritParentPermissions: false
+  projectMemberAccessRole: viewer
+  users:
+    - email: owner@example.com
+      role: admin
+  groups:
+    - name: Finance team
+      role: editor
+```
+
+The endpoints are:
+
+- `GET /api/v1/projects/{projectUuid}/spaces/code`
+- `POST /api/v1/projects/{projectUuid}/spaces/code`
+
+The full hierarchy path in `slug` is the portable identity. Uploads process
+parents before descendants and create missing spaces unless
+`--skip-space-create` is used. Changing the path creates another space; missing
+files do not move, delete, or revoke a remote space.
+
+For compatibility with older downloads that only contain a leaf space file,
+metadata-only uploads can recreate missing ancestor folders using names derived
+from each path segment. Version 1 files with an explicit `access` policy remain
+strict: every parent must already exist or have its own successfully applied
+space file. With `--skip-space-create`, missing spaces and their dependent
+content are reported as skipped while unrelated existing content continues.
+
+When `access` is present it replaces the complete direct policy: inheritance,
+the all-project-members role, direct human users, and direct groups. Empty
+arrays explicitly remove grants. Effective inherited access and expanded group
+members are never serialized. Legacy space files without `version` and
+`access` remain valid and update metadata without changing access.
+
+If direct access contains a principal without a portable identity, download
+still writes the space as a legacy metadata-only file and warns that access was
+omitted. Re-uploading that file leaves access unchanged; it never applies a
+partial policy that could revoke the unsupported grant. Descendant spaces are
+still downloaded independently when their own access is portable.
+
+Full project downloads and uploads include spaces by default. Use
+`--skip-spaces` to leave them alone or `--spaces-only` to operate only on space
+definitions. `--root-spaces` is a download-only legacy layout option and cannot
+be combined with `--nested`. Filtered chart and dashboard operations never
+reconcile unrelated space access. They still maintain metadata-only files for
+the referenced spaces so names remain portable; an existing versioned `access`
+block is preserved rather than replaced by embedded metadata.
+
+If the access-aware space endpoint is unavailable, a normal full download
+continues with the legacy metadata-only spaces embedded in chart and dashboard
+responses. `--spaces-only` remains strict because it has no content response to
+use as a fallback.
+
+Changing a space name or access policy requires actual permission to manage the
+resolved space. Broad content-as-code permission does not bypass restricted
+space authorization, and an unchanged legacy metadata-only file is treated as
+a no-op after confirming the caller can view the space.
+
+Keep organization deployments in this order:
+
+1. `lightdash upload --organization`
+2. Project spaces
+3. Project content
 
 ## Custom roles reference implementation
 

--- a/packages/backend/src/controllers/spaceController.ts
+++ b/packages/backend/src/controllers/spaceController.ts
@@ -2,11 +2,14 @@ import {
     AddSpaceGroupAccess,
     AddSpaceUserAccess,
     ApiErrorPayload,
+    ApiSpaceAsCodeListResponse,
+    ApiSpaceAsCodeUpsertResponse,
     ApiSpaceDeleteImpactResponse,
     ApiSpaceResponse,
     ApiSuccessEmpty,
     assertRegisteredAccount,
     CreateSpace,
+    SpaceAsCode,
     UpdateSpace,
 } from '@lightdash/common';
 import {
@@ -18,6 +21,7 @@ import {
     Patch,
     Path,
     Post,
+    Query,
     Request,
     Response,
     Route,
@@ -37,6 +41,60 @@ import { BaseController } from './baseController';
 @Response<ApiErrorPayload>('default', 'Error')
 @Tags('Spaces')
 export class SpaceController extends BaseController {
+    /**
+     * Get spaces and their direct access policy in code representation
+     * @summary List spaces as code
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('code')
+    @OperationId('getSpacesAsCode')
+    async getSpacesAsCode(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiSpaceAsCodeListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getCoderService()
+                .getSpaces(req.account!, projectUuid),
+        };
+    }
+
+    /**
+     * Create or update a space and its direct access policy from code
+     * @summary Upsert space as code
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('code')
+    @OperationId('upsertSpaceAsCode')
+    async upsertSpaceAsCode(
+        @Path() projectUuid: string,
+        @Body() space: SpaceAsCode,
+        @Request() req: express.Request,
+        @Query() skipSpaceCreate: boolean = false,
+        @Query() publicSpaceCreate: boolean = false,
+    ): Promise<ApiSpaceAsCodeUpsertResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getCoderService()
+                .upsertSpace(req.account!, projectUuid, space, {
+                    skipSpaceCreate,
+                    publicSpaceCreate,
+                }),
+        };
+    }
+
     /**
      * Get details for a space in a project
      * @summary Get space

--- a/packages/backend/src/ee/models/ServiceAccountModel.ts
+++ b/packages/backend/src/ee/models/ServiceAccountModel.ts
@@ -15,7 +15,7 @@ import * as crypto from 'crypto';
 import { Knex } from 'knex';
 import { OrganizationMembershipsTableName } from '../../database/entities/organizationMemberships';
 import { RolesTableName } from '../../database/entities/roles';
-import { DbUser } from '../../database/entities/users';
+import { DbUser, UserTableName } from '../../database/entities/users';
 import { deprecatedHash, hash } from '../../utils/hash';
 import {
     DbServiceAccounts,
@@ -335,6 +335,16 @@ export class ServiceAccountModel {
                 );
             }
 
+            const backingUser = await trx(UserTableName)
+                .where('user_uuid', existing.service_account_user_uuid)
+                .first('user_id')
+                .forUpdate();
+            if (!backingUser) {
+                throw new UnexpectedDatabaseError(
+                    `Service account ${serviceAccountUuid} is missing its backing user`,
+                );
+            }
+
             const serviceAccountUpdate: DbUpdateServiceAccount = {
                 description: data.description,
             };
@@ -378,9 +388,14 @@ export class ServiceAccountModel {
                     );
             }
 
-            await trx(ServiceAccountsTableName)
+            const updatedServiceAccounts = await trx(ServiceAccountsTableName)
                 .update(serviceAccountUpdate)
                 .where('service_account_uuid', serviceAccountUuid);
+            if (updatedServiceAccounts === 0) {
+                throw new NotFoundError(
+                    `Service account ${serviceAccountUuid} no longer exists`,
+                );
+            }
             await trx('users')
                 .update({ first_name: data.description })
                 .where('user_uuid', existing.service_account_user_uuid);

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -264,6 +264,27 @@ describe('FeatureFlagModel', () => {
 
             expect(result).toEqual({ id: DB_FLAG, enabled: true });
         });
+
+        it('uses the supplied transaction executor for database resolution', async () => {
+            const defaultDatabase = vi.fn(() => {
+                throw new Error('default database should not be used');
+            }) as unknown as Knex;
+            const trx = buildFakeDatabase({
+                flag: { default_enabled: true },
+            });
+            const model = buildModel({}, defaultDatabase);
+
+            await expect(
+                model.get(
+                    {
+                        featureFlagId: DB_FLAG,
+                        user: dbUser,
+                    },
+                    { trx },
+                ),
+            ).resolves.toEqual({ id: DB_FLAG, enabled: true });
+            expect(defaultDatabase).not.toHaveBeenCalled();
+        });
     });
 
     describe('default_enabled honoured over env fallback', () => {

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -15,6 +15,8 @@ export type FeatureFlagLogicArgs = {
     featureFlagId: string;
 };
 
+type FeatureFlagQueryOptions = { trx?: Knex };
+
 export class FeatureFlagModel {
     protected readonly database: Knex;
 
@@ -22,7 +24,10 @@ export class FeatureFlagModel {
 
     protected featureFlagHandlers: Record<
         string,
-        (args: FeatureFlagLogicArgs) => Promise<FeatureFlag>
+        (
+            args: FeatureFlagLogicArgs,
+            options?: FeatureFlagQueryOptions,
+        ) => Promise<FeatureFlag>
     >;
 
     constructor(args: { database: Knex; lightdashConfig: LightdashConfig }) {
@@ -35,15 +40,19 @@ export class FeatureFlagModel {
                 this.getEnableTimezoneSupportEnabled.bind(this),
             [FeatureFlags.EnableDataApps]:
                 this.getEnableDataAppsEnabled.bind(this),
-            [FeatureFlags.ResultsCacheEnabled]: (flagArgs) =>
+            [FeatureFlags.ResultsCacheEnabled]: (flagArgs, options) =>
                 this.getWithEnvFallback(
                     flagArgs,
                     this.lightdashConfig.results.cacheEnabled,
+                    options,
                 ),
         };
     }
 
-    public async get(args: FeatureFlagLogicArgs): Promise<FeatureFlag> {
+    public async get(
+        args: FeatureFlagLogicArgs,
+        options: FeatureFlagQueryOptions = {},
+    ): Promise<FeatureFlag> {
         // 1a. Check env var enable-allowlist (self-hosted escape hatch)
         if (this.lightdashConfig.enabledFeatureFlags.has(args.featureFlagId)) {
             return { id: args.featureFlagId, enabled: true };
@@ -57,11 +66,11 @@ export class FeatureFlagModel {
         // 2. Check per-flag config handlers
         const handler = this.featureFlagHandlers[args.featureFlagId];
         if (handler) {
-            return handler(args);
+            return handler(args, options);
         }
 
         // 3. Check database (user override > org override > flag default)
-        const dbResult = await this.tryGetFromDatabase(args);
+        const dbResult = await this.tryGetFromDatabase(args, options);
         if (dbResult !== null) {
             return dbResult;
         }
@@ -82,21 +91,23 @@ export class FeatureFlagModel {
 
     private async getEnableTimezoneSupportEnabled(
         args: FeatureFlagLogicArgs,
+        options: FeatureFlagQueryOptions = {},
     ): Promise<FeatureFlag> {
         if (this.lightdashConfig.query.enableTimezoneSupport) {
             return { id: args.featureFlagId, enabled: true };
         }
-        const dbResult = await this.tryGetFromDatabase(args);
+        const dbResult = await this.tryGetFromDatabase(args, options);
         return dbResult ?? { id: args.featureFlagId, enabled: false };
     }
 
     private async getEnableDataAppsEnabled(
         args: FeatureFlagLogicArgs,
+        options: FeatureFlagQueryOptions = {},
     ): Promise<FeatureFlag> {
         if (this.lightdashConfig.appRuntime.enabled) {
             return { id: args.featureFlagId, enabled: true };
         }
-        const dbResult = await this.tryGetFromDatabase(args);
+        const dbResult = await this.tryGetFromDatabase(args, options);
         return dbResult ?? { id: args.featureFlagId, enabled: false };
     }
 
@@ -106,16 +117,18 @@ export class FeatureFlagModel {
     private async getWithEnvFallback(
         args: FeatureFlagLogicArgs,
         envFallback: boolean,
+        options: FeatureFlagQueryOptions = {},
     ): Promise<FeatureFlag> {
-        const dbResult = await this.tryGetFromDatabase(args);
+        const dbResult = await this.tryGetFromDatabase(args, options);
         return dbResult ?? { id: args.featureFlagId, enabled: envFallback };
     }
 
     protected async tryGetFromDatabase(
         args: FeatureFlagLogicArgs,
+        { trx = this.database }: FeatureFlagQueryOptions = {},
     ): Promise<FeatureFlag | null> {
         try {
-            return await this.getFromDatabase(args);
+            return await FeatureFlagModel.getFromDatabase(args, trx);
         } catch (e) {
             Logger.warn(
                 `Failed to check feature flag ${args.featureFlagId} from database, falling through: ${e}`,
@@ -124,10 +137,11 @@ export class FeatureFlagModel {
         }
     }
 
-    private async getFromDatabase(
+    private static async getFromDatabase(
         args: FeatureFlagLogicArgs,
+        trx: Knex,
     ): Promise<FeatureFlag | null> {
-        const flag = await this.database(FeatureFlagsTableName)
+        const flag = await trx(FeatureFlagsTableName)
             .where('flag_id', args.featureFlagId)
             .first();
 
@@ -141,9 +155,7 @@ export class FeatureFlagModel {
         // `user.userUuid`; passing it to a `uuid` column raises a Postgres
         // type error and would prevent the org-override lookup below.
         if (args.user?.userUuid && UUID_REGEX.test(args.user.userUuid)) {
-            const userOverride = await this.database(
-                FeatureFlagOverridesTableName,
-            )
+            const userOverride = await trx(FeatureFlagOverridesTableName)
                 .where('flag_id', args.featureFlagId)
                 .where('user_uuid', args.user.userUuid)
                 .first();
@@ -156,9 +168,7 @@ export class FeatureFlagModel {
         }
 
         if (args.user?.organizationUuid) {
-            const orgOverride = await this.database(
-                FeatureFlagOverridesTableName,
-            )
+            const orgOverride = await trx(FeatureFlagOverridesTableName)
                 .where('flag_id', args.featureFlagId)
                 .where('organization_uuid', args.user.organizationUuid)
                 .whereNull('user_uuid')

--- a/packages/backend/src/models/GroupsModel.test.ts
+++ b/packages/backend/src/models/GroupsModel.test.ts
@@ -1,6 +1,9 @@
-import { ProjectMemberRole } from '@lightdash/common';
+import { ProjectMemberRole, PromotionAction } from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { GroupTableName } from '../database/entities/groups';
+import { OrganizationTableName } from '../database/entities/organizations';
 import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
 import { GroupsModel } from './GroupsModel';
 
@@ -72,5 +75,42 @@ describe('GroupsModel', () => {
         expect(query.sql).toContain('set "role" = $1, "role_uuid" = $2 where');
         expect(query.bindings).toContain(ProjectMemberRole.VIEWER);
         expect(query.bindings).toContain(null);
+    });
+
+    it('locks an existing group before replacing memberships as code', async () => {
+        tracker.on
+            .select(OrganizationTableName)
+            .responseOnce({ organization_id: 2 });
+        tracker.on
+            .select(GroupTableName)
+            .responseOnce({ group_uuid: 'group-uuid' });
+        tracker.on
+            .select(GroupMembershipTableName)
+            .responseOnce([{ user_id: 3 }]);
+        tracker.on.delete(GroupMembershipTableName).responseOnce(1);
+        tracker.on.update(GroupTableName).responseOnce(1);
+
+        await expect(
+            model.upsertGroupAsCode({
+                organizationUuid: 'organization-uuid',
+                name: 'Finance',
+                memberEmails: [],
+                actorUserUuid: 'actor-user-uuid',
+            }),
+        ).resolves.toEqual({
+            action: PromotionAction.UPDATE,
+            groupUuid: 'group-uuid',
+        });
+
+        const groupLockIndex = tracker.history.select.findIndex(
+            ({ sql }) =>
+                sql.includes(`from "${GroupTableName}"`) &&
+                sql.includes('for update'),
+        );
+        const membershipReadIndex = tracker.history.select.findIndex(
+            ({ sql }) => sql.includes(`from "${GroupMembershipTableName}"`),
+        );
+        expect(groupLockIndex).toBeGreaterThanOrEqual(0);
+        expect(membershipReadIndex).toBeGreaterThan(groupLockIndex);
     });
 });

--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -116,8 +116,9 @@ export class GroupsModel {
             name?: string; // will exact match on name
         },
         paginateArgs?: KnexPaginateArgs,
+        { trx = this.database }: { trx?: Knex } = {},
     ): Promise<KnexPaginatedData<Group[]>> {
-        let query = this.database('groups')
+        let query = trx('groups')
             .innerJoin(
                 'organizations',
                 'groups.organization_id',
@@ -239,12 +240,15 @@ export class GroupsModel {
         };
     }
 
-    async findUserInGroups(filters: {
-        userUuid: string;
-        organizationUuid: string;
-        groupUuids?: string[];
-    }): Promise<GroupMembership[]> {
-        const query = this.database(GroupMembershipTableName)
+    async findUserInGroups(
+        filters: {
+            userUuid: string;
+            organizationUuid: string;
+            groupUuids?: string[];
+        },
+        { trx = this.database }: { trx?: Knex } = {},
+    ): Promise<GroupMembership[]> {
+        const query = trx(GroupMembershipTableName)
             .innerJoin(
                 UserTableName,
                 `${GroupMembershipTableName}.user_id`,
@@ -272,7 +276,7 @@ export class GroupsModel {
             );
         }
 
-        const rows = await query;
+        const rows = await query.forShare();
         return rows.map((row) => ({
             groupUuid: row.group_uuid,
             userUuid: row.user_uuid,
@@ -701,7 +705,8 @@ export class GroupsModel {
                     organization_id: organization.organization_id,
                     name,
                 })
-                .first<Pick<DbGroup, 'group_uuid'>>('group_uuid');
+                .first<Pick<DbGroup, 'group_uuid'>>('group_uuid')
+                .forUpdate();
 
             if (!existingGroup) {
                 const [createdGroup] = await trx(GroupTableName)

--- a/packages/backend/src/models/OrganizationMemberProfileModel.test.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.test.ts
@@ -1,0 +1,81 @@
+import { OrganizationMemberRole } from '@lightdash/common';
+import knex from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { UserTableName } from '../database/entities/users';
+import { OrganizationMemberProfileModel } from './OrganizationMemberProfileModel';
+
+describe('OrganizationMemberProfileModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new OrganizationMemberProfileModel({ database });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    describe('findOrganizationMembersByEmails', () => {
+        it('does not query for an empty email list', async () => {
+            await expect(
+                model.findOrganizationMembersByEmails('organization-uuid', []),
+            ).resolves.toEqual([]);
+            expect(tracker.history.select).toHaveLength(0);
+        });
+
+        it('normalizes emails and returns every matching member', async () => {
+            const now = new Date('2026-01-01T00:00:00.000Z');
+            tracker.on.select(OrganizationMembershipsTableName).responseOnce([
+                {
+                    user_uuid: 'user-1',
+                    user_created_at: now,
+                    user_updated_at: now,
+                    first_name: 'First',
+                    last_name: 'Member',
+                    is_active: true,
+                    email: 'member@example.com',
+                    organization_uuid: 'organization-uuid',
+                    role: OrganizationMemberRole.MEMBER,
+                    role_uuid: null,
+                    expires_at: undefined,
+                    avatar_gradient: null,
+                    avatar_content_hash: null,
+                },
+                {
+                    user_uuid: 'user-2',
+                    user_created_at: now,
+                    user_updated_at: now,
+                    first_name: 'Duplicate',
+                    last_name: 'Member',
+                    is_active: true,
+                    email: 'MEMBER@example.com',
+                    organization_uuid: 'organization-uuid',
+                    role: OrganizationMemberRole.MEMBER,
+                    role_uuid: null,
+                    expires_at: undefined,
+                    avatar_gradient: null,
+                    avatar_content_hash: null,
+                },
+            ]);
+            tracker.on.select(UserTableName).responseOnce([
+                { user_uuid: 'user-1', has_authentication: true },
+                { user_uuid: 'user-2', has_authentication: true },
+            ]);
+
+            const members = await model.findOrganizationMembersByEmails(
+                'organization-uuid',
+                [' MEMBER@example.com ', 'member@example.com'],
+            );
+
+            expect(members).toHaveLength(2);
+            const memberQuery = tracker.history.select[0];
+            expect(memberQuery.sql).toContain('LOWER');
+            expect(memberQuery.sql).toContain('"users"."is_internal"');
+            expect(memberQuery.bindings).toContain('organization-uuid');
+            expect(memberQuery.bindings).toContainEqual(['member@example.com']);
+        });
+    });
+});

--- a/packages/backend/src/models/OrganizationMemberProfileModel.ts
+++ b/packages/backend/src/models/OrganizationMemberProfileModel.ts
@@ -259,6 +259,47 @@ export class OrganizationMemberProfileModel {
         );
     }
 
+    async findOrganizationMembersByEmails(
+        organizationUuid: string,
+        emails: string[],
+    ): Promise<OrganizationMemberProfile[]> {
+        const normalizedEmails = [
+            ...new Set(emails.map((email) => email.trim().toLowerCase())),
+        ];
+        if (normalizedEmails.length === 0) return [];
+
+        const members = await this.queryBuilder()
+            .where(
+                `${OrganizationTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .whereRaw('LOWER(??) = ANY(?::text[])', [
+                `${EmailTableName}.email`,
+                normalizedEmails,
+            ])
+            .select<DbOrganizationMemberProfile[]>(SelectColumns)
+            .orderBy(`${EmailTableName}.email`, 'asc')
+            .orderBy(`${UserTableName}.user_uuid`, 'asc');
+
+        const usersHaveAuthenticationRows =
+            await UserModel.findIfUsersHaveAuthentication(this.database, {
+                userUuids: members.map((member) => member.user_uuid),
+            });
+        const usersHaveAuthenticationMap = new Map(
+            usersHaveAuthenticationRows.map((row) => [
+                row.user_uuid,
+                row.has_authentication,
+            ]),
+        );
+
+        return members.map((member) =>
+            OrganizationMemberProfileModel.parseRow(
+                member,
+                usersHaveAuthenticationMap.get(member.user_uuid) || false,
+            ),
+        );
+    }
+
     async getOrganizationMembersAndGroups(
         organizationUuid: string,
         includeGroups?: number,

--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -114,6 +114,28 @@ describe('ProjectModel', () => {
         expect(tracker.history.update).toHaveLength(1);
     });
 
+    test('checks project membership without requiring an email row', async () => {
+        tracker.on
+            .select(({ sql }) => sql.includes(ProjectMembershipsTableName))
+            .response([{ user_id: 1 }]);
+
+        await expect(
+            model.hasProjectMembership(projectUuid, 'service-account-user'),
+        ).resolves.toBe(true);
+        expect(tracker.history.select).toHaveLength(1);
+        expect(tracker.history.select[0].sql).not.toContain('emails');
+    });
+
+    test('returns false when a user has no project membership', async () => {
+        tracker.on
+            .select(({ sql }) => sql.includes(ProjectMembershipsTableName))
+            .response([]);
+
+        await expect(
+            model.hasProjectMembership(projectUuid, 'unassigned-user'),
+        ).resolves.toBe(false);
+    });
+
     describe('should convert outdated metric filters in explores', () => {
         test('should add fieldRef property when metric filters have fieldId', () => {
             expect(

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1726,6 +1726,30 @@ export class ProjectModel {
         };
     }
 
+    async hasProjectMembership(
+        projectUuid: string,
+        userUuid: string,
+        { trx = this.database }: { trx?: Knex } = {},
+    ): Promise<boolean> {
+        const membership = await trx(ProjectMembershipsTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectMembershipsTableName}.project_id`,
+                `${ProjectTableName}.project_id`,
+            )
+            .innerJoin(
+                UserTableName,
+                `${ProjectMembershipsTableName}.user_id`,
+                `${UserTableName}.user_id`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .where(`${UserTableName}.user_uuid`, userUuid)
+            .first(`${ProjectMembershipsTableName}.user_id`)
+            .forShare();
+
+        return membership !== undefined;
+    }
+
     async getProjectAccess(
         projectUuid: string,
     ): Promise<ProjectMemberProfile[]> {

--- a/packages/backend/src/models/SpaceModel.test.ts
+++ b/packages/backend/src/models/SpaceModel.test.ts
@@ -1,0 +1,1032 @@
+import { ParameterError, SpaceMemberRole } from '@lightdash/common';
+import knex from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { EmailTableName } from '../database/entities/emails';
+import {
+    FeatureFlagOverridesTableName,
+    FeatureFlagsTableName,
+} from '../database/entities/featureFlags';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
+import { GroupTableName } from '../database/entities/groups';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
+import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
+import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
+import { ProjectTableName } from '../database/entities/projects';
+import { ScopedRolesTableName } from '../database/entities/roles';
+import {
+    SpaceGroupAccessTableName,
+    SpaceTableName,
+    SpaceUserAccessTableName,
+} from '../database/entities/spaces';
+import { UserTableName } from '../database/entities/users';
+import { SpaceModel } from './SpaceModel';
+
+describe('SpaceModel space access as code', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new SpaceModel({ database });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    beforeEach(() => {
+        tracker.on.select('pg_advisory_xact_lock').response({});
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    const projectRow = {
+        projectId: 1,
+        organizationId: 2,
+        organizationUuid: 'organization-uuid',
+    };
+
+    const spaceRow = {
+        organizationUuid: 'organization-uuid',
+        projectUuid: 'project-uuid',
+        uuid: 'space-uuid',
+        name: 'Finance',
+        slug: 'finance',
+        path: 'finance',
+        parentSpaceUuid: null,
+        inheritParentPermissions: false,
+        projectMemberAccessRole: null,
+        isDefaultUserSpace: false,
+    };
+
+    const applyInput = {
+        projectUuid: 'project-uuid',
+        userId: 1,
+        actorUserUuid: 'actor-user-uuid',
+        actorServiceAccountUuid: null,
+        spaceUuid: 'space-uuid',
+        name: 'Finance',
+        path: 'finance',
+        parentSpaceUuid: null,
+        inheritParentPermissionsOnCreate: false,
+    };
+
+    const mockProject = () => {
+        tracker.on
+            .select(({ sql }) => sql.includes(`from "${ProjectTableName}"`))
+            .responseOnce(projectRow);
+    };
+
+    type MockAuthorizationSourcesOptions = {
+        organizationRoleUuid?: string | null;
+        projectRoleUuid?: string | null;
+        groupUuids?: string[];
+        projectGroupRoles?: Array<{
+            groupUuid: string;
+            roleUuid: string | null;
+        }>;
+        directUsers?: Array<{
+            userUuid: string;
+            userId: number;
+            isInternal?: boolean;
+            hasOrganizationMembership?: boolean;
+            primaryEmail?: string | null;
+        }>;
+        desiredUsers?: Array<{
+            userUuid: string;
+            userId: number;
+            email: string;
+            isInternal?: boolean;
+            hasOrganizationMembership?: boolean;
+        }>;
+        directGroups?: Array<{
+            groupUuid: string;
+            organizationId: number;
+            name?: string;
+        }>;
+        desiredGroups?: Array<{
+            groupUuid: string;
+            organizationId: number;
+            name: string;
+        }>;
+        queriedDirectGroupUuids?: string[];
+        isActive?: boolean;
+        isInternal?: boolean;
+        serviceAccountExists?: boolean;
+    };
+
+    const mockAuthorizationSources = ({
+        organizationRoleUuid = null,
+        projectRoleUuid = null,
+        groupUuids = [],
+        projectGroupRoles = [],
+        directUsers = [],
+        desiredUsers = [],
+        directGroups = [],
+        desiredGroups = [],
+        queriedDirectGroupUuids = [],
+        isActive = true,
+        isInternal = false,
+        serviceAccountExists = true,
+    }: MockAuthorizationSourcesOptions = {}) => {
+        const identityUsers = [
+            ...directUsers.map((directUser) => ({
+                ...directUser,
+                primaryEmail:
+                    directUser.primaryEmail === undefined
+                        ? `${directUser.userUuid}@example.com`
+                        : directUser.primaryEmail,
+            })),
+            ...desiredUsers.map((desiredUser) => ({
+                ...desiredUser,
+                primaryEmail: desiredUser.email,
+            })),
+        ];
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${UserTableName}"`) &&
+                    sql.includes('"is_active" as "isActive"') &&
+                    sql.includes('for share'),
+            )
+            .responseOnce([
+                {
+                    userId: 1,
+                    userUuid: 'actor-user-uuid',
+                    isActive,
+                    isInternal,
+                },
+                ...identityUsers.map((identityUser) => ({
+                    userId: identityUser.userId,
+                    userUuid: identityUser.userUuid,
+                    isActive: true,
+                    isInternal: identityUser.isInternal ?? false,
+                })),
+            ]);
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(
+                        `from "${OrganizationMembershipsTableName}"`,
+                    ) && sql.includes('for share'),
+            )
+            .responseOnce([
+                { userId: 1, roleUuid: organizationRoleUuid },
+                ...identityUsers
+                    .filter(
+                        ({ hasOrganizationMembership = true }) =>
+                            hasOrganizationMembership,
+                    )
+                    .map(({ userId }) => ({ userId, roleUuid: null })),
+            ]);
+        if (identityUsers.length > 0) {
+            tracker.on
+                .select(
+                    ({ sql }) =>
+                        sql.includes(`from "${EmailTableName}"`) &&
+                        sql.includes('for share'),
+                )
+                .responseOnce(
+                    identityUsers.flatMap((identityUser) =>
+                        identityUser.primaryEmail === null
+                            ? []
+                            : [
+                                  {
+                                      userId: identityUser.userId,
+                                      email: identityUser.primaryEmail,
+                                  },
+                              ],
+                    ),
+                );
+        }
+        if (isInternal) {
+            tracker.on
+                .select(
+                    ({ sql }) =>
+                        sql.includes('from "service_accounts"') &&
+                        sql.includes('for share'),
+                )
+                .responseOnce(
+                    serviceAccountExists
+                        ? { service_account_uuid: 'service-account-uuid' }
+                        : undefined,
+                );
+        }
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${GroupMembershipTableName}"`) &&
+                    !sql.includes('for share'),
+            )
+            .responseOnce(groupUuids.map((groupUuid) => ({ groupUuid })));
+        if (
+            groupUuids.length > 0 ||
+            directGroups.length > 0 ||
+            desiredGroups.length > 0 ||
+            queriedDirectGroupUuids.length > 0
+        ) {
+            tracker.on
+                .select(
+                    ({ sql }) =>
+                        sql.includes(`from "${GroupTableName}"`) &&
+                        sql.includes('for share'),
+                )
+                .responseOnce([
+                    ...groupUuids.map((groupUuid) => ({
+                        groupUuid,
+                        organizationId: 2,
+                        name: groupUuid,
+                    })),
+                    ...directGroups,
+                    ...desiredGroups,
+                ]);
+        }
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${GroupMembershipTableName}"`) &&
+                    sql.includes('for share'),
+            )
+            .responseOnce(groupUuids.map((groupUuid) => ({ groupUuid })));
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${ProjectMembershipsTableName}"`) &&
+                    sql.includes('for share'),
+            )
+            .responseOnce(
+                projectRoleUuid === null
+                    ? undefined
+                    : { roleUuid: projectRoleUuid },
+            );
+        if (groupUuids.length > 0) {
+            tracker.on
+                .select(
+                    ({ sql }) =>
+                        sql.includes(`from "${ProjectGroupAccessTableName}"`) &&
+                        sql.includes('for share'),
+                )
+                .responseOnce(projectGroupRoles);
+        }
+        if (
+            organizationRoleUuid !== null ||
+            projectRoleUuid !== null ||
+            projectGroupRoles.some(({ roleUuid }) => roleUuid !== null)
+        ) {
+            tracker.on
+                .select(
+                    ({ sql }) =>
+                        sql.includes(`from "${ScopedRolesTableName}"`) &&
+                        sql.includes('for share'),
+                )
+                .responseOnce([]);
+        }
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${FeatureFlagsTableName}"`) &&
+                    sql.includes('for share'),
+            )
+            .responseOnce({ flag_id: 'custom-roles' });
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${FeatureFlagOverridesTableName}"`) &&
+                    sql.includes('for share'),
+            )
+            .responseOnce([]);
+    };
+
+    const mockExistingSpace = (
+        rows = [
+            {
+                spaceUuid: 'space-uuid',
+                parentSpaceUuid: null,
+                isDefaultUserSpace: false,
+            },
+        ],
+        accessChainRow: { parentSpaceUuid: string | null } | undefined = {
+            parentSpaceUuid: null,
+        },
+        {
+            directUserUuids = [],
+            directGroupUuids = [],
+            authorizationSources = {},
+        }: {
+            directUserUuids?: string[];
+            directGroupUuids?: string[];
+            authorizationSources?: MockAuthorizationSourcesOptions;
+        } = {},
+    ) => {
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceTableName}"`) &&
+                    sql.includes('for share'),
+            )
+            .responseOnce(accessChainRow);
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceTableName}"`) &&
+                    sql.includes('"path" =') &&
+                    sql.includes('for update'),
+            )
+            .responseOnce(rows);
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceUserAccessTableName}"`) &&
+                    !sql.includes('join') &&
+                    !sql.includes('for update'),
+            )
+            .responseOnce(directUserUuids.map((userUuid) => ({ userUuid })));
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceGroupAccessTableName}"`) &&
+                    !sql.includes('join') &&
+                    !sql.includes('for update'),
+            )
+            .responseOnce(directGroupUuids.map((groupUuid) => ({ groupUuid })));
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceUserAccessTableName}"`) &&
+                    sql.includes('for update'),
+            )
+            .responseOnce(directUserUuids.map((userUuid) => ({ userUuid })));
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceGroupAccessTableName}"`) &&
+                    sql.includes('for update'),
+            )
+            .responseOnce(directGroupUuids.map((groupUuid) => ({ groupUuid })));
+        mockAuthorizationSources({
+            ...authorizationSources,
+            queriedDirectGroupUuids: directGroupUuids,
+        });
+    };
+
+    const mockReturnedSpace = () => {
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceTableName}"`) &&
+                    sql.includes(`join "${ProjectTableName}"`),
+            )
+            .responseOnce([spaceRow]);
+    };
+
+    it('returns every active project space, including default spaces for the caller to filter', async () => {
+        mockReturnedSpace();
+
+        const result = await model.getSpacesByProjectUuid('project-uuid');
+
+        expect(result).toEqual([spaceRow]);
+        expect(tracker.history.select[0].sql).toContain(
+            `"${SpaceTableName}"."deleted_at" is null`,
+        );
+        expect(tracker.history.select[0].sql).not.toContain(
+            `"${SpaceTableName}"."is_default_user_space" =`,
+        );
+    });
+
+    it('resolves principals before replacing exact access', async () => {
+        mockProject();
+        tracker.on
+            .select(({ sql }) =>
+                sql.includes(`join "${OrganizationMembershipsTableName}"`),
+            )
+            .responseOnce([
+                {
+                    userUuid: 'user-uuid',
+                    email: 'owner@example.com',
+                    isInternal: false,
+                },
+            ]);
+        tracker.on
+            .select(GroupTableName)
+            .responseOnce([{ groupUuid: 'group-uuid', name: 'Finance team' }]);
+        mockExistingSpace(undefined, undefined, {
+            authorizationSources: {
+                desiredUsers: [
+                    {
+                        userUuid: 'user-uuid',
+                        userId: 2,
+                        email: 'owner@example.com',
+                    },
+                ],
+                desiredGroups: [
+                    {
+                        groupUuid: 'group-uuid',
+                        organizationId: 2,
+                        name: 'Finance team',
+                    },
+                ],
+            },
+        });
+        tracker.on
+            .select(({ sql }) =>
+                sql.includes(`from "${SpaceUserAccessTableName}"`),
+            )
+            .responseOnce([]);
+        tracker.on.update(SpaceTableName).responseOnce(1);
+        tracker.on.delete(SpaceUserAccessTableName).responseOnce(1);
+        tracker.on.delete(SpaceGroupAccessTableName).responseOnce(1);
+        tracker.on.insert(SpaceUserAccessTableName).responseOnce(1);
+        tracker.on.insert(SpaceGroupAccessTableName).responseOnce(1);
+        mockReturnedSpace();
+        const beforeMutation = vi.fn(async () => undefined);
+
+        await model.applySpaceAsCode(
+            {
+                ...applyInput,
+                access: {
+                    inheritParentPermissions: false,
+                    projectMemberAccessRole: SpaceMemberRole.VIEWER,
+                    users: [
+                        {
+                            email: 'OWNER@example.com',
+                            role: SpaceMemberRole.ADMIN,
+                        },
+                    ],
+                    groups: [
+                        {
+                            name: 'Finance team',
+                            role: SpaceMemberRole.EDITOR,
+                        },
+                    ],
+                },
+            },
+            { trx: database, beforeMutation },
+        );
+
+        expect(beforeMutation).toHaveBeenCalledWith(database, {
+            userAccess: [
+                {
+                    userUuid: 'user-uuid',
+                    role: SpaceMemberRole.ADMIN,
+                },
+            ],
+        });
+        expect(tracker.history.update).toHaveLength(1);
+        expect(tracker.history.delete).toHaveLength(2);
+        expect(tracker.history.insert).toHaveLength(2);
+        expect(tracker.history.insert[0].bindings).toEqual([
+            SpaceMemberRole.ADMIN,
+            'space-uuid',
+            'user-uuid',
+        ]);
+        expect(tracker.history.insert[1].bindings).toEqual([
+            'group-uuid',
+            SpaceMemberRole.EDITOR,
+            'space-uuid',
+        ]);
+    });
+
+    it('fails unresolved users before mutating the space', async () => {
+        mockProject();
+        mockExistingSpace();
+        tracker.on
+            .select(({ sql }) =>
+                sql.includes(`join "${OrganizationMembershipsTableName}"`),
+            )
+            .responseOnce([]);
+
+        await expect(
+            model.applySpaceAsCode(
+                {
+                    ...applyInput,
+                    access: {
+                        inheritParentPermissions: false,
+                        projectMemberAccessRole: null,
+                        users: [
+                            {
+                                email: 'missing@example.com',
+                                role: SpaceMemberRole.ADMIN,
+                            },
+                        ],
+                        groups: [],
+                    },
+                },
+                { trx: database },
+            ),
+        ).rejects.toThrow(ParameterError);
+
+        expect(tracker.history.update).toHaveLength(0);
+        expect(tracker.history.delete).toHaveLength(0);
+        expect(tracker.history.insert).toHaveLength(0);
+    });
+
+    it('rejects a requested user whose portable identity changed before locking', async () => {
+        mockProject();
+        tracker.on
+            .select(({ sql }) =>
+                sql.includes(`join "${OrganizationMembershipsTableName}"`),
+            )
+            .responseOnce([
+                {
+                    userUuid: 'user-uuid',
+                    email: 'owner@example.com',
+                    isInternal: false,
+                },
+            ]);
+        mockExistingSpace(undefined, undefined, {
+            authorizationSources: {
+                desiredUsers: [
+                    {
+                        userUuid: 'user-uuid',
+                        userId: 2,
+                        email: 'renamed@example.com',
+                    },
+                ],
+            },
+        });
+        const beforeMutation = vi.fn(async () => undefined);
+
+        await expect(
+            model.applySpaceAsCode(
+                {
+                    ...applyInput,
+                    access: {
+                        inheritParentPermissions: false,
+                        projectMemberAccessRole: null,
+                        users: [
+                            {
+                                email: 'owner@example.com',
+                                role: SpaceMemberRole.ADMIN,
+                            },
+                        ],
+                        groups: [],
+                    },
+                },
+                { trx: database, beforeMutation },
+            ),
+        ).rejects.toThrow('requested space user identity changed');
+
+        expect(beforeMutation).not.toHaveBeenCalled();
+        expect(tracker.history.update).toHaveLength(0);
+        expect(tracker.history.delete).toHaveLength(0);
+    });
+
+    it('removes unsupported existing direct users when access is replaced', async () => {
+        mockProject();
+        mockExistingSpace(undefined, undefined, {
+            directUserUuids: ['service-account-uuid'],
+            authorizationSources: {
+                directUsers: [
+                    {
+                        userUuid: 'service-account-uuid',
+                        userId: 2,
+                        isInternal: true,
+                    },
+                ],
+            },
+        });
+        tracker.on
+            .select(({ sql }) =>
+                sql.includes(`from "${SpaceUserAccessTableName}"`),
+            )
+            .responseOnce([]);
+        tracker.on.update(SpaceTableName).responseOnce(1);
+        tracker.on.delete(SpaceUserAccessTableName).responseOnce(1);
+        tracker.on.delete(SpaceGroupAccessTableName).responseOnce(1);
+        mockReturnedSpace();
+
+        await model.applySpaceAsCode(
+            {
+                ...applyInput,
+                access: {
+                    inheritParentPermissions: false,
+                    projectMemberAccessRole: null,
+                    users: [],
+                    groups: [],
+                },
+            },
+            { trx: database },
+        );
+
+        expect(tracker.history.update).toHaveLength(1);
+        expect(tracker.history.delete).toHaveLength(2);
+    });
+
+    it('runs the final lockout guard after locking access and before mutation', async () => {
+        mockProject();
+        mockExistingSpace();
+        const beforeMutation = vi.fn(async () => {
+            throw new ParameterError('policy changed concurrently');
+        });
+
+        await expect(
+            model.applySpaceAsCode(
+                {
+                    ...applyInput,
+                    access: {
+                        inheritParentPermissions: false,
+                        projectMemberAccessRole: null,
+                        users: [],
+                        groups: [],
+                    },
+                },
+                { trx: database, beforeMutation },
+            ),
+        ).rejects.toThrow('policy changed concurrently');
+
+        expect(beforeMutation).toHaveBeenCalledWith(database, {
+            userAccess: [],
+        });
+        expect(tracker.history.update).toHaveLength(0);
+        expect(tracker.history.delete).toHaveLength(0);
+    });
+
+    it('locks authorization sources in a deadlock-safe order before the final check', async () => {
+        mockProject();
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceTableName}"`) &&
+                    sql.includes('for share'),
+            )
+            .responseOnce({ parentSpaceUuid: null });
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceTableName}"`) &&
+                    sql.includes('"path" =') &&
+                    sql.includes('for update'),
+            )
+            .responseOnce([
+                {
+                    spaceUuid: 'space-uuid',
+                    parentSpaceUuid: null,
+                    isDefaultUserSpace: false,
+                },
+            ]);
+        mockAuthorizationSources({
+            organizationRoleUuid: 'organization-role-uuid',
+            projectRoleUuid: 'project-role-uuid',
+            groupUuids: ['group-b', 'group-a'],
+            projectGroupRoles: [
+                {
+                    groupUuid: 'group-a',
+                    roleUuid: 'group-role-uuid',
+                },
+            ],
+            isInternal: true,
+        });
+        const beforeMutation = vi.fn(async () => {
+            throw new ParameterError('stop before mutation');
+        });
+
+        await expect(
+            model.applySpaceAsCode(
+                {
+                    ...applyInput,
+                    actorServiceAccountUuid: 'service-account-uuid',
+                },
+                { trx: database, beforeMutation },
+            ),
+        ).rejects.toThrow('stop before mutation');
+
+        const shareLocks = tracker.history.select
+            .filter(({ sql }) => sql.includes('for share'))
+            .map(({ sql }) => {
+                if (sql.includes(`from "${SpaceTableName}"`)) return 'space';
+                if (sql.includes(`from "${UserTableName}"`)) return 'user';
+                if (sql.includes(`from "${OrganizationMembershipsTableName}"`))
+                    return 'organizationMembership';
+                if (sql.includes('from "service_accounts"'))
+                    return 'serviceAccount';
+                if (sql.includes(`from "${GroupTableName}"`)) return 'group';
+                if (sql.includes(`from "${GroupMembershipTableName}"`))
+                    return 'groupMembership';
+                if (sql.includes(`from "${ProjectMembershipsTableName}"`))
+                    return 'projectMembership';
+                if (sql.includes(`from "${ProjectGroupAccessTableName}"`))
+                    return 'projectGroupAccess';
+                if (sql.includes(`from "${ScopedRolesTableName}"`))
+                    return 'scopedRole';
+                if (sql.includes(`from "${FeatureFlagsTableName}"`))
+                    return 'featureFlag';
+                if (sql.includes(`from "${FeatureFlagOverridesTableName}"`))
+                    return 'featureFlagOverride';
+                return 'unexpected';
+            });
+        expect(shareLocks).toEqual([
+            'space',
+            'user',
+            'organizationMembership',
+            'serviceAccount',
+            'group',
+            'groupMembership',
+            'projectMembership',
+            'projectGroupAccess',
+            'scopedRole',
+            'featureFlag',
+            'featureFlagOverride',
+        ]);
+        const groupLock = tracker.history.select.find(
+            ({ sql }) =>
+                sql.includes(`from "${GroupTableName}"`) &&
+                sql.includes('for share'),
+        );
+        expect(groupLock?.sql).toContain('order by "group_uuid" asc');
+        expect(beforeMutation).toHaveBeenCalledOnce();
+    });
+
+    it('rejects an inactive actor before the authorization callback', async () => {
+        mockProject();
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceTableName}"`) &&
+                    sql.includes('for share'),
+            )
+            .responseOnce({ parentSpaceUuid: null });
+        mockAuthorizationSources({ isActive: false });
+        const beforeMutation = vi.fn(async () => undefined);
+
+        await expect(
+            model.applySpaceAsCode(applyInput, {
+                trx: database,
+                beforeMutation,
+            }),
+        ).rejects.toThrow('no longer active');
+        expect(beforeMutation).not.toHaveBeenCalled();
+        expect(tracker.history.update).toHaveLength(0);
+    });
+
+    it('requires the exact authenticated service account to remain live', async () => {
+        mockProject();
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceTableName}"`) &&
+                    sql.includes('for share'),
+            )
+            .responseOnce({ parentSpaceUuid: null });
+        mockAuthorizationSources({
+            isInternal: true,
+            serviceAccountExists: false,
+        });
+        const beforeMutation = vi.fn(async () => undefined);
+
+        await expect(
+            model.applySpaceAsCode(
+                {
+                    ...applyInput,
+                    actorServiceAccountUuid: 'service-account-uuid',
+                },
+                { trx: database, beforeMutation },
+            ),
+        ).rejects.toThrow('service account no longer exists');
+        expect(beforeMutation).not.toHaveBeenCalled();
+        expect(tracker.history.update).toHaveLength(0);
+    });
+
+    it('serializes interactive direct access writes with as-code replacement', async () => {
+        tracker.on.insert(SpaceUserAccessTableName).responseOnce(1);
+
+        await model.addSpaceAccess(
+            'space-uuid',
+            'user-uuid',
+            SpaceMemberRole.EDITOR,
+        );
+
+        expect(
+            tracker.history.select.some(
+                ({ sql, bindings }) =>
+                    sql.includes('pg_advisory_xact_lock') &&
+                    bindings.includes('space-uuid'),
+            ),
+        ).toBe(true);
+        expect(tracker.history.insert).toHaveLength(1);
+    });
+
+    it('updates only the name when access is omitted', async () => {
+        mockProject();
+        mockExistingSpace();
+        tracker.on.update(SpaceTableName).responseOnce(1);
+        mockReturnedSpace();
+        const beforeMutation = vi.fn(async () => undefined);
+
+        await model.applySpaceAsCode(
+            { ...applyInput, name: 'Finance renamed' },
+            { trx: database, beforeMutation },
+        );
+
+        expect(beforeMutation).toHaveBeenCalledWith(database, {
+            userAccess: [],
+        });
+        expect(tracker.history.update).toHaveLength(1);
+        expect(tracker.history.update[0].sql).toContain('set "name" = $1');
+        expect(tracker.history.update[0].sql).not.toContain(
+            'inherit_parent_permissions',
+        );
+        expect(tracker.history.delete).toHaveLength(0);
+        expect(tracker.history.insert).toHaveLength(0);
+    });
+
+    it('rechecks path identity inside the write transaction', async () => {
+        mockProject();
+        mockExistingSpace([]);
+
+        await expect(
+            model.applySpaceAsCode(applyInput, { trx: database }),
+        ).rejects.toThrow('changed or became ambiguous');
+
+        expect(tracker.history.update).toHaveLength(0);
+        expect(tracker.history.delete).toHaveLength(0);
+        expect(tracker.history.insert).toHaveLength(0);
+        expect(
+            tracker.history.select.some(({ sql }) =>
+                sql.includes('pg_advisory_xact_lock'),
+            ),
+        ).toBe(true);
+    });
+
+    it('locks the full access chain before taking the target row update lock', async () => {
+        mockProject();
+        let chainQueryCount = 0;
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceTableName}"`) &&
+                    sql.includes('for share'),
+            )
+            .response(() => {
+                chainQueryCount += 1;
+                return chainQueryCount === 1
+                    ? { parentSpaceUuid: 'parent-space-uuid' }
+                    : { parentSpaceUuid: null };
+            });
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceTableName}"`) &&
+                    sql.includes('"path" =') &&
+                    sql.includes('for update'),
+            )
+            .responseOnce([
+                {
+                    spaceUuid: 'space-uuid',
+                    parentSpaceUuid: 'parent-space-uuid',
+                    isDefaultUserSpace: false,
+                },
+            ]);
+        mockAuthorizationSources();
+        const beforeMutation = vi.fn(async () => {
+            throw new ParameterError('stop before mutation');
+        });
+
+        await expect(
+            model.applySpaceAsCode(
+                { ...applyInput, parentSpaceUuid: 'parent-space-uuid' },
+                { trx: database, beforeMutation },
+            ),
+        ).rejects.toThrow('stop before mutation');
+
+        const advisoryLockBindings = tracker.history.select
+            .filter(({ sql }) => sql.includes('pg_advisory_xact_lock'))
+            .map(({ bindings }) => bindings);
+        expect(advisoryLockBindings).toEqual([
+            [2, 'project-uuid:space:finance'],
+            [3, 'space-uuid'],
+            [3, 'parent-space-uuid'],
+        ]);
+        const lastShareLockIndex = tracker.history.select.findLastIndex(
+            ({ sql }) => sql.includes('for share'),
+        );
+        const updateLockIndex = tracker.history.select.findIndex(({ sql }) =>
+            sql.includes('for update'),
+        );
+        expect(updateLockIndex).toBeGreaterThan(lastShareLockIndex);
+    });
+
+    it('copies parent direct access for legacy non-inheriting child creation', async () => {
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${ProjectTableName}"`) &&
+                    sql.includes('join "organizations"'),
+            )
+            .responseOnce(projectRow);
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceTableName}"`) &&
+                    sql.includes('for share'),
+            )
+            .responseOnce({ parentSpaceUuid: null });
+        mockAuthorizationSources();
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceTableName}"`) &&
+                    sql.includes('"path" =') &&
+                    sql.includes('for update'),
+            )
+            .responseOnce([]);
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceTableName}"`) &&
+                    sql.includes('"space_uuid" =') &&
+                    sql.includes('"project_id" ='),
+            )
+            .responseOnce({
+                path: 'parent',
+                isDefaultUserSpace: false,
+            });
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${ProjectTableName}"`) &&
+                    !sql.includes('join "organizations"'),
+            )
+            .responseOnce([{ project_id: 1 }]);
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceTableName}"`) &&
+                    sql.includes('"slug" ='),
+            )
+            .responseOnce(undefined);
+        tracker.on.insert(SpaceTableName).responseOnce([
+            {
+                space_uuid: 'child-space-uuid',
+                name: 'Child',
+                slug: 'child',
+                path: 'parent.child',
+                parent_space_uuid: 'parent-space-uuid',
+                inherit_parent_permissions: false,
+                project_member_access_role: null,
+                color_palette_uuid: null,
+            },
+        ]);
+        tracker.on.select(SpaceUserAccessTableName).responseOnce([
+            {
+                user_uuid: 'legacy-user-uuid',
+                space_role: SpaceMemberRole.ADMIN,
+            },
+        ]);
+        tracker.on.select(SpaceGroupAccessTableName).responseOnce([
+            {
+                group_uuid: 'legacy-group-uuid',
+                space_role: SpaceMemberRole.EDITOR,
+            },
+        ]);
+        tracker.on.insert(SpaceUserAccessTableName).responseOnce(1);
+        tracker.on.insert(SpaceGroupAccessTableName).responseOnce(1);
+        tracker.on
+            .select(
+                ({ sql }) =>
+                    sql.includes(`from "${SpaceTableName}"`) &&
+                    sql.includes(`join "${ProjectTableName}"`),
+            )
+            .responseOnce([
+                {
+                    ...spaceRow,
+                    uuid: 'child-space-uuid',
+                    name: 'Child',
+                    slug: 'child',
+                    path: 'parent.child',
+                    parentSpaceUuid: 'parent-space-uuid',
+                },
+            ]);
+
+        await model.applySpaceAsCode(
+            {
+                projectUuid: 'project-uuid',
+                userId: 1,
+                actorUserUuid: 'actor-user-uuid',
+                actorServiceAccountUuid: null,
+                spaceUuid: null,
+                name: 'Child',
+                path: 'parent.child',
+                parentSpaceUuid: 'parent-space-uuid',
+                inheritParentPermissionsOnCreate: false,
+                copyParentAccessOnLegacyCreate: true,
+            },
+            { trx: database },
+        );
+
+        const userCopy = tracker.history.insert.find(({ sql }) =>
+            sql.includes(`"${SpaceUserAccessTableName}"`),
+        );
+        const groupCopy = tracker.history.insert.find(({ sql }) =>
+            sql.includes(`"${SpaceGroupAccessTableName}"`),
+        );
+        expect(userCopy?.bindings).toContain('child-space-uuid');
+        expect(userCopy?.bindings).toContain('legacy-user-uuid');
+        expect(groupCopy?.bindings).toContain('child-space-uuid');
+        expect(groupCopy?.bindings).toContain('legacy-group-uuid');
+        const actorUserLocks = tracker.history.select.filter(
+            ({ sql }) =>
+                sql.includes(`from "${UserTableName}"`) &&
+                sql.includes('for share'),
+        );
+        expect(actorUserLocks).toHaveLength(1);
+        expect(actorUserLocks[0].bindings).toContain('actor-user-uuid');
+    });
+});

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -2,6 +2,8 @@ import {
     ChartKind,
     ChartSourceType,
     ChartType,
+    CommercialFeatureFlags,
+    ForbiddenError,
     getLtreePathFromSlug,
     NotFoundError,
     ParameterError,
@@ -20,7 +22,14 @@ import {
     DashboardsTableName,
     DashboardVersionsTableName,
 } from '../database/entities/dashboards';
+import { EmailTableName } from '../database/entities/emails';
+import {
+    FeatureFlagOverridesTableName,
+    FeatureFlagsTableName,
+} from '../database/entities/featureFlags';
+import { GroupMembershipTableName } from '../database/entities/groupMemberships';
 import { GroupTableName } from '../database/entities/groups';
+import { OrganizationMembershipsTableName } from '../database/entities/organizationMemberships';
 import {
     DbOrganization,
     OrganizationTableName,
@@ -33,7 +42,10 @@ import {
     PinnedListTableName,
     PinnedSpaceTableName,
 } from '../database/entities/pinnedList';
+import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
+import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
 import { DbProject, ProjectTableName } from '../database/entities/projects';
+import { ScopedRolesTableName } from '../database/entities/roles';
 import {
     SavedChartsTableName,
     SavedChartVersionsTableName,
@@ -50,6 +62,8 @@ import { DbValidationTable } from '../database/entities/validation';
 import { traceSpan } from '../tracing/tracing';
 import { wrapSentryTransaction } from '../utils';
 import {
+    acquireProjectSlugLock,
+    acquireSpaceAccessLock,
     generateUniqueSlug,
     generateUniqueSpaceSlug,
 } from '../utils/SlugUtils';
@@ -58,6 +72,52 @@ import type { GetDashboardDetailsQuery } from './DashboardModel/DashboardModel';
 type SpaceModelArguments = {
     database: Knex;
 };
+
+const SERVICE_ACCOUNTS_TABLE_NAME = 'service_accounts';
+
+export type SpaceCodeModel = {
+    organizationUuid: string;
+    projectUuid: string;
+    uuid: string;
+    name: string;
+    slug: string;
+    path: string;
+    parentSpaceUuid: string | null;
+    inheritParentPermissions: boolean;
+    projectMemberAccessRole: SpaceMemberRole | null;
+    isDefaultUserSpace: boolean;
+};
+
+export type SpaceCodeAccessInput = {
+    inheritParentPermissions: boolean;
+    projectMemberAccessRole: SpaceMemberRole | null;
+    users: Array<{ email: string; role: SpaceMemberRole }>;
+    groups: Array<{ name: string; role: SpaceMemberRole }>;
+};
+
+export type ResolvedSpaceCodeUserAccess = {
+    userUuid: string;
+    role: SpaceMemberRole;
+};
+
+export type ApplySpaceAsCodeInput = {
+    projectUuid: string;
+    userId: number;
+    actorUserUuid: string;
+    actorServiceAccountUuid: string | null;
+    spaceUuid: string | null;
+    name: string;
+    path: string;
+    parentSpaceUuid: string | null;
+    inheritParentPermissionsOnCreate: boolean;
+    copyParentAccessOnLegacyCreate?: boolean;
+    access?: SpaceCodeAccessInput;
+};
+
+type SpaceCodeQueryRow = Omit<SpaceCodeModel, 'projectMemberAccessRole'> & {
+    projectMemberAccessRole: string | null;
+};
+
 export class SpaceModel {
     private database: Knex;
 
@@ -66,6 +126,906 @@ export class SpaceModel {
     constructor(args: SpaceModelArguments) {
         this.database = args.database;
         this.MOST_POPULAR_OR_RECENTLY_UPDATED_LIMIT = 10;
+    }
+
+    private static async querySpacesForCode(
+        {
+            projectUuid,
+            path,
+            spaceUuid,
+        }: {
+            projectUuid: string;
+            path?: string;
+            spaceUuid?: string;
+        },
+        trx: Knex,
+    ): Promise<SpaceCodeModel[]> {
+        const query = trx(SpaceTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .select<SpaceCodeQueryRow[]>({
+                organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                projectUuid: `${ProjectTableName}.project_uuid`,
+                uuid: `${SpaceTableName}.space_uuid`,
+                name: `${SpaceTableName}.name`,
+                slug: `${SpaceTableName}.slug`,
+                path: `${SpaceTableName}.path`,
+                parentSpaceUuid: `${SpaceTableName}.parent_space_uuid`,
+                inheritParentPermissions: `${SpaceTableName}.inherit_parent_permissions`,
+                projectMemberAccessRole: `${SpaceTableName}.project_member_access_role`,
+                isDefaultUserSpace: `${SpaceTableName}.is_default_user_space`,
+            });
+
+        if (path !== undefined) {
+            void query.where(`${SpaceTableName}.path`, path);
+        }
+        if (spaceUuid !== undefined) {
+            void query.where(`${SpaceTableName}.space_uuid`, spaceUuid);
+        }
+
+        const rows = await query
+            .orderByRaw('nlevel(??)', [`${SpaceTableName}.path`])
+            .orderBy(`${SpaceTableName}.path`)
+            .orderBy(`${SpaceTableName}.space_uuid`);
+
+        return rows.map((row) => ({
+            ...row,
+            projectMemberAccessRole:
+                (row.projectMemberAccessRole as SpaceMemberRole) ?? null,
+        }));
+    }
+
+    async getSpacesByProjectUuid(
+        projectUuid: string,
+        { trx = this.database }: { trx?: Knex } = {},
+    ): Promise<SpaceCodeModel[]> {
+        return SpaceModel.querySpacesForCode({ projectUuid }, trx);
+    }
+
+    async findByProjectAndPath(
+        projectUuid: string,
+        path: string,
+        { trx = this.database }: { trx?: Knex } = {},
+    ): Promise<SpaceCodeModel[]> {
+        return SpaceModel.querySpacesForCode({ projectUuid, path }, trx);
+    }
+
+    private static async lockSpaceAccessChain(
+        trx: Knex,
+        projectId: number,
+        startingSpaceUuid: string,
+        visitedSpaceUuids = new Set<string>(),
+    ): Promise<void> {
+        if (visitedSpaceUuids.has(startingSpaceUuid)) {
+            throw new ParameterError('Space hierarchy contains a parent cycle');
+        }
+        visitedSpaceUuids.add(startingSpaceUuid);
+
+        await acquireSpaceAccessLock(trx, startingSpaceUuid);
+        const space: { parentSpaceUuid: string | null } | undefined = await trx(
+            SpaceTableName,
+        )
+            .where({
+                project_id: projectId,
+                space_uuid: startingSpaceUuid,
+            })
+            .whereNull('deleted_at')
+            .first({ parentSpaceUuid: 'parent_space_uuid' })
+            .forShare();
+
+        if (space === undefined) {
+            throw new ParameterError(
+                'Space hierarchy changed while applying space as code',
+            );
+        }
+
+        if (space.parentSpaceUuid !== null) {
+            await SpaceModel.lockSpaceAccessChain(
+                trx,
+                projectId,
+                space.parentSpaceUuid,
+                visitedSpaceUuids,
+            );
+        }
+    }
+
+    private static async lockActorAuthorizationSources(
+        trx: Knex,
+        {
+            userId,
+            userUuid,
+            serviceAccountUuid,
+            organizationId,
+            organizationUuid,
+            projectId,
+            projectUuid,
+            directUserUuids,
+            directGroupUuids,
+            desiredUsers,
+            desiredGroups,
+            directAccessSpaceUuid,
+        }: {
+            userId: number;
+            userUuid: string;
+            serviceAccountUuid: string | null;
+            organizationId: number;
+            organizationUuid: string;
+            projectId: number;
+            projectUuid: string;
+            directUserUuids: string[];
+            directGroupUuids: string[];
+            desiredUsers: Array<{ userUuid: string; email: string }>;
+            desiredGroups: Array<{ groupUuid: string; name: string }>;
+            directAccessSpaceUuid: string | null;
+        },
+    ): Promise<void> {
+        const userUuids = [
+            ...new Set([
+                userUuid,
+                ...directUserUuids,
+                ...desiredUsers.map((desiredUser) => desiredUser.userUuid),
+            ]),
+        ].sort();
+        const lockedUsers = await trx(UserTableName)
+            .whereIn('user_uuid', userUuids)
+            .select<
+                Array<{
+                    userId: number;
+                    userUuid: string;
+                    isActive: boolean;
+                    isInternal: boolean;
+                }>
+            >({
+                userId: 'user_id',
+                userUuid: 'user_uuid',
+                isActive: 'is_active',
+                isInternal: 'is_internal',
+            })
+            .orderBy('user_uuid')
+            .forShare();
+        const actor = lockedUsers.find(
+            (lockedUser) =>
+                lockedUser.userId === userId &&
+                lockedUser.userUuid === userUuid,
+        );
+        if (actor === undefined) {
+            throw new ForbiddenError('The authenticated user no longer exists');
+        }
+        if (!actor.isActive) {
+            throw new ForbiddenError(
+                'The authenticated user is no longer active',
+            );
+        }
+        if (actor.isInternal !== (serviceAccountUuid !== null)) {
+            throw new ForbiddenError(
+                'The authenticated account identity is no longer valid',
+            );
+        }
+
+        const organizationMemberships = await trx(
+            OrganizationMembershipsTableName,
+        )
+            .where('organization_id', organizationId)
+            .whereIn(
+                'user_id',
+                lockedUsers.map((lockedUser) => lockedUser.userId),
+            )
+            .select<Array<{ userId: number; roleUuid: string | null }>>({
+                userId: 'user_id',
+                roleUuid: 'role_uuid',
+            })
+            .orderBy('user_id')
+            .forShare();
+        const organizationMembership = organizationMemberships.find(
+            (membership) => membership.userId === userId,
+        );
+        if (organizationMembership === undefined) {
+            throw new ForbiddenError(
+                'The authenticated user is no longer a member of this organization',
+            );
+        }
+
+        const lockedUsersByUuid = new Map(
+            lockedUsers.map((lockedUser) => [lockedUser.userUuid, lockedUser]),
+        );
+        const organizationMembershipUserIds = new Set(
+            organizationMemberships.map((membership) => membership.userId),
+        );
+        const identityUserIds = [
+            ...new Set(
+                [
+                    ...directUserUuids,
+                    ...desiredUsers.map((desiredUser) => desiredUser.userUuid),
+                ].flatMap((identityUserUuid) => {
+                    const identityUser =
+                        lockedUsersByUuid.get(identityUserUuid);
+                    return identityUser === undefined
+                        ? []
+                        : [identityUser.userId];
+                }),
+            ),
+        ];
+        const primaryEmails =
+            identityUserIds.length === 0
+                ? []
+                : await trx(EmailTableName)
+                      .whereIn('user_id', identityUserIds)
+                      .where('is_primary', true)
+                      .select<Array<{ userId: number; email: string }>>({
+                          userId: 'user_id',
+                          email: 'email',
+                      })
+                      .orderBy('user_id')
+                      .orderBy('email')
+                      .forShare();
+        const primaryEmailsByUserId = primaryEmails.reduce(
+            (emails, primaryEmail) =>
+                emails.set(primaryEmail.userId, [
+                    ...(emails.get(primaryEmail.userId) ?? []),
+                    primaryEmail.email,
+                ]),
+            new Map<number, string[]>(),
+        );
+        if (
+            desiredUsers.some(({ userUuid: desiredUserUuid, email }) => {
+                const desiredUser = lockedUsersByUuid.get(desiredUserUuid);
+                if (
+                    desiredUser === undefined ||
+                    desiredUser.isInternal ||
+                    !organizationMembershipUserIds.has(desiredUser.userId)
+                ) {
+                    return true;
+                }
+                const emails = primaryEmailsByUserId.get(desiredUser.userId);
+                return (
+                    emails?.length !== 1 ||
+                    emails[0].trim().toLowerCase() !== email
+                );
+            })
+        ) {
+            throw new ParameterError(
+                'A requested space user identity changed while applying access as code',
+            );
+        }
+
+        if (serviceAccountUuid !== null) {
+            const serviceAccount = await trx(SERVICE_ACCOUNTS_TABLE_NAME)
+                .where({
+                    service_account_uuid: serviceAccountUuid,
+                    service_account_user_uuid: userUuid,
+                    organization_uuid: organizationUuid,
+                })
+                .first('service_account_uuid')
+                .forShare();
+            if (serviceAccount === undefined) {
+                throw new ForbiddenError(
+                    'The authenticated service account no longer exists',
+                );
+            }
+        }
+
+        const actorGroupUuids = await trx(GroupMembershipTableName)
+            .where({ organization_id: organizationId, user_id: userId })
+            .select<Array<{ groupUuid: string }>>({
+                groupUuid: 'group_uuid',
+            })
+            .orderBy('group_uuid');
+        const groupUuids = [
+            ...new Set([
+                ...actorGroupUuids.map(({ groupUuid }) => groupUuid),
+                ...directGroupUuids,
+                ...desiredGroups.map((desiredGroup) => desiredGroup.groupUuid),
+            ]),
+        ].sort();
+        const lockedGroups =
+            groupUuids.length === 0
+                ? []
+                : await trx(GroupTableName)
+                      .whereIn('group_uuid', groupUuids)
+                      .select<
+                          Array<{
+                              groupUuid: string;
+                              organizationId: number;
+                              name: string;
+                          }>
+                      >({
+                          groupUuid: 'group_uuid',
+                          organizationId: 'organization_id',
+                          name: 'name',
+                      })
+                      .orderBy('group_uuid')
+                      .forShare();
+        const lockedGroupsByUuid = new Map(
+            lockedGroups.map((group) => [group.groupUuid, group]),
+        );
+        if (
+            desiredGroups.some(({ groupUuid, name }) => {
+                const desiredGroup = lockedGroupsByUuid.get(groupUuid);
+                return (
+                    desiredGroup?.organizationId !== organizationId ||
+                    desiredGroup.name !== name
+                );
+            })
+        ) {
+            throw new ParameterError(
+                'A requested space group identity changed while applying access as code',
+            );
+        }
+
+        if (directAccessSpaceUuid !== null) {
+            const lockedDirectUsers = await trx(SpaceUserAccessTableName)
+                .where('space_uuid', directAccessSpaceUuid)
+                .select<Array<{ userUuid: string }>>({
+                    userUuid: 'user_uuid',
+                })
+                .orderBy('user_uuid')
+                .forUpdate();
+            const lockedDirectGroups = await trx(SpaceGroupAccessTableName)
+                .where('space_uuid', directAccessSpaceUuid)
+                .select<Array<{ groupUuid: string }>>({
+                    groupUuid: 'group_uuid',
+                })
+                .orderBy('group_uuid')
+                .forUpdate();
+            if (
+                lockedDirectUsers.length !== directUserUuids.length ||
+                lockedDirectUsers.some(
+                    ({ userUuid: lockedUserUuid }, index) =>
+                        lockedUserUuid !== directUserUuids[index],
+                ) ||
+                lockedDirectGroups.length !== directGroupUuids.length ||
+                lockedDirectGroups.some(
+                    ({ groupUuid: lockedGroupUuid }, index) =>
+                        lockedGroupUuid !== directGroupUuids[index],
+                )
+            ) {
+                throw new ParameterError(
+                    'Direct space access changed while applying access as code',
+                );
+            }
+        }
+
+        const groupMemberships =
+            actorGroupUuids.length === 0
+                ? []
+                : await trx(GroupMembershipTableName)
+                      .where({
+                          organization_id: organizationId,
+                          user_id: userId,
+                      })
+                      .whereIn(
+                          'group_uuid',
+                          actorGroupUuids.map(({ groupUuid }) => groupUuid),
+                      )
+                      .select<Array<{ groupUuid: string }>>({
+                          groupUuid: 'group_uuid',
+                      })
+                      .orderBy('group_uuid')
+                      .forShare();
+
+        const projectMembership = await trx(ProjectMembershipsTableName)
+            .where({ project_id: projectId, user_id: userId })
+            .first<{ roleUuid: string | null }>({ roleUuid: 'role_uuid' })
+            .forShare();
+
+        const projectGroupAccess =
+            groupMemberships.length === 0
+                ? []
+                : await trx(ProjectGroupAccessTableName)
+                      .where('project_uuid', projectUuid)
+                      .whereIn(
+                          'group_uuid',
+                          groupMemberships.map(({ groupUuid }) => groupUuid),
+                      )
+                      .select<
+                          Array<{
+                              groupUuid: string;
+                              roleUuid: string | null;
+                          }>
+                      >({
+                          groupUuid: 'group_uuid',
+                          roleUuid: 'role_uuid',
+                      })
+                      .orderBy('group_uuid')
+                      .forShare();
+
+        const roleUuids = [
+            organizationMembership.roleUuid,
+            projectMembership?.roleUuid,
+            ...projectGroupAccess.map(({ roleUuid }) => roleUuid),
+        ]
+            .filter((roleUuid): roleUuid is string => Boolean(roleUuid))
+            .sort();
+        const uniqueRoleUuids = [...new Set(roleUuids)];
+        if (uniqueRoleUuids.length > 0) {
+            await trx(ScopedRolesTableName)
+                .whereIn('role_uuid', uniqueRoleUuids)
+                .select('role_uuid', 'scope_name')
+                .orderBy('role_uuid')
+                .orderBy('scope_name')
+                .forShare();
+        }
+
+        await trx(FeatureFlagsTableName)
+            .where('flag_id', CommercialFeatureFlags.CustomRoles)
+            .first('flag_id')
+            .forShare();
+        await trx(FeatureFlagOverridesTableName)
+            .where('flag_id', CommercialFeatureFlags.CustomRoles)
+            .where((builder) => {
+                void builder
+                    .where('user_uuid', userUuid)
+                    .orWhere((organizationBuilder) => {
+                        void organizationBuilder
+                            .where('organization_uuid', organizationUuid)
+                            .whereNull('user_uuid');
+                    });
+            })
+            .select('feature_flag_override_id')
+            .orderBy('feature_flag_override_id')
+            .forShare();
+    }
+
+    async applySpaceAsCode(
+        input: ApplySpaceAsCodeInput,
+        {
+            trx,
+            beforeMutation,
+        }: {
+            trx?: Knex;
+            beforeMutation?: (
+                trx: Knex,
+                context: { userAccess: ResolvedSpaceCodeUserAccess[] },
+            ) => Promise<void>;
+        } = {},
+    ): Promise<SpaceCodeModel> {
+        const apply = async (transaction: Knex): Promise<SpaceCodeModel> => {
+            const project = await transaction(ProjectTableName)
+                .innerJoin(
+                    OrganizationTableName,
+                    `${OrganizationTableName}.organization_id`,
+                    `${ProjectTableName}.organization_id`,
+                )
+                .where(`${ProjectTableName}.project_uuid`, input.projectUuid)
+                .first<{
+                    projectId: number;
+                    organizationId: number;
+                    organizationUuid: string;
+                }>({
+                    projectId: `${ProjectTableName}.project_id`,
+                    organizationId: `${OrganizationTableName}.organization_id`,
+                    organizationUuid: `${OrganizationTableName}.organization_uuid`,
+                });
+
+            if (project === undefined) {
+                throw new NotFoundError(
+                    `Project with uuid ${input.projectUuid} does not exist`,
+                );
+            }
+
+            const normalizedUserEmails =
+                input.access?.users.map(({ email }) =>
+                    email.trim().toLowerCase(),
+                ) ?? [];
+            const groupNames =
+                input.access?.groups.map(({ name }) => name) ?? [];
+
+            if (
+                new Set(normalizedUserEmails).size !==
+                normalizedUserEmails.length
+            ) {
+                throw new ParameterError(
+                    'Space access contains duplicate user emails',
+                );
+            }
+            if (new Set(groupNames).size !== groupNames.length) {
+                throw new ParameterError(
+                    'Space access contains duplicate group names',
+                );
+            }
+
+            const { spaceUuid: requestedSpaceUuid } = input;
+            let spaceUuid = requestedSpaceUuid;
+            await acquireProjectSlugLock(
+                transaction,
+                input.projectUuid,
+                `space:${input.path}`,
+            );
+
+            const accessChainStartUuid =
+                requestedSpaceUuid ?? input.parentSpaceUuid;
+            if (accessChainStartUuid !== null) {
+                await SpaceModel.lockSpaceAccessChain(
+                    transaction,
+                    project.projectId,
+                    accessChainStartUuid,
+                );
+            }
+
+            const directUserUuids =
+                input.access !== undefined && requestedSpaceUuid !== null
+                    ? await transaction(SpaceUserAccessTableName)
+                          .where('space_uuid', requestedSpaceUuid)
+                          .select<Array<{ userUuid: string }>>({
+                              userUuid: 'user_uuid',
+                          })
+                          .orderBy('user_uuid')
+                          .then((rows) => rows.map(({ userUuid }) => userUuid))
+                    : [];
+            const directGroupUuids =
+                input.access !== undefined && requestedSpaceUuid !== null
+                    ? await transaction(SpaceGroupAccessTableName)
+                          .where('space_uuid', requestedSpaceUuid)
+                          .select<Array<{ groupUuid: string }>>({
+                              groupUuid: 'group_uuid',
+                          })
+                          .orderBy('group_uuid')
+                          .then((rows) =>
+                              rows.map(({ groupUuid }) => groupUuid),
+                          )
+                    : [];
+
+            const resolvedUsers =
+                normalizedUserEmails.length === 0
+                    ? []
+                    : await transaction(UserTableName)
+                          .innerJoin(
+                              OrganizationMembershipsTableName,
+                              `${OrganizationMembershipsTableName}.user_id`,
+                              `${UserTableName}.user_id`,
+                          )
+                          .innerJoin(
+                              EmailTableName,
+                              `${EmailTableName}.user_id`,
+                              `${UserTableName}.user_id`,
+                          )
+                          .where(
+                              `${OrganizationMembershipsTableName}.organization_id`,
+                              project.organizationId,
+                          )
+                          .where(`${EmailTableName}.is_primary`, true)
+                          .whereRaw('LOWER(??) = ANY(?::text[])', [
+                              `${EmailTableName}.email`,
+                              normalizedUserEmails,
+                          ])
+                          .select<
+                              Array<{
+                                  userUuid: string;
+                                  email: string;
+                                  isInternal: boolean;
+                              }>
+                          >({
+                              userUuid: `${UserTableName}.user_uuid`,
+                              email: `${EmailTableName}.email`,
+                              isInternal: `${UserTableName}.is_internal`,
+                          })
+                          .orderBy(`${UserTableName}.user_uuid`);
+
+            const usersByEmail = new Map<string, typeof resolvedUsers>();
+            for (const user of resolvedUsers) {
+                const email = user.email.trim().toLowerCase();
+                usersByEmail.set(email, [
+                    ...(usersByEmail.get(email) ?? []),
+                    user,
+                ]);
+            }
+
+            const userAccess =
+                input.access?.users.map((requestedUser, index) => {
+                    const email = normalizedUserEmails[index];
+                    const matches = usersByEmail.get(email) ?? [];
+                    if (matches.length === 0) {
+                        throw new ParameterError(
+                            `User ${email} is not a member of this organization`,
+                        );
+                    }
+                    if (matches.length > 1) {
+                        throw new ParameterError(
+                            `User email ${email} is ambiguous in this organization`,
+                        );
+                    }
+                    if (matches[0].isInternal) {
+                        throw new ParameterError(
+                            `Internal user ${email} cannot be assigned through space access as code`,
+                        );
+                    }
+                    return {
+                        userUuid: matches[0].userUuid,
+                        role: requestedUser.role,
+                    };
+                }) ?? [];
+
+            const resolvedGroups =
+                groupNames.length === 0
+                    ? []
+                    : await transaction(GroupTableName)
+                          .where(
+                              `${GroupTableName}.organization_id`,
+                              project.organizationId,
+                          )
+                          .whereIn(`${GroupTableName}.name`, groupNames)
+                          .select<Array<{ groupUuid: string; name: string }>>({
+                              groupUuid: `${GroupTableName}.group_uuid`,
+                              name: `${GroupTableName}.name`,
+                          })
+                          .orderBy(`${GroupTableName}.group_uuid`);
+
+            const groupsByName = new Map<string, typeof resolvedGroups>();
+            for (const group of resolvedGroups) {
+                groupsByName.set(group.name, [
+                    ...(groupsByName.get(group.name) ?? []),
+                    group,
+                ]);
+            }
+
+            const groupAccess =
+                input.access?.groups.map((requestedGroup) => {
+                    const matches = groupsByName.get(requestedGroup.name) ?? [];
+                    if (matches.length === 0) {
+                        throw new ParameterError(
+                            `Group ${requestedGroup.name} does not exist in this organization`,
+                        );
+                    }
+                    if (matches.length > 1) {
+                        throw new ParameterError(
+                            `Group name ${requestedGroup.name} is ambiguous in this organization`,
+                        );
+                    }
+                    return {
+                        groupUuid: matches[0].groupUuid,
+                        role: requestedGroup.role,
+                    };
+                }) ?? [];
+
+            await SpaceModel.lockActorAuthorizationSources(transaction, {
+                userId: input.userId,
+                userUuid: input.actorUserUuid,
+                serviceAccountUuid: input.actorServiceAccountUuid,
+                organizationId: project.organizationId,
+                organizationUuid: project.organizationUuid,
+                projectId: project.projectId,
+                projectUuid: input.projectUuid,
+                directUserUuids,
+                directGroupUuids,
+                desiredUsers: resolvedUsers.map(({ userUuid, email }) => ({
+                    userUuid,
+                    email: email.trim().toLowerCase(),
+                })),
+                desiredGroups: resolvedGroups,
+                directAccessSpaceUuid:
+                    input.access !== undefined ? requestedSpaceUuid : null,
+            });
+
+            const pathMatches = await transaction(SpaceTableName)
+                .where({
+                    project_id: project.projectId,
+                    path: input.path,
+                })
+                .whereNull('deleted_at')
+                .select<
+                    Array<{
+                        spaceUuid: string;
+                        parentSpaceUuid: string | null;
+                        isDefaultUserSpace: boolean;
+                    }>
+                >({
+                    spaceUuid: 'space_uuid',
+                    parentSpaceUuid: 'parent_space_uuid',
+                    isDefaultUserSpace: 'is_default_user_space',
+                })
+                .forUpdate();
+
+            if (spaceUuid !== null) {
+                if (
+                    pathMatches.length !== 1 ||
+                    pathMatches[0].spaceUuid !== spaceUuid
+                ) {
+                    throw new ParameterError(
+                        `Space hierarchy path ${input.path} changed or became ambiguous while applying access as code`,
+                    );
+                }
+                if (pathMatches[0].isDefaultUserSpace) {
+                    throw new ParameterError(
+                        'Generated personal spaces cannot be managed as code',
+                    );
+                }
+                if (pathMatches[0].parentSpaceUuid !== input.parentSpaceUuid) {
+                    throw new ParameterError(
+                        `Space hierarchy path ${input.path} has an inconsistent parent`,
+                    );
+                }
+            } else {
+                if (pathMatches.length > 0) {
+                    throw new ParameterError(
+                        `Space hierarchy path ${input.path} already exists`,
+                    );
+                }
+
+                const parentPath = input.path.includes('.')
+                    ? input.path.slice(0, input.path.lastIndexOf('.'))
+                    : null;
+                if (input.parentSpaceUuid !== null) {
+                    const parent = await transaction(SpaceTableName)
+                        .where({
+                            space_uuid: input.parentSpaceUuid,
+                            project_id: project.projectId,
+                        })
+                        .whereNull('deleted_at')
+                        .first<{
+                            path: string;
+                            isDefaultUserSpace: boolean;
+                        }>({
+                            path: 'path',
+                            isDefaultUserSpace: 'is_default_user_space',
+                        })
+                        .forUpdate();
+                    if (parent === undefined) {
+                        throw new NotFoundError(
+                            `Parent space with uuid ${input.parentSpaceUuid} does not exist in project ${input.projectUuid}`,
+                        );
+                    }
+                    if (
+                        parentPath === null ||
+                        parent.path !== parentPath ||
+                        parent.isDefaultUserSpace
+                    ) {
+                        throw new ParameterError(
+                            `Parent space is inconsistent with hierarchy path ${input.path}`,
+                        );
+                    }
+                } else if (parentPath !== null) {
+                    throw new ParameterError(
+                        `Space hierarchy path ${input.path} requires a parent space`,
+                    );
+                }
+            }
+
+            if (beforeMutation) {
+                await beforeMutation(transaction, { userAccess });
+            }
+
+            if (spaceUuid === null) {
+                const createdSpace = await this.createSpace(
+                    {
+                        name: input.name,
+                        inheritParentPermissions:
+                            input.access?.inheritParentPermissions ??
+                            input.inheritParentPermissionsOnCreate,
+                        parentSpaceUuid: input.parentSpaceUuid,
+                    },
+                    {
+                        projectUuid: input.projectUuid,
+                        userId: input.userId,
+                        path: input.path,
+                        trx: transaction,
+                    },
+                );
+                spaceUuid = createdSpace.uuid;
+            }
+
+            if (input.access !== undefined) {
+                await transaction(SpaceTableName)
+                    .where({
+                        space_uuid: spaceUuid,
+                        project_id: project.projectId,
+                    })
+                    .update({
+                        name: input.name,
+                        inherit_parent_permissions:
+                            input.access.inheritParentPermissions,
+                        project_member_access_role:
+                            input.access.projectMemberAccessRole,
+                    });
+
+                await Promise.all([
+                    transaction(SpaceUserAccessTableName)
+                        .where('space_uuid', spaceUuid)
+                        .delete(),
+                    transaction(SpaceGroupAccessTableName)
+                        .where('space_uuid', spaceUuid)
+                        .delete(),
+                ]);
+
+                if (userAccess.length > 0) {
+                    await transaction(SpaceUserAccessTableName).insert(
+                        userAccess.map(({ userUuid, role }) => ({
+                            space_uuid: spaceUuid,
+                            user_uuid: userUuid,
+                            space_role: role,
+                        })),
+                    );
+                }
+                if (groupAccess.length > 0) {
+                    await transaction(SpaceGroupAccessTableName).insert(
+                        groupAccess.map(({ groupUuid, role }) => ({
+                            space_uuid: spaceUuid,
+                            group_uuid: groupUuid,
+                            space_role: role,
+                        })),
+                    );
+                }
+            } else if (input.spaceUuid !== null) {
+                await transaction(SpaceTableName)
+                    .where({
+                        space_uuid: spaceUuid,
+                        project_id: project.projectId,
+                    })
+                    .update({ name: input.name });
+            } else if (
+                input.copyParentAccessOnLegacyCreate === true &&
+                input.parentSpaceUuid !== null &&
+                !input.inheritParentPermissionsOnCreate
+            ) {
+                const [parentUserAccess, parentGroupAccess] = await Promise.all(
+                    [
+                        transaction(SpaceUserAccessTableName)
+                            .where('space_uuid', input.parentSpaceUuid)
+                            .select('user_uuid', 'space_role'),
+                        transaction(SpaceGroupAccessTableName)
+                            .where('space_uuid', input.parentSpaceUuid)
+                            .select('group_uuid', 'space_role'),
+                    ],
+                );
+                if (parentUserAccess.length > 0) {
+                    await transaction(SpaceUserAccessTableName).insert(
+                        parentUserAccess.map(({ user_uuid, space_role }) => ({
+                            space_uuid: spaceUuid,
+                            user_uuid,
+                            space_role,
+                        })),
+                    );
+                }
+                if (parentGroupAccess.length > 0) {
+                    await transaction(SpaceGroupAccessTableName).insert(
+                        parentGroupAccess.map(({ group_uuid, space_role }) => ({
+                            space_uuid: spaceUuid,
+                            group_uuid,
+                            space_role,
+                        })),
+                    );
+                }
+            } else if (!input.inheritParentPermissionsOnCreate) {
+                const creator = await transaction(UserTableName)
+                    .where(`${UserTableName}.user_id`, input.userId)
+                    .first<{ userUuid: string }>({
+                        userUuid: `${UserTableName}.user_uuid`,
+                    });
+                if (creator === undefined) {
+                    throw new NotFoundError(
+                        `User with id ${input.userId} does not exist`,
+                    );
+                }
+                await transaction(SpaceUserAccessTableName).insert({
+                    space_uuid: spaceUuid,
+                    user_uuid: creator.userUuid,
+                    space_role: SpaceMemberRole.ADMIN,
+                });
+            }
+
+            const [space] = await SpaceModel.querySpacesForCode(
+                { projectUuid: input.projectUuid, spaceUuid },
+                transaction,
+            );
+            if (space === undefined) {
+                throw new NotFoundError(
+                    `Space with uuid ${spaceUuid} does not exist`,
+                );
+            }
+            return space;
+        };
+
+        if (trx !== undefined) return apply(trx);
+        return this.database.transaction(apply);
     }
 
     static async getSpaceIdAndName(db: Knex, spaceUuid: string | undefined) {
@@ -1353,20 +2313,23 @@ export class SpaceModel {
         spaceUuid: string,
         space: Partial<UpdateSpace>,
     ): Promise<void> {
-        const updateData: Record<string, unknown> = {
-            name: space.name,
-            inherit_parent_permissions: space.inheritParentPermissions,
-        };
-        if (space.projectMemberAccessRole !== undefined) {
-            updateData.project_member_access_role =
-                space.projectMemberAccessRole;
-        }
-        if (space.colorPaletteUuid !== undefined) {
-            updateData.color_palette_uuid = space.colorPaletteUuid;
-        }
-        await this.database(SpaceTableName)
-            .update(updateData)
-            .where('space_uuid', spaceUuid);
+        await this.database.transaction(async (trx) => {
+            await acquireSpaceAccessLock(trx, spaceUuid);
+            const updateData: Record<string, unknown> = {
+                name: space.name,
+                inherit_parent_permissions: space.inheritParentPermissions,
+            };
+            if (space.projectMemberAccessRole !== undefined) {
+                updateData.project_member_access_role =
+                    space.projectMemberAccessRole;
+            }
+            if (space.colorPaletteUuid !== undefined) {
+                updateData.color_palette_uuid = space.colorPaletteUuid;
+            }
+            await trx(SpaceTableName)
+                .update(updateData)
+                .where('space_uuid', spaceUuid);
+        });
     }
 
     /**
@@ -1381,6 +2344,7 @@ export class SpaceModel {
         groupAccessEntries: { groupUuid: string; role: SpaceMemberRole }[],
     ): Promise<void> {
         await this.database.transaction(async (trx) => {
+            await acquireSpaceAccessLock(trx, spaceUuid);
             if (userAccessEntries.length > 0) {
                 await trx(SpaceUserAccessTableName)
                     .insert(
@@ -1525,24 +2489,30 @@ export class SpaceModel {
         userUuid: string,
         spaceRole: SpaceMemberRole,
     ): Promise<void> {
-        await this.database(SpaceUserAccessTableName)
-            .insert({
-                space_uuid: spaceUuid,
-                user_uuid: userUuid,
-                space_role: spaceRole,
-            })
-            .onConflict(['user_uuid', 'space_uuid'])
-            .merge();
+        await this.database.transaction(async (trx) => {
+            await acquireSpaceAccessLock(trx, spaceUuid);
+            await trx(SpaceUserAccessTableName)
+                .insert({
+                    space_uuid: spaceUuid,
+                    user_uuid: userUuid,
+                    space_role: spaceRole,
+                })
+                .onConflict(['user_uuid', 'space_uuid'])
+                .merge();
+        });
     }
 
     async removeSpaceAccess(
         spaceUuid: string,
         userUuid: string,
     ): Promise<void> {
-        await this.database(SpaceUserAccessTableName)
-            .where('space_uuid', spaceUuid)
-            .andWhere('user_uuid', userUuid)
-            .delete();
+        await this.database.transaction(async (trx) => {
+            await acquireSpaceAccessLock(trx, spaceUuid);
+            await trx(SpaceUserAccessTableName)
+                .where('space_uuid', spaceUuid)
+                .andWhere('user_uuid', userUuid)
+                .delete();
+        });
     }
 
     async addSpaceGroupAccess(
@@ -1550,23 +2520,29 @@ export class SpaceModel {
         groupUuid: string,
         spaceRole: SpaceMemberRole,
     ): Promise<void> {
-        await this.database(SpaceGroupAccessTableName)
-            .insert({
-                space_uuid: spaceUuid,
-                group_uuid: groupUuid,
-                space_role: spaceRole,
-            })
-            .onConflict(['group_uuid', 'space_uuid'])
-            .merge();
+        await this.database.transaction(async (trx) => {
+            await acquireSpaceAccessLock(trx, spaceUuid);
+            await trx(SpaceGroupAccessTableName)
+                .insert({
+                    space_uuid: spaceUuid,
+                    group_uuid: groupUuid,
+                    space_role: spaceRole,
+                })
+                .onConflict(['group_uuid', 'space_uuid'])
+                .merge();
+        });
     }
 
     async removeSpaceGroupAccess(
         spaceUuid: string,
         groupUuid: string,
     ): Promise<void> {
-        await this.database(SpaceGroupAccessTableName)
-            .where('space_uuid', spaceUuid)
-            .andWhere('group_uuid', groupUuid)
-            .delete();
+        await this.database.transaction(async (trx) => {
+            await acquireSpaceAccessLock(trx, spaceUuid);
+            await trx(SpaceGroupAccessTableName)
+                .where('space_uuid', spaceUuid)
+                .andWhere('group_uuid', groupUuid)
+                .delete();
+        });
     }
 }

--- a/packages/backend/src/models/SpacePermissionModel.test.ts
+++ b/packages/backend/src/models/SpacePermissionModel.test.ts
@@ -1,7 +1,102 @@
-import { Knex } from 'knex';
+import { SpaceMemberRole } from '@lightdash/common';
+import knex, { Knex } from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import {
+    SpaceGroupAccessTableName,
+    SpaceUserAccessTableName,
+} from '../database/entities/spaces';
 import { SpacePermissionModel } from './SpacePermissionModel';
 
 describe('SpacePermissionModel', () => {
+    describe('getRawDirectAccess', () => {
+        const database = knex({ client: MockClient, dialect: 'pg' });
+        const model = new SpacePermissionModel(database);
+        let tracker: Tracker;
+
+        beforeAll(() => {
+            tracker = getTracker();
+        });
+
+        afterEach(() => {
+            tracker.reset();
+        });
+
+        it('does not query access tables for an empty space list', async () => {
+            await expect(model.getRawDirectAccess([])).resolves.toEqual({});
+            expect(tracker.history.select).toHaveLength(0);
+        });
+
+        it('returns persisted users and groups without expanding access', async () => {
+            tracker.on.select(SpaceUserAccessTableName).responseOnce([
+                {
+                    spaceUuid: 'space-uuid',
+                    userUuid: 'user-uuid',
+                    email: 'user@example.com',
+                    organizationMemberUserId: 1,
+                    isInternal: false,
+                    role: SpaceMemberRole.ADMIN,
+                },
+                {
+                    spaceUuid: 'space-uuid',
+                    userUuid: 'former-member-uuid',
+                    email: 'former@example.com',
+                    organizationMemberUserId: null,
+                    isInternal: false,
+                    role: SpaceMemberRole.VIEWER,
+                },
+            ]);
+            tracker.on.select(SpaceGroupAccessTableName).responseOnce([
+                {
+                    spaceUuid: 'space-uuid',
+                    groupUuid: 'group-uuid',
+                    name: 'Finance',
+                    role: SpaceMemberRole.EDITOR,
+                },
+            ]);
+
+            await expect(
+                model.getRawDirectAccess(['space-uuid', 'empty-space-uuid']),
+            ).resolves.toEqual({
+                'space-uuid': {
+                    users: [
+                        {
+                            userUuid: 'user-uuid',
+                            email: 'user@example.com',
+                            isInternal: false,
+                            role: SpaceMemberRole.ADMIN,
+                        },
+                        {
+                            userUuid: 'former-member-uuid',
+                            email: null,
+                            isInternal: false,
+                            role: SpaceMemberRole.VIEWER,
+                        },
+                    ],
+                    groups: [
+                        {
+                            groupUuid: 'group-uuid',
+                            name: 'Finance',
+                            role: SpaceMemberRole.EDITOR,
+                        },
+                    ],
+                },
+                'empty-space-uuid': { users: [], groups: [] },
+            });
+
+            const userQuery = tracker.history.select.find(({ sql }) =>
+                sql.includes(`"${SpaceUserAccessTableName}"`),
+            );
+            const groupQuery = tracker.history.select.find(({ sql }) =>
+                sql.includes(`"${SpaceGroupAccessTableName}"`),
+            );
+            expect(userQuery?.sql).toContain('"organization_memberships"');
+            expect(userQuery?.sql).toContain('"projects"."organization_id"');
+            expect(groupQuery?.sql).toContain(
+                '"groups"."organization_id" = "projects"."organization_id"',
+            );
+        });
+    });
+
     describe('getInheritanceChains', () => {
         // Regression guard: the inheritance chain query MUST use a recursive CTE
         // that walks parent_space_uuid FK pointers, NOT ltree path @> joins.
@@ -29,6 +124,62 @@ describe('SpacePermissionModel', () => {
             expect(capturedSql).toContain('WITH RECURSIVE');
             expect(capturedSql).toContain('parent_space_uuid');
             expect(capturedSql).not.toContain('@>');
+        });
+    });
+
+    describe('transaction executor', () => {
+        let tracker: Tracker;
+
+        beforeAll(() => {
+            tracker = getTracker();
+        });
+
+        afterEach(() => {
+            tracker.reset();
+        });
+
+        it('uses the provided transaction for every access-context query', async () => {
+            const databaseQuery = vi.fn(() => {
+                throw new Error('base database executor was used');
+            });
+            const databaseRaw = vi.fn(() => {
+                throw new Error('base database raw executor was used');
+            });
+            const database = Object.assign(databaseQuery, {
+                raw: databaseRaw,
+            }) as unknown as Knex;
+            const trx = knex({ client: MockClient, dialect: 'pg' });
+            tracker = getTracker();
+            tracker.reset();
+            const model = new SpacePermissionModel(database);
+            tracker.on
+                .any(/.*/)
+                .response(({ sql }) =>
+                    sql.includes('WITH RECURSIVE') ? { rows: [] } : [],
+                );
+
+            await expect(
+                model.getDirectSpaceAccess(['space-uuid'], undefined, { trx }),
+            ).resolves.toEqual({});
+            await expect(
+                model.getProjectSpaceAccess(['space-uuid'], undefined, {
+                    trx,
+                }),
+            ).resolves.toEqual({});
+            await expect(
+                model.getOrganizationSpaceAccess(['space-uuid'], undefined, {
+                    trx,
+                }),
+            ).resolves.toEqual({});
+            await expect(
+                model.getSpaceInfo(['space-uuid'], { trx }),
+            ).resolves.toEqual({});
+            await expect(
+                model.getInheritanceChains(['space-uuid'], { trx }),
+            ).resolves.toEqual({});
+
+            expect(databaseQuery).not.toHaveBeenCalled();
+            expect(databaseRaw).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/backend/src/models/SpacePermissionModel.ts
+++ b/packages/backend/src/models/SpacePermissionModel.ts
@@ -9,6 +9,7 @@ import {
     ProjectSpaceAccess,
     ProjectSpaceAccessOrigin,
     SpaceAccessUserMetadata,
+    SpaceMemberRole,
     type SpaceGroup,
     type SpaceInheritanceChain,
 } from '@lightdash/common';
@@ -30,8 +31,148 @@ import { UserAvatarsTableName } from '../database/entities/userAvatars';
 import { UserTableName } from '../database/entities/users';
 import { wrapSentryTransaction } from '../utils';
 
+export type RawSpaceUserAccess = {
+    userUuid: string;
+    email: string | null;
+    isInternal: boolean;
+    role: SpaceMemberRole;
+};
+
+export type RawSpaceGroupAccess = {
+    groupUuid: string;
+    name: string | null;
+    role: SpaceMemberRole;
+};
+
+export type RawSpaceDirectAccess = {
+    users: RawSpaceUserAccess[];
+    groups: RawSpaceGroupAccess[];
+};
+
 export class SpacePermissionModel {
     constructor(private readonly database: Knex) {}
+
+    /** Returns only rows persisted directly against each space. */
+    async getRawDirectAccess(
+        spaceUuids: string[],
+        { trx = this.database }: { trx?: Knex } = {},
+    ): Promise<Record<string, RawSpaceDirectAccess>> {
+        const result: Record<string, RawSpaceDirectAccess> = Object.fromEntries(
+            spaceUuids.map((spaceUuid) => [
+                spaceUuid,
+                { users: [], groups: [] },
+            ]),
+        );
+
+        if (spaceUuids.length === 0) return result;
+
+        const [users, groups] = await Promise.all([
+            trx(SpaceUserAccessTableName)
+                .innerJoin(
+                    SpaceTableName,
+                    `${SpaceTableName}.space_uuid`,
+                    `${SpaceUserAccessTableName}.space_uuid`,
+                )
+                .innerJoin(
+                    ProjectTableName,
+                    `${ProjectTableName}.project_id`,
+                    `${SpaceTableName}.project_id`,
+                )
+                .innerJoin(
+                    UserTableName,
+                    `${UserTableName}.user_uuid`,
+                    `${SpaceUserAccessTableName}.user_uuid`,
+                )
+                .leftJoin(
+                    OrganizationMembershipsTableName,
+                    function joinSourceOrganizationMembership() {
+                        this.on(
+                            `${OrganizationMembershipsTableName}.user_id`,
+                            `${UserTableName}.user_id`,
+                        ).andOn(
+                            `${OrganizationMembershipsTableName}.organization_id`,
+                            `${ProjectTableName}.organization_id`,
+                        );
+                    },
+                )
+                .leftJoin(EmailTableName, function joinPrimaryEmail() {
+                    this.on(
+                        `${EmailTableName}.user_id`,
+                        `${UserTableName}.user_id`,
+                    ).andOnVal(`${EmailTableName}.is_primary`, true);
+                })
+                .whereIn(`${SpaceUserAccessTableName}.space_uuid`, spaceUuids)
+                .select<
+                    Array<
+                        RawSpaceUserAccess & {
+                            spaceUuid: string;
+                            organizationMemberUserId: number | null;
+                        }
+                    >
+                >({
+                    spaceUuid: `${SpaceUserAccessTableName}.space_uuid`,
+                    userUuid: `${SpaceUserAccessTableName}.user_uuid`,
+                    email: `${EmailTableName}.email`,
+                    organizationMemberUserId: `${OrganizationMembershipsTableName}.user_id`,
+                    isInternal: `${UserTableName}.is_internal`,
+                    role: `${SpaceUserAccessTableName}.space_role`,
+                })
+                .orderBy(`${SpaceUserAccessTableName}.space_uuid`)
+                .orderBy(`${EmailTableName}.email`)
+                .orderBy(`${SpaceUserAccessTableName}.user_uuid`),
+            trx(SpaceGroupAccessTableName)
+                .innerJoin(
+                    SpaceTableName,
+                    `${SpaceTableName}.space_uuid`,
+                    `${SpaceGroupAccessTableName}.space_uuid`,
+                )
+                .innerJoin(
+                    ProjectTableName,
+                    `${ProjectTableName}.project_id`,
+                    `${SpaceTableName}.project_id`,
+                )
+                .leftJoin(
+                    GroupTableName,
+                    function joinSourceOrganizationGroup() {
+                        this.on(
+                            `${GroupTableName}.group_uuid`,
+                            `${SpaceGroupAccessTableName}.group_uuid`,
+                        ).andOn(
+                            `${GroupTableName}.organization_id`,
+                            `${ProjectTableName}.organization_id`,
+                        );
+                    },
+                )
+                .whereIn(`${SpaceGroupAccessTableName}.space_uuid`, spaceUuids)
+                .select<
+                    Array<
+                        RawSpaceGroupAccess & {
+                            spaceUuid: string;
+                        }
+                    >
+                >({
+                    spaceUuid: `${SpaceGroupAccessTableName}.space_uuid`,
+                    groupUuid: `${SpaceGroupAccessTableName}.group_uuid`,
+                    name: `${GroupTableName}.name`,
+                    role: `${SpaceGroupAccessTableName}.space_role`,
+                })
+                .orderBy(`${SpaceGroupAccessTableName}.space_uuid`)
+                .orderBy(`${GroupTableName}.name`)
+                .orderBy(`${SpaceGroupAccessTableName}.group_uuid`),
+        ]);
+
+        for (const { spaceUuid, organizationMemberUserId, ...user } of users) {
+            result[spaceUuid]?.users.push({
+                ...user,
+                email: organizationMemberUserId === null ? null : user.email,
+            });
+        }
+        for (const { spaceUuid, ...group } of groups) {
+            result[spaceUuid]?.groups.push(group);
+        }
+
+        return result;
+    }
 
     /**
      * Gets direct space access for a list of spaces
@@ -42,157 +183,153 @@ export class SpacePermissionModel {
     async getDirectSpaceAccess(
         spaceUuids: string[],
         filters?: { userUuid?: string },
+        { trx = this.database }: { trx?: Knex } = {},
     ): Promise<Record<string, DirectSpaceAccess[]>> {
         return wrapSentryTransaction(
             'SpaceModel.getDirectSpaceAccess',
             { spaceUuidsCount: spaceUuids.length },
             async () => {
-                const spacesDirectAccess: DirectSpaceAccess[] =
-                    await this.database(SpaceUserAccessTableName)
-                        .select({
-                            userUuid: `${SpaceUserAccessTableName}.user_uuid`,
-                            spaceUuid: `${SpaceUserAccessTableName}.space_uuid`,
-                            groupUuid: this.database.raw(`NULL`),
-                            role: `${SpaceUserAccessTableName}.space_role`,
-                            from: this.database.raw(
-                                `'${DirectSpaceAccessOrigin.USER_ACCESS}'`,
-                            ),
-                        })
-                        .whereIn(
-                            `${SpaceUserAccessTableName}.space_uuid`,
-                            spaceUuids,
-                        )
-                        .modify((qb) => {
-                            if (filters?.userUuid) {
-                                void qb.where(
-                                    `${SpaceUserAccessTableName}.user_uuid`,
-                                    filters.userUuid,
-                                );
-                            }
-                        })
-                        .union(
-                            this.database(SpaceGroupAccessTableName)
-                                .select({
-                                    userUuid: `${UserTableName}.user_uuid`,
-                                    spaceUuid: `${SpaceGroupAccessTableName}.space_uuid`,
-                                    groupUuid: `${SpaceGroupAccessTableName}.group_uuid`,
-                                    role: `${SpaceGroupAccessTableName}.space_role`,
-                                    from: this.database.raw(
-                                        `'${DirectSpaceAccessOrigin.GROUP_ACCESS}'`,
-                                    ),
-                                })
-                                .innerJoin(
-                                    GroupMembershipTableName,
-                                    `${GroupMembershipTableName}.group_uuid`,
-                                    `${SpaceGroupAccessTableName}.group_uuid`,
-                                )
-                                .innerJoin(
-                                    UserTableName,
-                                    `${GroupMembershipTableName}.user_id`,
-                                    `${UserTableName}.user_id`,
-                                )
-                                .whereIn(
-                                    `${SpaceGroupAccessTableName}.space_uuid`,
-                                    spaceUuids,
-                                )
-                                .modify((qb) => {
-                                    if (filters?.userUuid) {
-                                        void qb.where(
-                                            `${UserTableName}.user_uuid`,
-                                            filters.userUuid,
-                                        );
-                                    }
-                                }),
-                        )
-                        .union(
-                            // "All project members" — explicit project members
-                            this.database(SpaceTableName)
-                                .select({
-                                    userUuid: `${UserTableName}.user_uuid`,
-                                    spaceUuid: `${SpaceTableName}.space_uuid`,
-                                    groupUuid: this.database.raw(`NULL`),
-                                    role: `${SpaceTableName}.project_member_access_role`,
-                                    from: this.database.raw(
-                                        `'${DirectSpaceAccessOrigin.GROUP_ACCESS}'`,
-                                    ),
-                                })
-                                .innerJoin(
-                                    ProjectMembershipsTableName,
-                                    `${ProjectMembershipsTableName}.project_id`,
-                                    `${SpaceTableName}.project_id`,
-                                )
-                                .innerJoin(
-                                    UserTableName,
-                                    `${ProjectMembershipsTableName}.user_id`,
-                                    `${UserTableName}.user_id`,
-                                )
-                                .whereIn(
-                                    `${SpaceTableName}.space_uuid`,
-                                    spaceUuids,
-                                )
-                                .whereNotNull(
-                                    `${SpaceTableName}.project_member_access_role`,
-                                )
-                                .whereNull(`${SpaceTableName}.deleted_at`)
-                                .modify((qb) => {
-                                    if (filters?.userUuid) {
-                                        void qb.where(
-                                            `${UserTableName}.user_uuid`,
-                                            filters.userUuid,
-                                        );
-                                    }
-                                }),
-                        )
-                        .union(
-                            // "All project members" — org members with project access
-                            // (org role above 'member' implies project access)
-                            this.database(SpaceTableName)
-                                .select({
-                                    userUuid: `${UserTableName}.user_uuid`,
-                                    spaceUuid: `${SpaceTableName}.space_uuid`,
-                                    groupUuid: this.database.raw(`NULL`),
-                                    role: `${SpaceTableName}.project_member_access_role`,
-                                    from: this.database.raw(
-                                        `'${DirectSpaceAccessOrigin.GROUP_ACCESS}'`,
-                                    ),
-                                })
-                                .innerJoin(
-                                    ProjectTableName,
-                                    `${ProjectTableName}.project_id`,
-                                    `${SpaceTableName}.project_id`,
-                                )
-                                .innerJoin(
-                                    OrganizationMembershipsTableName,
-                                    `${OrganizationMembershipsTableName}.organization_id`,
-                                    `${ProjectTableName}.organization_id`,
-                                )
-                                .innerJoin(
-                                    UserTableName,
-                                    `${UserTableName}.user_id`,
-                                    `${OrganizationMembershipsTableName}.user_id`,
-                                )
-                                .whereIn(
-                                    `${SpaceTableName}.space_uuid`,
-                                    spaceUuids,
-                                )
-                                .whereNotNull(
-                                    `${SpaceTableName}.project_member_access_role`,
-                                )
-                                .whereNull(`${SpaceTableName}.deleted_at`)
-                                .where(
-                                    `${OrganizationMembershipsTableName}.role`,
-                                    '!=',
-                                    'member',
-                                )
-                                .modify((qb) => {
-                                    if (filters?.userUuid) {
-                                        void qb.where(
-                                            `${UserTableName}.user_uuid`,
-                                            filters.userUuid,
-                                        );
-                                    }
-                                }),
-                        );
+                const spacesDirectAccess: DirectSpaceAccess[] = await trx(
+                    SpaceUserAccessTableName,
+                )
+                    .select({
+                        userUuid: `${SpaceUserAccessTableName}.user_uuid`,
+                        spaceUuid: `${SpaceUserAccessTableName}.space_uuid`,
+                        groupUuid: trx.raw(`NULL`),
+                        role: `${SpaceUserAccessTableName}.space_role`,
+                        from: trx.raw(
+                            `'${DirectSpaceAccessOrigin.USER_ACCESS}'`,
+                        ),
+                    })
+                    .whereIn(
+                        `${SpaceUserAccessTableName}.space_uuid`,
+                        spaceUuids,
+                    )
+                    .modify((qb) => {
+                        if (filters?.userUuid) {
+                            void qb.where(
+                                `${SpaceUserAccessTableName}.user_uuid`,
+                                filters.userUuid,
+                            );
+                        }
+                    })
+                    .union(
+                        trx(SpaceGroupAccessTableName)
+                            .select({
+                                userUuid: `${UserTableName}.user_uuid`,
+                                spaceUuid: `${SpaceGroupAccessTableName}.space_uuid`,
+                                groupUuid: `${SpaceGroupAccessTableName}.group_uuid`,
+                                role: `${SpaceGroupAccessTableName}.space_role`,
+                                from: trx.raw(
+                                    `'${DirectSpaceAccessOrigin.GROUP_ACCESS}'`,
+                                ),
+                            })
+                            .innerJoin(
+                                GroupMembershipTableName,
+                                `${GroupMembershipTableName}.group_uuid`,
+                                `${SpaceGroupAccessTableName}.group_uuid`,
+                            )
+                            .innerJoin(
+                                UserTableName,
+                                `${GroupMembershipTableName}.user_id`,
+                                `${UserTableName}.user_id`,
+                            )
+                            .whereIn(
+                                `${SpaceGroupAccessTableName}.space_uuid`,
+                                spaceUuids,
+                            )
+                            .modify((qb) => {
+                                if (filters?.userUuid) {
+                                    void qb.where(
+                                        `${UserTableName}.user_uuid`,
+                                        filters.userUuid,
+                                    );
+                                }
+                            }),
+                    )
+                    .union(
+                        // "All project members" — explicit project members
+                        trx(SpaceTableName)
+                            .select({
+                                userUuid: `${UserTableName}.user_uuid`,
+                                spaceUuid: `${SpaceTableName}.space_uuid`,
+                                groupUuid: trx.raw(`NULL`),
+                                role: `${SpaceTableName}.project_member_access_role`,
+                                from: trx.raw(
+                                    `'${DirectSpaceAccessOrigin.GROUP_ACCESS}'`,
+                                ),
+                            })
+                            .innerJoin(
+                                ProjectMembershipsTableName,
+                                `${ProjectMembershipsTableName}.project_id`,
+                                `${SpaceTableName}.project_id`,
+                            )
+                            .innerJoin(
+                                UserTableName,
+                                `${ProjectMembershipsTableName}.user_id`,
+                                `${UserTableName}.user_id`,
+                            )
+                            .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+                            .whereNotNull(
+                                `${SpaceTableName}.project_member_access_role`,
+                            )
+                            .whereNull(`${SpaceTableName}.deleted_at`)
+                            .modify((qb) => {
+                                if (filters?.userUuid) {
+                                    void qb.where(
+                                        `${UserTableName}.user_uuid`,
+                                        filters.userUuid,
+                                    );
+                                }
+                            }),
+                    )
+                    .union(
+                        // "All project members" — org members with project access
+                        // (org role above 'member' implies project access)
+                        trx(SpaceTableName)
+                            .select({
+                                userUuid: `${UserTableName}.user_uuid`,
+                                spaceUuid: `${SpaceTableName}.space_uuid`,
+                                groupUuid: trx.raw(`NULL`),
+                                role: `${SpaceTableName}.project_member_access_role`,
+                                from: trx.raw(
+                                    `'${DirectSpaceAccessOrigin.GROUP_ACCESS}'`,
+                                ),
+                            })
+                            .innerJoin(
+                                ProjectTableName,
+                                `${ProjectTableName}.project_id`,
+                                `${SpaceTableName}.project_id`,
+                            )
+                            .innerJoin(
+                                OrganizationMembershipsTableName,
+                                `${OrganizationMembershipsTableName}.organization_id`,
+                                `${ProjectTableName}.organization_id`,
+                            )
+                            .innerJoin(
+                                UserTableName,
+                                `${UserTableName}.user_id`,
+                                `${OrganizationMembershipsTableName}.user_id`,
+                            )
+                            .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+                            .whereNotNull(
+                                `${SpaceTableName}.project_member_access_role`,
+                            )
+                            .whereNull(`${SpaceTableName}.deleted_at`)
+                            .where(
+                                `${OrganizationMembershipsTableName}.role`,
+                                '!=',
+                                'member',
+                            )
+                            .modify((qb) => {
+                                if (filters?.userUuid) {
+                                    void qb.where(
+                                        `${UserTableName}.user_uuid`,
+                                        filters.userUuid,
+                                    );
+                                }
+                            }),
+                    );
 
                 return spacesDirectAccess.reduce<
                     Record<string, DirectSpaceAccess[]>
@@ -217,88 +354,87 @@ export class SpacePermissionModel {
     async getProjectSpaceAccess(
         spaceUuids: string[],
         filters?: { userUuid?: string },
+        { trx = this.database }: { trx?: Knex } = {},
     ): Promise<Record<string, ProjectSpaceAccess[]>> {
         return wrapSentryTransaction(
             'SpaceModel.getProjectSpaceAccess',
             { spaceUuidsCount: spaceUuids.length },
             async () => {
-                const projectSpacesAccess: ProjectSpaceAccess[] =
-                    await this.database(SpaceTableName)
-                        .select({
-                            userUuid: `${UserTableName}.user_uuid`,
-                            spaceUuid: `${SpaceTableName}.space_uuid`,
-                            role: `${ProjectMembershipsTableName}.role`,
-                            from: this.database.raw(
-                                `'${ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP}'`,
-                            ),
-                        })
-                        .innerJoin(
-                            ProjectTableName,
-                            `${ProjectTableName}.project_id`,
-                            `${SpaceTableName}.project_id`,
-                        )
-                        .innerJoin(
-                            ProjectMembershipsTableName,
-                            `${ProjectMembershipsTableName}.project_id`,
-                            `${ProjectTableName}.project_id`,
-                        )
-                        .innerJoin(
-                            UserTableName,
-                            `${UserTableName}.user_id`,
-                            `${ProjectMembershipsTableName}.user_id`,
-                        )
-                        .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
-                        .modify((qb) => {
-                            if (filters?.userUuid) {
-                                void qb.where(
-                                    `${UserTableName}.user_uuid`,
-                                    filters.userUuid,
-                                );
-                            }
-                        })
-                        .union(
-                            this.database(SpaceTableName)
-                                .select({
-                                    userUuid: `${UserTableName}.user_uuid`,
-                                    spaceUuid: `${SpaceTableName}.space_uuid`,
-                                    role: `${ProjectGroupAccessTableName}.role`,
-                                    from: this.database.raw(
-                                        `'${ProjectSpaceAccessOrigin.GROUP_MEMBERSHIP}'`,
-                                    ),
-                                })
-                                .innerJoin(
-                                    ProjectTableName,
-                                    `${ProjectTableName}.project_id`,
-                                    `${SpaceTableName}.project_id`,
-                                )
-                                .innerJoin(
-                                    ProjectGroupAccessTableName,
-                                    `${ProjectGroupAccessTableName}.project_uuid`,
-                                    `${ProjectTableName}.project_uuid`,
-                                )
-                                .innerJoin(
-                                    GroupMembershipTableName,
-                                    `${GroupMembershipTableName}.group_uuid`,
-                                    `${ProjectGroupAccessTableName}.group_uuid`,
-                                )
-                                .innerJoin(
-                                    UserTableName,
-                                    `${UserTableName}.user_id`,
-                                    `${GroupMembershipTableName}.user_id`,
-                                )
-                                .whereIn(
-                                    `${SpaceTableName}.space_uuid`,
-                                    spaceUuids,
-                                )
-                                .modify((qb) => {
-                                    if (filters?.userUuid) {
-                                        void qb.where(
-                                            `${UserTableName}.user_uuid`,
-                                            filters.userUuid,
-                                        );
-                                    }
-                                }),
-                        );
+                const projectSpacesAccess: ProjectSpaceAccess[] = await trx(
+                    SpaceTableName,
+                )
+                    .select({
+                        userUuid: `${UserTableName}.user_uuid`,
+                        spaceUuid: `${SpaceTableName}.space_uuid`,
+                        role: `${ProjectMembershipsTableName}.role`,
+                        from: trx.raw(
+                            `'${ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP}'`,
+                        ),
+                    })
+                    .innerJoin(
+                        ProjectTableName,
+                        `${ProjectTableName}.project_id`,
+                        `${SpaceTableName}.project_id`,
+                    )
+                    .innerJoin(
+                        ProjectMembershipsTableName,
+                        `${ProjectMembershipsTableName}.project_id`,
+                        `${ProjectTableName}.project_id`,
+                    )
+                    .innerJoin(
+                        UserTableName,
+                        `${UserTableName}.user_id`,
+                        `${ProjectMembershipsTableName}.user_id`,
+                    )
+                    .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+                    .modify((qb) => {
+                        if (filters?.userUuid) {
+                            void qb.where(
+                                `${UserTableName}.user_uuid`,
+                                filters.userUuid,
+                            );
+                        }
+                    })
+                    .union(
+                        trx(SpaceTableName)
+                            .select({
+                                userUuid: `${UserTableName}.user_uuid`,
+                                spaceUuid: `${SpaceTableName}.space_uuid`,
+                                role: `${ProjectGroupAccessTableName}.role`,
+                                from: trx.raw(
+                                    `'${ProjectSpaceAccessOrigin.GROUP_MEMBERSHIP}'`,
+                                ),
+                            })
+                            .innerJoin(
+                                ProjectTableName,
+                                `${ProjectTableName}.project_id`,
+                                `${SpaceTableName}.project_id`,
+                            )
+                            .innerJoin(
+                                ProjectGroupAccessTableName,
+                                `${ProjectGroupAccessTableName}.project_uuid`,
+                                `${ProjectTableName}.project_uuid`,
+                            )
+                            .innerJoin(
+                                GroupMembershipTableName,
+                                `${GroupMembershipTableName}.group_uuid`,
+                                `${ProjectGroupAccessTableName}.group_uuid`,
+                            )
+                            .innerJoin(
+                                UserTableName,
+                                `${UserTableName}.user_id`,
+                                `${GroupMembershipTableName}.user_id`,
+                            )
+                            .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+                            .modify((qb) => {
+                                if (filters?.userUuid) {
+                                    void qb.where(
+                                        `${UserTableName}.user_uuid`,
+                                        filters.userUuid,
+                                    );
+                                }
+                            }),
+                    );
 
                 return projectSpacesAccess.reduce<
                     Record<string, ProjectSpaceAccess[]>
@@ -323,13 +459,14 @@ export class SpacePermissionModel {
     async getOrganizationSpaceAccess(
         spaceUuids: string[],
         filters?: { userUuid?: string },
+        { trx = this.database }: { trx?: Knex } = {},
     ): Promise<Record<string, OrganizationSpaceAccess[]>> {
         return wrapSentryTransaction(
             'SpaceModel.getOrganizationSpaceAccess',
             { spaceUuidsCount: spaceUuids.length },
             async () => {
                 const organizationSpacesAccess: OrganizationSpaceAccess[] =
-                    await this.database(SpaceTableName)
+                    await trx(SpaceTableName)
                         .select({
                             userUuid: `${UserTableName}.user_uuid`,
                             spaceUuid: `${SpaceTableName}.space_uuid`,
@@ -381,7 +518,10 @@ export class SpacePermissionModel {
         );
     }
 
-    async getSpaceInfo(spaceUuids: string[]): Promise<
+    async getSpaceInfo(
+        spaceUuids: string[],
+        { trx = this.database }: { trx?: Knex } = {},
+    ): Promise<
         Record<
             string,
             {
@@ -399,7 +539,7 @@ export class SpacePermissionModel {
                     return {};
                 }
 
-                const rows = await this.database(SpaceTableName)
+                const rows = await trx(SpaceTableName)
                     .select({
                         spaceUuid: `${SpaceTableName}.space_uuid`,
                         inheritParentPermissions: `${SpaceTableName}.inherit_parent_permissions`,
@@ -547,6 +687,7 @@ export class SpacePermissionModel {
      */
     async getInheritanceChains(
         spaceUuids: string[],
+        { trx = this.database }: { trx?: Knex } = {},
     ): Promise<Record<string, SpaceInheritanceChain>> {
         return wrapSentryTransaction(
             'SpacePermissionModel.getInheritanceChains',
@@ -565,7 +706,7 @@ export class SpacePermissionModel {
                     name: string;
                     inherit_parent_permissions: boolean;
                     parent_space_uuid: string | null;
-                }[] = await this.database
+                }[] = await trx
                     .raw(
                         `
                     WITH RECURSIVE chain AS (

--- a/packages/backend/src/models/UserModel.test.ts
+++ b/packages/backend/src/models/UserModel.test.ts
@@ -21,14 +21,21 @@ import {
 } from './UserModel';
 
 type TestableUserModel = {
-    hasAuthentication: (userUuid: string) => Promise<boolean>;
-    getUserProjectRoles: (userUuid: string) => Promise<never[]>;
+    hasAuthentication: (userUuid: string, trx?: Knex) => Promise<boolean>;
+    getUserProjectRoles: (
+        userUuid: string,
+        options?: { trx?: Knex },
+    ) => Promise<never[]>;
     getUserGroupProjectRoles: (
         userId: number,
         organizationId: number,
         userUuid: string,
+        trx?: Knex,
     ) => Promise<never[]>;
-    findServiceAccountByUserUuid: (userUuid: string) => Promise<
+    findServiceAccountByUserUuid: (
+        userUuid: string,
+        options?: { trx?: Knex },
+    ) => Promise<
         | {
               uuid: string;
               description: string;
@@ -39,13 +46,18 @@ type TestableUserModel = {
     >;
     customRoleScopes: (
         roleUuids: string[],
+        trx?: Knex,
     ) => Promise<Record<string, string[]>>;
     applyServiceAccountProjectMemberships: (
         userId: number,
         userUuid: string,
         builder: AbilityBuilder<MemberAbility>,
+        trx?: Knex,
     ) => Promise<void>;
-    generateUserAbilityBuilder: (user: DbUserDetails) => Promise<{
+    generateUserAbilityBuilder: (
+        user: DbUserDetails,
+        trx?: Knex,
+    ) => Promise<{
         abilityBuilder: AbilityBuilder<MemberAbility>;
     }>;
 };
@@ -294,8 +306,45 @@ describe('UserModel', () => {
             role_uuid: 'custom-role',
         });
 
-        expect(model.customRoleScopes).toHaveBeenCalledWith(['custom-role']);
+        expect(model.customRoleScopes).toHaveBeenCalledWith(
+            ['custom-role'],
+            expect.anything(),
+        );
         expect(model.findServiceAccountByUserUuid).not.toHaveBeenCalled();
         expectCollapsedDashboardProjectRule(abilityBuilder.rules);
+    });
+
+    it('uses one transaction executor for every ability source', async () => {
+        const model = createUserModel();
+        const trx = vi.fn() as unknown as Knex;
+
+        await model.generateUserAbilityBuilder(userDetails, trx);
+
+        expect(model.hasAuthentication).toHaveBeenCalledWith(
+            userDetails.user_uuid,
+            trx,
+        );
+        expect(model.getUserProjectRoles).toHaveBeenCalledWith(
+            userDetails.user_uuid,
+            { trx },
+        );
+        expect(model.getUserGroupProjectRoles).toHaveBeenCalledWith(
+            userDetails.user_id,
+            userDetails.organization_id,
+            userDetails.user_uuid,
+            trx,
+        );
+        expect(model.findServiceAccountByUserUuid).toHaveBeenCalledWith(
+            userDetails.user_uuid,
+            { trx },
+        );
+        expect(
+            model.applyServiceAccountProjectMemberships,
+        ).toHaveBeenCalledWith(
+            userDetails.user_id,
+            userDetails.user_uuid,
+            expect.anything(),
+            trx,
+        );
     });
 });

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -276,9 +276,12 @@ export class UserModel {
             .whereIn(`${UserTableName}.user_uuid`, filters.userUuids);
     }
 
-    private async hasAuthentication(userUuid: string): Promise<boolean> {
+    private async hasAuthentication(
+        userUuid: string,
+        trx: Knex = this.database,
+    ): Promise<boolean> {
         const [usersHaveAuthenticationRows] =
-            await UserModel.findIfUsersHaveAuthentication(this.database, {
+            await UserModel.findIfUsersHaveAuthentication(trx, {
                 userUuids: [userUuid],
             });
         if (usersHaveAuthenticationRows === undefined) {
@@ -586,6 +589,7 @@ export class UserModel {
 
     async getUserProjectRoles(
         userUuid: string,
+        { trx = this.database }: { trx?: Knex } = {},
     ): Promise<ProjectAbilityProfile[]> {
         type Row = {
             project_uuid: string;
@@ -594,7 +598,7 @@ export class UserModel {
             project_type: ProjectType;
             created_by_user_uuid: string | null;
         };
-        const projectMemberships = await this.database('project_memberships')
+        const projectMemberships = await trx('project_memberships')
             .leftJoin(
                 ProjectTableName,
                 'project_memberships.project_id',
@@ -624,9 +628,10 @@ export class UserModel {
         userId: number,
         organizationId: number,
         userUuid: string,
+        trx: Knex = this.database,
     ): Promise<ProjectAbilityProfile[]> {
         // Remember: primary key for an organization is organization_id,user_id - not user_id alone
-        const query = this.database('group_memberships')
+        const query = trx('group_memberships')
             .innerJoin(
                 'project_group_access',
                 'project_group_access.group_uuid',
@@ -659,12 +664,13 @@ export class UserModel {
 
     private async customRoleScopes(
         roleUuids: string[],
+        trx: Knex = this.database,
     ): Promise<Record<Role['roleUuid'], RoleWithScopes['scopes']>> {
         if (roleUuids.length === 0) {
             return {};
         }
 
-        const scopeData = await this.database(ScopedRolesTableName)
+        const scopeData = await trx(ScopedRolesTableName)
             .select('role_uuid', 'scope_name')
             .whereIn('role_uuid', roleUuids);
 
@@ -683,18 +689,22 @@ export class UserModel {
         return scopesRecord;
     }
 
-    private async generateUserAbilityBuilder(user: DbUserDetails): Promise<{
+    private async generateUserAbilityBuilder(
+        user: DbUserDetails,
+        trx: Knex = this.database,
+    ): Promise<{
         abilityBuilder: AbilityBuilder<MemberAbility>;
         lightdashUser: LightdashUser;
     }> {
         const [hasAuthentication, projectRoles, groupProjectRoles] =
             await Promise.all([
-                this.hasAuthentication(user.user_uuid),
-                this.getUserProjectRoles(user.user_uuid),
+                this.hasAuthentication(user.user_uuid, trx),
+                this.getUserProjectRoles(user.user_uuid, { trx }),
                 this.getUserGroupProjectRoles(
                     user.user_id,
                     user.organization_id,
                     user.user_uuid,
+                    trx,
                 ),
             ]);
         const lightdashUser = mapDbUserDetailsToLightdashUser(
@@ -723,9 +733,10 @@ export class UserModel {
             // the flag off, every CI workflow on those tokens would 403
             // overnight.
             if (user.role_uuid) {
-                const customRoleScopes = await this.customRoleScopes([
-                    user.role_uuid,
-                ]);
+                const customRoleScopes = await this.customRoleScopes(
+                    [user.role_uuid],
+                    trx,
+                );
                 const scopes = customRoleScopes[user.role_uuid];
                 if (scopes) {
                     const builder = new AbilityBuilder<MemberAbility>(Ability);
@@ -757,6 +768,7 @@ export class UserModel {
                         user.user_id,
                         user.user_uuid,
                         builder,
+                        trx,
                     );
                     builder.rules = collapseAbilityRules(builder.rules);
                     return {
@@ -771,6 +783,7 @@ export class UserModel {
             // ability set.
             const serviceAccount = await this.findServiceAccountByUserUuid(
                 user.user_uuid,
+                { trx },
             );
             if (serviceAccount) {
                 const builder = new AbilityBuilder<MemberAbility>(Ability);
@@ -784,6 +797,7 @@ export class UserModel {
                     user.user_id,
                     user.user_uuid,
                     builder,
+                    trx,
                 );
                 builder.rules = collapseAbilityRules(builder.rules);
                 return {
@@ -802,11 +816,14 @@ export class UserModel {
             ...groupProjectRoles.map((role) => role.roleUuid),
         ].filter((roleUuid): roleUuid is string => Boolean(roleUuid));
         const [customRoleScopes, customRolesFlag] = await Promise.all([
-            this.customRoleScopes(customRoleUuids),
-            this.featureFlagModel.get({
-                user: lightdashUser,
-                featureFlagId: CommercialFeatureFlags.CustomRoles,
-            }),
+            this.customRoleScopes(customRoleUuids, trx),
+            this.featureFlagModel.get(
+                {
+                    user: lightdashUser,
+                    featureFlagId: CommercialFeatureFlags.CustomRoles,
+                },
+                { trx },
+            ),
         ]);
         const { builder: abilityBuilder, invalidScopes } =
             getUserAbilityBuilder({
@@ -855,6 +872,7 @@ export class UserModel {
         userId: number,
         userUuid: string,
         builder: AbilityBuilder<MemberAbility>,
+        trx: Knex = this.database,
     ): Promise<void> {
         type Row = {
             project_uuid: string;
@@ -863,7 +881,7 @@ export class UserModel {
             project_type: ProjectType;
             created_by_user_uuid: string | null;
         };
-        const rows = await this.database(ProjectMembershipsTableName)
+        const rows = await trx(ProjectMembershipsTableName)
             .leftJoin(
                 ProjectTableName,
                 `${ProjectMembershipsTableName}.project_id`,
@@ -887,7 +905,7 @@ export class UserModel {
             .filter((u): u is string => u !== null);
         const customRoleScopes =
             customRoleUuids.length > 0
-                ? await this.customRoleScopes(customRoleUuids)
+                ? await this.customRoleScopes(customRoleUuids, trx)
                 : {};
         const isEnterprise =
             this.lightdashConfig.license.licenseKey !== undefined;
@@ -933,7 +951,10 @@ export class UserModel {
         }
     }
 
-    async findServiceAccountByUserUuid(userUuid: string): Promise<
+    async findServiceAccountByUserUuid(
+        userUuid: string,
+        { trx = this.database }: { trx?: Knex } = {},
+    ): Promise<
         | {
               uuid: string;
               description: string;
@@ -942,7 +963,7 @@ export class UserModel {
           }
         | undefined
     > {
-        const row = await this.database('service_accounts')
+        const row = await trx('service_accounts')
             .where('service_account_user_uuid', userUuid)
             .select<
                 {
@@ -1147,8 +1168,9 @@ export class UserModel {
     async findSessionUserAndOrgByUuid(
         userUuid: string,
         organizationUuid: string,
+        { trx = this.database }: { trx?: Knex } = {},
     ): Promise<SessionUser> {
-        const [user] = await userDetailsQueryBuilder(this.database)
+        const [user] = await userDetailsQueryBuilder(trx)
             .where('user_uuid', userUuid)
             .andWhere('organizations.organization_uuid', organizationUuid) // We filter organizationUuid here
             .select('*', 'organizations.created_at as organization_created_at');
@@ -1159,7 +1181,7 @@ export class UserModel {
             );
         }
         const { abilityBuilder, lightdashUser } =
-            await this.generateUserAbilityBuilder(user);
+            await this.generateUserAbilityBuilder(user, trx);
 
         return {
             ...lightdashUser,

--- a/packages/backend/src/services/CoderService/CoderService.contentVerification.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.contentVerification.test.ts
@@ -90,6 +90,9 @@ const buildService = () =>
         spacePermissionService: {} as unknown as SpacePermissionService,
         contentVerificationModel:
             contentVerificationModel as unknown as ContentVerificationModel,
+        groupsModel: {} as never,
+        organizationMemberProfileModel: {} as never,
+        userModel: {} as never,
     });
 
 const callSync = (

--- a/packages/backend/src/services/CoderService/CoderService.scheduledDeliveries.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.scheduledDeliveries.test.ts
@@ -313,6 +313,9 @@ const buildService = ({
         promoteService: {} as never,
         spacePermissionService: {} as never,
         contentVerificationModel: {} as never,
+        groupsModel: {} as never,
+        organizationMemberProfileModel: {} as never,
+        userModel: {} as never,
     });
 
     return {

--- a/packages/backend/src/services/CoderService/CoderService.spaces.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.spaces.test.ts
@@ -1,0 +1,798 @@
+import { Ability, type RawRuleOf } from '@casl/ability';
+import {
+    Account,
+    AnyType,
+    ContentAsCodeType,
+    ForbiddenError,
+    OrganizationMemberRole,
+    ParameterError,
+    PossibleAbilities,
+    ProjectType,
+    SessionUser,
+    SpaceAsCode,
+    SpaceAsCodeAction,
+    SpaceMemberRole,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { fromSession } from '../../auth/account';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { CoderService } from './CoderService';
+
+const PROJECT_UUID = 'project-uuid';
+const ORGANIZATION_UUID = 'organization-uuid';
+const USER_UUID = 'user-uuid';
+const SPACE_UUID = 'space-uuid';
+
+const project = {
+    projectUuid: PROJECT_UUID,
+    organizationUuid: ORGANIZATION_UUID,
+    upstreamProjectUuid: null,
+    type: ProjectType.DEFAULT,
+    createdByUserUuid: USER_UUID,
+};
+
+const makeSessionUser = (
+    rules: RawRuleOf<Ability<PossibleAbilities>>[] = [
+        {
+            subject: 'ContentAsCode',
+            action: ['view', 'create'],
+            conditions: { projectUuid: PROJECT_UUID },
+        },
+        {
+            subject: 'Space',
+            action: ['create', 'manage'],
+            conditions: { projectUuid: PROJECT_UUID },
+        },
+    ],
+    email: string | undefined = 'owner@example.com',
+    isActive = true,
+): SessionUser =>
+    ({
+        userUuid: USER_UUID,
+        userId: 1,
+        email,
+        firstName: 'Space',
+        lastName: 'Owner',
+        organizationUuid: ORGANIZATION_UUID,
+        role: OrganizationMemberRole.MEMBER,
+        isActive,
+        ability: new Ability<PossibleAbilities>(rules),
+        abilityRules: [],
+    }) as unknown as SessionUser;
+
+const makeUser = (
+    rules?: RawRuleOf<Ability<PossibleAbilities>>[],
+    email?: string,
+): Account => fromSession(makeSessionUser(rules, email));
+
+const rootSpace = {
+    organizationUuid: ORGANIZATION_UUID,
+    projectUuid: PROJECT_UUID,
+    uuid: SPACE_UUID,
+    name: 'Finance',
+    slug: 'finance',
+    path: 'finance',
+    parentSpaceUuid: null,
+    inheritParentPermissions: false,
+    projectMemberAccessRole: null,
+    isDefaultUserSpace: false,
+};
+
+const spaceAsCode = (overrides: Partial<SpaceAsCode> = {}): SpaceAsCode => ({
+    contentType: ContentAsCodeType.SPACE,
+    version: 1,
+    spaceName: 'Finance',
+    slug: 'finance',
+    access: {
+        inheritParentPermissions: false,
+        projectMemberAccessRole: null,
+        users: [
+            {
+                email: 'owner@example.com',
+                role: SpaceMemberRole.ADMIN,
+            },
+        ],
+        groups: [],
+    },
+    ...overrides,
+});
+
+const buildService = ({
+    spaces = [rootSpace],
+    accessibleSpaceUuids = [SPACE_UUID],
+    rawAccess = {
+        [SPACE_UUID]: {
+            users: [
+                {
+                    userUuid: USER_UUID,
+                    email: 'owner@example.com',
+                    isInternal: false,
+                    role: SpaceMemberRole.ADMIN,
+                },
+            ],
+            groups: [],
+        },
+    },
+    groups = [],
+    canManage = true,
+    canResults,
+    hasProjectMembership = false,
+    resolvedUserAccess,
+    refreshedUser = makeSessionUser(),
+}: {
+    spaces?: AnyType[];
+    accessibleSpaceUuids?: string[];
+    rawAccess?: Record<string, AnyType>;
+    groups?: AnyType[];
+    canManage?: boolean;
+    canResults?: boolean[];
+    hasProjectMembership?: boolean;
+    resolvedUserAccess?: Array<{
+        userUuid: string;
+        role: SpaceMemberRole;
+    }>;
+    refreshedUser?: SessionUser;
+} = {}) => {
+    const mutableSpaces = [...spaces];
+    const transaction = {} as AnyType;
+    const projectModel = {
+        get: vi.fn(async () => project),
+        getSummary: vi.fn(async () => project),
+        hasProjectMembership: vi.fn(async () => hasProjectMembership),
+    };
+    const spaceModel = {
+        getSpacesByProjectUuid: vi.fn(async () => mutableSpaces),
+        findByProjectAndPath: vi.fn(
+            async (_projectUuid: string, path: string) =>
+                mutableSpaces.filter((space) => space.path === path),
+        ),
+        applySpaceAsCode: vi.fn(async (input, options) => {
+            const transactionallyResolvedUserAccess =
+                resolvedUserAccess ??
+                input.access?.users.map(
+                    ({ role }: { role: SpaceMemberRole }) => ({
+                        userUuid: USER_UUID,
+                        role,
+                    }),
+                ) ??
+                [];
+            await options?.beforeMutation?.(transaction, {
+                userAccess: transactionallyResolvedUserAccess,
+            });
+            if (input.spaceUuid !== null) return rootSpace;
+
+            const createdSpace = {
+                ...rootSpace,
+                uuid: `created-${input.path}`,
+                name: input.name,
+                slug: input.path.slice(input.path.lastIndexOf('.') + 1),
+                path: input.path,
+                parentSpaceUuid: input.parentSpaceUuid,
+                inheritParentPermissions:
+                    input.access?.inheritParentPermissions ??
+                    input.inheritParentPermissionsOnCreate,
+            };
+            mutableSpaces.push(createdSpace);
+            return createdSpace;
+        }),
+    };
+    const spacePermissionService = {
+        getAccessibleSpaceUuids: vi.fn(async () => accessibleSpaceUuids),
+        getRawDirectAccess: vi.fn(async () => rawAccess),
+        can: vi.fn(async () => canResults?.shift() ?? canManage),
+        getSpaceAccessContext: vi.fn(async () => ({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            inheritsFromOrgOrProject: false,
+            access: [],
+            admins: [],
+        })),
+    };
+    const userModel = {
+        findSessionUserAndOrgByUuid: vi.fn(async () => refreshedUser),
+    };
+    const service = new CoderService({
+        lightdashConfig: lightdashConfigMock,
+        analytics: analyticsMock,
+        projectModel: projectModel as AnyType,
+        savedChartModel: {} as AnyType,
+        savedSqlModel: {} as AnyType,
+        dashboardModel: {} as AnyType,
+        spaceModel: spaceModel as AnyType,
+        schedulerModel: {} as AnyType,
+        schedulerService: {} as AnyType,
+        savedChartService: {} as AnyType,
+        dashboardService: {} as AnyType,
+        schedulerClient: {} as AnyType,
+        promoteService: {} as AnyType,
+        spacePermissionService: spacePermissionService as AnyType,
+        contentVerificationModel: {} as AnyType,
+        groupsModel: {
+            find: vi.fn(async ({ name }) => ({
+                data: groups.filter((group) => group.name === name),
+                pagination: {},
+            })),
+            findUserInGroups: vi.fn(async () => []),
+        } as AnyType,
+        organizationMemberProfileModel: {
+            findOrganizationMembersByEmails: vi.fn(async () => [
+                {
+                    userUuid: USER_UUID,
+                    email: 'owner@example.com',
+                },
+            ]),
+        } as AnyType,
+        userModel: userModel as AnyType,
+    });
+    return {
+        service,
+        projectModel,
+        spaceModel,
+        spacePermissionService,
+        userModel,
+        transaction,
+    };
+};
+
+describe('CoderService spaces as code', () => {
+    test('exports accessible empty spaces with deterministic direct access', async () => {
+        const { service } = buildService();
+
+        await expect(
+            service.getSpaces(makeUser(), PROJECT_UUID),
+        ).resolves.toEqual({
+            spaces: [spaceAsCode()],
+            skipped: [],
+        });
+    });
+
+    test('excludes personal spaces and reports children with inaccessible ancestors', async () => {
+        const child = {
+            ...rootSpace,
+            uuid: 'child-uuid',
+            name: 'Child',
+            slug: 'child',
+            path: 'private_parent.child',
+            parentSpaceUuid: 'private-parent-uuid',
+        };
+        const privateParent = {
+            ...rootSpace,
+            uuid: 'private-parent-uuid',
+            path: 'private_parent',
+        };
+        const personal = {
+            ...rootSpace,
+            uuid: 'personal-uuid',
+            path: 'personal',
+            isDefaultUserSpace: true,
+        };
+        const { service } = buildService({
+            spaces: [privateParent, child, personal],
+            accessibleSpaceUuids: [child.uuid, personal.uuid],
+            rawAccess: {},
+        });
+
+        await expect(
+            service.getSpaces(makeUser(), PROJECT_UUID),
+        ).resolves.toEqual({
+            spaces: [],
+            skipped: [
+                {
+                    slug: 'private-parent/child',
+                    reason: 'An ancestor space is not accessible for portable export',
+                },
+            ],
+        });
+    });
+
+    test('exports metadata-only spaces with nonportable access and keeps descendants', async () => {
+        const child = {
+            ...rootSpace,
+            uuid: 'child-uuid',
+            name: 'Child',
+            path: 'finance.child',
+            parentSpaceUuid: SPACE_UUID,
+        };
+        const { service, spaceModel } = buildService({
+            spaces: [rootSpace, child],
+            accessibleSpaceUuids: [SPACE_UUID, child.uuid],
+            rawAccess: {
+                [SPACE_UUID]: {
+                    users: [
+                        {
+                            userUuid: 'service-account-uuid',
+                            email: null,
+                            isInternal: true,
+                            role: SpaceMemberRole.ADMIN,
+                        },
+                    ],
+                    groups: [],
+                },
+                [child.uuid]: { users: [], groups: [] },
+            },
+        });
+
+        const result = await service.getSpaces(makeUser(), PROJECT_UUID);
+        expect(result).toEqual({
+            spaces: [
+                {
+                    contentType: ContentAsCodeType.SPACE,
+                    spaceName: 'Finance',
+                    slug: 'finance',
+                },
+                {
+                    contentType: ContentAsCodeType.SPACE,
+                    version: 1,
+                    spaceName: 'Child',
+                    slug: 'finance/child',
+                    access: {
+                        inheritParentPermissions: false,
+                        projectMemberAccessRole: null,
+                        users: [],
+                        groups: [],
+                    },
+                },
+            ],
+            skipped: [
+                {
+                    slug: 'finance',
+                    reason: 'Direct access contains a user without a portable organization identity',
+                },
+            ],
+        });
+        await expect(
+            service.upsertSpace(makeUser(), PROJECT_UUID, result.spaces[0]),
+        ).resolves.toEqual({ action: SpaceAsCodeAction.NO_CHANGES });
+        expect(spaceModel.applySpaceAsCode).not.toHaveBeenCalled();
+    });
+
+    test('returns no changes without writing when normalized direct state matches', async () => {
+        const { service, spaceModel } = buildService();
+
+        await expect(
+            service.upsertSpace(makeUser(), PROJECT_UUID, spaceAsCode()),
+        ).resolves.toEqual({ action: SpaceAsCodeAction.NO_CHANGES });
+        expect(spaceModel.applySpaceAsCode).not.toHaveBeenCalled();
+    });
+
+    test('legacy metadata-only files update names without replacing access', async () => {
+        const { service, spaceModel } = buildService();
+        const legacy: SpaceAsCode = {
+            contentType: ContentAsCodeType.SPACE,
+            spaceName: 'Renamed finance',
+            slug: 'finance',
+        };
+
+        await expect(
+            service.upsertSpace(makeUser(), PROJECT_UUID, legacy),
+        ).resolves.toEqual({ action: SpaceAsCodeAction.UPDATE });
+        expect(spaceModel.applySpaceAsCode).toHaveBeenCalledWith(
+            expect.not.objectContaining({ access: expect.anything() }),
+            { beforeMutation: expect.any(Function) },
+        );
+    });
+
+    test('rejects access without version and unknown properties before lookup', async () => {
+        const { service, spaceModel } = buildService();
+        const withoutVersion = {
+            ...spaceAsCode(),
+            version: undefined,
+        } as SpaceAsCode;
+        await expect(
+            service.upsertSpace(makeUser(), PROJECT_UUID, withoutVersion),
+        ).rejects.toThrow('Space access requires space schema version 1');
+
+        await expect(
+            service.upsertSpace(makeUser(), PROJECT_UUID, {
+                ...spaceAsCode(),
+                unexpected: true,
+            } as SpaceAsCode),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(spaceModel.findByProjectAndPath).not.toHaveBeenCalled();
+    });
+
+    test('rejects duplicate database paths and unauthorized existing spaces', async () => {
+        const duplicate = { ...rootSpace, uuid: 'duplicate-uuid' };
+        const duplicateService = buildService({
+            spaces: [rootSpace, duplicate],
+        }).service;
+        await expect(
+            duplicateService.upsertSpace(
+                makeUser(),
+                PROJECT_UUID,
+                spaceAsCode(),
+            ),
+        ).rejects.toThrow('Multiple spaces use hierarchy path');
+
+        const unauthorized = buildService({ canManage: false });
+        await expect(
+            unauthorized.service.upsertSpace(
+                makeUser(),
+                PROJECT_UUID,
+                spaceAsCode({ spaceName: 'Renamed' }),
+            ),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(unauthorized.spaceModel.applySpaceAsCode).not.toHaveBeenCalled();
+    });
+
+    test('manage ContentAsCode does not bypass manage Space on an existing restricted space', async () => {
+        const contentManager = makeUser([
+            { subject: 'ContentAsCode', action: 'manage' },
+        ]);
+        const { service, spaceModel } = buildService({ canManage: false });
+
+        await expect(
+            service.upsertSpace(
+                contentManager,
+                PROJECT_UUID,
+                spaceAsCode({ spaceName: 'Renamed finance' }),
+            ),
+        ).rejects.toThrow(
+            'You don\'t have permission to manage space "finance"',
+        );
+        expect(spaceModel.applySpaceAsCode).not.toHaveBeenCalled();
+    });
+
+    test('manage ContentAsCode does not bypass create Space for a missing space', async () => {
+        const contentManager = makeUser([
+            { subject: 'ContentAsCode', action: 'manage' },
+        ]);
+        const { service, spaceModel } = buildService({ spaces: [] });
+
+        await expect(
+            service.upsertSpace(
+                contentManager,
+                PROJECT_UUID,
+                spaceAsCode({ slug: 'new-space' }),
+            ),
+        ).rejects.toThrow(
+            'You don\'t have permission to create space "new-space"',
+        );
+        expect(spaceModel.applySpaceAsCode).not.toHaveBeenCalled();
+    });
+
+    test('never adopts a generated personal space', async () => {
+        const personal = {
+            ...rootSpace,
+            isDefaultUserSpace: true,
+        };
+        const { service, spaceModel } = buildService({ spaces: [personal] });
+
+        await expect(
+            service.upsertSpace(makeUser(), PROJECT_UUID, spaceAsCode()),
+        ).rejects.toThrow(
+            'Generated personal space "finance" cannot be managed as code',
+        );
+        expect(spaceModel.applySpaceAsCode).not.toHaveBeenCalled();
+    });
+
+    test('rejects uploader lockout before exact access replacement', async () => {
+        const assignedOnlySessionUser = makeSessionUser([
+            { subject: 'ContentAsCode', action: 'create' },
+            {
+                subject: 'Space',
+                action: 'manage',
+                conditions: {
+                    projectUuid: PROJECT_UUID,
+                    access: {
+                        $elemMatch: {
+                            userUuid: USER_UUID,
+                            role: SpaceMemberRole.ADMIN,
+                        },
+                    },
+                },
+            },
+        ]);
+        const assignedOnlyUser = fromSession(assignedOnlySessionUser);
+        const { service, spaceModel } = buildService({
+            refreshedUser: assignedOnlySessionUser,
+        });
+
+        await expect(
+            service.upsertSpace(
+                assignedOnlyUser,
+                PROJECT_UUID,
+                spaceAsCode({
+                    spaceName: 'Renamed',
+                    access: {
+                        inheritParentPermissions: false,
+                        projectMemberAccessRole: null,
+                        users: [],
+                        groups: [],
+                    },
+                }),
+            ),
+        ).rejects.toThrow(
+            'Space access would remove your permission to manage the space',
+        );
+        expect(spaceModel.applySpaceAsCode).toHaveBeenCalledTimes(1);
+    });
+
+    test('project-member access only protects an uploader with project membership', async () => {
+        const rules: RawRuleOf<Ability<PossibleAbilities>>[] = [
+            { subject: 'ContentAsCode', action: 'create' },
+            {
+                subject: 'Space',
+                action: 'manage',
+                conditions: {
+                    projectUuid: PROJECT_UUID,
+                    access: {
+                        $elemMatch: {
+                            userUuid: USER_UUID,
+                            role: SpaceMemberRole.ADMIN,
+                        },
+                    },
+                },
+            },
+        ];
+        const assignedOnlySessionUser = makeSessionUser(rules);
+        const assignedOnlyUser = fromSession(assignedOnlySessionUser);
+        const desired = spaceAsCode({
+            spaceName: 'Renamed',
+            access: {
+                inheritParentPermissions: false,
+                projectMemberAccessRole: SpaceMemberRole.ADMIN,
+                users: [],
+                groups: [],
+            },
+        });
+
+        await expect(
+            buildService({
+                refreshedUser: assignedOnlySessionUser,
+            }).service.upsertSpace(assignedOnlyUser, PROJECT_UUID, desired),
+        ).rejects.toThrow(
+            'Space access would remove your permission to manage the space',
+        );
+
+        await expect(
+            buildService({
+                hasProjectMembership: true,
+                refreshedUser: assignedOnlySessionUser,
+            }).service.upsertSpace(assignedOnlyUser, PROJECT_UUID, desired),
+        ).resolves.toEqual({ action: SpaceAsCodeAction.UPDATE });
+
+        const serviceAccountSessionUser = makeSessionUser(rules, undefined);
+        const serviceAccountUser = fromSession(serviceAccountSessionUser);
+        await expect(
+            buildService({
+                hasProjectMembership: true,
+                refreshedUser: serviceAccountSessionUser,
+            }).service.upsertSpace(serviceAccountUser, PROJECT_UUID, desired),
+        ).resolves.toEqual({ action: SpaceAsCodeAction.UPDATE });
+    });
+
+    test('uses transactionally resolved users for final uploader retention', async () => {
+        const assignedOnlySessionUser = makeSessionUser([
+            { subject: 'ContentAsCode', action: 'create' },
+            {
+                subject: 'Space',
+                action: 'manage',
+                conditions: {
+                    projectUuid: PROJECT_UUID,
+                    access: {
+                        $elemMatch: {
+                            userUuid: USER_UUID,
+                            role: SpaceMemberRole.ADMIN,
+                        },
+                    },
+                },
+            },
+        ]);
+        const assignedOnlyUser = fromSession(assignedOnlySessionUser);
+        const { service, spaceModel } = buildService({
+            refreshedUser: assignedOnlySessionUser,
+            resolvedUserAccess: [
+                {
+                    userUuid: 'different-user-uuid',
+                    role: SpaceMemberRole.ADMIN,
+                },
+            ],
+        });
+
+        await expect(
+            service.upsertSpace(
+                assignedOnlyUser,
+                PROJECT_UUID,
+                spaceAsCode({
+                    spaceName: 'Renamed',
+                    access: {
+                        inheritParentPermissions: false,
+                        projectMemberAccessRole: null,
+                        users: [
+                            {
+                                email: 'owner@example.com',
+                                role: SpaceMemberRole.ADMIN,
+                            },
+                        ],
+                        groups: [],
+                    },
+                }),
+            ),
+        ).rejects.toThrow(
+            'Space access would remove your permission to manage the space',
+        );
+        expect(spaceModel.applySpaceAsCode).toHaveBeenCalledTimes(1);
+    });
+
+    test('rejects an access replacement when current manage access is revoked after preflight', async () => {
+        const refreshedUser = makeSessionUser();
+        const {
+            service,
+            spaceModel,
+            spacePermissionService,
+            userModel,
+            transaction,
+        } = buildService({
+            canResults: [true, false],
+            refreshedUser,
+        });
+
+        await expect(
+            service.upsertSpace(
+                makeUser(),
+                PROJECT_UUID,
+                spaceAsCode({ spaceName: 'Renamed finance' }),
+            ),
+        ).rejects.toThrow(
+            'You don\'t have permission to manage space "finance"',
+        );
+        expect(spaceModel.applySpaceAsCode).toHaveBeenCalledTimes(1);
+        expect(userModel.findSessionUserAndOrgByUuid).toHaveBeenCalledWith(
+            USER_UUID,
+            ORGANIZATION_UUID,
+            { trx: transaction },
+        );
+        expect(spacePermissionService.can).toHaveBeenLastCalledWith(
+            'manage',
+            expect.objectContaining({ ability: refreshedUser.ability }),
+            SPACE_UUID,
+            { trx: transaction },
+        );
+    });
+
+    test('allows a view-only identical legacy metadata file to remain unchanged', async () => {
+        const { service, spaceModel, spacePermissionService } = buildService({
+            canManage: false,
+            canResults: [true],
+        });
+
+        await expect(
+            service.upsertSpace(makeUser(), PROJECT_UUID, {
+                contentType: ContentAsCodeType.SPACE,
+                spaceName: 'Finance',
+                slug: 'finance',
+            }),
+        ).resolves.toEqual({ action: SpaceAsCodeAction.NO_CHANGES });
+        expect(spacePermissionService.can).toHaveBeenCalledTimes(1);
+        expect(spacePermissionService.can).toHaveBeenCalledWith(
+            'view',
+            expect.anything(),
+            SPACE_UUID,
+        );
+        expect(spaceModel.applySpaceAsCode).not.toHaveBeenCalled();
+    });
+
+    test('recursively creates missing ancestors for a legacy metadata-only leaf', async () => {
+        const { service, spaceModel } = buildService({ spaces: [] });
+
+        await expect(
+            service.upsertSpace(makeUser(), PROJECT_UUID, {
+                contentType: ContentAsCodeType.SPACE,
+                spaceName: 'Quarterly reports',
+                slug: 'company/finance/reports',
+            }),
+        ).resolves.toEqual({ action: SpaceAsCodeAction.CREATE });
+
+        expect(
+            spaceModel.applySpaceAsCode.mock.calls.map(([input]) => ({
+                name: input.name,
+                path: input.path,
+                parentSpaceUuid: input.parentSpaceUuid,
+            })),
+        ).toEqual([
+            {
+                name: 'Company',
+                path: 'company',
+                parentSpaceUuid: null,
+            },
+            {
+                name: 'Finance',
+                path: 'company.finance',
+                parentSpaceUuid: 'created-company',
+            },
+            {
+                name: 'Quarterly reports',
+                path: 'company.finance.reports',
+                parentSpaceUuid: 'created-company.finance',
+            },
+        ]);
+    });
+
+    test('does not synthesize missing parents for explicit access or skip-space-create', async () => {
+        const explicit = buildService({ spaces: [] });
+        await expect(
+            explicit.service.upsertSpace(
+                makeUser(),
+                PROJECT_UUID,
+                spaceAsCode({ slug: 'parent/child' }),
+            ),
+        ).rejects.toThrow('Parent space "parent" must exist before');
+        expect(explicit.spaceModel.applySpaceAsCode).not.toHaveBeenCalled();
+
+        const skipped = buildService({ spaces: [] });
+        await expect(
+            skipped.service.upsertSpace(
+                makeUser(),
+                PROJECT_UUID,
+                {
+                    contentType: ContentAsCodeType.SPACE,
+                    spaceName: 'Child',
+                    slug: 'parent/child',
+                },
+                { skipSpaceCreate: true },
+            ),
+        ).rejects.toThrow('does not exist, skipping creation');
+        expect(skipped.spaceModel.applySpaceAsCode).not.toHaveBeenCalled();
+    });
+
+    test('rejects a caller whose content-as-code ability belongs to another project', async () => {
+        const otherProjectUser = makeUser([
+            {
+                subject: 'ContentAsCode',
+                action: 'create',
+                conditions: { projectUuid: 'other-project-uuid' },
+            },
+            {
+                subject: 'Space',
+                action: 'manage',
+                conditions: { projectUuid: 'other-project-uuid' },
+            },
+        ]);
+        const { service, spaceModel } = buildService();
+
+        await expect(
+            service.upsertSpace(
+                otherProjectUser,
+                PROJECT_UUID,
+                spaceAsCode({ spaceName: 'Renamed finance' }),
+            ),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(spaceModel.findByProjectAndPath).not.toHaveBeenCalled();
+    });
+
+    test('warns when replacing direct access without a portable identity', async () => {
+        const { service, spaceModel } = buildService({
+            rawAccess: {
+                [SPACE_UUID]: {
+                    users: [],
+                    groups: [
+                        {
+                            groupUuid: 'ambiguous-group-uuid',
+                            name: 'Finance team',
+                            role: SpaceMemberRole.ADMIN,
+                        },
+                    ],
+                },
+            },
+            groups: [
+                { uuid: 'first-group-uuid', name: 'Finance team' },
+                { uuid: 'second-group-uuid', name: 'Finance team' },
+            ],
+        });
+
+        await expect(
+            service.upsertSpace(
+                makeUser(),
+                PROJECT_UUID,
+                spaceAsCode({ spaceName: 'Renamed finance' }),
+            ),
+        ).resolves.toEqual({
+            action: SpaceAsCodeAction.UPDATE,
+            warnings: [
+                'Applying this access policy will remove direct service-account, internal-user, or unresolved user/group grants that cannot be represented as code',
+            ],
+        });
+        expect(spaceModel.applySpaceAsCode).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -676,6 +676,9 @@ describe('CoderService', () => {
                 schedulerClient: {} as AnyType,
                 spaceModel: {} as AnyType,
                 spacePermissionService: {} as AnyType,
+                groupsModel: {} as AnyType,
+                organizationMemberProfileModel: {} as AnyType,
+                userModel: {} as AnyType,
             });
 
             const result = await service.convertTileWithSlugsToUuids(

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -11,6 +11,8 @@ import {
     ApiGoogleSheetsSyncAsCodeUpsertResponse,
     ApiScheduledDeliveryAsCodeListResponse,
     ApiScheduledDeliveryAsCodeUpsertResponse,
+    ApiSpaceAsCodeListResponse,
+    ApiSpaceAsCodeUpsertResponse,
     ApiVirtualViewAsCodeListResponse,
     ApiVirtualViewAsCodeUpsertResponse,
     assertUnreachable,
@@ -59,6 +61,7 @@ import {
     isSqlTableCalculation,
     NotFoundError,
     NotificationFrequency,
+    OrganizationMemberRole,
     ParameterError,
     Project,
     ProjectType,
@@ -74,9 +77,11 @@ import {
     snakeCaseName,
     Space,
     SpaceAsCode,
+    SpaceAsCodeAction,
     SpaceMemberRole,
     SqlChartAsCode,
     UpdatedByUser,
+    validateEmail,
     VirtualViewAsCode,
     type ContentVerificationInfo,
     type CustomDimension,
@@ -95,17 +100,26 @@ import {
     type SpaceSummaryBase,
     type TableCalculation,
 } from '@lightdash/common';
+import type { Knex } from 'knex';
 import isEqual from 'lodash/isEqual';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
+import { getAccountApiAccessContext } from '../../auth/account';
 import { LightdashConfig } from '../../config/parseConfig';
 import { ContentVerificationModel } from '../../models/ContentVerificationModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { GroupsModel } from '../../models/GroupsModel';
+import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
 import { SavedSqlModel } from '../../models/SavedSqlModel';
 import { SchedulerModel } from '../../models/SchedulerModel';
-import { SpaceModel } from '../../models/SpaceModel';
+import {
+    SpaceModel,
+    type ResolvedSpaceCodeUserAccess,
+} from '../../models/SpaceModel';
+import type { RawSpaceDirectAccess } from '../../models/SpacePermissionModel';
+import { UserModel } from '../../models/UserModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { BaseService } from '../BaseService';
 import { DashboardService } from '../DashboardService/DashboardService';
@@ -151,6 +165,9 @@ type CoderServiceArguments = {
     spacePermissionService: SpacePermissionService;
     contentVerificationModel: ContentVerificationModel;
     projectService?: ProjectService;
+    groupsModel: GroupsModel;
+    organizationMemberProfileModel: OrganizationMemberProfileModel;
+    userModel: UserModel;
 };
 
 type UpsertContentAsCodeOptions = {
@@ -276,6 +293,12 @@ export class CoderService extends BaseService {
 
     projectService?: ProjectService;
 
+    groupsModel: GroupsModel;
+
+    organizationMemberProfileModel: OrganizationMemberProfileModel;
+
+    userModel: UserModel;
+
     static getChartContentAsCodePermissionChecks(
         nextChart: ChartAsCode,
         currentChart?: CurrentChartSqlItems,
@@ -353,6 +376,9 @@ export class CoderService extends BaseService {
         spacePermissionService,
         contentVerificationModel,
         projectService,
+        groupsModel,
+        organizationMemberProfileModel,
+        userModel,
     }: CoderServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -371,6 +397,9 @@ export class CoderService extends BaseService {
         this.spacePermissionService = spacePermissionService;
         this.contentVerificationModel = contentVerificationModel;
         this.projectService = projectService;
+        this.groupsModel = groupsModel;
+        this.organizationMemberProfileModel = organizationMemberProfileModel;
+        this.userModel = userModel;
     }
 
     private static transformVirtualView(
@@ -702,6 +731,1019 @@ export class CoderService extends BaseService {
             spaceName: space.name,
             slug: getContentAsCodePathFromLtreePath(space.path),
         }));
+    }
+
+    private static assertObjectKeys(
+        value: unknown,
+        allowedKeys: readonly string[],
+        label: string,
+    ): asserts value is Record<string, unknown> {
+        if (
+            typeof value !== 'object' ||
+            value === null ||
+            Array.isArray(value)
+        ) {
+            throw new ParameterError(`${label} must be an object`);
+        }
+        const unknownKeys = Object.keys(value).filter(
+            (key) => !allowedKeys.includes(key),
+        );
+        if (unknownKeys.length > 0) {
+            throw new ParameterError(
+                `${label} contains unknown properties: ${unknownKeys.join(', ')}`,
+            );
+        }
+    }
+
+    private static normalizeSpaceAsCode(spaceInput: SpaceAsCode): SpaceAsCode {
+        CoderService.assertObjectKeys(
+            spaceInput,
+            ['contentType', 'version', 'spaceName', 'slug', 'access'],
+            'Space',
+        );
+        if (spaceInput.contentType !== ContentAsCodeType.SPACE) {
+            throw new ParameterError('Invalid space contentType');
+        }
+        if (spaceInput.version !== undefined && spaceInput.version !== 1) {
+            throw new ParameterError(
+                `Unsupported space version ${spaceInput.version}`,
+            );
+        }
+        if (
+            typeof spaceInput.spaceName !== 'string' ||
+            !spaceInput.spaceName.trim()
+        ) {
+            throw new ParameterError('Space name is required');
+        }
+        if (
+            typeof spaceInput.slug !== 'string' ||
+            spaceInput.slug !== spaceInput.slug.trim() ||
+            !/^[a-z0-9-]+(?:\/[a-z0-9-]+)*$/.test(spaceInput.slug) ||
+            getContentAsCodePathFromLtreePath(
+                getLtreePathFromContentAsCodePath(spaceInput.slug),
+            ) !== spaceInput.slug
+        ) {
+            throw new ParameterError(
+                'Space slug must be a canonical hierarchy path',
+            );
+        }
+        if (spaceInput.access === undefined) {
+            return {
+                contentType: ContentAsCodeType.SPACE,
+                ...(spaceInput.version === 1 ? { version: 1 as const } : {}),
+                spaceName: spaceInput.spaceName,
+                slug: spaceInput.slug,
+            };
+        }
+        if (spaceInput.version !== 1) {
+            throw new ParameterError(
+                'Space access requires space schema version 1',
+            );
+        }
+
+        CoderService.assertObjectKeys(
+            spaceInput.access,
+            [
+                'inheritParentPermissions',
+                'projectMemberAccessRole',
+                'users',
+                'groups',
+            ],
+            'Space access',
+        );
+        const { access } = spaceInput;
+        if (typeof access.inheritParentPermissions !== 'boolean') {
+            throw new ParameterError(
+                'inheritParentPermissions must be a boolean',
+            );
+        }
+        const validRoles = new Set(Object.values(SpaceMemberRole));
+        if (
+            access.projectMemberAccessRole !== null &&
+            !validRoles.has(access.projectMemberAccessRole)
+        ) {
+            throw new ParameterError(
+                'projectMemberAccessRole must be viewer, editor, admin, or null',
+            );
+        }
+        if (!Array.isArray(access.users) || !Array.isArray(access.groups)) {
+            throw new ParameterError(
+                'Space access users and groups must be arrays',
+            );
+        }
+
+        const users = access.users.map((entry, index) => {
+            CoderService.assertObjectKeys(
+                entry,
+                ['email', 'role'],
+                `Space access user ${index + 1}`,
+            );
+            if (
+                typeof entry.email !== 'string' ||
+                !validateEmail(entry.email.trim())
+            ) {
+                throw new ParameterError(
+                    `Space access user ${index + 1} has an invalid email`,
+                );
+            }
+            if (!validRoles.has(entry.role)) {
+                throw new ParameterError(
+                    `Space access user ${entry.email} has an invalid role`,
+                );
+            }
+            return {
+                email: entry.email.trim().toLowerCase(),
+                role: entry.role,
+            };
+        });
+        const duplicateEmails = users
+            .map(({ email }) => email)
+            .filter((email, index, emails) => emails.indexOf(email) !== index);
+        if (duplicateEmails.length > 0) {
+            throw new ParameterError(
+                `Space access contains duplicate users: ${[
+                    ...new Set(duplicateEmails),
+                ].join(', ')}`,
+            );
+        }
+
+        const groups = access.groups.map((entry, index) => {
+            CoderService.assertObjectKeys(
+                entry,
+                ['name', 'role'],
+                `Space access group ${index + 1}`,
+            );
+            if (typeof entry.name !== 'string' || !entry.name.trim()) {
+                throw new ParameterError(
+                    `Space access group ${index + 1} requires a name`,
+                );
+            }
+            if (!validRoles.has(entry.role)) {
+                throw new ParameterError(
+                    `Space access group ${entry.name} has an invalid role`,
+                );
+            }
+            return { name: entry.name, role: entry.role };
+        });
+        const duplicateGroups = groups
+            .map(({ name }) => name)
+            .filter((name, index, names) => names.indexOf(name) !== index);
+        if (duplicateGroups.length > 0) {
+            throw new ParameterError(
+                `Space access contains duplicate groups: ${[
+                    ...new Set(duplicateGroups),
+                ].join(', ')}`,
+            );
+        }
+
+        return {
+            contentType: ContentAsCodeType.SPACE,
+            version: 1,
+            spaceName: spaceInput.spaceName,
+            slug: spaceInput.slug,
+            access: {
+                inheritParentPermissions: access.inheritParentPermissions,
+                projectMemberAccessRole: access.projectMemberAccessRole,
+                users: users.sort((left, right) =>
+                    left.email.localeCompare(right.email),
+                ),
+                groups: groups.sort((left, right) =>
+                    left.name.localeCompare(right.name),
+                ),
+            },
+        };
+    }
+
+    async getSpaces(
+        account: Account,
+        projectUuid: string,
+    ): Promise<ApiSpaceAsCodeListResponse['results']> {
+        const { user } = getAccountApiAccessContext(account);
+        const project = await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(account);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('ContentAsCode', {
+                    projectUuid,
+                    organizationUuid: project.organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError('You are not allowed to download spaces');
+        }
+
+        const allProjectSpaces =
+            await this.spaceModel.getSpacesByProjectUuid(projectUuid);
+        const projectSpaces = allProjectSpaces.filter(
+            (space) => !space.isDefaultUserSpace,
+        );
+        const accessibleSpaceUuids = new Set(
+            await this.spacePermissionService.getAccessibleSpaceUuids(
+                'view',
+                user,
+                projectSpaces.map(({ uuid }) => uuid),
+            ),
+        );
+        const rawAccess = await this.spacePermissionService.getRawDirectAccess(
+            projectSpaces.map(({ uuid }) => uuid),
+        );
+        const directUserEmails = [
+            ...new Set(
+                Object.values(rawAccess)
+                    .flatMap(({ users }) => users)
+                    .flatMap(({ email }) =>
+                        email === null ? [] : [email.toLowerCase()],
+                    ),
+            ),
+        ];
+        const organizationMembers =
+            await this.organizationMemberProfileModel.findOrganizationMembersByEmails(
+                project.organizationUuid,
+                directUserEmails,
+            );
+        const membersByUuid = new Map(
+            organizationMembers.map((member) => [member.userUuid, member]),
+        );
+        const memberEmailCounts = organizationMembers.reduce<
+            Map<string, number>
+        >((counts, member) => {
+            const email = member.email.toLowerCase();
+            counts.set(email, (counts.get(email) ?? 0) + 1);
+            return counts;
+        }, new Map());
+        const rawGroups = Object.values(rawAccess).flatMap(
+            ({ groups }) => groups,
+        );
+        const uniqueRawGroups = [
+            ...new Map(
+                rawGroups.map((group) => [group.groupUuid, group]),
+            ).values(),
+        ];
+        const portableGroupUuids = new Set(
+            (
+                await Promise.all(
+                    uniqueRawGroups.map(async (group) => {
+                        if (group.name === null) return null;
+                        const matches = (
+                            await this.groupsModel.find({
+                                organizationUuid: project.organizationUuid,
+                                name: group.name,
+                            })
+                        ).data;
+                        return matches.length === 1 &&
+                            matches[0].uuid === group.groupUuid
+                            ? group.groupUuid
+                            : null;
+                    }),
+                )
+            ).filter((groupUuid): groupUuid is string => groupUuid !== null),
+        );
+        const pathCounts = allProjectSpaces.reduce<Map<string, number>>(
+            (counts, space) =>
+                counts.set(space.path, (counts.get(space.path) ?? 0) + 1),
+            new Map(),
+        );
+        const spaces: SpaceAsCode[] = [];
+        const skipped: ApiSpaceAsCodeListResponse['results']['skipped'] = [];
+        const skippedPaths = new Set<string>();
+        const skippedSpaceUuids = new Set<string>();
+        const spacesByUuid = new Map(
+            allProjectSpaces.map((space) => [space.uuid, space]),
+        );
+
+        projectSpaces
+            .filter(({ uuid }) => accessibleSpaceUuids.has(uuid))
+            .sort((left, right) => {
+                const depthDifference =
+                    left.path.split('.').length - right.path.split('.').length;
+                return depthDifference || left.path.localeCompare(right.path);
+            })
+            .forEach((space) => {
+                const slug = getContentAsCodePathFromLtreePath(space.path);
+                if ((pathCounts.get(space.path) ?? 0) > 1) {
+                    skippedSpaceUuids.add(space.uuid);
+                    if (!skippedPaths.has(space.path)) {
+                        skipped.push({
+                            slug,
+                            reason: 'Multiple spaces use this hierarchy path',
+                        });
+                        skippedPaths.add(space.path);
+                    }
+                    return;
+                }
+                const directParentPath = space.path.includes('.')
+                    ? space.path.slice(0, space.path.lastIndexOf('.'))
+                    : null;
+                if (
+                    (directParentPath === null) !==
+                    (space.parentSpaceUuid === null)
+                ) {
+                    skippedSpaceUuids.add(space.uuid);
+                    skipped.push({
+                        slug,
+                        reason: 'Space parent does not match its hierarchy path',
+                    });
+                    return;
+                }
+                const visitedAncestorUuids = new Set<string>();
+                let ancestorUuid = space.parentSpaceUuid;
+                let descendantPath = space.path;
+                while (ancestorUuid !== null) {
+                    if (visitedAncestorUuids.has(ancestorUuid)) {
+                        skippedSpaceUuids.add(space.uuid);
+                        skipped.push({
+                            slug,
+                            reason: 'Space hierarchy contains a parent cycle',
+                        });
+                        return;
+                    }
+                    visitedAncestorUuids.add(ancestorUuid);
+                    const ancestor = spacesByUuid.get(ancestorUuid);
+                    const expectedAncestorPath = descendantPath.slice(
+                        0,
+                        descendantPath.lastIndexOf('.'),
+                    );
+                    if (
+                        !ancestor ||
+                        ancestor.isDefaultUserSpace ||
+                        !accessibleSpaceUuids.has(ancestorUuid) ||
+                        skippedSpaceUuids.has(ancestorUuid)
+                    ) {
+                        skippedSpaceUuids.add(space.uuid);
+                        skipped.push({
+                            slug,
+                            reason: skippedSpaceUuids.has(ancestorUuid)
+                                ? 'An ancestor space could not be exported portably'
+                                : 'An ancestor space is not accessible for portable export',
+                        });
+                        return;
+                    }
+                    if (ancestor.path !== expectedAncestorPath) {
+                        skippedSpaceUuids.add(space.uuid);
+                        skipped.push({
+                            slug,
+                            reason: 'Space parent does not match its hierarchy path',
+                        });
+                        return;
+                    }
+                    descendantPath = ancestor.path;
+                    ancestorUuid = ancestor.parentSpaceUuid;
+                }
+
+                const directAccess = rawAccess[space.uuid] ?? {
+                    users: [],
+                    groups: [],
+                };
+                const metadataOnlySpace: SpaceAsCode = {
+                    contentType: ContentAsCodeType.SPACE,
+                    spaceName: space.name,
+                    slug,
+                };
+                if (
+                    directAccess.users.some(
+                        ({ userUuid, email, isInternal }) => {
+                            if (isInternal || email === null) return true;
+                            const member = membersByUuid.get(userUuid);
+                            const normalizedEmail = email.toLowerCase();
+                            return (
+                                member === undefined ||
+                                member.email.toLowerCase() !==
+                                    normalizedEmail ||
+                                memberEmailCounts.get(normalizedEmail) !== 1
+                            );
+                        },
+                    )
+                ) {
+                    spaces.push(metadataOnlySpace);
+                    skipped.push({
+                        slug,
+                        reason: 'Direct access contains a user without a portable organization identity',
+                    });
+                    return;
+                }
+                if (
+                    directAccess.groups.some(
+                        ({ groupUuid, name }) =>
+                            name === null || !portableGroupUuids.has(groupUuid),
+                    )
+                ) {
+                    spaces.push(metadataOnlySpace);
+                    skipped.push({
+                        slug,
+                        reason: 'Direct access contains a group without a portable name',
+                    });
+                    return;
+                }
+
+                const users = directAccess.users.map(({ email, role }) => ({
+                    email: email!.toLowerCase(),
+                    role,
+                }));
+                const groups = directAccess.groups.map(({ name, role }) => ({
+                    name: name!,
+                    role,
+                }));
+                if (
+                    new Set(users.map(({ email }) => email)).size !==
+                        users.length ||
+                    new Set(groups.map(({ name }) => name)).size !==
+                        groups.length
+                ) {
+                    spaces.push(metadataOnlySpace);
+                    skipped.push({
+                        slug,
+                        reason: 'Direct access contains ambiguous portable principals',
+                    });
+                    return;
+                }
+
+                spaces.push({
+                    ...metadataOnlySpace,
+                    version: 1,
+                    access: {
+                        inheritParentPermissions:
+                            space.inheritParentPermissions,
+                        projectMemberAccessRole: space.projectMemberAccessRole,
+                        users: users.sort((left, right) =>
+                            left.email.localeCompare(right.email),
+                        ),
+                        groups: groups.sort((left, right) =>
+                            left.name.localeCompare(right.name),
+                        ),
+                    },
+                });
+            });
+
+        return { spaces, skipped };
+    }
+
+    private async assertSpaceUploaderRetainsManage({
+        user,
+        auditedAbility,
+        project,
+        parentSpaceUuid,
+        access,
+        trx,
+        resolvedUserAccess,
+    }: {
+        user: SessionUser;
+        auditedAbility: ReturnType<CoderService['createAuditedAbility']>;
+        project: Pick<Project, 'projectUuid' | 'organizationUuid'>;
+        parentSpaceUuid: string | null;
+        access: NonNullable<SpaceAsCode['access']>;
+        trx: Knex;
+        resolvedUserAccess: ResolvedSpaceCodeUserAccess[];
+    }): Promise<void> {
+        let inheritsFromOrgOrProject =
+            access.inheritParentPermissions && parentSpaceUuid === null;
+        const proposedUserAccess: Array<{
+            userUuid: string;
+            role: SpaceMemberRole;
+        }> = [];
+
+        if (access.inheritParentPermissions && parentSpaceUuid !== null) {
+            const parentContext =
+                await this.spacePermissionService.getSpaceAccessContext(
+                    user.userUuid,
+                    parentSpaceUuid,
+                    { trx },
+                );
+            inheritsFromOrgOrProject = parentContext.inheritsFromOrgOrProject;
+            proposedUserAccess.push(...parentContext.access);
+        }
+        const directActorAccess = resolvedUserAccess.find(
+            ({ userUuid }) => userUuid === user.userUuid,
+        );
+        if (directActorAccess) {
+            proposedUserAccess.push({
+                userUuid: user.userUuid,
+                role: directActorAccess.role,
+            });
+        }
+        if (
+            access.projectMemberAccessRole !== null &&
+            ((await this.projectModel.hasProjectMembership(
+                project.projectUuid,
+                user.userUuid,
+                { trx },
+            )) ||
+                (user.role !== undefined &&
+                    user.role !== OrganizationMemberRole.MEMBER))
+        ) {
+            proposedUserAccess.push({
+                userUuid: user.userUuid,
+                role: access.projectMemberAccessRole,
+            });
+        }
+
+        const requestedGroups = access.groups.filter(
+            ({ role }) => role === SpaceMemberRole.ADMIN,
+        );
+        if (requestedGroups.length > 0) {
+            const groups = (
+                await Promise.all(
+                    requestedGroups.map(({ name }) =>
+                        this.groupsModel.find(
+                            {
+                                organizationUuid: project.organizationUuid,
+                                name,
+                            },
+                            undefined,
+                            { trx },
+                        ),
+                    ),
+                )
+            ).flatMap(({ data }) => data);
+            if (groups.length !== requestedGroups.length) {
+                // Let transactional principal validation report missing or
+                // ambiguous groups instead of masking it as a lockout.
+                return;
+            }
+            const memberships = await this.groupsModel.findUserInGroups(
+                {
+                    userUuid: user.userUuid,
+                    organizationUuid: project.organizationUuid,
+                    groupUuids: groups.map(({ uuid }) => uuid),
+                },
+                { trx },
+            );
+            if (
+                memberships.some(({ userUuid }) => userUuid === user.userUuid)
+            ) {
+                proposedUserAccess.push({
+                    userUuid: user.userUuid,
+                    role: SpaceMemberRole.ADMIN,
+                });
+            }
+        }
+
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('Space', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid: project.projectUuid,
+                    inheritsFromOrgOrProject,
+                    access: proposedUserAccess,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Space access would remove your permission to manage the space',
+            );
+        }
+    }
+
+    private async validateSpaceAccessPrincipals(
+        organizationUuid: string,
+        access: NonNullable<SpaceAsCode['access']>,
+    ): Promise<void> {
+        const members =
+            await this.organizationMemberProfileModel.findOrganizationMembersByEmails(
+                organizationUuid,
+                access.users.map(({ email }) => email),
+            );
+        const membersByEmail = members.reduce<Map<string, typeof members>>(
+            (map, member) => {
+                const email = member.email.toLowerCase();
+                map.set(email, [...(map.get(email) ?? []), member]);
+                return map;
+            },
+            new Map(),
+        );
+        access.users.forEach(({ email }) => {
+            const matches = membersByEmail.get(email) ?? [];
+            if (matches.length === 0) {
+                throw new ParameterError(
+                    `User ${email} is not a member of this organization`,
+                );
+            }
+            if (matches.length > 1) {
+                throw new ParameterError(
+                    `User email ${email} is ambiguous in this organization`,
+                );
+            }
+        });
+
+        const groupMatches = await Promise.all(
+            access.groups.map(async ({ name }) => ({
+                name,
+                matches: (
+                    await this.groupsModel.find({
+                        organizationUuid,
+                        name,
+                    })
+                ).data,
+            })),
+        );
+        groupMatches.forEach(({ name, matches }) => {
+            if (matches.length === 0) {
+                throw new ParameterError(
+                    `Group ${name} does not exist in this organization`,
+                );
+            }
+            if (matches.length > 1) {
+                throw new ParameterError(
+                    `Group name ${name} is ambiguous in this organization`,
+                );
+            }
+        });
+    }
+
+    private async hasNonPortableDirectSpaceAccess(
+        organizationUuid: string,
+        access: RawSpaceDirectAccess,
+    ): Promise<boolean> {
+        const emails = access.users.flatMap(({ email }) =>
+            email === null ? [] : [email.toLowerCase()],
+        );
+        const members =
+            await this.organizationMemberProfileModel.findOrganizationMembersByEmails(
+                organizationUuid,
+                [...new Set(emails)],
+            );
+        const membersByUuid = new Map(
+            members.map((member) => [member.userUuid, member]),
+        );
+        const memberEmailCounts = members.reduce<Map<string, number>>(
+            (counts, member) => {
+                const email = member.email.toLowerCase();
+                counts.set(email, (counts.get(email) ?? 0) + 1);
+                return counts;
+            },
+            new Map(),
+        );
+        if (
+            access.users.some(({ userUuid, email, isInternal }) => {
+                if (isInternal || email === null) return true;
+                const normalizedEmail = email.toLowerCase();
+                const member = membersByUuid.get(userUuid);
+                return (
+                    member === undefined ||
+                    member.email.toLowerCase() !== normalizedEmail ||
+                    memberEmailCounts.get(normalizedEmail) !== 1
+                );
+            })
+        ) {
+            return true;
+        }
+
+        const portableGroups = await Promise.all(
+            access.groups.map(async ({ groupUuid, name }) => {
+                if (name === null) return false;
+                const matches = (
+                    await this.groupsModel.find({ organizationUuid, name })
+                ).data;
+                return matches.length === 1 && matches[0].uuid === groupUuid;
+            }),
+        );
+        return portableGroups.some((portable) => !portable);
+    }
+
+    async upsertSpace(
+        account: Account,
+        projectUuid: string,
+        spaceInput: SpaceAsCode,
+        options: {
+            skipSpaceCreate?: boolean;
+            publicSpaceCreate?: boolean;
+        } = {},
+    ): Promise<ApiSpaceAsCodeUpsertResponse['results']> {
+        const { user } = getAccountApiAccessContext(account);
+        const desiredSpace = CoderService.normalizeSpaceAsCode(spaceInput);
+        const project = await this.projectModel.get(projectUuid);
+        if (!project) {
+            throw new NotFoundError(`Project ${projectUuid} not found`);
+        }
+        const auditedAbility = this.createAuditedAbility(account);
+        CoderService.checkContentAsCodeWriteAccess({
+            auditedAbility,
+            project,
+            slug: desiredSpace.slug,
+        });
+
+        const path = getLtreePathFromContentAsCodePath(desiredSpace.slug);
+        const matches = await this.spaceModel.findByProjectAndPath(
+            projectUuid,
+            path,
+        );
+        if (matches.some(({ isDefaultUserSpace }) => isDefaultUserSpace)) {
+            throw new ParameterError(
+                `Generated personal space "${desiredSpace.slug}" cannot be managed as code`,
+            );
+        }
+        if (matches.length > 1) {
+            throw new ParameterError(
+                `Multiple spaces use hierarchy path "${desiredSpace.slug}"`,
+            );
+        }
+        const existingSpace = matches[0];
+        if (!existingSpace && options.skipSpaceCreate) {
+            throw new NotFoundError(
+                `Space ${desiredSpace.slug} does not exist, skipping creation`,
+            );
+        }
+
+        const parentPath = path.includes('.')
+            ? path.slice(0, path.lastIndexOf('.'))
+            : null;
+        let parentSpace = null;
+        if (parentPath !== null) {
+            let parentMatches = await this.spaceModel.findByProjectAndPath(
+                projectUuid,
+                parentPath,
+            );
+            if (
+                parentMatches.length === 0 &&
+                desiredSpace.access === undefined &&
+                !existingSpace
+            ) {
+                const parentSlug =
+                    getContentAsCodePathFromLtreePath(parentPath);
+                const parentPathSegment = parentPath.slice(
+                    parentPath.lastIndexOf('.') + 1,
+                );
+                await this.upsertSpace(
+                    account,
+                    projectUuid,
+                    {
+                        contentType: ContentAsCodeType.SPACE,
+                        spaceName: friendlyName(parentPathSegment),
+                        slug: parentSlug,
+                    },
+                    options,
+                );
+                parentMatches = await this.spaceModel.findByProjectAndPath(
+                    projectUuid,
+                    parentPath,
+                );
+            }
+            if (
+                parentMatches.some(
+                    ({ isDefaultUserSpace }) => isDefaultUserSpace,
+                )
+            ) {
+                throw new ParameterError(
+                    `Generated personal space "${getContentAsCodePathFromLtreePath(
+                        parentPath,
+                    )}" cannot be used as an as-code parent`,
+                );
+            }
+            if (parentMatches.length !== 1) {
+                throw new ParameterError(
+                    parentMatches.length === 0
+                        ? `Parent space "${getContentAsCodePathFromLtreePath(
+                              parentPath,
+                          )}" must exist before "${desiredSpace.slug}"`
+                        : `Multiple spaces use parent hierarchy path "${getContentAsCodePathFromLtreePath(
+                              parentPath,
+                          )}"`,
+                );
+            }
+            [parentSpace] = parentMatches;
+        }
+        const parentSpaceUuid = parentSpace?.uuid ?? null;
+        if (
+            existingSpace &&
+            existingSpace.parentSpaceUuid !== parentSpaceUuid
+        ) {
+            throw new ParameterError(
+                `Existing space "${desiredSpace.slug}" has an inconsistent parent`,
+            );
+        }
+
+        const metadataChanged =
+            !existingSpace || existingSpace.name !== desiredSpace.spaceName;
+        if (
+            existingSpace &&
+            desiredSpace.access === undefined &&
+            !metadataChanged
+        ) {
+            if (
+                !(await this.spacePermissionService.can(
+                    'view',
+                    user,
+                    existingSpace.uuid,
+                ))
+            ) {
+                throw new ForbiddenError(
+                    `You don't have permission to view space "${desiredSpace.slug}"`,
+                );
+            }
+            return { action: SpaceAsCodeAction.NO_CHANGES };
+        }
+
+        if (existingSpace) {
+            if (
+                !(await this.spacePermissionService.can(
+                    'manage',
+                    user,
+                    existingSpace.uuid,
+                ))
+            ) {
+                throw new ForbiddenError(
+                    `You don't have permission to manage space "${desiredSpace.slug}"`,
+                );
+            }
+        } else {
+            if (
+                auditedAbility.cannot(
+                    'create',
+                    subject('Space', {
+                        organizationUuid: project.organizationUuid,
+                        projectUuid,
+                        metadata: { spaceName: desiredSpace.spaceName },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError(
+                    `You don't have permission to create space "${desiredSpace.slug}"`,
+                );
+            }
+            if (
+                parentSpaceUuid !== null &&
+                !(await this.spacePermissionService.can(
+                    'manage',
+                    user,
+                    parentSpaceUuid,
+                ))
+            ) {
+                throw new ForbiddenError(
+                    `You don't have permission to create a child of space "${getContentAsCodePathFromLtreePath(
+                        parentPath!,
+                    )}"`,
+                );
+            }
+        }
+
+        const rawAccess = existingSpace
+            ? ((
+                  await this.spacePermissionService.getRawDirectAccess([
+                      existingSpace.uuid,
+                  ])
+              )[existingSpace.uuid] ?? { users: [], groups: [] })
+            : { users: [], groups: [] };
+        const hasNonPortableDirectAccess =
+            desiredSpace.access !== undefined && existingSpace !== undefined
+                ? await this.hasNonPortableDirectSpaceAccess(
+                      project.organizationUuid,
+                      rawAccess,
+                  )
+                : false;
+        const warnings =
+            desiredSpace.access && hasNonPortableDirectAccess
+                ? [
+                      'Applying this access policy will remove direct service-account, internal-user, or unresolved user/group grants that cannot be represented as code',
+                  ]
+                : [];
+
+        if (desiredSpace.access) {
+            await this.validateSpaceAccessPrincipals(
+                project.organizationUuid,
+                desiredSpace.access,
+            );
+        }
+
+        let accessChanged = desiredSpace.access !== undefined;
+        if (
+            existingSpace &&
+            desiredSpace.access &&
+            !hasNonPortableDirectAccess
+        ) {
+            const currentAccess = {
+                inheritParentPermissions:
+                    existingSpace.inheritParentPermissions,
+                projectMemberAccessRole: existingSpace.projectMemberAccessRole,
+                users: rawAccess.users
+                    .map(({ email, role }) => ({
+                        email: email!.toLowerCase(),
+                        role,
+                    }))
+                    .sort((left, right) =>
+                        left.email.localeCompare(right.email),
+                    ),
+                groups: rawAccess.groups
+                    .map(({ name, role }) => ({ name: name!, role }))
+                    .sort((left, right) => left.name.localeCompare(right.name)),
+            };
+            accessChanged = !isEqual(currentAccess, desiredSpace.access);
+        }
+        if (existingSpace && !metadataChanged && !accessChanged) {
+            return { action: SpaceAsCodeAction.NO_CHANGES };
+        }
+
+        const applyInput = {
+            projectUuid,
+            userId: user.userId,
+            actorUserUuid: user.userUuid,
+            actorServiceAccountUuid:
+                account.authentication.type === 'service-account'
+                    ? account.authentication.serviceAccountUuid
+                    : null,
+            spaceUuid: existingSpace?.uuid ?? null,
+            name: desiredSpace.spaceName,
+            path,
+            parentSpaceUuid,
+            inheritParentPermissionsOnCreate:
+                parentSpace?.inheritParentPermissions ??
+                options.publicSpaceCreate === true,
+            ...(desiredSpace.access === undefined && parentSpaceUuid !== null
+                ? { copyParentAccessOnLegacyCreate: true }
+                : {}),
+            ...(desiredSpace.access ? { access: desiredSpace.access } : {}),
+        };
+        await this.spaceModel.applySpaceAsCode(applyInput, {
+            beforeMutation: async (trx, { userAccess }) => {
+                const reloadedUser =
+                    await this.userModel.findSessionUserAndOrgByUuid(
+                        user.userUuid,
+                        project.organizationUuid,
+                        { trx },
+                    );
+                if (!reloadedUser.isActive) {
+                    throw new ForbiddenError(
+                        'The authenticated user is no longer active',
+                    );
+                }
+                const currentUser: SessionUser = {
+                    ...reloadedUser,
+                    requestContext: user.requestContext,
+                    serviceAccount: user.serviceAccount,
+                };
+                const currentAbility = this.createAuditedAbility(currentUser);
+                CoderService.checkContentAsCodeWriteAccess({
+                    auditedAbility: currentAbility,
+                    project,
+                    slug: desiredSpace.slug,
+                });
+
+                if (
+                    existingSpace &&
+                    !(await this.spacePermissionService.can(
+                        'manage',
+                        currentUser,
+                        existingSpace.uuid,
+                        { trx },
+                    ))
+                ) {
+                    throw new ForbiddenError(
+                        `You don't have permission to manage space "${desiredSpace.slug}"`,
+                    );
+                }
+                if (
+                    !existingSpace &&
+                    currentAbility.cannot(
+                        'create',
+                        subject('Space', {
+                            organizationUuid: project.organizationUuid,
+                            projectUuid,
+                            metadata: {
+                                spaceName: desiredSpace.spaceName,
+                            },
+                        }),
+                    )
+                ) {
+                    throw new ForbiddenError(
+                        `You don't have permission to create space "${desiredSpace.slug}"`,
+                    );
+                }
+                if (
+                    !existingSpace &&
+                    parentSpaceUuid !== null &&
+                    !(await this.spacePermissionService.can(
+                        'manage',
+                        currentUser,
+                        parentSpaceUuid,
+                        { trx },
+                    ))
+                ) {
+                    throw new ForbiddenError(
+                        `You don't have permission to create a child of space "${getContentAsCodePathFromLtreePath(
+                            parentPath!,
+                        )}"`,
+                    );
+                }
+                if (desiredSpace.access) {
+                    await this.assertSpaceUploaderRetainsManage({
+                        user: currentUser,
+                        auditedAbility: currentAbility,
+                        project,
+                        parentSpaceUuid,
+                        access: desiredSpace.access!,
+                        trx,
+                        resolvedUserAccess: userAccess,
+                    });
+                }
+            },
+        });
+
+        return {
+            action: existingSpace
+                ? SpaceAsCodeAction.UPDATE
+                : SpaceAsCodeAction.CREATE,
+            ...(warnings.length > 0 ? { warnings } : {}),
+        };
     }
 
     private static transformChart(

--- a/packages/backend/src/services/CoderService/CoderService.upsertContentAccess.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.upsertContentAccess.test.ts
@@ -140,6 +140,9 @@ const buildService = () =>
             })),
         } as AnyType,
         contentVerificationModel: {} as AnyType,
+        groupsModel: {} as AnyType,
+        organizationMemberProfileModel: {} as AnyType,
+        userModel: {} as AnyType,
     });
 
 describe('CoderService content-as-code space permissions', () => {

--- a/packages/backend/src/services/CoderService/CoderService.upsertSqlChart.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.upsertSqlChart.test.ts
@@ -101,6 +101,9 @@ const buildService = (
             can: vi.fn(async () => true),
         } as unknown as SpacePermissionService,
         contentVerificationModel: {} as unknown as ContentVerificationModel,
+        groupsModel: {} as never,
+        organizationMemberProfileModel: {} as never,
+        userModel: {} as never,
     });
 
 const stubSpace = (service: CoderService, uuid: string = SPACE_UUID) =>

--- a/packages/backend/src/services/CoderService/CoderService.virtualViews.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.virtualViews.test.ts
@@ -108,6 +108,9 @@ const buildService = (existing: Explore | null = virtualView) => {
         spacePermissionService: {} as never,
         contentVerificationModel: {} as never,
         projectService: projectService as never,
+        groupsModel: {} as never,
+        organizationMemberProfileModel: {} as never,
+        userModel: {} as never,
     });
     return { service, projectService };
 };

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1194,6 +1194,10 @@ export class ServiceRepository
                     contentVerificationModel:
                         this.models.getContentVerificationModel(),
                     projectService: this.getProjectService(),
+                    groupsModel: this.models.getGroupsModel(),
+                    organizationMemberProfileModel:
+                        this.models.getOrganizationMemberProfileModel(),
+                    userModel: this.models.getUserModel(),
                 }),
         );
     }

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -1,3 +1,4 @@
+import { Ability } from '@casl/ability';
 import {
     DirectSpaceAccessOrigin,
     NotFoundError,
@@ -6,10 +7,13 @@ import {
     type DirectSpaceAccess,
     type OrganizationMemberRole,
     type OrganizationSpaceAccess,
+    type PossibleAbilities,
     type ProjectMemberRole,
     type ProjectSpaceAccess,
+    type SessionUser,
     type SpaceInheritanceChain,
 } from '@lightdash/common';
+import { type Knex } from 'knex';
 import { SpaceModel } from '../../models/SpaceModel';
 import { SpacePermissionModel } from '../../models/SpacePermissionModel';
 import { SpacePermissionService } from './SpacePermissionService';
@@ -19,6 +23,7 @@ const createMockSpacePermissionModel = () => ({
         vi.fn<
             (
                 spaceUuids: string[],
+                options?: { trx?: Knex },
             ) => Promise<Record<string, SpaceInheritanceChain>>
         >(),
     getDirectSpaceAccess:
@@ -26,6 +31,7 @@ const createMockSpacePermissionModel = () => ({
             (
                 spaceUuids: string[],
                 filters?: { userUuid?: string },
+                options?: { trx?: Knex },
             ) => Promise<Record<string, DirectSpaceAccess[]>>
         >(),
     getProjectSpaceAccess:
@@ -33,6 +39,7 @@ const createMockSpacePermissionModel = () => ({
             (
                 spaceUuids: string[],
                 filters?: { userUuid?: string },
+                options?: { trx?: Knex },
             ) => Promise<Record<string, ProjectSpaceAccess[]>>
         >(),
     getOrganizationSpaceAccess:
@@ -40,11 +47,15 @@ const createMockSpacePermissionModel = () => ({
             (
                 spaceUuids: string[],
                 filters?: { userUuid?: string },
+                options?: { trx?: Knex },
             ) => Promise<Record<string, OrganizationSpaceAccess[]>>
         >(),
     getSpaceInfo:
         vi.fn<
-            (spaceUuids: string[]) => Promise<
+            (
+                spaceUuids: string[],
+                options?: { trx?: Knex },
+            ) => Promise<
                 Record<
                     string,
                     {
@@ -67,6 +78,83 @@ describe('SpacePermissionService', () => {
 
     afterEach(() => {
         vi.resetAllMocks();
+    });
+
+    test('fails closed when any requested space has no access context', async () => {
+        mockPermissionModel.getInheritanceChains.mockResolvedValue({});
+        mockPermissionModel.getDirectSpaceAccess.mockResolvedValue({});
+        mockPermissionModel.getProjectSpaceAccess.mockResolvedValue({});
+        mockPermissionModel.getOrganizationSpaceAccess.mockResolvedValue({});
+        mockPermissionModel.getSpaceInfo.mockResolvedValue({});
+        const user = {
+            userUuid: 'user-uuid',
+            ability: new Ability<PossibleAbilities>([
+                { action: 'manage', subject: 'Space' },
+            ]),
+        } as unknown as SessionUser;
+
+        await expect(
+            service.can('manage', user, 'missing-space'),
+        ).resolves.toBe(false);
+    });
+
+    test('uses the provided transaction for every access-context query', async () => {
+        const spaceUuid = 'space-uuid';
+        const userUuid = 'user-uuid';
+        const trx = {} as Knex;
+        mockPermissionModel.getInheritanceChains.mockResolvedValue({
+            [spaceUuid]: {
+                chain: [
+                    {
+                        spaceUuid,
+                        spaceName: 'Space',
+                        inheritParentPermissions: true,
+                    },
+                ],
+                inheritsFromOrgOrProject: true,
+            },
+        });
+        mockPermissionModel.getDirectSpaceAccess.mockResolvedValue({});
+        mockPermissionModel.getProjectSpaceAccess.mockResolvedValue({});
+        mockPermissionModel.getOrganizationSpaceAccess.mockResolvedValue({});
+        mockPermissionModel.getSpaceInfo.mockResolvedValue({
+            [spaceUuid]: {
+                projectUuid: 'project-uuid',
+                organizationUuid: 'organization-uuid',
+            },
+        });
+        const user = {
+            userUuid,
+            ability: new Ability<PossibleAbilities>([
+                { action: 'manage', subject: 'Space' },
+            ]),
+        } as unknown as SessionUser;
+
+        await expect(
+            service.can('manage', user, spaceUuid, { trx }),
+        ).resolves.toBe(true);
+
+        expect(mockPermissionModel.getInheritanceChains).toHaveBeenCalledWith(
+            [spaceUuid],
+            { trx },
+        );
+        expect(mockPermissionModel.getDirectSpaceAccess).toHaveBeenCalledWith(
+            [spaceUuid],
+            { userUuid },
+            { trx },
+        );
+        expect(mockPermissionModel.getProjectSpaceAccess).toHaveBeenCalledWith(
+            [spaceUuid],
+            { userUuid },
+            { trx },
+        );
+        expect(
+            mockPermissionModel.getOrganizationSpaceAccess,
+        ).toHaveBeenCalledWith([spaceUuid], { userUuid }, { trx });
+        expect(mockPermissionModel.getSpaceInfo).toHaveBeenCalledWith(
+            [spaceUuid],
+            { trx },
+        );
     });
 
     describe('getSpacesCaslContext (via getAllSpaceAccessContext)', () => {
@@ -124,10 +212,14 @@ describe('SpacePermissionService', () => {
             // Project access was fetched for the root space
             expect(
                 mockPermissionModel.getProjectSpaceAccess,
-            ).toHaveBeenCalledWith(['root-space'], undefined);
+            ).toHaveBeenCalledWith(['root-space'], undefined, {
+                trx: undefined,
+            });
             expect(
                 mockPermissionModel.getOrganizationSpaceAccess,
-            ).toHaveBeenCalledWith(['root-space'], undefined);
+            ).toHaveBeenCalledWith(['root-space'], undefined, {
+                trx: undefined,
+            });
         });
 
         test('space with inherit=false is treated as private, direct access user gets role', async () => {
@@ -337,6 +429,7 @@ describe('SpacePermissionService', () => {
             ).toHaveBeenCalledWith(
                 expect.arrayContaining(['child-space', 'parent-space']),
                 undefined,
+                { trx: undefined },
             );
         });
 
@@ -393,7 +486,9 @@ describe('SpacePermissionService', () => {
             // Project access fetched for the root space (last in chain)
             expect(
                 mockPermissionModel.getProjectSpaceAccess,
-            ).toHaveBeenCalledWith(['root-space'], undefined);
+            ).toHaveBeenCalledWith(['root-space'], undefined, {
+                trx: undefined,
+            });
             // User gets access via project membership
             expect(result.access).toHaveLength(1);
             expect(result.access[0].userUuid).toBe(userUuid);

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -13,6 +13,7 @@ import {
     type SpaceAccessUserMetadata,
     type SpaceGroup,
 } from '@lightdash/common';
+import { Knex } from 'knex';
 import { SpaceModel } from '../../models/SpaceModel';
 import { SpacePermissionModel } from '../../models/SpacePermissionModel';
 import { BaseService } from '../BaseService';
@@ -51,18 +52,35 @@ export class SpacePermissionService extends BaseService {
         action: AbilityAction,
         user: SessionUser,
         spaceUuids: string[] | string,
+        { trx }: { trx?: Knex } = {},
     ): Promise<boolean> {
         const spaceUuidsArray = Array.isArray(spaceUuids)
             ? spaceUuids
             : [spaceUuids];
 
-        const accessContext = await this.getSpacesCaslContext(spaceUuidsArray, {
-            userUuid: user.userUuid,
-        });
+        const accessContext = await this.getSpacesCaslContext(
+            spaceUuidsArray,
+            {
+                userUuid: user.userUuid,
+            },
+            { trx },
+        );
+
+        const uniqueSpaceUuids = [...new Set(spaceUuidsArray)];
+        if (
+            uniqueSpaceUuids.some(
+                (spaceUuid) => accessContext[spaceUuid] === undefined,
+            )
+        ) {
+            return false;
+        }
 
         const auditedAbility = this.createAuditedAbility(user);
-        return Object.values(accessContext).every((access) =>
-            auditedAbility.can(action, subject('Space', access)),
+        return uniqueSpaceUuids.every((spaceUuid) =>
+            auditedAbility.can(
+                action,
+                subject('Space', accessContext[spaceUuid]),
+            ),
         );
     }
 
@@ -90,6 +108,11 @@ export class SpacePermissionService extends BaseService {
             .map(([spaceUuid]) => spaceUuid);
     }
 
+    /** Returns persisted direct grants without inherited or expanded access. */
+    async getRawDirectAccess(spaceUuids: string[]) {
+        return this.spacePermissionModel.getRawDirectAccess(spaceUuids);
+    }
+
     /**
      * Returns the CASL context for a space (organizationUuid, projectUuid, inheritsFromOrgOrProject, access)
      * without performing any permission checks. Callers use this to build their own
@@ -98,10 +121,15 @@ export class SpacePermissionService extends BaseService {
     async getSpaceAccessContext(
         userUuid: string,
         spaceUuid: string,
+        { trx }: { trx?: Knex } = {},
     ): Promise<SpaceAccessContextForCasl> {
-        const accessContext = await this.getSpacesCaslContext([spaceUuid], {
-            userUuid,
-        });
+        const accessContext = await this.getSpacesCaslContext(
+            [spaceUuid],
+            {
+                userUuid,
+            },
+            { trx },
+        );
         const ctx = accessContext[spaceUuid];
         if (!ctx) {
             throw new NotFoundError(
@@ -120,8 +148,9 @@ export class SpacePermissionService extends BaseService {
     async getSpacesAccessContext(
         userUuid: string,
         spaceUuids: string[],
+        { trx }: { trx?: Knex } = {},
     ): Promise<Record<string, SpaceAccessContextForCasl>> {
-        return this.getSpacesCaslContext(spaceUuids, { userUuid });
+        return this.getSpacesCaslContext(spaceUuids, { userUuid }, { trx });
     }
 
     /**
@@ -156,14 +185,15 @@ export class SpacePermissionService extends BaseService {
     private async getSpacesCaslContext(
         spaceUuidsArg: string[],
         filters?: { userUuid?: string },
+        { trx }: { trx?: Knex } = {},
     ): Promise<Record<string, SpaceAccessContextForCasl>> {
         const uniqueSpaceUuids = [...new Set(spaceUuidsArg)];
 
         // Get inheritance chains for all spaces in a single batched query
-        const chainMap =
-            await this.spacePermissionModel.getInheritanceChains(
-                uniqueSpaceUuids,
-            );
+        const chainMap = await this.spacePermissionModel.getInheritanceChains(
+            uniqueSpaceUuids,
+            { trx },
+        );
         const chains = uniqueSpaceUuids
             .filter((uuid) => chainMap[uuid] !== undefined)
             .map((uuid) => ({
@@ -196,11 +226,13 @@ export class SpacePermissionService extends BaseService {
                 this.spacePermissionModel.getDirectSpaceAccess(
                     allChainSpaceUuids,
                     filters,
+                    { trx },
                 ),
                 allChainsRootSpaceUuids.length > 0
                     ? this.spacePermissionModel.getProjectSpaceAccess(
                           allChainsRootSpaceUuids,
                           filters,
+                          { trx },
                       )
                     : Promise.resolve(
                           {} as Record<string, ProjectSpaceAccess[]>,
@@ -209,11 +241,14 @@ export class SpacePermissionService extends BaseService {
                     ? this.spacePermissionModel.getOrganizationSpaceAccess(
                           allChainsRootSpaceUuids,
                           filters,
+                          { trx },
                       )
                     : Promise.resolve(
                           {} as Record<string, OrganizationSpaceAccess[]>,
                       ),
-                this.spacePermissionModel.getSpaceInfo(uniqueSpaceUuids),
+                this.spacePermissionModel.getSpaceInfo(uniqueSpaceUuids, {
+                    trx,
+                }),
             ]);
 
         // For each requested space, aggregate access from its chain

--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -1,5 +1,6 @@
 import {
     AbilityAction,
+    NotFoundError,
     OrganizationMemberRole,
     ProjectMemberRole,
     SpaceMemberRole,
@@ -1011,6 +1012,22 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
         });
         mockSpacePermissionService.getGroupAccess.mockResolvedValue([]);
         mockSpacePermissionService.getUserMetadataByUuids.mockResolvedValue({});
+    });
+
+    test('getSpace returns not found when the space is missing', async () => {
+        mockSpaceModel.get.mockRejectedValueOnce(
+            new NotFoundError('Space not found'),
+        );
+
+        await expect(
+            service.getSpace(
+                'project-uuid',
+                mockUser as unknown as SessionUser,
+                'deleted-space-uuid',
+            ),
+        ).rejects.toBeInstanceOf(NotFoundError);
+        expect(mockSpaceModel.get).toHaveBeenCalledOnce();
+        expect(mockSpacePermissionService.can).not.toHaveBeenCalled();
     });
 
     test('copies permissions when transitioning inheritParentPermissions true → false with flag enabled', async () => {

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -217,6 +217,11 @@ export class SpaceService
         user: SessionUser,
         spaceUuid: string,
     ): Promise<Space> {
+        const space = await this.spaceModel.get(spaceUuid);
+        if (space.projectUuid !== projectUuid) {
+            throw new NotFoundError(`Space with uuid ${spaceUuid} not found`);
+        }
+
         if (!(await this.spacePermissionService.can('view', user, spaceUuid))) {
             throw new ForbiddenError();
         }

--- a/packages/backend/src/utils/SlugUtils.ts
+++ b/packages/backend/src/utils/SlugUtils.ts
@@ -17,6 +17,7 @@ type SlugTables =
 // Namespace 1 is already used by cached explores (ProjectModel), so use 2 here
 // to avoid clashing with that lock space.
 const CONTENT_AS_CODE_SLUG_LOCK_NAMESPACE = 2;
+const SPACE_ACCESS_LOCK_NAMESPACE = 3;
 
 /**
  * Take a transaction-scoped Postgres advisory lock keyed on (projectUuid, slug).
@@ -40,6 +41,16 @@ export const acquireProjectSlugLock = async (
     await trx.raw('SELECT pg_advisory_xact_lock(?, hashtext(?))', [
         CONTENT_AS_CODE_SLUG_LOCK_NAMESPACE,
         `${projectUuid}:${slug}`,
+    ]);
+};
+
+export const acquireSpaceAccessLock = async (
+    trx: Knex,
+    spaceUuid: string,
+): Promise<void> => {
+    await trx.raw('SELECT pg_advisory_xact_lock(?, hashtext(?))', [
+        SPACE_ACCESS_LOCK_NAMESPACE,
+        spaceUuid,
     ]);
 };
 

--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -1,10 +1,15 @@
 import {
     CartesianSeriesType,
     ChartType,
+    ContentAsCodeType,
     DashboardAsCode,
+    LightdashError,
+    SpaceAsCodeAction,
+    SpaceMemberRole,
     type CartesianChartConfig,
     type ChartAsCode,
     type Series,
+    type SpaceAsCode,
 } from '@lightdash/common';
 import { promises as fs } from 'fs';
 import * as os from 'os';
@@ -12,7 +17,7 @@ import * as path from 'path';
 import { vi } from 'vitest';
 import GlobalState from '../globalState';
 import { lightdashApi } from './dbt/apiClient';
-import { testHelpers } from './download';
+import { downloadContent, testHelpers } from './download';
 
 vi.mock('./dbt/apiClient', async (importOriginal) => ({
     ...(await importOriginal<typeof import('./dbt/apiClient')>()),
@@ -20,11 +25,20 @@ vi.mock('./dbt/apiClient', async (importOriginal) => ({
 }));
 
 const {
+    assertUniqueSpacePaths,
+    downloadSpaces,
     getDashboardChartSlugs,
+    getFlatSpaceFileNames,
     readAiAgentFiles,
+    readSpaceFiles,
+    readSpaceNames,
     sanitizeChartForDownload,
+    shouldFallBackToEmbeddedSpaces,
     shouldDownloadAiAgents,
+    upsertSpaces,
     upsertVirtualViews,
+    validateSpaceIdentity,
+    writeSpaceFiles,
 } = testHelpers;
 
 type LooseDashboard = DashboardAsCode & { needsUpdating: boolean };
@@ -404,5 +418,764 @@ describe('shouldDownloadAiAgents', () => {
                 appsOnly: true,
             }),
         ).toBe(false);
+    });
+});
+
+describe('space files', () => {
+    const accessSpace = (slug: string): SpaceAsCode =>
+        ({
+            contentType: 'space',
+            version: 1,
+            spaceName: slug,
+            slug,
+            access: {
+                inheritParentPermissions: false,
+                projectMemberAccessRole: null,
+                users: [],
+                groups: [],
+            },
+        }) as SpaceAsCode;
+
+    beforeEach(() => {
+        vi.mocked(lightdashApi).mockReset();
+    });
+
+    const embeddedSpaceResponse = (spaceName: string) => ({
+        charts: [makeChart([])],
+        languageMap: undefined,
+        missingIds: [],
+        offset: 1,
+        spaces: [
+            {
+                contentType: ContentAsCodeType.SPACE,
+                spaceName,
+                slug: 'test-space',
+            },
+        ],
+        total: 1,
+    });
+
+    it('writes new flat space files under spaces by default', async () => {
+        const tmpDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'space-code-flat-folder-'),
+        );
+        try {
+            await writeSpaceFiles(
+                [accessSpace('finance')],
+                'project',
+                tmpDir,
+                'flat',
+            );
+
+            await expect(
+                fs.readFile(
+                    path.join(tmpDir, 'spaces', 'finance.space.yml'),
+                    'utf-8',
+                ),
+            ).resolves.toContain('slug: finance');
+            await expect(
+                fs.access(path.join(tmpDir, 'finance.space.yml')),
+            ).rejects.toMatchObject({ code: 'ENOENT' });
+        } finally {
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it('supports the legacy root-spaces flat layout', async () => {
+        const tmpDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'space-code-root-layout-'),
+        );
+        try {
+            await writeSpaceFiles(
+                [accessSpace('finance')],
+                'project',
+                tmpDir,
+                'flat',
+                'root',
+            );
+
+            await expect(
+                fs.readFile(path.join(tmpDir, 'finance.space.yml'), 'utf-8'),
+            ).resolves.toContain('slug: finance');
+            await expect(
+                fs.access(path.join(tmpDir, 'spaces')),
+            ).rejects.toMatchObject({ code: 'ENOENT' });
+        } finally {
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it('preserves existing access when filtered metadata updates a space file', async () => {
+        const tmpDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'space-code-filtered-policy-'),
+        );
+        vi.mocked(lightdashApi).mockResolvedValue(
+            embeddedSpaceResponse('Updated finance') as never,
+        );
+        const existingFile = path.join(tmpDir, 'finance.space.yml');
+        await fs.writeFile(
+            existingFile,
+            `access:
+  groups: []
+  inheritParentPermissions: false
+  projectMemberAccessRole: null
+  users:
+    - email: owner@example.com
+      role: admin
+contentType: space
+slug: test-space
+spaceName: Finance
+version: 1
+`,
+        );
+
+        try {
+            await downloadContent(
+                ['pivoted-chart'],
+                'charts',
+                'project-uuid',
+                'project',
+                tmpDir,
+                false,
+                false,
+                false,
+                false,
+                false,
+            );
+
+            await expect(readSpaceFiles(tmpDir)).resolves.toEqual([
+                expect.objectContaining({
+                    filePath: existingFile,
+                    space: {
+                        contentType: 'space',
+                        version: 1,
+                        spaceName: 'Updated finance',
+                        slug: 'test-space',
+                        access: {
+                            inheritParentPermissions: false,
+                            projectMemberAccessRole: null,
+                            users: [
+                                {
+                                    email: 'owner@example.com',
+                                    role: SpaceMemberRole.ADMIN,
+                                },
+                            ],
+                            groups: [],
+                        },
+                    },
+                }),
+            ]);
+            await expect(
+                fs.access(
+                    path.join(tmpDir, 'spaces', 'updated-finance.space.yml'),
+                ),
+            ).rejects.toMatchObject({ code: 'ENOENT' });
+        } finally {
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it('writes nested definitions inside each full space path', async () => {
+        const tmpDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'space-code-nested-layout-'),
+        );
+        try {
+            await writeSpaceFiles(
+                [
+                    { ...accessSpace('parent'), spaceName: 'Parent' },
+                    {
+                        ...accessSpace('parent/child'),
+                        spaceName: 'Child',
+                    },
+                ],
+                'project',
+                tmpDir,
+                'nested',
+            );
+
+            await expect(
+                fs.readFile(
+                    path.join(tmpDir, 'project', 'parent', 'parent.space.yml'),
+                    'utf-8',
+                ),
+            ).resolves.toContain('slug: parent');
+            await expect(
+                fs.readFile(
+                    path.join(
+                        tmpDir,
+                        'project',
+                        'parent',
+                        'child',
+                        'child.space.yml',
+                    ),
+                    'utf-8',
+                ),
+            ).resolves.toContain('slug: parent/child');
+            await expect(
+                fs.access(path.join(tmpDir, 'spaces')),
+            ).rejects.toMatchObject({ code: 'ENOENT' });
+        } finally {
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it('downloads metadata-only spaces when access cannot be exported', async () => {
+        const tmpDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'space-code-metadata-fallback-'),
+        );
+        const logSpy = vi
+            .spyOn(GlobalState, 'log')
+            .mockImplementation(() => undefined);
+        await fs.writeFile(
+            path.join(tmpDir, 'finance.space.yml'),
+            `access:
+  groups: []
+  inheritParentPermissions: false
+  projectMemberAccessRole: null
+  users: []
+contentType: space
+slug: finance
+spaceName: Finance
+version: 1
+`,
+        );
+        vi.mocked(lightdashApi).mockResolvedValue({
+            spaces: [
+                {
+                    contentType: ContentAsCodeType.SPACE,
+                    spaceName: 'Finance',
+                    slug: 'finance',
+                },
+            ],
+            skipped: [
+                {
+                    slug: 'finance',
+                    reason: 'Direct access contains a user without a portable organization identity',
+                },
+            ],
+        });
+
+        try {
+            await expect(
+                downloadSpaces('project-uuid', 'Project', tmpDir),
+            ).resolves.toBe(1);
+            await expect(readSpaceFiles(tmpDir)).resolves.toEqual([
+                expect.objectContaining({
+                    space: {
+                        contentType: 'space',
+                        spaceName: 'Finance',
+                        slug: 'finance',
+                    },
+                }),
+            ]);
+            const downloadedFile = await fs.readFile(
+                path.join(tmpDir, 'finance.space.yml'),
+                'utf-8',
+            );
+            expect(downloadedFile).not.toContain('access:');
+            expect(downloadedFile).not.toContain('version:');
+            await expect(
+                fs.access(path.join(tmpDir, 'spaces', 'finance.space.yml')),
+            ).rejects.toMatchObject({ code: 'ENOENT' });
+            expect(logSpy).toHaveBeenCalledWith(
+                expect.stringContaining(
+                    'Downloaded space "finance" without access',
+                ),
+            );
+            expect(logSpy).not.toHaveBeenCalledWith(
+                expect.stringContaining('Skipped space "finance"'),
+            );
+        } finally {
+            logSpy.mockRestore();
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it('accepts legacy metadata-only files without a version', () => {
+        expect(
+            validateSpaceIdentity(
+                {
+                    contentType: 'space',
+                    spaceName: 'Finance',
+                    slug: 'company/finance',
+                },
+                'finance.space.yml',
+            ),
+        ).toEqual({
+            contentType: 'space',
+            spaceName: 'Finance',
+            slug: 'company/finance',
+        });
+    });
+
+    it('reads legacy space names without validating access policy', async () => {
+        const tmpDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'space-name-test-'),
+        );
+        try {
+            await fs.writeFile(
+                path.join(tmpDir, 'finance.space.yml'),
+                `access:
+  unsupported: true
+contentType: space
+spaceName: Finance operations
+slug: finance
+version: 99
+`,
+            );
+            await fs.writeFile(
+                path.join(tmpDir, 'invalid.space.yml'),
+                'contentType: [invalid\n',
+            );
+
+            await expect(readSpaceFiles(tmpDir)).rejects.toThrow(
+                'Invalid version',
+            );
+            await expect(readSpaceNames(tmpDir)).resolves.toEqual({
+                finance: 'Finance operations',
+            });
+        } finally {
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it('requires version 1 when access is present', () => {
+        expect(() =>
+            validateSpaceIdentity(
+                {
+                    contentType: 'space',
+                    spaceName: 'Finance',
+                    slug: 'finance',
+                    access: {
+                        inheritParentPermissions: false,
+                        projectMemberAccessRole: null,
+                        users: [],
+                        groups: [],
+                    },
+                },
+                'finance.space.yml',
+            ),
+        ).toThrow('version 1 is required when access is present');
+    });
+
+    it('normalizes emails and rejects duplicate principals', () => {
+        const parsed = validateSpaceIdentity(
+            {
+                contentType: 'space',
+                version: 1,
+                spaceName: 'Finance',
+                slug: 'finance',
+                access: {
+                    inheritParentPermissions: false,
+                    projectMemberAccessRole: SpaceMemberRole.VIEWER,
+                    users: [
+                        {
+                            email: ' Alice@Example.com ',
+                            role: SpaceMemberRole.ADMIN,
+                        },
+                    ],
+                    groups: [
+                        {
+                            name: 'Finance team',
+                            role: SpaceMemberRole.EDITOR,
+                        },
+                    ],
+                },
+            },
+            'finance.space.yml',
+        );
+
+        expect(parsed.access?.users).toEqual([
+            { email: 'alice@example.com', role: SpaceMemberRole.ADMIN },
+        ]);
+
+        expect(() =>
+            validateSpaceIdentity(
+                {
+                    ...parsed,
+                    access: {
+                        ...parsed.access,
+                        users: [
+                            {
+                                email: 'alice@example.com',
+                                role: SpaceMemberRole.ADMIN,
+                            },
+                            {
+                                email: 'ALICE@example.com',
+                                role: SpaceMemberRole.VIEWER,
+                            },
+                        ],
+                    },
+                },
+                'finance.space.yml',
+            ),
+        ).toThrow('Duplicate user email "alice@example.com"');
+
+        expect(() =>
+            validateSpaceIdentity(
+                {
+                    ...parsed,
+                    access: {
+                        ...parsed.access,
+                        groups: [
+                            {
+                                name: 'Finance team',
+                                role: SpaceMemberRole.EDITOR,
+                            },
+                            {
+                                name: 'Finance team',
+                                role: SpaceMemberRole.VIEWER,
+                            },
+                        ],
+                    },
+                },
+                'finance.space.yml',
+            ),
+        ).toThrow('Duplicate group name "Finance team"');
+    });
+
+    it('reads nested definitions parent-first', async () => {
+        const tmpDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'space-code-test-'),
+        );
+        try {
+            await fs.mkdir(path.join(tmpDir, 'nested'));
+            await fs.writeFile(
+                path.join(tmpDir, 'nested', 'child.space.yml'),
+                `contentType: space\nspaceName: Child\nslug: parent/child\n`,
+            );
+            await fs.writeFile(
+                path.join(tmpDir, 'parent.space.yml'),
+                `contentType: space\nspaceName: Parent\nslug: parent\n`,
+            );
+
+            await expect(readSpaceFiles(tmpDir)).resolves.toEqual([
+                expect.objectContaining({
+                    space: expect.objectContaining({ slug: 'parent' }),
+                }),
+                expect.objectContaining({
+                    space: expect.objectContaining({ slug: 'parent/child' }),
+                }),
+            ]);
+        } finally {
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it('rejects non-canonical and colliding normalized paths', () => {
+        expect(() =>
+            validateSpaceIdentity(
+                {
+                    contentType: 'space',
+                    spaceName: 'Finance',
+                    slug: 'Parent_With.Space',
+                },
+                'finance.space.yml',
+            ),
+        ).toThrow('canonical lowercase slash-separated path');
+
+        expect(() =>
+            assertUniqueSpacePaths([
+                {
+                    filePath: 'one.space.yml',
+                    space: accessSpace('parent-child'),
+                },
+                {
+                    filePath: 'two.space.yml',
+                    space: {
+                        ...accessSpace('parent-child'),
+                        slug: 'parent_child',
+                    },
+                },
+            ]),
+        ).toThrow('resolve to the same normalized path');
+    });
+
+    it('uses deterministic collision-safe flat filenames', () => {
+        const spaces = [
+            { ...accessSpace('finance-a'), spaceName: 'Finance!' },
+            { ...accessSpace('finance-b'), spaceName: 'Finance?' },
+        ];
+
+        const first = getFlatSpaceFileNames(spaces);
+        expect(first).toEqual(
+            getFlatSpaceFileNames([...spaces].reverse()).reverse(),
+        );
+        expect(new Set(first).size).toBe(2);
+        expect(
+            first.every((fileName) =>
+                /^finance-[a-f0-9]{8}\.space\.yml$/.test(fileName),
+            ),
+        ).toBe(true);
+    });
+
+    it('never overwrites an existing filename owned by another slug', async () => {
+        const tmpDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'space-code-protected-file-'),
+        );
+        const protectedContent =
+            'contentType: space\nspaceName: Existing\nslug: existing\n';
+        try {
+            await fs.writeFile(
+                path.join(tmpDir, 'finance.space.yml'),
+                protectedContent,
+            );
+            await writeSpaceFiles(
+                [
+                    {
+                        ...accessSpace('new-finance'),
+                        spaceName: 'Finance',
+                    },
+                ],
+                'project',
+                tmpDir,
+                'flat',
+            );
+
+            await expect(
+                fs.readFile(path.join(tmpDir, 'finance.space.yml'), 'utf-8'),
+            ).resolves.toBe(protectedContent);
+            const newSpaceFile = (await fs.readdir(tmpDir)).find(
+                (fileName) =>
+                    fileName !== 'finance.space.yml' &&
+                    fileName.endsWith('.space.yml'),
+            );
+            expect(newSpaceFile).toBeDefined();
+            expect(
+                await fs.readFile(path.join(tmpDir, newSpaceFile!), 'utf-8'),
+            ).toContain('slug: new-finance');
+            await expect(
+                fs.access(path.join(tmpDir, 'spaces')),
+            ).rejects.toMatchObject({ code: 'ENOENT' });
+        } finally {
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it('uses the legacy root layout for new slugs when a root space file exists', async () => {
+        const tmpDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'space-code-mixed-layout-'),
+        );
+        try {
+            await fs.writeFile(
+                path.join(tmpDir, 'finance.space.yml'),
+                'contentType: space\nspaceName: Old finance\nslug: finance\n',
+            );
+            await writeSpaceFiles(
+                [
+                    { ...accessSpace('finance'), spaceName: 'New finance' },
+                    { ...accessSpace('operations'), spaceName: 'Operations' },
+                ],
+                'project',
+                tmpDir,
+                'flat',
+            );
+
+            await expect(
+                fs.readFile(path.join(tmpDir, 'finance.space.yml'), 'utf-8'),
+            ).resolves.toContain('spaceName: New finance');
+            await expect(
+                fs.readFile(path.join(tmpDir, 'operations.space.yml'), 'utf-8'),
+            ).resolves.toContain('slug: operations');
+            await expect(
+                fs.access(path.join(tmpDir, 'spaces')),
+            ).rejects.toMatchObject({ code: 'ENOENT' });
+            expect(
+                (await readSpaceFiles(tmpDir)).map(({ space }) => space.slug),
+            ).toEqual(['finance', 'operations']);
+        } finally {
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it('rejects duplicate existing slugs across layouts before writing', async () => {
+        const tmpDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'space-code-duplicate-layout-'),
+        );
+        try {
+            await fs.mkdir(path.join(tmpDir, 'spaces'));
+            const duplicate =
+                'contentType: space\nspaceName: Finance\nslug: finance\n';
+            await fs.writeFile(
+                path.join(tmpDir, 'finance.space.yml'),
+                duplicate,
+            );
+            await fs.writeFile(
+                path.join(tmpDir, 'spaces', 'finance.space.yml'),
+                duplicate,
+            );
+
+            await expect(
+                writeSpaceFiles(
+                    [accessSpace('operations')],
+                    'project',
+                    tmpDir,
+                    'flat',
+                ),
+            ).rejects.toThrow(
+                'Multiple existing space files use slug "finance"',
+            );
+            await expect(
+                fs.access(path.join(tmpDir, 'spaces', 'operations.space.yml')),
+            ).rejects.toMatchObject({ code: 'ENOENT' });
+        } finally {
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it('fails a space download when the space endpoint is unavailable', async () => {
+        const tmpDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'space-code-api-failure-'),
+        );
+        vi.mocked(lightdashApi).mockRejectedValue(
+            new Error('space endpoint unavailable'),
+        );
+
+        try {
+            const error = await downloadSpaces(
+                'project-uuid',
+                'Project',
+                tmpDir,
+            ).catch((caughtError: unknown) => caughtError);
+
+            expect(error).toMatchObject({
+                name: 'SpaceAsCodeFetchError',
+                message: 'space endpoint unavailable',
+            });
+            expect(shouldFallBackToEmbeddedSpaces(error, false)).toBe(true);
+            expect(shouldFallBackToEmbeddedSpaces(error, true)).toBe(false);
+        } finally {
+            await fs.rm(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it('uploads parent-first and aggregates API actions', async () => {
+        const logSpy = vi
+            .spyOn(GlobalState, 'log')
+            .mockImplementation(() => undefined);
+        vi.mocked(lightdashApi)
+            .mockResolvedValueOnce({
+                action: SpaceAsCodeAction.CREATE,
+                warnings: ['A direct service-account grant will be removed'],
+            } as never)
+            .mockResolvedValueOnce({
+                action: SpaceAsCodeAction.UPDATE,
+            } as never);
+        const changes = await upsertSpaces(
+            'project-uuid',
+            [
+                { filePath: 'child.space.yml', space: accessSpace('a/b') },
+                { filePath: 'parent.space.yml', space: accessSpace('a') },
+            ],
+            {},
+            false,
+            false,
+        );
+
+        expect(changes).toEqual({
+            'spaces created': 1,
+            'spaces updated': 1,
+        });
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'A direct service-account grant will be removed',
+            ),
+        );
+        expect(
+            vi
+                .mocked(lightdashApi)
+                .mock.calls.map(
+                    ([request]) =>
+                        JSON.parse(
+                            typeof request.body === 'string'
+                                ? request.body
+                                : '{}',
+                        ).slug,
+                ),
+        ).toEqual(['a', 'a/b']);
+        logSpy.mockRestore();
+    });
+
+    it('treats missing spaces and descendants as nonfatal with skip-space-create', async () => {
+        vi.mocked(lightdashApi)
+            .mockRejectedValueOnce(
+                new LightdashError({
+                    message: 'Space a does not exist, skipping creation',
+                    name: 'NotFoundError',
+                    statusCode: 404,
+                    data: {},
+                }),
+            )
+            .mockResolvedValueOnce({
+                action: SpaceAsCodeAction.NO_CHANGES,
+            } as never);
+
+        await expect(
+            upsertSpaces(
+                'project-uuid',
+                [
+                    { filePath: 'child.space.yml', space: accessSpace('a/b') },
+                    { filePath: 'other.space.yml', space: accessSpace('z') },
+                    { filePath: 'parent.space.yml', space: accessSpace('a') },
+                ],
+                {},
+                true,
+                false,
+            ),
+        ).resolves.toEqual({
+            'spaces skipped': 2,
+            'spaces unchanged': 1,
+        });
+        expect(lightdashApi).toHaveBeenCalledTimes(2);
+        expect(
+            vi
+                .mocked(lightdashApi)
+                .mock.calls.map(
+                    ([request]) =>
+                        JSON.parse(
+                            typeof request.body === 'string'
+                                ? request.body
+                                : '{}',
+                        ).slug,
+                ),
+        ).toEqual(['a', 'z']);
+    });
+
+    it('skips descendants after a parent failure and blocks content', async () => {
+        const summarySpy = vi
+            .spyOn(console, 'info')
+            .mockImplementation(() => undefined);
+        vi.mocked(lightdashApi)
+            .mockRejectedValueOnce(new Error('parent rejected'))
+            .mockResolvedValueOnce({
+                action: SpaceAsCodeAction.CREATE,
+            } as never);
+        const changes: Record<string, number> = {};
+
+        await expect(
+            upsertSpaces(
+                'project-uuid',
+                [
+                    { filePath: 'child.space.yml', space: accessSpace('a/b') },
+                    { filePath: 'other.space.yml', space: accessSpace('z') },
+                    { filePath: 'parent.space.yml', space: accessSpace('a') },
+                ],
+                changes,
+                false,
+                false,
+            ),
+        ).rejects.toThrow('content upload was not started');
+        expect(lightdashApi).toHaveBeenCalledTimes(2);
+        expect(changes).toEqual({
+            'spaces with errors': 1,
+            'spaces created': 1,
+            'spaces dependency skipped': 1,
+        });
+        expect(summarySpy.mock.calls.map(([message]) => message)).toEqual([
+            'Total spaces with errors: 1 ',
+            'Total spaces created: 1 ',
+            'Total spaces dependency skipped: 1 ',
+        ]);
+        summarySpy.mockRestore();
     });
 });

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -79,7 +79,6 @@ import {
     resolveAppsLimit,
     selectAppsToDownload,
     shouldFallBackToSpaceScopedListing,
-    shouldWarnAllSkipped,
     type AppDownloadFailure,
 } from './apps/appsDownload';
 import {
@@ -104,6 +103,27 @@ import {
     uploadOrganizationContent,
 } from './organizationContent';
 import { logSelectedProject, selectProject } from './selectProject';
+import {
+    assertUniqueSpacePaths,
+    createSpaceAsCodeDownloadError,
+    createSpaceAsCodeUploadError,
+    downloadSpaces,
+    getFlatSpaceFileNames,
+    getSpaceNames,
+    getUniqueExistingSpaceFilePathsBySlug,
+    isSpaceAsCodeDownloadError,
+    isSpaceAsCodeFetchError,
+    isSpaceAsCodeUploadError,
+    logUploadChanges,
+    readSpaceFiles,
+    readSpaceNames,
+    shouldFallBackToEmbeddedSpaces,
+    sortSpaceFilesParentFirst,
+    upsertSpaces,
+    validateSpaceIdentity,
+    writeSpaceFiles,
+    type SpaceCodeFile,
+} from './spacesAsCode';
 
 export type DownloadHandlerOptions = {
     verbose: boolean;
@@ -127,7 +147,9 @@ export type DownloadHandlerOptions = {
     public: boolean;
     includeCharts: boolean;
     nested: boolean; // Use nested folder structure (projectName/spaceSlug/charts|dashboards)
-    skipSpaces: boolean; // Skip writing space metadata files during download
+    rootSpaces: boolean; // Write new flat space files at the content root (legacy layout)
+    skipSpaces: boolean; // Skip first-class space definitions and access
+    spacesOnly?: boolean; // Download/upload only first-class space definitions
     skipCharts: boolean; // Skip downloading charts and SQL charts
     skipDashboards: boolean; // Skip downloading dashboards
     skipAlerts: boolean;
@@ -313,103 +335,21 @@ const writeContent = async (
     };
 };
 
-/**
- * Writes space YAML files for each space in the download results.
- * In flat mode, files go in the base download directory.
- * In nested mode, files go in the root of each space's directory.
- */
-const writeSpaceFiles = async (
-    spaces: SpaceAsCode[],
-    projectName: string,
-    customPath?: string,
-    folderScheme: FolderScheme = 'flat',
-): Promise<void> => {
-    if (spaces.length === 0) return;
-
-    const baseDir = getDownloadFolder(customPath);
-    const seen = new Set<string>();
-
-    for (const space of spaces) {
-        // Deduplicate across paginated API responses
-        if (!seen.has(space.slug)) {
-            seen.add(space.slug);
-
-            let outputDir: string;
-            if (folderScheme === 'nested') {
-                outputDir = path.join(baseDir, projectName, space.slug);
-            } else {
-                outputDir = baseDir;
-            }
-
-            await fs.mkdir(outputDir, { recursive: true });
-
-            const fileName = `${generateSlug(space.spaceName)}.space.yml`;
-            const filePath = path.join(outputDir, fileName);
-            const content = yaml.dump(space, {
-                quotingType: '"',
-                sortKeys: true,
-            });
-            await fs.writeFile(filePath, content);
-            GlobalState.debug(`Wrote space file: ${filePath}`);
-        }
+function getPromoteAction(action: PromotionAction) {
+    switch (action) {
+        case PromotionAction.CREATE:
+            return 'created';
+        case PromotionAction.UPDATE:
+            return 'updated';
+        case PromotionAction.DELETE:
+            return 'deleted';
+        case PromotionAction.NO_CHANGES:
+            return 'skipped';
+        default:
+            assertUnreachable(action, `Unknown promotion action: ${action}`);
     }
-};
-
-/**
- * Reads all .space.yml files from the download directory and returns
- * a map of space slug → original space name. Used during upload to
- * preserve human-readable space names instead of deriving them from slugs.
- */
-const readSpaceNames = async (
-    customPath?: string,
-): Promise<Record<string, string>> => {
-    const baseDir = getDownloadFolder(customPath);
-    const spaceNames: Record<string, string> = {};
-
-    try {
-        const allEntries = await fs.readdir(baseDir, {
-            recursive: true,
-            withFileTypes: true,
-        });
-
-        await Promise.all(
-            allEntries
-                .filter(
-                    (entry) =>
-                        entry.isFile() && entry.name.endsWith('.space.yml'),
-                )
-                .map(async (file) => {
-                    try {
-                        const filePath = path.join(file.parentPath, file.name);
-                        const fileContent = await fs.readFile(
-                            filePath,
-                            'utf-8',
-                        );
-                        const parsed = yaml.load(fileContent) as Record<
-                            string,
-                            unknown
-                        >;
-                        if (
-                            parsed?.contentType ===
-                                ContentAsCodeTypeEnum.SPACE &&
-                            typeof parsed.slug === 'string' &&
-                            typeof parsed.spaceName === 'string'
-                        ) {
-                            spaceNames[parsed.slug] = parsed.spaceName;
-                        }
-                    } catch (e) {
-                        GlobalState.debug(
-                            `Skipping space file ${file.name}: ${getErrorMessage(e)}`,
-                        );
-                    }
-                }),
-        );
-    } catch {
-        // Directory doesn't exist or can't be read — return empty map
-    }
-
-    return spaceNames;
-};
+    return 'skipped';
+}
 
 const hasUnsortedKeys = (obj: unknown): boolean => {
     if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
@@ -431,6 +371,7 @@ const isLightdashContentFile = (folder: string, entry: Dirent) =>
     entry.parentPath &&
     entry.parentPath.endsWith(path.sep + folder) &&
     entry.name.endsWith('.yml') &&
+    !entry.name.endsWith('.space.yml') &&
     !entry.name.endsWith('.language.map.yml');
 
 const isLooseContentFile = (entry: Dirent) =>
@@ -617,7 +558,7 @@ const readLooseCodeFiles = async (
                             ),
                         );
                     } else if (contentType === ContentAsCodeTypeEnum.SPACE) {
-                        // Space YAML files are metadata-only until the next PR
+                        // Space files are handled by the dedicated space phase.
                     } else {
                         GlobalState.debug(
                             `Skipping ${file.name}: no recognized contentType`,
@@ -767,6 +708,7 @@ export const downloadContent = async (
     nested: boolean = false,
     skipSpaces: boolean = false,
     stripPivotSeries: boolean = false,
+    rootSpaces: boolean = false,
 ): Promise<[number, string[], MetadataEntry[], SpaceAsCode[]]> => {
     const spinner = GlobalState.getActiveSpinner();
     const contentFilters = parseContentFilters(ids);
@@ -888,7 +830,17 @@ export const downloadContent = async (
 
     // Write space YAML files
     if (!skipSpaces) {
-        await writeSpaceFiles(allSpaces, projectName, customPath, folderScheme);
+        const uniqueSpaces = [
+            ...new Map(allSpaces.map((space) => [space.slug, space])).values(),
+        ];
+        await writeSpaceFiles(
+            uniqueSpaces,
+            projectName,
+            customPath,
+            folderScheme,
+            rootSpaces ? 'root' : 'folder',
+            true,
+        );
     }
 
     return [total, [...new Set(chartSlugs)], allMetadataEntries, allSpaces];
@@ -908,22 +860,6 @@ const getGoogleSheetsFolder = (customPath?: string): string =>
 
 const getVirtualViewsFolder = (customPath?: string): string =>
     path.join(getDownloadFolder(customPath), 'virtual-views');
-
-function getPromoteAction(action: PromotionAction) {
-    switch (action) {
-        case PromotionAction.CREATE:
-            return 'created';
-        case PromotionAction.UPDATE:
-            return 'updated';
-        case PromotionAction.DELETE:
-            return 'deleted';
-        case PromotionAction.NO_CHANGES:
-            return 'skipped';
-        default:
-            assertUnreachable(action, `Unknown promotion action: ${action}`);
-    }
-    return 'skipped';
-}
 
 const downloadVirtualViews = async (
     projectId: string,
@@ -1440,8 +1376,10 @@ export const downloadHandler = async (
     const isOrganizationDownload = options.organization === true;
 
     const includeAll = options.includeAll === true;
-    const includeApps = options.includeApps === true || includeAll;
-    const includeAllOptionalContent = includeAll && !options.appsOnly;
+    const includeApps =
+        !options.spacesOnly && (options.includeApps === true || includeAll);
+    const includeAllOptionalContent =
+        includeAll && !options.appsOnly && !options.spacesOnly;
     const { limit: appsLimit, noEffectWarning: appsLimitWarning } =
         resolveAppsLimit(options.appsLimit, includeApps);
     if (appsLimitWarning) {
@@ -1466,6 +1404,56 @@ export const downloadHandler = async (
         options.includeGoogleSheets = false;
         options.includeScheduledDeliveries = false;
         options.includeVirtualViews = false;
+    }
+
+    if (options.spacesOnly) {
+        if (options.skipSpaces) {
+            throw new ParameterError(
+                'Nothing to download: --spaces-only cannot be combined with --skip-spaces.',
+            );
+        }
+        options.skipCharts = true;
+        options.skipDashboards = true;
+        options.agents = [];
+        options.alerts = [];
+        options.apps = [];
+        options.googleSheets = [];
+        options.scheduledDeliveries = [];
+        options.virtualViews = [];
+        options.includeAgents = false;
+        options.includeApps = false;
+        options.includeAlerts = false;
+        options.includeGoogleSheets = false;
+        options.includeScheduledDeliveries = false;
+        options.includeVirtualViews = false;
+    }
+
+    if (options.rootSpaces && options.nested) {
+        throw new ParameterError(
+            '--root-spaces cannot be combined with --nested',
+        );
+    }
+
+    const hasFilters =
+        !options.spacesOnly &&
+        (options.charts.length > 0 ||
+            options.dashboards.length > 0 ||
+            options.agents.length > 0 ||
+            options.alerts.length > 0 ||
+            options.googleSheets.length > 0 ||
+            options.scheduledDeliveries.length > 0 ||
+            options.virtualViews.length > 0);
+    const shouldDownloadSpaces =
+        !isOrganizationDownload && !options.skipSpaces && !hasFilters;
+    let skipEmbeddedSpaces = !hasFilters || options.skipSpaces;
+    if (shouldDownloadSpaces) {
+        try {
+            await getUniqueExistingSpaceFilePathsBySlug(
+                getDownloadFolder(options.path),
+            );
+        } catch (error) {
+            throw createSpaceAsCodeDownloadError(getErrorMessage(error));
+        }
     }
 
     await checkLightdashVersion();
@@ -1499,8 +1487,11 @@ export const downloadHandler = async (
     // Log current project info
     logSelectedProject(projectSelection, config, 'Downloading from');
 
-    const spinner = GlobalState.startSpinner(`Downloading charts`);
-    spinner.start(`Downloading content from project`);
+    const spinner = GlobalState.startSpinner(
+        options.spacesOnly
+            ? `Downloading spaces`
+            : `Downloading content from project`,
+    );
 
     // Fetch project details to get project name for folder structure
     const project = await lightdashApi<Project>({
@@ -1524,20 +1515,38 @@ export const downloadHandler = async (
         },
     });
     try {
-        const hasFilters =
-            options.charts.length > 0 ||
-            options.dashboards.length > 0 ||
-            options.agents.length > 0 ||
-            options.alerts.length > 0 ||
-            options.googleSheets.length > 0 ||
-            options.scheduledDeliveries.length > 0 ||
-            options.virtualViews.length > 0;
-
-        // When downloading specific charts or dashboards, skip space metadata
-        const skipSpaces = options.skipSpaces || hasFilters;
-
         let allMetadataEntries: MetadataEntry[] = [];
-        let allSpaces: SpaceAsCode[] = [];
+
+        if (shouldDownloadSpaces) {
+            if (!options.spacesOnly) spinner.start(`Downloading spaces`);
+            try {
+                const spaceTotal = await downloadSpaces(
+                    projectId,
+                    projectName,
+                    options.path,
+                    options.nested,
+                    options.rootSpaces,
+                );
+                spinner.succeed(`Downloaded ${spaceTotal} spaces`);
+            } catch (error) {
+                if (
+                    !shouldFallBackToEmbeddedSpaces(error, options.spacesOnly)
+                ) {
+                    throw isSpaceAsCodeFetchError(error)
+                        ? createSpaceAsCodeDownloadError(getErrorMessage(error))
+                        : error;
+                }
+                skipEmbeddedSpaces = false;
+                spinner.warn(
+                    styles.warning(
+                        'Space access is unavailable; continuing with legacy space metadata where available.',
+                    ),
+                );
+                GlobalState.debug(
+                    `Could not download access-aware spaces: ${getErrorMessage(error)}`,
+                );
+            }
+        }
 
         if (
             includeAllOptionalContent ||
@@ -1560,46 +1569,41 @@ export const downloadHandler = async (
                     styles.warning(`No charts filters provided, skipping`),
                 );
             } else {
-                const [
-                    regularChartTotal,
-                    ,
-                    regularChartMeta,
-                    regularChartSpaces,
-                ] = await downloadContent(
-                    options.charts,
-                    'charts',
-                    projectId,
-                    projectName,
-                    options.path,
-                    options.languageMap,
-                    options.nested,
-                    skipSpaces,
-                    options.stripPivotSeries,
-                );
-                spinner.succeed(`Downloaded ${regularChartTotal} charts`);
-                allMetadataEntries = [
-                    ...allMetadataEntries,
-                    ...regularChartMeta,
-                ];
-                allSpaces = [...allSpaces, ...regularChartSpaces];
-
-                // Download SQL charts
-                spinner.start(`Downloading SQL charts`);
-                const [sqlChartTotal, , sqlChartMeta, sqlChartSpaces] =
+                const [regularChartTotal, , regularChartMeta] =
                     await downloadContent(
                         options.charts,
-                        'sqlCharts',
+                        'charts',
                         projectId,
                         projectName,
                         options.path,
                         options.languageMap,
                         options.nested,
-                        skipSpaces,
-                        false,
+                        skipEmbeddedSpaces,
+                        options.stripPivotSeries,
+                        options.rootSpaces,
                     );
+                spinner.succeed(`Downloaded ${regularChartTotal} charts`);
+                allMetadataEntries = [
+                    ...allMetadataEntries,
+                    ...regularChartMeta,
+                ];
+
+                // Download SQL charts
+                spinner.start(`Downloading SQL charts`);
+                const [sqlChartTotal, , sqlChartMeta] = await downloadContent(
+                    options.charts,
+                    'sqlCharts',
+                    projectId,
+                    projectName,
+                    options.path,
+                    options.languageMap,
+                    options.nested,
+                    skipEmbeddedSpaces,
+                    false,
+                    options.rootSpaces,
+                );
                 spinner.succeed(`Downloaded ${sqlChartTotal} SQL charts`);
                 allMetadataEntries = [...allMetadataEntries, ...sqlChartMeta];
-                allSpaces = [...allSpaces, ...sqlChartSpaces];
 
                 chartTotal = regularChartTotal + sqlChartTotal;
             }
@@ -1615,21 +1619,19 @@ export const downloadHandler = async (
                 let chartSlugs: string[] = [];
 
                 let dashMeta: MetadataEntry[];
-                let dashSpaces: SpaceAsCode[];
-                [dashboardTotal, chartSlugs, dashMeta, dashSpaces] =
-                    await downloadContent(
-                        options.dashboards,
-                        'dashboards',
-                        projectId,
-                        projectName,
-                        options.path,
-                        options.languageMap,
-                        options.nested,
-                        skipSpaces,
-                        false,
-                    );
+                [dashboardTotal, chartSlugs, dashMeta] = await downloadContent(
+                    options.dashboards,
+                    'dashboards',
+                    projectId,
+                    projectName,
+                    options.path,
+                    options.languageMap,
+                    options.nested,
+                    skipEmbeddedSpaces,
+                    false,
+                    options.rootSpaces,
+                );
                 allMetadataEntries = [...allMetadataEntries, ...dashMeta];
-                allSpaces = [...allSpaces, ...dashSpaces];
 
                 spinner.succeed(`Downloaded ${dashboardTotal} dashboards`);
 
@@ -1642,44 +1644,40 @@ export const downloadHandler = async (
                         `Downloading ${chartSlugs.length} charts linked to dashboards`,
                     );
 
-                    const [
-                        regularCharts,
-                        ,
-                        linkedChartMeta,
-                        linkedChartSpaces,
-                    ] = await downloadContent(
-                        chartSlugs,
-                        'charts',
-                        projectId,
-                        projectName,
-                        options.path,
-                        options.languageMap,
-                        options.nested,
-                        skipSpaces,
-                        options.stripPivotSeries,
-                    );
-                    allMetadataEntries = [
-                        ...allMetadataEntries,
-                        ...linkedChartMeta,
-                    ];
-                    allSpaces = [...allSpaces, ...linkedChartSpaces];
-
-                    const [sqlCharts, , linkedSqlMeta, linkedSqlSpaces] =
+                    const [regularCharts, , linkedChartMeta] =
                         await downloadContent(
                             chartSlugs,
-                            'sqlCharts',
+                            'charts',
                             projectId,
                             projectName,
                             options.path,
                             options.languageMap,
                             options.nested,
-                            skipSpaces,
+                            skipEmbeddedSpaces,
+                            options.stripPivotSeries,
+                            options.rootSpaces,
                         );
+                    allMetadataEntries = [
+                        ...allMetadataEntries,
+                        ...linkedChartMeta,
+                    ];
+
+                    const [sqlCharts, , linkedSqlMeta] = await downloadContent(
+                        chartSlugs,
+                        'sqlCharts',
+                        projectId,
+                        projectName,
+                        options.path,
+                        options.languageMap,
+                        options.nested,
+                        skipEmbeddedSpaces,
+                        false,
+                        options.rootSpaces,
+                    );
                     allMetadataEntries = [
                         ...allMetadataEntries,
                         ...linkedSqlMeta,
                     ];
-                    allSpaces = [...allSpaces, ...linkedSqlSpaces];
 
                     spinner.succeed(
                         `Downloaded ${
@@ -1690,7 +1688,7 @@ export const downloadHandler = async (
             }
         }
 
-        if (shouldDownloadAiAgents(options)) {
+        if (!options.spacesOnly && shouldDownloadAiAgents(options)) {
             spinner.start(`Downloading AI agents`);
             const agentTotal = await downloadAiAgents(
                 projectId,
@@ -1912,12 +1910,6 @@ export const downloadHandler = async (
             }
         }
 
-        // Report space definitions count
-        if (!skipSpaces) {
-            const uniqueSpaceCount = new Set(allSpaces.map((s) => s.slug)).size;
-            spinner.succeed(`Downloaded ${uniqueSpaceCount} space definitions`);
-        }
-
         // Write metadata file with all downloadedAt timestamps
         const metadataToWrite: LightdashMetadata = {
             version: 1,
@@ -1968,6 +1960,7 @@ export const downloadHandler = async (
                 error: `${error}`,
             },
         });
+        if (isSpaceAsCodeDownloadError(error)) throw error;
     }
 };
 
@@ -2005,20 +1998,6 @@ const storeUploadChanges = (
     });
 
     return updatedChanges;
-};
-
-const logUploadChanges = (changes: Record<string, number>) => {
-    Object.entries(changes).forEach(([key, value]) => {
-        console.info(`Total ${key}: ${value} `);
-    });
-
-    if (shouldWarnAllSkipped(changes)) {
-        console.warn(
-            styles.warning(
-                `\nAll content was skipped (no local changes detected). Use --force to upload all content, e.g. when uploading to a new project.`,
-            ),
-        );
-    }
 };
 
 // SQL charts have 'sql' field instead of 'tableName'/'metricQuery'
@@ -2404,7 +2383,32 @@ export const uploadHandler = async (
 ): Promise<void> => {
     GlobalState.setVerbose(options.verbose);
 
+    if (options.spacesOnly && options.skipSpaces) {
+        throw new ParameterError(
+            'Nothing to upload: --spaces-only cannot be combined with --skip-spaces.',
+        );
+    }
+
     const isOrganizationUpload = options.organization === true;
+    const hasFilters =
+        !options.spacesOnly &&
+        (options.charts.length > 0 ||
+            options.dashboards.length > 0 ||
+            options.agents.length > 0 ||
+            options.alerts.length > 0 ||
+            options.googleSheets.length > 0 ||
+            options.scheduledDeliveries.length > 0 ||
+            options.virtualViews.length > 0);
+    const shouldReconcileSpaces =
+        !isOrganizationUpload && !options.skipSpaces && !hasFilters;
+    let preflightSpaceFiles: SpaceCodeFile[] = [];
+    if (shouldReconcileSpaces) {
+        try {
+            preflightSpaceFiles = await readSpaceFiles(options.path);
+        } catch (error) {
+            throw createSpaceAsCodeUploadError(getErrorMessage(error));
+        }
+    }
 
     if (options.gzip) {
         setGzipEnabled(true);
@@ -2457,19 +2461,45 @@ export const uploadHandler = async (
 
     let uploadResource = 'content as code';
     try {
+        uploadResource = 'space definitions';
+        const spaceFiles = preflightSpaceFiles;
+        const spaceNames = shouldReconcileSpaces
+            ? getSpaceNames(spaceFiles)
+            : await readSpaceNames(options.path);
+        if (spaceFiles.length > 0) {
+            GlobalState.log(`Found ${spaceFiles.length} space definition(s)`);
+        }
+
+        if (shouldReconcileSpaces) {
+            changes = await upsertSpaces(
+                projectId,
+                spaceFiles,
+                changes,
+                options.skipSpaceCreate,
+                options.public,
+            );
+        } else if (hasFilters) {
+            GlobalState.debug(
+                'Skipping space access reconciliation for a filtered content upload',
+            );
+        }
+
+        if (options.spacesOnly) {
+            await LightdashAnalytics.track({
+                event: 'upload.completed',
+                properties: {
+                    userId: config.user?.userUuid,
+                    organizationId: config.user?.organizationUuid,
+                    projectId,
+                    timeToCompleted: (Date.now() - start) / 1000,
+                },
+            });
+            logUploadChanges(changes);
+            return;
+        }
+
         const uploadPermissions =
             await getContentAsCodeUploadPermissions(projectId);
-
-        // If any filter is provided, we skip those items without filters
-        // eg: if a --charts filter is provided, we skip dashboards if no --dashboards filter is provided
-        const hasFilters =
-            options.charts.length > 0 ||
-            options.dashboards.length > 0 ||
-            options.agents.length > 0 ||
-            options.alerts.length > 0 ||
-            options.googleSheets.length > 0 ||
-            options.scheduledDeliveries.length > 0 ||
-            options.virtualViews.length > 0;
 
         // Discover loose YAML files (outside charts/ and dashboards/) classified by contentType
         uploadResource = 'content files';
@@ -2510,15 +2540,6 @@ export const uploadHandler = async (
                 styles.warning(
                     `Concurrency limit exceeded. Using maximum of 1000 instead of ${options.concurrency}`,
                 ),
-            );
-        }
-
-        // Read space definition files to preserve original space names during upload
-        uploadResource = 'space definitions';
-        const spaceNames = await readSpaceNames(options.path);
-        if (Object.keys(spaceNames).length > 0) {
-            GlobalState.log(
-                `Found ${Object.keys(spaceNames).length} space definition(s)`,
             );
         }
 
@@ -3024,16 +3045,26 @@ export const uploadHandler = async (
                 error: getErrorMessage(error),
             },
         });
-        if (error instanceof AiAgentAsCodeUploadError) {
+        if (isSpaceAsCodeUploadError(error)) throw error;
+        if (error instanceof AiAgentAsCodeUploadError)
             throw error.originalError;
-        }
     }
 };
 
 export const testHelpers = {
+    assertUniqueSpacePaths,
+    downloadSpaces,
+    getFlatSpaceFileNames,
     getDashboardChartSlugs,
     readAiAgentFiles,
+    readSpaceFiles,
+    readSpaceNames,
     sanitizeChartForDownload,
+    shouldFallBackToEmbeddedSpaces,
     shouldDownloadAiAgents,
+    sortSpaceFilesParentFirst,
+    upsertSpaces,
     upsertVirtualViews,
+    validateSpaceIdentity,
+    writeSpaceFiles,
 };

--- a/packages/cli/src/handlers/spacesAsCode.ts
+++ b/packages/cli/src/handlers/spacesAsCode.ts
@@ -1,0 +1,941 @@
+/* eslint-disable no-await-in-loop */
+/* eslint-disable no-param-reassign */
+import {
+    ApiSpaceAsCodeListResponse,
+    ApiSpaceAsCodeUpsertResponse,
+    assertUnreachable,
+    ContentAsCodeType as ContentAsCodeTypeEnum,
+    generateSlug,
+    getContentAsCodePathFromLtreePath,
+    getErrorMessage,
+    getLtreePathFromContentAsCodePath,
+    LightdashError,
+    ParameterError,
+    SpaceAsCodeAction,
+    SpaceMemberRole,
+    validateEmail,
+    type SpaceAsCode,
+} from '@lightdash/common';
+import { createHash } from 'crypto';
+import { promises as fs, type Dirent } from 'fs';
+import * as yaml from 'js-yaml';
+import * as path from 'path';
+import GlobalState from '../globalState';
+import * as styles from '../styles';
+import { shouldWarnAllSkipped } from './apps/appsDownload';
+import { getDownloadFolder } from './contentAsCodePaths';
+import { lightdashApi } from './dbt/apiClient';
+
+type FolderScheme = 'flat' | 'nested';
+type FlatSpaceLayout = 'folder' | 'root';
+
+export type SpaceCodeFile = {
+    filePath: string;
+    space: SpaceAsCode;
+};
+
+type SpaceIdentity = {
+    contentType: ContentAsCodeTypeEnum.SPACE;
+    slug: string;
+};
+
+const SPACE_FILENAME_MAX_LENGTH = 200;
+const SPACE_FILENAME_HASH_LENGTH = 8;
+
+const isSpaceIdentity = (value: unknown): value is SpaceIdentity =>
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    'contentType' in value &&
+    value.contentType === ContentAsCodeTypeEnum.SPACE &&
+    'slug' in value &&
+    typeof value.slug === 'string';
+
+const listSpaceFilePaths = async (baseDir: string): Promise<string[]> =>
+    (
+        await fs.readdir(baseDir, {
+            recursive: true,
+            withFileTypes: true,
+        })
+    )
+        .filter((entry) => entry.isFile() && entry.name.endsWith('.space.yml'))
+        .map((entry) => path.join(entry.parentPath, entry.name))
+        .sort((left, right) => left.localeCompare(right));
+
+const hasRootSpaceFile = async (baseDir: string): Promise<boolean> => {
+    try {
+        return (await fs.readdir(baseDir, { withFileTypes: true })).some(
+            (entry) => entry.isFile() && entry.name.endsWith('.space.yml'),
+        );
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+        throw error;
+    }
+};
+
+const getStableSpaceHash = (
+    value: string,
+    length: number = SPACE_FILENAME_HASH_LENGTH,
+): string => createHash('sha256').update(value).digest('hex').slice(0, length);
+
+const getSpaceFilenameBase = (space: SpaceAsCode): string => {
+    const normalizedName = space.spaceName
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '');
+    const base = /[a-z0-9]/i.test(normalizedName)
+        ? generateSlug(normalizedName)
+        : `space-${getStableSpaceHash(space.slug)}`;
+
+    return base.slice(0, SPACE_FILENAME_MAX_LENGTH);
+};
+
+export const getFlatSpaceFileNames = (spaces: SpaceAsCode[]): string[] => {
+    const bases = spaces.map(getSpaceFilenameBase);
+    const counts = bases.reduce<Map<string, number>>(
+        (result, base) => result.set(base, (result.get(base) ?? 0) + 1),
+        new Map(),
+    );
+
+    return spaces.map((space, index) => {
+        const base = bases[index];
+        if ((counts.get(base) ?? 0) === 1) return `${base}.space.yml`;
+
+        const suffix = `-${getStableSpaceHash(space.slug)}`;
+        return `${base.slice(
+            0,
+            SPACE_FILENAME_MAX_LENGTH - suffix.length,
+        )}${suffix}.space.yml`;
+    });
+};
+
+const assertKnownKeys = (
+    value: Record<string, unknown>,
+    allowedKeys: string[],
+    field: string,
+    filePath: string,
+): void => {
+    const unknownKeys = Object.keys(value).filter(
+        (key) => !allowedKeys.includes(key),
+    );
+    if (unknownKeys.length > 0) {
+        throw new ParameterError(
+            `Invalid ${field} in space file "${filePath}": unknown ${
+                unknownKeys.length === 1 ? 'property' : 'properties'
+            } ${unknownKeys.map((key) => `"${key}"`).join(', ')}`,
+        );
+    }
+};
+
+const isSpaceMemberRole = (value: unknown): value is SpaceMemberRole =>
+    Object.values(SpaceMemberRole).includes(value as SpaceMemberRole);
+
+export const validateSpaceIdentity = (
+    parsed: unknown,
+    filePath: string,
+): SpaceAsCode => {
+    if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        Array.isArray(parsed)
+    ) {
+        throw new ParameterError(
+            `Invalid space file "${filePath}": expected a YAML object`,
+        );
+    }
+
+    assertKnownKeys(
+        parsed as Record<string, unknown>,
+        ['contentType', 'version', 'spaceName', 'slug', 'access'],
+        'space document',
+        filePath,
+    );
+
+    if (
+        !('contentType' in parsed) ||
+        parsed.contentType !== ContentAsCodeTypeEnum.SPACE
+    ) {
+        throw new ParameterError(
+            `Invalid contentType in space file "${filePath}": expected "${ContentAsCodeTypeEnum.SPACE}"`,
+        );
+    }
+    if (
+        !('spaceName' in parsed) ||
+        typeof parsed.spaceName !== 'string' ||
+        parsed.spaceName.trim().length === 0
+    ) {
+        throw new ParameterError(
+            `Invalid spaceName in space file "${filePath}": expected a non-empty string`,
+        );
+    }
+    if (
+        !('slug' in parsed) ||
+        typeof parsed.slug !== 'string' ||
+        parsed.slug.trim().length === 0 ||
+        parsed.slug !== parsed.slug.trim() ||
+        !/^[a-z0-9-]+(?:\/[a-z0-9-]+)*$/.test(parsed.slug) ||
+        getContentAsCodePathFromLtreePath(
+            getLtreePathFromContentAsCodePath(parsed.slug),
+        ) !== parsed.slug ||
+        parsed.slug
+            .split('/')
+            .some((part) => part.length === 0 || part === '.' || part === '..')
+    ) {
+        throw new ParameterError(
+            `Invalid slug in space file "${filePath}": expected a canonical lowercase slash-separated path`,
+        );
+    }
+
+    if ('version' in parsed && parsed.version !== 1) {
+        throw new ParameterError(
+            `Invalid version in space file "${filePath}": expected 1`,
+        );
+    }
+
+    if ('access' in parsed && parsed.access !== undefined) {
+        if (!('version' in parsed) || parsed.version !== 1) {
+            throw new ParameterError(
+                `Invalid version in space file "${filePath}": version 1 is required when access is present`,
+            );
+        }
+        if (
+            typeof parsed.access !== 'object' ||
+            parsed.access === null ||
+            Array.isArray(parsed.access)
+        ) {
+            throw new ParameterError(
+                `Invalid access in space file "${filePath}": expected an object`,
+            );
+        }
+
+        const access = parsed.access as Record<string, unknown>;
+        assertKnownKeys(
+            access,
+            [
+                'inheritParentPermissions',
+                'projectMemberAccessRole',
+                'users',
+                'groups',
+            ],
+            'access',
+            filePath,
+        );
+        if (typeof access.inheritParentPermissions !== 'boolean') {
+            throw new ParameterError(
+                `Invalid access.inheritParentPermissions in space file "${filePath}": expected a boolean`,
+            );
+        }
+        if (
+            access.projectMemberAccessRole !== null &&
+            !isSpaceMemberRole(access.projectMemberAccessRole)
+        ) {
+            throw new ParameterError(
+                `Invalid access.projectMemberAccessRole in space file "${filePath}": expected viewer, editor, admin, or null`,
+            );
+        }
+        if (!Array.isArray(access.users) || !Array.isArray(access.groups)) {
+            throw new ParameterError(
+                `Invalid access in space file "${filePath}": users and groups must be arrays`,
+            );
+        }
+
+        const userEmails = new Set<string>();
+        const users = access.users.map((item, index) => {
+            if (
+                typeof item !== 'object' ||
+                item === null ||
+                Array.isArray(item)
+            ) {
+                throw new ParameterError(
+                    `Invalid access.users[${index}] in space file "${filePath}": expected an object`,
+                );
+            }
+            const user = item as Record<string, unknown>;
+            assertKnownKeys(
+                user,
+                ['email', 'role'],
+                `access.users[${index}]`,
+                filePath,
+            );
+            if (
+                typeof user.email !== 'string' ||
+                user.email.trim().length === 0 ||
+                !validateEmail(user.email.trim()) ||
+                !isSpaceMemberRole(user.role)
+            ) {
+                throw new ParameterError(
+                    `Invalid access.users[${index}] in space file "${filePath}": expected a valid email and a viewer, editor, or admin role`,
+                );
+            }
+            const email = user.email.trim().toLowerCase();
+            if (userEmails.has(email)) {
+                throw new ParameterError(
+                    `Duplicate user email "${email}" in space file "${filePath}"`,
+                );
+            }
+            userEmails.add(email);
+            return { email, role: user.role };
+        });
+
+        const groupNames = new Set<string>();
+        const groups = access.groups.map((item, index) => {
+            if (
+                typeof item !== 'object' ||
+                item === null ||
+                Array.isArray(item)
+            ) {
+                throw new ParameterError(
+                    `Invalid access.groups[${index}] in space file "${filePath}": expected an object`,
+                );
+            }
+            const group = item as Record<string, unknown>;
+            assertKnownKeys(
+                group,
+                ['name', 'role'],
+                `access.groups[${index}]`,
+                filePath,
+            );
+            if (
+                typeof group.name !== 'string' ||
+                group.name.trim().length === 0 ||
+                !isSpaceMemberRole(group.role)
+            ) {
+                throw new ParameterError(
+                    `Invalid access.groups[${index}] in space file "${filePath}": expected a non-empty name and a viewer, editor, or admin role`,
+                );
+            }
+            if (groupNames.has(group.name)) {
+                throw new ParameterError(
+                    `Duplicate group name "${group.name}" in space file "${filePath}"`,
+                );
+            }
+            groupNames.add(group.name);
+            return { name: group.name, role: group.role };
+        });
+
+        return {
+            ...(parsed as SpaceAsCode),
+            access: {
+                inheritParentPermissions: access.inheritParentPermissions,
+                projectMemberAccessRole: access.projectMemberAccessRole,
+                users,
+                groups,
+            },
+        } as SpaceAsCode;
+    }
+
+    return parsed as SpaceAsCode;
+};
+
+export const assertUniqueSpacePaths = (files: SpaceCodeFile[]): void => {
+    const exactPaths = new Map<string, string>();
+    const normalizedPaths = new Map<
+        string,
+        { slug: string; filePath: string }
+    >();
+
+    files.forEach(({ filePath, space }) => {
+        const existingExact = exactPaths.get(space.slug);
+        if (existingExact) {
+            throw new ParameterError(
+                `Duplicate space slug "${space.slug}" in "${existingExact}" and "${filePath}"`,
+            );
+        }
+        exactPaths.set(space.slug, filePath);
+
+        const normalizedPath = getLtreePathFromContentAsCodePath(space.slug);
+        const existingNormalized = normalizedPaths.get(normalizedPath);
+        if (existingNormalized) {
+            throw new ParameterError(
+                `Space paths "${existingNormalized.slug}" (${existingNormalized.filePath}) and "${space.slug}" (${filePath}) resolve to the same normalized path "${normalizedPath}"`,
+            );
+        }
+        normalizedPaths.set(normalizedPath, { slug: space.slug, filePath });
+    });
+};
+
+export const sortSpaceFilesParentFirst = (
+    files: SpaceCodeFile[],
+): SpaceCodeFile[] =>
+    [...files].sort((left, right) => {
+        const depthDifference =
+            left.space.slug.split('/').length -
+            right.space.slug.split('/').length;
+        return (
+            depthDifference || left.space.slug.localeCompare(right.space.slug)
+        );
+    });
+
+const getExistingSpaceFileNames = async (
+    outputDir: string,
+): Promise<Map<string, string[]>> => {
+    let entries: Dirent[];
+    try {
+        entries = await fs.readdir(outputDir, { withFileTypes: true });
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return new Map();
+        }
+        throw error;
+    }
+
+    const filesBySlug = new Map<string, string[]>();
+    for (const entry of entries.filter(({ name }) =>
+        name.endsWith('.space.yml'),
+    )) {
+        let slug: string | null = null;
+        if (entry.isFile()) {
+            try {
+                const parsed = yaml.load(
+                    await fs.readFile(
+                        path.join(outputDir, entry.name),
+                        'utf-8',
+                    ),
+                );
+                if (isSpaceIdentity(parsed)) {
+                    slug = parsed.slug;
+                }
+            } catch {
+                // An unreadable existing file still reserves its filename.
+            }
+        }
+
+        const ownerKey = slug ?? `\0${entry.name}`;
+        filesBySlug.set(ownerKey, [
+            ...(filesBySlug.get(ownerKey) ?? []),
+            entry.name,
+        ]);
+    }
+    return filesBySlug;
+};
+
+const getExistingSpaceFilePathsBySlug = async (
+    baseDir: string,
+): Promise<Map<string, string[]>> => {
+    let filePaths: string[];
+    try {
+        filePaths = await listSpaceFilePaths(baseDir);
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return new Map();
+        }
+        throw error;
+    }
+
+    const filesBySlug = new Map<string, string[]>();
+    for (const filePath of filePaths) {
+        try {
+            const parsed = yaml.load(await fs.readFile(filePath, 'utf-8'));
+            if (isSpaceIdentity(parsed)) {
+                filesBySlug.set(parsed.slug, [
+                    ...(filesBySlug.get(parsed.slug) ?? []),
+                    filePath,
+                ]);
+            }
+        } catch {
+            // Filename allocation still reserves unreadable files in their directory.
+        }
+    }
+
+    return filesBySlug;
+};
+
+export const getUniqueExistingSpaceFilePathsBySlug = async (
+    baseDir: string,
+): Promise<Map<string, string[]>> => {
+    const filesBySlug = await getExistingSpaceFilePathsBySlug(baseDir);
+    for (const [slug, filePaths] of filesBySlug) {
+        if (filePaths.length > 1) {
+            throw new ParameterError(
+                `Multiple existing space files use slug "${slug}": ${filePaths
+                    .map((filePath) => path.relative(baseDir, filePath))
+                    .join(', ')}`,
+            );
+        }
+    }
+    return filesBySlug;
+};
+
+const getCollisionSafeSpaceFileName = (
+    space: SpaceAsCode,
+    usedFileNames: Set<string>,
+): string => {
+    const base = getSpaceFilenameBase(space);
+    const getCandidate = (suffix: string) =>
+        `${base.slice(
+            0,
+            SPACE_FILENAME_MAX_LENGTH - suffix.length,
+        )}${suffix}.space.yml`;
+
+    for (const hashLength of [8, 12, 16, 24, 32, 64]) {
+        const candidate = getCandidate(
+            `-${getStableSpaceHash(space.slug, hashLength)}`,
+        );
+        if (!usedFileNames.has(candidate.toLowerCase())) return candidate;
+    }
+
+    for (let index = 1; index <= 100; index += 1) {
+        const candidate = getCandidate(
+            `-${getStableSpaceHash(space.slug, 64)}-${index}`,
+        );
+        if (!usedFileNames.has(candidate.toLowerCase())) return candidate;
+    }
+
+    throw new ParameterError(
+        `Could not allocate a safe filename for space "${space.slug}"`,
+    );
+};
+
+const allocateSpaceFileNames = async (
+    spaces: SpaceAsCode[],
+    outputDir: string,
+    preferredFileNames: string[],
+): Promise<string[]> => {
+    const existingFilesBySlug = await getExistingSpaceFileNames(outputDir);
+    const usedFileNames = new Set(
+        [...existingFilesBySlug.values()]
+            .flat()
+            .map((fileName) => fileName.toLowerCase()),
+    );
+
+    return spaces.map((space, index) => {
+        const existingFileName = existingFilesBySlug.get(space.slug)?.[0];
+        if (existingFileName !== undefined) return existingFileName;
+
+        const preferredFileName = preferredFileNames[index];
+        const fileName = !usedFileNames.has(preferredFileName.toLowerCase())
+            ? preferredFileName
+            : getCollisionSafeSpaceFileName(space, usedFileNames);
+        usedFileNames.add(fileName.toLowerCase());
+        return fileName;
+    });
+};
+
+/** Writes first-class space YAML files returned by GET /spaces/code. */
+export const writeSpaceFiles = async (
+    spaces: SpaceAsCode[],
+    projectName: string,
+    customPath?: string,
+    folderScheme: FolderScheme = 'flat',
+    flatSpaceLayout: FlatSpaceLayout = 'folder',
+    preserveExistingPolicy: boolean = false,
+): Promise<void> => {
+    const baseDir = getDownloadFolder(customPath);
+    if (spaces.length === 0) return;
+    const existingFilesBySlug = preserveExistingPolicy
+        ? await getExistingSpaceFilePathsBySlug(baseDir)
+        : await getUniqueExistingSpaceFilePathsBySlug(baseDir);
+    if (preserveExistingPolicy) {
+        spaces.forEach(({ slug }) => {
+            const existingPaths = existingFilesBySlug.get(slug) ?? [];
+            if (existingPaths.length > 1) {
+                throw new ParameterError(
+                    `Multiple existing space files use slug "${slug}": ${existingPaths
+                        .map((filePath) => path.relative(baseDir, filePath))
+                        .join(', ')}`,
+                );
+            }
+        });
+    }
+
+    const files = spaces.map((space) => ({
+        filePath: `downloaded space "${space.slug}"`,
+        space,
+    }));
+    assertUniqueSpacePaths(files);
+
+    const useRootFlatLayout =
+        flatSpaceLayout === 'root' ||
+        (folderScheme === 'flat' && (await hasRootSpaceFile(baseDir)));
+
+    const plannedPathsBySlug = new Map<string, string>();
+    const newSpacesByDirectory = new Map<string, SpaceAsCode[]>();
+    for (const space of spaces) {
+        const existingFilePath = existingFilesBySlug.get(space.slug)?.[0];
+        if (existingFilePath !== undefined) {
+            plannedPathsBySlug.set(space.slug, existingFilePath);
+        } else {
+            let outputDir: string;
+            if (folderScheme === 'nested') {
+                outputDir = path.join(baseDir, projectName, space.slug);
+            } else if (useRootFlatLayout) {
+                outputDir = baseDir;
+            } else {
+                outputDir = path.join(baseDir, 'spaces');
+            }
+            newSpacesByDirectory.set(outputDir, [
+                ...(newSpacesByDirectory.get(outputDir) ?? []),
+                space,
+            ]);
+        }
+    }
+
+    for (const [outputDir, newSpaces] of [...newSpacesByDirectory].sort(
+        ([left], [right]) => left.localeCompare(right),
+    )) {
+        const fileNames = await allocateSpaceFileNames(
+            newSpaces,
+            outputDir,
+            getFlatSpaceFileNames(newSpaces),
+        );
+        newSpaces.forEach((space, index) => {
+            plannedPathsBySlug.set(
+                space.slug,
+                path.join(outputDir, fileNames[index]),
+            );
+        });
+    }
+
+    const plannedPaths = [...plannedPathsBySlug.values()].map((filePath) =>
+        filePath.toLowerCase(),
+    );
+    if (new Set(plannedPaths).size !== plannedPaths.length) {
+        throw new ParameterError(
+            'Multiple spaces would be written to the same file path',
+        );
+    }
+
+    for (const space of spaces) {
+        const filePath = plannedPathsBySlug.get(space.slug);
+        if (filePath === undefined) {
+            throw new ParameterError(
+                `Could not determine a filename for space "${space.slug}"`,
+            );
+        }
+        let spaceToWrite = space;
+        if (
+            preserveExistingPolicy &&
+            space.access === undefined &&
+            existingFilesBySlug.has(space.slug)
+        ) {
+            const existing = yaml.load(await fs.readFile(filePath, 'utf-8'));
+            if (
+                typeof existing !== 'object' ||
+                existing === null ||
+                Array.isArray(existing) ||
+                !('contentType' in existing) ||
+                existing.contentType !== ContentAsCodeTypeEnum.SPACE ||
+                !('slug' in existing) ||
+                existing.slug !== space.slug
+            ) {
+                throw new ParameterError(
+                    `Existing space file "${filePath}" changed while downloading`,
+                );
+            }
+            spaceToWrite = {
+                ...space,
+                ...('version' in existing ? { version: existing.version } : {}),
+                ...('access' in existing ? { access: existing.access } : {}),
+            } as SpaceAsCode;
+        }
+        await fs.mkdir(path.dirname(filePath), { recursive: true });
+        await fs.writeFile(
+            filePath,
+            yaml.dump(spaceToWrite, { quotingType: '"', sortKeys: true }),
+        );
+        GlobalState.debug(`Wrote space file: ${filePath}`);
+    }
+};
+
+export const readSpaceFiles = async (
+    customPath?: string,
+): Promise<SpaceCodeFile[]> => {
+    const baseDir = getDownloadFolder(customPath);
+
+    try {
+        const files: SpaceCodeFile[] = [];
+        for (const filePath of await listSpaceFilePaths(baseDir)) {
+            let parsed: unknown;
+            try {
+                parsed = yaml.load(await fs.readFile(filePath, 'utf-8'));
+            } catch (error) {
+                throw new ParameterError(
+                    `Invalid YAML in space file "${filePath}": ${getErrorMessage(error)}`,
+                );
+            }
+            files.push({
+                filePath,
+                space: validateSpaceIdentity(parsed, filePath),
+            });
+        }
+
+        assertUniqueSpacePaths(files);
+        return sortSpaceFilesParentFirst(files);
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+        throw error;
+    }
+};
+
+/** Reads legacy identity fields without validating unrelated access policy. */
+export const readSpaceNames = async (
+    customPath?: string,
+): Promise<Record<string, string>> => {
+    const baseDir = getDownloadFolder(customPath);
+    const spaceNames: Array<[string, string]> = [];
+
+    try {
+        for (const filePath of await listSpaceFilePaths(baseDir)) {
+            try {
+                const parsed = yaml.load(await fs.readFile(filePath, 'utf-8'));
+                if (
+                    isSpaceIdentity(parsed) &&
+                    'spaceName' in parsed &&
+                    typeof parsed.spaceName === 'string'
+                ) {
+                    spaceNames.push([parsed.slug, parsed.spaceName]);
+                }
+            } catch (error) {
+                GlobalState.debug(
+                    `Skipping space file ${path.basename(filePath)}: ${getErrorMessage(error)}`,
+                );
+            }
+        }
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+            GlobalState.debug(
+                `Skipping space names in ${baseDir}: ${getErrorMessage(error)}`,
+            );
+        }
+    }
+
+    return Object.fromEntries(spaceNames);
+};
+
+export const getSpaceNames = (files: SpaceCodeFile[]): Record<string, string> =>
+    Object.fromEntries(files.map(({ space }) => [space.slug, space.spaceName]));
+const getSpacePromoteAction = (
+    action: ApiSpaceAsCodeUpsertResponse['results']['action'],
+): 'created' | 'updated' | 'unchanged' => {
+    switch (action) {
+        case SpaceAsCodeAction.CREATE:
+            return 'created';
+        case SpaceAsCodeAction.UPDATE:
+            return 'updated';
+        case SpaceAsCodeAction.NO_CHANGES:
+            return 'unchanged';
+        default:
+            return assertUnreachable(
+                action,
+                `Unknown space promotion action: ${action}`,
+            );
+    }
+};
+
+const SPACE_AS_CODE_DOWNLOAD_ERROR_NAME = 'SpaceAsCodeDownloadError';
+
+export const createSpaceAsCodeDownloadError = (
+    message: string,
+): ParameterError => {
+    const error = new ParameterError(message);
+    error.name = SPACE_AS_CODE_DOWNLOAD_ERROR_NAME;
+    return error;
+};
+
+export const isSpaceAsCodeDownloadError = (error: unknown): error is Error =>
+    error instanceof Error && error.name === SPACE_AS_CODE_DOWNLOAD_ERROR_NAME;
+
+const SPACE_AS_CODE_FETCH_ERROR_NAME = 'SpaceAsCodeFetchError';
+
+const createSpaceAsCodeFetchError = (message: string): ParameterError => {
+    const error = new ParameterError(message);
+    error.name = SPACE_AS_CODE_FETCH_ERROR_NAME;
+    return error;
+};
+
+export const isSpaceAsCodeFetchError = (error: unknown): error is Error =>
+    error instanceof Error && error.name === SPACE_AS_CODE_FETCH_ERROR_NAME;
+
+export const shouldFallBackToEmbeddedSpaces = (
+    error: unknown,
+    spacesOnly: boolean | undefined,
+): boolean => isSpaceAsCodeFetchError(error) && spacesOnly !== true;
+
+export const downloadSpaces = async (
+    projectId: string,
+    projectName: string,
+    customPath?: string,
+    nested: boolean = false,
+    rootSpaces: boolean = false,
+): Promise<number> => {
+    try {
+        await getUniqueExistingSpaceFilePathsBySlug(
+            getDownloadFolder(customPath),
+        );
+        let results: ApiSpaceAsCodeListResponse['results'];
+        try {
+            results = await lightdashApi<ApiSpaceAsCodeListResponse['results']>(
+                {
+                    method: 'GET',
+                    url: `/api/v1/projects/${projectId}/spaces/code`,
+                    body: undefined,
+                },
+            );
+        } catch (error) {
+            throw createSpaceAsCodeFetchError(getErrorMessage(error));
+        }
+
+        const downloadedWithoutAccessSlugs = new Set(
+            results.spaces
+                .filter((space) => space.access === undefined)
+                .map((space) => space.slug),
+        );
+        results.skipped.forEach((skipped) =>
+            GlobalState.log(
+                styles.warning(
+                    downloadedWithoutAccessSlugs.has(skipped.slug)
+                        ? `Downloaded space "${skipped.slug}" without access: ${skipped.reason}`
+                        : `Skipped space "${skipped.slug}": ${skipped.reason}`,
+                ),
+            ),
+        );
+        const spaces = sortSpaceFilesParentFirst(
+            results.spaces.map((space) => ({
+                filePath: `downloaded space "${space.slug}"`,
+                space,
+            })),
+        ).map(({ space }) => space);
+        await writeSpaceFiles(
+            spaces,
+            projectName,
+            customPath,
+            nested ? 'nested' : 'flat',
+            rootSpaces ? 'root' : 'folder',
+        );
+
+        return spaces.length;
+    } catch (error) {
+        if (isSpaceAsCodeFetchError(error)) throw error;
+        throw createSpaceAsCodeDownloadError(getErrorMessage(error));
+    }
+};
+
+const SPACE_AS_CODE_UPLOAD_ERROR_NAME = 'SpaceAsCodeUploadError';
+
+export const createSpaceAsCodeUploadError = (
+    message: string,
+): ParameterError => {
+    const error = new ParameterError(message);
+    error.name = SPACE_AS_CODE_UPLOAD_ERROR_NAME;
+    return error;
+};
+
+export const isSpaceAsCodeUploadError = (error: unknown): error is Error =>
+    error instanceof Error && error.name === SPACE_AS_CODE_UPLOAD_ERROR_NAME;
+
+export const logUploadChanges = (changes: Record<string, number>) => {
+    Object.entries(changes).forEach(([key, value]) => {
+        console.info(`Total ${key}: ${value} `);
+    });
+
+    if (shouldWarnAllSkipped(changes)) {
+        console.warn(
+            styles.warning(
+                `\nAll content was skipped (no local changes detected). Use --force to upload all content, e.g. when uploading to a new project.`,
+            ),
+        );
+    }
+};
+
+export const upsertSpaces = async (
+    projectId: string,
+    files: SpaceCodeFile[],
+    changes: Record<string, number>,
+    skipSpaceCreate: boolean,
+    publicSpaceCreate: boolean,
+): Promise<Record<string, number>> => {
+    if (files.length === 0) return changes;
+
+    const failedPaths = new Set<string>();
+    const skippedPaths = new Set<string>();
+
+    for (const { filePath, space } of sortSpaceFilesParentFirst(files)) {
+        const failedParent = [...failedPaths].find((failedPath) =>
+            space.slug.startsWith(`${failedPath}/`),
+        );
+        const skippedParent = [...skippedPaths].find((skippedPath) =>
+            space.slug.startsWith(`${skippedPath}/`),
+        );
+        if (failedParent !== undefined) {
+            changes['spaces dependency skipped'] =
+                (changes['spaces dependency skipped'] ?? 0) + 1;
+            failedPaths.add(space.slug);
+            GlobalState.log(
+                styles.warning(
+                    `Skipped space "${space.slug}" (${filePath}) because parent "${failedParent}" failed`,
+                ),
+            );
+        } else if (skippedParent !== undefined) {
+            changes['spaces skipped'] = (changes['spaces skipped'] ?? 0) + 1;
+            skippedPaths.add(space.slug);
+            GlobalState.log(
+                styles.warning(
+                    `Skipped space "${space.slug}" (${filePath}) because parent "${skippedParent}" does not exist and --skip-space-create is true`,
+                ),
+            );
+        } else {
+            try {
+                const params = new URLSearchParams({
+                    skipSpaceCreate: String(skipSpaceCreate),
+                    publicSpaceCreate: String(
+                        publicSpaceCreate && space.access === undefined,
+                    ),
+                });
+                const result = await lightdashApi<
+                    ApiSpaceAsCodeUpsertResponse['results']
+                >({
+                    method: 'POST',
+                    url: `/api/v1/projects/${projectId}/spaces/code?${params.toString()}`,
+                    body: JSON.stringify(space),
+                });
+                const action = getSpacePromoteAction(result.action);
+                const key = `spaces ${action}`;
+                changes[key] = (changes[key] ?? 0) + 1;
+                result.warnings?.forEach((warning) =>
+                    GlobalState.log(
+                        styles.warning(
+                            `Space "${space.slug}" (${filePath}): ${warning}`,
+                        ),
+                    ),
+                );
+                GlobalState.debug(
+                    `Space "${space.slug}" (${filePath}): ${result.action}`,
+                );
+            } catch (error) {
+                if (
+                    skipSpaceCreate &&
+                    error instanceof LightdashError &&
+                    error.name === 'NotFoundError'
+                ) {
+                    skippedPaths.add(space.slug);
+                    changes['spaces skipped'] =
+                        (changes['spaces skipped'] ?? 0) + 1;
+                    GlobalState.log(
+                        styles.warning(
+                            `Skipped space "${space.slug}" (${filePath}) because it does not exist and --skip-space-create is true`,
+                        ),
+                    );
+                } else {
+                    failedPaths.add(space.slug);
+                    changes['spaces with errors'] =
+                        (changes['spaces with errors'] ?? 0) + 1;
+                    GlobalState.log(
+                        styles.error(
+                            `Error upserting space "${space.slug}" (${filePath}): ${getErrorMessage(error)}`,
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
+    const failed = changes['spaces with errors'] ?? 0;
+    const dependencySkipped = changes['spaces dependency skipped'] ?? 0;
+    if (failed > 0 || dependencySkipped > 0) {
+        logUploadChanges(changes);
+        throw createSpaceAsCodeUploadError(
+            `${failed} space definition(s) failed and ${dependencySkipped} dependent definition(s) were skipped; content upload was not started`,
+        );
+    }
+
+    return changes;
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -831,6 +831,11 @@ const downloadCommand = program
         false,
     )
     .option(
+        '--root-spaces',
+        'write new flat space definitions at the content root instead of spaces/ (legacy layout)',
+        false,
+    )
+    .option(
         '--project <project uuid>',
         'specify a project UUID to download',
         parseProjectArgument,
@@ -838,7 +843,12 @@ const downloadCommand = program
     )
     .option(
         '--skip-spaces',
-        'skip writing space metadata files during download',
+        'skip downloading space definitions and access',
+        false,
+    )
+    .option(
+        '--spaces-only',
+        'download only space definitions and access',
         false,
     )
     .option('--skip-charts', 'skip downloading charts', false)
@@ -948,6 +958,12 @@ const uploadCommand = program
         'Skip space creation if it does not exist',
         false,
     )
+    .option(
+        '--skip-spaces',
+        'skip uploading space definitions and access',
+        false,
+    )
+    .option('--spaces-only', 'upload only space definitions and access', false)
     .option('--public', 'Create new spaces as public instead of private', false)
     .option('--skip-agents', 'skip uploading AI agents', false)
     .option('--skip-alerts', 'skip uploading alerts', false)

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -124,6 +124,8 @@ import {
     type ApiGoogleSheetsSyncAsCodeUpsertResponse,
     type ApiScheduledDeliveryAsCodeListResponse,
     type ApiScheduledDeliveryAsCodeUpsertResponse,
+    type ApiSpaceAsCodeListResponse,
+    type ApiSpaceAsCodeUpsertResponse,
     type ApiSqlChartAsCodeListResponse,
     type ApiVirtualViewAsCodeListResponse,
     type ApiVirtualViewAsCodeUpsertResponse,
@@ -1179,6 +1181,8 @@ type ApiResults =
     | ApiScheduledDeliveryAsCodeUpsertResponse['results']
     | ApiVirtualViewAsCodeListResponse['results']
     | ApiVirtualViewAsCodeUpsertResponse['results']
+    | ApiSpaceAsCodeListResponse['results']
+    | ApiSpaceAsCodeUpsertResponse['results']
     | ApiChartAsCodeUpsertResponse['results']
     | ApiGetMetricsTree['results']
     | ApiGetMetricsTreeResponse['results']

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -24,6 +24,7 @@ import type {
     SchedulerFormat,
     SchedulerImageOptions,
     SchedulerPdfOptions,
+    SpaceMemberRole,
     SqlChart,
     ThresholdOptions,
 } from '..';
@@ -286,12 +287,63 @@ export type DashboardAsCode = Omit<
     verification?: ContentVerificationInfo | null;
 };
 
+export type SpaceAsCodeUserAccess = {
+    /** Primary email of a human organization member. */
+    email: string;
+    role: SpaceMemberRole;
+};
+
+export type SpaceAsCodeGroupAccess = {
+    /** Exact, case-sensitive organization group name. */
+    name: string;
+    role: SpaceMemberRole;
+};
+
+export type SpaceAsCodeAccess = {
+    inheritParentPermissions: boolean;
+    projectMemberAccessRole: SpaceMemberRole | null;
+    users: SpaceAsCodeUserAccess[];
+    groups: SpaceAsCodeGroupAccess[];
+};
+
 export type SpaceAsCode = {
     contentType: ContentAsCodeType.SPACE;
+    /** Optional only for backwards-compatible metadata-only files. */
+    version?: 1;
     /** The original human-readable space name (preserves emoji, casing, etc.) */
     spaceName: string;
-    /** The space slug used for file naming and cross-referencing */
+    /** Full portable hierarchy path used for identity and cross-referencing. */
     slug: string;
+    /** Omission leaves the existing access policy unchanged. */
+    access?: SpaceAsCodeAccess;
+};
+
+export type SpaceAsCodeSkip = {
+    slug: string;
+    reason: string;
+};
+
+export enum SpaceAsCodeAction {
+    CREATE = 'CREATE',
+    UPDATE = 'UPDATE',
+    NO_CHANGES = 'NO_CHANGES',
+}
+
+export type ApiSpaceAsCodeListResponse = {
+    status: 'ok';
+    results: {
+        spaces: SpaceAsCode[];
+        skipped: SpaceAsCodeSkip[];
+    };
+};
+
+export type ApiSpaceAsCodeUpsertResponse = {
+    status: 'ok';
+    results: {
+        action: SpaceAsCodeAction;
+        /** Destructive effects that could not be represented in the input file. */
+        warnings?: string[];
+    };
 };
 
 export type VirtualViewAsCode = {

--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -15,6 +15,9 @@ describe('Space', () => {
     const createPrivateSpace = () => {
         const timestamp = new Date().toISOString();
         let privateSpaceUrl: string;
+        let privateSpaceUuid: string;
+        let privateChartUuid: string;
+        let privateDashboardUuid: string;
 
         // Create private space
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/home`);
@@ -41,6 +44,7 @@ describe('Space', () => {
             .should('match', /\/spaces\/[0-9a-f-]{36}$/)
             .then((url) => {
                 privateSpaceUrl = url;
+                privateSpaceUuid = url.split('/').at(-1)!;
             });
 
         // Create new chart
@@ -72,21 +76,29 @@ describe('Space', () => {
             .click();
 
         cy.contains('Success! Chart was saved.').should('exist');
-        cy.url().should('match', /\/saved\/[0-9a-f-]{36}\/view$/);
+        cy.url()
+            .should('match', /\/saved\/[0-9a-f-]{36}\/view$/)
+            .then((url) => {
+                privateChartUuid = url.split('/').at(-2)!;
+            });
 
-        cy.then(() => {
-            cy.visit(privateSpaceUrl);
-        });
-
-        // Create new dashboard
-        cy.get('[data-testid="Space/AddButton"]').click();
-        cy.contains('Create new dashboard').click();
-        cy.findByPlaceholderText('eg. KPI Dashboard').type(
-            `Private dashboard ${timestamp}`,
+        cy.then(() =>
+            cy
+                .request<{ results: { uuid: string } }>({
+                    method: 'POST',
+                    url: `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/dashboards`,
+                    body: {
+                        name: `Private dashboard ${timestamp}`,
+                        spaceUuid: privateSpaceUuid,
+                        tiles: [],
+                        tabs: [],
+                    },
+                })
+                .then((response) => {
+                    expect(response.status).to.eq(201);
+                    privateDashboardUuid = response.body.results.uuid;
+                }),
         );
-        cy.findByText('Next').click();
-        cy.findByText('Create').click();
-        cy.url().should('match', /\/dashboards\/[0-9a-f-]{36}\/edit$/);
 
         cy.then(() => {
             cy.visit(privateSpaceUrl);
@@ -96,38 +108,17 @@ describe('Space', () => {
         cy.contains('All').click();
         cy.contains(`Private dashboard ${timestamp}`);
         cy.contains(`Private chart ${timestamp}`);
+
+        return cy.then(() => ({
+            privateSpaceUuid,
+            privateChartUuid,
+            privateDashboardUuid,
+        }));
     };
 
     it('Another non-admin user cannot see private content', () => {
-        createPrivateSpace();
-
-        // We assume the previous test has been run and the private space has been created
-        // If this is causing issues, try reusing the `createPrivateChart` from spacePermissions.cy.ts
-        cy.request({
-            url: `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces`,
-            failOnStatusCode: false,
-        }).then((resp) => {
-            expect(resp.status).to.eq(200);
-            const privateSpace = resp.body.results.find(
-                (space) =>
-                    space.name.toLowerCase().startsWith('private space') &&
-                    space.chartCount !== '0' &&
-                    space.dashboardCount !== '0',
-            ); // Get a private space with charts and dashboards
-            expect(privateSpace).to.not.eq(undefined);
-
-            cy.request({
-                url: `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces/${privateSpace.uuid}`,
-                failOnStatusCode: false,
-            }).then((spaceResp) => {
-                expect(spaceResp.status).to.eq(200);
-
-                const privateChart = spaceResp.body.results.queries[0];
-                const privateDashboard = spaceResp.body.results.dashboards[0];
-
-                expect(privateChart).to.not.eq(undefined);
-                expect(privateDashboard).to.not.eq(undefined);
-
+        createPrivateSpace().then(
+            ({ privateSpaceUuid, privateChartUuid, privateDashboardUuid }) => {
                 cy.loginWithPermissions('member', [
                     {
                         role: 'editor',
@@ -150,25 +141,17 @@ describe('Space', () => {
                 cy.contains(JAFFLE_SHOP_SPACE_NAME);
                 cy.contains('Private space').should('not.exist');
 
-                // Navigate to private space and make sure we get a forbidden error
-                cy.visit(
-                    `/projects/${SEED_PROJECT.project_uuid}/spaces/${privateSpace.uuid}`,
-                );
-                cy.contains('You need access');
-
-                // Navigate to private chart and make sure we get a forbidden error
-                cy.visit(
-                    `/projects/${SEED_PROJECT.project_uuid}/saved/${privateChart.uuid}`,
-                );
-                cy.contains('You need access');
-
-                // Navigate to private dashboard and make sure we get a forbidden error
-                cy.visit(
-                    `/projects/${SEED_PROJECT.project_uuid}/dashboards/${privateDashboard.uuid}`,
-                );
-                cy.contains('You need access');
-            });
-        });
+                for (const url of [
+                    `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces/${privateSpaceUuid}`,
+                    `/api/v2/projects/${SEED_PROJECT.project_uuid}/saved/${privateChartUuid}`,
+                    `/api/v2/projects/${SEED_PROJECT.project_uuid}/dashboards/${privateDashboardUuid}`,
+                ]) {
+                    cy.request({ url, failOnStatusCode: false })
+                        .its('status')
+                        .should('eq', 403);
+                }
+            },
+        );
     });
 });
 


### PR DESCRIPTION


- Legacy space files without `access` never change permissions.
- Existing flat/nested files are reused without duplication.
- Normal downloads fall back to legacy metadata if the new endpoint fails.
- Non-portable access downloads as metadata-only, preventing accidental revocation.
- Explicit `access` replacement requires actual `manage:Space`; broad content-as-code access cannot bypass this.
- Authorization and uploader lockout are rechecked transactionally.
- Generated personal spaces remain excluded.
- Added complete destructive warnings for ambiguous/deleted user and group identities.



![CleanShot 2026-07-16 at 13.11.33@2x.png](https://app.graphite.com/user-attachments/assets/a0f8ff09-9e83-4f41-83d4-5e5bde027d02.png)

![CleanShot 2026-07-16 at 13.11.42@2x.png](https://app.graphite.com/user-attachments/assets/8efe33e9-7bcf-4863-886c-ff7af9404ab5.png)



## Summary

- add project-scoped space-as-code download and upload with deterministic direct access policies
- preserve metadata-only files and existing root, `spaces/`, and nested layouts while defaulting new flat downloads to `spaces/`
- process spaces before dependent content and add `--skip-spaces`, `--spaces-only`, and `--root-spaces`
- require actual manage access on the resolved space, validate portable identities transactionally, reject uploader lockout, and serialize concurrent authorization changes

## Verification

- focused backend regression suite: 15 files, 213 passed, 1 pre-existing skipped test
- CLI suite: 27 files, 263 passed
- common, backend, and CLI typechecks
- focused ESLint and oxfmt checks
- API generation run twice with byte-stable output; generated artifacts remain release-workflow-owned per the repository pre-commit policy
- live download/upload round trip covering create, update, revoke, unchanged, missing-principal rollback, metadata-only fallback, restricted-space denial, and concurrent permission revocation

Closes: PROD-8927