### PR TITLE
fix: gate MCP scheduled deliveries by permission

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -574,6 +574,7 @@ const makeMcpService = ({
             aiWritebackEnabled: false,
             grepFieldsEnabled: true,
             mcpContentWritesEnabled: true,
+            scheduledDeliveryEnabled: true,
             runSqlEnabled: true,
         });
     }

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1311,7 +1311,9 @@ export class McpService extends BaseService {
                 );
             },
         );
+    }
 
+    private registerCreateScheduledDeliveryTool(): void {
         this.registerTrackedTool(
             mcpCreateScheduledDeliveryTool.name,
             {
@@ -1357,12 +1359,14 @@ export class McpService extends BaseService {
             aiWritebackEnabled: boolean;
             grepFieldsEnabled: boolean;
             mcpContentWritesEnabled: boolean;
+            scheduledDeliveryEnabled: boolean;
             runSqlEnabled: boolean;
         } = {
             projectPinned: false,
             aiWritebackEnabled: false,
             grepFieldsEnabled: false,
             mcpContentWritesEnabled: true,
+            scheduledDeliveryEnabled: true,
             runSqlEnabled: true,
         },
     ): void {
@@ -1844,6 +1848,10 @@ export class McpService extends BaseService {
         // admins can prevent MCP clients from modifying managed content.
         if (options.mcpContentWritesEnabled) {
             this.registerContentWriteTools();
+        }
+
+        if (options.scheduledDeliveryEnabled) {
+            this.registerCreateScheduledDeliveryTool();
         }
 
         // When the project is pinned via header, hide the project-selection
@@ -3259,6 +3267,7 @@ export class McpService extends BaseService {
         aiWritebackEnabled?: boolean;
         grepFieldsEnabled?: boolean;
         mcpContentWritesEnabled?: boolean;
+        scheduledDeliveryEnabled?: boolean;
         runSqlEnabled?: boolean;
     }): Promise<McpServer> {
         const newServer = Sentry.wrapMcpServerWithSentry(
@@ -3295,6 +3304,7 @@ export class McpService extends BaseService {
             aiWritebackEnabled: options?.aiWritebackEnabled ?? false,
             grepFieldsEnabled: options?.grepFieldsEnabled ?? false,
             mcpContentWritesEnabled: options?.mcpContentWritesEnabled ?? true,
+            scheduledDeliveryEnabled: options?.scheduledDeliveryEnabled ?? true,
             runSqlEnabled: options?.runSqlEnabled ?? true,
         });
         this.mcpServer = originalServer;
@@ -3532,6 +3542,16 @@ export class McpService extends BaseService {
     ): Promise<boolean> {
         return this.aiOrganizationSettingsService.isMcpContentWritesEnabled(
             user,
+        );
+    }
+
+    public async isCreateScheduledDeliveryEnabled(
+        user: SessionUser,
+    ): Promise<boolean> {
+        const settingEnabled = await this.isMcpContentWritesEnabled(user);
+        return (
+            settingEnabled &&
+            this.createAuditedAbility(user).can('create', 'ScheduledDeliveries')
         );
     }
 

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -1,7 +1,13 @@
-import { mcpToolDefinitions } from '@lightdash/common';
+import { Ability } from '@casl/ability';
+import {
+    mcpToolDefinitions,
+    type PossibleAbilities,
+    type SessionUser,
+} from '@lightdash/common';
 import type { ZodRawShape, ZodTypeAny } from 'zod';
 import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
+import { defaultSessionUser } from '../../../auth/account/account.mock';
 import {
     getMcpAnalystPrompt,
     MCP_ANALYST_PROMPT,
@@ -86,11 +92,15 @@ const schemaToJson = (
     );
 };
 
-const makeMcpService = (): McpService =>
+const makeMcpService = (mcpContentWritesEnabled = true): McpService =>
     new McpService({
         aiAgentService: {},
         aiAgentToolsService: { createRuntime: vi.fn() },
-        aiOrganizationSettingsService: {},
+        aiOrganizationSettingsService: {
+            isMcpContentWritesEnabled: vi
+                .fn()
+                .mockResolvedValue(mcpContentWritesEnabled),
+        },
         aiRouterService: {},
         aiWritebackService: {},
         analytics: {},
@@ -190,4 +200,74 @@ describe('MCP tool contracts', () => {
             McpToolName.RUN_SQL,
         );
     });
+
+    it('registers content and scheduled-delivery tools independently', async () => {
+        const mcpService = makeMcpService();
+
+        mockRegisteredMcpTools.length = 0;
+        await mcpService.createServer({
+            mcpContentWritesEnabled: false,
+            scheduledDeliveryEnabled: true,
+        });
+        expect(mockRegisteredMcpTools.map(({ name }) => name)).not.toContain(
+            McpToolName.CREATE_CONTENT,
+        );
+        expect(mockRegisteredMcpTools.map(({ name }) => name)).not.toContain(
+            McpToolName.EDIT_CONTENT,
+        );
+        expect(mockRegisteredMcpTools.map(({ name }) => name)).toContain(
+            McpToolName.CREATE_SCHEDULED_DELIVERY,
+        );
+
+        mockRegisteredMcpTools.length = 0;
+        await mcpService.createServer({
+            mcpContentWritesEnabled: true,
+            scheduledDeliveryEnabled: false,
+        });
+        expect(mockRegisteredMcpTools.map(({ name }) => name)).toContain(
+            McpToolName.CREATE_CONTENT,
+        );
+        expect(mockRegisteredMcpTools.map(({ name }) => name)).toContain(
+            McpToolName.EDIT_CONTENT,
+        );
+        expect(mockRegisteredMcpTools.map(({ name }) => name)).not.toContain(
+            McpToolName.CREATE_SCHEDULED_DELIVERY,
+        );
+    });
+
+    it.each<{
+        settingEnabled: boolean;
+        rules: ConstructorParameters<typeof Ability<PossibleAbilities>>[0];
+        expected: boolean;
+    }>([
+        {
+            settingEnabled: false,
+            rules: [{ action: 'create', subject: 'ScheduledDeliveries' }],
+            expected: false,
+        },
+        { settingEnabled: true, rules: [], expected: false },
+        {
+            settingEnabled: true,
+            rules: [{ action: 'create', subject: 'ScheduledDeliveries' }],
+            expected: true,
+        },
+        {
+            settingEnabled: true,
+            rules: [{ action: 'manage', subject: 'ScheduledDeliveries' }],
+            expected: true,
+        },
+    ])(
+        'gates scheduled delivery registration by setting and permission',
+        async ({ settingEnabled, rules, expected }) => {
+            const mcpService = makeMcpService(settingEnabled);
+            const user: SessionUser = {
+                ...defaultSessionUser,
+                ability: new Ability<PossibleAbilities>(rules),
+            };
+
+            await expect(
+                mcpService.isCreateScheduledDeliveryEnabled(user),
+            ).resolves.toBe(expected);
+        },
+    );
 });

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -288,11 +288,15 @@ mcpRouter.all(
                 // loop on) a tool they can never invoke.
                 // These lookups are independent, so resolve them together
                 // rather than paying each round trip serially per request.
-                const [grepFieldsEnabled, mcpContentWritesEnabled] =
-                    await Promise.all([
-                        mcpService.isAiGrepFieldsEnabled(req.user!),
-                        mcpService.isMcpContentWritesEnabled(req.user!),
-                    ]);
+                const [
+                    grepFieldsEnabled,
+                    mcpContentWritesEnabled,
+                    scheduledDeliveryEnabled,
+                ] = await Promise.all([
+                    mcpService.isAiGrepFieldsEnabled(req.user!),
+                    mcpService.isMcpContentWritesEnabled(req.user!),
+                    mcpService.isCreateScheduledDeliveryEnabled(req.user!),
+                ]);
                 const mcpServer = await mcpService.createServer({
                     projectPinned: headerProjectUuid !== undefined,
                     // The run_ai_writeback tool is always registered now that
@@ -300,6 +304,7 @@ mcpRouter.all(
                     aiWritebackEnabled: true,
                     grepFieldsEnabled,
                     mcpContentWritesEnabled,
+                    scheduledDeliveryEnabled,
                     runSqlEnabled: mcpService.isRunSqlEnabled(req.user!),
                 });
                 const transport = new StreamableHTTPServerTransport({


### PR DESCRIPTION
## Description

- Split `create_scheduled_delivery` registration from the content write tools.
- Let `isCreateScheduledDeliveryEnabled` own both the organization setting and `create:ScheduledDeliveries` checks.
- Preserve the existing content-tool behavior unchanged.

## Validation

- Focused MCP contract and query-polling tests (39 passed)
- Backend fast typecheck
- Focused backend ESLint

Closes: ZAP-637
Relates: ZAP-542
Relates: #24734