### PR TITLE
fix(homepage): inert builder composer, bigger day-0 chat font, announcements mention content-only

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -641,22 +641,27 @@ const generateContentMentionSuggestion = ({
     getProjectUuid,
     getPriorityItems,
     onPopupOpenChange,
+    includeFilesAndRepositories,
 }: {
     getProjectUuid: () => string | undefined;
     getPriorityItems: () => ContentMentionSuggestionItem[];
     onPopupOpenChange?: (open: boolean) => void;
+    includeFilesAndRepositories: boolean;
 }): MentionOptions['suggestion'] => ({
     char: '@',
     allowSpaces: true,
     pluginKey: contentMentionPluginKey,
     items: async ({ query }) => {
         const projectUuid = getProjectUuid();
-        const [contentItems, fileItems, repositoryItems] = await Promise.all([
-            buildContentMentionSuggestionItems({
-                projectUuid,
-                query,
-                priorityItems: getPriorityItems(),
-            }),
+        const contentItems = await buildContentMentionSuggestionItems({
+            projectUuid,
+            query,
+            priorityItems: getPriorityItems(),
+        });
+        // Files / repositories are only mentionable in the AI-agent composer;
+        // other surfaces (e.g. homepage announcements) mention content only.
+        if (!includeFilesAndRepositories) return contentItems;
+        const [fileItems, repositoryItems] = await Promise.all([
             getProjectFileSuggestions(projectUuid, query),
             getRepositorySuggestions(projectUuid, query),
         ]);
@@ -786,10 +791,12 @@ export const createContentMentionExtension = ({
     getProjectUuid,
     getPriorityItems,
     onPopupOpenChange,
+    includeFilesAndRepositories = true,
 }: {
     getProjectUuid: () => string | undefined;
     getPriorityItems: () => ContentMentionSuggestionItem[];
     onPopupOpenChange?: (open: boolean) => void;
+    includeFilesAndRepositories?: boolean;
 }) =>
     Mention.extend({
         name: CONTENT_MENTION_NAME,
@@ -837,6 +844,7 @@ export const createContentMentionExtension = ({
             getProjectUuid,
             getPriorityItems,
             onPopupOpenChange,
+            includeFilesAndRepositories,
         }),
         renderText: ({ node }) =>
             typeof node.attrs.label === 'string' ? node.attrs.label : '',

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.module.css
@@ -1,3 +1,9 @@
+/* Bump the composer text to a comfortable reading size on the homepage —
+   overrides AgentChatInput's dense (sm) editor font, which only applies here. */
+.composer :global(.ProseMirror) {
+    font-size: var(--mantine-font-size-md) !important;
+}
+
 .pill {
     font-size: 12px;
     font-weight: 500;

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
@@ -28,7 +28,7 @@ import classes from './DayOneAskInput.module.css';
 
 const AI_ROUTER_QUERY_KEY = 'ai-router';
 
-type Props = { projectUuid: string };
+type Props = { projectUuid: string; preview?: boolean };
 
 // AgentSelector (rendered inside AgentChatInput below) already calls
 // useAiRouterConfig() to build its own dropdown. Calling that same hook a
@@ -93,7 +93,7 @@ const SuggestionPills: FC<{
 // (not via AgentChatInput's own `showSuggestions`) so they keep the design's
 // pill styling, and so a specific reference agent can power them even when
 // the composer itself is in Auto mode.
-const DayOneAskInputInner: FC<Props> = ({ projectUuid }) => {
+const DayOneAskInputInner: FC<Props> = ({ projectUuid, preview = false }) => {
     const navigate = useNavigate();
     const { setPendingPrompt } = usePendingPrompt();
     const { data: agents, isLoading: isLoadingAgents } = useProjectAiAgents({
@@ -198,7 +198,10 @@ const DayOneAskInputInner: FC<Props> = ({ projectUuid }) => {
     }
 
     return (
-        <>
+        // In the builder (preview) the composer stays visually active but the
+        // whole subtree is `inert`: no focus, no typing, no submit — it just
+        // shows what viewers will get.
+        <div className={classes.composer} inert={preview}>
             <AgentChatInput
                 projectUuid={projectUuid}
                 agents={agents}
@@ -223,13 +226,13 @@ const DayOneAskInputInner: FC<Props> = ({ projectUuid }) => {
                         : undefined
                 }
             />
-            {canCreateThread && (
+            {(canCreateThread || preview) && (
                 <SuggestionPills
                     chips={suggestionsQuery.data?.chips ?? []}
                     onPick={handleChipPick}
                 />
             )}
-        </>
+        </div>
     );
 };
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
@@ -15,10 +15,13 @@ const dayPart = (): string => {
 // The day-0 hero, as a reusable unit: greeting + the real agent chat
 // composer with live suggestions. Shared between DayOneHomepage (always
 // greets) and this block (greeting is a per-homepage toggle).
-export const AskAiHero: FC<{ projectUuid: string; showGreeting: boolean }> = ({
-    projectUuid,
-    showGreeting,
-}) => {
+export const AskAiHero: FC<{
+    projectUuid: string;
+    showGreeting: boolean;
+    // In the builder the composer is shown as a preview: it looks real but is
+    // inert, so editing admins can't accidentally start a conversation.
+    preview?: boolean;
+}> = ({ projectUuid, showGreeting, preview = false }) => {
     const { user } = useApp();
     return (
         <Stack gap={16} align="center" w="100%">
@@ -37,7 +40,7 @@ export const AskAiHero: FC<{ projectUuid: string; showGreeting: boolean }> = ({
                 </Text>
             )}
             <Box w="100%">
-                <DayOneAskInput projectUuid={projectUuid} />
+                <DayOneAskInput projectUuid={projectUuid} preview={preview} />
             </Box>
         </Stack>
     );
@@ -68,6 +71,7 @@ export const AskAiHeroBlockBuild: FC<BuildComponentProps> = ({
             <AskAiHero
                 projectUuid={projectUuid}
                 showGreeting={block.config.showGreeting}
+                preview
             />
             <Switch
                 label="Show greeting"

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/announcementExtensions.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/announcements/announcementExtensions.ts
@@ -20,5 +20,6 @@ export const createAnnouncementExtensions = (
     createContentMentionExtension({
         getProjectUuid,
         getPriorityItems: () => [],
+        includeFilesAndRepositories: false,
     }),
 ];


### PR DESCRIPTION
Stacked on #25660. Three homepage-builder fixes.

## Changes

**Builder composer is inert** — the Ask AI composer shown in the builder kept working (you could type and start a real conversation while editing). It now renders as an inert preview: the wrapper carries React's `inert`, so it keeps its full look (placeholder, normal colors, suggestion pills) but can't be focused, typed into, or submitted, and no longer steals autofocus. Verified: a programmatic `.focus()` on the editor fails and `activeElement` stays `body`.

**Bigger day-0 chat font** — the homepage composer editor text went from the dense `sm` size to `md` (16px), on both day-0 and the Ask AI block (shared `DayOneAskInput`). Scoped override so other `dense` composers (agent threads) are unaffected.

**Announcements `@`-mention is content-only** — the announcement composer's `@` menu was offering project files and repositories (meant only for the AI-agent composer). Added an `includeFilesAndRepositories` flag to `createContentMentionExtension` (defaults `true`, so the AI composer is unchanged) and pass `false` from the announcement editor. Verified via network: typing `@revenue` fires only `/content?contentTypes=chart&contentTypes=dashboard`, with zero `project-files`/`repositories` requests.

## Verification
Frontend typecheck + oxlint clean. Live via Chrome DevTools: composer inert (computed font 16px), `@`-mention network trace content-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)