### PR TITLE
feat: pass active dashboard tab to Ask AI

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -6411,6 +6411,11 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                     const overrides = item.runtimeOverrides;
                     if (!overrides) return headline;
                     const overrideLines: string[] = [];
+                    if (overrides.activeTab) {
+                        overrideLines.push(
+                            `  Active tab: "${overrides.activeTab.name}"`,
+                        );
+                    }
                     if (overrides.dashboardFilters) {
                         overrideLines.push(
                             `  Filters applied:\n    ${JSON.stringify(serializeDashboardFiltersForAiContext(overrides.dashboardFilters))}`,

--- a/packages/backend/src/ee/services/AiAgentService/pinnedContextMessage.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/pinnedContextMessage.test.ts
@@ -37,6 +37,23 @@ describe('AiAgentService.createPinnedContextMessage review pins', () => {
         );
     });
 
+    it('renders the active dashboard tab name without its uuid', () => {
+        const content = buildMessage([
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dashboard-1',
+                dashboardSlug: 'exec-dashboard',
+                displayName: 'Executive dashboard',
+                pinnedVersionUuid: null,
+                runtimeOverrides: {
+                    activeTab: { uuid: 'tab-uuid', name: 'Customers' },
+                },
+            },
+        ]);
+        expect(content).toContain('Active tab: "Customers"');
+        expect(content).not.toContain('tab-uuid');
+    });
+
     it('renders dashboard filter overrides', () => {
         const dashboardFilters: DashboardFilters = {
             dimensions: [

--- a/packages/backend/src/ee/services/ai/compaction.test.ts
+++ b/packages/backend/src/ee/services/ai/compaction.test.ts
@@ -127,6 +127,38 @@ describe('AI context compaction helpers', () => {
         );
     });
 
+    it('preserves the active dashboard tab in compacted context', () => {
+        const serialized = Compaction.serializeConversation([
+            {
+                role: 'user',
+                uuid: 'prompt-1',
+                threadUuid: 'thread-1',
+                message: 'Summarize this dashboard',
+                createdAt: new Date().toISOString(),
+                user: { uuid: 'user-1', name: 'Test User' },
+                context: [
+                    {
+                        type: 'dashboard',
+                        dashboardUuid: 'dashboard-1',
+                        dashboardSlug: 'dashboard-1',
+                        displayName: 'Executive dashboard',
+                        pinnedVersionUuid: null,
+                        runtimeOverrides: {
+                            activeTab: {
+                                uuid: 'tab-1',
+                                name: 'Customers',
+                            },
+                        },
+                    },
+                ],
+                steers: [],
+                hidden: false,
+            },
+        ]);
+
+        expect(serialized).toContain('active tab "Customers"');
+    });
+
     it('filters raw prompt rows after the latest compaction boundary', () => {
         const filtered = Compaction.filterThreadMessagesAfterCompaction(
             [

--- a/packages/backend/src/ee/services/ai/compaction.ts
+++ b/packages/backend/src/ee/services/ai/compaction.ts
@@ -189,8 +189,12 @@ export class Compaction {
         switch (item.type) {
             case 'chart':
                 return `chart ${item.displayName ?? item.chartUuid} (${item.chartUuid})`;
-            case 'dashboard':
-                return `dashboard ${item.displayName ?? item.dashboardUuid} (${item.dashboardUuid})`;
+            case 'dashboard': {
+                const activeTab = item.runtimeOverrides?.activeTab;
+                return `dashboard ${item.displayName ?? item.dashboardUuid} (${item.dashboardUuid})${
+                    activeTab ? `; active tab "${activeTab.name}"` : ''
+                }`;
+            }
             case 'thread':
                 return `conversation ${item.displayName ?? item.threadUuid} (${item.threadUuid})`;
             // Spell out the repo-filesystem mount path so the agent reads the

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -44,7 +44,13 @@ export type AiDashboardFilters = {
     tableCalculations: AiDashboardFilterRule[];
 };
 
+export type AiDashboardActiveTab = {
+    uuid: string;
+    name: string;
+};
+
 export type AiDashboardRuntimeOverrides = {
+    activeTab?: AiDashboardActiveTab;
     dashboardFilters?: AiDashboardFilters;
     dashboardParameters?: ParametersValuesMap;
     dateZoom?: DateZoom | null;

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDashboardPageContextCuration.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDashboardPageContextCuration.test.ts
@@ -9,6 +9,7 @@ vi.mock('../store/hooks', () => ({
 }));
 
 const runtimeOverrides = {
+    activeTab: { uuid: 'tab-1', name: 'Overview' },
     dashboardFilters: {
         dimensions: [],
         metrics: [],
@@ -22,7 +23,7 @@ const currentDashboard: LauncherCurrentDashboard = {
     projectUuid: 'project-1',
     uuid: 'dashboard-a',
     name: 'Orders',
-    activeTabUuid: null,
+    activeTabUuid: 'tab-1',
     runtimeOverrides,
 };
 

--- a/packages/frontend/src/ee/features/aiCopilot/store/dashboardPageContext.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/dashboardPageContext.test.ts
@@ -2,6 +2,7 @@ import { type DashboardFilters } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
 import { type LauncherCurrentDashboard } from './aiAgentLauncherSlice';
 import {
+    addActiveTabToDashboardRuntimeOverrides,
     getCurrentDashboardPromptContext,
     getDashboardParametersValuesMap,
     getNonDefaultDashboardRuntimeOverrides,
@@ -46,6 +47,26 @@ const currentDashboard = (
 });
 
 describe('dashboard page context', () => {
+    it('adds the active tab to the dashboard context snapshot', () => {
+        expect(
+            addActiveTabToDashboardRuntimeOverrides({
+                activeTab: { uuid: 'tab-1', name: 'Overview' },
+                runtimeOverrides: null,
+            }),
+        ).toEqual({
+            activeTab: { uuid: 'tab-1', name: 'Overview' },
+        });
+    });
+
+    it('leaves tabless dashboards without runtime context', () => {
+        expect(
+            addActiveTabToDashboardRuntimeOverrides({
+                activeTab: undefined,
+                runtimeOverrides: null,
+            }),
+        ).toBeNull();
+    });
+
     it('omits default runtime values', () => {
         expect(
             getNonDefaultDashboardRuntimeOverrides({
@@ -117,6 +138,7 @@ describe('dashboard page context', () => {
 
     it('does not attach unchanged runtime values again', () => {
         const runtimeOverrides = {
+            activeTab: { uuid: 'tab-1', name: 'Overview' },
             dashboardFilters: filtered,
             dashboardParameters: { region: 'EU' },
             dateZoom: { granularity: 'Week' },
@@ -132,6 +154,32 @@ describe('dashboard page context', () => {
                 projectUuid: 'project-1',
             }),
         ).toEqual([]);
+    });
+
+    it('attaches a changed active tab', () => {
+        expect(
+            getCurrentDashboardPromptContext({
+                currentDashboard: currentDashboard({
+                    activeTab: { uuid: 'tab-2', name: 'Customers' },
+                }),
+                previousDashboardContext: {
+                    type: 'dashboard',
+                    dashboardUuid: 'dashboard-1',
+                    runtimeOverrides: {
+                        activeTab: { uuid: 'tab-1', name: 'Overview' },
+                    },
+                },
+                projectUuid: 'project-1',
+            }),
+        ).toEqual([
+            {
+                type: 'dashboard',
+                dashboardUuid: 'dashboard-1',
+                runtimeOverrides: {
+                    activeTab: { uuid: 'tab-2', name: 'Customers' },
+                },
+            },
+        ]);
     });
 
     it('attaches changed filters', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/store/dashboardPageContext.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/dashboardPageContext.ts
@@ -5,6 +5,7 @@ import {
     type AiPromptContextInput,
     type DashboardFilters,
     type DashboardParameters,
+    type DashboardTab,
     type DateZoom,
     type ParametersValuesMap,
 } from '@lightdash/common';
@@ -51,6 +52,20 @@ export const getNonDefaultDashboardRuntimeOverrides = ({
 
     return Object.keys(overrides).length > 0 ? overrides : null;
 };
+
+export const addActiveTabToDashboardRuntimeOverrides = ({
+    activeTab,
+    runtimeOverrides,
+}: {
+    activeTab: Pick<DashboardTab, 'uuid' | 'name'> | null | undefined;
+    runtimeOverrides: AiDashboardRuntimeOverrides | null;
+}): AiDashboardRuntimeOverrides | null =>
+    activeTab
+        ? {
+              ...runtimeOverrides,
+              activeTab: { uuid: activeTab.uuid, name: activeTab.name },
+          }
+        : runtimeOverrides;
 
 export const getDashboardParametersValuesMap = (
     parameters: DashboardParameters,

--- a/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
@@ -11,6 +11,7 @@ import { useParams } from 'react-router';
 import { scrollToDashboardTile } from '../../components/common/Dashboard/scrollToDashboardTile';
 import { setCurrentDashboard } from '../../ee/features/aiCopilot/store/aiAgentLauncherSlice';
 import {
+    addActiveTabToDashboardRuntimeOverrides,
     getDashboardParametersValuesMap,
     getNonDefaultDashboardRuntimeOverrides,
 } from '../../ee/features/aiCopilot/store/dashboardPageContext';
@@ -109,8 +110,8 @@ const DashboardAiAgentContextBridge = () => {
             dateZoomGranularity ? { granularity: dateZoomGranularity } : null,
         [dateZoomGranularity],
     );
-    const dashboardRuntimeOverrides = useMemo(
-        () =>
+    const dashboardRuntimeOverrides = useMemo(() => {
+        const nonDefaultRuntimeOverrides =
             getNonDefaultDashboardRuntimeOverrides({
                 defaultFilters: originalDashboardFilters,
                 effectiveFilters: allFilters,
@@ -118,16 +119,20 @@ const DashboardAiAgentContextBridge = () => {
                 effectiveParameters: parameterValues,
                 defaultDateZoom,
                 effectiveDateZoom,
-            }),
-        [
-            allFilters,
-            defaultDateZoom,
-            defaultParameterValues,
-            effectiveDateZoom,
-            originalDashboardFilters,
-            parameterValues,
-        ],
-    );
+            });
+        return addActiveTabToDashboardRuntimeOverrides({
+            activeTab,
+            runtimeOverrides: nonDefaultRuntimeOverrides,
+        });
+    }, [
+        activeTab,
+        allFilters,
+        defaultDateZoom,
+        defaultParameterValues,
+        effectiveDateZoom,
+        originalDashboardFilters,
+        parameterValues,
+    ]);
     const dashboardQueryKey = useMemo(
         () => ['saved_dashboard_query', dashboardUuidOrSlug, projectUuid],
         [dashboardUuidOrSlug, projectUuid],


### PR DESCRIPTION
## Summary
- attach the active dashboard tab to Ask AI dashboard context
- reattach context when the tab or dashboard changes, while deduplicating unchanged prompts
- preserve the tab name through prompt construction and conversation compaction

## Verification
- frontend focused tests: 16 passed
- backend focused tests: 19 passed
- common, frontend, and backend fast typechecks
- Browser and PostgreSQL: initial tab, switched tab, unchanged tab, new single-tab dashboard, and unchanged single-tab dashboard
- independent review agent: No findings.

Closes: PROD-8949
Relates: PROD-7781
Relates: PROD-8948