### PR TITLE
fix(homepage): reserve height for day-0 AI chips so they fade in without shifting

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.module.css
@@ -4,6 +4,17 @@
     font-size: var(--mantine-font-size-md) !important;
 }
 
+/* One chip-line of height reserved up front (pill: 12px text + 10px padding +
+   2px border = 30px) so late-arriving chips don't shove the composer. */
+.pillRow {
+    margin-top: 12px;
+    min-height: 30px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 6px;
+}
+
 .pill {
     font-size: 12px;
     font-weight: 500;
@@ -18,10 +29,44 @@
     gap: 6px;
     font-family: inherit;
     transition: all 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+    animation: pillIn 0.28s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.pill:nth-child(2) {
+    animation-delay: 40ms;
+}
+.pill:nth-child(3) {
+    animation-delay: 80ms;
+}
+.pill:nth-child(4) {
+    animation-delay: 120ms;
+}
+.pill:nth-child(5) {
+    animation-delay: 160ms;
+}
+.pill:nth-child(6) {
+    animation-delay: 200ms;
+}
+
+@keyframes pillIn {
+    from {
+        opacity: 0;
+        transform: translateY(4px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 .pill:hover {
     border-color: var(--mantine-color-ldGray-4);
     color: var(--mantine-color-ldGray-9);
     box-shadow: var(--mantine-shadow-subtle);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .pill {
+        animation: none;
+    }
 }

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
@@ -4,7 +4,7 @@ import {
     type AiPromptContextItem,
     type AiRouter,
 } from '@lightdash/common';
-import { Anchor, Group, Skeleton } from '@mantine-8/core';
+import { Anchor, Skeleton } from '@mantine-8/core';
 import { IconArrowUpRight } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState, type FC } from 'react';
@@ -58,13 +58,20 @@ const useAiRouterEnabledFromCache = (): boolean | undefined => {
     return enabled;
 };
 
+// The chips come from an LLM generation, so on a cold view they land a second
+// or two after the composer. The row reserves one chip-line of height while
+// loading so their arrival never shoves the greeting/composer up; the chips
+// then fade + rise in, staggered, so it reads as intentional rather than a
+// pop. Once the query settles with no chips (e.g. generation failed past its
+// retry) the row collapses so there's no permanent empty gap.
 const SuggestionPills: FC<{
     chips: AgentSuggestion[];
+    loading: boolean;
     onPick: (chip: AgentSuggestion) => void;
-}> = ({ chips, onPick }) => {
-    if (chips.length === 0) return null;
+}> = ({ chips, loading, onPick }) => {
+    if (!loading && chips.length === 0) return null;
     return (
-        <Group gap={6} justify="center" mt={12}>
+        <div className={classes.pillRow}>
             {chips.map((chip) => (
                 <button
                     key={chip.label}
@@ -80,7 +87,7 @@ const SuggestionPills: FC<{
                     {chip.label}
                 </button>
             ))}
-        </Group>
+        </div>
     );
 };
 
@@ -229,6 +236,7 @@ const DayOneAskInputInner: FC<Props> = ({ projectUuid, preview = false }) => {
             {(canCreateThread || preview) && (
                 <SuggestionPills
                     chips={suggestionsQuery.data?.chips ?? []}
+                    loading={suggestionsQuery.isLoading}
                     onPick={handleChipPick}
                 />
             )}


### PR DESCRIPTION
## What & why

On the day-0 homepage hero, the AI suggestion chips are produced by an **LLM generation** (`generateAgentSuggestions`), so on a cold view they arrive ~1–3s after the composer has already rendered. Until now `SuggestionPills` rendered `null` while empty, so when the chips resolved they **popped in and shoved the greeting + composer upward** — a visible layout shift that read as janky.

## Change

- **Reserve one chip-line of height** (`min-height: 30px`) below the composer while `suggestionsQuery.isLoading`, so nothing moves when the chips land.
- **Fade + 4px rise on arrival, staggered ~40ms per chip**, so the appearance reads as intentional rather than a pop.
- **Collapse the row** if the query settles with no chips (error path past `retry: 1`) — no permanent empty gap. `SUGGESTION_FALLBACK_CHIPS` normally guarantees chips, so this is the rare case.
- **`prefers-reduced-motion`**: entrance animation is dropped.

Frontend-only, no backend or hook changes. Applies identically to the live day-0 hero and the builder preview. The reserved row matches exactly one line of 3–4 short chips (the day-0 norm); a rare wrap to two lines nudges down slightly, which is acceptable.

## Not doing

Skeleton pills or a "loading…" copy line (both over-narrate a wait that should feel instant), and no change to *which* agent sources the chips — the Auto-mode reference-agent behavior stays.

## Verification

- `pnpm -F frontend typecheck:fast` ✅
- `pnpm -F frontend run linter` on the changed file ✅
- Visual pass in the live app still pending — the dev server runs off the main checkout, not this worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVV1fkGwqTvg9MuSS6bzjs