### PR TITLE
feat(homepage): "Viewing as" switcher as a sub-bar under the preview toolbar

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.module.css
@@ -546,11 +546,21 @@
     white-space: nowrap;
 }
 
+/* Slim sub-bar directly under the toolbar, holding the "Viewing as" switcher. */
+.previewBar {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    padding: 8px 16px;
+    background: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-dark-7)
+    );
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+}
+
 .viewAsBar {
-    padding: 8px 12px;
-    border: 1px solid var(--mantine-color-ldGray-2);
-    border-radius: 10px;
-    background: light-dark(#fff, var(--mantine-color-dark-6));
+    align-items: center;
 }
 
 .viewAsLabel {
@@ -560,4 +570,5 @@
 
 .viewAsBadge {
     flex-shrink: 0;
+    max-width: 260px;
 }

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -24,6 +24,7 @@ import {
     migrateHomepageConfig,
     type HomepageBlock,
     type HomepageConfig,
+    type HomepageViewAsTarget,
     type ProjectHomepage as ProjectHomepageType,
 } from '@lightdash/common';
 import {
@@ -85,7 +86,11 @@ import {
     usePublishHomepage,
     useUpdateHomepageDraft,
 } from './hooks/useProjectHomepage';
-import { PreviewPane } from './PreviewPane';
+import {
+    PreviewPane,
+    ViewAsControl,
+    type HomepageViewType,
+} from './PreviewPane';
 import { PublishModal } from './PublishModal';
 
 type DragSource =
@@ -466,6 +471,15 @@ export const HomepageEditor: FC<Props> = ({
         migrateHomepageConfig(homepage.draftConfig),
     );
     const [isPreviewing, setIsPreviewing] = useState(false);
+    const [viewType, setViewType] = useState<HomepageViewType>('everyone');
+    const [viewTarget, setViewTarget] = useState<HomepageViewAsTarget | null>(
+        null,
+    );
+    const togglePreview = () => {
+        setIsPreviewing((prev) => !prev);
+        setViewType('everyone');
+        setViewTarget(null);
+    };
     const [debouncedDraft] = useDebouncedValue(draft, 800);
     const [hasConflict, setHasConflict] = useState(false);
     // Share the exact initial draft reference so the autosave effect's identity
@@ -761,7 +775,7 @@ export const HomepageEditor: FC<Props> = ({
                 <button
                     type="button"
                     className={classes.tbBtn}
-                    onClick={() => setIsPreviewing((prev) => !prev)}
+                    onClick={togglePreview}
                 >
                     <MantineIcon
                         icon={isPreviewing ? IconPencil : IconEye}
@@ -788,6 +802,17 @@ export const HomepageEditor: FC<Props> = ({
                     <Button size="xs" onClick={onConflictReload}>
                         Reload homepage
                     </Button>
+                </div>
+            )}
+            {isPreviewing && (
+                <div className={classes.previewBar}>
+                    <ViewAsControl
+                        projectUuid={projectUuid}
+                        viewType={viewType}
+                        target={viewTarget}
+                        onViewTypeChange={setViewType}
+                        onTargetChange={setViewTarget}
+                    />
                 </div>
             )}
 
@@ -833,6 +858,7 @@ export const HomepageEditor: FC<Props> = ({
                                 <PreviewPane
                                     draft={draft}
                                     projectUuid={projectUuid}
+                                    target={viewTarget}
                                 />
                             ) : (
                                 <Stack gap={0} flex={1} miw={0}>

--- a/packages/frontend/src/ee/features/homepageBuilder/PreviewPane.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PreviewPane.tsx
@@ -17,7 +17,7 @@ import {
     Text,
 } from '@mantine-8/core';
 import { IconExternalLink } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import { type FC } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useOrganizationGroups } from '../../../hooks/useOrganizationGroups';
@@ -26,7 +26,7 @@ import classes from './HomepageEditor.module.css';
 import { useHomepageViewAs } from './hooks/useProjectHomepage';
 import { PublishedHomepage } from './PublishedHomepage';
 
-type ViewType = 'everyone' | 'user' | 'group' | 'role';
+export type HomepageViewType = 'everyone' | 'user' | 'group' | 'role';
 
 const reasonLabel = (
     reason: HomepageViewAsReason,
@@ -46,191 +46,184 @@ const reasonLabel = (
     }
 };
 
-// The preview canvas: shows the draft as everyone sees it, with an inline
-// "Viewing as" switcher to resolve the homepage a specific user/group/role
-// actually lands on (through the real precedence chain).
-export const PreviewPane: FC<{
-    draft: HomepageConfig;
+// The "Viewing as" switcher — lives in the builder toolbar during preview so
+// the canvas below stays the real rendered homepage.
+export const ViewAsControl: FC<{
     projectUuid: string;
-}> = ({ draft, projectUuid }) => {
-    const [viewType, setViewType] = useState<ViewType>('everyone');
-    const [target, setTarget] = useState<HomepageViewAsTarget | null>(null);
-
+    viewType: HomepageViewType;
+    target: HomepageViewAsTarget | null;
+    onViewTypeChange: (viewType: HomepageViewType) => void;
+    onTargetChange: (target: HomepageViewAsTarget | null) => void;
+}> = ({ projectUuid, viewType, target, onViewTypeChange, onTargetChange }) => {
     const { data: users } = useOrganizationUsers({
         projectUuid,
         enabled: viewType === 'user',
     });
     const { data: groups } = useOrganizationGroups(
         {},
-        { enabled: viewType === 'group' },
+        { enabled: viewType === 'group' || target !== null },
     );
     const result = useHomepageViewAs(projectUuid, target);
 
     const groupNames = new Map(
         (groups ?? []).map((group) => [group.uuid, group.name]),
     );
-    const targetLabel =
-        target?.type === 'user'
-            ? (users ?? []).find((user) => user.userUuid === target.userUuid)
-                  ?.email
-            : target?.type === 'group'
-              ? groupNames.get(target.groupUuid)
-              : target?.type === 'role'
-                ? ProjectMemberRoleLabels[target.role]
-                : undefined;
-
-    const handleTypeChange = (value: string) => {
-        setViewType(value as ViewType);
-        setTarget(null);
-    };
 
     return (
-        <Stack gap="md">
-            <Group className={classes.viewAsBar} gap="sm" wrap="nowrap">
-                <Text
+        <Group className={classes.viewAsBar} gap="xs" wrap="nowrap">
+            <Text
+                size="xs"
+                fw={600}
+                tt="uppercase"
+                c="dimmed"
+                className={classes.viewAsLabel}
+            >
+                Viewing as
+            </Text>
+            <SegmentedControl
+                size="xs"
+                value={viewType}
+                onChange={(value) => {
+                    onViewTypeChange(value as HomepageViewType);
+                    onTargetChange(null);
+                }}
+                data={[
+                    { value: 'everyone', label: 'Everyone' },
+                    { value: 'user', label: 'User' },
+                    { value: 'group', label: 'Group' },
+                    { value: 'role', label: 'Role' },
+                ]}
+            />
+            {viewType === 'user' && (
+                <Select
                     size="xs"
-                    fw={600}
-                    tt="uppercase"
-                    c="dimmed"
-                    className={classes.viewAsLabel}
-                >
-                    Viewing as
-                </Text>
-                <SegmentedControl
-                    size="xs"
-                    value={viewType}
-                    onChange={handleTypeChange}
-                    data={[
-                        { value: 'everyone', label: 'Everyone' },
-                        { value: 'user', label: 'User' },
-                        { value: 'group', label: 'Group' },
-                        { value: 'role', label: 'Role' },
-                    ]}
-                />
-                {viewType === 'user' && (
-                    <Select
-                        size="xs"
-                        placeholder="Pick a user"
-                        searchable
-                        flex={1}
-                        data={(users ?? []).map((user) => ({
-                            value: user.userUuid,
-                            label: `${user.firstName} ${user.lastName} (${user.email})`,
-                        }))}
-                        value={target?.type === 'user' ? target.userUuid : null}
-                        onChange={(value) =>
-                            setTarget(
-                                value
-                                    ? { type: 'user', userUuid: value }
-                                    : null,
-                            )
-                        }
-                    />
-                )}
-                {viewType === 'group' && (
-                    <Select
-                        size="xs"
-                        placeholder="Pick a group"
-                        searchable
-                        flex={1}
-                        data={(groups ?? []).map((group) => ({
-                            value: group.uuid,
-                            label: group.name,
-                        }))}
-                        value={
-                            target?.type === 'group' ? target.groupUuid : null
-                        }
-                        onChange={(value) =>
-                            setTarget(
-                                value
-                                    ? { type: 'group', groupUuid: value }
-                                    : null,
-                            )
-                        }
-                    />
-                )}
-                {viewType === 'role' && (
-                    <Select
-                        size="xs"
-                        placeholder="Pick a role"
-                        flex={1}
-                        data={Object.values(ProjectMemberRole).map((role) => ({
-                            value: role,
-                            label: ProjectMemberRoleLabels[role],
-                        }))}
-                        value={target?.type === 'role' ? target.role : null}
-                        onChange={(value) =>
-                            setTarget(
-                                value
-                                    ? {
-                                          type: 'role',
-                                          role: value as ProjectMemberRole,
-                                      }
-                                    : null,
-                            )
-                        }
-                    />
-                )}
-                {target && result.data?.resolved?.type === 'homepage' && (
-                    <Badge
-                        variant="light"
-                        tt="none"
-                        className={classes.viewAsBadge}
-                    >
-                        {result.data.resolved.homepage.name}
-                        {result.data.reason
-                            ? ` · ${reasonLabel(result.data.reason, groupNames)}`
-                            : ''}
-                    </Badge>
-                )}
-            </Group>
-
-            {!target ? (
-                <PublishedHomepage config={draft} projectUuid={projectUuid} />
-            ) : result.isInitialLoading ? (
-                <Group justify="center" p="xl">
-                    <Loader size="sm" />
-                </Group>
-            ) : result.data?.resolved == null ? (
-                <Card withBorder p="md">
-                    <Text size="sm" c="dimmed">
-                        No published homepage applies to {targetLabel} — they
-                        land on the day-one default.
-                    </Text>
-                </Card>
-            ) : result.data.resolved.type === 'dashboard' ? (
-                <Card withBorder p="md">
-                    <Group gap="xs">
-                        <Text size="sm">
-                            {targetLabel} lands directly on a dashboard
-                            {result.data.reason
-                                ? ` (${reasonLabel(result.data.reason, groupNames)})`
-                                : ''}
-                            .
-                        </Text>
-                        <Anchor
-                            component={Link}
-                            to={`/projects/${projectUuid}/dashboards/${result.data.resolved.dashboardUuid}/view`}
-                            target="_blank"
-                            size="sm"
-                        >
-                            <Group gap={4} wrap="nowrap">
-                                Open dashboard
-                                <MantineIcon
-                                    icon={IconExternalLink}
-                                    size="sm"
-                                />
-                            </Group>
-                        </Anchor>
-                    </Group>
-                </Card>
-            ) : (
-                <PublishedHomepage
-                    config={result.data.resolved.homepage.config}
-                    projectUuid={projectUuid}
-                    personalPlaceholders
+                    placeholder="Pick a user"
+                    searchable
+                    w={220}
+                    data={(users ?? []).map((user) => ({
+                        value: user.userUuid,
+                        label: `${user.firstName} ${user.lastName} (${user.email})`,
+                    }))}
+                    value={target?.type === 'user' ? target.userUuid : null}
+                    onChange={(value) =>
+                        onTargetChange(
+                            value ? { type: 'user', userUuid: value } : null,
+                        )
+                    }
                 />
             )}
-        </Stack>
+            {viewType === 'group' && (
+                <Select
+                    size="xs"
+                    placeholder="Pick a group"
+                    searchable
+                    w={200}
+                    data={(groups ?? []).map((group) => ({
+                        value: group.uuid,
+                        label: group.name,
+                    }))}
+                    value={target?.type === 'group' ? target.groupUuid : null}
+                    onChange={(value) =>
+                        onTargetChange(
+                            value ? { type: 'group', groupUuid: value } : null,
+                        )
+                    }
+                />
+            )}
+            {viewType === 'role' && (
+                <Select
+                    size="xs"
+                    placeholder="Pick a role"
+                    w={160}
+                    data={Object.values(ProjectMemberRole).map((role) => ({
+                        value: role,
+                        label: ProjectMemberRoleLabels[role],
+                    }))}
+                    value={target?.type === 'role' ? target.role : null}
+                    onChange={(value) =>
+                        onTargetChange(
+                            value
+                                ? {
+                                      type: 'role',
+                                      role: value as ProjectMemberRole,
+                                  }
+                                : null,
+                        )
+                    }
+                />
+            )}
+            {target && result.data?.resolved?.type === 'homepage' && (
+                <Badge
+                    variant="light"
+                    tt="none"
+                    className={classes.viewAsBadge}
+                >
+                    {result.data.resolved.homepage.name}
+                    {result.data.reason
+                        ? ` · ${reasonLabel(result.data.reason, groupNames)}`
+                        : ''}
+                </Badge>
+            )}
+        </Group>
+    );
+};
+
+// The preview canvas — the real rendered homepage for the chosen audience.
+export const PreviewPane: FC<{
+    draft: HomepageConfig;
+    projectUuid: string;
+    target: HomepageViewAsTarget | null;
+}> = ({ draft, projectUuid, target }) => {
+    const result = useHomepageViewAs(projectUuid, target);
+
+    if (!target) {
+        return <PublishedHomepage config={draft} projectUuid={projectUuid} />;
+    }
+    if (result.isInitialLoading) {
+        return (
+            <Group justify="center" p="xl">
+                <Loader size="sm" />
+            </Group>
+        );
+    }
+    if (result.data?.resolved == null) {
+        return (
+            <Stack align="center" gap="xs" p="xl">
+                <Text size="sm" c="dimmed">
+                    No published homepage applies — this viewer lands on the
+                    day-one default.
+                </Text>
+            </Stack>
+        );
+    }
+    if (result.data.resolved.type === 'dashboard') {
+        const { dashboardUuid } = result.data.resolved;
+        return (
+            <Card withBorder p="md" maw={640} mx="auto" mt="xl">
+                <Group gap="xs">
+                    <Text size="sm">
+                        This viewer lands directly on a dashboard.
+                    </Text>
+                    <Anchor
+                        component={Link}
+                        to={`/projects/${projectUuid}/dashboards/${dashboardUuid}/view`}
+                        target="_blank"
+                        size="sm"
+                    >
+                        <Group gap={4} wrap="nowrap">
+                            Open dashboard
+                            <MantineIcon icon={IconExternalLink} size="sm" />
+                        </Group>
+                    </Anchor>
+                </Group>
+            </Card>
+        );
+    }
+    return (
+        <PublishedHomepage
+            config={result.data.resolved.homepage.config}
+            projectUuid={projectUuid}
+            personalPlaceholders
+        />
     );
 };


### PR DESCRIPTION
## What & why

Follow-up to the View-as-in-Preview work. The "Viewing as" switcher previously rendered as a bar **inside the preview canvas** (pushing the page down), then briefly **inside the top toolbar** (too crowded). This lands it as a **slim full-width sub-bar directly beneath the builder toolbar** — hugging the top bar, but out of it — so the canvas below is purely the rendered homepage (the "real deal").

## Changes

- `PreviewPane.tsx` splits into two exports:
  - **`ViewAsControl`** — the switcher (segmented control Everyone/User/Group/Role + audience `Select` + resolution `Badge`).
  - **`PreviewPane`** — just the rendered body for the chosen audience (draft for Everyone; resolved published homepage / day-one default / dashboard-redirect otherwise).
- View-as state (`viewType`, `target`) lifts to `HomepageEditor`; the sub-bar renders only while previewing and resets to Everyone on every preview toggle.
- CSS: new `.previewBar` strip under the toolbar; `.viewAsBar` is a plain inline group.

## Verification

- `pnpm -F frontend typecheck:fast` clean · oxlint 0/0
- Driven live at `:3400`: enter Preview → switcher sits in the sub-bar under the toolbar, toolbar uncrowded, canvas is the bare rendered homepage; User/Group/Role swaps in the audience select inline and re-resolves the render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pAmqbwEWhY21kkmRKyycZ
