### PR TITLE
fix(homepage): don't fire a spurious autosave on editor mount

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -450,9 +450,9 @@ export const HomepageEditor: FC<Props> = ({
     const [isPreviewing, setIsPreviewing] = useState(false);
     const [debouncedDraft] = useDebouncedValue(draft, 800);
     const [hasConflict, setHasConflict] = useState(false);
-    const lastSavedRef = useRef<HomepageConfig>(
-        migrateHomepageConfig(homepage.draftConfig),
-    );
+    // Share the exact initial draft reference so the autosave effect's identity
+    // check sees no change on mount (avoids a spurious save on every load).
+    const lastSavedRef = useRef<HomepageConfig>(draft);
     // Compare-and-set token so a stale editor can never clobber newer state
     const baseUpdatedAtRef = useRef<Date>(homepage.updatedAt);
 


### PR DESCRIPTION
The Greeting-removal migration (migrateHomepageConfig) was invoked twice on mount — once for the draft state, once for the lastSaved ref — yielding two equal-but-distinct config objects. The autosave effect compares by reference, so it saw a change on mount and **saved on every page load**, bumping the homepage's updatedAt and amplifying 'changed somewhere else' conflicts when more than one editor/tab is open. Fix: initialise the ref from the same initial draft reference so the mount comparison is a no-op. No spurious save, no needless updatedAt bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)