### PR TITLE
fix(migrations): detect dbt-source FK by column, not derived name

### DIFF
--- a/packages/backend/src/ee/database/migrations/20260630170000_add_dbt_source_to_ai_writeback_thread.ts
+++ b/packages/backend/src/ee/database/migrations/20260630170000_add_dbt_source_to_ai_writeback_thread.ts
@@ -3,18 +3,21 @@ import { Knex } from 'knex';
 const AiWritebackThreadTableName = 'ai_writeback_thread';
 const ProjectDbtSourcesTableName = 'project_dbt_sources';
 const ColumnName = 'project_dbt_source_uuid';
-// Knex derives this name from table + column when the FK is created below; it is
-// the constraint that actually exists in already-migrated databases.
-const ForeignKeyName = 'ai_writeback_thread_project_dbt_source_uuid_foreign';
 
+// Detect the FK by the column it constrains rather than its derived name, so this
+// never depends on Knex's naming convention. dropForeign()/foreign() below still
+// derive that name, which is fine — they use the exact value Knex created it with.
 async function hasForeignKey(knex: Knex): Promise<boolean> {
     const result = await knex.raw(
         `SELECT 1
-           FROM pg_constraint
-          WHERE conname = ?
-            AND conrelid = to_regclass(?)
-            AND contype = 'f'`,
-        [ForeignKeyName, AiWritebackThreadTableName],
+           FROM information_schema.table_constraints tc
+           JOIN information_schema.key_column_usage kcu
+             ON tc.constraint_name = kcu.constraint_name
+            AND tc.constraint_schema = kcu.constraint_schema
+          WHERE tc.constraint_type = 'FOREIGN KEY'
+            AND tc.table_name = ?
+            AND kcu.column_name = ?`,
+        [AiWritebackThreadTableName, ColumnName],
     );
     return result.rows.length > 0;
 }

--- a/packages/backend/src/ee/database/migrations/20260630170000_add_dbt_source_to_ai_writeback_thread.ts
+++ b/packages/backend/src/ee/database/migrations/20260630170000_add_dbt_source_to_ai_writeback_thread.ts
@@ -4,19 +4,20 @@ const AiWritebackThreadTableName = 'ai_writeback_thread';
 const ProjectDbtSourcesTableName = 'project_dbt_sources';
 const ColumnName = 'project_dbt_source_uuid';
 
-// Detect the FK by the column it constrains rather than its derived name, so this
-// never depends on Knex's naming convention. dropForeign()/foreign() below still
-// derive that name, which is fine — they use the exact value Knex created it with.
+// Detect the FK by the column it constrains, resolved through to_regclass so it
+// respects search_path and never depends on Knex's naming convention.
+// dropForeign()/foreign() below still derive that name — fine, they use the exact
+// value Knex created it with.
 async function hasForeignKey(knex: Knex): Promise<boolean> {
     const result = await knex.raw(
         `SELECT 1
-           FROM information_schema.table_constraints tc
-           JOIN information_schema.key_column_usage kcu
-             ON tc.constraint_name = kcu.constraint_name
-            AND tc.constraint_schema = kcu.constraint_schema
-          WHERE tc.constraint_type = 'FOREIGN KEY'
-            AND tc.table_name = ?
-            AND kcu.column_name = ?`,
+           FROM pg_constraint c
+           JOIN pg_attribute a
+             ON a.attrelid = c.conrelid
+            AND a.attnum = ANY (c.conkey)
+          WHERE c.conrelid = to_regclass(?)
+            AND c.contype = 'f'
+            AND a.attname = ?`,
         [AiWritebackThreadTableName, ColumnName],
     );
     return result.rows.length > 0;


### PR DESCRIPTION
Follow-up to #25623.

That fix guarded on a hard-coded, Knex-derived FK name (`ai_writeback_thread_project_dbt_source_uuid_foreign`). It's correct today, but the hard-coded string is the single spot that would silently misfire if the naming assumption were ever wrong — `down()` would no-op and the rollback bug would quietly come back.

This looks the FK up by the column it constrains instead, so there's no name dependency at all. `dropForeign()`/`foreign()` still derive the name, which is safe because they use the exact value Knex created it with.

Re-ran the same end-to-end rollback verification against a throwaway DB — all checks still pass (forward migrate, blocked-drop repro, rollback-last preserves data, reapply restores the FK, full-rollback ordering drops the table, idempotency).