### PR TITLE
fix: group Explorer selected fields by table and show row actions on hover

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.module.css
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.module.css
@@ -80,16 +80,6 @@
     background-color: var(--ld-field-default-bg-hover);
 }
 
-/* Inner flex so the field and table labels align on their text baselines
-   despite different font sizes */
-.labels {
-    display: flex;
-    align-items: baseline;
-    gap: 8px;
-    min-width: 0;
-    flex: 1 1 auto;
-}
-
 .actions {
     display: flex;
     align-items: center;
@@ -99,33 +89,22 @@
 }
 
 .label {
+    flex: 1 1 auto;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     font-size: 14px;
+    text-align: left;
 }
 
-/* Large shrink factor so the table name yields before the field name */
-.tableLabel {
-    flex-shrink: 1000;
-    min-width: 4ch;
-    overflow: hidden;
-    text-overflow: ellipsis;
+.groupHeader {
+    flex-shrink: 0;
+    padding: 4px 12px;
     font-size: 12px;
-    white-space: nowrap;
-}
-
-.row[data-field-kind='dimension'] .tableLabel {
-    color: var(--ld-field-dimension-color);
-}
-
-.row[data-field-kind='metric'] .tableLabel {
-    color: var(--ld-field-metric-color);
-}
-
-.row[data-field-kind='default'] .tableLabel {
-    color: var(--ld-field-default-color);
+    font-weight: 500;
+    color: var(--mantine-color-ldGray-6);
+    user-select: none;
 }
 
 @keyframes row-enter {

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.module.css
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.module.css
@@ -106,8 +106,12 @@
     font-size: 14px;
 }
 
+/* Large shrink factor so the table name yields before the field name */
 .tableLabel {
-    flex-shrink: 0;
+    flex-shrink: 1000;
+    min-width: 4ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
     font-size: 12px;
     white-space: nowrap;
 }

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -11,6 +11,7 @@ import { UnstyledButton, ActionIcon } from '@mantine-8/core';
 import { Tooltip } from '@mantine/core';
 import { IconFilter } from '@tabler/icons-react';
 import {
+    Fragment,
     memo,
     useCallback,
     useEffect,
@@ -64,7 +65,7 @@ type RowProps = {
 };
 
 const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
-    const { fieldId, item, tableLabel, isDimension: isDim, isExiting } = row;
+    const { fieldId, item, isDimension: isDim, isExiting } = row;
 
     const dispatch = useExplorerDispatch();
     const addFilter = useAddFilter();
@@ -148,15 +149,8 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
             data-testid={`selected-field-${fieldId}`}
         >
             <FieldIcon item={item} size="md" />
-            <span className={classes.labels}>
-                <span className={classes.label} title={label}>
-                    {label}
-                </span>
-                {tableLabel && (
-                    <span className={classes.tableLabel} title={tableLabel}>
-                        {tableLabel}
-                    </span>
-                )}
+            <span className={classes.label} title={label}>
+                {label}
             </span>
             <span className={classes.actions}>
                 {showFilterAction && (
@@ -294,18 +288,47 @@ const SelectedFieldsSectionComponent: FC<Props> = ({ fields, onDeselect }) => {
         return result;
     }, [fields, exitingFields]);
 
+    // Group rows by table, groups ordered by first appearance
+    const groups = useMemo(() => {
+        const result: { tableLabel: string | null; rows: RenderedRow[] }[] = [];
+        const byLabel = new Map<string | null, RenderedRow[]>();
+        rows.forEach((row) => {
+            const groupRows = byLabel.get(row.tableLabel);
+            if (groupRows) {
+                groupRows.push(row);
+            } else {
+                const newGroupRows = [row];
+                byLabel.set(row.tableLabel, newGroupRows);
+                result.push({
+                    tableLabel: row.tableLabel,
+                    rows: newGroupRows,
+                });
+            }
+        });
+        return result;
+    }, [rows]);
+
     if (rows.length === 0) return null;
 
     return (
         <div className={classes.section}>
             <div className={classes.divider}>Selected</div>
             <div className={classes.list} data-testid="SelectedFieldsSection">
-                {rows.map((row) => (
-                    <SelectedFieldRow
-                        key={row.fieldId}
-                        row={row}
-                        onDeselect={onDeselect}
-                    />
+                {groups.map((group) => (
+                    <Fragment key={group.tableLabel ?? '__no_table__'}>
+                        {group.tableLabel && (
+                            <div className={classes.groupHeader}>
+                                {group.tableLabel}
+                            </div>
+                        )}
+                        {group.rows.map((row) => (
+                            <SelectedFieldRow
+                                key={row.fieldId}
+                                row={row}
+                                onDeselect={onDeselect}
+                            />
+                        ))}
+                    </Fragment>
                 ))}
             </div>
             <div className={classes.divider}>All fields</div>

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -153,7 +153,9 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
                     {label}
                 </span>
                 {tableLabel && (
-                    <span className={classes.tableLabel}>{tableLabel}</span>
+                    <span className={classes.tableLabel} title={tableLabel}>
+                        {tableLabel}
+                    </span>
                 )}
             </span>
             <span className={classes.actions}>
@@ -175,15 +177,18 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
                         </ActionIcon>
                     </Tooltip>
                 )}
-                <TreeSingleNodeActions
-                    item={item}
-                    isHovered={isHover}
-                    isSelected
-                    isOpened={isMenuOpen}
-                    hasDescription={!!description}
-                    onViewDescription={onOpenDescriptionView}
-                    onMenuChange={onToggleMenu}
-                />
+                {/* Mounted on hover only so the labels get the space at rest */}
+                {(isHover || isMenuOpen) && (
+                    <TreeSingleNodeActions
+                        item={item}
+                        isHovered={isHover}
+                        isSelected={false}
+                        isOpened={isMenuOpen}
+                        hasDescription={!!description}
+                        onViewDescription={onOpenDescriptionView}
+                        onMenuChange={onToggleMenu}
+                    />
+                )}
             </span>
         </UnstyledButton>
     );


### PR DESCRIPTION
## Summary

In the pinned "Selected" section of the Explorer field tree, each row showed the field name and the table name inline. The table label had `flex-shrink: 0`, so with a long table name the field name was truncated instead — and at narrow widths both ended up with ellipses.

This groups the Selected section by table instead:

- Rows are grouped under a small per-table header (groups ordered by first appearance in the selection), and each row shows only the field icon + name — a single, rarely-needed ellipsis instead of two.
- Row actions (filter + 3-dot menu) now mount on hover only (and stay while the menu is open), matching the rest of the sidebar. Previously a hidden 28px placeholder still reserved the space; now the label gets the full row width at rest.
- Deselect exit animations, re-select mid-exit, and per-kind row colors are unchanged; a group's header disappears once its last row finishes animating out.

## Testing

- Verified in the Explorer with fields from two joined tables: grouped headers, hover-only actions, group header removal on deselect, and truncation at narrow sidebar widths.
- `pnpm -F frontend typecheck:fast` and lint pass.

Closes: PROD-8939
Closes: #25631

🤖 Generated with [Claude Code](https://claude.com/claude-code)