### PR TITLE
feat: pass dashboard runtime context to Ask AI

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -6408,9 +6408,26 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                 case 'dashboard': {
                     const name = item.displayName ?? '(name unavailable)';
                     const headline = `- Dashboard "${name}" (dashboardSlug: ${item.dashboardSlug ?? '(slug unavailable)'})`;
-                    const filters = item.runtimeOverrides?.dashboardFilters;
-                    return filters
-                        ? `${headline}\n  Filters applied:\n    ${JSON.stringify(serializeDashboardFiltersForAiContext(filters))}`
+                    const overrides = item.runtimeOverrides;
+                    if (!overrides) return headline;
+                    const overrideLines: string[] = [];
+                    if (overrides.dashboardFilters) {
+                        overrideLines.push(
+                            `  Filters applied:\n    ${JSON.stringify(serializeDashboardFiltersForAiContext(overrides.dashboardFilters))}`,
+                        );
+                    }
+                    if (overrides.dashboardParameters) {
+                        overrideLines.push(
+                            `  Parameter values: ${JSON.stringify(overrides.dashboardParameters)}`,
+                        );
+                    }
+                    if (overrides.dateZoom !== undefined) {
+                        overrideLines.push(
+                            `  Date zoom: ${JSON.stringify(overrides.dateZoom)}`,
+                        );
+                    }
+                    return overrideLines.length > 0
+                        ? `${headline}\n${overrideLines.join('\n')}`
                         : headline;
                 }
                 case 'thread': {

--- a/packages/backend/src/ee/services/AiAgentService/pinnedContextMessage.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/pinnedContextMessage.test.ts
@@ -82,6 +82,43 @@ describe('AiAgentService.createPinnedContextMessage review pins', () => {
         expect(content).not.toContain('requiredGroupId');
     });
 
+    it('renders dashboard parameter and date zoom overrides', () => {
+        const content = buildMessage([
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dashboard-1',
+                dashboardSlug: 'exec-dashboard',
+                displayName: 'Executive dashboard',
+                pinnedVersionUuid: null,
+                runtimeOverrides: {
+                    dashboardParameters: {
+                        region: 'EU',
+                        tiers: ['gold'],
+                    },
+                    dateZoom: { granularity: 'Week' },
+                },
+            },
+        ]);
+        expect(content).toContain(
+            'Parameter values: {"region":"EU","tiers":["gold"]}',
+        );
+        expect(content).toContain('Date zoom: {"granularity":"Week"}');
+    });
+
+    it('renders an explicit no-date-zoom override', () => {
+        const content = buildMessage([
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dashboard-1',
+                dashboardSlug: 'exec-dashboard',
+                displayName: 'Executive dashboard',
+                pinnedVersionUuid: null,
+                runtimeOverrides: { dateZoom: null },
+            },
+        ]);
+        expect(content).toContain('Date zoom: null');
+    });
+
     it('renders a pull_request line with number, status and title', () => {
         const content = buildMessage([
             {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -15467,6 +15467,14 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                dateZoom: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'DateZoom' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                dashboardParameters: { ref: 'ParametersValuesMap' },
                 dashboardFilters: { ref: 'AiDashboardFilters' },
             },
             validators: {},

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -17060,6 +17060,17 @@
             },
             "AiDashboardRuntimeOverrides": {
                 "properties": {
+                    "dateZoom": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/DateZoom"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "dashboardParameters": {
+                        "$ref": "#/components/schemas/ParametersValuesMap"
+                    },
                     "dashboardFilters": {
                         "$ref": "#/components/schemas/AiDashboardFilters"
                     }

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -46,6 +46,8 @@ export type AiDashboardFilters = {
 
 export type AiDashboardRuntimeOverrides = {
     dashboardFilters?: AiDashboardFilters;
+    dashboardParameters?: ParametersValuesMap;
+    dateZoom?: DateZoom | null;
 };
 
 export type AiThread = {

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDashboardPageContextCuration.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDashboardPageContextCuration.test.ts
@@ -14,6 +14,8 @@ const runtimeOverrides = {
         metrics: [],
         tableCalculations: [],
     },
+    dashboardParameters: { region: 'EU' },
+    dateZoom: { granularity: 'Week' },
 };
 
 const currentDashboard: LauncherCurrentDashboard = {

--- a/packages/frontend/src/ee/features/aiCopilot/store/dashboardPageContext.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/dashboardPageContext.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { type LauncherCurrentDashboard } from './aiAgentLauncherSlice';
 import {
     getCurrentDashboardPromptContext,
+    getDashboardParametersValuesMap,
     getNonDefaultDashboardRuntimeOverrides,
 } from './dashboardPageContext';
 
@@ -45,11 +46,15 @@ const currentDashboard = (
 });
 
 describe('dashboard page context', () => {
-    it('omits default filters', () => {
+    it('omits default runtime values', () => {
         expect(
             getNonDefaultDashboardRuntimeOverrides({
                 defaultFilters: emptyFilters,
                 effectiveFilters: { ...emptyFilters },
+                defaultParameters: { region: 'US' },
+                effectiveParameters: { region: 'US' },
+                defaultDateZoom: { granularity: 'Month' },
+                effectiveDateZoom: { granularity: 'Month' },
             }),
         ).toBeNull();
     });
@@ -58,6 +63,10 @@ describe('dashboard page context', () => {
         const overrides = getNonDefaultDashboardRuntimeOverrides({
             defaultFilters: emptyFilters,
             effectiveFilters: filtered,
+            defaultParameters: {},
+            effectiveParameters: {},
+            defaultDateZoom: null,
+            effectiveDateZoom: null,
         });
         expect(overrides?.dashboardFilters?.dimensions[0]).toEqual({
             label: 'Country',
@@ -67,8 +76,51 @@ describe('dashboard page context', () => {
         });
     });
 
-    it('does not attach unchanged filters again', () => {
-        const runtimeOverrides = { dashboardFilters: filtered };
+    it('captures non-default parameter values and date zoom', () => {
+        expect(
+            getNonDefaultDashboardRuntimeOverrides({
+                defaultFilters: emptyFilters,
+                effectiveFilters: emptyFilters,
+                defaultParameters: { region: 'US' },
+                effectiveParameters: { region: 'EU', tiers: ['gold'] },
+                defaultDateZoom: { granularity: 'Month' },
+                effectiveDateZoom: { granularity: 'Week' },
+            }),
+        ).toEqual({
+            dashboardParameters: { region: 'EU', tiers: ['gold'] },
+            dateZoom: { granularity: 'Week' },
+        });
+    });
+
+    it('captures selecting no date zoom when a saved default exists', () => {
+        expect(
+            getNonDefaultDashboardRuntimeOverrides({
+                defaultFilters: emptyFilters,
+                effectiveFilters: emptyFilters,
+                defaultParameters: {},
+                effectiveParameters: {},
+                defaultDateZoom: { granularity: 'Month' },
+                effectiveDateZoom: null,
+            }),
+        ).toEqual({ dateZoom: null });
+    });
+
+    it('converts saved dashboard parameters to effective values', () => {
+        expect(
+            getDashboardParametersValuesMap({
+                region: { parameterName: 'region', value: 'US' },
+                tiers: { parameterName: 'tiers', value: ['gold'] },
+                empty: { parameterName: 'empty', value: '' },
+            }),
+        ).toEqual({ region: 'US', tiers: ['gold'] });
+    });
+
+    it('does not attach unchanged runtime values again', () => {
+        const runtimeOverrides = {
+            dashboardFilters: filtered,
+            dashboardParameters: { region: 'EU' },
+            dateZoom: { granularity: 'Week' },
+        };
         expect(
             getCurrentDashboardPromptContext({
                 currentDashboard: currentDashboard(runtimeOverrides),

--- a/packages/frontend/src/ee/features/aiCopilot/store/dashboardPageContext.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/dashboardPageContext.ts
@@ -4,6 +4,9 @@ import {
     type AiPromptContext,
     type AiPromptContextInput,
     type DashboardFilters,
+    type DashboardParameters,
+    type DateZoom,
+    type ParametersValuesMap,
 } from '@lightdash/common';
 import isEqual from 'lodash/isEqual';
 import { type LauncherCurrentDashboard } from './aiAgentLauncherSlice';
@@ -21,16 +24,46 @@ type DashboardContext = DashboardContextInput | DashboardContextItem;
 export const getNonDefaultDashboardRuntimeOverrides = ({
     defaultFilters,
     effectiveFilters,
+    defaultParameters,
+    effectiveParameters,
+    defaultDateZoom,
+    effectiveDateZoom,
 }: {
     defaultFilters: DashboardFilters;
     effectiveFilters: DashboardFilters;
-}): AiDashboardRuntimeOverrides | null =>
-    isEqual(defaultFilters, effectiveFilters)
-        ? null
-        : {
-              dashboardFilters:
-                  serializeDashboardFiltersForAiContext(effectiveFilters),
-          };
+    defaultParameters: ParametersValuesMap;
+    effectiveParameters: ParametersValuesMap;
+    defaultDateZoom: DateZoom | null;
+    effectiveDateZoom: DateZoom | null;
+}): AiDashboardRuntimeOverrides | null => {
+    const overrides: AiDashboardRuntimeOverrides = {};
+
+    if (!isEqual(defaultFilters, effectiveFilters)) {
+        overrides.dashboardFilters =
+            serializeDashboardFiltersForAiContext(effectiveFilters);
+    }
+    if (!isEqual(defaultParameters, effectiveParameters)) {
+        overrides.dashboardParameters = effectiveParameters;
+    }
+    if (!isEqual(defaultDateZoom, effectiveDateZoom)) {
+        overrides.dateZoom = effectiveDateZoom;
+    }
+
+    return Object.keys(overrides).length > 0 ? overrides : null;
+};
+
+export const getDashboardParametersValuesMap = (
+    parameters: DashboardParameters,
+): ParametersValuesMap =>
+    Object.fromEntries(
+        Object.entries(parameters).flatMap(([key, parameter]) =>
+            parameter.value === null ||
+            parameter.value === undefined ||
+            parameter.value === ''
+                ? []
+                : [[key, parameter.value]],
+        ),
+    );
 
 export const getLastDashboardContext = (
     context: Array<AiPromptContextInput[number] | AiPromptContext[number]>,

--- a/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
@@ -2,6 +2,7 @@ import {
     type DashboardChartTile,
     type DashboardFilters,
     type DashboardTile,
+    type DateZoom,
     isDashboardChartTileType,
 } from '@lightdash/common';
 import { useQueryClient } from '@tanstack/react-query';
@@ -9,7 +10,10 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useParams } from 'react-router';
 import { scrollToDashboardTile } from '../../components/common/Dashboard/scrollToDashboardTile';
 import { setCurrentDashboard } from '../../ee/features/aiCopilot/store/aiAgentLauncherSlice';
-import { getNonDefaultDashboardRuntimeOverrides } from '../../ee/features/aiCopilot/store/dashboardPageContext';
+import {
+    getDashboardParametersValuesMap,
+    getNonDefaultDashboardRuntimeOverrides,
+} from '../../ee/features/aiCopilot/store/dashboardPageContext';
 import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
@@ -59,6 +63,14 @@ const DashboardAiAgentContextBridge = () => {
     const originalDashboardFilters = useDashboardContext(
         (c) => c.originalDashboardFilters,
     );
+    const parameterValues = useDashboardContext((c) => c.parameterValues);
+    const dateZoomGranularity = useDashboardContext(
+        (c) => c.dateZoomGranularity,
+    );
+    const defaultDateZoomGranularity = useDashboardContext(
+        (c) => c.defaultDateZoomGranularity,
+    );
+    const isDateZoomDisabled = useDashboardContext((c) => c.isDateZoomDisabled);
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
     const setDashboardTiles = useDashboardContext((c) => c.setDashboardTiles);
     const setDashboardTabs = useDashboardContext((c) => c.setDashboardTabs);
@@ -81,13 +93,40 @@ const DashboardAiAgentContextBridge = () => {
 
     const currentDashboardSlug = dashboard?.slug;
     const currentDashboardUuid = dashboard?.uuid;
+    const defaultParameterValues = useMemo(
+        () => getDashboardParametersValuesMap(dashboard?.parameters ?? {}),
+        [dashboard?.parameters],
+    );
+    const defaultDateZoom = useMemo<DateZoom | null>(
+        () =>
+            defaultDateZoomGranularity && !isDateZoomDisabled
+                ? { granularity: defaultDateZoomGranularity }
+                : null,
+        [defaultDateZoomGranularity, isDateZoomDisabled],
+    );
+    const effectiveDateZoom = useMemo<DateZoom | null>(
+        () =>
+            dateZoomGranularity ? { granularity: dateZoomGranularity } : null,
+        [dateZoomGranularity],
+    );
     const dashboardRuntimeOverrides = useMemo(
         () =>
             getNonDefaultDashboardRuntimeOverrides({
                 defaultFilters: originalDashboardFilters,
                 effectiveFilters: allFilters,
+                defaultParameters: defaultParameterValues,
+                effectiveParameters: parameterValues,
+                defaultDateZoom,
+                effectiveDateZoom,
             }),
-        [allFilters, originalDashboardFilters],
+        [
+            allFilters,
+            defaultDateZoom,
+            defaultParameterValues,
+            effectiveDateZoom,
+            originalDashboardFilters,
+            parameterValues,
+        ],
     );
     const dashboardQueryKey = useMemo(
         () => ['saved_dashboard_query', dashboardUuidOrSlug, projectUuid],


### PR DESCRIPTION
## Summary
- attach non-default dashboard parameter values and date zoom to Ask AI context
- reuse prompt-context snapshot deduplication so unchanged runtime values are not reattached
- preserve explicit no-date-zoom overrides when a saved default exists

## Verification
- focused frontend and backend tests
- common, frontend, and backend fast typechecks
- Browser and PostgreSQL: initial runtime snapshot, parameter-reset snapshot, and unchanged prompt omitted from context
- independent review agent: no findings after fixes

Closes: PROD-8948
Relates: PROD-7781