### PR TITLE
feat: opt-in config to emit audit log actor as a JSON string

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -133,6 +133,7 @@ export const lightdashConfigMock: LightdashConfig = {
         fileFormat: undefined,
         fileLevel: undefined,
         filePath: '',
+        auditActorAsString: false,
     },
     maxPayloadSize: '',
     pivotTable: { maxColumnLimit: 0 },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1235,6 +1235,7 @@ export type LoggingConfig = {
     fileFormat: LoggingFormat | undefined;
     fileLevel: LoggingLevel | undefined;
     filePath: string;
+    auditActorAsString: boolean;
 };
 
 export type MultiProjectSetupEntry = {
@@ -2902,6 +2903,8 @@ export const parseConfig = (): LightdashConfig => {
                     ? undefined
                     : parseLoggingLevel(process.env.LIGHTDASH_LOG_FILE_LEVEL),
             filePath: process.env.LIGHTDASH_LOG_FILE_PATH || './logs/all.log',
+            auditActorAsString:
+                process.env.LIGHTDASH_LOG_AUDIT_ACTOR_AS_STRING === 'true',
         },
         ai: {
             copilot: copilotConfig,

--- a/packages/backend/src/logging/winston.test.ts
+++ b/packages/backend/src/logging/winston.test.ts
@@ -1,9 +1,13 @@
+import { vi } from 'vitest';
+import { lightdashConfig } from '../config/lightdashConfig';
 import { AuditLogEvent } from './auditLog';
 import {
     formatAuditAction,
     formatAuditActor,
     formatAuditMessage,
     formatAuditResource,
+    logAuditEvent,
+    winstonLogger,
 } from './winston';
 
 describe('formatAuditAction', () => {
@@ -267,6 +271,61 @@ describe('formatAuditMessage', () => {
             }),
         ).toBe(
             'anonymous user viewed Dashboard -> dashboardUuid: dash-uuid, dashboardName: Sales Overview (allowed)',
+        );
+    });
+});
+
+describe('logAuditEvent', () => {
+    const event: AuditLogEvent = {
+        id: 'event-uuid',
+        timestamp: '2026-04-02T15:00:00.000Z',
+        actor: {
+            type: 'session',
+            uuid: 'user-uuid',
+            email: 'john@company.com',
+            organizationUuid: 'org-uuid',
+            organizationRole: 'admin',
+        },
+        action: 'update',
+        resource: {
+            type: 'Dashboard',
+            organizationUuid: 'org-uuid',
+        },
+        context: {},
+        status: 'allowed',
+    };
+
+    const originalAuditActorAsString =
+        lightdashConfig.logging.auditActorAsString;
+
+    afterEach(() => {
+        lightdashConfig.logging.auditActorAsString = originalAuditActorAsString;
+        vi.restoreAllMocks();
+    });
+
+    it('emits the actor as a nested object by default', () => {
+        const logSpy = vi
+            .spyOn(winstonLogger, 'log')
+            .mockImplementation(() => winstonLogger);
+        lightdashConfig.logging.auditActorAsString = false;
+
+        logAuditEvent(event);
+
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ actor: event.actor }),
+        );
+    });
+
+    it('emits the actor as a JSON string when auditActorAsString is enabled', () => {
+        const logSpy = vi
+            .spyOn(winstonLogger, 'log')
+            .mockImplementation(() => winstonLogger);
+        lightdashConfig.logging.auditActorAsString = true;
+
+        logAuditEvent(event);
+
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ actor: JSON.stringify(event.actor) }),
         );
     });
 });

--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -271,6 +271,10 @@ export const logAuditEvent = (event: AuditLogEvent): void => {
         level: 'audit',
         message: formatAuditMessage(event),
         ...event,
+        // Opt-in for deployments whose log indexers map `actor` as text
+        ...(lightdashConfig.logging.auditActorAsString
+            ? { actor: JSON.stringify(event.actor) }
+            : {}),
     });
 };
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8913/audit-logs-opt-in-config-to-emit-the-actor-field-as-a-json-string

### Description:
Adds `LIGHTDASH_LOG_AUDIT_ACTOR_AS_STRING` (default off). When enabled, audit log events serialize the actor field to a JSON string instead of a nested object, so log indexers that map the field as text (e.g. Elasticsearch) don't drop it.


Default (flag off):

```jsonc
{
    "action": "view",
    "actor": {
        "email": "demo@lightdash.com",
        "firstName": "David",
        "groupMemberships": [],
        "lastName": "Attenborough",
        "organizationRole": "admin",
        "organizationUuid": "172a2270-000f-42be-9c68-c4752c23ae51",
        "type": "pat",
        "uuid": "b264d83a-9000-426a-85ec-3f9c20f368ce"
    },
    "status": "allowed",
    "timestamp": "2026-07-16 10:02:34"
    // ...
}

```


Flag on:

```jsonc
{
    "action": "view",
    "actor": "{\"uuid\":\"b264d83a-9000-426a-85ec-3f9c20f368ce\",\"firstName\":\"David\",\"lastName\":\"Attenborough\",\"email\":\"demo@lightdash.com\",\"organizationUuid\":\"172a2270-000f-42be-9c68-c4752c23ae51\",\"organizationRole\":\"admin\",\"groupMemberships\":[],\"type\":\"pat\"}",
    "status": "allowed",
    "timestamp": "2026-07-16 10:03:43"
    // ...
}

```