### PR TITLE
style(homepage): compact single-line slash-command menu

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/SlashCommandMenuItem.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/SlashCommandMenuItem.module.css
@@ -1,23 +1,10 @@
-.iconSquare {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    width: 26px;
-    height: 26px;
-    border-radius: 6px;
-    background-color: var(--mantine-color-ldGray-1);
-    color: var(--mantine-color-ldGray-6);
-
-    @mixin dark {
-        background-color: var(--mantine-color-ldDark-4);
-        color: var(--mantine-color-ldGray-6);
-    }
+.item {
+    padding: 4px 8px;
 }
 
-.text {
-    min-width: 0;
-    flex: 1;
+.icon {
+    flex-shrink: 0;
+    color: var(--mantine-color-ldGray-6);
 }
 
 .label {
@@ -28,9 +15,4 @@
     @mixin dark {
         color: var(--mantine-color-ldGray-8);
     }
-}
-
-.description {
-    font-size: 11.5px;
-    color: var(--mantine-color-ldGray-5);
 }

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/SlashCommandMenuItem.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/markdownEditor/SlashCommandMenuItem.tsx
@@ -1,4 +1,4 @@
-import { Group, Stack, Text } from '@mantine-8/core';
+import { Group, Text } from '@mantine-8/core';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { PolymorphicGroupButton } from '../../../../../components/common/PolymorphicGroupButton';
 import suggestionStyles from '../../../../../components/common/SuggestionList/SuggestionList.module.css';
@@ -12,19 +12,12 @@ export const renderSlashCommandItem = (
 ) => (
     <PolymorphicGroupButton
         onClick={onClick}
-        className={suggestionStyles.suggestionItem}
+        className={`${suggestionStyles.suggestionItem} ${classes.item}`}
         data-selected={isSelected}
     >
-        <Group wrap="nowrap" gap="xs">
-            <div className={classes.iconSquare}>
-                <MantineIcon icon={item.icon} size={14} />
-            </div>
-            <Stack gap={0} className={classes.text}>
-                <Text className={classes.label}>{item.label}</Text>
-                <Text className={classes.description} truncate>
-                    {item.description}
-                </Text>
-            </Stack>
+        <Group wrap="nowrap" gap={8}>
+            <MantineIcon icon={item.icon} size={14} className={classes.icon} />
+            <Text className={classes.label}>{item.label}</Text>
         </Group>
     </PolymorphicGroupButton>
 );


### PR DESCRIPTION
The markdown block's `/` add-element menu had tall two-line items (label + description) with a 26px icon square. Made each option a **single-line row** — small inline icon + label only — so the menu is much shorter and cleaner. Labels (Text, Heading 1, Bulleted list, Quote, Divider…) are self-explanatory, so the description line was pure height.

Live-verified: all 9 options fit in a compact low-height list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)