### PR TITLE
fix(homepage): greet pre-5am as evening, not morning

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
@@ -3,14 +3,8 @@ import { type FC } from 'react';
 import useApp from '../../../../providers/App/useApp';
 import { useAiAgentButtonVisibility } from '../../aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { DayOneAskInput } from '../DayOneAskInput';
+import { dayPart } from './dayPart';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
-
-const dayPart = (): string => {
-    const hour = new Date().getHours();
-    if (hour < 12) return 'morning';
-    if (hour < 18) return 'afternoon';
-    return 'evening';
-};
 
 // The day-0 hero, as a reusable unit: greeting + the real agent chat
 // composer with live suggestions. Shared between DayOneHomepage (always
@@ -35,8 +29,8 @@ export const AskAiHero: FC<{
                     ta="center"
                     m={0}
                 >
-                    Good {dayPart()}, {user.data?.firstName}. What do you want
-                    to know?
+                    Good {dayPart(new Date().getHours())},{' '}
+                    {user.data?.firstName}. What do you want to know?
                 </Text>
             )}
             <Box w="100%">

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/dayPart.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/dayPart.test.ts
@@ -1,0 +1,24 @@
+import { dayPart } from './dayPart';
+
+describe('dayPart', () => {
+    it('greets late night (midnight to 4:59) as evening', () => {
+        expect(dayPart(0)).toBe('evening');
+        expect(dayPart(1)).toBe('evening');
+        expect(dayPart(4)).toBe('evening');
+    });
+
+    it('greets 5:00 to 11:59 as morning', () => {
+        expect(dayPart(5)).toBe('morning');
+        expect(dayPart(11)).toBe('morning');
+    });
+
+    it('greets 12:00 to 17:59 as afternoon', () => {
+        expect(dayPart(12)).toBe('afternoon');
+        expect(dayPart(17)).toBe('afternoon');
+    });
+
+    it('greets 18:00 to 23:59 as evening', () => {
+        expect(dayPart(18)).toBe('evening');
+        expect(dayPart(23)).toBe('evening');
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/dayPart.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/dayPart.ts
@@ -1,0 +1,7 @@
+// Late night (before 5am) greets as evening: nobody's morning starts at midnight.
+export const dayPart = (hour: number): 'morning' | 'afternoon' | 'evening' => {
+    if (hour < 5) return 'evening';
+    if (hour < 12) return 'morning';
+    if (hour < 18) return 'afternoon';
+    return 'evening';
+};


### PR DESCRIPTION
## Problem

The homepage greeting bands were `<12 → morning`, `<18 → afternoon`, else evening — so anyone working past midnight got "Good morning" at 00:30, which reads wrong: calendar-morning and human-morning diverge between midnight and ~5am.

## Change

- `dayPart` now treats **midnight–4:59 as evening** (the least-wrong greeting for late-night sessions, with no new copy). Bands: 5–12 morning, 12–18 afternoon, 18–5 evening.
- Extracted `dayPart(hour)` into its own module with the hour passed in (`new Date().getHours()` stays at the call site), so the band edges are unit-testable — added tests pinning all six boundaries.

## Who's affected

Anyone viewing a homepage hero with the greeting enabled (day-1 default homepage and the ask-AI hero block — both share this one function) between 00:00 and 04:59 local time. All other hours are unchanged.

A dedicated late-night greeting ("Working late?") was considered and deliberately deferred — that's a copy/personality decision, not a bug fix.

Relates: ZAP-626

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBbNVUhwQLTuJgFb1tc1By