### PR TITLE
feat(agents): filter admin threads by user

### DIFF
--- a/packages/frontend/src/components/common/FilterFacet/FilterFacet.tsx
+++ b/packages/frontend/src/components/common/FilterFacet/FilterFacet.tsx
@@ -258,7 +258,7 @@ const FilterFacet = ({
                                 onSearchChange(e.currentTarget.value)
                             }
                             leftSection={
-                                <MantineIcon icon={IconSearch} size="xs" />
+                                <MantineIcon icon={IconSearch} size="md" />
                             }
                             rightSection={
                                 loading || loadingMore ? (

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
@@ -95,6 +95,7 @@ const AiAgentAdminThreadsTable = ({
         search,
         selectedProjectUuids,
         selectedAgentUuids,
+        selectedUserUuids,
         selectedSource,
         selectedFeedback,
         sortField,
@@ -103,6 +104,7 @@ const AiAgentAdminThreadsTable = ({
         setSearch,
         setSelectedProjectUuids,
         setSelectedAgentUuids,
+        setSelectedUserUuids,
         setSelectedSource,
         setSelectedFeedback,
         setSorting,
@@ -747,6 +749,8 @@ const AiAgentAdminThreadsTable = ({
                 setSelectedProjectUuids={setSelectedProjectUuids}
                 selectedAgentUuids={selectedAgentUuids}
                 setSelectedAgentUuids={setSelectedAgentUuids}
+                selectedUserUuids={selectedUserUuids}
+                setSelectedUserUuids={setSelectedUserUuids}
                 selectedSource={selectedSource}
                 setSelectedSource={setSelectedSource}
                 selectedFeedback={selectedFeedback}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminTopToolbar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminTopToolbar.tsx
@@ -16,6 +16,7 @@ import { FeedbackFilter } from './FeedbackFilter';
 import ProjectsFilter from './ProjectsFilter';
 import { SearchFilter } from './SearchFilter';
 import { SourceFilter } from './SourceFilter';
+import UsersFilter from './UsersFilter';
 
 type AiAgentAdminTopToolbarProps = GroupProps &
     Pick<
@@ -23,11 +24,13 @@ type AiAgentAdminTopToolbarProps = GroupProps &
         | 'search'
         | 'selectedProjectUuids'
         | 'selectedAgentUuids'
+        | 'selectedUserUuids'
         | 'selectedSource'
         | 'selectedFeedback'
         | 'setSearch'
         | 'setSelectedProjectUuids'
         | 'setSelectedAgentUuids'
+        | 'setSelectedUserUuids'
         | 'setSelectedSource'
         | 'setSelectedFeedback'
     > & {
@@ -47,6 +50,8 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
         setSelectedProjectUuids,
         selectedAgentUuids,
         setSelectedAgentUuids,
+        selectedUserUuids,
+        setSelectedUserUuids,
         selectedSource,
         setSelectedSource,
         selectedFeedback,
@@ -100,6 +105,18 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                             selectedAgentUuids={selectedAgentUuids}
                             setSelectedAgentUuids={setSelectedAgentUuids}
                             selectedProjectUuids={selectedProjectUuids}
+                        />
+                        <Divider
+                            orientation="vertical"
+                            w={1}
+                            h={20}
+                            style={{
+                                alignSelf: 'center',
+                            }}
+                        />
+                        <UsersFilter
+                            selectedUserUuids={selectedUserUuids}
+                            setSelectedUserUuids={setSelectedUserUuids}
                         />
                         <Divider
                             orientation="vertical"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/UsersFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/UsersFilter.tsx
@@ -1,0 +1,87 @@
+import { useDebouncedValue } from '@mantine/hooks';
+import { IconUser } from '@tabler/icons-react';
+import { useCallback, useMemo, useState, type FC } from 'react';
+import FilterFacet, {
+    type FilterFacetOption,
+} from '../../../../../components/common/FilterFacet';
+import { useInfiniteOrganizationUsers } from '../../../../../hooks/useOrganizationUsers';
+import { type useAiAgentAdminFilters } from '../../hooks/useAiAgentAdminFilters';
+
+type UsersFilterProps = Pick<
+    ReturnType<typeof useAiAgentAdminFilters>,
+    'selectedUserUuids' | 'setSelectedUserUuids'
+>;
+
+const getUserDisplayName = (
+    firstName: string | undefined,
+    lastName: string | undefined,
+    email: string,
+) => {
+    const name = [firstName, lastName].filter(Boolean).join(' ');
+    return name || email;
+};
+
+const UsersFilter: FC<UsersFilterProps> = ({
+    selectedUserUuids,
+    setSelectedUserUuids,
+}) => {
+    const [searchValue, setSearchValue] = useState('');
+    const [debouncedSearchValue] = useDebouncedValue(searchValue, 300);
+    const { data, isLoading, isFetching, hasNextPage, fetchNextPage } =
+        useInfiniteOrganizationUsers(
+            {
+                searchInput: debouncedSearchValue,
+                pageSize: 25,
+            },
+            { keepPreviousData: true },
+        );
+
+    const options = useMemo<FilterFacetOption[]>(() => {
+        const users = data?.pages.flatMap((page) => page.data) ?? [];
+        const seen = new Set<string>();
+
+        return users
+            .filter((user) => {
+                if (seen.has(user.userUuid)) return false;
+                seen.add(user.userUuid);
+                return true;
+            })
+            .map((user) => {
+                const displayName = getUserDisplayName(
+                    user.firstName,
+                    user.lastName,
+                    user.email,
+                );
+                return {
+                    value: user.userUuid,
+                    label: displayName,
+                    searchLabel: `${displayName} ${user.email}`,
+                };
+            });
+    }, [data]);
+
+    const handleScrollEnd = useCallback(() => {
+        if (isFetching || !hasNextPage) return;
+        void fetchNextPage();
+    }, [fetchNextPage, hasNextPage, isFetching]);
+
+    return (
+        <FilterFacet
+            label="User"
+            icon={IconUser}
+            options={options}
+            selected={selectedUserUuids}
+            onChange={setSelectedUserUuids}
+            tooltipLabel="Filter threads by user"
+            searchValue={searchValue}
+            onSearchChange={setSearchValue}
+            searchPlaceholder="Search users..."
+            loading={isLoading}
+            loadingMore={isFetching && !isLoading}
+            onScrollEnd={handleScrollEnd}
+            emptyLabel="No users found."
+        />
+    );
+};
+
+export default UsersFilter;

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminFilters.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminFilters.test.tsx
@@ -1,0 +1,43 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+import { useAiAgentAdminFilters } from './useAiAgentAdminFilters';
+
+const USER_UUID = '55de7cc5-4d4b-4d09-a441-85eca10ba60a';
+
+const createWrapper = (search = '') =>
+    function Wrapper({ children }: PropsWithChildren) {
+        return (
+            <MemoryRouter
+                initialEntries={[`/generalSettings/ai/threads${search}`]}
+            >
+                {children}
+            </MemoryRouter>
+        );
+    };
+
+describe('useAiAgentAdminFilters', () => {
+    it('loads user filters from the URL and includes them in API filters', () => {
+        const { result } = renderHook(() => useAiAgentAdminFilters(), {
+            wrapper: createWrapper(`?users=${USER_UUID}`),
+        });
+
+        expect(result.current.selectedUserUuids).toEqual([USER_UUID]);
+        expect(result.current.apiFilters.userUuids).toEqual([USER_UUID]);
+        expect(result.current.hasActiveFilters).toBe(true);
+    });
+
+    it('updates the selected users and API filters', async () => {
+        const { result } = renderHook(() => useAiAgentAdminFilters(), {
+            wrapper: createWrapper(),
+        });
+
+        act(() => result.current.setSelectedUserUuids([USER_UUID]));
+
+        await waitFor(() => {
+            expect(result.current.selectedUserUuids).toEqual([USER_UUID]);
+            expect(result.current.apiFilters.userUuids).toEqual([USER_UUID]);
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminFilters.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdminFilters.ts
@@ -11,6 +11,7 @@ export interface AiAgentAdminFiltersState {
     search: AiAgentAdminFilters['search'];
     selectedProjectUuids: NonNullable<AiAgentAdminFilters['projectUuids']>;
     selectedAgentUuids: NonNullable<AiAgentAdminFilters['agentUuids']>;
+    selectedUserUuids: NonNullable<AiAgentAdminFilters['userUuids']>;
     selectedSource: 'all' | AiAgentAdminFilters['createdFrom'];
     selectedFeedback: 'all' | 'thumbs_up' | 'thumbs_down';
     sortField: AiAgentAdminSortField;
@@ -21,6 +22,7 @@ const DEFAULT_FILTERS: AiAgentAdminFiltersState = {
     search: undefined,
     selectedProjectUuids: [],
     selectedAgentUuids: [],
+    selectedUserUuids: [],
     selectedSource: 'all',
     selectedFeedback: 'all',
     sortField: 'createdAt',
@@ -37,6 +39,7 @@ export const useAiAgentAdminFilters = () => {
     const searchParam = useSearchParams<string>('search');
     const projectsParam = useSearchParams<string>('projects');
     const agentsParam = useSearchParams<string>('agents');
+    const usersParam = useSearchParams<string>('users');
     const sourceParam = useSearchParams<'web_app' | 'slack'>('source');
     const feedbackParam = useSearchParams<'thumbs_up' | 'thumbs_down'>(
         'feedback',
@@ -53,6 +56,9 @@ export const useAiAgentAdminFilters = () => {
             selectedAgentUuids:
                 agentsParam?.split(',').filter(Boolean) ||
                 DEFAULT_FILTERS.selectedAgentUuids,
+            selectedUserUuids:
+                usersParam?.split(',').filter(Boolean) ||
+                DEFAULT_FILTERS.selectedUserUuids,
             selectedSource: sourceParam || DEFAULT_FILTERS.selectedSource,
             selectedFeedback: feedbackParam || DEFAULT_FILTERS.selectedFeedback,
             sortField: sortByParam || DEFAULT_FILTERS.sortField,
@@ -62,6 +68,7 @@ export const useAiAgentAdminFilters = () => {
             searchParam,
             projectsParam,
             agentsParam,
+            usersParam,
             sourceParam,
             feedbackParam,
             sortByParam,
@@ -94,6 +101,13 @@ export const useAiAgentAdminFilters = () => {
                 searchParams.set(
                     'agents',
                     newFilters.selectedAgentUuids.join(','),
+                );
+            }
+
+            if (newFilters.selectedUserUuids.length > 0) {
+                searchParams.set(
+                    'users',
+                    newFilters.selectedUserUuids.join(','),
                 );
             }
 
@@ -158,6 +172,13 @@ export const useAiAgentAdminFilters = () => {
         [updateUrl, currentFilters],
     );
 
+    const setSelectedUserUuids = useCallback(
+        (userUuids: NonNullable<AiAgentAdminFilters['userUuids']>) => {
+            updateUrl({ ...currentFilters, selectedUserUuids: userUuids });
+        },
+        [updateUrl, currentFilters],
+    );
+
     const setSelectedSource = useCallback(
         (source: AiAgentAdminFiltersState['selectedSource']) => {
             updateUrl({ ...currentFilters, selectedSource: source });
@@ -195,6 +216,8 @@ export const useAiAgentAdminFilters = () => {
             (currentFilters.selectedAgentUuids &&
                 currentFilters.selectedAgentUuids.length !==
                     DEFAULT_FILTERS.selectedAgentUuids?.length) ||
+            currentFilters.selectedUserUuids.length !==
+                DEFAULT_FILTERS.selectedUserUuids.length ||
             currentFilters.selectedSource !== DEFAULT_FILTERS.selectedSource ||
             currentFilters.selectedFeedback !==
                 DEFAULT_FILTERS.selectedFeedback ||
@@ -224,6 +247,10 @@ export const useAiAgentAdminFilters = () => {
             result.agentUuids = currentFilters.selectedAgentUuids;
         }
 
+        if (currentFilters.selectedUserUuids.length > 0) {
+            result.userUuids = currentFilters.selectedUserUuids;
+        }
+
         if (currentFilters.selectedSource !== 'all') {
             result.createdFrom = currentFilters.selectedSource;
         }
@@ -245,6 +272,7 @@ export const useAiAgentAdminFilters = () => {
         setSearch,
         setSelectedProjectUuids,
         setSelectedAgentUuids,
+        setSelectedUserUuids,
         setSelectedSource,
         setSelectedFeedback,
         setSorting,


### PR DESCRIPTION
Closes: PROD-8933

Adds an organization user filter to the AI agent admin thread table.

Persists selections in the URL and passes them through the existing API filter.