### PR TITLE
fix(cli): actionable error when preview creation fails with no source project selected

### DIFF
--- a/packages/cli/src/handlers/dbt/apiClient.ts
+++ b/packages/cli/src/handlers/dbt/apiClient.ts
@@ -299,6 +299,14 @@ export const checkProjectCreationPermission = async (
                     return;
                 }
 
+                if (!upstreamProjectUuid) {
+                    throw new ForbiddenError(
+                        `No source project is selected. If your role allows creating previews from specific projects, that permission only applies when a source project is selected.\n` +
+                            `Run 'lightdash config set-project' to select a source project and try again.\n` +
+                            `If that doesn't help, contact your organization admin to request access to preview projects.`,
+                    );
+                }
+
                 throw new ForbiddenError(
                     `You don't have permission to create preview projects in this organization.\n` +
                         `This typically requires the 'developer' or 'admin' role.\n` +


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8947/cli-shows-misleading-permission-error-when-preview-has-no-source

### Description:
Project-scoped preview permissions (e.g. a custom role with create:Project@preview) only apply when a source project is selected. Previously the CLI fell back to the org-level check and reported that the 'developer' or 'admin' role was required, making a valid project-level role appear broken.


### Before:
<img width="967" height="286" alt="before" src="https://github.com/user-attachments/assets/f07a2630-8b65-403a-bf97-4bd1cbfc3e98" />


### After:
<img width="1294" height="286" alt="Screenshot 2026-07-16 at 14 22 38" src="https://github.com/user-attachments/assets/b3185fb1-1b8f-49aa-a91c-0debb4840ece" />
