### PR TITLE
fix: bound warehouse result chunk sizes to stop worker OOMs on large queries

### DIFF
--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
@@ -6,6 +6,10 @@ import {
 import { credentials, rows, schema } from './DatabricksWarehouseClient.mock';
 import { expectedFields } from './WarehouseClient.mock';
 
+const mocks = vi.hoisted(() => ({
+    fetchChunk: vi.fn(),
+}));
+
 vi.mock('@databricks/sql', async () => ({
     ...(await vi.importActual<typeof import('@databricks/sql')>(
         '@databricks/sql',
@@ -16,7 +20,9 @@ vi.mock('@databricks/sql', async () => ({
                 openSession: vi.fn(() => ({
                     executeStatement: vi.fn(() => ({
                         getSchema: vi.fn(async () => schema),
-                        fetchChunk: vi.fn(async () => rows),
+                        fetchChunk: mocks.fetchChunk.mockImplementation(
+                            async () => rows,
+                        ),
                         hasMoreRows: vi.fn(async () => false),
                         close: vi.fn(async () => undefined),
                     })),
@@ -36,6 +42,14 @@ describe('DatabricksWarehouseClient', () => {
 
         expect(results.fields).toEqual(expectedFields);
         expect(results.rows[0]).toEqual(rows[0]);
+    });
+
+    it('caps fetchChunk size to avoid materializing whole results', async () => {
+        const warehouse = new DatabricksWarehouseClient(credentials);
+
+        await warehouse.runQuery('fake sql');
+
+        expect(mocks.fetchChunk).toHaveBeenCalledWith({ maxRows: 5000 });
     });
 });
 

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -270,6 +270,9 @@ export class DatabricksSqlBuilder extends WarehouseBaseSqlBuilder {
 
 const DATABRICKS_SOCKET_TIMEOUT_MS = 60000;
 const DATABRICKS_QUERY_TIMEOUT_SECONDS = 300;
+// @databricks/sql defaults fetchChunk to 100k rows, which materializes entire
+// wide results in one array and can OOM the worker on large queries
+const DATABRICKS_FETCH_CHUNK_MAX_ROWS = 5000;
 
 export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabricksCredentials> {
     schema: string;
@@ -425,8 +428,9 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
 
             do {
                 // eslint-disable-next-line no-await-in-loop
-                const chunk = await query.fetchChunk();
-                console.log(chunk.length, ' - ♻️ rows fetched');
+                const chunk = await query.fetchChunk({
+                    maxRows: DATABRICKS_FETCH_CHUNK_MAX_ROWS,
+                });
                 // eslint-disable-next-line no-await-in-loop
                 await streamCallback({ fields, rows: chunk });
                 // eslint-disable-next-line no-await-in-loop

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
@@ -119,6 +119,15 @@ describe('SnowflakeWarehouseClient', () => {
         vi.clearAllMocks();
     });
 
+    it('caps result chunk size via CLIENT_RESULT_CHUNK_SIZE session parameter', async () => {
+        const warehouse = new SnowflakeWarehouseClient(credentials);
+        await warehouse.streamQuery('SELECT 1', () => {}, {});
+        const alterSessionSql = executeMock.mock.calls
+            .map((call) => call[0].sqlText as string)
+            .find((sql) => sql.startsWith('ALTER SESSION SET'));
+        expect(alterSessionSql).toContain('CLIENT_RESULT_CHUNK_SIZE = 16');
+    });
+
     it('configures the local application authorization-code flow with SDK defaults', () => {
         const warehouse = new SnowflakeWarehouseClient({
             ...credentials,

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -98,6 +98,8 @@ const EXTERNAL_BROWSER_AUTHENTICATOR = 'EXTERNALBROWSER';
 const OAUTH_AUTHORIZATION_CODE_AUTHENTICATOR = 'OAUTH_AUTHORIZATION_CODE';
 const SESSION_DISCOVERY_LIMIT = 100;
 const SESSION_SCHEMA_DISCOVERY_LIMIT = 1000;
+// Minimum allowed by Snowflake (range 16-160, default 160)
+const SNOWFLAKE_RESULT_CHUNK_SIZE_MB = 16;
 
 export type SnowflakeOAuthTokens = {
     accessToken: string;
@@ -1155,6 +1157,14 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             `Setting Snowflake session STATEMENT_TIMEOUT_IN_SECONDS = ${timeoutSeconds}`,
         );
         sessionParams.push(`STATEMENT_TIMEOUT_IN_SECONDS = ${timeoutSeconds}`);
+
+        // Snowflake grows result chunks up to 160MB and the driver holds ~4
+        // chunks in memory regardless of consumer backpressure, so uncapped
+        // chunks make heap usage scale with the query row limit and can OOM
+        // the worker on large results
+        sessionParams.push(
+            `CLIENT_RESULT_CHUNK_SIZE = ${SNOWFLAKE_RESULT_CHUNK_SIZE_MB}`,
+        );
 
         await this.executeStatements(
             connection,


### PR DESCRIPTION
## Problem

A single large async Explore query can OOM the warehouse worker (`FATAL ERROR: Reached heap limit`) — worker heap scales with the query row limit even though results stream to S3 with correct backpressure. The accumulation is inside the warehouse drivers, not our pipeline:

- **Snowflake**: the server grows result chunks geometrically (observed chunk map for a 100k-row result: 105 → 198 → ... → 21,633 → 27,695 rows per chunk, capped only by the 160MB default). `snowflake-sdk` always holds ~4 chunks fully materialized (current + 2 prefetched + previous), no matter how slowly we consume rows — so for large limits the in-flight window approaches the entire result. Backpressure can't help: it pauses row delivery, not chunk downloads.
- **Databricks**: `@databricks/sql` defaults `fetchChunk` to **100,000 rows**, so up to 100k rows materialize as one array delivered in a single callback (which also blocks the event loop while it serializes).

## Fix

- **Snowflake**: set session parameter `CLIENT_RESULT_CHUNK_SIZE = 16` (MB; documented range 16–160, default 160) in `prepareWarehouse`. Chunks become uniform (~2.8k rows for a 51-column result) and driver memory is constant regardless of limit. Note: the parameter bounds chunk size on Snowflake accounts with the server-side `2026_04` behavior-change bundle (rolling out since June; verified enabled on our dev account) — it is harmless where the bundle is not yet active.
- **Databricks**: pass `maxRows: 5000` to `fetchChunk` (and remove a leftover per-chunk debug log).

Both are results-identical: same rows, same order, only transfer chunking changes.

## Empirical before/after

All runs from today, before = parent commit, after = this branch. Query: 100,000 rows × 51 columns (40 strings, 5 numbers, 5 timestamps) generated server-side.

### End-to-end through the API (`QueryController` v2)

`POST /api/v2/projects/{uuid}/query/sql` against the dev stack (NATS disabled, so the API process executes the async worker path), node heap capped at 880MB to mirror prod worker headroom (1536Mi with ~640MB dev baseline). "Live heap" = forced-GC `heapUsed` sampled via the node inspector during execution.

| Warehouse | Before | After |
|---|---|---|
| Snowflake | 💥 API process killed (`FATAL ERROR ... heap out of memory`), query stuck in `executing` | ✅ `ready`, all 100k rows, live heap +38.7MB (639→677MB) |
| Databricks | 💥 API process killed, query stuck in `executing` | ✅ `ready`, all 100k rows, live heap +50.8MB (651→701MB) |

With no heap cap, the before-code spiked the API process by **+1,494MB RSS** (Snowflake) / **+690MB** (Databricks) for that single query.

### Standalone worker-path harness

Same pipeline (warehouse `executeAsyncQuery` → JSONL → S3 upload stream to MinIO), process heap capped at 256MB:

| Run | Before | After |
|---|---|---|
| Snowflake 100k | 💥 FATAL at ~20k rows consumed | ✅ peak heap 184MB |
| Snowflake 300k | — (100k already fatal) | ✅ peak heap 191MB (flat w.r.t. limit) |
| Databricks 100k | 💥 FATAL during first chunk | ✅ peak heap 144MB |

### Known trade-off

Smaller Snowflake chunks mean more fetch round trips: the 100k-row query's end-to-end time went from ~27s to ~40s on our dev account. Accepted — it only affects large extracts, and the alternative is the worker dying. (Part of the extra cost is an upstream `snowflake-sdk` bug that re-downloads already-loaded chunks, which we'll report separately.)

### Other warehouses

Audited empirically with the same harness (100k rows @ 256MB heap): Postgres 98MB, BigQuery 185MB, Trino 112MB, ClickHouse 97MB — all bounded, no change needed. Redshift shares the Postgres cursor streaming path; Athena pages at a fixed 1,000 rows.

## Tests

- Snowflake: asserts `ALTER SESSION` includes `CLIENT_RESULT_CHUNK_SIZE = 16`.
- Databricks: asserts `fetchChunk` is called with `maxRows: 5000`.

https://linear.app/lightdash/issue/PROD-8942
