### PR TITLE
fix: allow applying a required filter that has no default value

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.test.tsx
@@ -310,6 +310,123 @@ describe('FilterConfiguration', () => {
         );
     });
 
+    it('allows applying when required is toggled on a filter with default value enabled but no value set', async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+        const onSave = vi.fn();
+        const emptyDefaultValueRule: DashboardFilterRule = {
+            ...anyValueRule,
+            disabled: false,
+        };
+
+        renderWithProviders(
+            <FilterConfiguration
+                isEditMode
+                tiles={[]}
+                tabs={[]}
+                availableTileFilters={{}}
+                field={mockField}
+                defaultFilterRule={emptyDefaultValueRule}
+                originalFilterRule={emptyDefaultValueRule}
+                onSave={onSave}
+            />,
+        );
+
+        await user.click(screen.getByLabelText('Required'));
+
+        const applyButton = screen.getByRole('button', { name: 'Apply' });
+        expect(applyButton).toBeEnabled();
+        fireEvent.mouseDown(applyButton);
+
+        await waitFor(() => {
+            expect(onSave).toHaveBeenCalledTimes(1);
+        });
+        expect(onSave).toHaveBeenCalledWith(
+            expect.objectContaining({ required: true, disabled: true }),
+        );
+    });
+
+    it('also fixes the legacy checkbox when the flag is off: required with empty default value can apply', async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+        const onSave = vi.fn();
+        mockDashboardContext.current.isFilterRequirementsEnabled = false;
+        const emptyDefaultValueRule: DashboardFilterRule = {
+            ...anyValueRule,
+            disabled: false,
+        };
+
+        renderWithProviders(
+            <FilterConfiguration
+                isEditMode
+                tiles={[]}
+                tabs={[]}
+                availableTileFilters={{}}
+                field={mockField}
+                defaultFilterRule={emptyDefaultValueRule}
+                originalFilterRule={emptyDefaultValueRule}
+                onSave={onSave}
+            />,
+        );
+
+        await user.click(
+            screen.getByLabelText(
+                'Require viewers to pick a value to load the dashboard',
+            ),
+        );
+
+        const applyButton = screen.getByRole('button', { name: 'Apply' });
+        expect(applyButton).toBeEnabled();
+        fireEvent.mouseDown(applyButton);
+
+        await waitFor(() => {
+            expect(onSave).toHaveBeenCalledTimes(1);
+        });
+        expect(onSave).toHaveBeenCalledWith(
+            expect.objectContaining({ required: true, disabled: true }),
+        );
+    });
+
+    it('keeps Apply available when a required filter temporary value is cleared', async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+        const onSave = vi.fn();
+        const requiredWithTemporaryValue: DashboardFilterRule = {
+            ...anyValueRule,
+            disabled: false,
+            required: true,
+            values: ['adam'],
+        };
+
+        renderWithProviders(
+            <FilterConfiguration
+                isEditMode
+                tiles={[]}
+                tabs={[]}
+                availableTileFilters={{}}
+                field={mockField}
+                defaultFilterRule={requiredWithTemporaryValue}
+                originalFilterRule={requiredWithTemporaryValue}
+                onSave={onSave}
+            />,
+        );
+
+        const input = document.querySelector(
+            'input[type="search"]',
+        ) as HTMLInputElement;
+        expect(input).toBeTruthy();
+        fireEvent.focus(input);
+        await user.type(input, '{Backspace}');
+
+        const applyButton = screen.getByRole('button', { name: 'Apply' });
+        expect(applyButton).toBeEnabled();
+        fireEvent.mouseDown(applyButton);
+
+        await waitFor(() => {
+            expect(onSave).toHaveBeenCalledTimes(1);
+        });
+        expect(onSave).toHaveBeenCalledWith(
+            expect.objectContaining({ disabled: true, values: [] }),
+        );
+    });
+
     it('shows an enabled unchecked required toggle when the filter is not part of a rule', () => {
         renderWithProviders(
             <FilterConfiguration

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -37,6 +37,7 @@ import { flushSync } from 'react-dom';
 import FieldIcon from '../../../components/common/Filters/FieldIcon';
 import FieldLabel from '../../../components/common/Filters/FieldLabel';
 import MantineIcon from '../../../components/common/MantineIcon';
+import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../../../providers/Dashboard/useDashboardTileStatusContext';
 import { DEFAULT_TAB, FilterActions, FilterTabs } from './constants';
 import classes from './FilterConfiguration.module.css';
@@ -95,6 +96,9 @@ const FilterConfiguration: FC<Props> = ({
     onSave,
     onEditRequirementRules,
 }) => {
+    const isFilterRequirementsEnabled = useDashboardContext(
+        (c) => c.isFilterRequirementsEnabled,
+    );
     const [selectedTabId, setSelectedTabId] = useState<FilterTabs>(DEFAULT_TAB);
     const [selectedField, setSelectedField] = useState<
         DashboardFilterableField | undefined
@@ -169,13 +173,26 @@ const FilterConfiguration: FC<Props> = ({
                     !newFilterRule.required &&
                     !hasFilterValueSet(newFilterRule);
 
+                // In edit mode a required filter without a value is valueless
+                // by definition (dashboard save normalizes it to disabled),
+                // so it must not block Apply by demanding a default value
+                const isRequiredWithoutValue =
+                    isEditMode &&
+                    (!!newFilterRule.required ||
+                        (isFilterRequirementsEnabled &&
+                            !!newFilterRule.requiredGroupId)) &&
+                    !hasFilterValueSet(newFilterRule);
+
                 return {
                     ...newFilterRule,
-                    disabled: isNewFilterDisabled || shouldDisableInViewMode,
+                    disabled:
+                        isNewFilterDisabled ||
+                        shouldDisableInViewMode ||
+                        isRequiredWithoutValue,
                 };
             });
         },
-        [setDraftFilterRule, isEditMode],
+        [setDraftFilterRule, isEditMode, isFilterRequirementsEnabled],
     );
     const sqlChartTilesMetadata = useDashboardTileStatusContext(
         (c) => c.sqlChartTilesMetadata,


### PR DESCRIPTION
## Problem

In dashboard edit mode, toggling **Required** on a filter whose "Provide default value" switch is on but has no value yet leaves the Apply button permanently disabled. Since the default-value switch is hidden once the filter is required, there is no way to recover from that state. Clearing a required filter's temporary value hits the same trap.

## Cause

`handleToggleRequired` keeps the draft as `disabled: false, values: []`, and `isFilterEnabled` only auto-enables Apply for disabled rules in edit mode — otherwise it demands a value, even though required filters are valueless by definition (dashboard save normalizes them to `disabled: true, values: []`).

## Fix

`handleChangeFilterRule` (which every filter edit funnels through) now normalizes a filter that has a requirement and no value to `disabled: true` in edit mode, matching the dashboard-save normalization and the requirement-group paths. This fixes both the flag-on Required switch and the legacy flag-off checkbox; view mode is untouched.

## Testing

- 3 new regression tests (flag-on toggle, flag-off legacy checkbox, clearing a required filter's temporary value) — all failed on the previous code at the Apply assertion.
- Reproduced in-app against the previous code and verified the fix flag-on: required + temporary value, clearing the temporary value, and toggling required off all land in coherent, appliable states.

Relates: PROD-8661
