### PR TITLE
fix(e2e): deflake create-project tests by polling backend job status

### DIFF
--- a/packages/e2e/cypress/e2e/app/createProjects.cy.ts
+++ b/packages/e2e/cypress/e2e/app/createProjects.cy.ts
@@ -1,5 +1,6 @@
 import {
     CustomDimensionType,
+    JobStatusType,
     ResultRow,
     SEED_PROJECT,
 } from '@lightdash/common';
@@ -165,13 +166,34 @@ const configureSnowflakeWarehouse = (
     cy.get('input[name="warehouse.schema"]').type(config.schema);
 };
 
+// The app polls the compile job every 500ms, so 360 polls ≈ 3 minutes
+const waitForCompileJob = (attempt = 0): void => {
+    cy.wait('@jobStatus', { timeout: 30000 }).then(({ response }) => {
+        const job = response?.body?.results;
+        switch (job?.jobStatus) {
+            case JobStatusType.DONE:
+                return;
+            case JobStatusType.ERROR:
+                throw new Error(
+                    `Compile job failed: ${JSON.stringify(job.steps)}`,
+                );
+            default:
+                if (attempt >= 360) {
+                    throw new Error('Compile job did not finish');
+                }
+                waitForCompileJob(attempt + 1);
+        }
+    });
+};
+
 const testCompile = (): Cypress.Chainable<string> => {
     // Compile
+    cy.intercept('GET', '**/api/v1/jobs/*').as('jobStatus');
     cy.findByText('Test & deploy project').click();
-    cy.contains('Step 1/3', { timeout: 60000 });
-    cy.contains('Step 2/3', { timeout: 60000 });
-    cy.contains('Successfully synced dbt project!', { timeout: 60000 });
+    waitForCompileJob();
 
+    cy.url({ timeout: 30000 }).should('include', '/createProjectSettings');
+    cy.contains('Your project has connected successfully!');
     cy.contains(/selected \d+ models/);
     // Configure
     cy.contains('button', 'Save changes').click();


### PR DESCRIPTION
## Description

The `createProjects.cy.ts` warehouse tests (Postgres, BigQuery, Snowflake) flake in CI: they wait for the `Successfully synced dbt project!` toast, which auto-closes after 5 seconds. When the sync finishes near or past the 60s assertion deadline, the toast comes and goes unseen and the test fails — even though the failure screenshots show the app already on the post-sync success screen. The intermediate `Step 1/3` / `Step 2/3` toast assertions have the same race (a step completing between two 500ms job polls never renders).

Instead of watching transient toasts, the test now intercepts the app's own `/api/v1/jobs/:jobUuid` polling and waits until the backend reports the compile job `DONE` — failing fast with the job steps payload if it reports `ERROR` — then asserts the persistent post-sync screen (`/createProjectSettings` URL, success message, model count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)