### PR TITLE
feat(frontend): fall back to classic homepage when copilot is off

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -51,6 +51,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { useToggle } from 'react-use';
 import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
+import { useIsCopilotEnabled } from '../../../ee/features/aiCopilot/hooks/useIsCopilotEnabled';
 import AIDashboardSummary from '../../../ee/features/ambientAi/components/aiDashboardSummary';
 import {
     useClearPersonalHomepage,
@@ -265,8 +266,13 @@ const DashboardHeader = memo(
             toggleDashboardPinning({ uuid: dashboardUuid });
         }, [dashboardUuid, toggleDashboardPinning]);
 
-        const { isEnabled: isHomepageBuilderEnabled } =
+        const { isEnabled: isHomepageBuilderFlagEnabled } =
             useHomepageBuilderFlag();
+        const { isCopilotEnabled } = useIsCopilotEnabled();
+        // Without copilot the homepage builder falls back to the classic
+        // homepage (see Home.tsx), so its personal-homepage controls are hidden.
+        const isHomepageBuilderEnabled =
+            isHomepageBuilderFlagEnabled && isCopilotEnabled;
         const { data: resolvedHomepage } = useResolvedHomepage(projectUuid, {
             enabled: isHomepageBuilderEnabled,
         });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useIsCopilotEnabled.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useIsCopilotEnabled.ts
@@ -1,0 +1,17 @@
+import { CommercialFeatureFlags } from '@lightdash/common';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
+import { useAiOrganizationSettings } from './useAiOrganizationSettings';
+
+// Raw "copilot available" signal: the AI copilot flag or an active trial.
+// Unlike useAiAgentButtonVisibility this does not require agents to already
+// exist, so a copilot-enabled org with no agents still counts as enabled.
+export const useIsCopilotEnabled = () => {
+    const flagQuery = useServerFeatureFlag(CommercialFeatureFlags.AiCopilot);
+    const orgSettingsQuery = useAiOrganizationSettings();
+
+    const isLoading = flagQuery.isLoading || orgSettingsQuery.isLoading;
+    const isCopilotEnabled =
+        !!flagQuery.data?.enabled || !!orgSettingsQuery.data?.isTrial;
+
+    return { isCopilotEnabled, isLoading };
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
@@ -4,13 +4,14 @@ import { Button, Stack, Text, Title } from '@mantine-8/core';
 import { IconSquareRoundedPlus } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useState, type FC } from 'react';
-import { useParams, useSearchParams } from 'react-router';
+import { Navigate, useParams, useSearchParams } from 'react-router';
 import { v4 as uuidv4 } from 'uuid';
 import MantineIcon from '../../../components/common/MantineIcon';
 import Page from '../../../components/common/Page/Page';
 import ForbiddenPanel from '../../../components/ForbiddenPanel';
 import PageSpinner from '../../../components/PageSpinner';
 import useApp from '../../../providers/App/useApp';
+import { useIsCopilotEnabled } from '../aiCopilot/hooks/useIsCopilotEnabled';
 import { CreateHomepageModal } from './CreateHomepageModal';
 import { HomepageEditor } from './HomepageEditor';
 import {
@@ -33,6 +34,8 @@ export const HomepageBuilderPage: FC = () => {
     const { user } = useApp();
     const { isEnabled: isFlagEnabled, isLoading: isFlagLoading } =
         useHomepageBuilderFlag();
+    const { isCopilotEnabled, isLoading: isCopilotLoading } =
+        useIsCopilotEnabled();
     const homepage = useHomepageForBuilder(projectUuid, {
         enabled: isFlagEnabled,
         homepageUuid: selectedHomepageUuid,
@@ -51,9 +54,23 @@ export const HomepageBuilderPage: FC = () => {
             }),
         ) ?? false;
 
+    if (isFlagLoading || isCopilotLoading) {
+        return <PageSpinner />;
+    }
+
+    // Without copilot the builder is disabled (see Home.tsx) — send anyone who
+    // reaches this route directly back to the classic homepage.
+    if (isFlagEnabled && !isCopilotEnabled) {
+        return projectUuid ? (
+            <Navigate to={`/projects/${projectUuid}/home`} replace />
+        ) : (
+            <ForbiddenPanel />
+        );
+    }
+
     // Wait for a fresh fetch: the editor snapshots the draft on mount, so
     // seeding it from a stale cache would autosave old state over the server
-    if (isFlagLoading || (isFlagEnabled && !homepage.isFetchedAfterMount)) {
+    if (isFlagEnabled && !homepage.isFetchedAfterMount) {
         return <PageSpinner />;
     }
 

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -14,6 +14,7 @@ import PageSpinner from '../components/PageSpinner';
 import PinnedAndFavoritesSection from '../components/PinnedAndFavoritesSection';
 import AiSearchBox from '../ee/components/Home/AiSearchBox';
 import { useAiAgentButtonVisibility } from '../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
+import { useIsCopilotEnabled } from '../ee/features/aiCopilot/hooks/useIsCopilotEnabled';
 import { AdminHomepageControls } from '../ee/features/homepageBuilder/AdminHomepageControls';
 import { PersonalFavoritesStrip } from '../ee/features/homepageBuilder/blocks/FavoritesBlock';
 import { DayOneHomepage } from '../ee/features/homepageBuilder/DayOneHomepage';
@@ -51,7 +52,15 @@ const Home: FC = () => {
 
     const { user } = useApp();
     const isAiAgentsEnabled = useAiAgentButtonVisibility();
-    const { isEnabled: isHomepageBuilderEnabled } = useHomepageBuilderFlag();
+    const { isEnabled: isHomepageBuilderFlagEnabled } =
+        useHomepageBuilderFlag();
+    const { isCopilotEnabled, isLoading: isCopilotLoading } =
+        useIsCopilotEnabled();
+    // The builder's centerpiece is the AI hero, so without copilot it is a
+    // degraded experience — fall back to the classic homepage and hide the
+    // builder/customization until that is addressed.
+    const isHomepageBuilderEnabled =
+        isHomepageBuilderFlagEnabled && isCopilotEnabled;
     const resolvedHomepage = useResolvedHomepage(selectedProjectUuid, {
         enabled: isHomepageBuilderEnabled,
     });
@@ -61,7 +70,8 @@ const Home: FC = () => {
         project.isInitialLoading ||
         isMostPopularAndRecentlyUpdatedLoading ||
         pinnedItems.isInitialLoading ||
-        favorites.isInitialLoading;
+        favorites.isInitialLoading ||
+        isCopilotLoading;
 
     const error = onboarding.error || project.error;
 


### PR DESCRIPTION
## What

When the **homepage-builder** feature flag is ON but the **AI copilot** flag is OFF, fall back to the **classic (pre-builder) homepage** and hide the builder/customization surfaces.

**Why:** the builder's centerpiece is the AI hero (`ask-ai-hero`) block. Without copilot the hero renders nothing, so the day-0 / published-homepage experience is degraded. Until a copilot-less builder is addressed, we serve the proven classic homepage instead.

## Condition

`homepageBuilderFlag ON && copilot OFF` → treat the builder as **disabled** for rendering purposes.

The copilot signal is a new hook `useIsCopilotEnabled()` that reads the **raw** `ai-copilot` feature flag (or an active trial), deliberately **not** `useAiAgentButtonVisibility()`:

- `useAiAgentButtonVisibility()` additionally requires agents to already exist / view permission / `aiAgentsVisible`. We do not want to gate on those here — an org with copilot enabled but **no agents yet** should still get the builder (they can create agents from the hero).
- Trial orgs are treated as copilot-enabled (they have a working hero), matching the `isAiCopilotEnabledOrTrial` semantics the hero itself uses.

## What falls back / is hidden / is guarded

- **`Home.tsx`** — a single early fold: `isHomepageBuilderEnabled = isHomepageBuilderFlagEnabled && isCopilotEnabled`. Every builder branch (dashboard redirect, published homepage, day-0 homepage) and the `AdminHomepageControls` ("Customize homepage" / "New homepage") already gate on this, so they all disappear and the classic homepage renders. `isCopilotLoading` is added to the page-level loading gate to avoid a fallback→builder flash.
- **`DashboardHeader.tsx`** — the same fold, so the dashboard "Set as my homepage" personal-override control is hidden too (the override would be ignored by the fallback homepage, so exposing it would be inconsistent).
- **`HomepageBuilderPage.tsx`** (the `/homepage-builder` route) — when the flag is on but copilot is off, `<Navigate replace>` back to `/projects/:projectUuid/home`, so there is no way into the degraded builder by URL.
- New hook: **`useIsCopilotEnabled.ts`**.

## Scope decision

Treated the builder as **fully disabled** when copilot is off — not just the day-0/creation path. An already-published homepage and personal-dashboard overrides also fall back to the classic homepage while copilot is off. Rationale: editing a published homepage needs the builder anyway, and this keeps the behavior simple and consistent. Trade-off: copilot-off orgs temporarily lose personal-homepage overrides; acceptable until the copilot-less builder is addressed. When copilot is turned back on, everything returns automatically (flags/queries re-resolve).

The change is intentionally minimal and localized (a derived boolean per gate) so it merges cleanly with the concurrent `topBar` prop change to `<PublishedHomepage>` in `Home.tsx`.

## Verification

- `pnpm -F frontend typecheck:fast` — pass
- `pnpm -F frontend run linter <files>` (oxlint) — 0 warnings / 0 errors
- `npx oxfmt <files>` — formatted
- `pnpm -F frontend run unused-exports` — 0 modules with unused exports

**Live verification pending (team lead)** — the shared dev server serves the main checkout, not this worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ
