### PR TITLE
fix(homepage): replace add-content two-pane picker with a searchable multiselect

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -140,7 +140,20 @@ const CollectionPickerMultiSelect: FC<{
         setSelected((prev) => buildSelectionRefs(newUuids, prev, contentMap));
     };
 
-    const data = useMemo(() => groupContentBySpace(contentMap), [contentMap]);
+    const visibleUuids = useMemo(() => {
+        const pageUuids =
+            contentPages?.pages.flatMap((page) =>
+                page.data.map((content) => content.uuid),
+            ) ?? [];
+        return new Set([...pageUuids, ...selected.keys()]);
+    }, [contentPages?.pages, selected]);
+
+    const data = useMemo(() => {
+        const visibleContent = new Map(
+            [...contentMap].filter(([uuid]) => visibleUuids.has(uuid)),
+        );
+        return groupContentBySpace(visibleContent);
+    }, [contentMap, visibleUuids]);
 
     const renderOption = useCallback(
         ({ option }: ComboboxLikeRenderOptionInput<ComboboxItem>) => {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -13,7 +13,6 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import {
-    assertUnreachable,
     ContentType,
     contentToResourceViewItem,
     ResourceViewItemType,
@@ -21,32 +20,43 @@ import {
     type SummaryContent,
 } from '@lightdash/common';
 import {
-    Box,
     Button,
-    Checkbox,
-    Divider,
+    type ComboboxItem,
+    type ComboboxLikeRenderOptionInput,
     Group,
+    Loader,
+    MultiSelect,
     Skeleton,
     Stack,
     Text,
     TextInput,
 } from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { IconLayoutGrid, IconPin, IconPlus } from '@tabler/icons-react';
-import { useMemo, useRef, useState, type FC } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
 import { ResourceIcon } from '../../../../components/common/ResourceIcon';
-import SpaceSelector from '../../../../components/common/SpaceSelector/SpaceSelector';
 import { useFavoriteMutation } from '../../../../hooks/favorites/useFavoriteMutation';
 import { useFavorites } from '../../../../hooks/favorites/useFavorites';
 import { usePinnedItems } from '../../../../hooks/pinning/usePinnedItems';
 import { useInfiniteContent } from '../../../../hooks/useContent';
 import { useProject } from '../../../../hooks/useProject';
-import { useSpaceSummaries } from '../../../../hooks/useSpaces';
 import { reorderCollectionItems } from '../configOps';
 import { useCollectionContent } from '../hooks/useCollectionContent';
 import { BlockHeader } from './BlockShell';
 import classes from './blockStyles.module.css';
+import {
+    buildSelectionRefs,
+    groupContentBySpace,
+} from './collectionPickerUtils';
 import { ContentCard } from './ContentCard';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
@@ -55,145 +65,9 @@ const toFavoriteType = (content: SummaryContent) =>
         ? ResourceViewItemType.DASHBOARD
         : ResourceViewItemType.CHART;
 
-const toItemRef = (content: SummaryContent): HomepageCollectionItemRef => ({
-    contentType:
-        content.contentType === ContentType.DASHBOARD ? 'dashboard' : 'chart',
-    uuid: content.uuid,
-});
+const PICKER_PAGE_SIZE = 50;
 
-type SortKey = 'name' | 'updated' | 'type';
-
-const sortContent = (
-    items: SummaryContent[],
-    sort: SortKey,
-): SummaryContent[] =>
-    [...items].sort((a, b) => {
-        switch (sort) {
-            case 'name':
-                return a.name.localeCompare(b.name);
-            case 'updated':
-                return (
-                    new Date(b.lastUpdatedAt ?? 0).getTime() -
-                    new Date(a.lastUpdatedAt ?? 0).getTime()
-                );
-            case 'type':
-                return (
-                    a.contentType.localeCompare(b.contentType) ||
-                    a.name.localeCompare(b.name)
-                );
-            default:
-                return assertUnreachable(sort, 'Unknown collection sort');
-        }
-    });
-
-const PAGE_SIZE = 50;
-
-const ContentRow: FC<{
-    content: SummaryContent;
-    checked: boolean;
-    onToggle: () => void;
-}> = ({ content, checked, onToggle }) => (
-    <Group
-        gap="sm"
-        wrap="nowrap"
-        className={classes.pickerRow}
-        onClick={onToggle}
-    >
-        <Checkbox size="xs" checked={checked} readOnly />
-        <ResourceIcon item={contentToResourceViewItem(content)} />
-        <Text size="sm" truncate flex={1}>
-            {content.name}
-        </Text>
-    </Group>
-);
-
-// The right pane: the selected space's charts/dashboards, fetched lazily so
-// only the open space ever loads (scales to large projects).
-const SpaceContent: FC<{
-    projectUuid: string;
-    spaceUuid: string;
-    selected: Map<string, HomepageCollectionItemRef>;
-    onToggleItem: (content: SummaryContent) => void;
-    onToggleMany: (items: SummaryContent[]) => void;
-}> = ({ projectUuid, spaceUuid, selected, onToggleItem, onToggleMany }) => {
-    const { data, isFetching, hasNextPage, fetchNextPage, isFetchingNextPage } =
-        useInfiniteContent(
-            {
-                projectUuids: [projectUuid],
-                spaceUuids: [spaceUuid],
-                contentTypes: [ContentType.CHART, ContentType.DASHBOARD],
-                pageSize: PAGE_SIZE,
-            },
-            { enabled: true, keepPreviousData: true },
-        );
-    const items = useMemo(
-        () =>
-            sortContent(
-                (data?.pages ?? []).flatMap((page) => page.data),
-                'name',
-            ),
-        [data],
-    );
-
-    if (isFetching && items.length === 0) {
-        return (
-            <Stack gap={4} p="xs">
-                <Skeleton h={24} />
-                <Skeleton h={24} />
-                <Skeleton h={24} />
-            </Stack>
-        );
-    }
-    if (items.length === 0) {
-        return (
-            <Text size="sm" c="dimmed" p="sm">
-                This space has no charts or dashboards.
-            </Text>
-        );
-    }
-    const selectedCount = items.filter((content) =>
-        selected.has(content.uuid),
-    ).length;
-
-    return (
-        <Stack gap={2}>
-            <Group gap="sm" wrap="nowrap" className={classes.pickerRow}>
-                <Checkbox
-                    size="xs"
-                    checked={selectedCount === items.length}
-                    indeterminate={
-                        selectedCount > 0 && selectedCount < items.length
-                    }
-                    onChange={() => onToggleMany(items)}
-                />
-                <Text size="xs" c="dimmed" fw={600} tt="uppercase">
-                    Select all ({items.length})
-                </Text>
-            </Group>
-            {items.map((content) => (
-                <ContentRow
-                    key={content.uuid}
-                    content={content}
-                    checked={selected.has(content.uuid)}
-                    onToggle={() => onToggleItem(content)}
-                />
-            ))}
-            {hasNextPage && (
-                <Button
-                    variant="subtle"
-                    size="xs"
-                    w="fit-content"
-                    loading={isFetchingNextPage}
-                    onClick={() => void fetchNextPage()}
-                >
-                    Load more
-                </Button>
-            )}
-        </Stack>
-    );
-};
-
-const CollectionPicker: FC<{
+const CollectionPickerMultiSelect: FC<{
     projectUuid: string;
     initialSelected: HomepageCollectionItemRef[];
     onApply: (refs: HomepageCollectionItemRef[]) => void;
@@ -201,9 +75,59 @@ const CollectionPicker: FC<{
      * selection — the footer lives in MantineModal, outside this component. */
     registerApply: (commit: () => void) => void;
 }> = ({ projectUuid, initialSelected, onApply, registerApply }) => {
-    const [selectedSpaceUuid, setSelectedSpaceUuid] = useState<string | null>(
-        null,
+    const [searchQuery, setSearchQuery] = useState('');
+    const [debouncedSearchQuery] = useDebouncedValue(searchQuery, 300);
+    const viewportRef = useRef<HTMLDivElement>(null);
+
+    const initialUuids = useMemo(
+        () => initialSelected.map((ref) => ref.uuid),
+        [initialSelected],
     );
+    const { data: initialContent } = useCollectionContent(
+        projectUuid,
+        initialUuids,
+    );
+
+    const {
+        data: contentPages,
+        isFetching,
+        hasNextPage,
+        fetchNextPage,
+    } = useInfiniteContent(
+        {
+            projectUuids: [projectUuid],
+            contentTypes: [ContentType.CHART, ContentType.DASHBOARD],
+            search: debouncedSearchQuery,
+            pageSize: PICKER_PAGE_SIZE,
+        },
+        { keepPreviousData: true },
+    );
+
+    const [contentMap, setContentMap] = useState<Map<string, SummaryContent>>(
+        () => new Map(),
+    );
+
+    useEffect(() => {
+        const pages = contentPages?.pages.flatMap((page) => page.data) ?? [];
+        if (pages.length === 0) return;
+        setContentMap((prev) => {
+            const next = new Map(prev);
+            pages.forEach((content) => next.set(content.uuid, content));
+            return next;
+        });
+    }, [contentPages?.pages]);
+
+    useEffect(() => {
+        if (!initialContent || initialContent.length === 0) return;
+        setContentMap((prev) => {
+            const next = new Map(prev);
+            initialContent.forEach((content) =>
+                next.set(content.uuid, content),
+            );
+            return next;
+        });
+    }, [initialContent]);
+
     const [selected, setSelected] = useState<
         Map<string, HomepageCollectionItemRef>
     >(() => new Map(initialSelected.map((ref) => [ref.uuid, ref])));
@@ -212,66 +136,63 @@ const CollectionPicker: FC<{
     // latest selection (idempotent, so safe during render — no effect needed).
     registerApply(() => onApply([...selected.values()]));
 
-    const { data: spaces } = useSpaceSummaries(projectUuid, true);
+    const handleChange = (newUuids: string[]) => {
+        setSelected((prev) => buildSelectionRefs(newUuids, prev, contentMap));
+    };
 
-    const toggleItem = (content: SummaryContent) =>
-        setSelected((prev) => {
-            const next = new Map(prev);
-            if (next.has(content.uuid)) next.delete(content.uuid);
-            else next.set(content.uuid, toItemRef(content));
-            return next;
-        });
+    const data = useMemo(() => groupContentBySpace(contentMap), [contentMap]);
 
-    const toggleMany = (items: SummaryContent[]) =>
-        setSelected((prev) => {
-            const next = new Map(prev);
-            const allSelected = items.every((content) =>
-                next.has(content.uuid),
+    const renderOption = useCallback(
+        ({ option }: ComboboxLikeRenderOptionInput<ComboboxItem>) => {
+            const content = contentMap.get(option.value);
+            if (!content) return option.label;
+            return (
+                <Group gap="sm" wrap="nowrap">
+                    <ResourceIcon item={contentToResourceViewItem(content)} />
+                    <Text size="sm" truncate>
+                        {content.name}
+                    </Text>
+                </Group>
             );
-            items.forEach((content) => {
-                if (allSelected) next.delete(content.uuid);
-                else next.set(content.uuid, toItemRef(content));
-            });
-            return next;
-        });
+        },
+        [contentMap],
+    );
+
+    const handleScrollPositionChange = useCallback(
+        ({ y }: { x: number; y: number }) => {
+            if (!viewportRef.current || isFetching || !hasNextPage) return;
+            const { scrollHeight, clientHeight } = viewportRef.current;
+            if (scrollHeight <= clientHeight) return;
+            const isNearBottom = y >= scrollHeight - clientHeight - 50;
+            if (isNearBottom) void fetchNextPage();
+        },
+        [isFetching, hasNextPage, fetchNextPage],
+    );
 
     return (
-        <Stack gap="sm">
-            <Group align="stretch" gap="md" wrap="nowrap" h="min(64vh, 720px)">
-                <Box w={340} className={classes.pickerScrollList}>
-                    <SpaceSelector
-                        projectUuid={projectUuid}
-                        spaces={spaces}
-                        selectedSpaceUuid={selectedSpaceUuid}
-                        onSelectSpace={setSelectedSpaceUuid}
-                        itemType={undefined}
-                        isRootSelectionEnabled={false}
-                    />
-                </Box>
-                <Divider orientation="vertical" />
-                <Stack gap="xs" flex={1} miw={0}>
-                    <Text size="sm" c="dimmed">
-                        {selected.size} selected
-                    </Text>
-                    <Box flex={1} miw={0} className={classes.pickerScrollList}>
-                        {selectedSpaceUuid == null ? (
-                            <Text size="sm" c="dimmed" p="sm">
-                                Pick a space on the left to see its charts and
-                                dashboards.
-                            </Text>
-                        ) : (
-                            <SpaceContent
-                                key={selectedSpaceUuid}
-                                projectUuid={projectUuid}
-                                spaceUuid={selectedSpaceUuid}
-                                selected={selected}
-                                onToggleItem={toggleItem}
-                                onToggleMany={toggleMany}
-                            />
-                        )}
-                    </Box>
-                </Stack>
-            </Group>
+        <Stack gap="xs">
+            <Text size="sm" c="dimmed">
+                {selected.size} selected
+            </Text>
+            <MultiSelect
+                placeholder="Search charts and dashboards..."
+                searchable
+                clearable
+                searchValue={searchQuery}
+                onSearchChange={setSearchQuery}
+                value={[...selected.keys()]}
+                onChange={handleChange}
+                data={data}
+                renderOption={renderOption}
+                maxDropdownHeight={300}
+                nothingFoundMessage="No charts or dashboards found"
+                rightSection={isFetching ? <Loader size="xs" /> : null}
+                scrollAreaProps={{
+                    viewportRef,
+                    onScrollPositionChange: handleScrollPositionChange,
+                }}
+                filter={({ options }) => options}
+            />
         </Stack>
     );
 };
@@ -293,7 +214,7 @@ const CollectionPickerModal: FC<{
             onClose={onClose}
             title="Add content"
             icon={IconPlus}
-            size="min(92vw, 1280px)"
+            size="lg"
             confirmLabel="Apply"
             onConfirm={() => {
                 applyRef.current();
@@ -301,7 +222,7 @@ const CollectionPickerModal: FC<{
             }}
         >
             {opened && (
-                <CollectionPicker
+                <CollectionPickerMultiSelect
                     projectUuid={projectUuid}
                     initialSelected={initialSelected}
                     onApply={onApply}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/collectionPickerUtils.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/collectionPickerUtils.test.ts
@@ -1,0 +1,101 @@
+import { ContentType, type SummaryContent } from '@lightdash/common';
+import {
+    buildSelectionRefs,
+    groupContentBySpace,
+    toItemRef,
+} from './collectionPickerUtils';
+
+const chart = (uuid: string, name: string, spaceName: string): SummaryContent =>
+    ({
+        contentType: ContentType.CHART,
+        uuid,
+        name,
+        space: { uuid: `${spaceName}-uuid`, name: spaceName },
+    }) as SummaryContent;
+
+const dashboard = (
+    uuid: string,
+    name: string,
+    spaceName: string,
+): SummaryContent =>
+    ({
+        contentType: ContentType.DASHBOARD,
+        uuid,
+        name,
+        space: { uuid: `${spaceName}-uuid`, name: spaceName },
+    }) as SummaryContent;
+
+describe('toItemRef', () => {
+    it('maps a chart to a chart ref', () => {
+        expect(toItemRef(chart('c1', 'Chart 1', 'Space A'))).toEqual({
+            contentType: 'chart',
+            uuid: 'c1',
+        });
+    });
+
+    it('maps a dashboard to a dashboard ref', () => {
+        expect(toItemRef(dashboard('d1', 'Dashboard 1', 'Space A'))).toEqual({
+            contentType: 'dashboard',
+            uuid: 'd1',
+        });
+    });
+});
+
+describe('groupContentBySpace', () => {
+    it('groups content by space name, spaces and items sorted alphabetically', () => {
+        const contentMap = new Map([
+            ['c2', chart('c2', 'Zebra chart', 'Space B')],
+            ['c1', chart('c1', 'Alpha chart', 'Space B')],
+            ['d1', dashboard('d1', 'Some dashboard', 'Space A')],
+        ]);
+
+        expect(groupContentBySpace(contentMap)).toEqual([
+            {
+                group: 'Space A',
+                items: [{ value: 'd1', label: 'Some dashboard' }],
+            },
+            {
+                group: 'Space B',
+                items: [
+                    { value: 'c1', label: 'Alpha chart' },
+                    { value: 'c2', label: 'Zebra chart' },
+                ],
+            },
+        ]);
+    });
+
+    it('returns an empty array for an empty map', () => {
+        expect(groupContentBySpace(new Map())).toEqual([]);
+    });
+});
+
+describe('buildSelectionRefs', () => {
+    it('resolves newly-added uuids from the content map', () => {
+        const contentMap = new Map([['c1', chart('c1', 'Chart 1', 'Space A')]]);
+        const result = buildSelectionRefs(['c1'], new Map(), contentMap);
+        expect(result).toEqual(
+            new Map([['c1', { contentType: 'chart', uuid: 'c1' }]]),
+        );
+    });
+
+    it('preserves a previously-selected ref even if missing from the content map', () => {
+        const prevSelected = new Map([
+            ['stale1', { contentType: 'dashboard' as const, uuid: 'stale1' }],
+        ]);
+        const result = buildSelectionRefs(['stale1'], prevSelected, new Map());
+        expect(result).toEqual(prevSelected);
+    });
+
+    it('drops uuids no longer present in newUuids', () => {
+        const prevSelected = new Map([
+            ['c1', { contentType: 'chart' as const, uuid: 'c1' }],
+        ]);
+        const result = buildSelectionRefs([], prevSelected, new Map());
+        expect(result).toEqual(new Map());
+    });
+
+    it('silently skips a newly-added uuid absent from both prevSelected and contentMap', () => {
+        const result = buildSelectionRefs(['unknown'], new Map(), new Map());
+        expect(result).toEqual(new Map());
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/collectionPickerUtils.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/collectionPickerUtils.ts
@@ -1,0 +1,49 @@
+import {
+    ContentType,
+    type HomepageCollectionItemRef,
+    type SummaryContent,
+} from '@lightdash/common';
+import { type ComboboxItem, type ComboboxItemGroup } from '@mantine-8/core';
+
+export const toItemRef = (
+    content: SummaryContent,
+): HomepageCollectionItemRef => ({
+    contentType:
+        content.contentType === ContentType.DASHBOARD ? 'dashboard' : 'chart',
+    uuid: content.uuid,
+});
+
+export const groupContentBySpace = (
+    contentMap: Map<string, SummaryContent>,
+): ComboboxItemGroup[] => {
+    const bySpace = new Map<string, ComboboxItem[]>();
+    for (const content of contentMap.values()) {
+        const items = bySpace.get(content.space.name) ?? [];
+        items.push({ value: content.uuid, label: content.name });
+        bySpace.set(content.space.name, items);
+    }
+    return [...bySpace.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([group, items]) => ({
+            group,
+            items: [...items].sort((a, b) => a.label.localeCompare(b.label)),
+        }));
+};
+
+export const buildSelectionRefs = (
+    newUuids: string[],
+    prevSelected: Map<string, HomepageCollectionItemRef>,
+    contentMap: Map<string, SummaryContent>,
+): Map<string, HomepageCollectionItemRef> => {
+    const next = new Map<string, HomepageCollectionItemRef>();
+    newUuids.forEach((uuid) => {
+        const existing = prevSelected.get(uuid);
+        if (existing) {
+            next.set(uuid, existing);
+            return;
+        }
+        const content = contentMap.get(uuid);
+        if (content) next.set(uuid, toItemRef(content));
+    });
+    return next;
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/collectionPickerUtils.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/collectionPickerUtils.ts
@@ -18,6 +18,7 @@ export const groupContentBySpace = (
 ): ComboboxItemGroup[] => {
     const bySpace = new Map<string, ComboboxItem[]>();
     for (const content of contentMap.values()) {
+        if (!content.space) continue;
         const items = bySpace.get(content.space.name) ?? [];
         items.push({ value: content.uuid, label: content.name });
         bySpace.set(content.space.name, items);


### PR DESCRIPTION
## Summary
- Replaces the homepage builder's two-pane "Add content" picker (space tree + checkbox list, no search) with a single searchable Mantine v8 `MultiSelect` covering both charts and dashboards, grouped by space, 300ms-debounced search across the whole project, scroll-triggered pagination.
- Extracts `toItemRef`, `groupContentBySpace`, `buildSelectionRefs` into `collectionPickerUtils.ts` with unit tests.
- Fixes a search-narrowing bug found during review: the dropdown now restricts its visible options to the current search's results (union selected items), instead of accumulating results across searches indefinitely.

## Test plan
- [x] `pnpm -F frontend exec vitest run src/ee/features/homepageBuilder` — 75/75 pass (includes 8 new tests for the extracted helpers)
- [x] `pnpm -F frontend typecheck:fast` — clean
- [x] `pnpm -F frontend run linter` on changed files — clean
- [x] Manually verified in the running app via Chrome DevTools: search narrows correctly across queries, grouped-by-space dropdown with distinct chart/dashboard icons, select/apply, reopen shows prefetched pills with correct names before any search, Backspace removes a pill, Cancel discards in-modal changes
- [x] Confirmed compatible with the drag-to-reorder collection tiles feature already on `main` (rebased on top of it; both features' tests pass together)

Design spec: `~/Desktop/plans/2026-07-17-homepage-add-content-multiselect-design.md`
Implementation plan: `~/Desktop/plans/2026-07-17-homepage-add-content-multiselect-plan.md`