### PR TITLE
fix: gate MCP content write tools by permission

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -3545,6 +3545,14 @@ export class McpService extends BaseService {
         );
     }
 
+    public async isContentToolsEnabled(user: SessionUser): Promise<boolean> {
+        const settingEnabled = await this.isMcpContentWritesEnabled(user);
+        return (
+            settingEnabled &&
+            this.createAuditedAbility(user).can('create', 'ContentAsCode')
+        );
+    }
+
     public async isCreateScheduledDeliveryEnabled(
         user: SessionUser,
     ): Promise<boolean> {

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -270,4 +270,44 @@ describe('MCP tool contracts', () => {
             ).resolves.toBe(expected);
         },
     );
+
+    it.each<{
+        settingEnabled: boolean;
+        rules: ConstructorParameters<typeof Ability<PossibleAbilities>>[0];
+        expected: boolean;
+    }>([
+        {
+            settingEnabled: false,
+            rules: [{ action: 'create', subject: 'ContentAsCode' }],
+            expected: false,
+        },
+        {
+            settingEnabled: true,
+            rules: [],
+            expected: false,
+        },
+        {
+            settingEnabled: true,
+            rules: [{ action: 'create', subject: 'ContentAsCode' }],
+            expected: true,
+        },
+        {
+            settingEnabled: true,
+            rules: [{ action: 'manage', subject: 'ContentAsCode' }],
+            expected: true,
+        },
+    ])(
+        'gates MCP content tools by setting and permission',
+        async ({ settingEnabled, rules, expected }) => {
+            const mcpService = makeMcpService(settingEnabled);
+            const user: SessionUser = {
+                ...defaultSessionUser,
+                ability: new Ability<PossibleAbilities>(rules),
+            };
+
+            await expect(mcpService.isContentToolsEnabled(user)).resolves.toBe(
+                expected,
+            );
+        },
+    );
 });

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -294,7 +294,7 @@ mcpRouter.all(
                     scheduledDeliveryEnabled,
                 ] = await Promise.all([
                     mcpService.isAiGrepFieldsEnabled(req.user!),
-                    mcpService.isMcpContentWritesEnabled(req.user!),
+                    mcpService.isContentToolsEnabled(req.user!),
                     mcpService.isCreateScheduledDeliveryEnabled(req.user!),
                 ]);
                 const mcpServer = await mcpService.createServer({


### PR DESCRIPTION
## Description

- Add `isContentToolsEnabled` for the organization MCP-write setting plus `create:ContentAsCode` permission.
- Keep `isMcpContentWritesEnabled` as the setting-only check.
- Keep project, space, and content authorization enforced at invocation time.

## Validation

- Full stacked MCP contract and query-polling tests (43 passed)
- Backend fast typecheck
- Focused backend ESLint

Closes: ZAP-542
Closes: #24734