### PR TITLE
feat(homepage): add "Revert to published" to discard draft edits

### DIFF
--- a/packages/backend/src/ee/controllers/projectHomepageController.ts
+++ b/packages/backend/src/ee/controllers/projectHomepageController.ts
@@ -383,6 +383,31 @@ export class ProjectHomepageController extends BaseController {
         unauthorisedInDemo,
     ])
     @SuccessResponse('200', 'Success')
+    @Post('/{homepageUuid}/discard-draft')
+    @OperationId('discardProjectHomepageDraft')
+    async discardDraft(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() homepageUuid: UUID,
+    ): Promise<ApiProjectHomepageResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().discardDraft(
+                toSessionUser(req.account),
+                projectUuid,
+                homepageUuid,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
     @Post('/{homepageUuid}/publish')
     @OperationId('publishProjectHomepage')
     async publish(

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -1,6 +1,7 @@
 import {
     ConflictError,
     NotFoundError,
+    ParameterError,
     type HomepageAssignment,
     type HomepageAudience,
     type HomepageConfig,
@@ -111,6 +112,28 @@ export class ProjectHomepageModel {
                 .returning('*');
             return ProjectHomepageModel.mapDbHomepage(row);
         });
+    }
+
+    async discardDraft(homepageUuid: string): Promise<ProjectHomepage> {
+        const existing = await this.database(HomepagesTableName)
+            .where({ homepage_uuid: homepageUuid })
+            .first();
+        if (!existing) {
+            throw new NotFoundError('Homepage not found');
+        }
+        if (existing.published_config === null) {
+            throw new ParameterError(
+                'This homepage has never been published, so there is no version to revert to',
+            );
+        }
+        const [row] = await this.database(HomepagesTableName)
+            .where({ homepage_uuid: homepageUuid })
+            .update({
+                draft_config: existing.published_config,
+                updated_at: new Date(),
+            })
+            .returning('*');
+        return ProjectHomepageModel.mapDbHomepage(row);
     }
 
     async updateDraft(

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -133,6 +133,7 @@ const makeService = ({
             list: vi.fn().mockResolvedValue([]),
             create: vi.fn().mockResolvedValue(makeHomepage()),
             updateDraft: vi.fn().mockResolvedValue(makeHomepage()),
+            discardDraft: vi.fn().mockResolvedValue(makeHomepage()),
             publish: vi.fn().mockResolvedValue(makeHomepage()),
             delete: vi.fn().mockResolvedValue(undefined),
             ...projectHomepageModel,
@@ -292,6 +293,43 @@ describe('ProjectHomepageService', () => {
             true,
         );
         expect(result.publishedConfig).toEqual(validConfig);
+    });
+
+    it('discardDraft reverts the draft to the published config for an admin when the flag is on', async () => {
+        const discardDraft = vi.fn().mockResolvedValue(
+            makeHomepage({
+                draftConfig: validConfig,
+                publishedConfig: validConfig,
+            }),
+        );
+        const service = makeService({
+            projectHomepageModel: { discardDraft },
+        });
+
+        const result = await service.discardDraft(
+            makeAdminUser(),
+            PROJECT_UUID,
+            HOMEPAGE_UUID,
+        );
+
+        expect(discardDraft).toHaveBeenCalledWith(HOMEPAGE_UUID);
+        expect(result.draftConfig).toEqual(validConfig);
+    });
+
+    it('discardDraft throws NotFoundError for a homepage in another project', async () => {
+        const service = makeService({
+            projectHomepageModel: {
+                getByUuid: vi
+                    .fn()
+                    .mockResolvedValue(
+                        makeHomepage({ projectUuid: 'other-project-uuid' }),
+                    ),
+            },
+        });
+
+        await expect(
+            service.discardDraft(makeAdminUser(), PROJECT_UUID, HOMEPAGE_UUID),
+        ).rejects.toThrow(NotFoundError);
     });
 
     it('getPublishedHomepage resolves with the viewer’s groups and role', async () => {

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -57,6 +57,7 @@ export type ProjectHomepageServiceArguments = {
         | 'list'
         | 'create'
         | 'updateDraft'
+        | 'discardDraft'
         | 'publish'
         | 'delete'
     >;
@@ -415,6 +416,17 @@ export class ProjectHomepageService extends BaseService {
             draftConfig: data.draftConfig,
             baseUpdatedAt: data.baseUpdatedAt,
         });
+    }
+
+    async discardDraft(
+        user: SessionUser,
+        projectUuid: string,
+        homepageUuid: string,
+    ): Promise<ProjectHomepage> {
+        await this.assertFlagEnabled(user);
+        this.assertCanManage(user, projectUuid);
+        await this.getOwnedHomepage(projectUuid, homepageUuid);
+        return this.projectHomepageModel.discardDraft(homepageUuid);
     }
 
     async publishHomepage(

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageBuilderPage.tsx
@@ -171,7 +171,7 @@ export const HomepageBuilderPage: FC = () => {
                         void navigate(`/projects/${projectUuid}/home`);
                     }
                 }}
-                onConflictReload={async () => {
+                onReload={async () => {
                     await queryClient.refetchQueries([
                         'project_homepage',
                         projectUuid,

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -39,6 +39,7 @@ import {
 } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import {
+    IconArrowBackUp,
     IconArrowDown,
     IconArrowLeft,
     IconArrowRight,
@@ -83,6 +84,7 @@ import {
 import classes from './HomepageEditor.module.css';
 import {
     useDeleteHomepage,
+    useDiscardHomepageDraft,
     usePublishHomepage,
     useUpdateHomepageDraft,
 } from './hooks/useProjectHomepage';
@@ -440,7 +442,7 @@ type Props = {
     onSwitchHomepage: (homepageUuid: string) => void;
     onCreateNew: () => void;
     onDeleted: () => void;
-    onConflictReload: () => void;
+    onReload: () => void;
 };
 
 export const HomepageEditor: FC<Props> = ({
@@ -450,7 +452,7 @@ export const HomepageEditor: FC<Props> = ({
     onSwitchHomepage,
     onCreateNew,
     onDeleted,
-    onConflictReload,
+    onReload,
 }) => {
     const navigate = useNavigate();
     const updateMutation = useUpdateHomepageDraft(
@@ -462,7 +464,12 @@ export const HomepageEditor: FC<Props> = ({
         homepage.homepageUuid,
     );
     const deleteMutation = useDeleteHomepage(projectUuid);
+    const discardDraftMutation = useDiscardHomepageDraft(
+        projectUuid,
+        homepage.homepageUuid,
+    );
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const [isDiscardModalOpen, setIsDiscardModalOpen] = useState(false);
     const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
 
     const isAiEnabled = useAiAgentButtonVisibility();
@@ -556,6 +563,17 @@ export const HomepageEditor: FC<Props> = ({
             }
         }
         setIsPublishModalOpen(true);
+    };
+
+    const handleDiscardDraft = () => {
+        discardDraftMutation.mutate(undefined, {
+            // Remount from the reverted server state instead of patching local
+            // state — a stale debounced draft would otherwise re-save over it.
+            onSuccess: () => {
+                setIsDiscardModalOpen(false);
+                onReload();
+            },
+        });
     };
 
     const isDirty = draft !== lastSavedRef.current || updateMutation.isLoading;
@@ -772,6 +790,16 @@ export const HomepageEditor: FC<Props> = ({
                         Draft saved
                     </span>
                 )}
+                {homepage.publishedConfig !== null && (
+                    <button
+                        type="button"
+                        className={classes.tbBtn}
+                        onClick={() => setIsDiscardModalOpen(true)}
+                    >
+                        <MantineIcon icon={IconArrowBackUp} size={15} />
+                        Revert to published
+                    </button>
+                )}
                 <button
                     type="button"
                     className={classes.tbBtn}
@@ -799,7 +827,7 @@ export const HomepageEditor: FC<Props> = ({
                         This homepage was changed somewhere else — your latest
                         edits here can’t be saved.
                     </Text>
-                    <Button size="xs" onClick={onConflictReload}>
+                    <Button size="xs" onClick={onReload}>
                         Reload homepage
                     </Button>
                 </div>
@@ -1119,6 +1147,20 @@ export const HomepageEditor: FC<Props> = ({
                         },
                     )
                 }
+            />
+            <MantineModal
+                opened={isDiscardModalOpen}
+                onClose={() =>
+                    !discardDraftMutation.isLoading &&
+                    setIsDiscardModalOpen(false)
+                }
+                title="Revert to published"
+                role="alertdialog"
+                description="This discards your unpublished changes and restores the last published version of this homepage. This can't be undone."
+                confirmLabel="Revert draft"
+                cancelDisabled={discardDraftMutation.isLoading}
+                onConfirm={handleDiscardDraft}
+                confirmLoading={discardDraftMutation.isLoading}
             />
             <MantineModal
                 opened={isDeleteModalOpen}

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
@@ -108,6 +108,16 @@ const publishHomepageApi = async (
         body: JSON.stringify({ audience, allowPersonal }),
     });
 
+const discardHomepageDraftApi = async (
+    projectUuid: string,
+    homepageUuid: string,
+) =>
+    lightdashApi<ProjectHomepage>({
+        url: `/projects/${projectUuid}/homepage/${homepageUuid}/discard-draft`,
+        method: 'POST',
+        body: undefined,
+    });
+
 const viewAsApi = async (projectUuid: string, target: HomepageViewAsTarget) => {
     const params = new URLSearchParams({ targetType: target.type });
     if (target.type === 'user') params.set('userUuid', target.userUuid);
@@ -394,6 +404,33 @@ export const useUpdateGroupPriorities = (projectUuid: string) => {
             onError: ({ error }) => {
                 showToastApiError({
                     title: 'Failed to reorder group priority',
+                    apiError: error,
+                });
+            },
+        },
+    );
+};
+
+export const useDiscardHomepageDraft = (
+    projectUuid: string,
+    homepageUuid: string | undefined,
+) => {
+    const { showToastSuccess, showToastApiError } = useToaster();
+    const queryClient = useQueryClient();
+    return useMutation<ProjectHomepage, ApiError, void>(
+        () => discardHomepageDraftApi(projectUuid, homepageUuid!),
+        {
+            mutationKey: ['discard_project_homepage_draft'],
+            onSuccess: async () => {
+                await queryClient.invalidateQueries([
+                    PROJECT_HOMEPAGE_QUERY_KEY,
+                    projectUuid,
+                ]);
+                showToastSuccess({ title: 'Draft reverted to published' });
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to revert draft',
                     apiError: error,
                 });
             },


### PR DESCRIPTION
## What & why

Editing a published homepage in the builder had no escape hatch. The builder autosaves the draft on every change, and there was **no UI to throw the draft away and restore the last published version** — so once a homepage diverged into an unwanted draft, you were stuck with it.

This adds a **"Revert to published"** action.

## Changes

**Backend**
- `ProjectHomepageModel.discardDraft(homepageUuid)` — copies `published_config` → `draft_config`; rejects homepages that were never published (`ParameterError`).
- `ProjectHomepageService.discardDraft` + `POST /projects/{projectUuid}/homepage/{homepageUuid}/discard-draft` — mirror the existing publish path's feature-flag / permission / ownership guards.
- Unit tests for the new service method (revert path + cross-project rejection).

**Frontend**
- A **toolbar button next to Preview** (only rendered when a published version exists), opening a confirm modal.
- On success the editor **remounts from fresh server state** via the existing reload path (the same one the conflict banner's "Reload homepage" uses), rather than patching local state. This closes a race where the debounced autosave still held the pre-revert draft and could re-save it over the revert a beat later. Renamed the shared `onConflictReload` prop → `onReload` since two callers now use it.

## Generated API files

None committed. The backend `build`/`build:fast` scripts run `generate-api:build` before compiling, so `routes.ts`/`swagger.json` are regenerated from the controllers in CI, preview, and the production image — the new endpoint is wired everywhere from the `@Post('/{homepageUuid}/discard-draft')` decorator alone. Committing the regenerated files here only added ~130 lines of unrelated content-as-code type-name churn, so they're left out.

## Testing

Verified end-to-end in the running app (Chrome DevTools):
- Diverged a draft, clicked Revert → editor snaps back to the published version, saved indicator settles to "Draft saved", DB confirms `draft_config = published_config`, no stale re-save.
- Button correctly hidden for never-published homepages.
- Backend `typecheck:fast`, frontend `typecheck:fast`, oxlint, and homepage service tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)