### PR TITLE
fix(homepage): builder stuck on a spinner when the draft is cache-fresh

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
@@ -230,6 +230,10 @@ export const useHomepageForBuilder = (
             homepageUuid ?? 'default',
         ],
         queryFn: () => getHomepageForBuilder(projectUuid!, homepageUuid),
+        // The editor snapshots the draft on mount, so always refetch: with the
+        // global 30s staleTime a warm cache would skip the fetch, leaving
+        // isFetchedAfterMount false and the builder stuck on a spinner.
+        refetchOnMount: 'always',
     });
 
 export const useProjectHomepages = (


### PR DESCRIPTION
**Symptom:** opening the homepage builder (e.g. Home → Customize/New homepage) sometimes shows a loading spinner that only a browser refresh clears.

**Cause:** `HomepageBuilderPage` gates on `!homepage.isFetchedAfterMount` to wait for a fresh draft before mounting the editor. But `useHomepageForBuilder` set no `refetchOnMount`, and the app has a global `staleTime: 30000`. So if the builder draft was fetched within the last 30s, React Query serves it from cache **without** refetching on mount → `isFetchedAfterMount` never becomes `true` → the gate spins forever. A hard refresh clears the cache, so it works once.

**Fix:** `refetchOnMount: 'always'` on the builder query — guarantees a mount fetch (so `isFetchedAfterMount` flips true) and also honours the original intent of always snapshotting a fresh draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)