### PR TITLE
fix: allow user deletion when AI prompt interrupts or thread shares exist

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -53,7 +53,7 @@ export type DbAiThreadShare = {
     project_uuid: string;
     organization_uuid: string;
     snapshot_prompt_uuid: string;
-    created_by_user_uuid: string;
+    created_by_user_uuid: string | null;
     created_at: Date;
     revoked_at: Date | null;
 };
@@ -68,8 +68,7 @@ export type AiThreadShareTable = Knex.CompositeTableType<
         | 'project_uuid'
         | 'organization_uuid'
         | 'snapshot_prompt_uuid'
-        | 'created_by_user_uuid'
-    >,
+    > & { created_by_user_uuid: string },
     Pick<DbAiThreadShare, 'revoked_at'>
 >;
 
@@ -243,13 +242,15 @@ export const AiPromptInterruptTableName = 'ai_prompt_interrupt';
 export type DbAiPromptInterrupt = {
     ai_prompt_interrupt_uuid: string;
     ai_prompt_uuid: string;
-    created_by_user_uuid: string;
+    created_by_user_uuid: string | null;
     created_at: Date;
 };
 
 export type AiPromptInterruptTable = Knex.CompositeTableType<
     DbAiPromptInterrupt,
-    Pick<DbAiPromptInterrupt, 'ai_prompt_uuid' | 'created_by_user_uuid'>,
+    Pick<DbAiPromptInterrupt, 'ai_prompt_uuid'> & {
+        created_by_user_uuid: string;
+    },
     never
 >;
 

--- a/packages/backend/src/ee/database/migrations/20260716090000_fix_ai_user_fk_on_delete_set_null.ts
+++ b/packages/backend/src/ee/database/migrations/20260716090000_fix_ai_user_fk_on_delete_set_null.ts
@@ -1,0 +1,38 @@
+import { Knex } from 'knex';
+
+const AI_PROMPT_INTERRUPT_TABLE_NAME = 'ai_prompt_interrupt';
+const AI_THREAD_SHARE_TABLE_NAME = 'ai_thread_share';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AI_PROMPT_INTERRUPT_TABLE_NAME, (table) => {
+        table.dropForeign(['created_by_user_uuid']);
+    });
+
+    await knex.schema.alterTable(AI_PROMPT_INTERRUPT_TABLE_NAME, (table) => {
+        table.uuid('created_by_user_uuid').nullable().alter();
+        table
+            .foreign('created_by_user_uuid')
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL');
+    });
+
+    await knex.schema.alterTable(AI_THREAD_SHARE_TABLE_NAME, (table) => {
+        table.dropForeign(['created_by_user_uuid']);
+    });
+
+    await knex.schema.alterTable(AI_THREAD_SHARE_TABLE_NAME, (table) => {
+        table.uuid('created_by_user_uuid').nullable().alter();
+        table
+            .foreign('created_by_user_uuid')
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL');
+    });
+}
+
+export async function down(): Promise<void> {
+    // This migration fixes foreign key constraints that prevented user deletion.
+    // Rolling back would restore the broken state (and could fail on NULL values),
+    // so no rollback is provided for this bug fix.
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -272,7 +272,7 @@ export type CreateAiThreadShareResult = {
     projectUuid: string;
     organizationUuid: string;
     snapshotPromptUuid: string;
-    createdByUserUuid: string;
+    createdByUserUuid: string | null;
     createdAt: Date;
     revokedAt: Date | null;
 };

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -13583,6 +13583,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         return {
             ...share,
+            createdByUserUuid: user.userUuid,
             createdAt: share.createdAt.toISOString(),
             revokedAt: share.revokedAt?.toISOString() ?? null,
             shareUrl,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8898/cant-delete-user-with-ai-agents-db-error

### Description:
The `created_by_user_uuid` foreign keys on `ai_prompt_interrupt` and `ai_thread_share` had no `ON DELETE` action, so deleting a user who had ever interrupted an AI prompt or shared a thread failed with an FK violation. Recreate both FKs with `ON DELETE SET NULL` (matching ai_prompt and share conventions) and make the columns nullable.
