### PR TITLE
fix: validate AI compaction summaries before persisting

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4385,10 +4385,48 @@ export class AiAgentService extends BaseService {
         const serializedInput =
             Compaction.serializeConversation(messagesToCompact);
 
-        const summary = await generateCompactionSummary(compactionModel, {
-            previousSummary: latestCompaction?.summary,
-            conversation: serializedInput,
-        });
+        let summary: string;
+        try {
+            summary = await generateCompactionSummary(compactionModel, {
+                previousSummary: latestCompaction?.summary,
+                conversation: serializedInput,
+            });
+        } catch (error) {
+            // Compaction is best-effort: an uncompacted turn beats a failed one
+            Logger.warn(
+                `${compactionLogContext} skipped reason=summary-generation-failed error=${getErrorMessage(error)}`,
+            );
+            Sentry.captureException(error, {
+                tags: { aiThreadUuid: threadUuid },
+                extra: { promptUuid: prompt.promptUuid },
+            });
+            return latestCompaction ?? null;
+        }
+
+        if (
+            !Compaction.isUsableSummary({
+                summary,
+                serializedInputChars: serializedInput.length,
+            })
+        ) {
+            // Persisting a degenerate summary would destroy thread context
+            Logger.warn(
+                `${compactionLogContext} skipped reason=unusable-summary summaryChars=${summary.length} serializedInputChars=${serializedInput.length}`,
+            );
+            Sentry.captureMessage(
+                'AI compaction summary rejected as unusable',
+                {
+                    level: 'warning',
+                    tags: { aiThreadUuid: threadUuid },
+                    extra: {
+                        promptUuid: prompt.promptUuid,
+                        summaryChars: summary.length,
+                        serializedInputChars: serializedInput.length,
+                    },
+                },
+            );
+            return latestCompaction ?? null;
+        }
 
         const createdCompaction =
             await this.aiAgentModel.createThreadCompaction({

--- a/packages/backend/src/ee/services/AiAgentService/compactionSummaryGuard.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/compactionSummaryGuard.test.ts
@@ -1,0 +1,177 @@
+import { type SessionUser } from '@lightdash/common';
+import { generateCompactionSummary } from '../ai/agents/compactionGenerator';
+import { AiAgentService } from './AiAgentService';
+
+// Avoid constructing the real MCP runtime client (and its transitive deps) when
+// we new up the service with mostly-empty mocks below.
+vi.mock('../ai/AiAgentMcpRuntimeClient', () => ({
+    AiAgentMcpRuntimeClient: vi
+        .fn()
+        // eslint-disable-next-line prefer-arrow-callback
+        .mockImplementation(function MockAiAgentMcpRuntimeClient() {
+            return {};
+        }),
+}));
+
+vi.mock('../ai/agents/compactionGenerator', () => ({
+    generateCompactionSummary: vi.fn(),
+}));
+
+vi.mock('../ai/models', async (importOriginal) => ({
+    ...(await importOriginal<Record<string, unknown>>()),
+    getCompactionModelMetadata: vi.fn().mockReturnValue({
+        supportsCompaction: true,
+        contextWindowTokens: 200000,
+    }),
+    getModel: vi.fn().mockReturnValue({
+        model: 'test-model',
+        callOptions: {},
+        providerOptions: {},
+    }),
+}));
+
+const generateCompactionSummaryMock = vi.mocked(generateCompactionSummary);
+
+const previousUserMessage = {
+    role: 'user' as const,
+    uuid: 'prompt-prev',
+    threadUuid: 'thread-1',
+    message: 'Show me revenue by month for 2025, split by region. '.repeat(40),
+    createdAt: new Date().toISOString(),
+    user: { uuid: 'user-1', name: 'Test User' },
+    context: [],
+    steers: [],
+    hidden: false,
+};
+
+const buildService = () => {
+    const aiAgentModel = {
+        findLatestThreadCompaction: vi.fn().mockResolvedValue(null),
+        findThreadCompactionByTriggeringPrompt: vi.fn().mockResolvedValue(null),
+        findPreviousPromptInThread: vi.fn().mockResolvedValue({
+            ai_prompt_uuid: 'prompt-prev',
+            token_usage: { totalTokens: 190000 },
+        }),
+        findThreadMessages: vi.fn().mockResolvedValue([previousUserMessage]),
+        createThreadCompaction: vi.fn().mockResolvedValue({
+            ai_thread_compaction_uuid: 'compaction-1',
+            compacted_through_ai_prompt_uuid: 'prompt-prev',
+        }),
+    };
+    const orgAiCopilotConfigResolver = {
+        getCopilotConfig: vi.fn().mockResolvedValue({}),
+    };
+    const service = new AiAgentService({
+        aiAgentModel,
+        orgAiCopilotConfigResolver,
+        lightdashConfig: {},
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    return { service, aiAgentModel };
+};
+
+const user = {
+    userUuid: 'user-1',
+    organizationUuid: 'org-1',
+} as unknown as SessionUser;
+
+const prompt = {
+    promptUuid: 'prompt-current',
+    threadUuid: 'thread-1',
+    organizationUuid: 'org-1',
+    modelConfig: null,
+};
+
+const runCompaction = (service: AiAgentService) =>
+    (
+        service as unknown as {
+            maybeCompactThreadBeforeResponse: (
+                u: SessionUser,
+                args: { threadUuid: string; prompt: typeof prompt },
+            ) => Promise<unknown>;
+        }
+    ).maybeCompactThreadBeforeResponse(user, {
+        threadUuid: 'thread-1',
+        prompt,
+    });
+
+describe('AiAgentService compaction summary guard', () => {
+    beforeEach(() => {
+        generateCompactionSummaryMock.mockReset();
+    });
+
+    it('persists the compaction when the summary is usable', async () => {
+        const { service, aiAgentModel } = buildService();
+        generateCompactionSummaryMock.mockResolvedValue(
+            [
+                '## Goal',
+                'Analyze monthly revenue by region for 2025.',
+                '## Next Steps',
+                'Add month-over-month growth.',
+            ].join('\n'),
+        );
+
+        const compaction = await runCompaction(service);
+
+        expect(aiAgentModel.createThreadCompaction).toHaveBeenCalledTimes(1);
+        expect(compaction).toEqual(
+            expect.objectContaining({
+                ai_thread_compaction_uuid: 'compaction-1',
+            }),
+        );
+    });
+
+    it('does not persist a placeholder summary and does not throw', async () => {
+        const { service, aiAgentModel } = buildService();
+        generateCompactionSummaryMock.mockResolvedValue(
+            '[no further messages]',
+        );
+
+        const compaction = await runCompaction(service);
+
+        expect(aiAgentModel.createThreadCompaction).not.toHaveBeenCalled();
+        expect(compaction).toBeNull();
+    });
+
+    it('does not persist an empty summary and does not throw', async () => {
+        const { service, aiAgentModel } = buildService();
+        generateCompactionSummaryMock.mockResolvedValue('   \n  ');
+
+        const compaction = await runCompaction(service);
+
+        expect(aiAgentModel.createThreadCompaction).not.toHaveBeenCalled();
+        expect(compaction).toBeNull();
+    });
+
+    it('keeps the previous compaction when the new summary is rejected', async () => {
+        const { service, aiAgentModel } = buildService();
+        const previousCompaction = {
+            ai_thread_compaction_uuid: 'compaction-0',
+            compacted_through_ai_prompt_uuid: 'prompt-older',
+            summary: 'Earlier valid summary.',
+        };
+        aiAgentModel.findLatestThreadCompaction.mockResolvedValue(
+            previousCompaction,
+        );
+        generateCompactionSummaryMock.mockResolvedValue(
+            '[no assistant message]',
+        );
+
+        const compaction = await runCompaction(service);
+
+        expect(aiAgentModel.createThreadCompaction).not.toHaveBeenCalled();
+        expect(compaction).toBe(previousCompaction);
+    });
+
+    it('continues without compaction when summary generation throws', async () => {
+        const { service, aiAgentModel } = buildService();
+        generateCompactionSummaryMock.mockRejectedValue(
+            new Error('model unavailable'),
+        );
+
+        const compaction = await runCompaction(service);
+
+        expect(aiAgentModel.createThreadCompaction).not.toHaveBeenCalled();
+        expect(compaction).toBeNull();
+    });
+});

--- a/packages/backend/src/ee/services/ai/compaction.test.ts
+++ b/packages/backend/src/ee/services/ai/compaction.test.ts
@@ -187,6 +187,101 @@ describe('AI context compaction helpers', () => {
         ]);
     });
 
+    describe('isUsableSummary', () => {
+        const serializedInputChars = 10000;
+
+        it('rejects empty and whitespace-only summaries', () => {
+            expect(
+                Compaction.isUsableSummary({
+                    summary: '',
+                    serializedInputChars,
+                }),
+            ).toBe(false);
+            expect(
+                Compaction.isUsableSummary({
+                    summary: '   \n\t\n  ',
+                    serializedInputChars,
+                }),
+            ).toBe(false);
+        });
+
+        it('rejects placeholder-only summaries', () => {
+            expect(
+                Compaction.isUsableSummary({
+                    summary: '[no further messages]',
+                    serializedInputChars,
+                }),
+            ).toBe(false);
+            expect(
+                Compaction.isUsableSummary({
+                    summary: '[no assistant message]',
+                    serializedInputChars,
+                }),
+            ).toBe(false);
+            expect(
+                Compaction.isUsableSummary({
+                    summary: '  [no content]  \n[none]',
+                    serializedInputChars,
+                }),
+            ).toBe(false);
+        });
+
+        it('rejects summaries that are only markdown structure', () => {
+            expect(
+                Compaction.isUsableSummary({
+                    summary:
+                        '## Goal\n## Progress\n### Done\n[no further messages]\n## Next Steps',
+                    serializedInputChars,
+                }),
+            ).toBe(false);
+        });
+
+        it('rejects trivially short summaries for large inputs', () => {
+            expect(
+                Compaction.isUsableSummary({
+                    summary: '## Goal\nn/a',
+                    serializedInputChars: 10000,
+                }),
+            ).toBe(false);
+        });
+
+        it('accepts a short summary when the input is also small', () => {
+            expect(
+                Compaction.isUsableSummary({
+                    summary: 'User said hi.',
+                    serializedInputChars: 50,
+                }),
+            ).toBe(true);
+        });
+
+        it('accepts a legitimate structured summary', () => {
+            expect(
+                Compaction.isUsableSummary({
+                    summary: [
+                        '## Goal',
+                        'Analyze monthly revenue by region for 2025.',
+                        '## Progress',
+                        '### Done',
+                        'Built a bar chart of revenue by region (artifact "Revenue by region").',
+                        '## Next Steps',
+                        'Add a month-over-month growth metric.',
+                    ].join('\n'),
+                    serializedInputChars,
+                }),
+            ).toBe(true);
+        });
+
+        it('accepts summaries containing bracketed text within sentences', () => {
+            expect(
+                Compaction.isUsableSummary({
+                    summary:
+                        'User pinned chart [Revenue 2025] and asked for a breakdown by country.',
+                    serializedInputChars,
+                }),
+            ).toBe(true);
+        });
+    });
+
     it('matches the triggering prompt for compaction UI events', () => {
         expect(
             Compaction.isCompactionPrompt(

--- a/packages/backend/src/ee/services/ai/compaction.ts
+++ b/packages/backend/src/ee/services/ai/compaction.ts
@@ -10,8 +10,52 @@ const TOOL_RESULT_CHAR_LIMIT = 2000;
 const SUMMARY_MESSAGE_PREFIX =
     'Earlier conversation summary for this thread:\n\n';
 
+// Placeholder-only line, e.g. "[no further messages]" or "[no assistant message]"
+const PLACEHOLDER_LINE_REGEX = /^\[[^[\]]*\]$/;
+const MARKDOWN_HEADING_REGEX = /^#{1,6}(\s|$)/;
+
 export class Compaction {
     static readonly RESERVE_TOKENS = 16384;
+
+    static readonly MIN_MEANINGFUL_SUMMARY_CHARS = 20;
+
+    static readonly MIN_INPUT_CHARS_FOR_LENGTH_CHECK = 1000;
+
+    /**
+     * Guards against persisting a degenerate summary (which would destroy
+     * thread context). Conservative: only rejects clearly-bad summaries —
+     * empty/whitespace, placeholder-only output, or trivially short content
+     * relative to a large serialized input.
+     */
+    static isUsableSummary({
+        summary,
+        serializedInputChars,
+    }: {
+        summary: string;
+        serializedInputChars: number;
+    }): boolean {
+        // Content that isn't markdown structure or bracket-only placeholders
+        const meaningfulChars = summary
+            .split('\n')
+            .map((line) => line.trim())
+            .filter(
+                (line) =>
+                    line.length > 0 &&
+                    !MARKDOWN_HEADING_REGEX.test(line) &&
+                    !PLACEHOLDER_LINE_REGEX.test(line),
+            )
+            .join('\n').length;
+
+        if (meaningfulChars === 0) {
+            return false;
+        }
+
+        return !(
+            serializedInputChars >=
+                Compaction.MIN_INPUT_CHARS_FOR_LENGTH_CHECK &&
+            meaningfulChars < Compaction.MIN_MEANINGFUL_SUMMARY_CHARS
+        );
+    }
 
     static shouldCompactPrompt({
         totalTokens,


### PR DESCRIPTION
## Problem

In production threads, the AI thread compaction summary generator occasionally returned placeholder garbage (literally `[no further messages]` / `[no assistant message]`) despite receiving thousands of chars of serialized conversation. That output was persisted unvalidated as the thread's compaction summary, destroying thread context — the next turn denied that earlier charts/conversation existed.

## Changes

This PR is scoped to compaction summary validation only. The related scratch-note leakage (internal continuity notes appearing in user-visible responses) is tracked separately in #25716, which stays open for that half.

- New `Compaction.isUsableSummary` predicate: rejects summaries that are empty/whitespace, placeholder-only (bracket-only lines like `[no further messages]`), markdown-structure-only (headings + placeholders with no content), or trivially short relative to a large serialized input. Deliberately conservative — only clearly-bad summaries are rejected.
- `AiAgentService.maybeCompactThreadBeforeResponse` now guards the generated summary: on rejection it logs, captures to Sentry, and continues the turn without persisting a new compaction (keeping any previous compaction). An uncompacted turn is strictly better than destroyed context.
- Summary generation errors are also caught and treated the same way (warn + Sentry + continue uncompacted) instead of failing the whole turn.

## Testing

- Unit tests for the predicate (placeholders, empty/whitespace, structure-only, short-vs-input, legit summaries, bracketed text within sentences).
- Service-level tests: rejected/erroring summary → no compaction persisted, no throw, previous compaction retained; usable summary → persisted.
- `pnpm -F backend exec vitest run src/ee/services/ai/compaction.test.ts src/ee/services/AiAgentService/compactionSummaryGuard.test.ts` — 19 tests pass. Backend `typecheck:fast` and lint clean.
- E2E is not feasible here (the failure is model-dependent and cannot be triggered deterministically); coverage relies on the unit/service tests above.

Part of: PROD-8979
Part of #25716

🤖 Generated with [Claude Code](https://claude.com/claude-code)
