### PR TITLE
fix: include editors in AI content tooltip

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -767,7 +767,7 @@ export const AiAgentFormSetup = ({
                                             content
                                         </Text>
                                         <Tooltip
-                                            label="Requires data access to be enabled. Only works for users with content-as-code access (admins and developers)."
+                                            label="Requires data access to be enabled. Only works for users with content-as-code access (admins, developers, and editors)."
                                             withArrow
                                             withinPortal
                                             multiline


### PR DESCRIPTION
### Description

- Update the AI agent content-management tooltip to list editors alongside admins and developers.

### Validation

- `pnpm --filter @lightdash/frontend exec oxfmt src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx --check`
- `pnpm --filter @lightdash/frontend linter ./src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx`
- Verified the updated tooltip in the local app.
