### PR TITLE
fix(homepage): add-content picker — bigger modal, fixed footer, no overflow

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -18,7 +18,7 @@ import {
     TextInput,
 } from '@mantine-8/core';
 import { IconLayoutGrid, IconPin, IconPlus } from '@tabler/icons-react';
-import { useEffect, useMemo, useRef, useState, type FC } from 'react';
+import { useMemo, useRef, useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
 import { ResourceIcon } from '../../../../components/common/ResourceIcon';
@@ -193,9 +193,9 @@ const CollectionPicker: FC<{
         Map<string, HomepageCollectionItemRef>
     >(() => new Map(initialSelected.map((ref) => [ref.uuid, ref])));
 
-    useEffect(() => {
-        registerApply(() => onApply([...selected.values()]));
-    }, [selected, onApply, registerApply]);
+    // Re-point the parent's apply ref every render so it always commits the
+    // latest selection (idempotent, so safe during render — no effect needed).
+    registerApply(() => onApply([...selected.values()]));
 
     const { data: spaces } = useSpaceSummaries(projectUuid, true);
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -18,7 +18,7 @@ import {
     TextInput,
 } from '@mantine-8/core';
 import { IconLayoutGrid, IconPin, IconPlus } from '@tabler/icons-react';
-import { useMemo, useState, type FC } from 'react';
+import { useEffect, useMemo, useRef, useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
 import { ResourceIcon } from '../../../../components/common/ResourceIcon';
@@ -182,14 +182,20 @@ const CollectionPicker: FC<{
     projectUuid: string;
     initialSelected: HomepageCollectionItemRef[];
     onApply: (refs: HomepageCollectionItemRef[]) => void;
-    onClose: () => void;
-}> = ({ projectUuid, initialSelected, onApply, onClose }) => {
+    /** Hands the modal's Apply button a callback that commits the current
+     * selection — the footer lives in MantineModal, outside this component. */
+    registerApply: (commit: () => void) => void;
+}> = ({ projectUuid, initialSelected, onApply, registerApply }) => {
     const [selectedSpaceUuid, setSelectedSpaceUuid] = useState<string | null>(
         null,
     );
     const [selected, setSelected] = useState<
         Map<string, HomepageCollectionItemRef>
     >(() => new Map(initialSelected.map((ref) => [ref.uuid, ref])));
+
+    useEffect(() => {
+        registerApply(() => onApply([...selected.values()]));
+    }, [selected, onApply, registerApply]);
 
     const { data: spaces } = useSpaceSummaries(projectUuid, true);
 
@@ -217,7 +223,7 @@ const CollectionPicker: FC<{
     return (
         <Stack gap="sm">
             <Group align="stretch" gap="md" wrap="nowrap" h="min(64vh, 720px)">
-                <Box w={280} className={classes.pickerScrollList}>
+                <Box w={340} className={classes.pickerScrollList}>
                     <SpaceSelector
                         projectUuid={projectUuid}
                         spaces={spaces}
@@ -251,21 +257,6 @@ const CollectionPicker: FC<{
                     </Box>
                 </Stack>
             </Group>
-
-            <Group justify="flex-end" gap="xs">
-                <Button variant="default" size="xs" onClick={onClose}>
-                    Cancel
-                </Button>
-                <Button
-                    size="xs"
-                    onClick={() => {
-                        onApply([...selected.values()]);
-                        onClose();
-                    }}
-                >
-                    Apply
-                </Button>
-            </Group>
         </Stack>
     );
 };
@@ -276,24 +267,37 @@ const CollectionPickerModal: FC<{
     projectUuid: string;
     initialSelected: HomepageCollectionItemRef[];
     onApply: (refs: HomepageCollectionItemRef[]) => void;
-}> = ({ opened, onClose, projectUuid, initialSelected, onApply }) => (
-    <MantineModal
-        opened={opened}
-        onClose={onClose}
-        title="Add content"
-        icon={IconPlus}
-        size="1000px"
-    >
-        {opened && (
-            <CollectionPicker
-                projectUuid={projectUuid}
-                initialSelected={initialSelected}
-                onApply={onApply}
-                onClose={onClose}
-            />
-        )}
-    </MantineModal>
-);
+}> = ({ opened, onClose, projectUuid, initialSelected, onApply }) => {
+    // The Apply/Cancel footer is MantineModal's own — it lives outside the
+    // remountable picker body, so the picker hands its commit fn up via ref
+    // rather than rendering a duplicate footer inline.
+    const applyRef = useRef<() => void>(() => {});
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Add content"
+            icon={IconPlus}
+            size="min(92vw, 1280px)"
+            confirmLabel="Apply"
+            onConfirm={() => {
+                applyRef.current();
+                onClose();
+            }}
+        >
+            {opened && (
+                <CollectionPicker
+                    projectUuid={projectUuid}
+                    initialSelected={initialSelected}
+                    onApply={onApply}
+                    registerApply={(fn) => {
+                        applyRef.current = fn;
+                    }}
+                />
+            )}
+        </MantineModal>
+    );
+};
 
 export const CollectionBlockView: FC<BlockComponentProps> = ({
     block,

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -79,10 +79,7 @@ a .hoverCard:hover,
 
 .pickerScrollList {
     overflow-y: auto;
-    /* Flex items default to min-height: auto (sized to content), so without
-     * this the list refuses to shrink to its allotted box and grows past it
-     * instead of scrolling internally — pushing the whole modal taller than
-     * the viewport instead of scrolling just this list. */
+    /* override flex min-height:auto so the list shrinks and scrolls internally */
     min-height: 0;
 }
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -79,6 +79,11 @@ a .hoverCard:hover,
 
 .pickerScrollList {
     overflow-y: auto;
+    /* Flex items default to min-height: auto (sized to content), so without
+     * this the list refuses to shrink to its allotted box and grows past it
+     * instead of scrolling internally — pushing the whole modal taller than
+     * the viewport instead of scrolling just this list. */
+    min-height: 0;
 }
 
 .actionRow {


### PR DESCRIPTION
> Stacked on #25693 (`joaoviana/homepage-layout-defaults`), itself stacked on #25688.

## What

Fixes to the Collection block's "Add content" picker modal, found live while playing with the homepage builder.

- **Wider modal + sidebar** — 1280px modal (was Mantine's default `lg` ~800px), 340px space-tree sidebar (was 280px). The two-pane picker felt cramped with real space trees and long chart/dashboard names.
- **Footer buttons through MantineModal properly** — Cancel/Apply now use `onConfirm`/`confirmLabel` instead of a duplicate inline `<Group>` footer. Two knock-on benefits: consistent button styling with every other modal in the app, and the footer now stays pinned outside the scrollable body instead of scrolling away with a long content list. Since the footer lives in `MantineModal` (outside the picker body, which unmounts/remounts on open per the repo's reset-on-open convention), the picker hands its "commit current selection" callback up via a ref rather than duplicating a footer inline.
- **Real overflow bug fixed** — `.pickerScrollList` (the space tree + content list) had no `min-height`, so as a flex child it refused to shrink to its allotted box (the classic `min-height: auto` flex default) and instead grew to fit all its content, pushing the whole modal taller than the viewport once enough items were loaded via "Load more" — forcing a page-level scroll that clipped the modal header off-screen. Same root cause as two other overflow bugs found earlier this session in the collection card grid (`min-width`/`min-height: auto` on flex/grid children).

## Verification

- Reproduced live: loaded 52 items into the picker via repeated "Load more" clicks. Before: modal grew past the viewport, page had to scroll, header clipped off-screen. After: modal stays a contained 684px tall in an 862px viewport — confirmed via direct DOM measurement, not just visually.
- Confirmed Apply commits the current selection and closes the modal; Cancel closes without applying.
- Homepage suite (54 tests), typecheck, lint, unused-exports all clean — this PR only touches modal chrome/CSS, no resolver/type changes.

## Notes

- No new feature flag — presentation-only.
- No Linear ticket (per the earlier decision on this stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdmaziyqFVmFgQpjTHkv1y