### PR TITLE
fix: make prod image boot fully offline under non-root users

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -7,9 +7,11 @@ FROM node:20-bookworm-slim AS pnpm-base
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+# Fixed world-readable path so the pnpm cache resolves under any runtime UID (non-root securityContexts)
+ENV COREPACK_HOME="/usr/local/corepack"
 RUN npm i -g corepack@latest
 RUN corepack enable
-RUN corepack prepare pnpm@10.33.0 --activate
+RUN corepack prepare pnpm@10.33.0 --activate && chmod -R a+rX "$COREPACK_HOME"
 RUN pnpm config set store-dir /pnpm/store
 
 WORKDIR /usr/app
@@ -361,6 +363,8 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 FROM pnpm-base as prod
 
 ENV NODE_ENV production
+# Boot must work fully offline: pnpm is baked in, never fetch it from npmjs at runtime
+ENV COREPACK_ENABLE_NETWORK=0
 
 WORKDIR /usr/app
 


### PR DESCRIPTION
## Problem

In air-gapped / no-egress deployments running the container with a non-root securityContext (standard in hardened Kubernetes/OpenShift), startup fails trying to reach `registry.npmjs.org`:

```
! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-10.33.0.tgz
Network access disabled by the environment; can't reach https://registry.npmjs.org/pnpm/-/pnpm-10.33.0.tgz
```

The pinned pnpm **is** baked into the image, but `corepack prepare` runs as root at build time, so the cache lands in `/root/.cache/node/corepack` (mode 700). Any non-root runtime UID resolves a different `$HOME`, misses the cache, and Corepack falls back to downloading — a hard failure without npmjs egress. Root-run containers are unaffected (verified: cache hits are fully offline).

## Fix

- `COREPACK_HOME=/usr/local/corepack` in `pnpm-base`, world-readable after `corepack prepare` — the cache resolves under any runtime UID.
- `COREPACK_ENABLE_NETWORK=0` in the `prod` stage — boot never falls back to npmjs; a `packageManager` pin that drifts from the baked version fails loudly instead of silently downloading (which would have broken air-gapped installs anyway).

The entrypoint and `migrate-production` script are unchanged. Build stages are unaffected (same cache path, network available).

## Verification

All with `--network none`, real `packageManager` pin mounted:

| Scenario | Before | After |
|---|---|---|
| root | ✅ | ✅ |
| non-root uid 4242 | ❌ download attempt | ✅ |
| OpenShift-style uid 1000680000:0 | ❌ | ✅ |

The failing case reproduces the reported error byte-for-byte. A temporary CI smoke job (build pnpm-base, run `pnpm --version` with `--network none --user 1000680000:0`) also passed on an earlier revision of this PR before being dropped from the final diff: https://github.com/lightdash/lightdash/actions/runs/29505298926/job/87644578113

Closes: PROD-8930
Closes: #25617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

