### PR TITLE
fix: rebase naive timestamp columns via the connection data timezone

### DIFF
--- a/packages/api-tests/tests/dataTimezone.test.ts
+++ b/packages/api-tests/tests/dataTimezone.test.ts
@@ -336,6 +336,78 @@ describe('Data timezone — naive timestamps (Postgres)', () => {
     });
 });
 
+/**
+ * Raw time frame on naive columns. The raw frame passes the column through
+ * untouched, so its value must land on the same instant the truncated frames
+ * bucket into — event #1 stores wall-clock `2024-01-15 02:00:00`, which is
+ * instant 2024-01-14T17:00Z when the data timezone is Asia/Tokyo.
+ */
+const NTZ_RAW_KEY = 'timezone_test_event_timestamp_ntz_raw';
+const NTZ_HOUR_KEY = 'timezone_test_event_timestamp_ntz_hour';
+const AWARE_RAW_KEY = 'timezone_test_event_timestamp_raw';
+
+const toInstant = (
+    row: Record<string, { value: { raw: string; formatted: string } }>,
+    key: string,
+) => new Date(row[key].value.raw).toISOString();
+
+function runNaiveRawQuery(
+    client: ApiClient,
+    options: {
+        timezone: string;
+        projectUuid?: string;
+        maxAttempts?: number;
+    },
+) {
+    return runTimezoneTestQuery(client, {
+        dimensions: [NTZ_RAW_KEY, NTZ_HOUR_KEY, AWARE_RAW_KEY],
+        metrics: [],
+        eventIds: [1],
+        ...options,
+    });
+}
+
+describe('Data timezone — raw time frame on naive timestamps (Postgres)', () => {
+    beforeAll(async () => {
+        admin = await login();
+    });
+
+    afterAll(async () => {
+        await updateDataTimezone(admin, undefined);
+    });
+
+    it('dataTz=Asia/Tokyo, queryTz=Asia/Tokyo: raw equals the hour bucket and shows the stored wall clock', async () => {
+        await updateDataTimezone(admin, 'Asia/Tokyo');
+        const [row] = await runNaiveRawQuery(admin, {
+            timezone: 'Asia/Tokyo',
+        });
+        expect(toInstant(row, NTZ_RAW_KEY)).toBe('2024-01-14T17:00:00.000Z');
+        expect(toInstant(row, NTZ_RAW_KEY)).toBe(toInstant(row, NTZ_HOUR_KEY));
+        expect(row[NTZ_RAW_KEY].value.formatted).toContain('2024-01-15');
+        expect(row[NTZ_RAW_KEY].value.formatted).toContain('(+09:00)');
+        // Aware control: pinned instant, unaffected by the data timezone.
+        expect(toInstant(row, AWARE_RAW_KEY)).toBe('2024-01-15T02:00:00.000Z');
+    });
+
+    it('dataTz=Asia/Tokyo, queryTz=UTC: raw equals the hour bucket', async () => {
+        await updateDataTimezone(admin, 'Asia/Tokyo');
+        const [row] = await runNaiveRawQuery(admin, { timezone: 'UTC' });
+        expect(toInstant(row, NTZ_RAW_KEY)).toBe('2024-01-14T17:00:00.000Z');
+        expect(toInstant(row, NTZ_RAW_KEY)).toBe(toInstant(row, NTZ_HOUR_KEY));
+        expect(row[NTZ_RAW_KEY].value.formatted).toContain('2024-01-14');
+    });
+
+    it('without dataTimezone: raw naive values are read as UTC (unchanged baseline)', async () => {
+        await updateDataTimezone(admin, undefined);
+        const [row] = await runNaiveRawQuery(admin, {
+            timezone: 'Asia/Tokyo',
+        });
+        expect(toInstant(row, NTZ_RAW_KEY)).toBe('2024-01-15T02:00:00.000Z');
+        expect(toInstant(row, NTZ_RAW_KEY)).toBe(toInstant(row, NTZ_HOUR_KEY));
+        expect(toInstant(row, AWARE_RAW_KEY)).toBe('2024-01-15T02:00:00.000Z');
+    });
+});
+
 describe.skipIf(!hasBigqueryCredentials())(
     'Data timezone — naive timestamps (BigQuery)',
     () => {
@@ -449,6 +521,49 @@ describe.skipIf(!hasBigqueryCredentials())(
                 '2024-01-15': 4,
                 '2024-01-16': 2,
             });
+        });
+
+        it('raw frame, dataTz=Asia/Tokyo, queryTz=Asia/Tokyo: raw equals the hour bucket and shows the stored wall clock', async () => {
+            await updateDataTimezone(
+                bqAdmin,
+                'Asia/Tokyo',
+                bigqueryProjectUuid,
+            );
+            const [row] = await runNaiveRawQuery(bqAdmin, {
+                timezone: 'Asia/Tokyo',
+                projectUuid: bigqueryProjectUuid,
+                maxAttempts: BIGQUERY_MAX_ATTEMPTS,
+            });
+            expect(toInstant(row, NTZ_RAW_KEY)).toBe(
+                '2024-01-14T17:00:00.000Z',
+            );
+            expect(toInstant(row, NTZ_RAW_KEY)).toBe(
+                toInstant(row, NTZ_HOUR_KEY),
+            );
+            expect(row[NTZ_RAW_KEY].value.formatted).toContain('2024-01-15');
+            expect(row[NTZ_RAW_KEY].value.formatted).toContain('(+09:00)');
+            expect(toInstant(row, AWARE_RAW_KEY)).toBe(
+                '2024-01-15T02:00:00.000Z',
+            );
+        });
+
+        it('raw frame, dataTz=Asia/Tokyo, queryTz=UTC: raw equals the hour bucket', async () => {
+            await updateDataTimezone(
+                bqAdmin,
+                'Asia/Tokyo',
+                bigqueryProjectUuid,
+            );
+            const [row] = await runNaiveRawQuery(bqAdmin, {
+                timezone: 'UTC',
+                projectUuid: bigqueryProjectUuid,
+                maxAttempts: BIGQUERY_MAX_ATTEMPTS,
+            });
+            expect(toInstant(row, NTZ_RAW_KEY)).toBe(
+                '2024-01-14T17:00:00.000Z',
+            );
+            expect(toInstant(row, NTZ_RAW_KEY)).toBe(
+                toInstant(row, NTZ_HOUR_KEY),
+            );
         });
     },
 );

--- a/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.test.ts
+++ b/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.test.ts
@@ -27,6 +27,60 @@ describe('QueryHistoryModel', () => {
             expect(result.length).toBe(64);
         });
 
+        test('data timezone changes the hash', () => {
+            const withDataTz = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                timezone,
+                userUuid: null,
+                dataTimezone: 'Asia/Tokyo',
+            });
+            const withoutDataTz = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                timezone,
+                userUuid: null,
+            });
+            const withOtherDataTz = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                timezone,
+                userUuid: null,
+                dataTimezone: 'America/New_York',
+            });
+            expect(withDataTz).not.toBe(withoutDataTz);
+            expect(withDataTz).not.toBe(withOtherDataTz);
+        });
+
+        test('undefined data timezone keeps existing keys stable', () => {
+            const explicitUndefined = QueryHistoryModel.getCacheKey(
+                projectUuid,
+                {
+                    sql,
+                    timezone,
+                    userUuid: null,
+                    dataTimezone: undefined,
+                },
+            );
+            const omitted = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                timezone,
+                userUuid: null,
+            });
+            expect(explicitUndefined).toBe(omitted);
+        });
+
+        test('data timezone component cannot collide with the display timezone component', () => {
+            const displayOnly = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                timezone: 'UTC',
+                userUuid: null,
+            });
+            const dataOnly = QueryHistoryModel.getCacheKey(projectUuid, {
+                sql,
+                userUuid: null,
+                dataTimezone: 'UTC',
+            });
+            expect(displayOnly).not.toBe(dataOnly);
+        });
+
         test('should generate different hashes for different projects with same SQL', () => {
             const projectUuid2 = 'different-project-uuid';
             const hash1 = QueryHistoryModel.getCacheKey(projectUuid, {

--- a/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
+++ b/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
@@ -78,6 +78,7 @@ export class QueryHistoryModel {
             sql: string;
             timezone?: string;
             userUuid: string | null;
+            dataTimezone?: string;
         },
     ) {
         const CACHE_VERSION = 'v3'; // change when we want to force invalidation
@@ -93,6 +94,13 @@ export class QueryHistoryModel {
 
         if (resultsIdentifiers.timezone) {
             queryHashKey += `.${resultsIdentifiers.timezone}`;
+        }
+
+        // The session (data) timezone changes results without changing the
+        // SQL text. Appended only when defined so existing keys stay stable;
+        // prefixed so it cannot collide with the display timezone above.
+        if (resultsIdentifiers.dataTimezone) {
+            queryHashKey += `.dtz:${resultsIdentifiers.dataTimezone}`;
         }
 
         return crypto.createHash('sha256').update(queryHashKey).digest('hex');

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3672,6 +3672,19 @@ export class AsyncQueryService extends ProjectService {
                         );
                     }
 
+                    // Mirrors runAsyncWarehouseQuery's resolvedDataTimezone:
+                    // the session (data) timezone changes results without
+                    // changing the SQL text, so it is part of the cache key.
+                    const isTimezoneSupportEnabled =
+                        await this.isTimezoneSupportEnabled({
+                            userUuid: account.user.id,
+                            organizationUuid:
+                                account.organization.organizationUuid,
+                        });
+                    const resolvedDataTimezone = isTimezoneSupportEnabled
+                        ? warehouseCredentials.dataTimezone
+                        : undefined;
+
                     // Generate cache key from project and query identifiers
                     // Include user UUID to prevent cache sharing between users when user-specific credentials are in use
                     // Use the resolved timezone (not metricQuery.timezone) because the
@@ -3687,6 +3700,7 @@ export class AsyncQueryService extends ProjectService {
                                 warehouseCredentials.userWarehouseCredentialsUuid
                                     ? account.user.id
                                     : null,
+                            dataTimezone: resolvedDataTimezone,
                         },
                     );
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -6365,3 +6365,197 @@ describe('relative date metric filters evaluate at query time', () => {
         expect(query).not.toContain('2026-05-05');
     });
 });
+
+describe('RAW time frame naive-column rebase', () => {
+    const buildRawExplore = (
+        adapter: SupportedDbtAdapter = SupportedDbtAdapter.POSTGRES,
+        skipTimezoneConversion?: boolean,
+    ): Explore => ({
+        targetDatabase: adapter,
+        name: 'events',
+        label: 'events',
+        baseTable: 'events',
+        tags: [],
+        joinedTables: [],
+        tables: {
+            events: {
+                name: 'events',
+                label: 'events',
+                database: 'db',
+                schema: 's',
+                sqlTable: '"events"',
+                primaryKey: ['id'],
+                dimensions: {
+                    occurred_at: {
+                        type: DimensionType.TIMESTAMP,
+                        name: 'occurred_at',
+                        label: 'occurred_at',
+                        table: 'events',
+                        tableLabel: 'events',
+                        fieldType: FieldType.DIMENSION,
+                        sql: '${TABLE}.occurred_at',
+                        compiledSql: '"events".occurred_at',
+                        tablesReferences: ['events'],
+                        hidden: false,
+                        ...(skipTimezoneConversion
+                            ? { skipTimezoneConversion }
+                            : {}),
+                    },
+                    occurred_at_raw: {
+                        type: DimensionType.TIMESTAMP,
+                        name: 'occurred_at_raw',
+                        label: 'occurred_at_raw',
+                        table: 'events',
+                        tableLabel: 'events',
+                        fieldType: FieldType.DIMENSION,
+                        sql: '${TABLE}.occurred_at',
+                        compiledSql: '"events".occurred_at',
+                        tablesReferences: ['events'],
+                        hidden: false,
+                        timeInterval: TimeFrames.RAW,
+                        timeIntervalBaseDimensionName: 'occurred_at',
+                        timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+                    },
+                },
+                metrics: {
+                    event_count: {
+                        type: MetricType.COUNT,
+                        fieldType: FieldType.METRIC,
+                        table: 'events',
+                        tableLabel: 'events',
+                        name: 'event_count',
+                        label: 'event_count',
+                        sql: '${TABLE}.id',
+                        compiledSql: 'COUNT("events".id)',
+                        tablesReferences: ['events'],
+                        hidden: false,
+                    },
+                },
+                lineageGraph: {},
+            },
+        },
+    });
+
+    const rawQuery: CompiledMetricQuery = {
+        exploreName: 'events',
+        dimensions: ['events_occurred_at_raw'],
+        metrics: ['events_event_count'],
+        filters: {},
+        sorts: [],
+        limit: 100,
+        tableCalculations: [],
+        compiledTableCalculations: [],
+        compiledAdditionalMetrics: [],
+        compiledCustomDimensions: [],
+    };
+
+    test('flag on + non-UTC column timezone rebases the RAW SELECT to an instant (Postgres)', () => {
+        const { query } = buildQuery({
+            explore: buildRawExplore(),
+            compiledMetricQuery: rawQuery,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'Asia/Tokyo',
+        });
+        expect(query).toContain(
+            `("events".occurred_at)::timestamptz AS "events_occurred_at_raw"`,
+        );
+    });
+
+    test('flag on + non-UTC column timezone rebases the RAW SELECT to an instant (BigQuery)', () => {
+        const { query } = buildQuery({
+            explore: buildRawExplore(SupportedDbtAdapter.BIGQUERY),
+            compiledMetricQuery: rawQuery,
+            warehouseSqlBuilder: bigqueryClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'Asia/Tokyo',
+        });
+        expect(query).toContain(
+            'TIMESTAMP("events".occurred_at) AS `events_occurred_at_raw`',
+        );
+    });
+
+    test('UTC (default) column timezone leaves the RAW SELECT untouched', () => {
+        const { query } = buildQuery({
+            explore: buildRawExplore(),
+            compiledMetricQuery: rawQuery,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+        });
+        expect(query).toContain(
+            `"events".occurred_at AS "events_occurred_at_raw"`,
+        );
+        expect(query).not.toContain('::timestamptz');
+    });
+
+    test('flag off leaves the RAW SELECT untouched even with a column timezone', () => {
+        const { query } = buildQuery({
+            explore: buildRawExplore(),
+            compiledMetricQuery: rawQuery,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: false,
+            columnTimezone: 'Asia/Tokyo',
+        });
+        expect(query).toContain(
+            `"events".occurred_at AS "events_occurred_at_raw"`,
+        );
+        expect(query).not.toContain('::timestamptz');
+    });
+
+    test('convert_timezone: false opt-out leaves the RAW SELECT untouched', () => {
+        const { query } = buildQuery({
+            explore: buildRawExplore(SupportedDbtAdapter.POSTGRES, true),
+            compiledMetricQuery: rawQuery,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'Asia/Tokyo',
+        });
+        expect(query).toContain(
+            `"events".occurred_at AS "events_occurred_at_raw"`,
+        );
+        expect(query).not.toContain('::timestamptz');
+    });
+
+    test('RAW filter keeps the bare column (sargable) while the SELECT is rebased', () => {
+        const { query } = buildQuery({
+            explore: buildRawExplore(),
+            compiledMetricQuery: {
+                ...rawQuery,
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'f1',
+                                target: { fieldId: 'events_occurred_at_raw' },
+                                operator: FilterOperator.GREATER_THAN,
+                                values: ['2024-01-15 02:00:00'],
+                            },
+                        ],
+                    },
+                },
+            },
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'Asia/Tokyo',
+        });
+        expect(query).toContain(
+            `("events".occurred_at)::timestamptz AS "events_occurred_at_raw"`,
+        );
+        // The WHERE clause must keep the bare column for partition pruning.
+        const whereClause = query.slice(query.indexOf('WHERE'));
+        expect(whereClause).not.toContain('::timestamptz');
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -7,6 +7,7 @@ import {
     CompiledTableCalculation,
     CompileError,
     createFilterRuleFromModelRequiredFilterRule,
+    dateTruncTimezoneConversions,
     DEFAULT_FILTER_CASE_SENSITIVE,
     DimensionType,
     Explore,
@@ -657,9 +658,10 @@ export class MetricQueryBuilder {
             return dimension.compiledSql;
         }
 
+        const isRaw = dimension.timeInterval === TimeFrames.RAW;
         const isTruncatable = truncatableTimeFrames.has(dimension.timeInterval);
         const isExtractable = extractableTimeFrames.has(dimension.timeInterval);
-        if (!isTruncatable && !isExtractable) {
+        if (!isRaw && !isTruncatable && !isExtractable) {
             return dimension.compiledSql;
         }
 
@@ -682,6 +684,19 @@ export class MetricQueryBuilder {
 
         if (respectConvertTimezone && baseDimension.skipTimezoneConversion) {
             return dimension.compiledSql;
+        }
+
+        // RAW passes the base column through untouched, so a naive column is
+        // misparsed as UTC downstream — rebase it to a true instant via the
+        // session timezone (identity in value for aware columns). SELECT only:
+        // filters keep the bare column so raw predicates stay sargable.
+        if (isRaw) {
+            if (!respectConvertTimezone || this.columnTimezone === 'UTC') {
+                return dimension.compiledSql;
+            }
+            return dateTruncTimezoneConversions[adapterType].castToInstant(
+                baseDimension.compiledSql,
+            );
         }
 
         if (isTruncatable) {

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -322,7 +322,7 @@ const renderDateOrTimestampFilterSql = ({
     // TIMESTAMP boundary on BigQuery).
     const wrapTimezoneLiteral =
         !!useTimezoneAwareDateTrunc &&
-        !isTimezoneRoundTripNoOp(timezone, sourceTimezone);
+        !isTimezoneRoundTripNoOp(adapterType, timezone, sourceTimezone);
 
     const castValue = (value: string): string => {
         if (wrapTimezoneLiteral) {

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -147,7 +147,38 @@ describe('TimeFrames', () => {
             ).toEqual("DATE_TRUNC('DAY', ${TABLE}.created)");
         });
 
-        test('Matching non-UTC target and source short-circuits the wrap', () => {
+        // Databricks/Spark timestamps are instants (the wrap would double-shift
+        // them) and Trino/Athena sessions do not rebase naive columns — the
+        // equal-zones skip stays for those adapters.
+        test('Matching non-UTC target and source still short-circuits on instant-typed / session-inert adapters', () => {
+            const tz = 'America/New_York';
+            expect(
+                getSqlForTruncatedDate(
+                    SupportedDbtAdapter.DATABRICKS,
+                    TimeFrames.DAY,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                    undefined,
+                    tz,
+                    tz,
+                ),
+            ).toEqual("DATE_TRUNC('DAY', ${TABLE}.created)");
+            expect(
+                getSqlForTruncatedDate(
+                    SupportedDbtAdapter.TRINO,
+                    TimeFrames.DAY,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                    undefined,
+                    tz,
+                    tz,
+                ),
+            ).toEqual("DATE_TRUNC('DAY', ${TABLE}.created)");
+        });
+
+        // Only all-UTC short-circuits: a naive column needs the wrap's inner
+        // castToInstant rebase even when target and source match.
+        test('Matching non-UTC target and source keeps the wrap (naive columns need the rebase)', () => {
             const tz = 'America/New_York';
             expect(
                 getSqlForTruncatedDate(
@@ -159,7 +190,9 @@ describe('TimeFrames', () => {
                     tz,
                     tz,
                 ),
-            ).toEqual('TIMESTAMP_TRUNC(${TABLE}.created, DAY)');
+            ).toEqual(
+                "TIMESTAMP(DATETIME_TRUNC(DATETIME(TIMESTAMP(${TABLE}.created), 'America/New_York'), DAY), 'America/New_York')",
+            );
             expect(
                 getSqlForTruncatedDate(
                     SupportedDbtAdapter.SNOWFLAKE,
@@ -170,7 +203,9 @@ describe('TimeFrames', () => {
                     tz,
                     tz,
                 ),
-            ).toEqual("DATE_TRUNC('DAY', ${TABLE}.created)");
+            ).toEqual(
+                "CONVERT_TIMEZONE('America/New_York', 'UTC', DATE_TRUNC('DAY', CONVERT_TIMEZONE('America/New_York', 'America/New_York', ${TABLE}.created)))",
+            );
             expect(
                 getSqlForTruncatedDate(
                     SupportedDbtAdapter.POSTGRES,
@@ -181,7 +216,9 @@ describe('TimeFrames', () => {
                     tz,
                     tz,
                 ),
-            ).toEqual("DATE_TRUNC('DAY', ${TABLE}.created)");
+            ).toEqual(
+                "(DATE_TRUNC('DAY', (${TABLE}.created)::timestamptz AT TIME ZONE 'America/New_York')) AT TIME ZONE 'America/New_York'",
+            );
         });
 
         test('BigQuery 2-arg TIMESTAMP_TRUNC keeps original expr unchanged (DATETIME overload still applies)', () => {
@@ -1085,7 +1122,7 @@ describe('TimeFrames', () => {
             ).toEqual(`EXTRACT(MONTH FROM ${col})`);
         });
 
-        test('target timezone matching source timezone short-circuits the wrap', () => {
+        test('all-UTC short-circuits the wrap; matching non-UTC keeps it', () => {
             // UTC default source — most common BQ case, partition-pruning sensitive.
             expect(
                 getSqlForDatePart(
@@ -1107,7 +1144,8 @@ describe('TimeFrames', () => {
                     'UTC',
                 ),
             ).toEqual(`DATE_PART('DOW', ${col})`);
-            // Explicit matching non-UTC pair.
+            // Matching non-UTC pair: a naive column still needs the
+            // session-tz rebase inside the wrap.
             expect(
                 getSqlForDatePart(
                     SupportedDbtAdapter.BIGQUERY,
@@ -1118,7 +1156,9 @@ describe('TimeFrames', () => {
                     'America/New_York',
                     'America/New_York',
                 ),
-            ).toEqual(`EXTRACT(MONTH FROM ${col})`);
+            ).toEqual(
+                `EXTRACT(MONTH FROM TIMESTAMP(${col}) AT TIME ZONE 'America/New_York')`,
+            );
             expect(
                 getSqlForDatePart(
                     SupportedDbtAdapter.POSTGRES,
@@ -1129,7 +1169,9 @@ describe('TimeFrames', () => {
                     'America/New_York',
                     'America/New_York',
                 ),
-            ).toEqual(`DATE_PART('DOW', ${col})`);
+            ).toEqual(
+                `DATE_PART('DOW', (${col})::timestamptz AT TIME ZONE 'America/New_York')`,
+            );
         });
 
         test('DATE base dimension with timezone short-circuits (no wrap)', () => {
@@ -1310,7 +1352,7 @@ describe('TimeFrames', () => {
             ).toEqual(`FORMAT_DATETIME('%B', ${col})`);
         });
 
-        test('target timezone matching source timezone short-circuits the wrap', () => {
+        test('all-UTC short-circuits the wrap; matching non-UTC keeps it', () => {
             expect(
                 getSqlForDatePartName(
                     SupportedDbtAdapter.BIGQUERY,
@@ -1321,6 +1363,8 @@ describe('TimeFrames', () => {
                     'UTC',
                 ),
             ).toEqual(`FORMAT_DATETIME('%B', ${col})`);
+            // Matching non-UTC pair: a naive column still needs the
+            // session-tz rebase inside the wrap.
             expect(
                 getSqlForDatePartName(
                     SupportedDbtAdapter.POSTGRES,
@@ -1331,7 +1375,9 @@ describe('TimeFrames', () => {
                     'America/New_York',
                     'America/New_York',
                 ),
-            ).toEqual(`TO_CHAR(${col}, 'FMMonth')`);
+            ).toEqual(
+                `TO_CHAR((${col})::timestamptz AT TIME ZONE 'America/New_York', 'FMMonth')`,
+            );
             expect(
                 getSqlForDatePartName(
                     SupportedDbtAdapter.BIGQUERY,
@@ -1342,7 +1388,9 @@ describe('TimeFrames', () => {
                     'America/New_York',
                     'America/New_York',
                 ),
-            ).toEqual(`FORMAT_DATETIME('%B', ${col})`);
+            ).toEqual(
+                `FORMAT_TIMESTAMP('%B', TIMESTAMP(${col}), 'America/New_York')`,
+            );
         });
 
         test.each([
@@ -1437,6 +1485,86 @@ describe('TimeFrames', () => {
                 TimeFrames.QUARTER,
                 TimeFrames.YEAR,
             ]);
+        });
+    });
+
+    describe('castToInstant', () => {
+        const sql = '${TABLE}.created';
+
+        test('rebases a naive timestamp via the session timezone on session-property warehouses', () => {
+            expect(
+                dateTruncTimezoneConversions[
+                    SupportedDbtAdapter.BIGQUERY
+                ].castToInstant(sql),
+            ).toEqual('TIMESTAMP(${TABLE}.created)');
+            expect(
+                dateTruncTimezoneConversions[
+                    SupportedDbtAdapter.POSTGRES
+                ].castToInstant(sql),
+            ).toEqual('(${TABLE}.created)::timestamptz');
+            expect(
+                dateTruncTimezoneConversions[
+                    SupportedDbtAdapter.REDSHIFT
+                ].castToInstant(sql),
+            ).toEqual('(${TABLE}.created)::timestamptz');
+            expect(
+                dateTruncTimezoneConversions[
+                    SupportedDbtAdapter.DUCKDB
+                ].castToInstant(sql),
+            ).toEqual('(${TABLE}.created)::timestamptz');
+        });
+
+        test('pins ClickHouse serialization to UTC (values are instants)', () => {
+            expect(
+                dateTruncTimezoneConversions[
+                    SupportedDbtAdapter.CLICKHOUSE
+                ].castToInstant(sql),
+            ).toEqual("toTimeZone(${TABLE}.created, 'UTC')");
+        });
+
+        test('is identity where naive columns are handled elsewhere or the type is already an instant', () => {
+            // Snowflake: dbt translator already wraps naive columns to UTC.
+            // Databricks/Spark: TIMESTAMP is an instant — a rebase would double-shift.
+            // Trino/Athena: naive raw handling tracked separately.
+            [
+                SupportedDbtAdapter.SNOWFLAKE,
+                SupportedDbtAdapter.DATABRICKS,
+                SupportedDbtAdapter.SPARK,
+                SupportedDbtAdapter.TRINO,
+                SupportedDbtAdapter.ATHENA,
+            ].forEach((adapter) => {
+                expect(
+                    dateTruncTimezoneConversions[adapter].castToInstant(sql),
+                ).toEqual(sql);
+            });
+        });
+
+        test('is the inner term of toProjectTz (composition cannot drift)', () => {
+            const tz = 'America/New_York';
+            (
+                [
+                    [
+                        SupportedDbtAdapter.BIGQUERY,
+                        (inner: string) => `DATETIME(${inner}, '${tz}')`,
+                    ],
+                    [
+                        SupportedDbtAdapter.POSTGRES,
+                        (inner: string) => `${inner} AT TIME ZONE '${tz}'`,
+                    ],
+                    [
+                        SupportedDbtAdapter.REDSHIFT,
+                        (inner: string) => `${inner} AT TIME ZONE '${tz}'`,
+                    ],
+                    [
+                        SupportedDbtAdapter.DUCKDB,
+                        (inner: string) => `${inner} AT TIME ZONE '${tz}'`,
+                    ],
+                ] as const
+            ).forEach(([adapter, outer]) => {
+                const { toProjectTz, castToInstant } =
+                    dateTruncTimezoneConversions[adapter];
+                expect(toProjectTz(sql, tz)).toEqual(outer(castToInstant(sql)));
+            });
         });
     });
 });

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -88,12 +88,24 @@ type WarehouseConfig = {
  *  wrapped path truncates a naive project-local wall-clock, so `CAST(x AS DATE)`
  *  reads the right date. `sourceTimezone` is the timezone the
  *  column is in — only Snowflake uses it explicitly (in `CONVERT_TIMEZONE`);
- *  other adapters ignore it. */
+ *  other adapters ignore it.
+ *
+ *  `castToInstant` rebases a naive timestamp into a true instant via the
+ *  warehouse session timezone; identity in value for aware columns. It is the
+ *  inner term of `toProjectTz`, composed below so the two cannot drift. */
 type DateTruncTimezoneConversion = {
     toProjectTz: (sql: string, tz: string, sourceTimezone?: string) => string;
     toUTC: (sql: string, tz: string) => string;
     castAsDate: (sql: string, tz: string) => string;
+    castToInstant: (sql: string) => string;
 };
+
+const bigqueryCastToInstant = (sql: string) => `TIMESTAMP(${sql})`;
+const postgresLikeCastToInstant = (sql: string) => `(${sql})::timestamptz`;
+// ClickHouse DateTime values are instants; session_timezone only changes how
+// they serialize. Pinning to UTC keeps the wire value a parseable instant.
+const clickhouseCastToInstant = (sql: string) => `toTimeZone(${sql}, 'UTC')`;
+const identityCastToInstant = (sql: string) => sql;
 
 export const dateTruncTimezoneConversions: Record<
     SupportedDbtAdapter,
@@ -105,42 +117,55 @@ export const dateTruncTimezoneConversions: Record<
     // declared-TIMESTAMP dim can emit DATETIME at runtime; DATETIME(timestamp,
     // tz) requires a TIMESTAMP left side.
     [SupportedDbtAdapter.BIGQUERY]: {
-        toProjectTz: (sql, tz) => `DATETIME(TIMESTAMP(${sql}), '${tz}')`,
+        toProjectTz: (sql, tz) =>
+            `DATETIME(${bigqueryCastToInstant(sql)}, '${tz}')`,
         toUTC: (sql, tz) => `TIMESTAMP(${sql}, '${tz}')`,
         castAsDate: (sql) => `CAST(${sql} AS DATE)`,
+        castToInstant: bigqueryCastToInstant,
     },
     [SupportedDbtAdapter.SNOWFLAKE]: {
         toProjectTz: (sql, tz, sourceTimezone = 'UTC') =>
             `CONVERT_TIMEZONE('${sourceTimezone}', '${tz}', ${sql})`,
         toUTC: (sql, tz) => `CONVERT_TIMEZONE('${tz}', 'UTC', ${sql})`,
         castAsDate: (sql) => `CAST(${sql} AS DATE)`,
+        castToInstant: identityCastToInstant,
     },
     [SupportedDbtAdapter.POSTGRES]: {
-        toProjectTz: (sql, tz) => `(${sql})::timestamptz AT TIME ZONE '${tz}'`,
+        toProjectTz: (sql, tz) =>
+            `${postgresLikeCastToInstant(sql)} AT TIME ZONE '${tz}'`,
         toUTC: (sql, tz) => `(${sql}) AT TIME ZONE '${tz}'`,
         castAsDate: (sql) => `CAST(${sql} AS DATE)`,
+        castToInstant: postgresLikeCastToInstant,
     },
     [SupportedDbtAdapter.REDSHIFT]: {
-        toProjectTz: (sql, tz) => `(${sql})::timestamptz AT TIME ZONE '${tz}'`,
+        toProjectTz: (sql, tz) =>
+            `${postgresLikeCastToInstant(sql)} AT TIME ZONE '${tz}'`,
         toUTC: (sql, tz) => `(${sql}) AT TIME ZONE '${tz}'`,
         castAsDate: (sql) => `CAST(${sql} AS DATE)`,
+        castToInstant: postgresLikeCastToInstant,
     },
     [SupportedDbtAdapter.DUCKDB]: {
-        toProjectTz: (sql, tz) => `(${sql})::timestamptz AT TIME ZONE '${tz}'`,
+        toProjectTz: (sql, tz) =>
+            `${postgresLikeCastToInstant(sql)} AT TIME ZONE '${tz}'`,
         toUTC: (sql, tz) => `(${sql}) AT TIME ZONE '${tz}'`,
         castAsDate: (sql) => `CAST(${sql} AS DATE)`,
+        castToInstant: postgresLikeCastToInstant,
     },
+    // Databricks TIMESTAMP is an instant (LTZ-like), so a session-tz rebase
+    // would double-shift it — castToInstant stays identity.
     [SupportedDbtAdapter.DATABRICKS]: {
         toProjectTz: (sql, tz) =>
             `from_utc_timestamp(to_utc_timestamp(${sql}, current_timezone()), '${tz}')`,
         toUTC: (sql, tz) => `to_utc_timestamp(${sql}, '${tz}')`,
         castAsDate: (sql) => `CAST(${sql} AS DATE)`,
+        castToInstant: identityCastToInstant,
     },
     [SupportedDbtAdapter.SPARK]: {
         toProjectTz: (sql, tz) =>
             `from_utc_timestamp(to_utc_timestamp(${sql}, current_timezone()), '${tz}')`,
         toUTC: (sql, tz) => `to_utc_timestamp(${sql}, '${tz}')`,
         castAsDate: (sql) => `CAST(${sql} AS DATE)`,
+        castToInstant: identityCastToInstant,
     },
     // Trino returns `timestamp with time zone` values as strings like
     // "2024-01-14 00:00:00.000 America/New_York", which dayjs/moment can't
@@ -153,6 +178,7 @@ export const dateTruncTimezoneConversions: Record<
         toUTC: (sql, tz) =>
             `CAST(with_timezone(${sql}, '${tz}') AT TIME ZONE 'UTC' AS timestamp)`,
         castAsDate: (sql) => `CAST(${sql} AS DATE)`,
+        castToInstant: identityCastToInstant,
     },
     [SupportedDbtAdapter.ATHENA]: {
         toProjectTz: (sql, tz) =>
@@ -160,6 +186,7 @@ export const dateTruncTimezoneConversions: Record<
         toUTC: (sql, tz) =>
             `CAST(with_timezone(${sql}, '${tz}') AT TIME ZONE 'UTC' AS timestamp)`,
         castAsDate: (sql) => `CAST(${sql} AS DATE)`,
+        castToInstant: identityCastToInstant,
     },
     // Merge the DST fall-back: ClickHouse DateTime always carries a zone and
     // toTimeZone only relabels (instant domain), so the two folded instants
@@ -174,6 +201,7 @@ export const dateTruncTimezoneConversions: Record<
         toUTC: (sql, tz) =>
             `toTimeZone(toDateTime64(formatDateTime(${sql}, '%Y-%m-%d %H:%i:%S.%f'), 3, '${tz}'), 'UTC')`,
         castAsDate: (sql) => `CAST(${sql} AS DATE)`,
+        castToInstant: clickhouseCastToInstant,
     },
 };
 
@@ -711,25 +739,47 @@ const warehouseConfigs: Record<SupportedDbtAdapter, WarehouseConfig> = {
  * performed in the project TZ and the result is converted back to a proper
  * UTC instant so downstream consumers apply .tz(project_tz) uniformly.
  */
-// Source defaults to UTC when unset (matches `getColumnTimezone`). A wrap when
-// target equals source is semantically a no-op and defeats partition pruning
-// on warehouses like BigQuery — every wrap site (dim trunc, extract, format,
-// filter literal) shares this predicate so symmetry is enforced centrally.
+// Adapters that keep the wider target == source skip: Databricks/Spark
+// timestamps are instants (their wrap double-shifts them at equal zones) and
+// Trino/Athena sessions do not rebase naive columns, so the wrap buys nothing
+// there. Naive-column handling for these is tracked separately.
+const equalZonesSkipAdapters: ReadonlySet<SupportedDbtAdapter> = new Set([
+    SupportedDbtAdapter.DATABRICKS,
+    SupportedDbtAdapter.SPARK,
+    SupportedDbtAdapter.TRINO,
+    SupportedDbtAdapter.ATHENA,
+]);
+
+// Source defaults to UTC when unset (matches `getColumnTimezone`). On
+// session-property warehouses the wrap is a genuine no-op only when both
+// sides are UTC: for a naive column, target == source still requires the
+// wrap's inner `castToInstant` rebase — skipping it misreads the wall clock
+// as UTC downstream. The all-UTC skip avoids the cast that defeats partition
+// pruning on warehouses like BigQuery. Every wrap site (dim trunc, extract,
+// format, filter literal) shares this predicate so symmetry is enforced
+// centrally.
 export const isTimezoneRoundTripNoOp = (
+    adapterType: SupportedDbtAdapter,
     timezone: string,
     sourceTimezone?: string,
-): boolean => timezone === (sourceTimezone ?? 'UTC');
+): boolean => {
+    const source = sourceTimezone ?? 'UTC';
+    if (equalZonesSkipAdapters.has(adapterType)) return timezone === source;
+    return timezone === 'UTC' && source === 'UTC';
+};
 
 // Returns the resolved (timezone, sourceTimezone) when the dim needs a tz
 // wrap, else null. Wrap conditions: TIMESTAMP-typed dim AND a target timezone
 // AND target != source.
 const resolveTimezoneWrap = (
+    adapterType: SupportedDbtAdapter,
     type: DimensionType,
     timezone?: string,
     sourceTimezone?: string,
 ): { timezone: string; sourceTimezone?: string } | null => {
     if (type !== DimensionType.TIMESTAMP || !timezone) return null;
-    if (isTimezoneRoundTripNoOp(timezone, sourceTimezone)) return null;
+    if (isTimezoneRoundTripNoOp(adapterType, timezone, sourceTimezone))
+        return null;
     return { timezone, sourceTimezone };
 };
 
@@ -743,7 +793,12 @@ export const getSqlForTruncatedDate = (
     sourceTimezone?: string,
     castDayOrCoarserToDate: boolean = false,
 ): string => {
-    const wrap = resolveTimezoneWrap(type, timezone, sourceTimezone);
+    const wrap = resolveTimezoneWrap(
+        adapterType,
+        type,
+        timezone,
+        sourceTimezone,
+    );
     // GLITCH-452: day-or-coarser grains emit a real DATE so the warehouse type
     // matches the metadata; sub-day grains stay TIMESTAMP.
     const castToDate = castDayOrCoarserToDate && !isSubDayTimeFrame(timeFrame);
@@ -788,7 +843,12 @@ export const getSqlForDatePart = (
     timezone?: string,
     sourceTimezone?: string,
 ): string => {
-    const wrap = resolveTimezoneWrap(type, timezone, sourceTimezone);
+    const wrap = resolveTimezoneWrap(
+        adapterType,
+        type,
+        timezone,
+        sourceTimezone,
+    );
     const wrappedSql = wrap
         ? dateExtractsTimezoneConversions[adapterType].toExtractInputTz(
               originalSql,
@@ -816,7 +876,12 @@ export const getSqlForDatePartName = (
     timezone?: string,
     sourceTimezone?: string,
 ): string => {
-    const wrap = resolveTimezoneWrap(type, timezone, sourceTimezone);
+    const wrap = resolveTimezoneWrap(
+        adapterType,
+        type,
+        timezone,
+        sourceTimezone,
+    );
     if (!wrap) {
         return warehouseConfigs[adapterType].getSqlForDatePartName(
             timeFrame,


### PR DESCRIPTION
## Problem

With a warehouse **Data timezone** configured, naive (timezone-less) timestamp columns display shifted by the display timezone offset. A stored wall clock of `2026-01-15 10:00` (data timezone and display timezone both Asia/Tokyo) rendered as `19:00 (+09:00)` instead of `10:00 (+09:00)`.

Naive columns arrive on the wire with no offset: the session timezone we set pins *aware* columns but does nothing for *naive* ones, so the parse layer reads the bare wall clock as UTC and the formatter then shifts it by the display timezone. Two paths were affected:

- The **raw** time frame is a pure passthrough and was never rebased.
- **Sub-day truncated frames** (`hour`, `minute`, ...) broke whenever display timezone == data timezone != UTC: `isTimezoneRoundTripNoOp` skipped the conversion wrap on the assumption that target == source is a no-op, which is only true for aware columns. Day-and-coarser grains always survived because they compile to a real `DATE`, which the formatter never shifts.

## Fix

The conversion wrap's inner term (`(x)::timestamptz` on Postgres, `TIMESTAMP(x)` on BigQuery) already rebases naive values via the session timezone and is identity in value for aware ones, so no naive-vs-aware detection is needed. This PR:

- extracts that inner term into a named per-adapter `castToInstant` (composed inside `toProjectTz` so the two cannot drift; ClickHouse pins serialization with `toTimeZone(x, 'UTC')` since its values are instants)
- applies `castToInstant` to raw time frame dimensions in the SELECT only; filter rendering keeps the bare column so raw predicates stay sargable
- narrows `isTimezoneRoundTripNoOp` so the skip only applies when both timezones are UTC, scoped to session-property warehouses; Databricks/Spark/Trino/Athena keep the previous equal-zones skip and are byte-identical (their timestamps are instant-typed or their sessions do not rebase naive columns)
- adds the resolved data timezone to the results cache key (only when set), so changing the setting can never serve rows computed under the old one

No behavior change when the data timezone is unset or UTC, when the `EnableTimezoneSupport` flag is off, or for SQL runner / SQL charts (no dimensions, so the rewrite is never reached).

## Verification

- Live matrix on six warehouses (BigQuery, Postgres, ClickHouse, Databricks, Snowflake, Trino) via the async query API on the `timezone_test` model: raw now equals the truncated frames' instant in every configuration on the session-property warehouses, the aware control column never moves, and Snowflake (already correct via its translator) is untouched.
- DST boundaries (spring-forward and fall-back rows, data timezone America/New_York): 8/8 correct on Postgres and BigQuery, raw always inside its hour bucket.
- Filter results validated against hand-computed expectations from the seed data on both Postgres and BigQuery (equals / inBetween on day, equals on hour, across display timezones).
- **Partition pruning measured on BigQuery** (`INFORMATION_SCHEMA.JOBS_BY_USER` over a partitioned table): the SELECT cast processes exactly the same bytes as the bare query (176 B), while wrapping the column in the WHERE clause (deliberately avoided) would have full-scanned (32 KB). Raw-filter WHERE clauses are byte-identical to main.
- New API regression tests in `dataTimezone.test.ts` (Postgres seed plus credential-gated BigQuery) assert raw == hour instant, the stored wall clock renders unchanged when the timezones match, and the unset baseline is unchanged.

Closes: #25614
