### PR TITLE
feat(homepage): metric sparklines on KPI tiles

### DIFF
--- a/packages/backend/src/controllers/metricsExplorerController.ts
+++ b/packages/backend/src/controllers/metricsExplorerController.ts
@@ -3,6 +3,7 @@ import {
     ApiErrorPayload,
     assertRegisteredAccount,
     MetricTotalComparisonType,
+    type ApiMetricsExplorerQueryResults,
     type ApiMetricsExplorerTotalResults,
     type TimeFrames,
 } from '@lightdash/common';
@@ -67,6 +68,44 @@ export class MetricsExplorerController extends BaseController {
                 endDate,
                 body?.comparisonType,
                 body?.rollingDays,
+            );
+
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    /**
+     * Run a metric time series query for a sparkline
+     * @summary Run metric series query
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{explore}/{metric}/runMetricSeries')
+    @OperationId('runMetricSeries')
+    async runMetricSeries(
+        @Path() projectUuid: string,
+        @Path() explore: string,
+        @Path() metric: string,
+        @Request() req: express.Request,
+        @Query() granularity: TimeFrames,
+        @Query() startDate: string,
+        @Query() endDate: string,
+    ): Promise<ApiMetricsExplorerQueryResults> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+
+        const results = await this.services
+            .getMetricsExplorerService()
+            .getMetricSeries(
+                toSessionUser(req.account),
+                projectUuid,
+                explore,
+                metric,
+                granularity,
+                startDate,
+                endDate,
             );
 
         return {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -15347,6 +15347,18 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiDashboardActiveTab: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_DashboardFilterRule.Exclude_keyofDashboardFilterRule.id-or-tileTargets-or-lockedTabUuids-or-requiredGroupId__':
         {
             dataType: 'refAlias',
@@ -15476,6 +15488,7 @@ const models: TsoaRoute.Models = {
                 },
                 dashboardParameters: { ref: 'ParametersValuesMap' },
                 dashboardFilters: { ref: 'AiDashboardFilters' },
+                activeTab: { ref: 'AiDashboardActiveTab' },
             },
             validators: {},
         },
@@ -41607,6 +41620,120 @@ const models: TsoaRoute.Models = {
     MetricTotalComparisonType: {
         dataType: 'refEnum',
         enums: ['none', 'previous_period', 'rolling_days'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MetricExploreDataPoint: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                compareMetric: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        label: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        value: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'double' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                metric: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        label: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        value: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'double' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                segment: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                date: { dataType: 'datetime', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MetricExploreDataPointWithDateValue: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'MetricExploreDataPoint' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        dateValue: { dataType: 'double', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    MetricsExplorerQueryResults: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                points: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'MetricExploreDataPointWithDateValue',
+                    },
+                    required: true,
+                },
+                metric: {
+                    ref: 'MetricWithAssociatedTimeDimension',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiMetricsExplorerQueryResults: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'MetricsExplorerQueryResults', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiCompiledQueryResults: {
@@ -81696,6 +81823,97 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'runMetricTotal',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsMetricsExplorerController_runMetricSeries: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        explore: {
+            in: 'path',
+            name: 'explore',
+            required: true,
+            dataType: 'string',
+        },
+        metric: {
+            in: 'path',
+            name: 'metric',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        granularity: {
+            in: 'query',
+            name: 'granularity',
+            required: true,
+            ref: 'TimeFrames',
+        },
+        startDate: {
+            in: 'query',
+            name: 'startDate',
+            required: true,
+            dataType: 'string',
+        },
+        endDate: {
+            in: 'query',
+            name: 'endDate',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/metricsExplorer/:explore/:metric/runMetricSeries',
+        ...fetchMiddlewares<RequestHandler>(MetricsExplorerController),
+        ...fetchMiddlewares<RequestHandler>(
+            MetricsExplorerController.prototype.runMetricSeries,
+        ),
+
+        async function MetricsExplorerController_runMetricSeries(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsMetricsExplorerController_runMetricSeries,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<MetricsExplorerController>(
+                        MetricsExplorerController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'runMetricSeries',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16982,6 +16982,18 @@
                 "type": "object",
                 "description": "Runtime state captured at pin time for a chart context. When a user pins a\nchart from a dashboard view, these are the dashboard-level overrides that\nwere applied to the chart on screen at that moment."
             },
+            "AiDashboardActiveTab": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name", "uuid"],
+                "type": "object"
+            },
             "Pick_DashboardFilterRule.Exclude_keyofDashboardFilterRule.id-or-tileTargets-or-lockedTabUuids-or-requiredGroupId__": {
                 "properties": {
                     "label": {
@@ -17073,6 +17085,9 @@
                     },
                     "dashboardFilters": {
                         "$ref": "#/components/schemas/AiDashboardFilters"
+                    },
+                    "activeTab": {
+                        "$ref": "#/components/schemas/AiDashboardActiveTab"
                     }
                 },
                 "type": "object"
@@ -41686,6 +41701,96 @@
             "MetricTotalComparisonType": {
                 "enum": ["none", "previous_period", "rolling_days"],
                 "type": "string"
+            },
+            "MetricExploreDataPoint": {
+                "properties": {
+                    "compareMetric": {
+                        "properties": {
+                            "label": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "value": {
+                                "type": "number",
+                                "format": "double",
+                                "nullable": true
+                            }
+                        },
+                        "required": ["label", "value"],
+                        "type": "object"
+                    },
+                    "metric": {
+                        "properties": {
+                            "label": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "value": {
+                                "type": "number",
+                                "format": "double",
+                                "nullable": true
+                            }
+                        },
+                        "required": ["label", "value"],
+                        "type": "object"
+                    },
+                    "segment": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "date": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "required": ["compareMetric", "metric", "segment", "date"],
+                "type": "object"
+            },
+            "MetricExploreDataPointWithDateValue": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/MetricExploreDataPoint"
+                    },
+                    {
+                        "properties": {
+                            "dateValue": {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        },
+                        "required": ["dateValue"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "MetricsExplorerQueryResults": {
+                "properties": {
+                    "points": {
+                        "items": {
+                            "$ref": "#/components/schemas/MetricExploreDataPointWithDateValue"
+                        },
+                        "type": "array"
+                    },
+                    "metric": {
+                        "$ref": "#/components/schemas/MetricWithAssociatedTimeDimension"
+                    }
+                },
+                "required": ["points", "metric"],
+                "type": "object"
+            },
+            "ApiMetricsExplorerQueryResults": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/MetricsExplorerQueryResults"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
             },
             "ApiCompiledQueryResults": {
                 "properties": {
@@ -69887,6 +69992,87 @@
                         }
                     }
                 }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/metricsExplorer/{explore}/{metric}/runMetricSeries": {
+            "post": {
+                "operationId": "runMetricSeries",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiMetricsExplorerQueryResults"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Run a metric time series query for a sparkline",
+                "summary": "Run metric series query",
+                "tags": ["Metrics Explorer", "Metrics", "Explorer"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "explore",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "metric",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "granularity",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/TimeFrames"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "startDate",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "endDate",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/projects/{projectUuid}/metricsExplorer/{explore}/{metric}/compileMetricTotalQuery": {

--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.test.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.test.ts
@@ -1,0 +1,191 @@
+import { Ability } from '@casl/ability';
+import {
+    DimensionType,
+    FieldType,
+    MetricType,
+    OrganizationMemberRole,
+    TimeFrames,
+    type CompiledDimension,
+    type ItemsMap,
+    type MetricQuery,
+    type MetricWithAssociatedTimeDimension,
+    type PossibleAbilities,
+    type SessionUser,
+} from '@lightdash/common';
+import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import type { AsyncQueryService } from '../AsyncQueryService/AsyncQueryService';
+import type { CatalogService } from '../CatalogService/CatalogService';
+import type { ProjectService } from '../ProjectService/ProjectService';
+import { MetricsExplorerService } from './MetricsExplorerService';
+
+const PROJECT_UUID = 'project-uuid';
+const EXPLORE_NAME = 'orders';
+const METRIC_NAME = 'revenue';
+
+const user: SessionUser = {
+    userUuid: 'user-uuid',
+    email: 'user@example.com',
+    firstName: 'Test',
+    lastName: 'User',
+    organizationUuid: 'org-uuid',
+    organizationName: 'Test Org',
+    organizationCreatedAt: new Date(),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    avatarUrl: null,
+    avatarGradient: null,
+    timezone: null,
+    isSetupComplete: true,
+    userId: 0,
+    role: OrganizationMemberRole.ADMIN,
+    ability: new Ability<PossibleAbilities>([]),
+    isActive: true,
+    abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+};
+
+const metric: MetricWithAssociatedTimeDimension = {
+    name: METRIC_NAME,
+    table: EXPLORE_NAME,
+    fieldType: FieldType.METRIC,
+    type: MetricType.SUM,
+    label: 'Revenue',
+    tableLabel: 'Orders',
+    sql: '${TABLE}.revenue',
+    compiledSql: 'SUM("orders".revenue)',
+    tablesReferences: [EXPLORE_NAME],
+    hidden: false,
+    timeDimension: {
+        table: EXPLORE_NAME,
+        field: 'created_at',
+        interval: TimeFrames.WEEK,
+    },
+};
+
+// The week-truncated grouping dimension, keyed by getItemId + getFieldIdForDateDimension.
+const GROUP_BY_ID = `${EXPLORE_NAME}_created_at_week`;
+const METRIC_ID = `${EXPLORE_NAME}_${METRIC_NAME}`;
+
+const groupByDimension: CompiledDimension = {
+    name: 'created_at_week',
+    table: EXPLORE_NAME,
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.DATE,
+    label: 'Created at (week)',
+    sql: '${TABLE}.created_at',
+    compiledSql: 'DATE_TRUNC(\'week\', "orders".created_at)',
+    tablesReferences: [EXPLORE_NAME],
+    tableLabel: 'Orders',
+    hidden: false,
+};
+
+const buildService = () => {
+    const executeMetricQueryAndGetResults = vi.fn(
+        async (_args: { metricQuery: MetricQuery }) => ({
+            rows: [
+                { [GROUP_BY_ID]: '2026-01-19', [METRIC_ID]: 30 },
+                { [GROUP_BY_ID]: '2026-01-05', [METRIC_ID]: 10 },
+                { [GROUP_BY_ID]: '2026-01-12', [METRIC_ID]: 20 },
+            ],
+            fields: { [GROUP_BY_ID]: groupByDimension } as ItemsMap,
+            cacheMetadata: {},
+            pivotDetails: null,
+            displayTimezone: null,
+        }),
+    );
+
+    const catalogService = {
+        getMetric: vi.fn(async () => metric),
+    } as unknown as CatalogService;
+
+    const asyncQueryService = {
+        executeMetricQueryAndGetResults,
+    } as unknown as AsyncQueryService;
+
+    const service = new MetricsExplorerService({
+        projectModel: {} as ProjectModel,
+        projectService: {} as ProjectService,
+        catalogService,
+        asyncQueryService,
+    });
+
+    return { service, catalogService, executeMetricQueryAndGetResults };
+};
+
+describe('MetricsExplorerService.getMetricSeries', () => {
+    test('builds an ascending, unbounded-period series query', async () => {
+        const { service, executeMetricQueryAndGetResults } = buildService();
+
+        await service.getMetricSeries(
+            user,
+            PROJECT_UUID,
+            EXPLORE_NAME,
+            METRIC_NAME,
+            TimeFrames.WEEK,
+            '2026-01-01',
+            '2026-01-31',
+        );
+
+        expect(executeMetricQueryAndGetResults).toHaveBeenCalledTimes(1);
+        const { metricQuery } =
+            executeMetricQueryAndGetResults.mock.calls[0][0];
+
+        expect(metricQuery.dimensions).toEqual([GROUP_BY_ID]);
+        expect(metricQuery.metrics).toEqual([METRIC_ID]);
+        // Sorted ascending by the time dimension (oldest first).
+        expect(metricQuery.sorts).toEqual([
+            { fieldId: GROUP_BY_ID, descending: false },
+        ]);
+        // Series is not capped at 2 rows like the total query.
+        expect(metricQuery.limit).toBe(500);
+        // Single date range with an `and` filter — no previous-period `or`.
+        expect(metricQuery.filters.dimensions).toHaveProperty('and');
+        expect(metricQuery.filters.dimensions).not.toHaveProperty('or');
+    });
+
+    test('returns points sorted ascending by date', async () => {
+        const { service } = buildService();
+
+        const result = await service.getMetricSeries(
+            user,
+            PROJECT_UUID,
+            EXPLORE_NAME,
+            METRIC_NAME,
+            TimeFrames.WEEK,
+            '2026-01-01',
+            '2026-01-31',
+        );
+
+        expect(result.metric.name).toBe(METRIC_NAME);
+        expect(result.points.map((point) => point.metric.value)).toEqual([
+            10, 20, 30,
+        ]);
+        expect(
+            result.points.every(
+                (point, index) =>
+                    index === 0 ||
+                    point.dateValue >= result.points[index - 1].dateValue,
+            ),
+        ).toBe(true);
+    });
+
+    test('throws when the metric has no time dimension', async () => {
+        const { service, catalogService } = buildService();
+        (
+            catalogService.getMetric as ReturnType<typeof vi.fn>
+        ).mockResolvedValue({ ...metric, timeDimension: undefined });
+
+        await expect(
+            service.getMetricSeries(
+                user,
+                PROJECT_UUID,
+                EXPLORE_NAME,
+                METRIC_NAME,
+                TimeFrames.WEEK,
+                '2026-01-01',
+                '2026-01-31',
+            ),
+        ).rejects.toThrow('does not have a valid time dimension');
+    });
+});

--- a/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
+++ b/packages/backend/src/services/MetricsExplorerService/MetricsExplorerService.ts
@@ -4,15 +4,19 @@ import {
     getDateRangeFromString,
     getFieldIdForDateDimension,
     getItemId,
+    getMetricExplorerDataPoints,
     getMetricExplorerDateRangeFilters,
     getRollingPeriodDates,
+    isDimension,
     MetricTotalComparisonType,
     MetricTotalResults,
+    ParameterError,
     parseMetricValue,
     QueryExecutionContext,
     TimeFrames,
     type MetricExplorerDateRange,
     type MetricQuery,
+    type MetricsExplorerQueryResults,
     type MetricWithAssociatedTimeDimension,
     type SessionUser,
 } from '@lightdash/common';
@@ -30,6 +34,64 @@ export type MetricsExplorerArguments = {
     catalogService: CatalogService;
     projectService: ProjectService;
     asyncQueryService: AsyncQueryService;
+};
+
+const METRIC_SERIES_LIMIT = 500;
+
+const buildMetricSeriesQuery = ({
+    exploreName,
+    metric,
+    granularity,
+    dateRange,
+}: {
+    exploreName: string;
+    metric: MetricWithAssociatedTimeDimension;
+    granularity: TimeFrames;
+    dateRange: MetricExplorerDateRange;
+}): MetricQuery => {
+    const baseMetricId = getItemId(metric);
+    const metricTimeDimension = metric.timeDimension;
+    if (!metricTimeDimension) {
+        throw new Error('Time dimension not found');
+    }
+
+    const groupByTimeDimensionId = getItemId({
+        table: metricTimeDimension.table,
+        name: getFieldIdForDateDimension(
+            metricTimeDimension.field,
+            granularity,
+        ),
+    });
+
+    const filterTimeDimension = {
+        table: metricTimeDimension.table,
+        field: metricTimeDimension.field,
+        interval: TimeFrames.DAY,
+    };
+    const dateFilters = getMetricExplorerDateRangeFilters(
+        filterTimeDimension,
+        dateRange,
+    );
+
+    return {
+        exploreName,
+        dimensions: [groupByTimeDimensionId],
+        metrics: [baseMetricId],
+        filters: {
+            dimensions: {
+                id: uuidv4(),
+                and: dateFilters,
+            },
+        },
+        sorts: [
+            {
+                fieldId: groupByTimeDimensionId,
+                descending: false,
+            },
+        ],
+        limit: METRIC_SERIES_LIMIT,
+        tableCalculations: [],
+    };
 };
 
 export class MetricsExplorerService extends BaseService {
@@ -143,6 +205,104 @@ export class MetricsExplorerService extends BaseService {
             comparisonValue: parseMetricValue(currentRows[1]?.[baseMetricId]),
             metric,
         };
+    }
+
+    async getMetricSeries(
+        user: SessionUser,
+        projectUuid: string,
+        exploreName: string,
+        metricName: string,
+        granularity: TimeFrames,
+        startDate: string,
+        endDate: string,
+    ): Promise<MetricsExplorerQueryResults> {
+        const { result } = await measureTime(
+            () =>
+                this._getMetricSeries(
+                    user,
+                    projectUuid,
+                    exploreName,
+                    metricName,
+                    granularity,
+                    startDate,
+                    endDate,
+                ),
+            'getMetricSeries',
+            this.logger,
+            { granularity },
+        );
+
+        return result;
+    }
+
+    private async _getMetricSeries(
+        user: SessionUser,
+        projectUuid: string,
+        exploreName: string,
+        metricName: string,
+        granularity: TimeFrames,
+        startDate: string,
+        endDate: string,
+    ): Promise<MetricsExplorerQueryResults> {
+        const metric = await this.catalogService.getMetric(
+            fromSession(user),
+            projectUuid,
+            exploreName,
+            metricName,
+        );
+
+        if (!metric.timeDimension) {
+            throw new ParameterError(
+                `Metric ${metricName} does not have a valid time dimension`,
+            );
+        }
+
+        const isIsoDate = (value: string) => /^\d{4}-\d{2}-\d{2}$/.test(value);
+        if (!isIsoDate(startDate) || !isIsoDate(endDate)) {
+            throw new ParameterError(
+                'startDate and endDate must be YYYY-MM-DD dates',
+            );
+        }
+
+        const dateRange = getDateRangeFromString([startDate, endDate]);
+        const groupByTimeDimensionId = getItemId({
+            table: metric.timeDimension.table,
+            name: getFieldIdForDateDimension(
+                metric.timeDimension.field,
+                granularity,
+            ),
+        });
+        const metricQuery = buildMetricSeriesQuery({
+            exploreName,
+            metric,
+            granularity,
+            dateRange,
+        });
+
+        const { rows, fields } =
+            await this.asyncQueryService.executeMetricQueryAndGetResults({
+                account: fromSession(user),
+                projectUuid,
+                metricQuery,
+                context: QueryExecutionContext.METRICS_EXPLORER,
+            });
+
+        const timeDimension = fields[groupByTimeDimensionId];
+        if (!timeDimension || !isDimension(timeDimension)) {
+            throw new Error('Time dimension not found or invalid');
+        }
+
+        const { dataPoints } = getMetricExplorerDataPoints(
+            timeDimension,
+            metric,
+            rows,
+            null,
+        );
+        const points = dataPoints
+            .map((point) => ({ ...point, dateValue: point.date.valueOf() }))
+            .sort((a, b) => a.dateValue - b.dateValue);
+
+        return { metric, points };
     }
 
     private async buildMetricTotalQuery({

--- a/packages/common/src/types/metricsExplorer.ts
+++ b/packages/common/src/types/metricsExplorer.ts
@@ -1,5 +1,5 @@
 import { type MetricWithAssociatedTimeDimension } from './catalog';
-import { DimensionType, type Dimension, type ItemsMap } from './field';
+import { DimensionType, type Dimension } from './field';
 import { FilterOperator } from './filter';
 
 /**
@@ -68,11 +68,7 @@ export type MetricExploreDataPointWithDateValue = MetricExploreDataPoint & {
 
 export type MetricsExplorerQueryResults = {
     metric: MetricWithAssociatedTimeDimension;
-    compareMetric: MetricWithAssociatedTimeDimension | null;
-    segmentDimension: Dimension | null;
-    fields: ItemsMap;
-    results: MetricExploreDataPointWithDateValue[];
-    hasFilteredSeries: boolean;
+    points: MetricExploreDataPointWithDateValue[];
 };
 
 export type ApiMetricsExplorerQueryResults = {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricSparkline.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricSparkline.module.css
@@ -1,0 +1,5 @@
+.sparkline {
+    display: block;
+    width: 100%;
+    height: 40px;
+}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricSparkline.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricSparkline.tsx
@@ -1,0 +1,68 @@
+import { type MetricExploreDataPointWithDateValue } from '@lightdash/common';
+import { type EChartsOption } from 'echarts';
+import { useMemo, type FC } from 'react';
+import EChartsReact from '../../../../components/EChartsReactWrapper';
+import classes from './MetricSparkline.module.css';
+
+const NEUTRAL_COLOR = 'var(--mantine-color-ldGray-6)';
+const UP_COLOR = 'var(--mantine-color-green-6)';
+const DOWN_COLOR = 'var(--mantine-color-red-6)';
+
+const getSparklineColor = (change: number | undefined): string => {
+    if (change === undefined || change === 0) {
+        return NEUTRAL_COLOR;
+    }
+    return change > 0 ? UP_COLOR : DOWN_COLOR;
+};
+
+type Props = {
+    points: MetricExploreDataPointWithDateValue[];
+    change: number | undefined;
+};
+
+const MetricSparkline: FC<Props> = ({ points, change }) => {
+    const color = getSparklineColor(change);
+
+    const option = useMemo<EChartsOption>(
+        () => ({
+            animation: false,
+            grid: { left: 2, right: 2, top: 4, bottom: 4 },
+            xAxis: {
+                type: 'category',
+                show: false,
+                boundaryGap: false,
+                data: points.map((_, index) => index),
+            },
+            yAxis: {
+                type: 'value',
+                show: false,
+                splitLine: { show: false },
+            },
+            series: [
+                {
+                    type: 'line',
+                    data: points.map((point) => point.metric.value),
+                    smooth: true,
+                    silent: true,
+                    symbol: 'none',
+                    lineStyle: { width: 2, color },
+                    areaStyle: { opacity: 0.08, color },
+                },
+            ],
+            tooltip: { show: false },
+        }),
+        [points, color],
+    );
+
+    return (
+        <EChartsReact
+            className={classes.sparkline}
+            option={option}
+            notMerge
+            opts={{ renderer: 'svg' }}
+            style={{ height: 40, width: '100%' }}
+        />
+    );
+};
+
+export default MetricSparkline;

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
@@ -28,11 +28,18 @@ import { useMemo, useState, type FC } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
-import { useMetricsCatalog } from '../../../../features/metricsCatalog/hooks/useMetricsCatalog';
-import { useRunMetricTotal } from '../../../../features/metricsCatalog/hooks/useRunMetricExplorerQuery';
+import {
+    useMetric,
+    useMetricsCatalog,
+} from '../../../../features/metricsCatalog/hooks/useMetricsCatalog';
+import {
+    useRunMetricSeries,
+    useRunMetricTotal,
+} from '../../../../features/metricsCatalog/hooks/useRunMetricExplorerQuery';
 import { calculateComparisonValue } from '../../../../hooks/useBigNumberConfig';
 import { BlockHeader } from './BlockShell';
 import classes from './blockStyles.module.css';
+import MetricSparkline from './MetricSparkline';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const KPI_TIME_FRAME = TimeFrames.MONTH;
@@ -58,6 +65,29 @@ const MetricKpiCard: FC<{
         options: { retry: false },
     });
 
+    const { data: metric } = useMetric({
+        projectUuid,
+        tableName: metricRef.tableName,
+        metricName: metricRef.metricName,
+    });
+    const timeDimension = metric?.timeDimension ?? null;
+    const granularity = timeDimension?.interval ?? TimeFrames.WEEK;
+    const seriesDateRange = useMemo(
+        () =>
+            timeDimension
+                ? getDefaultDateRangeFromInterval(granularity)
+                : undefined,
+        [timeDimension, granularity],
+    );
+    const seriesQuery = useRunMetricSeries({
+        projectUuid,
+        exploreName: metricRef.tableName,
+        metricName: metricRef.metricName,
+        granularity,
+        dateRange: seriesDateRange,
+        options: { enabled: !!timeDimension, retry: false },
+    });
+
     const change = useMemo(() => {
         const value = totalQuery.data?.value;
         const compareValue = totalQuery.data?.comparisonValue;
@@ -72,7 +102,7 @@ const MetricKpiCard: FC<{
     }, [totalQuery.data]);
 
     if (totalQuery.isInitialLoading) {
-        return <Skeleton h={92} radius="md" />;
+        return <Skeleton h={120} radius="md" />;
     }
 
     return (
@@ -104,6 +134,18 @@ const MetricKpiCard: FC<{
                                   )
                                 : '-'}
                         </div>
+                        {timeDimension &&
+                            (seriesQuery.isInitialLoading ? (
+                                <Skeleton h={40} my={4} radius="sm" />
+                            ) : seriesQuery.data &&
+                              seriesQuery.data.points.length > 0 ? (
+                                <Box my={4}>
+                                    <MetricSparkline
+                                        points={seriesQuery.data.points}
+                                        change={change}
+                                    />
+                                </Box>
+                            ) : null)}
                         <Group gap={6}>
                             {change !== undefined && (
                                 <span

--- a/packages/frontend/src/features/metricsCatalog/hooks/useRunMetricExplorerQuery.ts
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useRunMetricExplorerQuery.ts
@@ -1,6 +1,7 @@
 import {
     METRICS_EXPLORER_DATE_FORMAT,
     type ApiCompiledQueryResults,
+    type ApiMetricsExplorerQueryResults,
     type ApiMetricsExplorerTotalResults,
     type MetricExplorerDateRange,
     type MetricTotalComparisonType,
@@ -110,6 +111,67 @@ const postCompileMetricTotalQuery = async ({
             comparisonType,
             rollingDays,
         }),
+    });
+};
+
+type RunMetricSeriesArgs = {
+    projectUuid: string;
+    exploreName: string;
+    metricName: string;
+    dateRange: MetricExplorerDateRange;
+    granularity: TimeFrames;
+};
+
+const postRunMetricSeries = async ({
+    projectUuid,
+    exploreName,
+    metricName,
+    dateRange,
+    granularity,
+}: RunMetricSeriesArgs) => {
+    const queryString = getUrlParams({
+        dateRange,
+        granularity,
+    });
+
+    return lightdashApi<ApiMetricsExplorerQueryResults['results']>({
+        url: `/projects/${projectUuid}/metricsExplorer/${exploreName}/${metricName}/runMetricSeries${
+            queryString ? `?${queryString}` : ''
+        }`,
+        method: 'POST',
+        body: undefined,
+    });
+};
+
+export const useRunMetricSeries = ({
+    projectUuid,
+    exploreName,
+    metricName,
+    dateRange,
+    granularity,
+    options,
+}: Partial<RunMetricSeriesArgs> & {
+    options?: UseQueryOptions<ApiMetricsExplorerQueryResults['results']>;
+}) => {
+    return useQuery({
+        queryKey: [
+            'runMetricSeries',
+            projectUuid,
+            exploreName,
+            metricName,
+            granularity,
+            dateRange?.[0],
+            dateRange?.[1],
+        ],
+        queryFn: () =>
+            postRunMetricSeries({
+                projectUuid: projectUuid!,
+                exploreName: exploreName!,
+                metricName: metricName!,
+                dateRange: dateRange!,
+                granularity: granularity!,
+            }),
+        ...options,
     });
 };
 


### PR DESCRIPTION
Renders each homepage metrics KPI tile with a **sparkline** alongside the existing number + delta. Independent PR off main (design: the metrics block already showed number + % delta; only the sparkline was missing).

## Changes
- **Backend:** new `POST /api/v1/projects/{projectUuid}/metricsExplorer/{explore}/{metric}/runMetricSeries` (query: `granularity`, `startDate`, `endDate`). `MetricsExplorerService.getMetricSeries` mirrors the existing total query but groups by the metric's associated time dimension over the window (single-range `and` filter, asc sort, `limit 500`), returning `{ metric, points }`. Auth inherits from `CatalogService.getMetric` + `AsyncQueryService` — the viewer runs the query as themselves, so low-permission homepage viewers degrade per-tile.
- **Common:** trimmed the dormant `MetricsExplorerQueryResults` type to `{ metric, points }`.
- **Frontend:** `useRunMetricSeries` hook; `MetricSparkline` (echarts SVG, non-interactive, green/red/neutral by delta sign); wired into `MetricKpiCard` between value and delta, with loading skeleton, per-tile error reuse, and a number-only fallback when a metric has no time dimension. Granularity/window derived from `timeDimension.interval`.

## Verification
`common` build, backend + frontend typecheck, 3 new backend unit tests (asc order, limit 500, `and`-not-`or`, no-time-dimension throw), and lint all pass. **Live-verification of the rendered tile pending** (kept draft until confirmed).

## Follow-up
Each tile currently fires total + series = 2 calls. The design's fold/batch optimization (one response per tile) was intentionally deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)