### PR TITLE
feat(homepage): label the block title input "Title"

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -205,7 +205,7 @@ export const CollectionBlockBuild: FC<BuildComponentProps> = ({
     return (
         <Stack gap="xs">
             <TextInput
-                aria-label="Collection title"
+                label="Title"
                 size="xs"
                 fw={600}
                 value={block.config.title}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
@@ -296,7 +296,7 @@ export const MetricsBlockBuild: FC<BuildComponentProps> = ({
     return (
         <Stack gap="xs">
             <TextInput
-                aria-label="Metrics title"
+                label="Title"
                 size="xs"
                 fw={600}
                 value={block.config.title}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -124,7 +124,7 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
     return (
         <Stack gap="xs">
             <TextInput
-                aria-label="Resources title"
+                label="Title"
                 size="xs"
                 fw={600}
                 value={block.config.title}


### PR DESCRIPTION
## What

The editable title field at the top of the **Metrics**, **Collection**, and **Resources** homepage blocks (build mode) had only an invisible `aria-label` — no visible label — so it wasn't obvious the field renames the block.

This adds a visible `label="Title"` to that `TextInput` on all three blocks, replacing the redundant `aria-label` (Mantine's `label` provides the accessible name).

## Why

Makes the block-title input self-explanatory in the builder.

## Screenshots

_Before:_ bare bold input. _After:_ input with a "Title" label above it.

Relates: ZAP-617