### PR TITLE
feat(homepage): positional layout rules — fold-aware hero, intro, compact composer, two axes

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -7,6 +7,7 @@ import { Box, Paper, Text } from '@mantine-8/core';
 import { type FC, type ReactNode } from 'react';
 import { type BlockWidthTier } from './blockLayout';
 import { getBlockDefinition } from './blocks/registry';
+import { type BlockPresentation } from './blocks/types';
 import layout from './homepageLayout.module.css';
 import {
     resolveHomepageLayout,
@@ -27,7 +28,8 @@ const BlockRenderer: FC<{
     block: HomepageBlock;
     projectUuid: string;
     personalPlaceholders: boolean;
-}> = ({ block, projectUuid, personalPlaceholders }) => {
+    presentation?: BlockPresentation;
+}> = ({ block, projectUuid, personalPlaceholders, presentation }) => {
     const definition = getBlockDefinition(block.type);
     if (!definition) return null;
     if (personalPlaceholders && PERSONAL_BLOCK_TYPES.includes(block.type)) {
@@ -46,7 +48,13 @@ const BlockRenderer: FC<{
         );
     }
     const { View } = definition;
-    return <View block={block} projectUuid={projectUuid} />;
+    return (
+        <View
+            block={block}
+            projectUuid={projectUuid}
+            presentation={presentation}
+        />
+    );
 };
 
 const RowRenderer: FC<{
@@ -57,6 +65,7 @@ const RowRenderer: FC<{
     <Box
         className={`${layout.row} ${TIER_CLASS[row.widthTier]}`}
         data-gap={row.gap}
+        data-role={row.role}
     >
         {row.columns.map((column) => (
             <Box
@@ -90,20 +99,22 @@ export const PublishedHomepage: FC<Props> = ({
     personalPlaceholders = false,
     topBar = null,
 }) => {
-    const { heroRow, rows } = resolveHomepageLayout(
-        migrateHomepageConfig(config),
-    );
+    const { hero, rows } = resolveHomepageLayout(migrateHomepageConfig(config));
 
     return (
         <div className={layout.page}>
             {topBar}
-            {heroRow && (
-                <div className={layout.heroSection}>
+            {hero && (
+                <div
+                    className={layout.heroSection}
+                    data-presentation={hero.presentation}
+                >
                     <div className={layout.hero}>
                         <BlockRenderer
-                            block={heroRow.columns[0].block}
+                            block={hero.row.columns[0].block}
                             projectUuid={projectUuid}
                             personalPlaceholders={personalPlaceholders}
+                            presentation="hero"
                         />
                     </div>
                 </div>

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -109,6 +109,18 @@ export const PublishedHomepage: FC<Props> = ({
                     className={layout.heroSection}
                     data-presentation={hero.presentation}
                 >
+                    {hero.companions.length > 0 && (
+                        <div className={layout.heroCompanions}>
+                            {hero.companions.map((row) => (
+                                <RowRenderer
+                                    key={row.id}
+                                    row={row}
+                                    projectUuid={projectUuid}
+                                    personalPlaceholders={personalPlaceholders}
+                                />
+                            ))}
+                        </div>
+                    )}
                     <div className={layout.hero}>
                         <BlockRenderer
                             block={hero.row.columns[0].block}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
@@ -1,0 +1,45 @@
+import { type HomepageAskAiHeroBlock } from '@lightdash/common';
+import { MantineProvider } from '@mantine-8/core';
+import { render, screen } from '@testing-library/react';
+import { AskAiHeroBlockView } from './AskAiHeroBlock';
+
+vi.mock('../DayOneAskInput', () => ({
+    DayOneAskInput: () => <div data-testid="ask-input" />,
+}));
+vi.mock('../../aiCopilot/hooks/useAiAgentsButtonVisibility', () => ({
+    useAiAgentButtonVisibility: () => true,
+}));
+vi.mock('../../../../providers/App/useApp', () => ({
+    default: () => ({ user: { data: { firstName: 'Test' } } }),
+}));
+
+const block: HomepageAskAiHeroBlock = {
+    id: 'b1',
+    type: 'ask-ai-hero',
+    config: { showGreeting: true },
+};
+
+const wrap = (ui: React.ReactNode) =>
+    render(<MantineProvider>{ui}</MantineProvider>);
+
+describe('AskAiHeroBlockView', () => {
+    it('greets in the hero slot', () => {
+        wrap(
+            <AskAiHeroBlockView
+                block={block}
+                projectUuid="p1"
+                presentation="hero"
+            />,
+        );
+        expect(
+            screen.getByText(/What do you want to know/),
+        ).toBeInTheDocument();
+        expect(screen.getByTestId('ask-input')).toBeInTheDocument();
+    });
+
+    it('renders inline mid-page without the greeting, even when toggled on', () => {
+        wrap(<AskAiHeroBlockView block={block} projectUuid="p1" />);
+        expect(screen.queryByText(/What do you want to know/)).toBeNull();
+        expect(screen.getByTestId('ask-input')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
@@ -43,13 +43,16 @@ export const AskAiHero: FC<{
 export const AskAiHeroBlockView: FC<BlockComponentProps> = ({
     block,
     projectUuid,
+    presentation = 'inline',
 }) => {
     const isAiEnabled = useAiAgentButtonVisibility();
     if (block.type !== 'ask-ai-hero' || !isAiEnabled) return null;
+    // Mid-page the composer renders inline: the greeting is hero-context only,
+    // even when the homepage has it toggled on.
     return (
         <AskAiHero
             projectUuid={projectUuid}
-            showGreeting={block.config.showGreeting}
+            showGreeting={presentation === 'hero' && block.config.showGreeting}
         />
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/BlockShell.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/BlockShell.tsx
@@ -14,6 +14,9 @@ type BlockHeaderProps = {
     title: ReactNode;
     pill?: string;
     mb?: number;
+    /** Centre the header — used when the block's content is centred too, so
+     * header and content read as one unit. */
+    centered?: boolean;
 };
 
 export const BlockHeader: FC<PropsWithChildren<BlockHeaderProps>> = ({
@@ -22,9 +25,15 @@ export const BlockHeader: FC<PropsWithChildren<BlockHeaderProps>> = ({
     title,
     pill,
     mb = 12,
+    centered = false,
     children,
 }) => (
-    <Box className={classes.sectionHeader} mb={mb}>
+    <Box
+        className={`${classes.sectionHeader}${
+            centered ? ` ${classes.sectionHeaderCentered}` : ''
+        }`}
+        mb={mb}
+    >
         <MantineIcon icon={icon} size={14} color={iconColor ?? 'ldGray.6'} />
         {typeof title === 'string' ? (
             <span className={classes.sectionTitle}>{title}</span>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -32,7 +32,7 @@ import {
     TextInput,
 } from '@mantine-8/core';
 import { IconLayoutGrid, IconPin, IconPlus } from '@tabler/icons-react';
-import { useMemo, useState, type FC } from 'react';
+import { useMemo, useRef, useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
 import { ResourceIcon } from '../../../../components/common/ResourceIcon';
@@ -197,14 +197,20 @@ const CollectionPicker: FC<{
     projectUuid: string;
     initialSelected: HomepageCollectionItemRef[];
     onApply: (refs: HomepageCollectionItemRef[]) => void;
-    onClose: () => void;
-}> = ({ projectUuid, initialSelected, onApply, onClose }) => {
+    /** Hands the modal's Apply button a callback that commits the current
+     * selection — the footer lives in MantineModal, outside this component. */
+    registerApply: (commit: () => void) => void;
+}> = ({ projectUuid, initialSelected, onApply, registerApply }) => {
     const [selectedSpaceUuid, setSelectedSpaceUuid] = useState<string | null>(
         null,
     );
     const [selected, setSelected] = useState<
         Map<string, HomepageCollectionItemRef>
     >(() => new Map(initialSelected.map((ref) => [ref.uuid, ref])));
+
+    // Re-point the parent's apply ref every render so it always commits the
+    // latest selection (idempotent, so safe during render — no effect needed).
+    registerApply(() => onApply([...selected.values()]));
 
     const { data: spaces } = useSpaceSummaries(projectUuid, true);
 
@@ -232,7 +238,7 @@ const CollectionPicker: FC<{
     return (
         <Stack gap="sm">
             <Group align="stretch" gap="md" wrap="nowrap" h="min(64vh, 720px)">
-                <Box w={280} className={classes.pickerScrollList}>
+                <Box w={340} className={classes.pickerScrollList}>
                     <SpaceSelector
                         projectUuid={projectUuid}
                         spaces={spaces}
@@ -266,21 +272,6 @@ const CollectionPicker: FC<{
                     </Box>
                 </Stack>
             </Group>
-
-            <Group justify="flex-end" gap="xs">
-                <Button variant="default" size="xs" onClick={onClose}>
-                    Cancel
-                </Button>
-                <Button
-                    size="xs"
-                    onClick={() => {
-                        onApply([...selected.values()]);
-                        onClose();
-                    }}
-                >
-                    Apply
-                </Button>
-            </Group>
         </Stack>
     );
 };
@@ -291,24 +282,37 @@ const CollectionPickerModal: FC<{
     projectUuid: string;
     initialSelected: HomepageCollectionItemRef[];
     onApply: (refs: HomepageCollectionItemRef[]) => void;
-}> = ({ opened, onClose, projectUuid, initialSelected, onApply }) => (
-    <MantineModal
-        opened={opened}
-        onClose={onClose}
-        title="Add content"
-        icon={IconPlus}
-        size="1000px"
-    >
-        {opened && (
-            <CollectionPicker
-                projectUuid={projectUuid}
-                initialSelected={initialSelected}
-                onApply={onApply}
-                onClose={onClose}
-            />
-        )}
-    </MantineModal>
-);
+}> = ({ opened, onClose, projectUuid, initialSelected, onApply }) => {
+    // The Apply/Cancel footer is MantineModal's own — it lives outside the
+    // remountable picker body, so the picker hands its commit fn up via ref
+    // rather than rendering a duplicate footer inline.
+    const applyRef = useRef<() => void>(() => {});
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Add content"
+            icon={IconPlus}
+            size="min(92vw, 1280px)"
+            confirmLabel="Apply"
+            onConfirm={() => {
+                applyRef.current();
+                onClose();
+            }}
+        >
+            {opened && (
+                <CollectionPicker
+                    projectUuid={projectUuid}
+                    initialSelected={initialSelected}
+                    onApply={onApply}
+                    registerApply={(fn) => {
+                        applyRef.current = fn;
+                    }}
+                />
+            )}
+        </MantineModal>
+    );
+};
 
 export const CollectionBlockView: FC<BlockComponentProps> = ({
     block,

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -231,7 +231,7 @@ const CollectionPicker: FC<{
 
     return (
         <Stack gap="sm">
-            <Group align="stretch" gap="md" wrap="nowrap" h={440}>
+            <Group align="stretch" gap="md" wrap="nowrap" h="min(64vh, 720px)">
                 <Box w={280} className={classes.pickerScrollList}>
                     <SpaceSelector
                         projectUuid={projectUuid}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -330,9 +330,16 @@ export const CollectionBlockView: FC<BlockComponentProps> = ({
     const favoriteUuids = new Set(
         (favorites ?? []).map((item) => item.data.uuid),
     );
+    // A partial row centres its cards, so centre the header with them — the
+    // whole block reads as one unit instead of a left-anchored orphan title.
+    const cardCount = (contents ?? uuids).length;
     return (
         <Stack gap={0}>
-            <BlockHeader icon={IconLayoutGrid} title={block.config.title} />
+            <BlockHeader
+                icon={IconLayoutGrid}
+                title={block.config.title}
+                centered={cardCount > 0 && cardCount < 3}
+            />
             {isInitialLoading ? (
                 <div className={classes.hugGrid}>
                     {uuids.slice(0, 3).map((uuid) => (

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -26,7 +26,6 @@ import {
     Checkbox,
     Divider,
     Group,
-    SimpleGrid,
     Skeleton,
     Stack,
     Text,
@@ -335,30 +334,34 @@ export const CollectionBlockView: FC<BlockComponentProps> = ({
         <Stack gap={0}>
             <BlockHeader icon={IconLayoutGrid} title={block.config.title} />
             {isInitialLoading ? (
-                <SimpleGrid cols={{ base: 1, sm: 3 }} spacing={12}>
+                <div className={classes.hugGrid}>
                     {uuids.slice(0, 3).map((uuid) => (
-                        <Skeleton key={uuid} h={108} radius="md" />
+                        <div key={uuid} className={classes.hugGridItem}>
+                            <Skeleton h={108} radius="md" />
+                        </div>
                     ))}
-                </SimpleGrid>
+                </div>
             ) : (
-                <SimpleGrid cols={{ base: 1, sm: 3 }} spacing={12}>
+                <div className={classes.hugGrid}>
                     {(contents ?? []).map((content) => (
-                        <ContentCard
-                            key={content.uuid}
-                            content={content}
-                            projectUuid={projectUuid}
-                            variant="tile"
-                            star={{
-                                isFavorite: favoriteUuids.has(content.uuid),
-                                onToggle: () =>
-                                    toggleFavorite({
-                                        contentType: toFavoriteType(content),
-                                        contentUuid: content.uuid,
-                                    }),
-                            }}
-                        />
+                        <div key={content.uuid} className={classes.hugGridItem}>
+                            <ContentCard
+                                content={content}
+                                projectUuid={projectUuid}
+                                variant="tile"
+                                star={{
+                                    isFavorite: favoriteUuids.has(content.uuid),
+                                    onToggle: () =>
+                                        toggleFavorite({
+                                            contentType:
+                                                toFavoriteType(content),
+                                            contentUuid: content.uuid,
+                                        }),
+                                }}
+                            />
+                        </div>
                     ))}
-                </SimpleGrid>
+                </div>
             )}
         </Stack>
     );
@@ -382,7 +385,7 @@ const SortableTile: FC<{
     return (
         <div
             ref={setNodeRef}
-            className={classes.sortableTile}
+            className={`${classes.sortableTile} ${classes.hugGridItem}`}
             data-dragging={isDragging}
             style={{
                 transform: CSS.Translate.toString(transform),
@@ -478,7 +481,7 @@ export const CollectionBlockBuild: FC<BuildComponentProps> = ({
                     items={(contents ?? []).map((content) => content.uuid)}
                     strategy={rectSortingStrategy}
                 >
-                    <SimpleGrid cols={{ base: 1, sm: 3 }} spacing={12}>
+                    <div className={classes.hugGrid}>
                         {(contents ?? []).map((content) => (
                             <SortableTile
                                 key={content.uuid}
@@ -498,15 +501,17 @@ export const CollectionBlockBuild: FC<BuildComponentProps> = ({
                                 }
                             />
                         ))}
-                        <button
-                            type="button"
-                            className={classes.addContentTile}
-                            onClick={() => setIsPickerOpen(true)}
-                        >
-                            <MantineIcon icon={IconPlus} size={14} />
-                            Add content
-                        </button>
-                    </SimpleGrid>
+                        <div className={classes.hugGridItem}>
+                            <button
+                                type="button"
+                                className={classes.addContentTile}
+                                onClick={() => setIsPickerOpen(true)}
+                            >
+                                <MantineIcon icon={IconPlus} size={14} />
+                                Add content
+                            </button>
+                        </div>
+                    </div>
                 </SortableContext>
             </DndContext>
             {block.config.items.length === 0 && importablePins.length > 0 && (

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
@@ -49,12 +49,14 @@ const FavoritePills: FC<{
     emptyText: string | null;
     maxVisible?: number;
     wrap?: 'wrap' | 'nowrap';
+    justify?: 'flex-start' | 'center';
 }> = ({
     projectUuid,
     isInteractive,
     emptyText,
     maxVisible = FAVORITES_DEFAULT_VISIBLE,
     wrap = 'wrap',
+    justify = 'flex-start',
 }) => {
     const { data: favorites } = useFavorites(projectUuid);
     const { mutate: toggleFavorite } = useFavoriteMutation(projectUuid);
@@ -80,7 +82,7 @@ const FavoritePills: FC<{
     const hiddenCount = favorites.length - maxVisible;
 
     return (
-        <Group gap={8} wrap={expanded ? 'wrap' : wrap}>
+        <Group gap={8} wrap={expanded ? 'wrap' : wrap} justify={justify}>
             {visible.map((item) => (
                 <Link
                     key={item.data.uuid}
@@ -164,10 +166,12 @@ export const FavoritesBlockView: FC<BlockComponentProps> = ({
                 icon={IconStar}
                 title={block.config.title}
                 pill="Only you see this"
+                centered
             />
             <FavoritePills
                 projectUuid={projectUuid}
                 isInteractive
+                justify="center"
                 emptyText="Star any dashboard or chart to keep it here — each person sees their own favorites."
             />
         </Stack>
@@ -185,10 +189,12 @@ export const FavoritesBlockBuild: FC<BuildComponentProps> = ({
                 icon={IconStar}
                 title={block.config.title}
                 pill="Personal per viewer"
+                centered
             />
             <FavoritePills
                 projectUuid={projectUuid}
                 isInteractive={false}
+                justify="center"
                 emptyText="Empty until this viewer stars something — each person sees their own favorites here."
             />
             <div className={classes.buildHint}>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
@@ -98,7 +98,7 @@ export const QuickActionCards: FC<{
     );
     if (visibleActions.length === 0) return null;
     return (
-        <Group gap={8}>
+        <Group gap={8} justify="center">
             {visibleActions.map((action, index) => {
                 const presentation = actionPresentation(action, projectUuid);
                 return (

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -79,6 +79,8 @@ a .hoverCard:hover,
 
 .pickerScrollList {
     overflow-y: auto;
+    /* override flex min-height:auto so the list shrinks and scrolls internally */
+    min-height: 0;
 }
 
 .actionRow {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -4,6 +4,10 @@
     gap: 7px;
 }
 
+.sectionHeaderCentered {
+    justify-content: center;
+}
+
 .sectionTitle {
     font-size: 11px;
     font-weight: 600;

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -343,6 +343,29 @@ a .hoverCard:hover,
     border-color: var(--mantine-color-ldGray-3);
 }
 
+/* Collection card grid: three-up like SimpleGrid, but a partial row centres
+ * instead of leaving dead columns on the right. */
+.hugGrid {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 12px;
+}
+
+/* Single-cell grid so the child (an inline <a> card) is blockified and
+ * stretched exactly like a SimpleGrid cell would. */
+.hugGridItem {
+    flex: 0 1 calc((100% - 24px) / 3);
+    min-width: 0;
+    display: grid;
+}
+
+@media (max-width: 47.99em) {
+    .hugGridItem {
+        flex-basis: 100%;
+    }
+}
+
 /* --- Resource cards ---------------------------------------------------- */
 
 .mediaGrid {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -364,6 +364,14 @@ a .hoverCard:hover,
     display: grid;
 }
 
+/* The blockifying grid gives its single child (the card) a fresh min-width:
+ * auto default of its own, sized to the untruncated title's natural width —
+ * so a long title (e.g. via Text truncate's white-space: nowrap) overflows
+ * the narrow cell instead of shrinking into it. */
+.hugGridItem > * {
+    min-width: 0;
+}
+
 @media (max-width: 47.99em) {
     .hugGridItem {
         flex-basis: 100%;

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/types.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/types.ts
@@ -1,8 +1,13 @@
 import { type HomepageBlock } from '@lightdash/common';
 
+// Where a block view renders: the page's centred hero slot or an inline body
+// row. Omission means 'inline'. Only ask-ai-hero currently differentiates.
+export type BlockPresentation = 'hero' | 'inline';
+
 export type BlockComponentProps = {
     block: HomepageBlock;
     projectUuid: string;
+    presentation?: BlockPresentation;
 };
 
 export type BuildComponentProps = BlockComponentProps & {

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -71,6 +71,17 @@
     align-items: center;
 }
 
+/* Chrome rows (quick-actions) riding above the composer inside the hero.
+ * They share the composer's axis so the opening reads as one composition. */
+.heroCompanions {
+    width: 100%;
+    margin-bottom: 26px;
+}
+
+.heroCompanions .row {
+    max-width: 720px;
+}
+
 .secondary {
     width: 100%;
     max-width: 1160px;
@@ -121,6 +132,16 @@
 .col {
     flex: 1 1 0;
     min-width: 0;
+    /* In multi-column rows the shorter column centres vertically instead of
+     * hugging the top edge next to a taller neighbour. Single-block rows are
+     * unaffected (column height equals content height). */
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.col > * {
+    width: 100%;
 }
 
 .col[data-weight='2'] {

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -34,7 +34,7 @@
  * variant is repeated so it can't win the specificity contest. */
 .heroSection[data-presentation='shared'],
 .page:has(.favBar) .heroSection[data-presentation='shared'] {
-    min-height: 56vh;
+    min-height: 50vh;
 }
 
 .favBar {

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -28,6 +28,15 @@
     );
 }
 
+/* Fold-aware hero: when body rows follow, the hero yields most of the viewport
+ * so the first row peeks above the fold. Solo heroes — and day-0, which never
+ * stamps the attribute — keep the full-viewport treatment above. The favBar
+ * variant is repeated so it can't win the specificity contest. */
+.heroSection[data-presentation='shared'],
+.page:has(.favBar) .heroSection[data-presentation='shared'] {
+    min-height: 56vh;
+}
+
 .favBar {
     display: flex;
     align-items: center;
@@ -85,6 +94,12 @@
 
 .row[data-gap='section'] {
     margin-top: 40px;
+}
+
+/* A lone leading text block opens the page: give it breathing room on top of
+ * the page padding so it reads as an intro, not just the first list item. */
+.row[data-role='intro'] {
+    padding-top: 24px;
 }
 
 .tierReading {

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
@@ -1,8 +1,81 @@
-import { type HomepageBlock, type HomepageConfig } from '@lightdash/common';
+import {
+    assertUnreachable,
+    type HomepageBlock,
+    type HomepageConfig,
+} from '@lightdash/common';
 import { resolveHomepageLayout } from './resolveHomepageLayout';
 
+// Typed per-block factory; `empty` builds the config-empty variant the
+// visibility filter drops.
+const makeBlock = (
+    id: string,
+    type: HomepageBlock['type'],
+    empty = false,
+): HomepageBlock => {
+    switch (type) {
+        case 'markdown':
+            return { id, type, config: { content: empty ? '  ' : 'hello' } };
+        case 'ask-ai-hero':
+            return { id, type, config: { showGreeting: true } };
+        case 'collection':
+            return {
+                id,
+                type,
+                config: {
+                    title: 't',
+                    items: empty ? [] : [{ contentType: 'chart', uuid: 'u' }],
+                },
+            };
+        case 'resources':
+            return {
+                id,
+                type,
+                config: {
+                    title: 't',
+                    items: empty
+                        ? []
+                        : [{ title: 'r', url: 'https://x', kind: 'link' }],
+                },
+            };
+        case 'announcements':
+            return {
+                id,
+                type,
+                config: {
+                    title: 't',
+                    items: empty ? [] : [{ text: 'x', date: 'd', author: 'a' }],
+                },
+            };
+        case 'quick-actions':
+            return {
+                id,
+                type,
+                config: { actions: empty ? [] : [{ type: 'ask-ai' }] },
+            };
+        case 'metrics':
+            return {
+                id,
+                type,
+                config: {
+                    title: 't',
+                    items: empty
+                        ? []
+                        : [{ tableName: 't', metricName: 'm', label: 'l' }],
+                },
+            };
+        case 'favorites':
+        case 'recent':
+            return { id, type, config: { title: 't' } };
+        default:
+            return assertUnreachable(type, 'Unknown homepage block type');
+    }
+};
+
 const block = (id: string, type: HomepageBlock['type']): HomepageBlock =>
-    ({ id, type, config: {} }) as HomepageBlock;
+    makeBlock(id, type);
+
+const emptyBlock = (id: string, type: HomepageBlock['type']): HomepageBlock =>
+    makeBlock(id, type, true);
 
 const makeConfig = (rows: HomepageBlock[][]): HomepageConfig => ({
     version: 1,
@@ -73,6 +146,68 @@ describe('resolveHomepageLayout', () => {
         ]);
         const { rows } = resolveHomepageLayout(config);
         expect(rows.map((r) => r.gap)).toEqual(['none', 'section']);
+    });
+
+    describe('config-empty blocks are invisible to the layout', () => {
+        it('an empty leading block does not demote the hero', () => {
+            const config = makeConfig([
+                [emptyBlock('ann', 'announcements')],
+                [block('a', 'ask-ai-hero')],
+                [block('c', 'collection')],
+            ]);
+            const { hero, rows } = resolveHomepageLayout(config);
+            expect(hero?.row.columns[0].block.type).toBe('ask-ai-hero');
+            expect(hero?.presentation).toBe('shared');
+            expect(rows.map((r) => r.id)).toEqual(['row-2']);
+        });
+
+        it('drops empty blocks from multi-column rows and empty rows entirely', () => {
+            const config = makeConfig([
+                [emptyBlock('r', 'resources'), block('f', 'favorites')],
+                [emptyBlock('m', 'metrics')],
+                [block('c', 'collection')],
+            ]);
+            const { rows } = resolveHomepageLayout(config);
+            expect(rows).toHaveLength(2);
+            expect(rows[0].columns.map((c) => c.block.id)).toEqual(['f']);
+            expect(rows[1].id).toBe('row-2');
+        });
+
+        it('a blank leading markdown does not claim the intro role', () => {
+            const config = makeConfig([
+                [emptyBlock('blank', 'markdown')],
+                [block('t', 'markdown')],
+                [block('c', 'collection')],
+            ]);
+            const { rows } = resolveHomepageLayout(config);
+            expect(rows[0].columns[0].block.id).toBe('t');
+            expect(rows[0].role).toBe('intro');
+        });
+    });
+
+    describe('hero companions', () => {
+        it('quick-actions above the composer join the hero instead of demoting it', () => {
+            const config = makeConfig([
+                [block('q', 'quick-actions')],
+                [block('a', 'ask-ai-hero')],
+                [block('c', 'collection')],
+            ]);
+            const { hero, rows } = resolveHomepageLayout(config);
+            expect(hero?.row.columns[0].block.type).toBe('ask-ai-hero');
+            expect(hero?.companions.map((r) => r.id)).toEqual(['row-0']);
+            expect(hero?.presentation).toBe('shared');
+            expect(rows.map((r) => r.id)).toEqual(['row-2']);
+        });
+
+        it('chrome rows without a composer after them stay ordinary body rows', () => {
+            const config = makeConfig([
+                [block('q', 'quick-actions')],
+                [block('c', 'collection')],
+            ]);
+            const { hero, rows } = resolveHomepageLayout(config);
+            expect(hero).toBeNull();
+            expect(rows.map((r) => r.id)).toEqual(['row-0', 'row-1']);
+        });
     });
 
     describe('fold-aware hero', () => {

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
@@ -77,6 +77,18 @@ const block = (id: string, type: HomepageBlock['type']): HomepageBlock =>
 const emptyBlock = (id: string, type: HomepageBlock['type']): HomepageBlock =>
     makeBlock(id, type, true);
 
+const collectionWithItems = (id: string, count: number): HomepageBlock => ({
+    id,
+    type: 'collection',
+    config: {
+        title: 't',
+        items: Array.from({ length: count }, (_, i) => ({
+            contentType: 'chart',
+            uuid: `u${i}`,
+        })),
+    },
+});
+
 const makeConfig = (rows: HomepageBlock[][]): HomepageConfig => ({
     version: 1,
     rows: rows.map((blocks, i) => ({ id: `row-${i}`, blocks })),
@@ -182,6 +194,32 @@ describe('resolveHomepageLayout', () => {
             const { rows } = resolveHomepageLayout(config);
             expect(rows[0].columns[0].block.id).toBe('t');
             expect(rows[0].role).toBe('intro');
+        });
+    });
+
+    describe('collection column weight scales with item count', () => {
+        it('a sparse collection (<3 items) matches its sibling 1:1 instead of hogging 2x width', () => {
+            const config = makeConfig([
+                [collectionWithItems('c', 1), block('f', 'favorites')],
+            ]);
+            const { rows } = resolveHomepageLayout(config);
+            expect(rows[0].columns.map((c) => c.weight)).toEqual([1, 1]);
+        });
+
+        it('a collection with 2 items still matches its sibling 1:1', () => {
+            const config = makeConfig([
+                [collectionWithItems('c', 2), block('f', 'favorites')],
+            ]);
+            const { rows } = resolveHomepageLayout(config);
+            expect(rows[0].columns.map((c) => c.weight)).toEqual([1, 1]);
+        });
+
+        it('a collection with 3+ items keeps the wider 2x column', () => {
+            const config = makeConfig([
+                [collectionWithItems('c', 3), block('f', 'favorites')],
+            ]);
+            const { rows } = resolveHomepageLayout(config);
+            expect(rows[0].columns.map((c) => c.weight)).toEqual([2, 1]);
         });
     });
 

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
@@ -10,13 +10,13 @@ const makeConfig = (rows: HomepageBlock[][]): HomepageConfig => ({
 });
 
 describe('resolveHomepageLayout', () => {
-    it('pulls a single leading ask-ai-hero into heroRow', () => {
+    it('pulls a single leading ask-ai-hero into the hero slot', () => {
         const config = makeConfig([
             [block('a', 'ask-ai-hero')],
             [block('b', 'collection')],
         ]);
-        const { heroRow, rows } = resolveHomepageLayout(config);
-        expect(heroRow?.id).toBe('row-0');
+        const { hero, rows } = resolveHomepageLayout(config);
+        expect(hero?.row.id).toBe('row-0');
         expect(rows.map((r) => r.id)).toEqual(['row-1']);
     });
 
@@ -24,15 +24,15 @@ describe('resolveHomepageLayout', () => {
         const config = makeConfig([
             [block('a', 'ask-ai-hero'), block('b', 'resources')],
         ]);
-        const { heroRow, rows } = resolveHomepageLayout(config);
-        expect(heroRow).toBeNull();
+        const { hero, rows } = resolveHomepageLayout(config);
+        expect(hero).toBeNull();
         expect(rows).toHaveLength(1);
     });
 
     it('does not treat a non-hero single block as a leading hero', () => {
         const config = makeConfig([[block('a', 'markdown')]]);
-        const { heroRow, rows } = resolveHomepageLayout(config);
-        expect(heroRow).toBeNull();
+        const { hero, rows } = resolveHomepageLayout(config);
+        expect(hero).toBeNull();
         expect(rows[0].widthTier).toBe('reading');
     });
 
@@ -73,5 +73,131 @@ describe('resolveHomepageLayout', () => {
         ]);
         const { rows } = resolveHomepageLayout(config);
         expect(rows.map((r) => r.gap)).toEqual(['none', 'section']);
+    });
+
+    describe('fold-aware hero', () => {
+        it('keeps the full viewport when the hero is the only content', () => {
+            const config = makeConfig([[block('a', 'ask-ai-hero')]]);
+            const { hero, rows } = resolveHomepageLayout(config);
+            expect(hero?.presentation).toBe('viewport');
+            expect(rows).toHaveLength(0);
+        });
+
+        it('yields to a shared viewport when body rows follow', () => {
+            const config = makeConfig([
+                [block('a', 'ask-ai-hero')],
+                [block('b', 'collection')],
+            ]);
+            const { hero } = resolveHomepageLayout(config);
+            expect(hero?.presentation).toBe('shared');
+        });
+    });
+
+    describe('leading-text intro', () => {
+        it('marks a lone leading markdown as intro and breaks the next row into a section', () => {
+            const config = makeConfig([
+                [block('t', 'markdown')],
+                [block('t2', 'markdown')], // grouped, but forced to section
+                [block('c', 'collection')],
+            ]);
+            const { rows } = resolveHomepageLayout(config);
+            expect(rows.map((r) => r.role)).toEqual(['intro', 'body', 'body']);
+            expect(rows.map((r) => r.gap)).toEqual([
+                'none',
+                'section',
+                'section',
+            ]);
+        });
+
+        it('does not mark an intro when a hero leads the page', () => {
+            const config = makeConfig([
+                [block('a', 'ask-ai-hero')],
+                [block('t', 'markdown')],
+            ]);
+            const { rows } = resolveHomepageLayout(config);
+            expect(rows[0].role).toBe('body');
+        });
+
+        it('does not mark a markdown inside a multi-column first row as intro', () => {
+            const config = makeConfig([
+                [block('t', 'markdown'), block('r', 'resources')],
+            ]);
+            const { rows } = resolveHomepageLayout(config);
+            expect(rows[0].role).toBe('body');
+        });
+
+        it('does not mark a mid-page markdown as intro', () => {
+            const config = makeConfig([
+                [block('c', 'collection')],
+                [block('t', 'markdown')],
+            ]);
+            const { rows } = resolveHomepageLayout(config);
+            expect(rows.map((r) => r.role)).toEqual(['body', 'body']);
+        });
+    });
+
+    describe('width smoothing (two axes)', () => {
+        it('promotes content rows to full when any full row exists', () => {
+            const config = makeConfig([
+                [block('c', 'collection')], // full
+                [block('r', 'resources')], // content -> promoted
+                [block('f', 'favorites')], // content -> promoted
+            ]);
+            const { rows } = resolveHomepageLayout(config);
+            expect(rows.map((r) => r.widthTier)).toEqual([
+                'full',
+                'full',
+                'full',
+            ]);
+        });
+
+        it('keeps content rows at content width when no full row exists', () => {
+            const config = makeConfig([
+                [block('r', 'resources')],
+                [block('f', 'favorites')],
+            ]);
+            const { rows } = resolveHomepageLayout(config);
+            expect(rows.map((r) => r.widthTier)).toEqual([
+                'content',
+                'content',
+            ]);
+        });
+
+        it('never widens focal rows (reading / composer)', () => {
+            const config = makeConfig([
+                [block('t', 'markdown')], // reading
+                [block('c', 'collection')], // full
+                [block('a', 'ask-ai-hero')], // composer (mid-page)
+            ]);
+            const { rows } = resolveHomepageLayout(config);
+            expect(rows.map((r) => r.widthTier)).toEqual([
+                'reading',
+                'full',
+                'composer',
+            ]);
+        });
+
+        it('renders the text/collection/ask-ai/favourites permutation on two axes', () => {
+            const config = makeConfig([
+                [block('t', 'markdown')],
+                [block('c', 'collection')],
+                [block('a', 'ask-ai-hero')],
+                [block('f', 'favorites')],
+            ]);
+            const { hero, rows } = resolveHomepageLayout(config);
+            expect(hero).toBeNull();
+            expect(rows.map((r) => r.widthTier)).toEqual([
+                'reading',
+                'full',
+                'composer',
+                'full', // was content — joins the wide axis
+            ]);
+            expect(rows.map((r) => r.role)).toEqual([
+                'intro',
+                'body',
+                'body',
+                'body',
+            ]);
+        });
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -9,6 +9,15 @@ const LEADING_HERO_TYPES: HomepageBlock['type'][] = ['ask-ai-hero'];
 // section has no gap (the section's own spacing separates it).
 export type RowGap = 'none' | 'grouped' | 'section';
 
+// 'viewport' = the hero is the only content, centred in the full viewport
+// (day-0 feel). 'shared' = body rows follow, so the hero yields part of the
+// viewport and the first row peeks above the fold.
+export type HeroPresentation = 'viewport' | 'shared';
+
+// 'intro' = a lone leading text block that opens the page and gets breathing
+// room; everything else is 'body'.
+export type RowRole = 'intro' | 'body';
+
 export type ResolvedColumn = {
     block: HomepageBlock;
     weight: number;
@@ -20,12 +29,13 @@ export type ResolvedRow = {
     // Max-width tier for the whole row. Single-block rows use their block's
     // tier; multi-column rows always span full width.
     widthTier: BlockWidthTier;
+    role: RowRole;
     columns: ResolvedColumn[];
 };
 
 export type ResolvedLayout = {
     // The leading hero, rendered vertically-centred above everything, or null.
-    heroRow: ResolvedRow | null;
+    hero: { row: ResolvedRow; presentation: HeroPresentation } | null;
     // Every other row, in order, with gaps derived from adjacency.
     rows: ResolvedRow[];
 };
@@ -53,7 +63,36 @@ const resolveRow = (
             ? 'grouped'
             : 'section';
     })();
-    return { id: row.id, gap, widthTier, columns };
+    return { id: row.id, gap, widthTier, role: 'body', columns };
+};
+
+// Width smoothing keeps the page to two visual axes. Focal rows (reading /
+// composer) are never widened — line length is sacred. Content rows join the
+// page's wide axis when any full row exists, so card-grid edges align instead
+// of zigzagging between four different widths.
+const smoothWidthTiers = (rows: ResolvedRow[]): ResolvedRow[] => {
+    if (!rows.some((row) => row.widthTier === 'full')) return rows;
+    return rows.map((row) =>
+        row.widthTier === 'content' ? { ...row, widthTier: 'full' } : row,
+    );
+};
+
+// A page that opens with a lone text block reads as a page intro: it gets
+// breathing room above, and the next row breaks away as its own section.
+const applyIntroRole = (rows: ResolvedRow[]): ResolvedRow[] => {
+    const [first, second, ...rest] = rows;
+    if (
+        !first ||
+        first.columns.length !== 1 ||
+        first.columns[0].block.type !== 'markdown'
+    ) {
+        return rows;
+    }
+    return [
+        { ...first, role: 'intro' as const },
+        ...(second ? [{ ...second, gap: 'section' as const }] : []),
+        ...rest,
+    ];
 };
 
 export const resolveHomepageLayout = (
@@ -61,8 +100,18 @@ export const resolveHomepageLayout = (
 ): ResolvedLayout => {
     const [first, ...rest] = config.rows;
     const hasLeadingHero = !!first && isLeadingHero(first.blocks);
-    const heroRow = hasLeadingHero ? resolveRow(first, true) : null;
     const bodyRows = hasLeadingHero ? rest : config.rows;
-    const rows = bodyRows.map((row, index) => resolveRow(row, index === 0));
-    return { heroRow, rows };
+    const resolved = bodyRows.map((row, index) => resolveRow(row, index === 0));
+    const smoothed = smoothWidthTiers(resolved);
+    const rows = hasLeadingHero ? smoothed : applyIntroRole(smoothed);
+    // A hero keeps the whole viewport only when it's alone; with body rows it
+    // yields so the first row peeks above the fold.
+    const hero = hasLeadingHero
+        ? {
+              row: resolveRow(first, true),
+              presentation:
+                  rows.length > 0 ? ('shared' as const) : ('viewport' as const),
+          }
+        : null;
+    return { hero, rows };
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -89,13 +89,24 @@ const toVisibleRows = (rows: HomepageConfig['rows']): HomepageConfig['rows'] =>
         }))
         .filter((row) => row.blocks.length > 0);
 
+// A collection's trait weight (2) assumes it has enough cards to fill a wide
+// column with its centred 3-col grid. With only 1-2 items the extra width is
+// just empty margin around a centred card, and it starves whatever it shares
+// the row with — so weight follows actual item count, not just block type.
+const columnWeightFor = (block: HomepageBlock): number => {
+    if (block.type === 'collection') {
+        return block.config.items.length >= 3 ? 2 : 1;
+    }
+    return traitFor(block.type).columnWeight;
+};
+
 const resolveRow = (
     row: HomepageConfig['rows'][number],
     isFirst: boolean,
 ): ResolvedRow => {
     const columns: ResolvedColumn[] = row.blocks.map((block) => ({
         block,
-        weight: traitFor(block.type).columnWeight,
+        weight: columnWeightFor(block),
     }));
     const single = row.blocks.length === 1;
     const widthTier: BlockWidthTier = single

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -1,9 +1,17 @@
-import { type HomepageBlock, type HomepageConfig } from '@lightdash/common';
+import {
+    assertUnreachable,
+    type HomepageBlock,
+    type HomepageConfig,
+} from '@lightdash/common';
 import { type BlockWidthTier, traitFor } from './blockLayout';
 
 // Only a single-block leading row of one of these types gets the day-0 style
 // vertically-centred hero treatment.
 const LEADING_HERO_TYPES: HomepageBlock['type'][] = ['ask-ai-hero'];
+
+// Chrome-like rows that may sit above the composer without demoting it — they
+// join the hero composition instead (day-0 has its chips above the hero too).
+const HERO_COMPANION_TYPES: HomepageBlock['type'][] = ['quick-actions'];
 
 // Gap before a row, as a token resolved to px in CSS. The first row of a
 // section has no gap (the section's own spacing separates it).
@@ -34,14 +42,52 @@ export type ResolvedRow = {
 };
 
 export type ResolvedLayout = {
-    // The leading hero, rendered vertically-centred above everything, or null.
-    hero: { row: ResolvedRow; presentation: HeroPresentation } | null;
+    // The leading hero composition, rendered vertically-centred above
+    // everything: optional chrome rows (quick-actions) + the composer row.
+    hero: {
+        companions: ResolvedRow[];
+        row: ResolvedRow;
+        presentation: HeroPresentation;
+    } | null;
     // Every other row, in order, with gaps derived from adjacency.
     rows: ResolvedRow[];
 };
 
 const isLeadingHero = (blocks: HomepageBlock[]): boolean =>
     blocks.length === 1 && LEADING_HERO_TYPES.includes(blocks[0].type);
+
+// Blocks whose config makes them provably render nothing (their Views return
+// null). The layout reasons about what will actually paint: an invisible block
+// must not demote the hero, leave a phantom row gap, or hold a ghost column.
+const isConfigEmptyBlock = (block: HomepageBlock): boolean => {
+    switch (block.type) {
+        case 'announcements':
+        case 'collection':
+        case 'resources':
+        case 'metrics':
+            return block.config.items.length === 0;
+        case 'quick-actions':
+            return block.config.actions.length === 0;
+        case 'markdown':
+            return block.config.content.trim() === '';
+        // Visibility depends on runtime data (viewer, AI availability), not
+        // config — always treat as visible.
+        case 'ask-ai-hero':
+        case 'favorites':
+        case 'recent':
+            return false;
+        default:
+            return assertUnreachable(block, 'Unknown homepage block type');
+    }
+};
+
+const toVisibleRows = (rows: HomepageConfig['rows']): HomepageConfig['rows'] =>
+    rows
+        .map((row) => ({
+            ...row,
+            blocks: row.blocks.filter((block) => !isConfigEmptyBlock(block)),
+        }))
+        .filter((row) => row.blocks.length > 0);
 
 const resolveRow = (
     row: HomepageConfig['rows'][number],
@@ -98,9 +144,18 @@ const applyIntroRole = (rows: ResolvedRow[]): ResolvedRow[] => {
 export const resolveHomepageLayout = (
     config: HomepageConfig,
 ): ResolvedLayout => {
-    const [first, ...rest] = config.rows;
-    const hasLeadingHero = !!first && isLeadingHero(first.blocks);
-    const bodyRows = hasLeadingHero ? rest : config.rows;
+    const visibleRows = toVisibleRows(config.rows);
+    // Leading chrome rows join the hero rather than demoting it: the composer
+    // is still "leading" with a quick-actions strip above it.
+    const composerIdx = visibleRows.findIndex(
+        (row) =>
+            !row.blocks.every((b) => HERO_COMPANION_TYPES.includes(b.type)),
+    );
+    const composerRow = composerIdx >= 0 ? visibleRows[composerIdx] : undefined;
+    const hasLeadingHero = !!composerRow && isLeadingHero(composerRow.blocks);
+    const bodyRows = hasLeadingHero
+        ? visibleRows.slice(composerIdx + 1)
+        : visibleRows;
     const resolved = bodyRows.map((row, index) => resolveRow(row, index === 0));
     const smoothed = smoothWidthTiers(resolved);
     const rows = hasLeadingHero ? smoothed : applyIntroRole(smoothed);
@@ -108,7 +163,10 @@ export const resolveHomepageLayout = (
     // yields so the first row peeks above the fold.
     const hero = hasLeadingHero
         ? {
-              row: resolveRow(first, true),
+              companions: visibleRows
+                  .slice(0, composerIdx)
+                  .map((row) => resolveRow(row, true)),
+              row: resolveRow(composerRow, true),
               presentation:
                   rows.length > 0 ? ('shared' as const) : ('viewport' as const),
           }


### PR DESCRIPTION
> Stacked on #25688 (`joaoviana/homepage-resource-cards`).

## What

Order-aware layout defaults for the homepage builder, so **any block permutation renders intentionally** — without hand-tuning specific arrangements. `resolveHomepageLayout` stays the single, pure, unit-tested brain; the renderer and CSS only consume its flags. The builder's Preview toggle renders through the same `PublishedHomepage`, so edit-preview parity is automatic.

## The rules

0. **Invisible blocks don't occupy layout slots** — blocks whose config provably renders nothing (zero items/actions, blank markdown — matching each View's own null-guard) are filtered before any rule runs. An empty announcements row can no longer demote the hero, leave a phantom gap, or hold a ghost column.
1. **Fold-aware hero** — a leading Ask-AI keeps the full viewport only when it's the *only* content; with body rows it takes ~50vh so the next row peeks above the fold. Day-0 and hero-only pages unchanged by construction.
2. **Hero companions** — leading quick-actions rows join the hero composition (chips above the composer, day-0 style) instead of demoting it: the greeting survives chrome above it. Companions share the composer's 720px axis.
3. **Compact mid-page Ask-AI** — blocks get `presentation: 'hero' | 'inline'`; a genuinely mid-page composer drops the greeting and renders inline.
4. **Leading-text intro** — a lone leading markdown gets breathing room and forces the next row to a section gap.
5. **Width smoothing ("two axes")** — reading/composer never widen; content rows promote to full when any full row exists, so card edges align instead of zigzagging 680→1160→720→960.
6. **Sparse collections centre as a unit** — the fixed 3-col SimpleGrid became a centred wrap-grid (full rows pixel-identical; wrapper cells are single-cell grids so inline `<a>` cards stay blockified); the section header centres with the cards.
7. **Centred strips + balanced splits** — quick-action chips and favourites pills centre with their headers; in multi-column rows the shorter column centres vertically instead of hugging the top.

Plus: taller add-content picker (64vh instead of a 440px crop).

## Verification

- 51 tests across the homepage suite — resolver cases for every rule (incl. the `text → collection → ask-ai → favourites` permutation, empty-leading-block hero protection, companions with/without a composer) + greeting hero/inline RTL.
- Typecheck, oxlint, unused-exports clean. Typed per-block test factory (no `as` casts).
- Verified against real published homepages via Playwright: fold-aware hero, chips-in-hero with greeting restored, centred sparse collections/favourites, balanced split rows. Includes a live-caught + fixed regression (un-blockified inline `<a>` cards) and a live-caught rule gap (invisible rows demoting the hero).

## Notes

- No new feature flag — rides the existing Homepage v2 gate; presentation-only, stored configs unchanged.
- No Linear ticket (per the earlier decision on this stack).
- Design doc: `~/Desktop/plans/2026-07-16-homepage-layout-defaults-design.md` (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdmaziyqFVmFgQpjTHkv1y