### PR TITLE
fix: align resource table search input

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -133,7 +133,6 @@ const DebouncedSearchInput = memo(
                         input: {
                             height: 32,
                             width: 309,
-                            padding: `${inputTheme.spacing.xs} ${inputTheme.spacing.sm}`,
                             textOverflow: 'ellipsis',
                             fontSize: inputTheme.fontSizes.sm,
                             fontWeight: 400,


### PR DESCRIPTION
## Summary

- preserve Mantine's left-section padding in resource table search inputs
- prevent the search icon from overlapping placeholder text across saved charts, dashboards, and spaces

## Testing

- `pnpm -F frontend typecheck:fast`
- `pnpm -F frontend run linter ./src/components/common/ResourceView/InfiniteResourceTable.tsx`
- `pnpm -F frontend exec oxfmt src/components/common/ResourceView/InfiniteResourceTable.tsx --check`
- Browser verification on saved charts, dashboards, and spaces
