### PR TITLE
fix: derive inherited space role from custom role scopes

### DIFF
--- a/packages/backend/src/models/SpacePermissionModel.ts
+++ b/packages/backend/src/models/SpacePermissionModel.ts
@@ -22,6 +22,7 @@ import { OrganizationTableName } from '../database/entities/organizations';
 import { ProjectGroupAccessTableName } from '../database/entities/projectGroupAccess';
 import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
 import { ProjectTableName } from '../database/entities/projects';
+import { ScopedRolesTableName } from '../database/entities/roles';
 import {
     SpaceGroupAccessTableName,
     SpaceTableName,
@@ -47,6 +48,15 @@ export type RawSpaceGroupAccess = {
 export type RawSpaceDirectAccess = {
     users: RawSpaceUserAccess[];
     groups: RawSpaceGroupAccess[];
+};
+
+/**
+ * Custom-role assignments persist a placeholder `viewer` in `role` and the
+ * real role in `role_uuid`, so callers need the uuid to derive the
+ * effective role from the custom role's scopes.
+ */
+export type ProjectSpaceAccessWithCustomRole = ProjectSpaceAccess & {
+    roleUuid: string | null;
 };
 
 export class SpacePermissionModel {
@@ -355,89 +365,93 @@ export class SpacePermissionModel {
         spaceUuids: string[],
         filters?: { userUuid?: string },
         { trx = this.database }: { trx?: Knex } = {},
-    ): Promise<Record<string, ProjectSpaceAccess[]>> {
+    ): Promise<Record<string, ProjectSpaceAccessWithCustomRole[]>> {
         return wrapSentryTransaction(
             'SpaceModel.getProjectSpaceAccess',
             { spaceUuidsCount: spaceUuids.length },
             async () => {
-                const projectSpacesAccess: ProjectSpaceAccess[] = await trx(
-                    SpaceTableName,
-                )
-                    .select({
-                        userUuid: `${UserTableName}.user_uuid`,
-                        spaceUuid: `${SpaceTableName}.space_uuid`,
-                        role: `${ProjectMembershipsTableName}.role`,
-                        from: trx.raw(
-                            `'${ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP}'`,
-                        ),
-                    })
-                    .innerJoin(
-                        ProjectTableName,
-                        `${ProjectTableName}.project_id`,
-                        `${SpaceTableName}.project_id`,
-                    )
-                    .innerJoin(
-                        ProjectMembershipsTableName,
-                        `${ProjectMembershipsTableName}.project_id`,
-                        `${ProjectTableName}.project_id`,
-                    )
-                    .innerJoin(
-                        UserTableName,
-                        `${UserTableName}.user_id`,
-                        `${ProjectMembershipsTableName}.user_id`,
-                    )
-                    .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
-                    .modify((qb) => {
-                        if (filters?.userUuid) {
-                            void qb.where(
-                                `${UserTableName}.user_uuid`,
-                                filters.userUuid,
-                            );
-                        }
-                    })
-                    .union(
-                        trx(SpaceTableName)
-                            .select({
-                                userUuid: `${UserTableName}.user_uuid`,
-                                spaceUuid: `${SpaceTableName}.space_uuid`,
-                                role: `${ProjectGroupAccessTableName}.role`,
-                                from: trx.raw(
-                                    `'${ProjectSpaceAccessOrigin.GROUP_MEMBERSHIP}'`,
-                                ),
-                            })
-                            .innerJoin(
-                                ProjectTableName,
-                                `${ProjectTableName}.project_id`,
-                                `${SpaceTableName}.project_id`,
-                            )
-                            .innerJoin(
-                                ProjectGroupAccessTableName,
-                                `${ProjectGroupAccessTableName}.project_uuid`,
-                                `${ProjectTableName}.project_uuid`,
-                            )
-                            .innerJoin(
-                                GroupMembershipTableName,
-                                `${GroupMembershipTableName}.group_uuid`,
-                                `${ProjectGroupAccessTableName}.group_uuid`,
-                            )
-                            .innerJoin(
-                                UserTableName,
-                                `${UserTableName}.user_id`,
-                                `${GroupMembershipTableName}.user_id`,
-                            )
-                            .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
-                            .modify((qb) => {
-                                if (filters?.userUuid) {
-                                    void qb.where(
-                                        `${UserTableName}.user_uuid`,
-                                        filters.userUuid,
-                                    );
-                                }
-                            }),
-                    );
+                const projectSpacesAccess: ProjectSpaceAccessWithCustomRole[] =
+                    await trx(SpaceTableName)
+                        .select({
+                            userUuid: `${UserTableName}.user_uuid`,
+                            spaceUuid: `${SpaceTableName}.space_uuid`,
+                            role: `${ProjectMembershipsTableName}.role`,
+                            roleUuid: `${ProjectMembershipsTableName}.role_uuid`,
+                            from: trx.raw(
+                                `'${ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP}'`,
+                            ),
+                        })
+                        .innerJoin(
+                            ProjectTableName,
+                            `${ProjectTableName}.project_id`,
+                            `${SpaceTableName}.project_id`,
+                        )
+                        .innerJoin(
+                            ProjectMembershipsTableName,
+                            `${ProjectMembershipsTableName}.project_id`,
+                            `${ProjectTableName}.project_id`,
+                        )
+                        .innerJoin(
+                            UserTableName,
+                            `${UserTableName}.user_id`,
+                            `${ProjectMembershipsTableName}.user_id`,
+                        )
+                        .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+                        .modify((qb) => {
+                            if (filters?.userUuid) {
+                                void qb.where(
+                                    `${UserTableName}.user_uuid`,
+                                    filters.userUuid,
+                                );
+                            }
+                        })
+                        .union(
+                            trx(SpaceTableName)
+                                .select({
+                                    userUuid: `${UserTableName}.user_uuid`,
+                                    spaceUuid: `${SpaceTableName}.space_uuid`,
+                                    role: `${ProjectGroupAccessTableName}.role`,
+                                    roleUuid: `${ProjectGroupAccessTableName}.role_uuid`,
+                                    from: trx.raw(
+                                        `'${ProjectSpaceAccessOrigin.GROUP_MEMBERSHIP}'`,
+                                    ),
+                                })
+                                .innerJoin(
+                                    ProjectTableName,
+                                    `${ProjectTableName}.project_id`,
+                                    `${SpaceTableName}.project_id`,
+                                )
+                                .innerJoin(
+                                    ProjectGroupAccessTableName,
+                                    `${ProjectGroupAccessTableName}.project_uuid`,
+                                    `${ProjectTableName}.project_uuid`,
+                                )
+                                .innerJoin(
+                                    GroupMembershipTableName,
+                                    `${GroupMembershipTableName}.group_uuid`,
+                                    `${ProjectGroupAccessTableName}.group_uuid`,
+                                )
+                                .innerJoin(
+                                    UserTableName,
+                                    `${UserTableName}.user_id`,
+                                    `${GroupMembershipTableName}.user_id`,
+                                )
+                                .whereIn(
+                                    `${SpaceTableName}.space_uuid`,
+                                    spaceUuids,
+                                )
+                                .modify((qb) => {
+                                    if (filters?.userUuid) {
+                                        void qb.where(
+                                            `${UserTableName}.user_uuid`,
+                                            filters.userUuid,
+                                        );
+                                    }
+                                }),
+                        );
 
                 return projectSpacesAccess.reduce<
-                    Record<string, ProjectSpaceAccess[]>
+                    Record<string, ProjectSpaceAccessWithCustomRole[]>
                 >((acc, projectSpaceAccess) => {
                     if (!acc[projectSpaceAccess.spaceUuid]) {
                         acc[projectSpaceAccess.spaceUuid] = [];
@@ -447,6 +461,36 @@ export class SpacePermissionModel {
                     return acc;
                 }, {});
             },
+        );
+    }
+
+    /**
+     * Gets the scope names for a list of custom roles
+     * @param roleUuids - the uuids of the roles to get scopes for
+     * @returns a record of role uuids to scope names
+     */
+    async getRoleScopes(
+        roleUuids: string[],
+        { trx = this.database }: { trx?: Knex } = {},
+    ): Promise<Record<string, string[]>> {
+        if (roleUuids.length === 0) return {};
+
+        const rows = await trx(ScopedRolesTableName)
+            .whereIn('role_uuid', roleUuids)
+            .select<{ roleUuid: string; scopeName: string }[]>({
+                roleUuid: 'role_uuid',
+                scopeName: 'scope_name',
+            });
+
+        return rows.reduce<Record<string, string[]>>(
+            (acc, { roleUuid, scopeName }) => {
+                if (!acc[roleUuid]) {
+                    acc[roleUuid] = [];
+                }
+                acc[roleUuid].push(scopeName);
+                return acc;
+            },
+            {},
         );
     }
 

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -9,13 +9,15 @@ import {
     type OrganizationSpaceAccess,
     type PossibleAbilities,
     type ProjectMemberRole,
-    type ProjectSpaceAccess,
     type SessionUser,
     type SpaceInheritanceChain,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
 import { SpaceModel } from '../../models/SpaceModel';
-import { SpacePermissionModel } from '../../models/SpacePermissionModel';
+import {
+    SpacePermissionModel,
+    type ProjectSpaceAccessWithCustomRole,
+} from '../../models/SpacePermissionModel';
 import { SpacePermissionService } from './SpacePermissionService';
 
 const createMockSpacePermissionModel = () => ({
@@ -40,7 +42,14 @@ const createMockSpacePermissionModel = () => ({
                 spaceUuids: string[],
                 filters?: { userUuid?: string },
                 options?: { trx?: Knex },
-            ) => Promise<Record<string, ProjectSpaceAccess[]>>
+            ) => Promise<Record<string, ProjectSpaceAccessWithCustomRole[]>>
+        >(),
+    getRoleScopes:
+        vi.fn<
+            (
+                roleUuids: string[],
+                options?: { trx?: Knex },
+            ) => Promise<Record<string, string[]>>
         >(),
     getOrganizationSpaceAccess:
         vi.fn<
@@ -185,6 +194,7 @@ describe('SpacePermissionService', () => {
                         userUuid,
                         spaceUuid: 'root-space',
                         role: 'editor' as ProjectMemberRole,
+                        roleUuid: null,
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                 ],
@@ -220,6 +230,74 @@ describe('SpacePermissionService', () => {
             ).toHaveBeenCalledWith(['root-space'], undefined, {
                 trx: undefined,
             });
+            // System-role access needs no scope lookup
+            expect(mockPermissionModel.getRoleScopes).not.toHaveBeenCalled();
+        });
+
+        test('custom-role holders get the space role derived from their scopes, not the placeholder role column', async () => {
+            const spaceUuid = 'root-space';
+            const customRoleUuid = 'custom-role-uuid';
+
+            mockPermissionModel.getInheritanceChains.mockResolvedValue({
+                'root-space': {
+                    chain: [
+                        {
+                            spaceUuid: 'root-space',
+                            spaceName: 'Root',
+                            inheritParentPermissions: true,
+                        },
+                    ],
+                    inheritsFromOrgOrProject: true,
+                },
+            });
+            mockPermissionModel.getDirectSpaceAccess.mockResolvedValue({});
+            // Custom-role assignments persist `role: viewer` as a placeholder
+            mockPermissionModel.getProjectSpaceAccess.mockResolvedValue({
+                'root-space': [
+                    {
+                        userUuid,
+                        spaceUuid: 'root-space',
+                        role: 'viewer' as ProjectMemberRole,
+                        roleUuid: customRoleUuid,
+                        from: ProjectSpaceAccessOrigin.GROUP_MEMBERSHIP,
+                    },
+                ],
+            });
+            mockPermissionModel.getOrganizationSpaceAccess.mockResolvedValue({
+                'root-space': [
+                    {
+                        userUuid,
+                        spaceUuid: 'root-space',
+                        role: 'member' as OrganizationMemberRole,
+                    },
+                ],
+            });
+            mockPermissionModel.getSpaceInfo.mockResolvedValue({
+                [spaceUuid]: {
+                    projectUuid,
+                    organizationUuid,
+                },
+            });
+            mockPermissionModel.getRoleScopes.mockResolvedValue({
+                [customRoleUuid]: [
+                    'manage:Space@public',
+                    'manage:Dashboard@space',
+                    'manage:SavedChart@space',
+                ],
+            });
+
+            const result = await service.getAllSpaceAccessContext(spaceUuid);
+
+            expect(mockPermissionModel.getRoleScopes).toHaveBeenCalledWith(
+                [customRoleUuid],
+                { trx: undefined },
+            );
+            expect(result.access).toEqual([
+                expect.objectContaining({
+                    userUuid,
+                    role: SpaceMemberRole.EDITOR,
+                }),
+            ]);
         });
 
         test('space with inherit=false is treated as private, direct access user gets role', async () => {
@@ -262,6 +340,7 @@ describe('SpacePermissionService', () => {
                         userUuid,
                         spaceUuid: 'private-space',
                         role: 'viewer' as ProjectMemberRole,
+                        roleUuid: null,
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                 ],
@@ -315,6 +394,7 @@ describe('SpacePermissionService', () => {
                         userUuid: adminUuid,
                         spaceUuid: 'private-space',
                         role: 'admin' as ProjectMemberRole,
+                        roleUuid: null,
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                 ],
@@ -466,6 +546,7 @@ describe('SpacePermissionService', () => {
                         userUuid,
                         spaceUuid: 'root-space',
                         role: 'editor' as ProjectMemberRole,
+                        roleUuid: null,
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                 ],
@@ -668,18 +749,21 @@ describe('SpacePermissionService', () => {
                         userUuid: 'project-admin',
                         spaceUuid,
                         role: 'admin' as ProjectMemberRole,
+                        roleUuid: null,
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                     {
                         userUuid: 'dual-admin',
                         spaceUuid,
                         role: 'admin' as ProjectMemberRole,
+                        roleUuid: null,
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                     {
                         userUuid: 'editor-user',
                         spaceUuid,
                         role: 'editor' as ProjectMemberRole,
+                        roleUuid: null,
                         from: ProjectSpaceAccessOrigin.PROJECT_MEMBERSHIP,
                     },
                 ],

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     getHighestSpaceRole,
+    getProjectRoleForSpaceAccess,
     NotFoundError,
     OrganizationMemberRole,
     ProjectMemberRole,
@@ -15,7 +16,10 @@ import {
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { SpaceModel } from '../../models/SpaceModel';
-import { SpacePermissionModel } from '../../models/SpacePermissionModel';
+import {
+    SpacePermissionModel,
+    type ProjectSpaceAccessWithCustomRole,
+} from '../../models/SpacePermissionModel';
 import { BaseService } from '../BaseService';
 
 export type SpaceAdmin = {
@@ -172,6 +176,51 @@ export class SpacePermissionService extends BaseService {
     }
 
     /**
+     * Custom-role project/group assignments persist a placeholder `viewer` in
+     * the legacy `role` column (the real role lives in `role_uuid`). Replace
+     * the placeholder with the role derived from the custom role's scopes so
+     * inherited space access reflects what the role actually grants.
+     */
+    private async resolveCustomRoleProjectAccess(
+        projectAccessMap: Record<string, ProjectSpaceAccessWithCustomRole[]>,
+        { trx }: { trx?: Knex } = {},
+    ): Promise<Record<string, ProjectSpaceAccess[]>> {
+        const customRoleUuids = [
+            ...new Set(
+                Object.values(projectAccessMap)
+                    .flat()
+                    .flatMap((access) =>
+                        access.roleUuid ? [access.roleUuid] : [],
+                    ),
+            ),
+        ];
+        if (customRoleUuids.length === 0) {
+            return projectAccessMap;
+        }
+
+        const scopesByRole = await this.spacePermissionModel.getRoleScopes(
+            customRoleUuids,
+            { trx },
+        );
+
+        return Object.fromEntries(
+            Object.entries(projectAccessMap).map(([spaceUuid, accessList]) => [
+                spaceUuid,
+                accessList.map(({ roleUuid, ...access }) =>
+                    roleUuid
+                        ? {
+                              ...access,
+                              role: getProjectRoleForSpaceAccess(
+                                  scopesByRole[roleUuid] ?? [],
+                              ),
+                          }
+                        : access,
+                ),
+            ]),
+        );
+    }
+
+    /**
      * Gets the access context for a list of space uuids so we can check against CASL.
      *
      * Chain-aware resolution: walks each space's inheritance chain (up to the
@@ -229,11 +278,17 @@ export class SpacePermissionService extends BaseService {
                     { trx },
                 ),
                 allChainsRootSpaceUuids.length > 0
-                    ? this.spacePermissionModel.getProjectSpaceAccess(
-                          allChainsRootSpaceUuids,
-                          filters,
-                          { trx },
-                      )
+                    ? this.spacePermissionModel
+                          .getProjectSpaceAccess(
+                              allChainsRootSpaceUuids,
+                              filters,
+                              { trx },
+                          )
+                          .then((access) =>
+                              this.resolveCustomRoleProjectAccess(access, {
+                                  trx,
+                              }),
+                          )
                     : Promise.resolve(
                           {} as Record<string, ProjectSpaceAccess[]>,
                       ),

--- a/packages/common/src/authorization/space/customRoleProjectRole.test.ts
+++ b/packages/common/src/authorization/space/customRoleProjectRole.test.ts
@@ -1,0 +1,18 @@
+import { ProjectMemberRole } from '../../types/projectMemberRole';
+import { convertProjectRoleToSpaceRole } from '../../utils/projectMemberRole';
+import { PROJECT_ROLE_TO_SCOPES_MAP } from '../roleToScopeMapping';
+import { getProjectRoleForSpaceAccess } from './customRoleProjectRole';
+
+describe('getProjectRoleForSpaceAccess', () => {
+    it.each(Object.values(ProjectMemberRole))(
+        'derives the same inherited space role as the system role %s it was duplicated from',
+        (role) => {
+            const derivedRole = getProjectRoleForSpaceAccess([
+                ...PROJECT_ROLE_TO_SCOPES_MAP[role],
+            ]);
+            expect(convertProjectRoleToSpaceRole(derivedRole)).toEqual(
+                convertProjectRoleToSpaceRole(role),
+            );
+        },
+    );
+});

--- a/packages/common/src/authorization/space/customRoleProjectRole.ts
+++ b/packages/common/src/authorization/space/customRoleProjectRole.ts
@@ -1,0 +1,23 @@
+import { ProjectMemberRole } from '../../types/projectMemberRole';
+
+/**
+ * Project-role equivalent of a custom role for space-access resolution.
+ *
+ * Custom-role assignments persist a placeholder `viewer` in the legacy `role`
+ * column of `project_memberships` / `project_group_access`, so the role that
+ * flows into inherited spaces must be derived from the custom role's scopes.
+ * The marker scopes mirror the system-role tiers: `manage:Space` is first
+ * granted at admin and `manage:Space@public` at editor, so the derived role
+ * converts to the same space role as the system role the scopes came from.
+ */
+export const getProjectRoleForSpaceAccess = (
+    scopes: string[],
+): ProjectMemberRole => {
+    if (scopes.includes('manage:Space')) {
+        return ProjectMemberRole.ADMIN;
+    }
+    if (scopes.includes('manage:Space@public')) {
+        return ProjectMemberRole.EDITOR;
+    }
+    return ProjectMemberRole.VIEWER;
+};

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -57,6 +57,7 @@ export * from './authorization/roleToScopeMapping';
 export * from './authorization/scopeAbilityBuilder';
 export * from './authorization/scopes';
 export * from './authorization/serviceAccountAbility';
+export * from './authorization/space/customRoleProjectRole';
 export * from './authorization/space/spaceAccessResolver';
 export * from './authorization/types';
 export * from './compiler/compilationReport';


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8956/custom-role-users-cannot-create-or-edit-content-in-inherited-access

### Description:
Custom-role project/group assignments persist a placeholder 'viewer' in the legacy role column (the real role lives in role_uuid), but space access resolution read only the role column. Custom-role holders were therefore treated as space viewers on inherited-access spaces and could not create or edit charts and dashboards there, even when the role was duplicated from Editor.

Space access resolution now derives the effective project role from the custom role's scopes: manage:Space maps to admin, manage:Space@public to editor, everything else to viewer. These markers first appear at the admin and editor tiers respectively, so a custom role duplicated from a system role resolves to the same inherited space role as that system role (covered by a parity test across all system roles).
