### PR TITLE
feat(frontend): homepage builder — reorder-only drag + explicit add-column

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.module.css
@@ -348,6 +348,74 @@
     vertical-align: -2px;
 }
 
+/* Explicit "add column" gutters. Idle: a slim "+" rail that collapses to zero
+   width so single-column rows stay full-width, expanding on row hover. During
+   a drag: a dashed drop slot that accepts the dragged block as a new column. */
+.columnRail {
+    flex: 0 0 0;
+    align-self: stretch;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: visible;
+    transition: flex-basis 0.15s ease;
+}
+
+.rowColumns:hover .columnRail,
+.columnRail[data-menu-open='true'] {
+    flex-basis: 24px;
+}
+
+.columnRailBtn {
+    width: 22px;
+    height: 22px;
+    border-radius: 999px;
+    border: 1px solid var(--mantine-color-ldGray-3);
+    background: light-dark(#fff, var(--mantine-color-dark-6));
+    color: var(--mantine-color-ldGray-6);
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    opacity: 0;
+    box-shadow: var(--mantine-shadow-subtle);
+    transition:
+        opacity 0.15s ease,
+        color 0.12s ease,
+        border-color 0.12s ease;
+}
+
+.rowColumns:hover .columnRailBtn,
+.columnRail[data-menu-open='true'] .columnRailBtn {
+    opacity: 1;
+}
+
+.columnRailBtn:hover {
+    color: var(--mantine-color-ldGray-9);
+    border-color: var(--mantine-color-ldGray-5);
+}
+
+.columnSlot {
+    flex: 0 0 56px;
+    align-self: stretch;
+    min-height: 72px;
+    border: 2px dashed var(--mantine-color-ldGray-3);
+    border-radius: 10px;
+    display: grid;
+    place-items: center;
+    color: var(--mantine-color-ldGray-4);
+    transition: all 0.12s ease-in-out;
+}
+
+.columnSlot[data-over='true'] {
+    flex-basis: 120px;
+    border-color: var(--mantine-color-blue-5);
+    color: var(--mantine-color-blue-5);
+    background: light-dark(
+        var(--mantine-color-blue-0),
+        var(--mantine-color-dark-5)
+    );
+}
+
 .endZoneActive {
     border-color: var(--mantine-color-blue-5);
     background: var(--mantine-color-blue-0);

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -53,7 +53,7 @@ import {
     IconUserSearch,
     IconUsers,
 } from '@tabler/icons-react';
-import { useEffect, useRef, useState, type FC } from 'react';
+import { Fragment, useEffect, useRef, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
@@ -66,6 +66,7 @@ import {
 } from './blocks/registry';
 import {
     addBlock,
+    canAddColumn,
     canDropInRow,
     canMoveDown,
     canMoveUp,
@@ -222,6 +223,72 @@ const EndDropZone: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
             {isEmpty
                 ? 'No blocks yet — click or drag one from the library.'
                 : 'Drag a block here, or click one in the library.'}
+        </div>
+    );
+};
+
+// The gutters around/between blocks in a row are where columns are added
+// deliberately. Idle: a slim "+" rail (revealed on row hover) that opens the
+// block menu. During a drag: a dashed drop slot that accepts the dragged block
+// as a new column. Both emit `slot:<rowIndex>:<insertIndex>` drop ids.
+const ColumnGutter: FC<{
+    rowIndex: number;
+    insertIndex: number;
+    isDragActive: boolean;
+    blocks: BlockDefinition[];
+    onAdd: (definition: BlockDefinition) => void;
+}> = ({ rowIndex, insertIndex, isDragActive, blocks, onAdd }) => {
+    const { setNodeRef, isOver } = useDroppable({
+        id: `slot:${rowIndex}:${insertIndex}`,
+        disabled: !isDragActive,
+    });
+    const [menuOpened, setMenuOpened] = useState(false);
+
+    if (isDragActive) {
+        return (
+            <div
+                ref={setNodeRef}
+                className={classes.columnSlot}
+                data-over={isOver}
+            >
+                <MantineIcon icon={IconPlus} size={14} />
+            </div>
+        );
+    }
+    return (
+        <div className={classes.columnRail} data-menu-open={menuOpened}>
+            <Menu
+                opened={menuOpened}
+                onChange={setMenuOpened}
+                position="bottom"
+                width={240}
+            >
+                <Menu.Target>
+                    <button
+                        type="button"
+                        className={classes.columnRailBtn}
+                        aria-label="Add column"
+                    >
+                        <MantineIcon icon={IconPlus} size={13} />
+                    </button>
+                </Menu.Target>
+                <Menu.Dropdown>
+                    {blocks.map((definition) => (
+                        <Menu.Item
+                            key={definition.type}
+                            leftSection={
+                                <MantineIcon
+                                    icon={definition.icon}
+                                    color="ldGray.6"
+                                />
+                            }
+                            onClick={() => onAdd(definition)}
+                        >
+                            {definition.label}
+                        </Menu.Item>
+                    ))}
+                </Menu.Dropdown>
+            </Menu>
         </div>
     );
 };
@@ -459,18 +526,15 @@ export const HomepageEditor: FC<Props> = ({
         useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     );
 
-    // A block being hovered is split into zones: the top/bottom bands reorder
-    // the dragged block into its own row above/below (the common case), the
-    // narrow left/right edges split it into the same row side-by-side, and
-    // the center defaults to reordering above — so merely passing over a
-    // block on the way elsewhere doesn't accidentally split it.
-    const ROW_ZONE_FRACTION = 0.3;
-    const CELL_EDGE_FRACTION = 0.15;
-
-    // Where would the dragged block land, given what the pointer is over?
+    // Dragging is reorder-only: dropping on a block moves the dragged block to
+    // a new row above/below it. It never splits two blocks into a shared row —
+    // columns are created deliberately via the explicit gutter affordance
+    // (rail click / drop slot, which emit `slot:` ids). The one exception is
+    // reordering columns *within* the dragged block's own multi-block row.
     const computeTarget = (
         config: HomepageConfig,
         event: DragOverEvent | DragEndEvent,
+        draggedBlockId: string | null,
     ): DropTarget | null => {
         const over = event.over;
         if (!over) return null;
@@ -479,40 +543,46 @@ export const HomepageEditor: FC<Props> = ({
         if (overId.startsWith('gap:')) {
             return { kind: 'row', rowIndex: Number(overId.split(':')[1]) };
         }
+        if (overId.startsWith('slot:')) {
+            const [, rowIdx, blockIdx] = overId.split(':');
+            return {
+                kind: 'cell',
+                rowIndex: Number(rowIdx),
+                blockIndex: Number(blockIdx),
+            };
+        }
         const location = locateBlock(config, overId);
         if (!location) return null;
         const activeRect = event.active.rect.current.translated;
-        const activeCenterX = activeRect
-            ? activeRect.left + activeRect.width / 2
-            : over.rect.left;
+
+        const draggedLocation = draggedBlockId
+            ? locateBlock(config, draggedBlockId)
+            : undefined;
+        const sameMultiBlockRow =
+            !!draggedLocation &&
+            draggedLocation.rowIndex === location.rowIndex &&
+            config.rows[location.rowIndex].blocks.length > 1;
+
+        if (sameMultiBlockRow) {
+            const activeCenterX = activeRect
+                ? activeRect.left + activeRect.width / 2
+                : over.rect.left;
+            const relX = (activeCenterX - over.rect.left) / over.rect.width;
+            return {
+                kind: 'cell',
+                rowIndex: location.rowIndex,
+                blockIndex: location.blockIndex + (relX < 0.5 ? 0 : 1),
+            };
+        }
+
         const activeCenterY = activeRect
             ? activeRect.top + activeRect.height / 2
             : over.rect.top;
         const relY = (activeCenterY - over.rect.top) / over.rect.height;
-
-        if (relY < ROW_ZONE_FRACTION) {
-            return { kind: 'row', rowIndex: location.rowIndex };
-        }
-        if (relY > 1 - ROW_ZONE_FRACTION) {
-            return { kind: 'row', rowIndex: location.rowIndex + 1 };
-        }
-
-        const relX = (activeCenterX - over.rect.left) / over.rect.width;
-        if (relX < CELL_EDGE_FRACTION) {
-            return {
-                kind: 'cell',
-                rowIndex: location.rowIndex,
-                blockIndex: location.blockIndex,
-            };
-        }
-        if (relX > 1 - CELL_EDGE_FRACTION) {
-            return {
-                kind: 'cell',
-                rowIndex: location.rowIndex,
-                blockIndex: location.blockIndex + 1,
-            };
-        }
-        return { kind: 'row', rowIndex: location.rowIndex };
+        return {
+            kind: 'row',
+            rowIndex: location.rowIndex + (relY < 0.5 ? 0 : 1),
+        };
     };
 
     // Live-preview move: relocate the block in the draft as the drag hovers,
@@ -564,7 +634,11 @@ export const HomepageEditor: FC<Props> = ({
         const source = event.active.data.current as DragSource | undefined;
         if (!source) return;
         setDraft((prev) => {
-            const target = computeTarget(prev, event);
+            const draggedId =
+                source.kind === 'new'
+                    ? (pendingNewBlockRef.current?.id ?? null)
+                    : source.blockId;
+            const target = computeTarget(prev, event, draggedId);
             if (!target) return prev;
             if (source.kind === 'new') {
                 if (!pendingNewBlockRef.current) {
@@ -598,9 +672,9 @@ export const HomepageEditor: FC<Props> = ({
             return;
         }
         setDraft((prev) => {
-            const target = computeTarget(prev, event);
             const blockId =
                 source.kind === 'new' ? pendingBlock?.id : source.blockId;
+            const target = computeTarget(prev, event, blockId ?? null);
             if (!blockId) {
                 // library drag released before any preview insert happened
                 if (source.kind === 'new' && target) {
@@ -834,92 +908,178 @@ export const HomepageEditor: FC<Props> = ({
                                                     gap="md"
                                                     align="stretch"
                                                     wrap="nowrap"
+                                                    className={
+                                                        classes.rowColumns
+                                                    }
                                                 >
-                                                    {row.blocks.map((block) => {
-                                                        const definition =
-                                                            getBlockDefinition(
-                                                                block.type,
+                                                    {row.blocks.map(
+                                                        (block, blockIndex) => {
+                                                            const definition =
+                                                                getBlockDefinition(
+                                                                    block.type,
+                                                                );
+                                                            if (!definition)
+                                                                return null;
+                                                            return (
+                                                                <Fragment
+                                                                    key={
+                                                                        block.id
+                                                                    }
+                                                                >
+                                                                    {canAddColumn(
+                                                                        draft,
+                                                                        rowIndex,
+                                                                    ) && (
+                                                                        <ColumnGutter
+                                                                            rowIndex={
+                                                                                rowIndex
+                                                                            }
+                                                                            insertIndex={
+                                                                                blockIndex
+                                                                            }
+                                                                            isDragActive={
+                                                                                activeDrag !==
+                                                                                null
+                                                                            }
+                                                                            blocks={
+                                                                                availableBlocks
+                                                                            }
+                                                                            onAdd={(
+                                                                                def,
+                                                                            ) =>
+                                                                                setDraft(
+                                                                                    (
+                                                                                        prev,
+                                                                                    ) =>
+                                                                                        dropNewBlock(
+                                                                                            prev,
+                                                                                            def.create(),
+                                                                                            {
+                                                                                                kind: 'cell',
+                                                                                                rowIndex,
+                                                                                                blockIndex,
+                                                                                            },
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                        />
+                                                                    )}
+                                                                    <BlockCard
+                                                                        block={
+                                                                            block
+                                                                        }
+                                                                        definition={
+                                                                            definition
+                                                                        }
+                                                                        projectUuid={
+                                                                            projectUuid
+                                                                        }
+                                                                        canUp={canMoveUp(
+                                                                            draft,
+                                                                            block.id,
+                                                                        )}
+                                                                        canDown={canMoveDown(
+                                                                            draft,
+                                                                            block.id,
+                                                                        )}
+                                                                        onUp={() =>
+                                                                            setDraft(
+                                                                                (
+                                                                                    prev,
+                                                                                ) =>
+                                                                                    moveBlockUp(
+                                                                                        prev,
+                                                                                        block.id,
+                                                                                    ),
+                                                                            )
+                                                                        }
+                                                                        onDown={() =>
+                                                                            setDraft(
+                                                                                (
+                                                                                    prev,
+                                                                                ) =>
+                                                                                    moveBlockDown(
+                                                                                        prev,
+                                                                                        block.id,
+                                                                                    ),
+                                                                            )
+                                                                        }
+                                                                        onDuplicate={() =>
+                                                                            setDraft(
+                                                                                (
+                                                                                    prev,
+                                                                                ) =>
+                                                                                    duplicateBlock(
+                                                                                        prev,
+                                                                                        block.id,
+                                                                                    ),
+                                                                            )
+                                                                        }
+                                                                        onRemove={() =>
+                                                                            setDraft(
+                                                                                (
+                                                                                    prev,
+                                                                                ) =>
+                                                                                    removeBlock(
+                                                                                        prev,
+                                                                                        block.id,
+                                                                                    ),
+                                                                            )
+                                                                        }
+                                                                        onChange={(
+                                                                            updated,
+                                                                        ) =>
+                                                                            setDraft(
+                                                                                (
+                                                                                    prev,
+                                                                                ) =>
+                                                                                    replaceBlock(
+                                                                                        prev,
+                                                                                        updated,
+                                                                                    ),
+                                                                            )
+                                                                        }
+                                                                    />
+                                                                </Fragment>
                                                             );
-                                                        if (!definition)
-                                                            return null;
-                                                        return (
-                                                            <BlockCard
-                                                                key={block.id}
-                                                                block={block}
-                                                                definition={
-                                                                    definition
-                                                                }
-                                                                projectUuid={
-                                                                    projectUuid
-                                                                }
-                                                                canUp={canMoveUp(
-                                                                    draft,
-                                                                    block.id,
-                                                                )}
-                                                                canDown={canMoveDown(
-                                                                    draft,
-                                                                    block.id,
-                                                                )}
-                                                                onUp={() =>
-                                                                    setDraft(
-                                                                        (
+                                                        },
+                                                    )}
+                                                    {canAddColumn(
+                                                        draft,
+                                                        rowIndex,
+                                                    ) && (
+                                                        <ColumnGutter
+                                                            rowIndex={rowIndex}
+                                                            insertIndex={
+                                                                row.blocks
+                                                                    .length
+                                                            }
+                                                            isDragActive={
+                                                                activeDrag !==
+                                                                null
+                                                            }
+                                                            blocks={
+                                                                availableBlocks
+                                                            }
+                                                            onAdd={(def) =>
+                                                                setDraft(
+                                                                    (prev) =>
+                                                                        dropNewBlock(
                                                                             prev,
-                                                                        ) =>
-                                                                            moveBlockUp(
-                                                                                prev,
-                                                                                block.id,
-                                                                            ),
-                                                                    )
-                                                                }
-                                                                onDown={() =>
-                                                                    setDraft(
-                                                                        (
-                                                                            prev,
-                                                                        ) =>
-                                                                            moveBlockDown(
-                                                                                prev,
-                                                                                block.id,
-                                                                            ),
-                                                                    )
-                                                                }
-                                                                onDuplicate={() =>
-                                                                    setDraft(
-                                                                        (
-                                                                            prev,
-                                                                        ) =>
-                                                                            duplicateBlock(
-                                                                                prev,
-                                                                                block.id,
-                                                                            ),
-                                                                    )
-                                                                }
-                                                                onRemove={() =>
-                                                                    setDraft(
-                                                                        (
-                                                                            prev,
-                                                                        ) =>
-                                                                            removeBlock(
-                                                                                prev,
-                                                                                block.id,
-                                                                            ),
-                                                                    )
-                                                                }
-                                                                onChange={(
-                                                                    updated,
-                                                                ) =>
-                                                                    setDraft(
-                                                                        (
-                                                                            prev,
-                                                                        ) =>
-                                                                            replaceBlock(
-                                                                                prev,
-                                                                                updated,
-                                                                            ),
-                                                                    )
-                                                                }
-                                                            />
-                                                        );
-                                                    })}
+                                                                            def.create(),
+                                                                            {
+                                                                                kind: 'cell',
+                                                                                rowIndex,
+                                                                                blockIndex:
+                                                                                    row
+                                                                                        .blocks
+                                                                                        .length,
+                                                                            },
+                                                                        ),
+                                                                )
+                                                            }
+                                                        />
+                                                    )}
                                                 </Group>
                                             </SortableContext>
                                         </Box>

--- a/packages/frontend/src/ee/features/homepageBuilder/configOps.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/configOps.ts
@@ -205,6 +205,16 @@ export const dropExistingBlock = (
     return withRows(config, insertAt(rows, block, adjusted));
 };
 
+// Whether a row can take another column (used to gate the explicit
+// add-column gutter affordances).
+export const canAddColumn = (
+    config: HomepageConfig,
+    rowIndex: number,
+): boolean => {
+    const row = config.rows[rowIndex];
+    return !!row && row.blocks.length < HOMEPAGE_MAX_BLOCKS_PER_ROW;
+};
+
 export const canDropInRow = (
     config: HomepageConfig,
     rowIndex: number,


### PR DESCRIPTION
Part of the homepage-builder "round 4" work (branches off main). Implements the approved DnD rework from ~/Desktop/plans/2026-07-16-homepage-dnd-rework.md.

## Summary

- **Drag = reorder only.** Dropping a block on another block now always moves it to a new row above/below (relY midpoint) — the accidental left/right **edge-split** into a shared row is gone.
- **Columns are created deliberately** via an explicit gutter affordance:
  - **Idle:** a slim `+` rail in each row gutter (collapsed to zero width so single-column rows stay full-width; revealed on row hover) → click opens the block menu → inserts a column at that position.
  - **During a drag:** the gutters become dashed **drop slots** that accept the dragged block as a new column.
- **Same-row horizontal reorder** of existing columns is preserved (relX within the dragged block's own multi-block row).
- Empty slots are **derived from the active drag, never persisted** — the `withRows` no-empty-rows invariant holds. No data-model, backend, or migration change. `canAddColumn` gates on `HOMEPAGE_MAX_BLOCKS_PER_ROW` (3).

## Verification

- `pnpm -F frontend typecheck:fast`, `run linter`, `oxfmt`, `unused-exports` — all clean.
- Live-verified in the browser: single-column rows stay full-width; hovering a row reveals the `+` rails; clicking a rail opens the block menu and adds a column (confirmed a 2-column ASK AI + Resources row forms, then removed cleanly). Drag-reorder and the during-drag drop-slots are structurally in place; **interactive drag QA (drag-to-reorder feel, drop-slot targeting) is worth a manual pass** since it's hard to drive reliably via automation.

## Open questions
- Discoverability of the hover-only `+` rail — building hover-first per the plan; can add an always-faint rail if it tests as too hidden.
- The plan's optional PR3 (left/right keyboard move buttons + keyboard DnD sensor) is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ