### PR TITLE
fix: use extra-small font for resource table footer

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -756,15 +756,15 @@ const InfiniteResourceTable = ({
                 }}
             >
                 {isFetching ? (
-                    <Text>Loading more...</Text>
+                    <Text fz="xs">Loading more...</Text>
                 ) : (
                     <Group gap="two">
-                        <Text>
+                        <Text fz="xs">
                             {hasNextPage
                                 ? 'Scroll for more results'
                                 : 'All results loaded'}
                         </Text>
-                        <Text fw={400} c="ldGray.6">
+                        <Text fz="xs" fw={400} c="ldGray.6">
                             {hasNextPage
                                 ? `(${flatData.length} of ${totalResults} loaded)`
                                 : `(${flatData.length})`}


### PR DESCRIPTION
## Summary

- match resource table footer typography with the AI Threads table
- set loading, result status, and loaded-count labels to `xs` (12px)

## Testing

- `pnpm -F frontend typecheck:fast`
- `pnpm -F frontend run linter ./src/components/common/ResourceView/InfiniteResourceTable.tsx`
- `pnpm -F frontend exec oxfmt src/components/common/ResourceView/InfiniteResourceTable.tsx --check`
- Browser verification on dashboards
