### PR TITLE
fix: merge duplicate dbt built-in macros and docs silently across dbt sources

### DIFF
--- a/packages/common/src/dbt/manifest.test.ts
+++ b/packages/common/src/dbt/manifest.test.ts
@@ -347,6 +347,92 @@ describe('combineManifestSources (N-way fold)', () => {
         ]);
     });
 
+    test('duplicate macros and docs union silently (lowest precedence wins) instead of colliding', () => {
+        // dbt namespaces macro/doc unique_ids by package, so two projects on
+        // the same adapter always share built-in ids like macro.dbt.* and
+        // doc.dbt.__overview__ — these must not surface as collisions.
+        const primary = buildManifest(
+            { 'model.a': modelNode('model.a') },
+            {
+                docs: {
+                    'doc.dbt.__overview__': { id: 'primary' },
+                } as unknown as DbtManifest['docs'],
+                macros: { 'macro.dbt.run_query': { id: 'primary' } },
+            },
+        );
+        const secondary = buildManifest(
+            { 'model.b': modelNode('model.b') },
+            {
+                docs: {
+                    'doc.dbt.__overview__': { id: 'secondary' },
+                } as unknown as DbtManifest['docs'],
+                macros: {
+                    'macro.dbt.run_query': { id: 'secondary' },
+                    'macro.proj.custom': { id: 'secondary' },
+                },
+            },
+        );
+
+        const { manifest, collisions } = combineManifestSources([
+            source('primary', 0, primary),
+            source('secondary', 1, secondary),
+        ]);
+
+        expect(collisions).toEqual([]);
+        expect(
+            (manifest.docs['doc.dbt.__overview__'] as unknown as { id: string })
+                .id,
+        ).toBe('primary');
+        expect(manifest.macros?.['macro.dbt.run_query']).toEqual({
+            id: 'primary',
+        });
+        expect(manifest.macros?.['macro.proj.custom']).toEqual({
+            id: 'secondary',
+        });
+    });
+
+    test('duplicate metrics, sources and semantic_models still report collisions', () => {
+        const primary = buildManifest(
+            { 'model.a': modelNode('model.a') },
+            {
+                metrics: {
+                    'metric.dup': { id: 'primary' },
+                } as unknown as DbtManifest['metrics'],
+                sources: { 'source.dup': { id: 'primary' } },
+                semantic_models: {
+                    'sm.dup': { id: 'primary' },
+                } as unknown as DbtManifest['semantic_models'],
+            },
+        );
+        const secondary = buildManifest(
+            { 'model.b': modelNode('model.b') },
+            {
+                metrics: {
+                    'metric.dup': { id: 'secondary' },
+                } as unknown as DbtManifest['metrics'],
+                sources: { 'source.dup': { id: 'secondary' } },
+                semantic_models: {
+                    'sm.dup': { id: 'secondary' },
+                } as unknown as DbtManifest['semantic_models'],
+            },
+        );
+
+        const { collisions } = combineManifestSources([
+            source('primary', 0, primary),
+            source('secondary', 1, secondary),
+        ]);
+
+        expect(collisions.map((c) => [c.section, c.key]).sort()).toEqual([
+            ['metrics', 'metric.dup'],
+            ['semantic_models', 'sm.dup'],
+            ['sources', 'source.dup'],
+        ]);
+        collisions.forEach((c) => {
+            expect(c.winningSource).toBe('primary');
+            expect(c.supersededSource).toBe('secondary');
+        });
+    });
+
     test('non-compiled and non-model non-primary nodes merge but are not added', () => {
         const primary = buildManifest({ 'model.a': modelNode('model.a') });
         const secondary = buildManifest({

--- a/packages/common/src/dbt/manifest.ts
+++ b/packages/common/src/dbt/manifest.ts
@@ -21,12 +21,18 @@ export type ManifestSource = {
     manifest: DbtManifest;
 };
 
+/**
+ * Sections where a repeated key is surfaced as a collision. `macros` and `docs`
+ * are deliberately absent: dbt namespaces their unique_ids by package (`dbt`,
+ * `dbt_postgres`, `dbt_utils`, …), so any two projects on the same adapter
+ * share hundreds of byte-identical built-in ids (`macro.dbt.*`,
+ * `doc.dbt.__overview__`). Those are unioned silently — lowest precedence
+ * wins — because a duplicate definition there loses no user data.
+ */
 export type ManifestCollisionSection =
     | 'nodes'
     | 'metrics'
-    | 'docs'
     | 'sources'
-    | 'macros'
     | 'semantic_models';
 
 /**
@@ -50,13 +56,15 @@ export type CombineManifestSourcesResult = {
 /**
  * Fold one manifest section (a `Record` keyed by unique_id) across sources in
  * precedence order. The first source to define a key wins; later sources hitting
- * an existing key are recorded as collisions and skipped. Sources iterate
- * lowest-precedence-first, so the lowest precedence wins.
+ * an existing key are skipped and recorded as collisions — unless `section` is
+ * `null`, which unions silently (used for `macros`/`docs`, see
+ * {@link ManifestCollisionSection}). Sources iterate lowest-precedence-first,
+ * so the lowest precedence wins.
  */
 const mergeSection = <T>(
     orderedSources: ManifestSource[],
     pick: (manifest: DbtManifest) => Record<string, T> | undefined,
-    section: ManifestCollisionSection,
+    section: ManifestCollisionSection | null,
     collisions: ManifestCollision[],
 ): Record<string, T> => {
     const merged: Record<string, T> = {};
@@ -66,12 +74,14 @@ const mergeSection = <T>(
         if (!entries) return;
         Object.entries(entries).forEach(([key, value]) => {
             if (key in merged) {
-                collisions.push({
-                    section,
-                    key,
-                    winningSource: winningSourceByKey[key],
-                    supersededSource: source.name,
-                });
+                if (section !== null) {
+                    collisions.push({
+                        section,
+                        key,
+                        winningSource: winningSourceByKey[key],
+                        supersededSource: source.name,
+                    });
+                }
             } else {
                 merged[key] = value;
                 winningSourceByKey[key] = source.name;
@@ -93,8 +103,10 @@ const mergeSection = <T>(
  *
  * `metrics`, `docs`, `sources`, `macros` and `semantic_models` are unioned across
  * sources (lower precedence wins on collision) — unlike the legacy two-manifest
- * merge which took them from the primary only. `metadata` (a single object, not a
- * keyed record) comes from the primary source.
+ * merge which took them from the primary only. `macros` and `docs` collide
+ * silently (see {@link ManifestCollisionSection}); the other sections report
+ * collisions. `metadata` (a single object, not a keyed record) comes from the
+ * primary source.
  *
  * `addedModelIds` lists compiled model unique_ids contributed by non-primary
  * sources (not present in the primary). Server-side the node's own `compiled`
@@ -129,7 +141,7 @@ export const combineManifestSources = (
     const mergedDocs = mergeSection(
         orderedSources,
         (manifest) => manifest.docs,
-        'docs',
+        null,
         collisions,
     );
     const mergedSources = mergeSection<AnyType>(
@@ -141,7 +153,7 @@ export const combineManifestSources = (
     const mergedMacros = mergeSection<AnyType>(
         orderedSources,
         (manifest) => manifest.macros,
-        'macros',
+        null,
         collisions,
     );
     const mergedSemanticModels = mergeSection<AnyType>(


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8937/multiple-dbt-sources-manifest-merge-fails-on-dbt-built-in-macrodoc

### Description:
Two dbt projects on the same warehouse adapter always share hundreds of byte-identical built-in unique_ids (macro.dbt.*, macro.dbt_<adapter>.*, doc.dbt.__overview__) because dbt namespaces them by package, not project. The multi-source manifest merge counted these as blocking collisions, so merging two standard dbt projects always failed before evaluating the user's own models.

Union macros and docs silently (lowest precedence wins); keep blocking collisions for nodes, metrics, sources and semantic_models, where a real clash would silently drop user data.
