### PR TITLE
fix(homepage): always-visible Viewing as control, decoupled from Preview

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.module.css
@@ -572,3 +572,29 @@
     flex-shrink: 0;
     max-width: 260px;
 }
+
+/* Matches .tbBtn's pill look so the audience picker reads as part of the same
+   row of controls, not a generic form input dropped underneath it. */
+.viewAsSelect {
+    height: 32px;
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: 8px;
+    background: light-dark(#fff, var(--mantine-color-dark-6));
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--mantine-color-ldGray-7);
+    transition: background 0.12s ease-in-out;
+}
+
+.viewAsSelect:hover {
+    background: var(--mantine-color-ldGray-1);
+}
+
+.viewAsSelect:focus {
+    border-color: var(--mantine-color-ldGray-4);
+}
+
+.viewAsDropdown {
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: 8px;
+}

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -487,9 +487,7 @@ export const HomepageEditor: FC<Props> = ({
         null,
     );
     const canvasMode = resolveCanvasMode(isPreviewing, viewTarget);
-    // While a specific audience is selected, the toggle button's job is to
-    // drop the audience and return to editing (not just flip isPreviewing —
-    // that alone wouldn't clear a selected audience).
+    // A selected audience must be cleared, not just have isPreviewing flipped.
     const handleToggleMode = () => {
         if (viewTarget !== null) {
             setViewType('everyone');

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -91,6 +91,7 @@ import {
     usePublishHomepage,
     useUpdateHomepageDraft,
 } from './hooks/useProjectHomepage';
+import { resolveCanvasMode } from './previewMode';
 import {
     PreviewPane,
     ViewAsControl,
@@ -485,10 +486,18 @@ export const HomepageEditor: FC<Props> = ({
     const [viewTarget, setViewTarget] = useState<HomepageViewAsTarget | null>(
         null,
     );
-    const togglePreview = () => {
+    const canvasMode = resolveCanvasMode(isPreviewing, viewTarget);
+    // While a specific audience is selected, the toggle button's job is to
+    // drop the audience and return to editing (not just flip isPreviewing —
+    // that alone wouldn't clear a selected audience).
+    const handleToggleMode = () => {
+        if (viewTarget !== null) {
+            setViewType('everyone');
+            setViewTarget(null);
+            setIsPreviewing(false);
+            return;
+        }
         setIsPreviewing((prev) => !prev);
-        setViewType('everyone');
-        setViewTarget(null);
     };
     const [debouncedDraft] = useDebouncedValue(draft, 800);
     const [hasConflict, setHasConflict] = useState(false);
@@ -833,13 +842,13 @@ export const HomepageEditor: FC<Props> = ({
                 <button
                     type="button"
                     className={classes.tbBtn}
-                    onClick={togglePreview}
+                    onClick={handleToggleMode}
                 >
                     <MantineIcon
-                        icon={isPreviewing ? IconPencil : IconEye}
+                        icon={canvasMode === 'preview' ? IconPencil : IconEye}
                         size={15}
                     />
-                    {isPreviewing ? 'Back to editing' : 'Preview'}
+                    {canvasMode === 'preview' ? 'Back to editing' : 'Preview'}
                 </button>
                 <button
                     type="button"
@@ -862,17 +871,15 @@ export const HomepageEditor: FC<Props> = ({
                     </Button>
                 </div>
             )}
-            {isPreviewing && (
-                <div className={classes.previewBar}>
-                    <ViewAsControl
-                        projectUuid={projectUuid}
-                        viewType={viewType}
-                        target={viewTarget}
-                        onViewTypeChange={setViewType}
-                        onTargetChange={setViewTarget}
-                    />
-                </div>
-            )}
+            <div className={classes.previewBar}>
+                <ViewAsControl
+                    projectUuid={projectUuid}
+                    viewType={viewType}
+                    target={viewTarget}
+                    onViewTypeChange={setViewType}
+                    onTargetChange={setViewTarget}
+                />
+            </div>
 
             <DndContext
                 sensors={sensors}
@@ -886,7 +893,7 @@ export const HomepageEditor: FC<Props> = ({
                 onDragCancel={handleDragCancel}
             >
                 <div className={classes.body}>
-                    {!isPreviewing && (
+                    {canvasMode === 'edit' && (
                         <aside className={classes.rail}>
                             <div className={classes.railTitle}>Blocks</div>
                             <Stack gap={6}>
@@ -912,7 +919,7 @@ export const HomepageEditor: FC<Props> = ({
                     )}
                     <div className={classes.canvas}>
                         <div className={classes.canvasInner}>
-                            {isPreviewing ? (
+                            {canvasMode === 'preview' ? (
                                 <PreviewPane
                                     draft={draft}
                                     projectUuid={projectUuid}

--- a/packages/frontend/src/ee/features/homepageBuilder/PreviewPane.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PreviewPane.tsx
@@ -46,8 +46,8 @@ const reasonLabel = (
     }
 };
 
-// The "Viewing as" switcher — lives in the builder toolbar during preview so
-// the canvas below stays the real rendered homepage.
+// The "Viewing as" switcher — always visible in the builder toolbar; picking
+// an audience forces the canvas below into the real rendered homepage.
 export const ViewAsControl: FC<{
     projectUuid: string;
     viewType: HomepageViewType;

--- a/packages/frontend/src/ee/features/homepageBuilder/PreviewPane.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PreviewPane.tsx
@@ -16,7 +16,12 @@ import {
     Stack,
     Text,
 } from '@mantine-8/core';
-import { IconExternalLink } from '@tabler/icons-react';
+import {
+    IconExternalLink,
+    IconShieldLock,
+    IconUser,
+    IconUsers,
+} from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -99,7 +104,14 @@ export const ViewAsControl: FC<{
                     size="xs"
                     placeholder="Pick a user"
                     searchable
-                    w={220}
+                    w={240}
+                    leftSection={
+                        <MantineIcon icon={IconUser} color="ldGray.6" />
+                    }
+                    classNames={{ input: classes.viewAsSelect }}
+                    comboboxProps={{
+                        classNames: { dropdown: classes.viewAsDropdown },
+                    }}
                     data={(users ?? []).map((user) => ({
                         value: user.userUuid,
                         label: `${user.firstName} ${user.lastName} (${user.email})`,
@@ -117,7 +129,14 @@ export const ViewAsControl: FC<{
                     size="xs"
                     placeholder="Pick a group"
                     searchable
-                    w={200}
+                    w={220}
+                    leftSection={
+                        <MantineIcon icon={IconUsers} color="ldGray.6" />
+                    }
+                    classNames={{ input: classes.viewAsSelect }}
+                    comboboxProps={{
+                        classNames: { dropdown: classes.viewAsDropdown },
+                    }}
                     data={(groups ?? []).map((group) => ({
                         value: group.uuid,
                         label: group.name,
@@ -134,7 +153,14 @@ export const ViewAsControl: FC<{
                 <Select
                     size="xs"
                     placeholder="Pick a role"
-                    w={160}
+                    w={180}
+                    leftSection={
+                        <MantineIcon icon={IconShieldLock} color="ldGray.6" />
+                    }
+                    classNames={{ input: classes.viewAsSelect }}
+                    comboboxProps={{
+                        classNames: { dropdown: classes.viewAsDropdown },
+                    }}
                     data={Object.values(ProjectMemberRole).map((role) => ({
                         value: role,
                         label: ProjectMemberRoleLabels[role],

--- a/packages/frontend/src/ee/features/homepageBuilder/previewMode.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/previewMode.test.ts
@@ -1,0 +1,23 @@
+import { resolveCanvasMode } from './previewMode';
+
+describe('resolveCanvasMode', () => {
+    it('is edit when not previewing and no audience is selected', () => {
+        expect(resolveCanvasMode(false, null)).toBe('edit');
+    });
+
+    it('is preview when manually previewing with no audience selected', () => {
+        expect(resolveCanvasMode(true, null)).toBe('preview');
+    });
+
+    it('is preview when an audience is selected, even while editing', () => {
+        expect(resolveCanvasMode(false, { type: 'user', userUuid: 'u1' })).toBe(
+            'preview',
+        );
+    });
+
+    it('is preview when both previewing and an audience is selected', () => {
+        expect(
+            resolveCanvasMode(true, { type: 'role', role: 'editor' as any }),
+        ).toBe('preview');
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/previewMode.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/previewMode.test.ts
@@ -1,3 +1,4 @@
+import { ProjectMemberRole } from '@lightdash/common';
 import { resolveCanvasMode } from './previewMode';
 
 describe('resolveCanvasMode', () => {
@@ -17,7 +18,10 @@ describe('resolveCanvasMode', () => {
 
     it('is preview when both previewing and an audience is selected', () => {
         expect(
-            resolveCanvasMode(true, { type: 'role', role: 'editor' as any }),
+            resolveCanvasMode(true, {
+                type: 'role',
+                role: ProjectMemberRole.EDITOR,
+            }),
         ).toBe('preview');
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/previewMode.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/previewMode.ts
@@ -1,0 +1,11 @@
+import { type HomepageViewAsTarget } from '@lightdash/common';
+
+export type CanvasMode = 'edit' | 'preview';
+
+// The canvas renders the read-only PreviewPane whenever the user has
+// manually toggled preview on, OR has picked a specific audience to view
+// as — picking an audience always wins, even mid-edit.
+export const resolveCanvasMode = (
+    isPreviewing: boolean,
+    viewTarget: HomepageViewAsTarget | null,
+): CanvasMode => (isPreviewing || viewTarget !== null ? 'preview' : 'edit');


### PR DESCRIPTION
## Summary
- The homepage builder's "Viewing as" audience selector used to be reachable only by first clicking "Preview" — now it's always visible in the toolbar.
- Selecting a specific audience (user/group/role) auto-switches the canvas into the read-only preview render, even while still editing; "Back to editing" clears the audience and returns to the editable canvas.
- Manual Preview/Everyone toggle behavior is unchanged.
- Decision logic extracted into a small pure, unit-tested helper (`resolveCanvasMode`) rather than inlined as another `isPreviewing` branch.

## Test plan
- [x] `previewMode.test.ts` — 4 unit tests covering all edit/preview × audience combinations
- [x] `pnpm -F frontend typecheck:fast` clean
- [x] `pnpm -F frontend run linter` clean on changed files
- [ ] Manual smoke test in a running EE-enabled environment (not run in this session — recommend before merge)