### PR TITLE
fix: prevent stale cross-tab prune from collapsing active AI launcher thread

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
@@ -48,7 +48,7 @@ const AiAgentsLauncherInner: FC = () => {
 
     const isAiAgentEnabled = useAiAgentButtonVisibility();
 
-    const { agents, selectedAgent, isResolving } =
+    const { agents, agentsUpdatedAt, selectedAgent, isResolving } =
         useDefaultAiAgent(activeProjectUuid);
 
     const dispatch = useAiAgentStoreDispatch();
@@ -169,6 +169,7 @@ const AiAgentsLauncherInner: FC = () => {
             <LauncherDock
                 projectUuid={activeProjectUuid}
                 agents={agents}
+                agentsUpdatedAt={agentsUpdatedAt}
                 selectedAgent={selectedAgent}
             />
             {transitionSavedChartPreview && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherDock.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherDock.tsx
@@ -22,12 +22,14 @@ import { useLauncherDock } from './useLauncherDock';
 type Props = {
     projectUuid: string;
     agents: AiAgentSummary[];
+    agentsUpdatedAt: number;
     selectedAgent: LauncherSelectedAgent;
 };
 
 export const LauncherDock: FC<Props> = ({
     projectUuid,
     agents,
+    agentsUpdatedAt,
     selectedAgent,
 }) => {
     const dispatch = useAiAgentStoreDispatch();
@@ -52,13 +54,18 @@ export const LauncherDock: FC<Props> = ({
         [agentsByUuid, dock],
     );
 
+    // The dock is shared across tabs: only prune deleted-agent items when this
+    // tab's agents list is newer than the item, else a stale cache in another
+    // tab would delete a thread created after it was fetched.
     useEffect(() => {
         dock.forEach((item) => {
+            if (item.threadId === activeThreadId) return;
+            if (agentsUpdatedAt <= (item.createdAt ?? 0)) return;
             if (!agentsByUuid.has(item.agentUuid)) {
                 removeItem(item.threadId);
             }
         });
-    }, [agentsByUuid, dock, removeItem]);
+    }, [activeThreadId, agentsByUuid, agentsUpdatedAt, dock, removeItem]);
 
     const handleSelect = (item: LauncherDockItem) => {
         dispatch(

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherDockProvider.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherDockProvider.tsx
@@ -41,7 +41,10 @@ export const LauncherDockProvider: FC<PropsWithChildren> = ({ children }) => {
                 );
                 return {
                     ...(prev ?? {}),
-                    [projectUuid]: trim([...without, item]),
+                    [projectUuid]: trim([
+                        ...without,
+                        { ...item, createdAt: item.createdAt ?? Date.now() },
+                    ]),
                 };
             });
         },

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/useDefaultAiAgent.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/useDefaultAiAgent.ts
@@ -51,6 +51,7 @@ export const useDefaultAiAgent = (projectUuid: string | undefined) => {
         agent: getConcreteLauncherAgent(selectedAgent),
         selectedAgent,
         agents: agents ?? [],
+        agentsUpdatedAt: agentsQuery.dataUpdatedAt,
         isResolving,
     };
 };

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
@@ -6,6 +6,8 @@ export type LauncherDockItem = {
     threadId: string;
     agentUuid: string;
     title: string;
+    // Optional: missing on items persisted before this field existed.
+    createdAt?: number;
 };
 
 export type LauncherPendingContext = {


### PR DESCRIPTION
### Description

The AI launcher dock is localStorage shared across tabs, and every tab pruned dock items against its own react-query agents cache. A tab whose agents list was fetched before a new agent existed would delete the freshly created thread's dock item, silently reverting the owning tab's panel to the empty composer while the response streamed invisibly (every retry created another orphaned thread).

Dock items now carry a `createdAt` timestamp and a tab only prunes an item when its agents list was fetched after the item was created, so a stale cache can never vouch for an agent's deletion. The active thread is never pruned. Legacy items without `createdAt` keep the old prune behavior, so cleanup of genuinely stale chips (#25162) still works.

### Testing

- Injected a dock item for a missing agent with `createdAt` newer than the agents fetch → survives; a legacy item without `createdAt` → pruned
- Asked a question via the dashboard Ask AI pill → thread view renders and streams, dock item written with `createdAt`
- `pnpm -F frontend typecheck:fast`, lint on changed files

Closes: PROD-8954
