### PR TITLE
feat(homepage): favorites top bar above hero + truncate/expand

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -77,16 +77,16 @@ type Props = {
     projectUuid: string;
     /** Render personal blocks as placeholders (admin view-as preview) */
     personalPlaceholders?: boolean;
-    /** Content rendered below the centred hero, above the remaining rows
-     * (e.g. the personal favorites strip). */
-    secondaryTop?: ReactNode;
+    /** Content pinned at the very top of the page, above the centred hero
+     * (e.g. the compact personal favorites bar). */
+    topBar?: ReactNode;
 };
 
 export const PublishedHomepage: FC<Props> = ({
     config,
     projectUuid,
     personalPlaceholders = false,
-    secondaryTop = null,
+    topBar = null,
 }) => {
     const [firstRow, ...restRows] = config.rows;
     const leadingHero =
@@ -99,6 +99,7 @@ export const PublishedHomepage: FC<Props> = ({
     if (leadingHero) {
         return (
             <div className={layout.page}>
+                {topBar}
                 <div className={layout.heroSection}>
                     <div className={layout.hero}>
                         <BlockRenderer
@@ -108,16 +109,13 @@ export const PublishedHomepage: FC<Props> = ({
                         />
                     </div>
                 </div>
-                {(secondaryTop || restRows.length > 0) && (
+                {restRows.length > 0 && (
                     <div className={layout.secondary}>
-                        <Stack gap={28}>
-                            {secondaryTop}
-                            <HomepageRows
-                                rows={restRows}
-                                projectUuid={projectUuid}
-                                personalPlaceholders={personalPlaceholders}
-                            />
-                        </Stack>
+                        <HomepageRows
+                            rows={restRows}
+                            projectUuid={projectUuid}
+                            personalPlaceholders={personalPlaceholders}
+                        />
                     </div>
                 )}
             </div>
@@ -126,15 +124,13 @@ export const PublishedHomepage: FC<Props> = ({
 
     return (
         <div className={layout.page}>
+            {topBar}
             <div className={layout.secondary}>
-                <Stack gap={28}>
-                    {secondaryTop}
-                    <HomepageRows
-                        rows={config.rows}
-                        projectUuid={projectUuid}
-                        personalPlaceholders={personalPlaceholders}
-                    />
-                </Stack>
+                <HomepageRows
+                    rows={config.rows}
+                    projectUuid={projectUuid}
+                    personalPlaceholders={personalPlaceholders}
+                />
             </div>
         </div>
     );

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
@@ -9,14 +9,17 @@ import {
     IconTerminal2,
     type Icon,
 } from '@tabler/icons-react';
-import { type FC, type MouseEvent } from 'react';
+import { useState, type FC, type MouseEvent } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { useFavoriteMutation } from '../../../../hooks/favorites/useFavoriteMutation';
 import { useFavorites } from '../../../../hooks/favorites/useFavorites';
+import layout from '../homepageLayout.module.css';
 import { BlockHeader } from './BlockShell';
 import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
+
+const FAVORITES_DEFAULT_VISIBLE = 8;
 
 const FAVORITE_ICONS: Partial<Record<ResourceViewItemType, Icon>> = {
     [ResourceViewItemType.CHART]: IconChartBar,
@@ -41,13 +44,26 @@ const favoriteUrl = (projectUuid: string, item: ResourceViewItem): string => {
 const FavoritePills: FC<{
     projectUuid: string;
     isInteractive: boolean;
-    emptyText: string;
-}> = ({ projectUuid, isInteractive, emptyText }) => {
+    /** Text shown when the user has no favorites. Pass `null` to render nothing
+     * (used by the top-bar variant, which hides itself when empty). */
+    emptyText: string | null;
+    maxVisible?: number;
+    wrap?: 'wrap' | 'nowrap';
+}> = ({
+    projectUuid,
+    isInteractive,
+    emptyText,
+    maxVisible = FAVORITES_DEFAULT_VISIBLE,
+    wrap = 'wrap',
+}) => {
     const { data: favorites } = useFavorites(projectUuid);
     const { mutate: toggleFavorite } = useFavoriteMutation(projectUuid);
+    const [expanded, setExpanded] = useState(false);
 
     if (!favorites || favorites.length === 0) {
-        return <div className={classes.dashedEmpty}>{emptyText}</div>;
+        return emptyText === null ? null : (
+            <div className={classes.dashedEmpty}>{emptyText}</div>
+        );
     }
 
     const handleUnfavorite = (e: MouseEvent, item: ResourceViewItem) => {
@@ -58,9 +74,14 @@ const FavoritePills: FC<{
         });
     };
 
+    const canTruncate = favorites.length > maxVisible;
+    const visible =
+        canTruncate && !expanded ? favorites.slice(0, maxVisible) : favorites;
+    const hiddenCount = favorites.length - maxVisible;
+
     return (
-        <Group gap={8}>
-            {favorites.map((item) => (
+        <Group gap={8} wrap={expanded ? 'wrap' : wrap}>
+            {visible.map((item) => (
                 <Link
                     key={item.data.uuid}
                     to={favoriteUrl(projectUuid, item)}
@@ -71,7 +92,9 @@ const FavoritePills: FC<{
                         size={15}
                         color="ldGray.6"
                     />
-                    {item.data.name}
+                    <span className={classes.favPillName}>
+                        {item.data.name}
+                    </span>
                     {isInteractive ? (
                         <MantineIcon
                             icon={IconStarFilled}
@@ -90,27 +113,45 @@ const FavoritePills: FC<{
                     )}
                 </Link>
             ))}
+            {canTruncate ? (
+                <button
+                    type="button"
+                    className={classes.favPillMore}
+                    onClick={() => setExpanded((prev) => !prev)}
+                >
+                    {expanded ? 'Show less' : `+${hiddenCount} more`}
+                </button>
+            ) : null}
         </Group>
     );
 };
 
-export const PersonalFavoritesStrip: FC<{ projectUuid: string }> = ({
+/** Compact one-line favorites bar pinned above the hero. Hides itself entirely
+ * when the user has no favorites. */
+export const PersonalFavoritesBar: FC<{ projectUuid: string }> = ({
     projectUuid,
-}) => (
-    <Stack gap={0}>
-        <BlockHeader
-            icon={IconStar}
-            title="My favorites"
-            pill="Only you see this"
-            mb={10}
-        />
-        <FavoritePills
-            projectUuid={projectUuid}
-            isInteractive
-            emptyText="Star any dashboard or chart below to keep it here, on every homepage."
-        />
-    </Stack>
-);
+}) => {
+    const { data: favorites } = useFavorites(projectUuid);
+
+    if (!favorites || favorites.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className={layout.favBar}>
+            <div className={layout.favBarLabel}>
+                <MantineIcon icon={IconStar} size={14} color="ldGray.6" />
+                <span className={layout.favBarLabelText}>Favorites</span>
+            </div>
+            <FavoritePills
+                projectUuid={projectUuid}
+                isInteractive
+                emptyText={null}
+                wrap="nowrap"
+            />
+        </div>
+    );
+};
 
 export const FavoritesBlockView: FC<BlockComponentProps> = ({
     block,

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -110,6 +110,7 @@ a .hoverCard:hover,
     display: inline-flex;
     align-items: center;
     gap: 8px;
+    max-width: 240px;
     background: light-dark(#fff, var(--mantine-color-dark-6));
     border: 1px solid var(--mantine-color-ldGray-2);
     border-radius: 8px;
@@ -121,6 +122,7 @@ a .hoverCard:hover,
     box-shadow: var(--mantine-shadow-subtle);
     transition: all 0.18s cubic-bezier(0.22, 1, 0.36, 1);
     cursor: pointer;
+    flex-shrink: 0;
 }
 
 .favPill:hover {
@@ -131,6 +133,36 @@ a .hoverCard:hover,
     box-shadow: var(--mantine-shadow-heavy);
     transform: translateY(-1px);
     text-decoration: none;
+}
+
+.favPillName {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.favPillMore {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+    background: transparent;
+    border: 1px dashed var(--mantine-color-ldGray-3);
+    border-radius: 8px;
+    padding: 7px 11px;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--mantine-color-ldGray-6);
+    white-space: nowrap;
+    cursor: pointer;
+    transition: all 0.15s ease-in-out;
+}
+
+.favPillMore:hover {
+    border-color: var(--mantine-color-ldGray-5);
+    color: var(--mantine-color-ldGray-7);
 }
 
 .starAccent {

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -4,6 +4,8 @@
  * section below. */
 
 .page {
+    --homepage-favbar-height: 48px;
+
     display: flex;
     flex-direction: column;
     padding: 32px 24px 64px;
@@ -15,6 +17,41 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
+}
+
+/* When the fav-bar is actually rendered above the hero, subtract its footprint
+ * so the hero stays centred in the remaining viewport. The bar hides itself
+ * when empty, so this only kicks in when there's really a bar. */
+.page:has(.favBar) .heroSection {
+    min-height: calc(
+        100vh - var(--navbar-height) - 72px - var(--homepage-favbar-height)
+    );
+}
+
+.favBar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    max-width: 1160px;
+    min-height: var(--homepage-favbar-height);
+    margin: 0 auto;
+    overflow-x: auto;
+}
+
+.favBarLabel {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
+.favBarLabelText {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--mantine-color-ldGray-6);
 }
 
 .hero {

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -15,7 +15,7 @@ import PinnedAndFavoritesSection from '../components/PinnedAndFavoritesSection';
 import AiSearchBox from '../ee/components/Home/AiSearchBox';
 import { useAiAgentButtonVisibility } from '../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { AdminHomepageControls } from '../ee/features/homepageBuilder/AdminHomepageControls';
-import { PersonalFavoritesStrip } from '../ee/features/homepageBuilder/blocks/FavoritesBlock';
+import { PersonalFavoritesBar } from '../ee/features/homepageBuilder/blocks/FavoritesBlock';
 import { DayOneHomepage } from '../ee/features/homepageBuilder/DayOneHomepage';
 import {
     useHomepageBuilderFlag,
@@ -117,9 +117,9 @@ const Home: FC = () => {
                 <PublishedHomepage
                     config={homepage.config}
                     projectUuid={project.data.projectUuid}
-                    secondaryTop={
+                    topBar={
                         homepage.allowPersonal && !hasFavoritesBlock ? (
-                            <PersonalFavoritesStrip
+                            <PersonalFavoritesBar
                                 projectUuid={project.data.projectUuid}
                             />
                         ) : null


### PR DESCRIPTION
## What & why

The published homepage buries the user's personal **Favorites** below a full-height, vertically-centred Ask-AI hero, and `FavoritePills` renders *every* favorite uncapped — so a user with many favorites gets an unbounded, multi-row block. This PR makes favorites **always visible at the very top** and **bounded**.

## Above-the-hero bar (the "on top always" decision)

Favorites now render as a **compact one-line bar pinned above the hero** (Option A from the plan), instead of below it via the old `secondaryTop` slot.

- `PublishedHomepage` gains a `topBar` slot rendered *above* `heroSection` in the leading-hero branch, and at the top of the page in the no-hero branch. The old `secondaryTop` prop is retired (only caller was `Home.tsx`).
- `PersonalFavoritesBar` is a slim, single-line, `wrap="nowrap"` strip inside an `overflow-x: auto` container with a small star "Favorites" label. It **renders nothing when the user has zero favorites** (no dashed prompt above the hero).

### Hero-centering math

The hero was deliberately centred at `min-height: calc(100vh - navbar - 72px)`. Putting a bar above it would push it off-centre, so the hero's `min-height` subtracts the bar's footprint (`--homepage-favbar-height: 48px`).

Crucially the subtraction is tied to the bar's **actual DOM presence** via `.page:has(.favBar) .heroSection`, not applied unconditionally. Because the bar hides itself when empty (renders `null`, so `.favBar` is absent from the DOM), the empty / admin-disabled case keeps the original centred `min-height` and the hero does **not** drift up 48px. When the bar is present, the hero stays centred in the remaining viewport. (`:has()` is already used across the frontend CSS.) On *expand*, the bar grows downward — a user-initiated action, acceptably nudging the hero lower.

## Truncate / expand UX

`FavoritePills` gains `maxVisible` (default **8**) with local `useState` expand/collapse — no persistence.

- Collapsed: `favorites.slice(0, 8)` + a trailing muted **`+N more`** pill.
- Expanded: all favorites (switches to a wrapping layout so you can scan them without horizontal scroll) + a **`Show less`** pill.
- `<= 8` favorites: no toggle.
- Long names are capped with `max-width` + ellipsis on the pill so they don't blow out the `nowrap` bar.

Gating is unchanged (`allowPersonal && !hasFavoritesBlock`). Truncation also benefits the below-hero `favorites` block and the builder preview immediately.

## Files touched

- `blocks/FavoritesBlock.tsx` — `maxVisible`/`wrap`/nullable `emptyText` + expand-collapse on `FavoritePills`; new `PersonalFavoritesBar`; `PersonalFavoritesStrip` removed.
- `PublishedHomepage.tsx` — `secondaryTop` → `topBar` slot above the hero.
- `homepageLayout.module.css` — `--homepage-favbar-height`, `:has(.favBar)` hero subtraction, `.favBar` scroll container + label.
- `blocks/blockStyles.module.css` — `.favPillMore`, `.favPillName` (ellipsis), `.favPill` max-width.
- `pages/Home.tsx` — wire the bar via `topBar` (gating unchanged).

## Verification

- `pnpm -F frontend typecheck:fast` ✅
- `pnpm -F frontend run linter <files>` (oxlint) ✅ 0 warnings/errors
- `pnpm -F frontend run unused-exports` ✅ 0 modules
- `npx oxfmt <files>` ✅

**Live verification pending (team lead)** — the shared dev server serves the main checkout, not this worktree, so the in-browser pass (bar centering with 0 / few / many favorites, expand/collapse, dark mode) is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ
