### PR TITLE
fix: guided setup label sizing and locked-state flashes on reload

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.tsx
@@ -84,29 +84,28 @@ const MemberInput: FC<MemberInputProps> = ({
     popoverProps,
     onChange,
 }) => (
-    <Group gap="xs" wrap="nowrap">
+    // Label sits on its own line above a full-width input so long field
+    // names aren't squeezed by the input column
+    <Stack gap={4}>
         {showLabel && (
-            <TruncatedText maxWidth={160} fz="xs" c="ldGray.6">
+            <TruncatedText maxWidth="100%" fz="xs" c="ldGray.6">
                 {label}
             </TruncatedText>
         )}
-        <Box flex={1} miw={0}>
-            <FilterInputComponent
-                filterType={
-                    field
-                        ? getFilterTypeFromItem(field)
-                        : getFilterTypeFromItemType(
-                              member.target.fallbackType ??
-                                  DimensionType.STRING,
-                          )
-                }
-                field={field}
-                rule={member}
-                popoverProps={popoverProps}
-                onChange={(newRule) => onChange(newRule as DashboardFilterRule)}
-            />
-        </Box>
-    </Group>
+        <FilterInputComponent
+            filterType={
+                field
+                    ? getFilterTypeFromItem(field)
+                    : getFilterTypeFromItemType(
+                          member.target.fallbackType ?? DimensionType.STRING,
+                      )
+            }
+            field={field}
+            rule={member}
+            popoverProps={popoverProps}
+            onChange={(newRule) => onChange(newRule as DashboardFilterRule)}
+        />
+    </Stack>
 );
 
 type RuleSummaryProps = {

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.tsx
@@ -86,7 +86,7 @@ const MemberInput: FC<MemberInputProps> = ({
 }) => (
     <Group gap="xs" wrap="nowrap">
         {showLabel && (
-            <TruncatedText maxWidth={90} w={90} fz="xs" c="ldGray.6">
+            <TruncatedText maxWidth={160} fz="xs" c="ldGray.6">
                 {label}
             </TruncatedText>
         )}

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.test.tsx
@@ -82,6 +82,15 @@ describe('GuidedFilterSetupOverlay', () => {
         delete (Element.prototype as Partial<Element>).scrollIntoView;
     });
 
+    it('renders nothing while the filterable fields are still loading', () => {
+        mockDashboardContext.current.isLoadingDashboardFilters = true;
+
+        renderWithProviders(<GuidedFilterSetupOverlay onDismiss={vi.fn()} />);
+
+        expect(screen.queryByRole('dialog')).toBeNull();
+        expect(screen.queryByTestId('guided-filter-setup')).toBeNull();
+    });
+
     it('renders the guided setup with the unmet rule and requirement progress', () => {
         renderWithProviders(<GuidedFilterSetupOverlay onDismiss={vi.fn()} />);
 

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.tsx
@@ -2,6 +2,7 @@ import { type WeekDay } from '@lightdash/common';
 import { Modal } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
 import { type FC } from 'react';
+import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import GuidedFilterSetup from './GuidedFilterSetup';
 
 type Props = {
@@ -26,6 +27,15 @@ const GuidedFilterSetupOverlay: FC<Props> = ({
     // the dropdown (the v6 date inputs don't set data-mantine-stop-propagation)
     const [isSubPopoverOpen, { open: openSubPopover, close: closeSubPopover }] =
         useDisclosure();
+
+    const isLoadingDashboardFilters = useDashboardContext(
+        (c) => c.isLoadingDashboardFilters,
+    );
+
+    // Until the filterable fields arrive every member resolves an undefined
+    // field, so inputs would render as the fallback type with validation
+    // errors and then swap; hold the whole card back instead
+    if (isLoadingDashboardFilters) return null;
 
     return (
         <Modal.Root

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/utils.test.ts
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/utils.test.ts
@@ -11,6 +11,7 @@ import {
     getFilterRequirementRules,
     getRequirementIneligibilityReason,
     isRequirementRuleSatisfied,
+    shouldShowLegacyLockedState,
 } from './utils';
 
 const createRule = (
@@ -183,5 +184,40 @@ describe('isRequirementRuleSatisfied', () => {
                 ],
             }),
         ).toBe(true);
+    });
+});
+
+describe('shouldShowLegacyLockedState', () => {
+    it('never shows while the flag query is unresolved', () => {
+        expect(
+            shouldShowLegacyLockedState({
+                isFlagResolved: false,
+                isFilterRequirementsEnabled: false,
+            }),
+        ).toBe(false);
+        expect(
+            shouldShowLegacyLockedState({
+                isFlagResolved: false,
+                isFilterRequirementsEnabled: true,
+            }),
+        ).toBe(false);
+    });
+
+    it('shows once the flag resolves disabled', () => {
+        expect(
+            shouldShowLegacyLockedState({
+                isFlagResolved: true,
+                isFilterRequirementsEnabled: false,
+            }),
+        ).toBe(true);
+    });
+
+    it('does not show when the flag resolves enabled', () => {
+        expect(
+            shouldShowLegacyLockedState({
+                isFlagResolved: true,
+                isFilterRequirementsEnabled: true,
+            }),
+        ).toBe(false);
     });
 });

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/utils.ts
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/utils.ts
@@ -30,6 +30,19 @@ export const getRequirementIneligibilityReason = (
     return null;
 };
 
+/**
+ * The legacy locked modal + blur only apply once the requirements feature
+ * flag has settled as disabled; while the flag query is unresolved no
+ * locked-state UI should render (tiles stay fail-closed regardless)
+ */
+export const shouldShowLegacyLockedState = ({
+    isFlagResolved,
+    isFilterRequirementsEnabled,
+}: {
+    isFlagResolved: boolean;
+    isFilterRequirementsEnabled: boolean;
+}): boolean => isFlagResolved && !isFilterRequirementsEnabled;
+
 export const getDashboardFilterRuleLabel = (
     filterRule: DashboardFilterRule,
     fieldsMap: Record<string, FilterableItem>,

--- a/packages/frontend/src/features/dashboardTabs/GridTile.test.tsx
+++ b/packages/frontend/src/features/dashboardTabs/GridTile.test.tsx
@@ -1,0 +1,102 @@
+import {
+    DashboardTileTypes,
+    LOADING_CHART_OVERLAY_CLASS,
+    type Dashboard,
+} from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../testing/testUtils';
+import GridTile from './GridTile';
+
+const mockDashboardContext = vi.hoisted(() => ({
+    current: {} as Record<string, unknown>,
+}));
+
+vi.mock('../../providers/Dashboard/useDashboardContext', () => ({
+    default: vi.fn((selector) => selector(mockDashboardContext.current)),
+}));
+
+// Locked chart tiles render TileBase directly; stub the heavy tile
+// components so the suite doesn't pull in the charting stack
+vi.mock('../../components/DashboardTiles/DashboardChartTile', () => ({
+    default: () => null,
+}));
+vi.mock('../../components/DashboardTiles/DashboardSqlChartTile', () => ({
+    default: () => null,
+}));
+vi.mock('../../components/DashboardTiles/DashboardDataAppTile', () => ({
+    default: () => null,
+}));
+
+const chartTile: Dashboard['tiles'][number] = {
+    uuid: 'tile-1',
+    type: DashboardTileTypes.SAVED_CHART,
+    x: 0,
+    y: 0,
+    h: 2,
+    w: 2,
+    tabUuid: undefined,
+    properties: {
+        savedChartUuid: 'chart-1',
+        title: 'Sales',
+    },
+};
+
+const renderLockedTile = () =>
+    renderWithProviders(
+        <GridTile
+            tile={chartTile}
+            index={0}
+            isEditMode={false}
+            locked
+            onEdit={vi.fn()}
+            onDelete={vi.fn()}
+            onAddTiles={vi.fn(async () => {})}
+        />,
+    );
+
+describe('GridTile (locked)', () => {
+    beforeEach(() => {
+        mockDashboardContext.current = {
+            isFilterRequirementsEnabled: false,
+            isFilterRequirementsFlagResolved: true,
+        };
+    });
+
+    it('shows the loading skeleton while the requirements flag is unresolved', () => {
+        mockDashboardContext.current.isFilterRequirementsFlagResolved = false;
+
+        const { container } = renderLockedTile();
+
+        expect(
+            container.querySelector(`.${LOADING_CHART_OVERLAY_CLASS}`),
+        ).not.toBeNull();
+        expect(
+            screen.queryByTestId('unmet-requirements-placeholder'),
+        ).toBeNull();
+    });
+
+    it('shows the unmet requirements placeholder once the flag resolves enabled', () => {
+        mockDashboardContext.current.isFilterRequirementsEnabled = true;
+
+        const { container } = renderLockedTile();
+
+        expect(
+            container.querySelector(`.${LOADING_CHART_OVERLAY_CLASS}`),
+        ).toBeNull();
+        expect(
+            screen.getByTestId('unmet-requirements-placeholder'),
+        ).toBeInTheDocument();
+    });
+
+    it('shows an empty tile once the flag resolves disabled', () => {
+        const { container } = renderLockedTile();
+
+        expect(
+            container.querySelector(`.${LOADING_CHART_OVERLAY_CLASS}`),
+        ).toBeNull();
+        expect(
+            screen.queryByTestId('unmet-requirements-placeholder'),
+        ).toBeNull();
+    });
+});

--- a/packages/frontend/src/features/dashboardTabs/GridTile.tsx
+++ b/packages/frontend/src/features/dashboardTabs/GridTile.tsx
@@ -36,6 +36,9 @@ const GridTileInner: FC<GridTileProps> = memo((props) => {
     const isFilterRequirementsEnabled = useDashboardContext(
         (c) => c.isFilterRequirementsEnabled,
     );
+    const isFilterRequirementsFlagResolved = useDashboardContext(
+        (c) => c.isFilterRequirementsFlagResolved,
+    );
 
     if (props.locked) {
         // Allow non-filterable tiles to show even when locked.
@@ -52,9 +55,16 @@ const GridTileInner: FC<GridTileProps> = memo((props) => {
             return <DataAppTile {...props} tile={tile} />;
         }
 
+        // While the flag query is unresolved neither locked experience has
+        // been chosen yet, so show the tile loading skeleton instead of an
+        // empty tile base
         return (
             <Box h="100%">
-                <TileBase isLoading={false} title={''} {...props}>
+                <TileBase
+                    isLoading={!isFilterRequirementsFlagResolved}
+                    title={''}
+                    {...props}
+                >
                     {isFilterRequirementsEnabled ? (
                         <UnmetRequirementsPlaceholder />
                     ) : undefined}

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -47,6 +47,7 @@ import { DashboardFiltersBar } from '../dashboardFilters/DashboardFiltersBar';
 import { DashboardFiltersBarSummary } from '../dashboardFilters/DashboardFiltersBarSummary';
 import { doesFilterApplyToTile } from '../dashboardFilters/FilterConfiguration/utils';
 import GuidedFilterSetupOverlay from '../dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay';
+import { shouldShowLegacyLockedState } from '../dashboardFilters/FilterRequirements/utils';
 import ErrorBoundary from '../errorBoundary/ErrorBoundary';
 import { AddTabModal } from './AddTabModal';
 import { TabDeleteModal } from './DeleteTabModal';
@@ -269,6 +270,9 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
 
     const isFilterRequirementsEnabled = useDashboardContext(
         (c) => c.isFilterRequirementsEnabled,
+    );
+    const isFilterRequirementsFlagResolved = useDashboardContext(
+        (c) => c.isFilterRequirementsFlagResolved,
     );
 
     const gridWrapperRef = useRef<HTMLDivElement>(null);
@@ -577,7 +581,10 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
 
     // Legacy locked UX (feature flag off): blur the grid behind the modal
     const legacyLockedBlur =
-        !isFilterRequirementsEnabled && hasUnmetFilterRequirementsForCurrentTab;
+        shouldShowLegacyLockedState({
+            isFlagResolved: isFilterRequirementsFlagResolved,
+            isFilterRequirementsEnabled,
+        }) && hasUnmetFilterRequirementsForCurrentTab;
 
     // Guided setup card over the locked grid; dismissal lasts until reload
     const [isGuidedSetupDismissed, setIsGuidedSetupDismissed] = useState(false);
@@ -1354,7 +1361,11 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                               )}
                                     </div>
                                 </Group>
-                                {!isFilterRequirementsEnabled && (
+                                {shouldShowLegacyLockedState({
+                                    isFlagResolved:
+                                        isFilterRequirementsFlagResolved,
+                                    isFilterRequirementsEnabled,
+                                }) && (
                                     <LockedDashboardModal
                                         opened={
                                             hasUnmetFilterRequirementsForCurrentTab &&

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -580,11 +580,12 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
     ]);
 
     // Legacy locked UX (feature flag off): blur the grid behind the modal
+    const showLegacyLockedState = shouldShowLegacyLockedState({
+        isFlagResolved: isFilterRequirementsFlagResolved,
+        isFilterRequirementsEnabled,
+    });
     const legacyLockedBlur =
-        shouldShowLegacyLockedState({
-            isFlagResolved: isFilterRequirementsFlagResolved,
-            isFilterRequirementsEnabled,
-        }) && hasUnmetFilterRequirementsForCurrentTab;
+        showLegacyLockedState && hasUnmetFilterRequirementsForCurrentTab;
 
     // Guided setup card over the locked grid; dismissal lasts until reload
     const [isGuidedSetupDismissed, setIsGuidedSetupDismissed] = useState(false);
@@ -1361,11 +1362,7 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                               )}
                                     </div>
                                 </Group>
-                                {shouldShowLegacyLockedState({
-                                    isFlagResolved:
-                                        isFilterRequirementsFlagResolved,
-                                    isFilterRequirementsEnabled,
-                                }) && (
+                                {showLegacyLockedState && (
                                     <LockedDashboardModal
                                         opened={
                                             hasUnmetFilterRequirementsForCurrentTab &&

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -1653,10 +1653,16 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
 
     // Unmet filter requirements. Flag off = main parity: `requiredGroupId`
     // is ignored and the legacy disabled-only test applies.
-    const { data: filterRequirementsFlag, isSuccess: isFilterFlagResolved } =
-        useServerFeatureFlag(FeatureFlags.DashboardFilterRequirements);
+    const {
+        data: filterRequirementsFlag,
+        isSuccess: isFilterFlagResolved,
+        isError: isFilterFlagErrored,
+    } = useServerFeatureFlag(FeatureFlags.DashboardFilterRequirements);
     const isFilterRequirementsEnabled =
         filterRequirementsFlag?.enabled === true;
+    // Settled either way; consumers hold locked-state UI back until then
+    const isFilterRequirementsFlagResolved =
+        isFilterFlagResolved || isFilterFlagErrored;
     const unmetFilterRequirements = useMemo(() => {
         const allFilterRules = [
             ...dashboardFilters.dimensions,
@@ -1741,6 +1747,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         hasTileComments,
         unmetFilterRequirements,
         isFilterRequirementsEnabled,
+        isFilterRequirementsFlagResolved,
         isDateZoomDisabled,
         setIsDateZoomDisabled,
         isAddFilterDisabled,

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -131,6 +131,7 @@ export type DashboardContextType = {
     hasTileComments: (tileUuid: string) => boolean;
     unmetFilterRequirements: UnmetFilterRequirement[];
     isFilterRequirementsEnabled: boolean;
+    isFilterRequirementsFlagResolved: boolean;
     isDateZoomDisabled: boolean;
     setIsDateZoomDisabled: Dispatch<SetStateAction<boolean>>;
     isAddFilterDisabled: boolean;


### PR DESCRIPTION
Fixes the dashboard filter requirements guided setup (`dashboard-filter-requirements` feature flag):

- Field names in "at least one of" groups were truncated by a fixed-width label column. Member labels now sit on their own line above a full-width input, so they get the full card width (layout follows the operator selector design, which a later branch in the stack builds on).
- On hard reload the locked-state UI flashed twice: the guided setup rendered broken inputs while available filters loaded, and the legacy locked modal + blur flashed while the feature-flag query was pending. Both now hold back until their data resolves; locked tiles show the standard loading skeleton in the meantime and stay fail-closed throughout.

### Before
<img width="420" height="364" alt="01-before-label-truncation" src="https://github.com/user-attachments/assets/526493e9-3240-4cbe-ac61-aaaa6697b5db" />

### After
<img width="418" height="443" alt="09-after-stacked-labels" src="https://github.com/user-attachments/assets/236e7e41-bf94-46e4-9e77-31379bcb5424" />

Closes: PROD-8970
Closes: #25709
