### PR TITLE
fix: improve Autopilot run activity log hierarchy

### DIFF
--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
@@ -48,7 +48,10 @@
         light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
     border-radius: var(--mantine-radius-md);
     overflow: hidden;
-    background-color: transparent;
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
     box-shadow: light-dark(
         0 1px 3px rgba(0, 0, 0, 0.04),
         0 1px 3px rgba(0, 0, 0, 0.4)
@@ -75,8 +78,14 @@
     font-weight: 500;
     text-transform: uppercase;
     letter-spacing: 0.4px;
-    color: light-dark(var(--mantine-color-gray-5), var(--mantine-color-dark-2));
-    background-color: transparent;
+    color: light-dark(
+        var(--mantine-color-ldGray-6),
+        var(--mantine-color-dark-1)
+    );
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
     padding: 7px 12px;
     border-bottom: 1px solid
         light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
@@ -516,23 +525,88 @@
     flex-shrink: 0;
 }
 
+/* Quiet run grouping */
+.quietGroupRow {
+    cursor: pointer;
+    user-select: none;
+    background-color: light-dark(
+        color-mix(
+            in srgb,
+            var(--mantine-color-ldGray-0) 50%,
+            var(--mantine-color-white)
+        ),
+        color-mix(
+            in srgb,
+            var(--mantine-color-dark-6) 40%,
+            var(--mantine-color-dark-7)
+        )
+    );
+    transition: background-color 120ms var(--ease-out-quart);
+}
+
+.quietGroupRow:hover {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-1),
+        var(--mantine-color-dark-6)
+    );
+}
+
+.quietGroupRowOpen {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-1),
+        var(--mantine-color-dark-6)
+    );
+}
+
+.quietGroupRow td {
+    padding: 2px 12px;
+    border-top: 1px solid
+        light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
+}
+
+.quietRunRow td {
+    padding: 2px 12px 2px 40px;
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
+}
+
+.quietRunMeta {
+    opacity: 0.7;
+}
+
 /* Run grouping */
 .runHeaderRow {
     cursor: pointer;
     user-select: none;
-    background-color: transparent;
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-7)
+    );
     transition: background-color 120ms var(--ease-out-quart);
 }
 
 .runHeaderRow:hover {
     background-color: light-dark(
-        var(--mantine-color-gray-1),
-        var(--mantine-color-dark-5)
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-dark-6)
+    );
+}
+
+.runHeaderRowOpen {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-dark-6)
     );
 }
 
 .runHeaderRow td {
-    padding: 8px 12px;
+    padding: 11px 12px;
     border-bottom: 1px solid
         light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
     border-top: 1px solid

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -1795,16 +1795,23 @@ const QuietRunsGroup: FC<{
                                     size={11}
                                     color="dimmed"
                                 />
-                                <Text
-                                    fz={10}
-                                    fw={600}
-                                    tt="uppercase"
-                                    c="dimmed"
-                                    lts={0.4}
-                                >
-                                    Run ·{' '}
-                                    {formatTimestamp(run.startedAt.toString())}
-                                </Text>
+                                <Group gap={4} wrap="nowrap">
+                                    <Text
+                                        fz={10}
+                                        fw={600}
+                                        tt="uppercase"
+                                        c="dimmed"
+                                        lts={0.4}
+                                    >
+                                        Run
+                                    </Text>
+                                    <Text fz={10} c="dimmed">
+                                        ·{' '}
+                                        {formatTimestamp(
+                                            run.startedAt.toString(),
+                                        )}
+                                    </Text>
+                                </Group>
                             </Group>
                             <Text fz={10} c="dimmed">
                                 No actions

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -49,6 +49,7 @@ import {
     IconHash,
     IconLayoutDashboard,
     IconPlayerPlay,
+    IconSelector,
     IconSettings,
     IconTool,
     IconTrash,
@@ -1540,7 +1541,9 @@ const RunHeaderRow: FC<{
     onToggle: () => void;
 }> = ({ run, variant, isOpen, expandable, onToggle }) => (
     <Table.Tr
-        className={classes.runHeaderRow}
+        className={`${classes.runHeaderRow} ${
+            isOpen ? classes.runHeaderRowOpen : ''
+        }`}
         onClick={expandable ? onToggle : undefined}
         style={expandable ? undefined : { cursor: 'default' }}
     >
@@ -1582,7 +1585,7 @@ const RunHeaderRow: FC<{
                             </Box>
                         </Tooltip>
                     )}
-                    <Text fz={11} fw={600} tt="uppercase" c="dimmed" lts={0.4}>
+                    <Text fz={11} fw={700} tt="uppercase" c="bright" lts={0.4}>
                         Run
                     </Text>
                     {variant !== 'live' && (
@@ -1685,7 +1688,7 @@ const RunRow: FC<{
                 expandable={expandable}
                 onToggle={onToggle}
             />
-            {variant === 'errored' && run.error && (
+            {variant === 'errored' && isOpen && run.error && (
                 <Table.Tr>
                     <Table.Td colSpan={3}>
                         <Text fz="xs" c="red.6" px="md" py={6}>
@@ -1739,6 +1742,79 @@ const RunRow: FC<{
         </Table.Tbody>
     );
 };
+
+// --- Quiet runs group ---
+
+type DisplayRow =
+    | { type: 'run'; run: ManagedAgentRun }
+    | { type: 'quietGroup'; groupId: string; runs: ManagedAgentRun[] };
+
+const QuietRunsGroup: FC<{
+    runs: ManagedAgentRun[];
+    isOpen: boolean;
+    onToggle: () => void;
+}> = ({ runs, isOpen, onToggle }) => (
+    <Table.Tbody>
+        <Table.Tr
+            className={`${classes.quietGroupRow} ${
+                isOpen ? classes.quietGroupRowOpen : ''
+            }`}
+            onClick={onToggle}
+        >
+            <Table.Td colSpan={3}>
+                <Tooltip
+                    label={`${runs.length} quiet ${
+                        runs.length === 1 ? 'run' : 'runs'
+                    }`}
+                    withinPortal
+                >
+                    <Box style={{ display: 'flex', justifyContent: 'center' }}>
+                        <MantineIcon
+                            icon={IconSelector}
+                            size={10}
+                            color="dimmed"
+                        />
+                    </Box>
+                </Tooltip>
+            </Table.Td>
+        </Table.Tr>
+        {isOpen &&
+            runs.map((run) => (
+                <Table.Tr key={run.runUuid} className={classes.quietRunRow}>
+                    <Table.Td colSpan={3}>
+                        <Group justify="space-between" wrap="nowrap">
+                            <Group
+                                gap={8}
+                                wrap="nowrap"
+                                className={classes.quietRunMeta}
+                            >
+                                <MantineIcon
+                                    icon={
+                                        TRIGGERED_BY_ICON[run.triggeredBy].icon
+                                    }
+                                    size={11}
+                                    color="dimmed"
+                                />
+                                <Text
+                                    fz={10}
+                                    fw={600}
+                                    tt="uppercase"
+                                    c="dimmed"
+                                    lts={0.4}
+                                >
+                                    Run ·{' '}
+                                    {formatTimestamp(run.startedAt.toString())}
+                                </Text>
+                            </Group>
+                            <Text fz={10} c="dimmed">
+                                No actions
+                            </Text>
+                        </Group>
+                    </Table.Td>
+                </Table.Tr>
+            ))}
+    </Table.Tbody>
+);
 
 // --- Page ---
 
@@ -1817,6 +1893,47 @@ export const ManagedAgentActivityPage: FC = () => {
     ]);
     const [selected, setSelected] = useState<ManagedAgentAction | null>(null);
     const [settingsOpen, setSettingsOpen] = useState(false);
+    const [openQuietGroups, setOpenQuietGroups] = useState<Set<string>>(
+        new Set(),
+    );
+
+    const toggleQuietGroup = useCallback((groupId: string) => {
+        setOpenQuietGroups((prev) => {
+            const next = new Set(prev);
+            if (next.has(groupId)) {
+                next.delete(groupId);
+            } else {
+                next.add(groupId);
+            }
+            return next;
+        });
+    }, []);
+
+    // Collapse consecutive completed runs without actions into a single
+    // expandable group. The newest run always stays visible.
+    const displayRows = useMemo<DisplayRow[]>(() => {
+        const rows: DisplayRow[] = [];
+        let quietRuns: ManagedAgentRun[] = [];
+        const flushQuietRuns = () => {
+            if (quietRuns.length === 0) return;
+            rows.push({
+                type: 'quietGroup',
+                groupId: quietRuns[0].runUuid,
+                runs: quietRuns,
+            });
+            quietRuns = [];
+        };
+        runs.forEach((run, index) => {
+            if (index > 0 && runVariant(run) === 'completed-empty') {
+                quietRuns.push(run);
+            } else {
+                flushQuietRuns();
+                rows.push({ type: 'run', run });
+            }
+        });
+        flushQuietRuns();
+        return rows;
+    }, [runs]);
     const [userOpenState, setUserOpenState] = useState<Map<string, boolean>>(
         new Map(),
     );
@@ -1961,7 +2078,24 @@ export const ManagedAgentActivityPage: FC = () => {
                                                 <Table.Th>Message</Table.Th>
                                             </Table.Tr>
                                         </Table.Thead>
-                                        {runs.map((run) => {
+                                        {displayRows.map((row) => {
+                                            if (row.type === 'quietGroup') {
+                                                return (
+                                                    <QuietRunsGroup
+                                                        key={`quiet-${row.groupId}`}
+                                                        runs={row.runs}
+                                                        isOpen={openQuietGroups.has(
+                                                            row.groupId,
+                                                        )}
+                                                        onToggle={() =>
+                                                            toggleQuietGroup(
+                                                                row.groupId,
+                                                            )
+                                                        }
+                                                    />
+                                                );
+                                            }
+                                            const { run } = row;
                                             const isLive =
                                                 run.status ===
                                                 ManagedAgentRunStatus.STARTED;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-8951

### Description:
Groups consecutive no-action Autopilot runs into compact expandable rows.
Improves run hierarchy with state-aware styling and collapsible failed-run details.


## Demo

<img width="1765" height="1288" alt="CleanShot 2026-07-16 at 13 22 11" src="https://github.com/user-attachments/assets/405d3c32-e100-4545-8dc6-8a222aed89e3" />

With expanded quiet runs

<img width="1767" height="1285" alt="CleanShot 2026-07-16 at 13 22 25" src="https://github.com/user-attachments/assets/503df0f8-19ac-4574-b443-0c35e4695fbe" />
