### PR TITLE
fix: date equals filter with multiple values only matched first value

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.mock.ts
+++ b/packages/common/src/compiler/filtersCompiler.mock.ts
@@ -417,6 +417,37 @@ export const TrinoInBetweenPastTwoYearsFilterSQL = `((customers.created) >= CAST
 export const InBetweenPastTwoYearsTimestampFilterSQL = `((customers.created) >= ('2021-04-04 00:00:00+00:00') AND (customers.created) <= ('2023-04-04 00:00:00+00:00'))`;
 export const TrinoInBetweenPastTwoYearsTimestampFilterSQL = `((customers.created) >= CAST('2021-04-04 00:00:00+00:00' AS timestamp) AND (customers.created) <= CAST('2023-04-04 00:00:00+00:00' AS timestamp))`;
 
+export const SingleValueEqualsDateFilter = {
+    id: 'id',
+    target: {
+        fieldId: 'fieldId',
+    },
+    operator: FilterOperator.EQUALS,
+    values: [new Date('15 Mar 2023 00:00:00 GMT')],
+};
+
+export const SingleValueEqualsDateFilterSQL = `(customers.created) = ('2023-03-15')`;
+
+export const MultiValueEqualsDateFilter = {
+    ...SingleValueEqualsDateFilter,
+    values: [
+        new Date('15 Mar 2023 00:00:00 GMT'),
+        new Date('22 May 2023 00:00:00 GMT'),
+    ],
+};
+
+export const MultiValueEqualsDateFilterSQL = `(customers.created) IN (('2023-03-15'),('2023-05-22'))`;
+export const TrinoMultiValueEqualsDateFilterSQL = `(customers.created) IN (CAST('2023-03-15' AS timestamp),CAST('2023-05-22' AS timestamp))`;
+export const MultiValueEqualsTimestampFilterSQL = `(customers.created) IN (('2023-03-15 00:00:00+00:00'),('2023-05-22 00:00:00+00:00'))`;
+
+export const MultiValueNotEqualsDateFilter = {
+    ...MultiValueEqualsDateFilter,
+    operator: FilterOperator.NOT_EQUALS,
+};
+
+export const MultiValueNotEqualsDateFilterSQL = `((customers.created) NOT IN (('2023-03-15'),('2023-05-22')) OR (customers.created) IS NULL)`;
+export const MultiValueNotEqualsTimestampFilterSQL = `((customers.created) NOT IN (('2023-03-15 00:00:00+00:00'),('2023-05-22 00:00:00+00:00')) OR (customers.created) IS NULL)`;
+
 const stringSingleValueFilter = {
     id: '701b6520-1b19-4051-a553-7615aee0b03d',
     target: { fieldId: 'customers_first_name' },

--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -74,11 +74,19 @@ import {
     InTheNextFilterBase,
     InThePastFilterBase,
     MonthToDateFilterBase,
+    MultiValueEqualsDateFilter,
+    MultiValueEqualsDateFilterSQL,
+    MultiValueEqualsTimestampFilterSQL,
+    MultiValueNotEqualsDateFilter,
+    MultiValueNotEqualsDateFilterSQL,
+    MultiValueNotEqualsTimestampFilterSQL,
     NumberDimensionMock,
     NumberFilterBase,
     NumberFilterBaseWithMultiValues,
     NumberOperatorsWithMultipleValues,
     QuarterToDateFilterBase,
+    SingleValueEqualsDateFilter,
+    SingleValueEqualsDateFilterSQL,
     stringFilterDimension,
     stringFilterRuleMocks,
     TrinoExpectedInTheCurrentFilterSQL,
@@ -101,6 +109,7 @@ import {
     TrinoInTheLast1MonthFilterSQL,
     TrinoInTheLast1WeekFilterSQL,
     TrinoInTheLast1YearFilterSQL,
+    TrinoMultiValueEqualsDateFilterSQL,
     WeekToDateFilterBase,
     YearToDateFilterBase,
 } from './filtersCompiler.mock';
@@ -661,6 +670,69 @@ describe('Filter SQL', () => {
                 timestampFormatter: formatTimestamp,
             }),
         ).toStrictEqual(TrinoInBetweenPastTwoYearsTimestampFilterSQL);
+    });
+
+    test('should return equals date filter sql for a single value', () => {
+        expect(
+            renderDateFilterSql({
+                dimensionSql: DimensionSqlMock,
+                filter: SingleValueEqualsDateFilter,
+                adapterType: adapterType.default,
+                timezone: 'UTC',
+            }),
+        ).toStrictEqual(SingleValueEqualsDateFilterSQL);
+    });
+    test('should return IN list for equals date filter with multiple values', () => {
+        expect(
+            renderDateFilterSql({
+                dimensionSql: DimensionSqlMock,
+                filter: MultiValueEqualsDateFilter,
+                adapterType: adapterType.default,
+                timezone: 'UTC',
+            }),
+        ).toStrictEqual(MultiValueEqualsDateFilterSQL);
+    });
+    test('should return IN list for equals date filter with multiple values for trino adapter', () => {
+        expect(
+            renderDateFilterSql({
+                dimensionSql: DimensionSqlMock,
+                filter: MultiValueEqualsDateFilter,
+                adapterType: adapterType.trino,
+                timezone: 'UTC',
+            }),
+        ).toStrictEqual(TrinoMultiValueEqualsDateFilterSQL);
+    });
+    test('should return NOT IN list for notEquals date filter with multiple values', () => {
+        expect(
+            renderDateFilterSql({
+                dimensionSql: DimensionSqlMock,
+                filter: MultiValueNotEqualsDateFilter,
+                adapterType: adapterType.default,
+                timezone: 'UTC',
+            }),
+        ).toStrictEqual(MultiValueNotEqualsDateFilterSQL);
+    });
+    test('should return IN list for equals timestamp filter with multiple values', () => {
+        expect(
+            renderTimestampFilterSql({
+                dimensionSql: DimensionSqlMock,
+                filter: MultiValueEqualsDateFilter,
+                adapterType: adapterType.default,
+                timezone: 'UTC',
+                timestampFormatter: formatTimestamp,
+            }),
+        ).toStrictEqual(MultiValueEqualsTimestampFilterSQL);
+    });
+    test('should return NOT IN list for notEquals timestamp filter with multiple values', () => {
+        expect(
+            renderTimestampFilterSql({
+                dimensionSql: DimensionSqlMock,
+                filter: MultiValueNotEqualsDateFilter,
+                adapterType: adapterType.default,
+                timezone: 'UTC',
+                timestampFormatter: formatTimestamp,
+            }),
+        ).toStrictEqual(MultiValueNotEqualsTimestampFilterSQL);
     });
 
     // To-date filter tests (system time: 04 Apr 2020 06:12:30 GMT)

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -361,15 +361,25 @@ const renderDateOrTimestampFilterSql = ({
 
     const settings = isDateFilterRule(filter) ? filter.settings : undefined;
 
+    // Multi-value equals/notEquals match any value, like string/number filters
+    const castValues = (values: Date[]): string =>
+        values.map((value) => castValue(literalFormatter(value))).join(',');
+
     switch (filter.operator) {
         case FilterOperator.EQUALS:
-            return `(${dimensionSql}) = ${castValue(
-                literalFormatter(filter.values?.[0]),
-            )}`;
+            return filter.values && filter.values.length > 1
+                ? `(${dimensionSql}) IN (${castValues(filter.values)})`
+                : `(${dimensionSql}) = ${castValue(
+                      literalFormatter(filter.values?.[0]),
+                  )}`;
         case FilterOperator.NOT_EQUALS:
-            return `((${dimensionSql}) != ${castValue(
-                literalFormatter(filter.values?.[0]),
-            )} OR (${dimensionSql}) IS NULL)`;
+            return filter.values && filter.values.length > 1
+                ? `((${dimensionSql}) NOT IN (${castValues(
+                      filter.values,
+                  )}) OR (${dimensionSql}) IS NULL)`
+                : `((${dimensionSql}) != ${castValue(
+                      literalFormatter(filter.values?.[0]),
+                  )} OR (${dimensionSql}) IS NULL)`;
         case FilterOperator.NULL:
             return `(${dimensionSql}) IS NULL`;
         case FilterOperator.NOT_NULL:


### PR DESCRIPTION
## Description

Date and timestamp filters using `equals` / `notEquals` with multiple values silently compiled SQL from only the first value, so a rule like `equals ["2023-03-15", "2023-05-22"]` matched only the first date with no error. String and number filters already compile multi-value equality as `IN (...)`.

Fix in `renderDateOrTimestampFilterSql` (`packages/common/src/compiler/filtersCompiler.ts`):

- `equals` with 2+ values → `(dim) IN (v1,v2,...)`
- `notEquals` with 2+ values → `((dim) NOT IN (v1,v2,...) OR (dim) IS NULL)`
- Single-value and empty-values behavior unchanged; per-adapter literal rendering (Trino/Athena `CAST`, timezone-aware wrap) preserved via the existing `castValue` helper.

Affects all query paths that reach the shared compiler (Explore, API, AI agent) on all warehouses.

### Before

```sql
WHERE (("orders".order_date) = ('2023-03-15'))  -- second value silently dropped
```

### After

```sql
WHERE (("orders".order_date) IN (('2023-03-15'),('2023-05-22')))
```

## How was this tested?

- Unit tests: multi-value date + timestamp `equals`/`notEquals` (default + Trino adapters) and single-value regression case in `filtersCompiler.test.ts`.
- E2E on seeded jaffle project: metric query on `orders` with dimension filter `orders_order_date equals ["2023-03-15","2023-05-22"]` returned 1 row before the fix, 2 rows (both dates) after.

Closes: PROD-8977
Closes: #25714

🤖 Generated with [Claude Code](https://claude.com/claude-code)
