### PR TITLE
fix: Revert "fix: bound warehouse result chunk sizes to stop worker OOMs on large queries"

### DIFF
--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
@@ -6,10 +6,6 @@ import {
 import { credentials, rows, schema } from './DatabricksWarehouseClient.mock';
 import { expectedFields } from './WarehouseClient.mock';
 
-const mocks = vi.hoisted(() => ({
-    fetchChunk: vi.fn(),
-}));
-
 vi.mock('@databricks/sql', async () => ({
     ...(await vi.importActual<typeof import('@databricks/sql')>(
         '@databricks/sql',
@@ -20,9 +16,7 @@ vi.mock('@databricks/sql', async () => ({
                 openSession: vi.fn(() => ({
                     executeStatement: vi.fn(() => ({
                         getSchema: vi.fn(async () => schema),
-                        fetchChunk: mocks.fetchChunk.mockImplementation(
-                            async () => rows,
-                        ),
+                        fetchChunk: vi.fn(async () => rows),
                         hasMoreRows: vi.fn(async () => false),
                         close: vi.fn(async () => undefined),
                     })),
@@ -42,14 +36,6 @@ describe('DatabricksWarehouseClient', () => {
 
         expect(results.fields).toEqual(expectedFields);
         expect(results.rows[0]).toEqual(rows[0]);
-    });
-
-    it('caps fetchChunk size to avoid materializing whole results', async () => {
-        const warehouse = new DatabricksWarehouseClient(credentials);
-
-        await warehouse.runQuery('fake sql');
-
-        expect(mocks.fetchChunk).toHaveBeenCalledWith({ maxRows: 5000 });
     });
 });
 

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -270,9 +270,6 @@ export class DatabricksSqlBuilder extends WarehouseBaseSqlBuilder {
 
 const DATABRICKS_SOCKET_TIMEOUT_MS = 60000;
 const DATABRICKS_QUERY_TIMEOUT_SECONDS = 300;
-// @databricks/sql defaults fetchChunk to 100k rows, which materializes entire
-// wide results in one array and can OOM the worker on large queries
-const DATABRICKS_FETCH_CHUNK_MAX_ROWS = 5000;
 
 export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabricksCredentials> {
     schema: string;
@@ -428,9 +425,8 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
 
             do {
                 // eslint-disable-next-line no-await-in-loop
-                const chunk = await query.fetchChunk({
-                    maxRows: DATABRICKS_FETCH_CHUNK_MAX_ROWS,
-                });
+                const chunk = await query.fetchChunk();
+                console.log(chunk.length, ' - ♻️ rows fetched');
                 // eslint-disable-next-line no-await-in-loop
                 await streamCallback({ fields, rows: chunk });
                 // eslint-disable-next-line no-await-in-loop

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
@@ -119,15 +119,6 @@ describe('SnowflakeWarehouseClient', () => {
         vi.clearAllMocks();
     });
 
-    it('caps result chunk size via CLIENT_RESULT_CHUNK_SIZE session parameter', async () => {
-        const warehouse = new SnowflakeWarehouseClient(credentials);
-        await warehouse.streamQuery('SELECT 1', () => {}, {});
-        const alterSessionSql = executeMock.mock.calls
-            .map((call) => call[0].sqlText as string)
-            .find((sql) => sql.startsWith('ALTER SESSION SET'));
-        expect(alterSessionSql).toContain('CLIENT_RESULT_CHUNK_SIZE = 16');
-    });
-
     it('configures the local application authorization-code flow with SDK defaults', () => {
         const warehouse = new SnowflakeWarehouseClient({
             ...credentials,

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -98,8 +98,6 @@ const EXTERNAL_BROWSER_AUTHENTICATOR = 'EXTERNALBROWSER';
 const OAUTH_AUTHORIZATION_CODE_AUTHENTICATOR = 'OAUTH_AUTHORIZATION_CODE';
 const SESSION_DISCOVERY_LIMIT = 100;
 const SESSION_SCHEMA_DISCOVERY_LIMIT = 1000;
-// Minimum allowed by Snowflake (range 16-160, default 160)
-const SNOWFLAKE_RESULT_CHUNK_SIZE_MB = 16;
 
 export type SnowflakeOAuthTokens = {
     accessToken: string;
@@ -1157,14 +1155,6 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             `Setting Snowflake session STATEMENT_TIMEOUT_IN_SECONDS = ${timeoutSeconds}`,
         );
         sessionParams.push(`STATEMENT_TIMEOUT_IN_SECONDS = ${timeoutSeconds}`);
-
-        // Snowflake grows result chunks up to 160MB and the driver holds ~4
-        // chunks in memory regardless of consumer backpressure, so uncapped
-        // chunks make heap usage scale with the query row limit and can OOM
-        // the worker on large results
-        sessionParams.push(
-            `CLIENT_RESULT_CHUNK_SIZE = ${SNOWFLAKE_RESULT_CHUNK_SIZE_MB}`,
-        );
 
         await this.executeStatements(
             connection,


### PR DESCRIPTION
Reverts lightdash/lightdash#25681