### PR TITLE
fix(scim): support Entra quoted primary role mappings

### DIFF
--- a/packages/backend/src/ee/controllers/scimUserController.ts
+++ b/packages/backend/src/ee/controllers/scimUserController.ts
@@ -69,6 +69,7 @@ export class ScimUserController extends BaseController {
                         value: 'viewer',
                         display: 'Viewer',
                         type: 'Organization',
+                        primary: true,
                     },
                     {
                         value: '3675b69e-8324-4110-bdca-059031aa8da3:editor',
@@ -136,6 +137,7 @@ export class ScimUserController extends BaseController {
                 value: 'viewer',
                 display: 'Viewer',
                 type: 'Organization',
+                primary: true,
             },
             {
                 value: '3675b69e-8324-4110-bdca-059031aa8da3:editor',

--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -687,6 +687,43 @@ describe('ScimService', () => {
                 }),
             );
         });
+
+        test.each([
+            'roles[primary eq true].value',
+            'roles[primary eq "True"].value',
+        ])(
+            'should replace the primary organization role using Entra path %s',
+            async (path) => {
+                const { rolesModel } = ScimServiceArgumentsMock;
+                const patchOp: ScimPatch = {
+                    schemas: [ScimSchemaType.PATCH],
+                    Operations: [
+                        {
+                            op: 'Add',
+                            path,
+                            value: OrganizationMemberRole.INTERACTIVE_VIEWER,
+                        },
+                    ],
+                };
+
+                await service.patchUser({
+                    account: mockScimAccount,
+                    userUuid: mockUser.userUuid,
+                    organizationUuid: mockUser.organizationUuid,
+                    patchOp,
+                });
+
+                expect(
+                    rolesModel.setUserOrgAndProjectRoles,
+                ).toHaveBeenCalledWith(
+                    mockUser.organizationUuid,
+                    mockUser.userUuid,
+                    OrganizationMemberRole.INTERACTIVE_VIEWER,
+                    [],
+                    true,
+                );
+            },
+        );
     });
 
     describe('updateGroup', () => {

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -70,6 +70,15 @@ type ScimServiceArguments = {
 
 const NO_ROLE_KEYWORD = 'no-role';
 
+// Entra exposes roles[primary eq "True"].value as a target mapping, even
+// though SCIM defines primary as a boolean. Normalize that specific filter
+// so the patch library can match our standards-compliant primary: true value.
+const normalizeScimPatchPath = (path: string): string =>
+    path.replace(
+        /roles\s*\[\s*primary\s+eq\s+["']true["']\s*\]/gi,
+        'roles[primary eq true]',
+    );
+
 export class ScimService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
 
@@ -1003,7 +1012,14 @@ export class ScimService extends BaseService {
             // use lib to construct patched user object
             const patchedDbUserObj = scimPatch(
                 scimDbUser as PatchLibScimResource,
-                patchOp.Operations,
+                patchOp.Operations.map((operation) =>
+                    operation.path === undefined
+                        ? operation
+                        : {
+                              ...operation,
+                              path: normalizeScimPatchPath(operation.path),
+                          },
+                ),
             );
             this.logger.info('SCIM: Applied patch operations to user', {
                 userUuid,
@@ -2053,7 +2069,12 @@ export class ScimService extends BaseService {
                     (role) => role.value === user.role,
                 );
                 if (scimRole) {
-                    allRoles.push(scimRole);
+                    allRoles.push({
+                        value: scimRole.value,
+                        display: scimRole.display,
+                        type: scimRole.type,
+                        primary: true,
+                    });
                 }
             }
 


### PR DESCRIPTION
### Problem
Microsoft Entra maps app roles using roles[primary eq "True"].value. Lightdash currently doesn’t identify the organization role as primary, and the quoted "True" doesn’t match SCIM’s boolean true.

When an existing user’s role changes, Entra appends the new role instead of replacing the old one. Lightdash then rejects the update because it contains two organization roles.

### Fix
- Mark the organization role as primary: true.
- Support Entra’s quoted "True" mapping.
- Preserve support for the standard boolean true mapping.

This allows Entra to migrate existing users between organization roles successfully.
