### PR TITLE
fix: shortcut boolean AI field-value search

### DIFF
--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -1,7 +1,9 @@
 import {
     Account,
     CatalogType,
+    DimensionType,
     Explore,
+    FieldType,
     FilterOperator,
     ForbiddenError,
     JobStatusType,
@@ -196,6 +198,116 @@ function makeRuntimeContext(
 }
 
 describe('AiAgentToolsService', () => {
+    it.each(['', 'tru', 'FALSE', 'unknown'])(
+        'returns the boolean domain for query "%s"',
+        async (query) => {
+            const searchFieldUniqueValues = vi.fn();
+            const service = makeService({
+                explores: {
+                    orders: makeExplore({
+                        name: 'orders',
+                        dimensions: {
+                            is_completed: {
+                                fieldType: FieldType.DIMENSION,
+                                type: DimensionType.BOOLEAN,
+                                name: 'is_completed',
+                                table: 'orders',
+                            },
+                        },
+                    }),
+                },
+                searchFieldUniqueValues,
+            });
+            const runtime = service.createRuntime(makeRuntimeContext());
+
+            await expect(
+                runtime.searchFieldValues({
+                    table: 'orders',
+                    fieldId: 'orders_is_completed',
+                    query,
+                }),
+            ).resolves.toEqual([true, false]);
+            expect(searchFieldUniqueValues).not.toHaveBeenCalled();
+        },
+    );
+
+    it('preserves curated boolean values and labels', async () => {
+        const searchFieldUniqueValues = vi.fn();
+        const service = makeService({
+            explores: {
+                orders: makeExplore({
+                    name: 'orders',
+                    dimensions: {
+                        is_completed: {
+                            fieldType: FieldType.DIMENSION,
+                            type: DimensionType.BOOLEAN,
+                            name: 'is_completed',
+                            table: 'orders',
+                            filterAutocomplete: {
+                                fetchFromWarehouse: false,
+                                values: [{ value: 'true', label: 'Yes' }],
+                            },
+                        },
+                    },
+                }),
+            },
+            searchFieldUniqueValues,
+        });
+        const runtime = service.createRuntime(makeRuntimeContext());
+
+        await expect(
+            runtime.searchFieldValues({
+                table: 'orders',
+                fieldId: 'orders_is_completed',
+                query: 'yes',
+            }),
+        ).resolves.toEqual(['true']);
+        expect(searchFieldUniqueValues).not.toHaveBeenCalled();
+    });
+
+    it('returns the boolean domain without applying warehouse filters', async () => {
+        const searchFieldUniqueValues = vi.fn();
+        const service = makeService({
+            explores: {
+                orders: makeExplore({
+                    name: 'orders',
+                    dimensions: {
+                        is_completed: {
+                            fieldType: FieldType.DIMENSION,
+                            type: DimensionType.BOOLEAN,
+                            name: 'is_completed',
+                            table: 'orders',
+                        },
+                    },
+                }),
+            },
+            searchFieldUniqueValues,
+        });
+        const runtime = service.createRuntime(makeRuntimeContext());
+
+        await expect(
+            runtime.searchFieldValues({
+                table: 'orders',
+                fieldId: 'orders_is_completed',
+                query: '',
+                filters: {
+                    dimensions: {
+                        id: 'filters',
+                        and: [
+                            {
+                                id: 'is-completed-filter',
+                                target: { fieldId: 'orders_is_completed' },
+                                operator: FilterOperator.EQUALS,
+                                values: [true],
+                            },
+                        ],
+                    },
+                },
+            }),
+        ).resolves.toEqual([true, false]);
+        expect(searchFieldUniqueValues).not.toHaveBeenCalled();
+    });
+
     it('filters explores by tags and merged user attribute overrides', async () => {
         const service = makeService({
             userAttributes: { access_level: ['1'] },

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -6,6 +6,7 @@ import {
     CatalogFilter,
     CatalogType,
     ContentType,
+    DimensionType,
     Explore,
     FeatureFlags,
     filterExploreByTags,
@@ -2099,7 +2100,7 @@ export class AiAgentToolsService extends BaseService {
                 const query = args.query ?? '';
                 const isEmptyQuery = query.trim() === '';
 
-                // Serve curated filter_autocomplete values before the warehouse guard.
+                // Serve values known from field metadata before the warehouse guard.
                 const curatedResult = await this.getStaticFieldValues(
                     context,
                     args,
@@ -2108,7 +2109,7 @@ export class AiAgentToolsService extends BaseService {
                 if (curatedResult) {
                     Logger.info(
                         `[ai-field-values] served ${curatedResult.results.length} ` +
-                            `curated values source=${context.source} ` +
+                            `static values source=${context.source} ` +
                             `table=${args.table} fieldId=${args.fieldId}`,
                     );
                     return context.source === 'mcp'
@@ -2190,17 +2191,12 @@ export class AiAgentToolsService extends BaseService {
         );
     }
 
-    /**
-     * Serve a dimension's curated `filter_autocomplete` values without touching
-     * the warehouse, mirroring the Explore filter UI (`useFieldValues`). Returns
-     * undefined when the field isn't curated (or can't be resolved) so the
-     * caller falls back to the warehouse lookup.
-     */
+    /** Serve values known from field metadata without querying the warehouse. */
     private async getStaticFieldValues(
         context: AiAgentToolsRuntimeContext,
         args: Parameters<SearchFieldValuesFn>[0],
         query: string,
-    ): Promise<FieldValueSearchResult<string> | undefined> {
+    ): Promise<FieldValueSearchResult<string | boolean> | undefined> {
         let explore: Explore;
         try {
             explore = await this.getExploreForRuntime(context, {
@@ -2215,20 +2211,28 @@ export class AiAgentToolsService extends BaseService {
         const field = findFieldByIdInExplore(explore, args.fieldId);
         if (!field || !isDimension(field)) return undefined;
         if (
-            !shouldUseStaticFilterAutocomplete(field.filterAutocomplete, query)
+            shouldUseStaticFilterAutocomplete(field.filterAutocomplete, query)
         ) {
-            return undefined;
+            const results = filterStaticFilterAutocompleteValues(
+                field.filterAutocomplete?.values ?? [],
+                query,
+            ).slice(0, 100);
+            return {
+                search: query,
+                results,
+                cached: false,
+                refreshedAt: new Date(),
+            };
         }
-        const results = filterStaticFilterAutocompleteValues(
-            field.filterAutocomplete?.values ?? [],
-            query,
-        ).slice(0, 100);
-        return {
-            search: query,
-            results,
-            cached: false,
-            refreshedAt: new Date(),
-        };
+        if (field.type === DimensionType.BOOLEAN) {
+            return {
+                search: query,
+                results: [true, false],
+                cached: false,
+                refreshedAt: new Date(),
+            };
+        }
+        return undefined;
     }
 
     private listKnowledgeDocuments(

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -451,7 +451,7 @@ export type SearchFieldValuesFn = (args: {
     fieldId: string;
     query: string;
     filters?: Filters;
-}) => Promise<string[]>;
+}) => Promise<Array<string | number | boolean>>;
 
 export type CreateOrUpdateArtifactFn = (data: {
     threadUuid: string;


### PR DESCRIPTION
## Description

The AI/MCP `searchFieldValues` path sent boolean dimensions to the warehouse field-values endpoint, which applies a string-only `include` filter and fails for booleans.

Boolean values are a fixed type domain. The tool runtime now resolves the field from Explore metadata and returns both `true` and `false` locally before feature-flag checks or warehouse access. Query text and warehouse filters intentionally do not change this domain. Curated autocomplete values and labels still take precedence. Non-boolean fields are unchanged.

The generic field-values endpoint is unchanged; this PR fixes the AI/MCP tool path only.

## How was this tested?

- `AiAgentToolsService.test.ts`: 30/30 passing, covering multiple query strings, curated labels, filters, and no warehouse call.
- Backend `typecheck:fast`.
- Focused backend lint and format checks.

Relates: PROD-8978
Relates: #25715