### PR TITLE
feat(homepage): rich resource cards — Claude artifacts, YouTube, smart-paste builder

### DIFF
--- a/packages/backend/src/ee/controllers/projectHomepageController.ts
+++ b/packages/backend/src/ee/controllers/projectHomepageController.ts
@@ -3,6 +3,7 @@ import {
     ParameterError,
     type ApiErrorPayload,
     type ApiHomepageAssignmentsResponse,
+    type ApiHomepageLinkMetadataResponse,
     type ApiHomepageViewAsResponse,
     type ApiProjectHomepageOrNullResponse,
     type ApiProjectHomepageResponse,
@@ -190,6 +191,27 @@ export class ProjectHomepageController extends BaseController {
                 toSessionUser(req.account),
                 projectUuid,
                 homepageUuid,
+            ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/link-metadata')
+    @OperationId('getHomepageLinkMetadata')
+    async getLinkMetadata(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Query() url: string,
+    ): Promise<ApiHomepageLinkMetadataResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().fetchLinkMetadata(
+                toSessionUser(req.account),
+                projectUuid,
+                url,
             ),
         };
     }

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -11,6 +11,7 @@ import {
     type HomepageAssignment,
     type HomepageAudience,
     type HomepageConfig,
+    type HomepageLinkMetadata,
     type HomepageRecentlyViewedItem,
     type HomepageViewAsResult,
     type HomepageViewAsTarget,
@@ -25,6 +26,14 @@ import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { BaseService } from '../../services/BaseService';
 import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
 import { type ProjectHomepageModel } from '../models/ProjectHomepageModel';
+import {
+    classifyResourceUrl,
+    parseOpenGraph,
+    parseYoutubeOembed,
+} from './homepageLinkMetadata';
+
+const LINK_METADATA_TIMEOUT_MS = 5_000;
+const LINK_METADATA_MAX_BYTES = 256 * 1024;
 
 export type ProjectHomepageServiceArguments = {
     projectHomepageModel: Pick<
@@ -417,5 +426,106 @@ export class ProjectHomepageService extends BaseService {
             audience,
             allowPersonal,
         );
+    }
+
+    // Bounded, request-scoped GET against an allowlisted host; caps time and
+    // body size and never follows redirects (SSRF hardening).
+    private static async fetchCapped(
+        url: string,
+        opts: { accept: string; requireContentType?: string },
+    ): Promise<string> {
+        const controller = new AbortController();
+        const timeout = setTimeout(
+            () => controller.abort(),
+            LINK_METADATA_TIMEOUT_MS,
+        );
+        try {
+            const response = await fetch(url, {
+                method: 'GET',
+                redirect: 'manual',
+                signal: controller.signal,
+                headers: {
+                    accept: opts.accept,
+                    'user-agent':
+                        'LightdashBot/1.0 (+https://www.lightdash.com)',
+                },
+            });
+            if (!response.ok) {
+                throw new Error(`Unexpected status ${response.status}`);
+            }
+            if (
+                opts.requireContentType &&
+                !(response.headers.get('content-type') ?? '').includes(
+                    opts.requireContentType,
+                )
+            ) {
+                throw new Error('Unexpected content-type');
+            }
+            const reader = response.body?.getReader();
+            if (!reader) return '';
+            const decoder = new TextDecoder();
+            let received = 0;
+            let text = '';
+            let truncated = false;
+            for (;;) {
+                // eslint-disable-next-line no-await-in-loop
+                const { done, value } = await reader.read();
+                if (done) break;
+                received += value.byteLength;
+                text += decoder.decode(value, { stream: true });
+                if (received >= LINK_METADATA_MAX_BYTES) {
+                    truncated = true;
+                    break;
+                }
+            }
+            if (truncated) await reader.cancel();
+            return text;
+        } finally {
+            clearTimeout(timeout);
+        }
+    }
+
+    /**
+     * Unfurl a pasted resource URL for the homepage builder. Rejects any host
+     * outside the allowlist (400); for allowed hosts, returns the detected kind
+     * with title/description/imageUrl (nulls if the fetch or parse fails, so the
+     * author can still add the item and type a title).
+     */
+    async fetchLinkMetadata(
+        user: SessionUser,
+        projectUuid: string,
+        url: string,
+    ): Promise<HomepageLinkMetadata> {
+        await this.assertFlagEnabled(user);
+        this.assertCanManage(user, projectUuid);
+
+        const provider = classifyResourceUrl(url);
+        try {
+            if (provider.fetchKind === 'oembed') {
+                const body = await ProjectHomepageService.fetchCapped(
+                    provider.fetchUrl,
+                    { accept: 'application/json' },
+                );
+                let json: unknown = null;
+                try {
+                    json = JSON.parse(body);
+                } catch {
+                    json = null;
+                }
+                return { kind: provider.kind, ...parseYoutubeOembed(json) };
+            }
+            const html = await ProjectHomepageService.fetchCapped(
+                provider.fetchUrl,
+                { accept: 'text/html', requireContentType: 'text/html' },
+            );
+            return { kind: provider.kind, ...parseOpenGraph(html) };
+        } catch {
+            return {
+                kind: provider.kind,
+                title: null,
+                description: null,
+                imageUrl: null,
+            };
+        }
     }
 }

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -35,6 +35,11 @@ import {
 
 const LINK_METADATA_TIMEOUT_MS = 5_000;
 const LINK_METADATA_MAX_BYTES = 256 * 1024;
+// Some providers (e.g. claude.ai) only server-render per-page OpenGraph tags for
+// recognised link-unfurl crawlers, so identify as one while staying honest about
+// who we are.
+const LINK_PREVIEW_USER_AGENT =
+    'Lightdash-LinkPreview/1.0 (+https://www.lightdash.com; like Slackbot-LinkExpanding)';
 
 export type ProjectHomepageServiceArguments = {
     projectHomepageModel: Pick<
@@ -453,6 +458,7 @@ export class ProjectHomepageService extends BaseService {
                     timeoutMs: LINK_METADATA_TIMEOUT_MS,
                     maxResponseBytes: LINK_METADATA_MAX_BYTES,
                     allowedContentTypes: ['application/json'],
+                    headers: { 'User-Agent': LINK_PREVIEW_USER_AGENT },
                 });
                 let json: unknown = null;
                 try {
@@ -467,6 +473,7 @@ export class ProjectHomepageService extends BaseService {
                 timeoutMs: LINK_METADATA_TIMEOUT_MS,
                 maxResponseBytes: LINK_METADATA_MAX_BYTES,
                 allowedContentTypes: ['text/html'],
+                headers: { 'User-Agent': LINK_PREVIEW_USER_AGENT },
             });
             return { kind: provider.kind, ...parseOpenGraph(bodyText) };
         } catch {

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -25,6 +25,7 @@ import { type GroupsModel } from '../../models/GroupsModel';
 import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { BaseService } from '../../services/BaseService';
 import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
+import { secureFetch } from '../../utils/secureFetch/secureFetch';
 import { type ProjectHomepageModel } from '../models/ProjectHomepageModel';
 import {
     classifyResourceUrl,
@@ -428,68 +429,13 @@ export class ProjectHomepageService extends BaseService {
         );
     }
 
-    // Bounded, request-scoped GET against an allowlisted host; caps time and
-    // body size and never follows redirects (SSRF hardening).
-    private static async fetchCapped(
-        url: string,
-        opts: { accept: string; requireContentType?: string },
-    ): Promise<string> {
-        const controller = new AbortController();
-        const timeout = setTimeout(
-            () => controller.abort(),
-            LINK_METADATA_TIMEOUT_MS,
-        );
-        try {
-            const response = await fetch(url, {
-                method: 'GET',
-                redirect: 'manual',
-                signal: controller.signal,
-                headers: {
-                    accept: opts.accept,
-                    'user-agent':
-                        'LightdashBot/1.0 (+https://www.lightdash.com)',
-                },
-            });
-            if (!response.ok) {
-                throw new Error(`Unexpected status ${response.status}`);
-            }
-            if (
-                opts.requireContentType &&
-                !(response.headers.get('content-type') ?? '').includes(
-                    opts.requireContentType,
-                )
-            ) {
-                throw new Error('Unexpected content-type');
-            }
-            const reader = response.body?.getReader();
-            if (!reader) return '';
-            const decoder = new TextDecoder();
-            let received = 0;
-            let text = '';
-            let truncated = false;
-            for (;;) {
-                // eslint-disable-next-line no-await-in-loop
-                const { done, value } = await reader.read();
-                if (done) break;
-                received += value.byteLength;
-                text += decoder.decode(value, { stream: true });
-                if (received >= LINK_METADATA_MAX_BYTES) {
-                    truncated = true;
-                    break;
-                }
-            }
-            if (truncated) await reader.cancel();
-            return text;
-        } finally {
-            clearTimeout(timeout);
-        }
-    }
-
     /**
      * Unfurl a pasted resource URL for the homepage builder. Rejects any host
      * outside the allowlist (400); for allowed hosts, returns the detected kind
      * with title/description/imageUrl (nulls if the fetch or parse fails, so the
-     * author can still add the item and type a title).
+     * author can still add the item and type a title). The outbound fetch is
+     * SSRF-hardened (https-only, private-IP blocking, redirect + size + time
+     * caps) via the shared `secureFetch` util.
      */
     async fetchLinkMetadata(
         user: SessionUser,
@@ -502,23 +448,27 @@ export class ProjectHomepageService extends BaseService {
         const provider = classifyResourceUrl(url);
         try {
             if (provider.fetchKind === 'oembed') {
-                const body = await ProjectHomepageService.fetchCapped(
-                    provider.fetchUrl,
-                    { accept: 'application/json' },
-                );
+                const { bodyText } = await secureFetch(provider.fetchUrl, {
+                    method: 'GET',
+                    timeoutMs: LINK_METADATA_TIMEOUT_MS,
+                    maxResponseBytes: LINK_METADATA_MAX_BYTES,
+                    allowedContentTypes: ['application/json'],
+                });
                 let json: unknown = null;
                 try {
-                    json = JSON.parse(body);
+                    json = JSON.parse(bodyText);
                 } catch {
                     json = null;
                 }
                 return { kind: provider.kind, ...parseYoutubeOembed(json) };
             }
-            const html = await ProjectHomepageService.fetchCapped(
-                provider.fetchUrl,
-                { accept: 'text/html', requireContentType: 'text/html' },
-            );
-            return { kind: provider.kind, ...parseOpenGraph(html) };
+            const { bodyText } = await secureFetch(provider.fetchUrl, {
+                method: 'GET',
+                timeoutMs: LINK_METADATA_TIMEOUT_MS,
+                maxResponseBytes: LINK_METADATA_MAX_BYTES,
+                allowedContentTypes: ['text/html'],
+            });
+            return { kind: provider.kind, ...parseOpenGraph(bodyText) };
         } catch {
             return {
                 kind: provider.kind,

--- a/packages/backend/src/ee/services/homepageLinkMetadata.test.ts
+++ b/packages/backend/src/ee/services/homepageLinkMetadata.test.ts
@@ -65,6 +65,11 @@ describe('classifyResourceUrl', () => {
             ParameterError,
         );
     });
+
+    it('rejects URLs longer than 2048 chars before parsing', () => {
+        const longUrl = `https://claude.ai/${'a'.repeat(2048)}`;
+        expect(() => classifyResourceUrl(longUrl)).toThrow(ParameterError);
+    });
 });
 
 describe('parseOpenGraph', () => {

--- a/packages/backend/src/ee/services/homepageLinkMetadata.test.ts
+++ b/packages/backend/src/ee/services/homepageLinkMetadata.test.ts
@@ -92,9 +92,19 @@ describe('parseOpenGraph', () => {
         );
     });
 
-    it('decodes HTML entities in content', () => {
-        const html = `<meta property="og:title" content="Sales &amp; Ops &#39;24">`;
-        expect(parseOpenGraph(html).title).toBe("Sales & Ops '24");
+    it('decodes named + numeric (decimal & hex) HTML entities', () => {
+        const html = `<meta property="og:title" content="Sales &amp; Ops &#39;24 &#8212; Caf&#xe9; &#8230;">`;
+        expect(parseOpenGraph(html).title).toBe("Sales & Ops '24 — Café …");
+    });
+
+    it('does not truncate a title containing an apostrophe', () => {
+        const html = `<meta property="og:title" content="Joao's dashboard">`;
+        expect(parseOpenGraph(html).title).toBe("Joao's dashboard");
+    });
+
+    it('leaves unknown/invalid entities untouched', () => {
+        const html = `<meta property="og:title" content="A &bogus; B &#zzz; C">`;
+        expect(parseOpenGraph(html).title).toBe('A &bogus; B &#zzz; C');
     });
 
     it('falls back to <title> when og:title is absent', () => {
@@ -112,17 +122,17 @@ describe('parseOpenGraph', () => {
 });
 
 describe('parseYoutubeOembed', () => {
-    it('maps oembed fields to metadata (channel as description)', () => {
+    it('maps + HTML-decodes oembed fields (channel as description)', () => {
         expect(
             parseYoutubeOembed({
-                title: 'Never Gonna Give You Up',
-                author_name: 'Rick Astley',
+                title: 'Ben &amp; Jerry&#39;s launch',
+                author_name: 'Ben &amp; Jerry',
                 thumbnail_url:
                     'https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg',
             }),
         ).toEqual({
-            title: 'Never Gonna Give You Up',
-            description: 'Rick Astley',
+            title: "Ben & Jerry's launch",
+            description: 'Ben & Jerry',
             imageUrl: 'https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg',
         });
     });

--- a/packages/backend/src/ee/services/homepageLinkMetadata.test.ts
+++ b/packages/backend/src/ee/services/homepageLinkMetadata.test.ts
@@ -1,0 +1,142 @@
+import { ParameterError } from '@lightdash/common';
+import {
+    classifyResourceUrl,
+    parseOpenGraph,
+    parseYoutubeOembed,
+} from './homepageLinkMetadata';
+
+describe('classifyResourceUrl', () => {
+    it('classifies Claude artifact URLs as html/claude', () => {
+        const result = classifyResourceUrl(
+            'https://claude.ai/public/artifacts/06c4efcb-9c37-4649-8f04-1c0c233555bb',
+        );
+        expect(result.kind).toBe('claude');
+        expect(result.fetchKind).toBe('html');
+    });
+
+    it('classifies claude.ai subdomains', () => {
+        expect(classifyResourceUrl('https://www.claude.ai/x').kind).toBe(
+            'claude',
+        );
+    });
+
+    it('classifies youtube.com / youtu.be as oembed/youtube', () => {
+        const watch = classifyResourceUrl(
+            'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        );
+        expect(watch.kind).toBe('youtube');
+        expect(watch.fetchKind).toBe('oembed');
+        expect(watch.fetchUrl).toContain('youtube.com/oembed');
+        expect(watch.fetchUrl).toContain(
+            encodeURIComponent('https://www.youtube.com/watch?v=dQw4w9WgXcQ'),
+        );
+
+        expect(classifyResourceUrl('https://youtu.be/dQw4w9WgXcQ').kind).toBe(
+            'youtube',
+        );
+    });
+
+    it('rejects hosts outside the allowlist', () => {
+        expect(() => classifyResourceUrl('https://evil.example.com')).toThrow(
+            ParameterError,
+        );
+        // SSRF: internal targets must never be reachable
+        expect(() => classifyResourceUrl('http://169.254.169.254/')).toThrow(
+            ParameterError,
+        );
+        expect(() => classifyResourceUrl('http://localhost:8080')).toThrow(
+            ParameterError,
+        );
+        // look-alike host must not slip past the suffix check
+        expect(() => classifyResourceUrl('https://notclaude.ai')).toThrow(
+            ParameterError,
+        );
+        expect(() => classifyResourceUrl('https://claude.ai.evil.com')).toThrow(
+            ParameterError,
+        );
+    });
+
+    it('rejects non-https protocols (incl. http to an allowlisted host)', () => {
+        expect(() => classifyResourceUrl('file:///etc/passwd')).toThrow(
+            ParameterError,
+        );
+        expect(() => classifyResourceUrl('not a url')).toThrow(ParameterError);
+        expect(() => classifyResourceUrl('http://claude.ai/x')).toThrow(
+            ParameterError,
+        );
+    });
+});
+
+describe('parseOpenGraph', () => {
+    // Real tags served by Claude public artifact pages (verified 2026-07-16).
+    const paletteLab = `<head>
+        <meta property="og:title" content="Palette Lab: Generate Color Palettes for Design">
+        <meta property="og:description" content="Create categorical, sequential, and diverging color palettes with interactive controls.">
+        <meta property="og:image" content="https://claude.ai/images/claude_ogimage.png">
+        <title>Claude</title>
+    </head>`;
+
+    it('extracts real per-artifact title and description + generic image', () => {
+        expect(parseOpenGraph(paletteLab)).toEqual({
+            title: 'Palette Lab: Generate Color Palettes for Design',
+            description:
+                'Create categorical, sequential, and diverging color palettes with interactive controls.',
+            imageUrl: 'https://claude.ai/images/claude_ogimage.png',
+        });
+    });
+
+    it('handles content-before-property attribute order', () => {
+        const html = `<meta content="Regex Tester - Live JavaScript Pattern Matcher" property="og:title">`;
+        expect(parseOpenGraph(html).title).toBe(
+            'Regex Tester - Live JavaScript Pattern Matcher',
+        );
+    });
+
+    it('decodes HTML entities in content', () => {
+        const html = `<meta property="og:title" content="Sales &amp; Ops &#39;24">`;
+        expect(parseOpenGraph(html).title).toBe("Sales & Ops '24");
+    });
+
+    it('falls back to <title> when og:title is absent', () => {
+        const html = `<head><title>Just a title</title></head>`;
+        expect(parseOpenGraph(html).title).toBe('Just a title');
+    });
+
+    it('returns nulls when nothing matches', () => {
+        expect(parseOpenGraph('<html></html>')).toEqual({
+            title: null,
+            description: null,
+            imageUrl: null,
+        });
+    });
+});
+
+describe('parseYoutubeOembed', () => {
+    it('maps oembed fields to metadata (channel as description)', () => {
+        expect(
+            parseYoutubeOembed({
+                title: 'Never Gonna Give You Up',
+                author_name: 'Rick Astley',
+                thumbnail_url:
+                    'https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg',
+            }),
+        ).toEqual({
+            title: 'Never Gonna Give You Up',
+            description: 'Rick Astley',
+            imageUrl: 'https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg',
+        });
+    });
+
+    it('returns nulls for non-object / empty payloads', () => {
+        expect(parseYoutubeOembed(null)).toEqual({
+            title: null,
+            description: null,
+            imageUrl: null,
+        });
+        expect(parseYoutubeOembed({})).toEqual({
+            title: null,
+            description: null,
+            imageUrl: null,
+        });
+    });
+});

--- a/packages/backend/src/ee/services/homepageLinkMetadata.ts
+++ b/packages/backend/src/ee/services/homepageLinkMetadata.ts
@@ -18,7 +18,12 @@ const isHostOrSubdomain = (hostname: string, domain: string): boolean =>
  * other host is rejected so this endpoint can never be pointed at internal
  * infrastructure. Returns what to fetch and how to parse it.
  */
+const MAX_URL_LENGTH = 2048;
+
 export const classifyResourceUrl = (rawUrl: string): ResourceProvider => {
+    if (rawUrl.length > MAX_URL_LENGTH) {
+        throw new ParameterError('URL is too long');
+    }
     let parsed: URL;
     try {
         parsed = new URL(rawUrl);

--- a/packages/backend/src/ee/services/homepageLinkMetadata.ts
+++ b/packages/backend/src/ee/services/homepageLinkMetadata.ts
@@ -1,0 +1,127 @@
+import { ParameterError, type HomepageResourceKind } from '@lightdash/common';
+
+/**
+ * Pure helpers for the homepage link-metadata endpoint: URL classification and
+ * OpenGraph / YouTube-oEmbed parsing. No network calls live here so the parsing
+ * is unit-testable against fixtures.
+ */
+
+export type ResourceProvider =
+    | { kind: 'claude'; fetchKind: 'html'; fetchUrl: string }
+    | { kind: 'youtube'; fetchKind: 'oembed'; fetchUrl: string };
+
+const isHostOrSubdomain = (hostname: string, domain: string): boolean =>
+    hostname === domain || hostname.endsWith(`.${domain}`);
+
+/**
+ * SSRF host allowlist. Only well-known public providers are reachable; every
+ * other host is rejected so this endpoint can never be pointed at internal
+ * infrastructure. Returns what to fetch and how to parse it.
+ */
+export const classifyResourceUrl = (rawUrl: string): ResourceProvider => {
+    let parsed: URL;
+    try {
+        parsed = new URL(rawUrl);
+    } catch {
+        throw new ParameterError('Invalid URL');
+    }
+    if (parsed.protocol !== 'https:') {
+        throw new ParameterError('Only https URLs are supported');
+    }
+    const host = parsed.hostname.toLowerCase();
+
+    if (isHostOrSubdomain(host, 'claude.ai')) {
+        return {
+            kind: 'claude',
+            fetchKind: 'html',
+            fetchUrl: parsed.toString(),
+        };
+    }
+    if (isHostOrSubdomain(host, 'youtube.com') || host === 'youtu.be') {
+        const oembed = new URL('https://www.youtube.com/oembed');
+        oembed.searchParams.set('url', parsed.toString());
+        oembed.searchParams.set('format', 'json');
+        return {
+            kind: 'youtube',
+            fetchKind: 'oembed',
+            fetchUrl: oembed.toString(),
+        };
+    }
+    throw new ParameterError(
+        'Only Claude Artifact and YouTube links can be unfurled',
+    );
+};
+
+const HTML_ENTITIES: Record<string, string> = {
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&quot;': '"',
+    '&#39;': "'",
+    '&#x27;': "'",
+    '&nbsp;': ' ',
+};
+
+const decodeEntities = (value: string): string =>
+    value.replace(
+        /&(?:amp|lt|gt|quot|nbsp|#39|#x27);/gi,
+        (match) => HTML_ENTITIES[match.toLowerCase()] ?? match,
+    );
+
+const readMeta = (html: string, key: string): string | null => {
+    const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // Handle both attribute orders: property-then-content and content-then-property.
+    const patterns = [
+        new RegExp(
+            `<meta[^>]+(?:property|name)=["']${escaped}["'][^>]*content=["']([^"']*)["']`,
+            'i',
+        ),
+        new RegExp(
+            `<meta[^>]+content=["']([^"']*)["'][^>]*(?:property|name)=["']${escaped}["']`,
+            'i',
+        ),
+    ];
+    for (const pattern of patterns) {
+        const match = html.match(pattern);
+        if (match?.[1]) return decodeEntities(match[1].trim());
+    }
+    return null;
+};
+
+export type ParsedLinkMetadata = {
+    title: string | null;
+    description: string | null;
+    imageUrl: string | null;
+};
+
+/** Parse OpenGraph tags from an HTML document, falling back to <title>. */
+export const parseOpenGraph = (html: string): ParsedLinkMetadata => {
+    const titleTag = html.match(/<title[^>]*>([^<]*)<\/title>/i)?.[1];
+    return {
+        title:
+            readMeta(html, 'og:title') ??
+            (titleTag ? decodeEntities(titleTag.trim()) : null),
+        description: readMeta(html, 'og:description'),
+        imageUrl: readMeta(html, 'og:image'),
+    };
+};
+
+/** Parse a YouTube oEmbed JSON response. */
+export const parseYoutubeOembed = (raw: unknown): ParsedLinkMetadata => {
+    if (typeof raw !== 'object' || raw === null) {
+        return { title: null, description: null, imageUrl: null };
+    }
+    const data = raw as Record<string, unknown>;
+    const asString = (value: unknown): string | null =>
+        typeof value === 'string' && value.length > 0 ? value : null;
+    return {
+        title: asString(data.title),
+        // oEmbed has no description; surface the channel as a subtle subtitle.
+        description: asString(data.author_name),
+        imageUrl: asString(data.thumbnail_url),
+    };
+};
+
+export const resourceKindForProvider = (
+    provider: ResourceProvider,
+): HomepageResourceKind => provider.kind;

--- a/packages/backend/src/ee/services/homepageLinkMetadata.ts
+++ b/packages/backend/src/ee/services/homepageLinkMetadata.ts
@@ -1,4 +1,4 @@
-import { ParameterError, type HomepageResourceKind } from '@lightdash/common';
+import { ParameterError } from '@lightdash/common';
 
 /**
  * Pure helpers for the homepage link-metadata endpoint: URL classification and
@@ -52,38 +52,61 @@ export const classifyResourceUrl = (rawUrl: string): ResourceProvider => {
     );
 };
 
-const HTML_ENTITIES: Record<string, string> = {
-    '&amp;': '&',
-    '&lt;': '<',
-    '&gt;': '>',
-    '&quot;': '"',
-    '&#39;': "'",
-    '&#x27;': "'",
-    '&nbsp;': ' ',
+const NAMED_ENTITIES: Record<string, string> = {
+    amp: '&',
+    lt: '<',
+    gt: '>',
+    quot: '"',
+    apos: "'",
+    nbsp: ' ',
+    mdash: '—',
+    ndash: '–',
+    hellip: '…',
+    lsquo: '‘',
+    rsquo: '’',
+    ldquo: '“',
+    rdquo: '”',
 };
 
+// Decode numeric character references (decimal + hex) and the common named
+// entities. og:title / oEmbed titles routinely encode smart quotes and dashes
+// as numeric refs (e.g. &#8217;, &#x2014;).
 const decodeEntities = (value: string): string =>
-    value.replace(
-        /&(?:amp|lt|gt|quot|nbsp|#39|#x27);/gi,
-        (match) => HTML_ENTITIES[match.toLowerCase()] ?? match,
-    );
+    value.replace(/&(#x?[0-9a-f]+|[a-z0-9]+);/gi, (match, body: string) => {
+        const b = body.toLowerCase();
+        if (b[0] === '#') {
+            const code =
+                b[1] === 'x'
+                    ? parseInt(b.slice(2), 16)
+                    : parseInt(b.slice(1), 10);
+            if (Number.isNaN(code) || code < 0 || code > 0x10ffff) return match;
+            try {
+                return String.fromCodePoint(code);
+            } catch {
+                return match;
+            }
+        }
+        return NAMED_ENTITIES[b] ?? match;
+    });
 
 const readMeta = (html: string, key: string): string | null => {
     const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    // Handle both attribute orders: property-then-content and content-then-property.
+    // Capture the content with a back-referenced quote so an embedded apostrophe
+    // (in a "…") or quote doesn't truncate the value. Handle both attribute
+    // orders: property-then-content and content-then-property.
     const patterns = [
         new RegExp(
-            `<meta[^>]+(?:property|name)=["']${escaped}["'][^>]*content=["']([^"']*)["']`,
+            `<meta[^>]+(?:property|name)=["']${escaped}["'][^>]*content=("|')(.*?)\\1`,
             'i',
         ),
         new RegExp(
-            `<meta[^>]+content=["']([^"']*)["'][^>]*(?:property|name)=["']${escaped}["']`,
+            `<meta[^>]+content=("|')(.*?)\\1[^>]*(?:property|name)=["']${escaped}["']`,
             'i',
         ),
     ];
     for (const pattern of patterns) {
         const match = html.match(pattern);
-        if (match?.[1]) return decodeEntities(match[1].trim());
+        if (match?.[2]) return decodeEntities(match[2].trim());
     }
     return null;
 };
@@ -114,14 +137,15 @@ export const parseYoutubeOembed = (raw: unknown): ParsedLinkMetadata => {
     const data = raw as Record<string, unknown>;
     const asString = (value: unknown): string | null =>
         typeof value === 'string' && value.length > 0 ? value : null;
+    // oEmbed HTML-encodes title/author — decode to match the OpenGraph path.
+    const decoded = (value: unknown): string | null => {
+        const str = asString(value);
+        return str === null ? null : decodeEntities(str);
+    };
     return {
-        title: asString(data.title),
+        title: decoded(data.title),
         // oEmbed has no description; surface the channel as a subtle subtitle.
-        description: asString(data.author_name),
+        description: decoded(data.author_name),
         imageUrl: asString(data.thumbnail_url),
     };
 };
-
-export const resourceKindForProvider = (
-    provider: ResourceProvider,
-): HomepageResourceKind => provider.kind;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1534,6 +1534,8 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['video'] },
                 { dataType: 'enum', enums: ['doc'] },
                 { dataType: 'enum', enums: ['link'] },
+                { dataType: 'enum', enums: ['claude'] },
+                { dataType: 'enum', enums: ['youtube'] },
             ],
             validators: {},
         },
@@ -1544,10 +1546,24 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                imageUrl: { dataType: 'string' },
+                description: { dataType: 'string' },
                 kind: { ref: 'HomepageResourceKind', required: true },
                 url: { dataType: 'string', required: true },
                 title: { dataType: 'string', required: true },
             },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageResourcesLayout: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['card'] },
+                { dataType: 'enum', enums: ['list'] },
+            ],
             validators: {},
         },
     },
@@ -1560,6 +1576,7 @@ const models: TsoaRoute.Models = {
                 config: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        layout: { ref: 'HomepageResourcesLayout' },
                         items: {
                             dataType: 'array',
                             array: {
@@ -2119,6 +2136,58 @@ const models: TsoaRoute.Models = {
     ApiProjectHomepageOrNullResponse: {
         dataType: 'refAlias',
         type: { ref: 'ApiSuccess_ProjectHomepage-or-null_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    HomepageLinkMetadata: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                imageUrl: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                title: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                kind: { ref: 'HomepageResourceKind', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_HomepageLinkMetadata_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'HomepageLinkMetadata', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiHomepageLinkMetadataResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_HomepageLinkMetadata_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     HomepageRecentlyViewedItem: {
@@ -50657,6 +50726,68 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getForBuilder',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectHomepageController_getLinkMetadata: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        url: { in: 'query', name: 'url', required: true, dataType: 'string' },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/homepage/link-metadata',
+        ...fetchMiddlewares<RequestHandler>(ProjectHomepageController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectHomepageController.prototype.getLinkMetadata,
+        ),
+
+        async function ProjectHomepageController_getLinkMetadata(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectHomepageController_getLinkMetadata,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectHomepageController>(
+                        ProjectHomepageController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getLinkMetadata',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1515,10 +1515,16 @@
             },
             "HomepageResourceKind": {
                 "type": "string",
-                "enum": ["video", "doc", "link"]
+                "enum": ["video", "doc", "link", "claude", "youtube"]
             },
             "HomepageResourceItem": {
                 "properties": {
+                    "imageUrl": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
                     "kind": {
                         "$ref": "#/components/schemas/HomepageResourceKind"
                     },
@@ -1532,10 +1538,17 @@
                 "required": ["kind", "url", "title"],
                 "type": "object"
             },
+            "HomepageResourcesLayout": {
+                "type": "string",
+                "enum": ["card", "list"]
+            },
             "HomepageResourcesBlock": {
                 "properties": {
                     "config": {
                         "properties": {
+                            "layout": {
+                                "$ref": "#/components/schemas/HomepageResourcesLayout"
+                            },
                             "items": {
                                 "items": {
                                     "$ref": "#/components/schemas/HomepageResourceItem"
@@ -2129,6 +2142,45 @@
             },
             "ApiProjectHomepageOrNullResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_ProjectHomepage-or-null_"
+            },
+            "HomepageLinkMetadata": {
+                "properties": {
+                    "imageUrl": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "title": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "kind": {
+                        "$ref": "#/components/schemas/HomepageResourceKind"
+                    }
+                },
+                "required": ["imageUrl", "description", "title", "kind"],
+                "type": "object",
+                "description": "Detected metadata for a pasted resource URL (Claude Artifact / YouTube)."
+            },
+            "ApiSuccess_HomepageLinkMetadata_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/HomepageLinkMetadata"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiHomepageLinkMetadataResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_HomepageLinkMetadata_"
             },
             "HomepageRecentlyViewedItem": {
                 "properties": {
@@ -50100,6 +50152,53 @@
                         "required": false,
                         "schema": {
                             "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/homepage/link-metadata": {
+            "get": {
+                "operationId": "getHomepageLinkMetadata",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiHomepageLinkMetadataResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "url",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
                         }
                     }
                 ]

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -24,18 +24,41 @@ export type HomepageCollectionBlock = {
     config: { title: string; items: HomepageCollectionItemRef[] };
 };
 
-export type HomepageResourceKind = 'video' | 'doc' | 'link';
+export type HomepageResourceKind =
+    | 'video'
+    | 'doc'
+    | 'link'
+    | 'claude'
+    | 'youtube';
 
 export type HomepageResourceItem = {
     title: string;
     url: string;
     kind: HomepageResourceKind;
+    // Optional for back-compat with already-stored items; new items always set them.
+    description?: string;
+    imageUrl?: string;
 };
+
+export type HomepageResourcesLayout = 'card' | 'list';
 
 export type HomepageResourcesBlock = {
     id: string;
     type: 'resources';
-    config: { title: string; items: HomepageResourceItem[] };
+    config: {
+        title: string;
+        items: HomepageResourceItem[];
+        // Optional for back-compat: undefined renders as 'list'.
+        layout?: HomepageResourcesLayout;
+    };
+};
+
+/** Detected metadata for a pasted resource URL (Claude Artifact / YouTube). */
+export type HomepageLinkMetadata = {
+    kind: HomepageResourceKind;
+    title: string | null;
+    description: string | null;
+    imageUrl: string | null;
 };
 
 export type HomepageAnnouncementItem = {
@@ -261,6 +284,8 @@ export type UpdateProjectHomepageDraftRequest = {
     /** Compare-and-set token: the updatedAt the client based its edit on */
     baseUpdatedAt: Date;
 };
+
+export type ApiHomepageLinkMetadataResponse = ApiSuccess<HomepageLinkMetadata>;
 
 export type ApiProjectHomepageResponse = ApiSuccess<ProjectHomepage>;
 export type ApiProjectHomepagesResponse = ApiSuccess<ProjectHomepage[]>;

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -53,6 +53,7 @@ import type {
     ApiGetAppResponse,
     ApiGetDataAppVizResponse,
     ApiGetUserAgentPreferencesResponse,
+    ApiHomepageLinkMetadataResponse,
     ApiHomepageViewAsResponse,
     ApiListDataAppVizsResponse,
     ApiManagedAgentActionResponse,
@@ -1289,6 +1290,7 @@ type ApiResults =
     | ApiProjectHomepageOrNullResponse['results']
     | ApiResolvedHomepageResponse['results']
     | ApiHomepageViewAsResponse['results']
+    | ApiHomepageLinkMetadataResponse['results']
     | ApiProjectColorPaletteResponse['results']
     | ApiOrganizationBrandResponse['results']
     | ApiManagedAgentRunResponse['results']

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.test.tsx
@@ -1,0 +1,129 @@
+import { type HomepageResourcesBlock } from '@lightdash/common';
+import { MantineProvider } from '@mantine-8/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fetchHomepageLinkMetadata } from '../hooks/useHomepageLinkMetadata';
+import {
+    ResourcesBlockBuild,
+    ResourcesBlockView,
+    resolveResourceUrl,
+} from './ResourcesBlock';
+
+vi.mock('../hooks/useHomepageLinkMetadata', () => ({
+    fetchHomepageLinkMetadata: vi.fn(),
+}));
+
+const mockFetch = vi.mocked(fetchHomepageLinkMetadata);
+
+const wrap = (ui: React.ReactNode) =>
+    render(<MantineProvider>{ui}</MantineProvider>);
+
+const block = (
+    config: Partial<HomepageResourcesBlock['config']>,
+): HomepageResourcesBlock => ({
+    id: 'b1',
+    type: 'resources',
+    config: { title: 'Getting started', items: [], ...config },
+});
+
+const claudeItem = {
+    url: 'https://claude.ai/public/artifacts/abc',
+    kind: 'claude' as const,
+    title: 'Palette Lab',
+    description: 'Generate color palettes',
+    imageUrl: 'https://claude.ai/images/claude_ogimage.png',
+};
+
+describe('ResourcesBlockView', () => {
+    it('renders a card with title, description and a link to the resource', () => {
+        wrap(
+            <ResourcesBlockView
+                projectUuid="p1"
+                block={block({ layout: 'card', items: [claudeItem] })}
+            />,
+        );
+        expect(screen.getByText('Palette Lab')).toBeInTheDocument();
+        expect(screen.getByText('Generate color palettes')).toBeInTheDocument();
+        expect(screen.getByRole('link')).toHaveAttribute(
+            'href',
+            claudeItem.url,
+        );
+    });
+
+    it('renders a compact row in list layout', () => {
+        wrap(
+            <ResourcesBlockView
+                projectUuid="p1"
+                block={block({ layout: 'list', items: [claudeItem] })}
+            />,
+        );
+        expect(screen.getByText('Palette Lab')).toBeInTheDocument();
+        expect(screen.getByRole('link')).toHaveAttribute(
+            'href',
+            claudeItem.url,
+        );
+    });
+
+    it('renders nothing when there are no items', () => {
+        wrap(
+            <ResourcesBlockView projectUuid="p1" block={block({ items: [] })} />,
+        );
+        expect(screen.queryByRole('link')).toBeNull();
+        expect(screen.queryByText('Getting started')).toBeNull();
+    });
+});
+
+describe('ResourcesBlockBuild smart paste', () => {
+    beforeEach(() => mockFetch.mockReset());
+
+    it('resolves an allowlisted URL into a fully-populated item', async () => {
+        mockFetch.mockResolvedValue({
+            kind: 'claude',
+            title: 'Palette Lab',
+            description: 'Generate color palettes',
+            imageUrl: 'https://claude.ai/images/claude_ogimage.png',
+        });
+        const onChange = vi.fn();
+        wrap(
+            <ResourcesBlockBuild
+                projectUuid="p1"
+                onChange={onChange}
+                block={block({ layout: 'card', items: [] })}
+            />,
+        );
+
+        fireEvent.change(
+            screen.getByPlaceholderText(/Paste a Claude artifact/i),
+            { target: { value: claudeItem.url } },
+        );
+        fireEvent.click(screen.getByLabelText('Add resource'));
+
+        await waitFor(() => expect(onChange).toHaveBeenCalled());
+        const committed = onChange.mock.calls.at(-1)![0];
+        expect(committed.config.items).toEqual([claudeItem]);
+    });
+
+    it('falls back to a plain link when the host is not allowlisted', async () => {
+        mockFetch.mockRejectedValueOnce(new Error('400'));
+        await expect(
+            resolveResourceUrl('p1', 'https://example.com/handbook'),
+        ).resolves.toEqual({
+            url: 'https://example.com/handbook',
+            kind: 'link',
+            title: 'example.com',
+        });
+    });
+
+    it('adds https:// to a bare host before resolving', async () => {
+        mockFetch.mockResolvedValueOnce({
+            kind: 'youtube',
+            title: 'Clip',
+            description: 'Channel',
+            imageUrl: 'https://i.ytimg.com/vi/x/hqdefault.jpg',
+        });
+        await resolveResourceUrl('p1', 'youtube.com/watch?v=x');
+        expect(mockFetch).toHaveBeenCalledWith(
+            'p1',
+            'https://youtube.com/watch?v=x',
+        );
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.test.tsx
@@ -2,11 +2,8 @@ import { type HomepageResourcesBlock } from '@lightdash/common';
 import { MantineProvider } from '@mantine-8/core';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { fetchHomepageLinkMetadata } from '../hooks/useHomepageLinkMetadata';
-import {
-    ResourcesBlockBuild,
-    ResourcesBlockView,
-    resolveResourceUrl,
-} from './ResourcesBlock';
+import { ResourcesBlockBuild, ResourcesBlockView } from './ResourcesBlock';
+import { resolveResourceUrl } from './resourceUrls';
 
 vi.mock('../hooks/useHomepageLinkMetadata', () => ({
     fetchHomepageLinkMetadata: vi.fn(),
@@ -65,7 +62,10 @@ describe('ResourcesBlockView', () => {
 
     it('renders nothing when there are no items', () => {
         wrap(
-            <ResourcesBlockView projectUuid="p1" block={block({ items: [] })} />,
+            <ResourcesBlockView
+                projectUuid="p1"
+                block={block({ items: [] })}
+            />,
         );
         expect(screen.queryByRole('link')).toBeNull();
         expect(screen.queryByText('Getting started')).toBeNull();
@@ -111,6 +111,36 @@ describe('ResourcesBlockBuild smart paste', () => {
             kind: 'link',
             title: 'example.com',
         });
+    });
+
+    it('ignores non-URL words when pasting prose around a link', async () => {
+        mockFetch.mockResolvedValue({
+            kind: 'claude',
+            title: 'Palette Lab',
+            description: null,
+            imageUrl: null,
+        });
+        const onChange = vi.fn();
+        wrap(
+            <ResourcesBlockBuild
+                projectUuid="p1"
+                onChange={onChange}
+                block={block({ layout: 'card', items: [] })}
+            />,
+        );
+
+        fireEvent.change(
+            screen.getByPlaceholderText(/Paste a Claude artifact/i),
+            { target: { value: `Check this out: ${claudeItem.url}` } },
+        );
+        fireEvent.click(screen.getByLabelText('Add resource'));
+
+        await waitFor(() => expect(onChange).toHaveBeenCalled());
+        const committed = onChange.mock.calls.at(-1)![0];
+        // Only the URL becomes a resource; "Check", "this", "out:" are dropped.
+        expect(committed.config.items).toHaveLength(1);
+        expect(committed.config.items[0].url).toBe(claudeItem.url);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
     it('adds https:// to a bare host before resolving', async () => {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -76,7 +76,11 @@ const CardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
     const meta = kindMeta(item.kind);
     const [imgFailed, setImgFailed] = useState(false);
     const [faviconFailed, setFaviconFailed] = useState(false);
-    if (item.imageUrl && !imgFailed) {
+    const favicon = faviconUrl(item.url);
+
+    // A real per-item photo (e.g. a YouTube still) fills the frame sharply.
+    // Claude's og:image is generic/soft, so it's treated as a backdrop instead.
+    if (item.imageUrl && item.kind !== 'claude' && !imgFailed) {
         return (
             <div className={classes.resThumb}>
                 <img
@@ -88,21 +92,33 @@ const CardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
             </div>
         );
     }
-    const favicon = faviconUrl(item.url);
+
+    // No sharp photo → blurred colour backdrop (claude's card, else the site's
+    // own favicon) with the crisp favicon floating on top.
+    const backdrop = item.kind === 'claude' ? item.imageUrl : favicon;
     return (
-        <div
-            className={`${classes.resThumb} ${classes.resThumbFallback} ${meta.thumbAccent}`}
-        >
+        <div className={`${classes.resThumbTile} ${meta.thumbAccent}`}>
+            {backdrop ? (
+                <img
+                    className={classes.resThumbBackdrop}
+                    src={backdrop}
+                    alt=""
+                    loading="lazy"
+                    aria-hidden
+                />
+            ) : null}
             {favicon && !faviconFailed ? (
                 <img
-                    className={classes.resFavicon}
+                    className={classes.resFaviconFloat}
                     src={favicon}
-                    alt=""
+                    alt={item.title}
                     loading="lazy"
                     onError={() => setFaviconFailed(true)}
                 />
             ) : (
-                <MantineIcon icon={meta.icon} size={22} />
+                <div className={classes.resGlyphFloat}>
+                    <MantineIcon icon={meta.icon} size={26} />
+                </div>
             )}
         </div>
     );
@@ -111,7 +127,7 @@ const CardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
 const RowThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
     const [imgFailed, setImgFailed] = useState(false);
     const [faviconFailed, setFaviconFailed] = useState(false);
-    if (item.imageUrl && !imgFailed) {
+    if (item.imageUrl && item.kind !== 'claude' && !imgFailed) {
         return (
             <div className={classes.rowThumb}>
                 <img

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -1,67 +1,178 @@
 import {
     type HomepageResourceItem,
     type HomepageResourceKind,
+    type HomepageResourcesLayout,
 } from '@lightdash/common';
-import { ActionIcon, Group, Select, Stack, TextInput } from '@mantine-8/core';
+import {
+    ActionIcon,
+    Group,
+    SegmentedControl,
+    Select,
+    Stack,
+    Textarea,
+    TextInput,
+} from '@mantine-8/core';
 import {
     IconBook,
+    IconBrandYoutube,
     IconExternalLink,
+    IconLayoutGrid,
+    IconLayoutList,
     IconLink,
     IconPlus,
+    IconSparkles,
+    IconTrash,
     IconVideo,
-    IconX,
     type Icon,
 } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import {
+    useEffect,
+    useRef,
+    useState,
+    type ClipboardEvent,
+    type FC,
+    type KeyboardEvent,
+} from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
+import { fetchHomepageLinkMetadata } from '../hooks/useHomepageLinkMetadata';
 import { BlockHeader, IconSquare, MiniPill } from './BlockShell';
 import classes from './blockStyles.module.css';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
-const KIND_ICONS: Record<HomepageResourceKind, Icon> = {
-    video: IconVideo,
-    doc: IconBook,
-    link: IconLink,
+const KIND_META: Record<
+    HomepageResourceKind,
+    { icon: Icon; label: string; thumbAccent: string }
+> = {
+    video: { icon: IconVideo, label: 'Video', thumbAccent: '' },
+    doc: { icon: IconBook, label: 'Doc', thumbAccent: '' },
+    link: { icon: IconLink, label: 'Link', thumbAccent: '' },
+    claude: {
+        icon: IconSparkles,
+        label: 'Claude',
+        thumbAccent: classes.resThumbClaude,
+    },
+    youtube: {
+        icon: IconBrandYoutube,
+        label: 'YouTube',
+        thumbAccent: classes.resThumbYoutube,
+    },
 };
 
-const KIND_LABELS: Record<HomepageResourceKind, string> = {
-    video: 'Video',
-    doc: 'Doc',
-    link: 'Link',
+const KIND_OPTIONS = (Object.keys(KIND_META) as HomepageResourceKind[]).map(
+    (kind) => ({ value: kind, label: KIND_META[kind].label }),
+);
+
+const kindMeta = (kind: HomepageResourceKind) =>
+    KIND_META[kind] ?? KIND_META.link;
+
+const hostnameOf = (url: string): string => {
+    try {
+        return new URL(url).hostname.replace(/^www\./, '');
+    } catch {
+        return url;
+    }
 };
 
-const ResourceRow: FC<{
-    item: HomepageResourceItem;
-    onRemove?: () => void;
-}> = ({ item, onRemove }) => {
-    const body = (
-        <>
-            <IconSquare icon={KIND_ICONS[item.kind] ?? IconLink} />
-            <div className={classes.flexFill}>
-                <div className={classes.rowName}>{item.title}</div>
-                <div className={classes.rowMeta}>{item.url}</div>
+const faviconUrl = (url: string): string | null => {
+    try {
+        return `https://www.google.com/s2/favicons?domain=${
+            new URL(url).hostname
+        }&sz=64`;
+    } catch {
+        return null;
+    }
+};
+
+const normalizeUrl = (raw: string): string =>
+    /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+
+// --- Thumbnails -------------------------------------------------------------
+
+const CardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
+    const meta = kindMeta(item.kind);
+    if (item.imageUrl) {
+        return (
+            <div className={classes.resThumb}>
+                <img src={item.imageUrl} alt={item.title} loading="lazy" />
             </div>
-            <MiniPill>{KIND_LABELS[item.kind] ?? 'Link'}</MiniPill>
-            {onRemove ? (
-                <ActionIcon
-                    variant="subtle"
-                    color="ldGray.6"
-                    size="sm"
-                    aria-label={`Remove resource ${item.title}`}
-                    onClick={onRemove}
-                >
-                    <MantineIcon icon={IconX} />
-                </ActionIcon>
-            ) : (
-                <MantineIcon
-                    icon={IconExternalLink}
-                    size={14}
-                    color="ldGray.4"
+        );
+    }
+    const favicon = faviconUrl(item.url);
+    return (
+        <div
+            className={`${classes.resThumb} ${classes.resThumbFallback} ${meta.thumbAccent}`}
+        >
+            {favicon ? (
+                <img
+                    className={classes.resFavicon}
+                    src={favicon}
+                    alt=""
+                    loading="lazy"
                 />
+            ) : (
+                <MantineIcon icon={meta.icon} size={22} />
             )}
-        </>
+        </div>
     );
-    if (onRemove) return <div className={classes.listRow}>{body}</div>;
+};
+
+const RowThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
+    if (item.imageUrl) {
+        return (
+            <div className={classes.rowThumb}>
+                <img src={item.imageUrl} alt="" loading="lazy" />
+            </div>
+        );
+    }
+    const favicon = faviconUrl(item.url);
+    if (favicon) {
+        return (
+            <div className={`${classes.rowThumb} ${classes.rowThumbFallback}`}>
+                <img
+                    className={classes.rowFavicon}
+                    src={favicon}
+                    alt=""
+                    loading="lazy"
+                />
+            </div>
+        );
+    }
+    return <IconSquare icon={kindMeta(item.kind).icon} />;
+};
+
+// --- Read-only presentation (published + preview) ---------------------------
+
+const ResourceCard: FC<{ item: HomepageResourceItem }> = ({ item }) => {
+    const meta = kindMeta(item.kind);
+    return (
+        <a
+            href={item.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`${classes.mediaCard} ${classes.clickable} ${classes.plainLink}`}
+        >
+            <CardThumb item={item} />
+            <div className={classes.mediaBody}>
+                <div className={classes.mediaKind}>
+                    <MantineIcon icon={meta.icon} size={12} />
+                    <span>{meta.label}</span>
+                    <MantineIcon
+                        icon={IconExternalLink}
+                        size={12}
+                        className={classes.mediaExternal}
+                    />
+                </div>
+                <div className={classes.mediaTitle}>{item.title}</div>
+                {item.description ? (
+                    <div className={classes.mediaDesc}>{item.description}</div>
+                ) : null}
+            </div>
+        </a>
+    );
+};
+
+const ResourceRow: FC<{ item: HomepageResourceItem }> = ({ item }) => {
+    const meta = kindMeta(item.kind);
     return (
         <a
             href={item.url}
@@ -69,7 +180,15 @@ const ResourceRow: FC<{
             rel="noopener noreferrer"
             className={`${classes.listRow} ${classes.clickable} ${classes.plainLink}`}
         >
-            {body}
+            <RowThumb item={item} />
+            <div className={classes.flexFill}>
+                <div className={classes.rowName}>{item.title}</div>
+                <div className={classes.rowMeta}>
+                    {item.description || hostnameOf(item.url)}
+                </div>
+            </div>
+            <MiniPill>{meta.label}</MiniPill>
+            <MantineIcon icon={IconExternalLink} size={14} color="ldGray.4" />
         </a>
     );
 };
@@ -78,123 +197,368 @@ export const ResourcesBlockView: FC<BlockComponentProps> = ({ block }) => {
     if (block.type !== 'resources' || block.config.items.length === 0) {
         return null;
     }
+    const layout: HomepageResourcesLayout = block.config.layout ?? 'list';
     return (
         <Stack gap={0}>
             <BlockHeader icon={IconBook} title={block.config.title} />
-            <div className={classes.listCard}>
-                {block.config.items.map((item) => (
-                    <ResourceRow key={item.url} item={item} />
-                ))}
-            </div>
+            {layout === 'card' ? (
+                <div className={classes.mediaGrid}>
+                    {block.config.items.map((item, i) => (
+                        <ResourceCard key={`${item.url}-${i}`} item={item} />
+                    ))}
+                </div>
+            ) : (
+                <div className={classes.listCard}>
+                    {block.config.items.map((item, i) => (
+                        <ResourceRow key={`${item.url}-${i}`} item={item} />
+                    ))}
+                </div>
+            )}
         </Stack>
     );
 };
 
+// --- Skeletons (in-flight paste) --------------------------------------------
+
+const SkeletonCard: FC = () => (
+    <div className={classes.mediaCard}>
+        <div className={`${classes.resThumb} ${classes.skeletonBlock}`} />
+        <div className={classes.mediaBody}>
+            <div className={`${classes.skeletonLine} ${classes.skeletonKind}`} />
+            <div className={classes.skeletonLine} />
+            <div
+                className={`${classes.skeletonLine} ${classes.skeletonShort}`}
+            />
+        </div>
+    </div>
+);
+
+const SkeletonRow: FC = () => (
+    <div className={classes.listRow}>
+        <div className={`${classes.rowThumb} ${classes.skeletonBlock}`} />
+        <div className={classes.flexFill}>
+            <div className={classes.skeletonLine} />
+            <div
+                className={`${classes.skeletonLine} ${classes.skeletonShort} ${classes.skeletonRowSecond}`}
+            />
+        </div>
+    </div>
+);
+
+// --- Editable build cards/rows ----------------------------------------------
+
+type EditProps = {
+    item: HomepageResourceItem;
+    onPatch: (patch: Partial<HomepageResourceItem>) => void;
+    onRemove: () => void;
+};
+
+const KindSelect: FC<{
+    value: HomepageResourceKind;
+    onChange: (kind: HomepageResourceKind) => void;
+}> = ({ value, onChange }) => (
+    <Select
+        size="xs"
+        w={104}
+        variant="unstyled"
+        data={KIND_OPTIONS}
+        value={value}
+        allowDeselect={false}
+        onChange={(v) => v && onChange(v as HomepageResourceKind)}
+        aria-label="Resource kind"
+    />
+);
+
+const BuildCard: FC<EditProps> = ({ item, onPatch, onRemove }) => (
+    <div className={classes.mediaCard}>
+        <CardThumb item={item} />
+        <div className={classes.mediaBody}>
+            <Group gap={4} justify="space-between" wrap="nowrap">
+                <KindSelect
+                    value={item.kind}
+                    onChange={(kind) => onPatch({ kind })}
+                />
+                <ActionIcon
+                    variant="subtle"
+                    color="ldGray.6"
+                    size="sm"
+                    aria-label={`Remove ${item.title}`}
+                    onClick={onRemove}
+                >
+                    <MantineIcon icon={IconTrash} />
+                </ActionIcon>
+            </Group>
+            <TextInput
+                variant="unstyled"
+                size="xs"
+                placeholder="Title"
+                value={item.title}
+                className={classes.mediaTitleInput}
+                onChange={(e) => onPatch({ title: e.currentTarget.value })}
+            />
+            <Textarea
+                variant="unstyled"
+                size="xs"
+                autosize
+                minRows={1}
+                maxRows={3}
+                placeholder="Description"
+                value={item.description ?? ''}
+                onChange={(e) =>
+                    onPatch({ description: e.currentTarget.value || undefined })
+                }
+            />
+        </div>
+    </div>
+);
+
+const BuildRow: FC<EditProps> = ({ item, onPatch, onRemove }) => (
+    <div className={classes.listRow}>
+        <RowThumb item={item} />
+        <div className={classes.flexFill}>
+            <TextInput
+                variant="unstyled"
+                size="xs"
+                placeholder="Title"
+                value={item.title}
+                onChange={(e) => onPatch({ title: e.currentTarget.value })}
+            />
+            <TextInput
+                variant="unstyled"
+                size="xs"
+                placeholder="Description"
+                value={item.description ?? ''}
+                onChange={(e) =>
+                    onPatch({ description: e.currentTarget.value || undefined })
+                }
+            />
+        </div>
+        <KindSelect value={item.kind} onChange={(kind) => onPatch({ kind })} />
+        <ActionIcon
+            variant="subtle"
+            color="ldGray.6"
+            size="sm"
+            aria-label={`Remove ${item.title}`}
+            onClick={onRemove}
+        >
+            <MantineIcon icon={IconTrash} />
+        </ActionIcon>
+    </div>
+);
+
+// --- Build container --------------------------------------------------------
+
+type BatchEntry = {
+    key: number;
+    url: string;
+    item: HomepageResourceItem | null;
+};
+
+export const resolveResourceUrl = async (
+    projectUuid: string,
+    rawUrl: string,
+): Promise<HomepageResourceItem> => {
+    const url = normalizeUrl(rawUrl.trim());
+    try {
+        const meta = await fetchHomepageLinkMetadata(projectUuid, url);
+        return {
+            url,
+            kind: meta.kind,
+            title: meta.title ?? hostnameOf(url),
+            ...(meta.description ? { description: meta.description } : {}),
+            ...(meta.imageUrl ? { imageUrl: meta.imageUrl } : {}),
+        };
+    } catch {
+        // Host outside the allowlist (or fetch failure) → plain link.
+        return { url, kind: 'link', title: hostnameOf(url) };
+    }
+};
+
 export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
     block,
+    projectUuid,
     onChange,
 }) => {
-    const [title, setTitle] = useState('');
-    const [url, setUrl] = useState('');
-    const [kind, setKind] = useState<string | null>('link');
-    if (block.type !== 'resources') return null;
+    const [pasteValue, setPasteValue] = useState('');
+    const [batch, setBatch] = useState<BatchEntry[]>([]);
+    const keyCounter = useRef(0);
 
-    const addResource = () => {
-        const trimmedTitle = title.trim();
-        const trimmedUrl = url.trim();
-        if (!trimmedTitle || !trimmedUrl) return;
+    // Flush the paste batch into config once every URL has resolved — a single
+    // commit avoids racing parallel appends against a stale block snapshot.
+    useEffect(() => {
+        if (block.type !== 'resources') return;
+        if (batch.length === 0 || batch.some((e) => e.item === null)) return;
+        const resolved = batch.map((e) => e.item as HomepageResourceItem);
         onChange({
             ...block,
             config: {
                 ...block.config,
-                items: [
-                    ...block.config.items,
-                    {
-                        title: trimmedTitle,
-                        url: trimmedUrl,
-                        kind: (kind ?? 'link') as HomepageResourceKind,
-                    },
-                ],
+                items: [...block.config.items, ...resolved],
             },
         });
-        setTitle('');
-        setUrl('');
+        setBatch([]);
+    }, [batch, block, onChange]);
+
+    if (block.type !== 'resources') return null;
+    const { items } = block.config;
+    const layout: HomepageResourcesLayout = block.config.layout ?? 'list';
+
+    const patchConfig = (patch: Partial<typeof block.config>) =>
+        onChange({ ...block, config: { ...block.config, ...patch } });
+
+    const patchItem = (index: number, patch: Partial<HomepageResourceItem>) =>
+        patchConfig({
+            items: items.map((it, i) =>
+                i === index ? { ...it, ...patch } : it,
+            ),
+        });
+
+    const removeItem = (index: number) =>
+        patchConfig({ items: items.filter((_, i) => i !== index) });
+
+    const startResolving = (text: string) => {
+        const urls = Array.from(
+            new Set(
+                text
+                    .split(/\s+/)
+                    .map((s) => s.trim())
+                    .filter(Boolean),
+            ),
+        );
+        if (urls.length === 0) return;
+        setPasteValue('');
+        const entries: BatchEntry[] = urls.map((url) => {
+            keyCounter.current += 1;
+            return { key: keyCounter.current, url, item: null };
+        });
+        setBatch((prev) => [...prev, ...entries]);
+        entries.forEach((entry) => {
+            void resolveResourceUrl(projectUuid, entry.url).then((item) =>
+                setBatch((prev) =>
+                    prev.map((e) =>
+                        e.key === entry.key ? { ...e, item } : e,
+                    ),
+                ),
+            );
+        });
     };
+
+    const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
+        const text = e.clipboardData.getData('text');
+        if (text.trim()) {
+            e.preventDefault();
+            startResolving(text);
+        }
+    };
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            startResolving(pasteValue);
+        }
+    };
+
+    const resolvedBatch = batch.filter(
+        (e): e is BatchEntry & { item: HomepageResourceItem } =>
+            e.item !== null,
+    );
+    const pendingCount = batch.length - resolvedBatch.length;
 
     return (
         <Stack gap="xs">
-            <TextInput
-                label="Title"
-                size="xs"
-                fw={600}
-                value={block.config.title}
-                onChange={(e) =>
-                    onChange({
-                        ...block,
-                        config: {
-                            ...block.config,
-                            title: e.currentTarget.value,
-                        },
-                    })
-                }
-            />
-            <div className={classes.listCard}>
-                {block.config.items.map((item) => (
-                    <ResourceRow
-                        key={item.url}
-                        item={item}
-                        onRemove={() =>
-                            onChange({
-                                ...block,
-                                config: {
-                                    ...block.config,
-                                    items: block.config.items.filter(
-                                        (i) => i.url !== item.url,
-                                    ),
-                                },
-                            })
-                        }
-                    />
-                ))}
-            </div>
-            <Group gap="xs" align="flex-end">
+            <Group
+                justify="space-between"
+                wrap="nowrap"
+                gap="xs"
+                align="flex-end"
+            >
                 <TextInput
                     label="Title"
                     size="xs"
+                    fw={600}
                     flex={1}
-                    placeholder="e.g. Intro to Lightdash (3 min)"
-                    value={title}
-                    onChange={(e) => setTitle(e.currentTarget.value)}
+                    value={block.config.title}
+                    onChange={(e) =>
+                        patchConfig({ title: e.currentTarget.value })
+                    }
                 />
-                <TextInput
-                    label="URL"
+                <SegmentedControl
                     size="xs"
-                    flex={1}
-                    placeholder="https://…"
-                    value={url}
-                    onChange={(e) => setUrl(e.currentTarget.value)}
-                />
-                <Select
-                    label="Kind"
-                    size="xs"
-                    w={90}
+                    value={layout}
+                    onChange={(v) =>
+                        patchConfig({ layout: v as HomepageResourcesLayout })
+                    }
                     data={[
-                        { value: 'link', label: 'Link' },
-                        { value: 'doc', label: 'Doc' },
-                        { value: 'video', label: 'Video' },
+                        {
+                            value: 'card',
+                            label: <MantineIcon icon={IconLayoutGrid} />,
+                        },
+                        {
+                            value: 'list',
+                            label: <MantineIcon icon={IconLayoutList} />,
+                        },
                     ]}
-                    value={kind}
-                    onChange={setKind}
+                />
+            </Group>
+
+            {layout === 'card' ? (
+                <div className={classes.mediaGrid}>
+                    {items.map((item, i) => (
+                        <BuildCard
+                            key={`${item.url}-${i}`}
+                            item={item}
+                            onPatch={(patch) => patchItem(i, patch)}
+                            onRemove={() => removeItem(i)}
+                        />
+                    ))}
+                    {resolvedBatch.map((e) => (
+                        <ResourceCard key={e.key} item={e.item} />
+                    ))}
+                    {Array.from({ length: pendingCount }).map((_, i) => (
+                        <SkeletonCard key={`sk-${i}`} />
+                    ))}
+                </div>
+            ) : (
+                <div className={classes.listCard}>
+                    {items.map((item, i) => (
+                        <BuildRow
+                            key={`${item.url}-${i}`}
+                            item={item}
+                            onPatch={(patch) => patchItem(i, patch)}
+                            onRemove={() => removeItem(i)}
+                        />
+                    ))}
+                    {resolvedBatch.map((e) => (
+                        <ResourceRow key={e.key} item={e.item} />
+                    ))}
+                    {Array.from({ length: pendingCount }).map((_, i) => (
+                        <SkeletonRow key={`sk-${i}`} />
+                    ))}
+                </div>
+            )}
+
+            <Group gap="xs" align="flex-end">
+                <TextInput
+                    size="xs"
+                    flex={1}
+                    placeholder="Paste a Claude artifact, YouTube, or any link…"
+                    value={pasteValue}
+                    onChange={(e) => setPasteValue(e.currentTarget.value)}
+                    onPaste={handlePaste}
+                    onKeyDown={handleKeyDown}
                 />
                 <ActionIcon
                     variant="default"
                     size="lg"
                     aria-label="Add resource"
-                    onClick={addResource}
+                    onClick={() => startResolving(pasteValue)}
                 >
                     <MantineIcon icon={IconPlus} />
                 </ActionIcon>
             </Group>
+            <div className={classes.buildHint}>
+                Paste multiple links (one per line) to add them all at once.
+            </div>
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -41,6 +41,7 @@ import {
     hostnameOf,
     looksLikeUrl,
     resolveResourceUrl,
+    safeImageUrl,
 } from './resourceUrls';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
@@ -77,14 +78,15 @@ const CardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
     const [imgFailed, setImgFailed] = useState(false);
     const [faviconFailed, setFaviconFailed] = useState(false);
     const favicon = faviconUrl(item.url);
+    const imageUrl = safeImageUrl(item.imageUrl);
 
     // A real per-item photo (e.g. a YouTube still) fills the frame sharply.
     // Claude's og:image is generic/soft, so it's treated as a backdrop instead.
-    if (item.imageUrl && item.kind !== 'claude' && !imgFailed) {
+    if (imageUrl && item.kind !== 'claude' && !imgFailed) {
         return (
             <div className={classes.resThumb}>
                 <img
-                    src={item.imageUrl}
+                    src={imageUrl}
                     alt={item.title}
                     loading="lazy"
                     onError={() => setImgFailed(true)}
@@ -95,7 +97,7 @@ const CardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
 
     // No sharp photo → blurred colour backdrop (claude's card, else the site's
     // own favicon) with the crisp favicon floating on top.
-    const backdrop = item.kind === 'claude' ? item.imageUrl : favicon;
+    const backdrop = item.kind === 'claude' ? imageUrl : favicon;
     return (
         <div className={`${classes.resThumbTile} ${meta.thumbAccent}`}>
             {backdrop ? (
@@ -127,11 +129,12 @@ const CardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
 const RowThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
     const [imgFailed, setImgFailed] = useState(false);
     const [faviconFailed, setFaviconFailed] = useState(false);
-    if (item.imageUrl && item.kind !== 'claude' && !imgFailed) {
+    const imageUrl = safeImageUrl(item.imageUrl);
+    if (imageUrl && item.kind !== 'claude' && !imgFailed) {
         return (
             <div className={classes.rowThumb}>
                 <img
-                    src={item.imageUrl}
+                    src={imageUrl}
                     alt=""
                     loading="lazy"
                     onError={() => setImgFailed(true)}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -34,9 +34,14 @@ import {
     type KeyboardEvent,
 } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
-import { fetchHomepageLinkMetadata } from '../hooks/useHomepageLinkMetadata';
 import { BlockHeader, IconSquare, MiniPill } from './BlockShell';
 import classes from './blockStyles.module.css';
+import {
+    faviconUrl,
+    hostnameOf,
+    looksLikeUrl,
+    resolveResourceUrl,
+} from './resourceUrls';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const KIND_META: Record<
@@ -65,35 +70,21 @@ const KIND_OPTIONS = (Object.keys(KIND_META) as HomepageResourceKind[]).map(
 const kindMeta = (kind: HomepageResourceKind) =>
     KIND_META[kind] ?? KIND_META.link;
 
-const hostnameOf = (url: string): string => {
-    try {
-        return new URL(url).hostname.replace(/^www\./, '');
-    } catch {
-        return url;
-    }
-};
-
-const faviconUrl = (url: string): string | null => {
-    try {
-        return `https://www.google.com/s2/favicons?domain=${
-            new URL(url).hostname
-        }&sz=64`;
-    } catch {
-        return null;
-    }
-};
-
-const normalizeUrl = (raw: string): string =>
-    /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
-
 // --- Thumbnails -------------------------------------------------------------
 
 const CardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
     const meta = kindMeta(item.kind);
-    if (item.imageUrl) {
+    const [imgFailed, setImgFailed] = useState(false);
+    const [faviconFailed, setFaviconFailed] = useState(false);
+    if (item.imageUrl && !imgFailed) {
         return (
             <div className={classes.resThumb}>
-                <img src={item.imageUrl} alt={item.title} loading="lazy" />
+                <img
+                    src={item.imageUrl}
+                    alt={item.title}
+                    loading="lazy"
+                    onError={() => setImgFailed(true)}
+                />
             </div>
         );
     }
@@ -102,12 +93,13 @@ const CardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
         <div
             className={`${classes.resThumb} ${classes.resThumbFallback} ${meta.thumbAccent}`}
         >
-            {favicon ? (
+            {favicon && !faviconFailed ? (
                 <img
                     className={classes.resFavicon}
                     src={favicon}
                     alt=""
                     loading="lazy"
+                    onError={() => setFaviconFailed(true)}
                 />
             ) : (
                 <MantineIcon icon={meta.icon} size={22} />
@@ -117,15 +109,22 @@ const CardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
 };
 
 const RowThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
-    if (item.imageUrl) {
+    const [imgFailed, setImgFailed] = useState(false);
+    const [faviconFailed, setFaviconFailed] = useState(false);
+    if (item.imageUrl && !imgFailed) {
         return (
             <div className={classes.rowThumb}>
-                <img src={item.imageUrl} alt="" loading="lazy" />
+                <img
+                    src={item.imageUrl}
+                    alt=""
+                    loading="lazy"
+                    onError={() => setImgFailed(true)}
+                />
             </div>
         );
     }
     const favicon = faviconUrl(item.url);
-    if (favicon) {
+    if (favicon && !faviconFailed) {
         return (
             <div className={`${classes.rowThumb} ${classes.rowThumbFallback}`}>
                 <img
@@ -133,6 +132,7 @@ const RowThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
                     src={favicon}
                     alt=""
                     loading="lazy"
+                    onError={() => setFaviconFailed(true)}
                 />
             </div>
         );
@@ -162,7 +162,9 @@ const ResourceCard: FC<{ item: HomepageResourceItem }> = ({ item }) => {
                         className={classes.mediaExternal}
                     />
                 </div>
-                <div className={classes.mediaTitle}>{item.title}</div>
+                <div className={classes.mediaTitle}>
+                    {item.title || hostnameOf(item.url)}
+                </div>
                 {item.description ? (
                     <div className={classes.mediaDesc}>{item.description}</div>
                 ) : null}
@@ -224,7 +226,9 @@ const SkeletonCard: FC = () => (
     <div className={classes.mediaCard}>
         <div className={`${classes.resThumb} ${classes.skeletonBlock}`} />
         <div className={classes.mediaBody}>
-            <div className={`${classes.skeletonLine} ${classes.skeletonKind}`} />
+            <div
+                className={`${classes.skeletonLine} ${classes.skeletonKind}`}
+            />
             <div className={classes.skeletonLine} />
             <div
                 className={`${classes.skeletonLine} ${classes.skeletonShort}`}
@@ -354,26 +358,6 @@ type BatchEntry = {
     item: HomepageResourceItem | null;
 };
 
-export const resolveResourceUrl = async (
-    projectUuid: string,
-    rawUrl: string,
-): Promise<HomepageResourceItem> => {
-    const url = normalizeUrl(rawUrl.trim());
-    try {
-        const meta = await fetchHomepageLinkMetadata(projectUuid, url);
-        return {
-            url,
-            kind: meta.kind,
-            title: meta.title ?? hostnameOf(url),
-            ...(meta.description ? { description: meta.description } : {}),
-            ...(meta.imageUrl ? { imageUrl: meta.imageUrl } : {}),
-        };
-    } catch {
-        // Host outside the allowlist (or fetch failure) → plain link.
-        return { url, kind: 'link', title: hostnameOf(url) };
-    }
-};
-
 export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
     block,
     projectUuid,
@@ -422,7 +406,7 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
                 text
                     .split(/\s+/)
                     .map((s) => s.trim())
-                    .filter(Boolean),
+                    .filter(looksLikeUrl),
             ),
         );
         if (urls.length === 0) return;
@@ -435,9 +419,7 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
         entries.forEach((entry) => {
             void resolveResourceUrl(projectUuid, entry.url).then((item) =>
                 setBatch((prev) =>
-                    prev.map((e) =>
-                        e.key === entry.key ? { ...e, item } : e,
-                    ),
+                    prev.map((e) => (e.key === entry.key ? { ...e, item } : e)),
                 ),
             );
         });

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -385,6 +385,54 @@ a .hoverCard:hover,
     color: var(--mantine-color-ldGray-6);
 }
 
+/* App-store style tile: blurred colour backdrop + crisp floating favicon */
+.resThumbTile {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    display: grid;
+    place-items: center;
+    background: var(--mantine-color-ldGray-1);
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.resThumbBackdrop {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: blur(18px) saturate(1.25);
+    transform: scale(1.35);
+    animation: resFadeIn 0.2s ease-out;
+}
+
+.resFaviconFloat,
+.resGlyphFloat {
+    position: relative;
+    z-index: 1;
+    width: 46px;
+    height: 46px;
+    border-radius: 12px;
+    object-fit: contain;
+    background: light-dark(#fff, var(--mantine-color-dark-5));
+    box-shadow:
+        0 3px 14px rgba(0, 0, 0, 0.22),
+        0 0 0 1px rgba(0, 0, 0, 0.04);
+    animation: resFadeIn 0.2s ease-out;
+}
+
+.resFaviconFloat {
+    padding: 8px;
+}
+
+.resGlyphFloat {
+    display: grid;
+    place-items: center;
+    color: var(--mantine-color-ldGray-7);
+}
+
 .resThumbClaude {
     background: light-dark(#f8ede8, #3a2a22);
     color: light-dark(#c15f3c, #e0916f);

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -328,3 +328,222 @@ a .hoverCard:hover,
     background: var(--mantine-color-ldGray-0);
     border-color: var(--mantine-color-ldGray-3);
 }
+
+/* --- Resource cards ---------------------------------------------------- */
+
+.mediaGrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+    gap: 10px;
+}
+
+.mediaCard {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: 10px;
+    background: light-dark(#fff, var(--mantine-color-dark-6));
+    box-shadow: var(--mantine-shadow-subtle);
+    color: inherit;
+    text-decoration: none;
+    transition: all 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.mediaCard.clickable:hover {
+    box-shadow: var(--mantine-shadow-heavy);
+    transform: translateY(-2px);
+    text-decoration: none;
+    color: inherit;
+}
+
+.resThumb {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    background: var(--mantine-color-ldGray-1);
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+}
+
+.resThumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    animation: resFadeIn 0.2s ease-out;
+    transition: transform 0.25s ease;
+}
+
+.mediaCard.clickable:hover .resThumb img {
+    transform: scale(1.03);
+}
+
+.resThumbFallback {
+    display: grid;
+    place-items: center;
+    color: var(--mantine-color-ldGray-6);
+}
+
+.resThumbClaude {
+    background: light-dark(#f8ede8, #3a2a22);
+    color: light-dark(#c15f3c, #e0916f);
+}
+
+.resThumbYoutube {
+    background: light-dark(#fdecec, #3a2323);
+    color: light-dark(#c0392b, #e07a6f);
+}
+
+.resFavicon {
+    width: 30px;
+    height: 30px;
+    border-radius: 7px;
+    object-fit: contain;
+    animation: resFadeIn 0.2s ease-out;
+}
+
+.mediaBody {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 9px 11px 11px;
+}
+
+.mediaKind {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--mantine-color-ldGray-5);
+}
+
+.mediaExternal {
+    margin-left: auto;
+    color: var(--mantine-color-ldGray-4);
+}
+
+.mediaTitle {
+    font-size: 13.5px;
+    font-weight: 600;
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.mediaDesc {
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--mantine-color-ldGray-6);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.mediaTitleInput input {
+    font-weight: 600;
+}
+
+/* Small leading thumbnail for list rows */
+.rowThumb {
+    width: 34px;
+    height: 34px;
+    border-radius: 7px;
+    overflow: hidden;
+    flex-shrink: 0;
+    border: 1px solid var(--mantine-color-ldGray-2);
+    background: var(--mantine-color-ldGray-1);
+}
+
+.rowThumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.rowThumbFallback {
+    display: grid;
+    place-items: center;
+}
+
+.rowFavicon {
+    width: 20px;
+    height: 20px;
+    object-fit: contain;
+}
+
+/* Skeletons while a pasted link resolves */
+.skeletonBlock,
+.skeletonLine {
+    background: linear-gradient(
+        90deg,
+        var(--mantine-color-ldGray-1),
+        var(--mantine-color-ldGray-2),
+        var(--mantine-color-ldGray-1)
+    );
+    background-size: 200% 100%;
+    animation: resShimmer 1.2s ease-in-out infinite;
+    border-radius: 6px;
+}
+
+.skeletonLine {
+    height: 10px;
+}
+
+.skeletonKind {
+    width: 40%;
+}
+
+.skeletonShort {
+    width: 60%;
+}
+
+.skeletonRowSecond {
+    margin-top: 5px;
+}
+
+@keyframes resShimmer {
+    0% {
+        background-position: 200% 0;
+    }
+    100% {
+        background-position: -200% 0;
+    }
+}
+
+@keyframes resFadeIn {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .mediaCard,
+    .resThumb img {
+        transition: none;
+    }
+    .mediaCard.clickable:hover {
+        transform: none;
+    }
+    .mediaCard.clickable:hover .resThumb img {
+        transform: none;
+    }
+    .resThumb img,
+    .resFavicon {
+        animation: none;
+    }
+    .skeletonBlock,
+    .skeletonLine {
+        animation: none;
+    }
+}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
@@ -103,12 +103,12 @@ export const blockLibrary: BlockDefinition[] = [
     {
         type: 'resources',
         label: 'Resources',
-        description: 'Curated links — docs, videos, request forms.',
+        description: 'Rich cards — Claude artifacts, YouTube, docs, links.',
         icon: IconBook,
         create: () => ({
             id: uuidv4(),
             type: 'resources',
-            config: { title: 'Getting started', items: [] },
+            config: { title: 'Getting started', items: [], layout: 'card' },
         }),
         View: ResourcesBlockView,
         Build: ResourcesBlockBuild,

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/resourceUrls.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/resourceUrls.test.ts
@@ -1,0 +1,37 @@
+import { faviconUrl, safeImageUrl } from './resourceUrls';
+
+describe('faviconUrl', () => {
+    it('builds a favicon URL for public hostnames', () => {
+        expect(faviconUrl('https://docs.example.com/page')).toBe(
+            'https://www.google.com/s2/favicons?domain=docs.example.com&sz=128',
+        );
+    });
+
+    it('returns null for non-public hostnames', () => {
+        expect(faviconUrl('http://localhost:3000')).toBeNull();
+        expect(faviconUrl('https://intranet')).toBeNull();
+        expect(faviconUrl('https://10.0.0.5/dashboard')).toBeNull();
+        expect(faviconUrl('https://wiki.corp.local/page')).toBeNull();
+        expect(faviconUrl('https://vault.internal')).toBeNull();
+        expect(faviconUrl('https://[::1]/')).toBeNull();
+    });
+
+    it('returns null for unparseable URLs', () => {
+        expect(faviconUrl('not a url')).toBeNull();
+    });
+});
+
+describe('safeImageUrl', () => {
+    it('passes through https URLs', () => {
+        expect(safeImageUrl('https://img.example.com/x.png')).toBe(
+            'https://img.example.com/x.png',
+        );
+    });
+
+    it('rejects non-https schemes and missing values', () => {
+        expect(safeImageUrl('http://img.example.com/x.png')).toBeNull();
+        expect(safeImageUrl('javascript:alert(1)')).toBeNull();
+        expect(safeImageUrl('data:image/svg+xml;base64,PHN2Zz4=')).toBeNull();
+        expect(safeImageUrl(undefined)).toBeNull();
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/resourceUrls.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/resourceUrls.ts
@@ -1,0 +1,49 @@
+import { type HomepageResourceItem } from '@lightdash/common';
+import { fetchHomepageLinkMetadata } from '../hooks/useHomepageLinkMetadata';
+
+export const hostnameOf = (url: string): string => {
+    try {
+        return new URL(url).hostname.replace(/^www\./, '');
+    } catch {
+        return url;
+    }
+};
+
+export const faviconUrl = (url: string): string | null => {
+    try {
+        return `https://www.google.com/s2/favicons?domain=${
+            new URL(url).hostname
+        }&sz=64`;
+    } catch {
+        return null;
+    }
+};
+
+const normalizeUrl = (raw: string): string =>
+    /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+
+// A pasted token is only treated as a resource if it looks like a URL — either
+// an explicit scheme or a bare `host.tld/…`. Keeps prose words out of the batch.
+export const looksLikeUrl = (token: string): boolean =>
+    /^https?:\/\//i.test(token) ||
+    /^[\w-]+(\.[\w-]+)+(\/|$|\?|#|:)/.test(token);
+
+export const resolveResourceUrl = async (
+    projectUuid: string,
+    rawUrl: string,
+): Promise<HomepageResourceItem> => {
+    const url = normalizeUrl(rawUrl.trim());
+    try {
+        const meta = await fetchHomepageLinkMetadata(projectUuid, url);
+        return {
+            url,
+            kind: meta.kind,
+            title: meta.title ?? hostnameOf(url),
+            ...(meta.description ? { description: meta.description } : {}),
+            ...(meta.imageUrl ? { imageUrl: meta.imageUrl } : {}),
+        };
+    } catch {
+        // Host outside the allowlist (or fetch failure) → plain link.
+        return { url, kind: 'link', title: hostnameOf(url) };
+    }
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/resourceUrls.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/resourceUrls.ts
@@ -13,7 +13,7 @@ export const faviconUrl = (url: string): string | null => {
     try {
         return `https://www.google.com/s2/favicons?domain=${
             new URL(url).hostname
-        }&sz=64`;
+        }&sz=128`;
     } catch {
         return null;
     }

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/resourceUrls.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/resourceUrls.ts
@@ -9,15 +9,26 @@ export const hostnameOf = (url: string): string => {
     }
 };
 
+// Don't leak non-public hostnames (intranet links, IP literals) to Google.
+const isPublicHostname = (hostname: string): boolean =>
+    hostname.includes('.') &&
+    !hostname.includes(':') &&
+    !/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname) &&
+    !/\.(local|internal|localhost)$/i.test(hostname);
+
 export const faviconUrl = (url: string): string | null => {
     try {
-        return `https://www.google.com/s2/favicons?domain=${
-            new URL(url).hostname
-        }&sz=128`;
+        const { hostname } = new URL(url);
+        if (!isPublicHostname(hostname)) return null;
+        return `https://www.google.com/s2/favicons?domain=${hostname}&sz=128`;
     } catch {
         return null;
     }
 };
+
+// Config is API-writable, so only https images are ever used as <img> sources.
+export const safeImageUrl = (url: string | undefined): string | null =>
+    url?.startsWith('https://') ? url : null;
 
 const normalizeUrl = (raw: string): string =>
     /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageLinkMetadata.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useHomepageLinkMetadata.ts
@@ -1,0 +1,20 @@
+import { type HomepageLinkMetadata } from '@lightdash/common';
+import { lightdashApi } from '../../../../api';
+
+/**
+ * Unfurl a pasted resource URL via the homepage builder endpoint. Resolves with
+ * the detected kind + title/description/imageUrl for allowlisted hosts (Claude /
+ * YouTube); rejects for any other host so the caller can fall back to a plain
+ * link.
+ */
+export const fetchHomepageLinkMetadata = (
+    projectUuid: string,
+    url: string,
+): Promise<HomepageLinkMetadata> => {
+    const query = new URLSearchParams({ url });
+    return lightdashApi<HomepageLinkMetadata>({
+        url: `/projects/${projectUuid}/homepage/link-metadata?${query.toString()}`,
+        method: 'GET',
+        body: undefined,
+    });
+};


### PR DESCRIPTION
## What

Turns the homepage **Resources** block into rich resource cards. Extends the existing block (no new block type) so an author can drop a **Claude Artifact**, a **YouTube video**, or **any link** and get a polished card — real title + description, thumbnail, link-out — or a dense list row.

## Why

Resources was a plain title/URL/kind list. Claude artifacts and YouTube links expose real metadata for free (OpenGraph / oEmbed), so we can auto-fill the title + description and show a thumbnail, and make *building* the block feel like pasting links into a chat and watching them unfurl.

## Changes

- **Data model** (`packages/common/src/ee/homepage/types.ts`): `HomepageResourceKind` gains `claude` + `youtube`; `HomepageResourceItem` gains optional `description`/`imageUrl` (back-compat with stored configs); block config gains `layout?: 'card' | 'list'`.
- **Backend** — `GET /projects/{projectUuid}/homepage/link-metadata?url=`:
  - SSRF host **allowlist**: `claude.ai` (+subdomains), `youtube.com` (+subdomains), `youtu.be` only. Any other host → 400.
  - Bounded fetch: 5s `AbortController` timeout, `redirect: 'manual'`, 256 KB read cap, `text/html` guard.
  - Claude → OpenGraph scrape (real title + description; `og:image` is the generic Claude card). YouTube → oEmbed (real title + video-still thumbnail; channel as description).
  - Synchronous API-pod call, gated on the existing `manage ProjectHomepage` ability.
- **Frontend builder** — Smart Paste → live card (skeleton → fills in), multi-paste (parallel resolve), inline-editable title/description + kind override, favicon tiles for plain links, card/list toggle. Non-allowlisted hosts fall back to a plain `link`.
- **View** — card layout (16:9 `object-fit:cover` thumb, 2-line clamps, hover lift + thumb zoom, `prefers-reduced-motion` off-switch, dark-mode thumb border) or the existing compact list. Undefined layout → `list` (existing published homepages unchanged).

## Test plan

- Backend: 12 unit tests — URL classification + allowlist rejection (incl. SSRF look-alikes `notclaude.ai`, `claude.ai.evil.com`, `169.254.169.254`, `localhost`), OpenGraph parse (both attr orders, entity decode, `<title>` fallback), YouTube oEmbed parse. Fixtures are real published artifacts (Palette Lab, Regex Tester).
- Frontend: 6 tests — card/list view, smart-paste happy path, non-allowlisted link fallback, bare-host `https://` normalize.
- `pnpm generate-api`, backend/common/frontend typechecks, eslint + oxlint all green.

## Notes

- **No Linear ticket** — feature came from an ad-hoc request; add a `Closes:`/`Relates:` line if one should track it.
- **Not gated by a new flag** — rides the existing Homepage v2 flag.
- Out of scope: per-artifact screenshots (headless pipeline), generic-host unfurl, iframe embed (blocked by `frame-ancestors 'self'`), item drag-reorder.
- Live-app visual verification (light/dark) still pending — the shared dev server runs against the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdmaziyqFVmFgQpjTHkv1y