### PR TITLE
fix: surface MCP OAuth start errors

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3777,16 +3777,26 @@ export class AiAgentService extends BaseService {
             await this.assertCanUsePersonalMcpCredentials(user, projectUuid);
         }
 
-        return this.aiAgentMcpRuntimeClient.startOAuthConnection({
-            projectUuid,
-            mcpServerUuid,
-            credentialScope,
-            userUuid: credentialScope === 'user' ? user.userUuid : undefined,
-            actorUserUuid: user.userUuid,
-            serverUrl: server.url,
-            connectionStatusOnAuthorization:
-                options?.connectionStatusOnAuthorization,
-        });
+        try {
+            return await this.aiAgentMcpRuntimeClient.startOAuthConnection({
+                projectUuid,
+                mcpServerUuid,
+                credentialScope,
+                userUuid:
+                    credentialScope === 'user' ? user.userUuid : undefined,
+                actorUserUuid: user.userUuid,
+                serverUrl: server.url,
+                connectionStatusOnAuthorization:
+                    options?.connectionStatusOnAuthorization,
+            });
+        } catch (error) {
+            const message = getErrorMessage(error);
+            Logger.error(
+                `[AiAgent][MCP][${mcpServerUuid}] Failed to start OAuth authorization: ${message}`,
+                error,
+            );
+            throw new ParameterError(message);
+        }
     }
 
     public async completeMcpOAuthConnection(args: {

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiMcpServers.ts
@@ -1,3 +1,4 @@
+import { isApiError } from '@lightdash/common';
 import type {
     ApiAiMcpGithubAvailabilityResponse,
     ApiAiMcpOAuthCredentialRequest,
@@ -524,11 +525,12 @@ export const useRefreshAiMcpServerToolsMutation = (projectUuid: string) => {
 
 export const useStartMcpOAuthConnectionMutation = (projectUuid: string) => {
     const queryClient = useQueryClient();
-    const { showToastError, showToastSuccess } = useToaster();
+    const { showToastApiError, showToastError, showToastSuccess } =
+        useToaster();
 
     return useMutation<
         void,
-        Error,
+        unknown,
         {
             mcpServerUuid: string;
             credentialScope?: ApiAiMcpOAuthCredentialRequest['credentialScope'];
@@ -561,9 +563,18 @@ export const useStartMcpOAuthConnectionMutation = (projectUuid: string) => {
             });
         },
         onError: (error) => {
+            if (isApiError(error)) {
+                showToastApiError({
+                    title: 'Authentication failed',
+                    apiError: error.error,
+                });
+                return;
+            }
+
             showToastError({
                 title: 'Authentication failed',
-                subtitle: error.message || 'Please try again',
+                subtitle:
+                    error instanceof Error ? error.message : 'Please try again',
             });
         },
     });


### PR DESCRIPTION
## Summary

- log MCP OAuth startup failures with MCP server context and the internal cause
- return sanitized, actionable errors for known OAuth metadata and dynamic registration problems while preserving unknown failures as server errors
- show backend API details in the authentication toast while retaining popup and network error fallbacks

## Testing

- Browser on `http://localhost:3022`: a mismatched protected resource URL showed the specific metadata error before any OAuth popup opened; browser tab count stayed unchanged
- backend and frontend `typecheck:fast`
- targeted backend ESLint and frontend Oxlint
- Oxfmt and `git diff --check`
- final review agent: no findings

Closes: PROD-8967
Closes: #25700
