### PR TITLE
fix(homepage): hide the duplicate action on singleton blocks

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -380,15 +380,17 @@ const BlockCard: FC<BlockCardProps> = ({
                             <MantineIcon icon={IconArrowDown} />
                         </ActionIcon>
                     </Tooltip>
-                    <Tooltip label="Duplicate">
-                        <ActionIcon
-                            variant="subtle"
-                            color="ldGray.6"
-                            onClick={onDuplicate}
-                        >
-                            <MantineIcon icon={IconCopy} />
-                        </ActionIcon>
-                    </Tooltip>
+                    {!definition.singleton && (
+                        <Tooltip label="Duplicate">
+                            <ActionIcon
+                                variant="subtle"
+                                color="ldGray.6"
+                                onClick={onDuplicate}
+                            >
+                                <MantineIcon icon={IconCopy} />
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
                     <Tooltip label="Remove">
                         <ActionIcon
                             variant="subtle"


### PR DESCRIPTION
Singleton blocks (Ask AI, Metrics, Announcements, Recently viewed) can only exist once per homepage — they already drop out of the block library once placed — but the block hover controls still showed **Duplicate**, which let you create a second copy and break the singleton invariant. Hide the Duplicate action when the block's definition is a singleton (move/remove stay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)