### PR TITLE
fix: flex-shrink priority inversion in SelectedFieldsSection

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.module.css
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.module.css
@@ -99,6 +99,7 @@
 }
 
 .label {
+    flex-shrink: 0;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -107,9 +108,11 @@
 }
 
 .tableLabel {
-    flex-shrink: 0;
-    font-size: 12px;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
+    font-size: 12px;
 }
 
 .row[data-field-kind='dimension'] .tableLabel {


### PR DESCRIPTION
## Summary

When the sidebar becomes narrow, the selected field row did not prioritize the correct content for truncation. The table label (`.tableLabel`) was prevented from shrinking (`flex-shrink: 0`), causing the field name (`.label`) to be truncated first—even though the table name is secondary information.

### Changes

- Prevent the field name (`.label`) from shrinking (`flex-shrink: 0`) so it remains fully visible.
- Allow the table label (`.tableLabel`) to shrink by removing `flex-shrink: 0`.
- Add `overflow: hidden` and `text-overflow: ellipsis` to `.tableLabel` so it truncates gracefully when space is limited.

### Result

The field name is now always prioritized, while the table name is truncated only when necessary. This provides a better user experience by preserving the most important information.

This behavior is also consistent with the existing layout strategy used in `TreeSingleNode`, where the field name is prioritized and action elements do not shrink.

close: #25631 