### PR TITLE
feat: add tree content as code CLI output

### DIFF
--- a/packages/cli/src/handlers/organizationContent/index.test.ts
+++ b/packages/cli/src/handlers/organizationContent/index.test.ts
@@ -81,6 +81,15 @@ describe('organization content download', () => {
         );
     });
 
+    it('reports a duration for every downloaded resource', async () => {
+        await downloadOrganizationContent({ config });
+
+        expect(spinner.succeed).toHaveBeenCalledTimes(3);
+        spinner.succeed.mock.calls.forEach(([message]) =>
+            expect(message).toMatch(/\(\d+ms\)$/),
+        );
+    });
+
     it('still fails for other group download errors', async () => {
         vi.mocked(downloadGroups).mockRejectedValue(new Error('Network error'));
 
@@ -171,6 +180,15 @@ describe('organization content upload sequencing', () => {
             'groups:start',
             'groups:end',
         ]);
+    });
+
+    it('reports a duration for every uploaded resource', async () => {
+        await uploadOrganizationContent({ config });
+
+        expect(spinner.succeed).toHaveBeenCalledTimes(3);
+        spinner.succeed.mock.calls.forEach(([message]) =>
+            expect(message).toMatch(/\(\d+ms\)$/),
+        );
     });
 
     it('does not start users or groups when custom roles fail', async () => {

--- a/packages/cli/src/handlers/organizationContent/index.ts
+++ b/packages/cli/src/handlers/organizationContent/index.ts
@@ -7,6 +7,7 @@ import { LightdashAnalytics } from '../../analytics/analytics';
 import { type Config } from '../../config';
 import GlobalState from '../../globalState';
 import * as styles from '../../styles';
+import { createContentAsCodeOutput } from '../../terminal/contentAsCodeOutput';
 import {
     assertCodeResourceDependencyOrder,
     ORGANIZATION_CODE_RESOURCES,
@@ -51,6 +52,17 @@ const isGroupServiceDisabledError = (error: unknown): boolean =>
     error.statusCode === 403 &&
     error.message === 'Group service is not enabled';
 
+const getElapsedMilliseconds = (startedAt: number): number =>
+    Date.now() - startedAt;
+
+const measureAction = async <T>(
+    action: () => Promise<T>,
+): Promise<{ value: T; durationMs: number }> => {
+    const startedAt = Date.now();
+    const value = await action();
+    return { value, durationMs: getElapsedMilliseconds(startedAt) };
+};
+
 export const getOrganizationContentFolder = (customPath?: string): string =>
     getDownloadFolder(customPath);
 
@@ -76,44 +88,83 @@ export const downloadOrganizationContent = async ({
         },
     });
 
-    const spinner = GlobalState.startSpinner(`Downloading custom roles`);
+    const output = createContentAsCodeOutput({
+        operation: 'download',
+        scope: 'organization',
+        initialLabel: 'Custom roles',
+    });
     try {
-        const customRolesTotal = await downloadCustomRoles(
-            organizationUuid,
-            organizationContentPath,
+        const { value: customRolesTotal, durationMs: customRolesDurationMs } =
+            await measureAction(() =>
+                downloadCustomRoles(organizationUuid, organizationContentPath),
+            );
+        output.completeItem(
+            {
+                label: 'Custom roles',
+                detail: `${customRolesTotal} downloaded`,
+                durationMs: customRolesDurationMs,
+            },
+            'Users',
         );
-        spinner.succeed(`Downloaded ${customRolesTotal} custom roles`);
-
-        spinner.start(`Downloading users`);
-        const usersTotal = await downloadUsers(
-            organizationUuid,
-            organizationContentPath,
+        const { value: usersTotal, durationMs: usersDurationMs } =
+            await measureAction(() =>
+                downloadUsers(organizationUuid, organizationContentPath),
+            );
+        output.completeItem(
+            {
+                label: 'Users',
+                detail: `${usersTotal} downloaded`,
+                durationMs: usersDurationMs,
+            },
+            'Groups',
         );
-        spinner.succeed(`Downloaded ${usersTotal} users`);
-
-        spinner.start(`Downloading groups`);
+        const groupsStartedAt = Date.now();
         let groupsTotal = 0;
+        let groupsDurationMs: number;
         try {
             groupsTotal = await downloadGroups(
                 organizationUuid,
                 organizationContentPath,
             );
-            spinner.succeed(`Downloaded ${groupsTotal} groups`);
+            groupsDurationMs = getElapsedMilliseconds(groupsStartedAt);
+            output.completeItem(
+                {
+                    label: 'Groups',
+                    detail: `${groupsTotal} downloaded`,
+                    durationMs: groupsDurationMs,
+                },
+                null,
+            );
         } catch (error) {
+            groupsDurationMs = getElapsedMilliseconds(groupsStartedAt);
             if (!isGroupServiceDisabledError(error)) {
                 throw error;
             }
-            spinner.stop();
+            output.completeItem(
+                {
+                    label: 'Groups',
+                    detail: 'service unavailable',
+                    durationMs: groupsDurationMs,
+                    variant: 'warning',
+                },
+                null,
+            );
             GlobalState.debug(
                 '> Warning: groups were not downloaded because the group service is not enabled',
             );
         }
 
-        GlobalState.log(
-            styles.success(
-                `Downloaded organization content saved to ${organizationContentPath}`,
-            ),
+        const renderedSummary = output.complete(
+            organizationContentPath,
+            (Date.now() - start) / 1000,
         );
+        if (!renderedSummary) {
+            GlobalState.log(
+                styles.success(
+                    `Downloaded organization content saved to ${organizationContentPath}`,
+                ),
+            );
+        }
 
         await LightdashAnalytics.track({
             event: 'download.completed',
@@ -128,9 +179,7 @@ export const downloadOrganizationContent = async ({
             },
         });
     } catch (error) {
-        spinner.fail(
-            `Failed to download organization content: ${getErrorMessage(error)}`,
-        );
+        output.fail(getErrorMessage(error), (Date.now() - start) / 1000, true);
         await LightdashAnalytics.track({
             event: 'download.error',
             properties: {
@@ -168,18 +217,22 @@ export const uploadOrganizationContent = async ({
         },
     });
 
-    const spinner = GlobalState.startSpinner(`Uploading custom roles`);
+    const output = createContentAsCodeOutput({
+        operation: 'upload',
+        scope: 'organization',
+        initialLabel: 'Custom roles',
+    });
     try {
-        const summary = await uploadCustomRoles(
-            organizationUuid,
-            organizationContentPath,
-        );
+        const { value: summary, durationMs: customRolesDurationMs } =
+            await measureAction(() =>
+                uploadCustomRoles(organizationUuid, organizationContentPath),
+            );
         const summaryMessage = formatCustomRoleUploadSummary(summary);
         if (summary.failed > 0) {
             summary.failures.forEach(({ message }) =>
                 GlobalState.log(styles.error(message)),
             );
-            spinner.stop();
+            output.prepareForFailureDetails();
             const skippedGroups = await countDependencySkippedGroups(
                 organizationContentPath,
             );
@@ -192,20 +245,28 @@ export const uploadOrganizationContent = async ({
                 `Processed custom roles: ${summaryMessage}`,
             );
         }
-        spinner.succeed(`Uploaded custom roles: ${summaryMessage}`);
-
-        spinner.start(`Uploading users`);
-        const userSummary = await uploadUsers(
-            organizationUuid,
-            organizationContentPath,
-            sendInvites,
+        output.completeItem(
+            {
+                label: 'Custom roles',
+                detail: summaryMessage,
+                durationMs: customRolesDurationMs,
+            },
+            'Users',
         );
+        const { value: userSummary, durationMs: usersDurationMs } =
+            await measureAction(() =>
+                uploadUsers(
+                    organizationUuid,
+                    organizationContentPath,
+                    sendInvites,
+                ),
+            );
         const userSummaryMessage = formatUserUploadSummary(userSummary);
         if (userSummary.failed > 0) {
             userSummary.failures.forEach(({ message }) =>
                 GlobalState.log(styles.error(message)),
             );
-            spinner.stop();
+            output.prepareForFailureDetails();
             const skippedGroups = await countDependencySkippedGroups(
                 organizationContentPath,
             );
@@ -218,29 +279,47 @@ export const uploadOrganizationContent = async ({
                 `Processed users: ${userSummaryMessage}`,
             );
         }
-        spinner.succeed(`Uploaded users: ${userSummaryMessage}`);
-
-        spinner.start(`Uploading groups`);
-        const groupSummary = await uploadGroups(
-            organizationUuid,
-            organizationContentPath,
+        output.completeItem(
+            {
+                label: 'Users',
+                detail: userSummaryMessage,
+                durationMs: usersDurationMs,
+            },
+            'Groups',
         );
+        const { value: groupSummary, durationMs: groupsDurationMs } =
+            await measureAction(() =>
+                uploadGroups(organizationUuid, organizationContentPath),
+            );
         const groupSummaryMessage = formatGroupUploadSummary(groupSummary);
         if (groupSummary.failed > 0) {
             groupSummary.failures.forEach(({ message }) =>
                 GlobalState.log(styles.error(message)),
             );
-            spinner.stop();
+            output.prepareForFailureDetails();
             throw createGroupPartialUploadError(
                 `Processed groups: ${groupSummaryMessage}`,
             );
         }
-        spinner.succeed(`Uploaded groups: ${groupSummaryMessage}`);
-        GlobalState.log(
-            styles.success(
-                `Uploaded organization content from ${organizationContentPath}`,
-            ),
+        output.completeItem(
+            {
+                label: 'Groups',
+                detail: groupSummaryMessage,
+                durationMs: groupsDurationMs,
+            },
+            null,
         );
+        const renderedSummary = output.complete(
+            organizationContentPath,
+            (Date.now() - start) / 1000,
+        );
+        if (!renderedSummary) {
+            GlobalState.log(
+                styles.success(
+                    `Uploaded organization content from ${organizationContentPath}`,
+                ),
+            );
+        }
         await LightdashAnalytics.track({
             event: 'upload.completed',
             properties: {
@@ -262,11 +341,11 @@ export const uploadOrganizationContent = async ({
             },
         });
     } catch (error) {
-        if (!isPartialUploadError(error)) {
-            spinner.fail(
-                `Failed to upload organization content: ${getErrorMessage(error)}`,
-            );
-        }
+        output.fail(
+            getErrorMessage(error),
+            (Date.now() - start) / 1000,
+            !isPartialUploadError(error),
+        );
         await LightdashAnalytics.track({
             event: 'upload.error',
             properties: {

--- a/packages/cli/src/handlers/organizationContent/users.test.ts
+++ b/packages/cli/src/handlers/organizationContent/users.test.ts
@@ -13,6 +13,7 @@ import { vi } from 'vitest';
 import { lightdashApi } from '../dbt/apiClient';
 import {
     downloadUsers,
+    formatUserUploadSummary,
     getUsersFolder,
     readUserFiles,
     uploadUsers,
@@ -54,6 +55,23 @@ describe('users as code', () => {
     afterEach(async () => {
         vi.restoreAllMocks();
         await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('formats upload results using CRUD statuses only', () => {
+        expect(
+            formatUserUploadSummary({
+                created: 1,
+                updated: 2,
+                unchanged: 3,
+                awaitingAuthentication: 4,
+                invited: 5,
+                skippedAuthenticated: 6,
+                skippedDisabled: 7,
+                skippedValidInvite: 8,
+                failed: 9,
+                failures: [],
+            }),
+        ).toBe('1 created, 2 updated, 3 unchanged, 9 failed');
     });
 
     it('downloads deterministic portable users and preserves unknown YAML', async () => {

--- a/packages/cli/src/handlers/organizationContent/users.ts
+++ b/packages/cli/src/handlers/organizationContent/users.ts
@@ -61,24 +61,13 @@ type UserFile = { filePath: string; document: UserAsCode };
 export const getUsersFolder = (organizationContentPath: string): string =>
     path.join(organizationContentPath, USER_CODE_RESOURCE.folderName);
 
-export const formatUserUploadSummary = (summary: UserUploadSummary): string => {
-    const invitationSummary = [
-        `${summary.invited} invited`,
-        `${
-            summary.skippedAuthenticated +
-            summary.skippedDisabled +
-            summary.skippedValidInvite
-        } invitation-skipped`,
-    ];
-    return [
+export const formatUserUploadSummary = (summary: UserUploadSummary): string =>
+    [
         `${summary.created} created`,
         `${summary.updated} updated`,
         `${summary.unchanged} unchanged`,
-        `${summary.awaitingAuthentication} awaiting authentication`,
-        invitationSummary.join(', '),
         `${summary.failed} failed`,
     ].join(', ');
-};
 
 export const readUserFiles = async (
     organizationContentPath: string,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -744,7 +744,12 @@ const ORGANIZATION_MODE_OPTIONS = new Set([
 ]);
 
 const withOrganizationMode =
-    <Options extends { organization: boolean; sendInvites?: boolean }>(
+    <
+        Options extends {
+            organization: boolean;
+            sendInvites?: boolean;
+        },
+    >(
         handler: (options: Options) => Promise<void>,
     ) =>
     async (options: Options, command: Command): Promise<void> => {

--- a/packages/cli/src/terminal/contentAsCodeOutput.test.ts
+++ b/packages/cli/src/terminal/contentAsCodeOutput.test.ts
@@ -1,0 +1,152 @@
+import GlobalState from '../globalState';
+import {
+    createContentAsCodeOutput,
+    formatContentAsCodeAction,
+    formatContentAsCodeComplete,
+    formatContentAsCodeFailure,
+    formatContentAsCodeProgress,
+} from './contentAsCodeOutput';
+
+describe('content as code terminal output', () => {
+    it('formats fallback actions with aligned labels and muted metadata', () => {
+        const output = formatContentAsCodeAction({
+            label: 'Custom roles',
+            detail: '34 downloaded',
+            durationMs: 245,
+        });
+
+        expect(output).toContain('Custom roles   34 downloaded (245ms)');
+    });
+
+    it('formats running progress as a tree', () => {
+        const output = formatContentAsCodeProgress({
+            operation: 'download',
+            scope: 'organization',
+            activeLabel: 'Groups',
+            items: [
+                {
+                    label: 'Custom roles',
+                    detail: '34 downloaded',
+                    durationMs: 85,
+                },
+                {
+                    label: 'Users',
+                    detail: '9 downloaded',
+                    durationMs: 107,
+                },
+            ],
+        });
+
+        expect(output).toContain('Downloading content as code (organization)');
+        expect(output).toContain('└ ✓ Custom roles · 34 downloaded (85ms)');
+        expect(output).toContain('└ ✓ Users · 9 downloaded (107ms)');
+        expect(output).toContain('└ ◐ Groups · downloading…');
+    });
+
+    it('renders one borderless completion tree', () => {
+        const output = formatContentAsCodeComplete({
+            operation: 'upload',
+            scope: 'organization',
+            path: '/tmp/lightdash',
+            elapsedSeconds: 1.2,
+            items: [
+                {
+                    label: 'Custom roles',
+                    detail: '1 created, 2 unchanged',
+                    durationMs: 245,
+                },
+                { label: 'Users', detail: '4 updated', durationMs: 31 },
+                {
+                    label: 'Groups',
+                    detail: 'service unavailable',
+                    durationMs: 12,
+                    variant: 'warning',
+                },
+            ],
+        });
+
+        expect(output).toContain(
+            '✓ Uploaded content as code (organization) · 1.2s',
+        );
+        expect(output).toContain('└ ✓ Custom roles');
+        expect(output).toContain('(245ms)');
+        expect(output).toContain('└ ⚠ Groups');
+        expect(output).toContain('└ Read from /tmp/lightdash');
+        expect(output).not.toMatch(/[╭╮╰╯│─]/);
+    });
+
+    it('formats failures with completed and failed tree rows', () => {
+        const output = formatContentAsCodeFailure({
+            operation: 'download',
+            scope: 'organization',
+            elapsedSeconds: 0.4,
+            items: [
+                {
+                    label: 'Custom roles',
+                    detail: '34 downloaded',
+                    durationMs: 85,
+                },
+            ],
+            failedItem: {
+                label: 'Users',
+                detail: '403 forbidden',
+                durationMs: 52,
+            },
+        });
+
+        expect(output).toContain(
+            'Failed to download content as code (organization) · 0.4s',
+        );
+        expect(output).toContain('└ ✓ Custom roles · 34 downloaded (85ms)');
+        expect(output).toContain('└ × Users · 403 forbidden (52ms)');
+    });
+
+    it('replaces running progress with one persistent completion tree', () => {
+        const originalIsTTY = process.stderr.isTTY;
+        Object.defineProperty(process.stderr, 'isTTY', {
+            configurable: true,
+            value: true,
+        });
+        vi.stubEnv('CI', 'false');
+        vi.stubEnv('TERM', 'xterm');
+        vi.stubEnv('NO_UNICODE', 'false');
+        const spinner = {
+            text: '',
+            start: vi.fn(),
+            succeed: vi.fn(),
+            stop: vi.fn(),
+            fail: vi.fn(),
+        };
+        vi.spyOn(GlobalState, 'startSpinner').mockReturnValue(spinner as never);
+        const write = vi
+            .spyOn(process.stderr, 'write')
+            .mockImplementation(() => true);
+
+        const output = createContentAsCodeOutput({
+            operation: 'download',
+            scope: 'organization',
+            initialLabel: 'Custom roles',
+        });
+        output.completeItem(
+            {
+                label: 'Custom roles',
+                detail: '34 downloaded',
+                durationMs: 85,
+            },
+            'Users',
+        );
+
+        expect(spinner.succeed).not.toHaveBeenCalled();
+        expect(spinner.text).toContain('└ ◐ Users · downloading…');
+        expect(output.complete('/tmp/lightdash', 0.6)).toBe(true);
+        expect(spinner.stop).toHaveBeenCalledOnce();
+        expect(write).toHaveBeenCalledOnce();
+
+        Object.defineProperty(process.stderr, 'isTTY', {
+            configurable: true,
+            value: originalIsTTY,
+        });
+        vi.unstubAllEnvs();
+        vi.restoreAllMocks();
+    });
+});

--- a/packages/cli/src/terminal/contentAsCodeOutput.ts
+++ b/packages/cli/src/terminal/contentAsCodeOutput.ts
@@ -1,0 +1,255 @@
+import chalk from 'chalk';
+import GlobalState from '../globalState';
+
+export type ContentAsCodeOutputVariant = 'success' | 'warning';
+
+export type ContentAsCodeOutputItem = {
+    label: string;
+    detail: string;
+    durationMs: number;
+    variant?: ContentAsCodeOutputVariant;
+};
+
+export type ContentAsCodeOutputProps = {
+    operation: 'download' | 'upload';
+    scope: 'organization' | 'project';
+    path: string;
+    elapsedSeconds: number;
+    items: ContentAsCodeOutputItem[];
+};
+
+type ContentAsCodeProgressProps = Pick<
+    ContentAsCodeOutputProps,
+    'operation' | 'scope' | 'items'
+> & {
+    activeLabel: string;
+};
+
+type ContentAsCodeFailureProps = Pick<
+    ContentAsCodeOutputProps,
+    'operation' | 'scope' | 'elapsedSeconds' | 'items'
+> & {
+    failedItem: Omit<ContentAsCodeOutputItem, 'variant'>;
+};
+
+const ACTION_LABEL_WIDTH = 14;
+const TREE_CONNECTOR = chalk.gray('└');
+
+const getDurationLabel = (durationMs: number) =>
+    `(${Math.round(durationMs)}ms)`;
+
+const getOperationLabel = (
+    operation: ContentAsCodeOutputProps['operation'],
+    tense: 'running' | 'complete',
+) => {
+    if (operation === 'download') {
+        return tense === 'running' ? 'Downloading' : 'Downloaded';
+    }
+    return tense === 'running' ? 'Uploading' : 'Uploaded';
+};
+
+export const formatDurationTag = (durationMs: number) =>
+    chalk.gray(getDurationLabel(durationMs));
+
+export const formatContentAsCodeAction = ({
+    label,
+    detail,
+    durationMs,
+}: Pick<ContentAsCodeOutputItem, 'label' | 'detail' | 'durationMs'>) =>
+    `${chalk.bold(label.padEnd(ACTION_LABEL_WIDTH))} ${chalk.gray(
+        detail,
+    )} ${formatDurationTag(durationMs)}`;
+
+const formatTreeItem = ({
+    label,
+    detail,
+    durationMs,
+    variant = 'success',
+}: ContentAsCodeOutputItem) => {
+    const status = variant === 'success' ? chalk.green('✓') : chalk.yellow('⚠');
+    return `  ${TREE_CONNECTOR} ${status} ${chalk.bold(label)} ${chalk.gray(
+        `· ${detail}`,
+    )} ${formatDurationTag(durationMs)}`;
+};
+
+export const formatContentAsCodeProgress = ({
+    operation,
+    scope,
+    items,
+    activeLabel,
+}: ContentAsCodeProgressProps) => {
+    const header = `${chalk.bold(
+        getOperationLabel(operation, 'running'),
+    )} content as code ${chalk.gray(`(${scope})`)}`;
+    const completedItems = items.map(formatTreeItem);
+    const activeItem = `  ${TREE_CONNECTOR} ${chalk.yellow('◐')} ${chalk.bold(
+        activeLabel,
+    )} ${chalk.gray(`· ${getOperationLabel(operation, 'running').toLowerCase()}…`)}`;
+
+    return [header, ...completedItems, activeItem].join('\n');
+};
+
+export const formatContentAsCodeFailure = ({
+    operation,
+    scope,
+    elapsedSeconds,
+    items,
+    failedItem,
+}: ContentAsCodeFailureProps) => {
+    const operationLabel = operation === 'download' ? 'download' : 'upload';
+    const header = `${chalk.bold(
+        `Failed to ${operationLabel}`,
+    )} content as code ${chalk.gray(`(${scope}) · ${elapsedSeconds.toFixed(1)}s`)}`;
+    const failed = `  ${TREE_CONNECTOR} ${chalk.red('×')} ${chalk.bold(
+        failedItem.label,
+    )} ${chalk.red(`· ${failedItem.detail}`)} ${chalk.red(
+        getDurationLabel(failedItem.durationMs),
+    )}`;
+
+    return [header, ...items.map(formatTreeItem), failed].join('\n');
+};
+
+export const formatContentAsCodeComplete = ({
+    operation,
+    scope,
+    path,
+    elapsedSeconds,
+    items,
+}: ContentAsCodeOutputProps) => {
+    const operationLabel = getOperationLabel(operation, 'complete');
+    const pathLabel = operation === 'download' ? 'Saved to' : 'Read from';
+    const header = `${chalk.green('✓')} ${chalk.bold(
+        operationLabel,
+    )} content as code ${chalk.gray(`(${scope}) · ${elapsedSeconds.toFixed(1)}s`)}`;
+    const pathItem = `  ${TREE_CONNECTOR} ${chalk.gray(pathLabel)} ${chalk.bold(
+        path,
+    )}`;
+
+    return [header, ...items.map(formatTreeItem), pathItem].join('\n');
+};
+
+export const canRenderContentAsCodeTree = (): boolean =>
+    Boolean(
+        process.stderr.isTTY &&
+        process.env.CI !== 'true' &&
+        process.env.TERM !== 'dumb' &&
+        process.env.NO_UNICODE !== '1' &&
+        process.env.NO_UNICODE !== 'true',
+    );
+
+export const renderContentAsCodeComplete = (
+    props: ContentAsCodeOutputProps,
+): boolean => {
+    if (!canRenderContentAsCodeTree()) {
+        return false;
+    }
+
+    process.stderr.write(`${formatContentAsCodeComplete(props)}\n`);
+    return true;
+};
+
+type CreateContentAsCodeOutputProps = Pick<
+    ContentAsCodeOutputProps,
+    'operation' | 'scope'
+> & {
+    initialLabel: string;
+};
+
+export const createContentAsCodeOutput = ({
+    operation,
+    scope,
+    initialLabel,
+}: CreateContentAsCodeOutputProps) => {
+    const useTree = canRenderContentAsCodeTree();
+    const items: ContentAsCodeOutputItem[] = [];
+    let activeLabel = initialLabel;
+    let activeStartedAt = Date.now();
+    const runningLabel = getOperationLabel(operation, 'running');
+    const spinner = GlobalState.startSpinner(
+        useTree
+            ? formatContentAsCodeProgress({
+                  operation,
+                  scope,
+                  items,
+                  activeLabel,
+              })
+            : `${runningLabel} ${activeLabel.toLowerCase()}`,
+    );
+
+    const setActive = (label: string) => {
+        activeLabel = label;
+        activeStartedAt = Date.now();
+        if (useTree) {
+            spinner.text = formatContentAsCodeProgress({
+                operation,
+                scope,
+                items,
+                activeLabel,
+            });
+        } else {
+            spinner.start(`${runningLabel} ${activeLabel.toLowerCase()}`);
+        }
+    };
+
+    return {
+        completeItem: (
+            item: ContentAsCodeOutputItem,
+            nextLabel: string | null,
+        ) => {
+            items.push(item);
+            if (!useTree) {
+                if (item.variant === 'warning') {
+                    spinner.stop();
+                } else {
+                    spinner.succeed(formatContentAsCodeAction(item));
+                }
+            }
+            if (nextLabel !== null) {
+                setActive(nextLabel);
+            }
+        },
+        prepareForFailureDetails: () => {
+            if (!useTree) {
+                spinner.stop();
+            }
+        },
+        complete: (path: string, elapsedSeconds: number): boolean => {
+            if (!useTree) {
+                return false;
+            }
+            spinner.stop();
+            return renderContentAsCodeComplete({
+                operation,
+                scope,
+                path,
+                elapsedSeconds,
+                items,
+            });
+        },
+        fail: (
+            detail: string,
+            elapsedSeconds: number,
+            showFallback: boolean,
+        ) => {
+            if (useTree) {
+                spinner.fail(
+                    formatContentAsCodeFailure({
+                        operation,
+                        scope,
+                        elapsedSeconds,
+                        items,
+                        failedItem: {
+                            label: activeLabel,
+                            detail,
+                            durationMs: Date.now() - activeStartedAt,
+                        },
+                    }),
+                );
+            } else if (showFallback) {
+                spinner.fail(
+                    `Failed to ${operation} ${scope} content: ${detail}`,
+                );
+            }
+        },
+    };
+};


### PR DESCRIPTION
![CLI tree output](https://app.graphite.com/user-attachments/assets/727b56c6-b545-4791-a347-d99e98ba1c32.png)

## Summary

- replace the bordered organization content-as-code recap with compact tree output
- show consistent running, completed, and failed states without duplicating resource results
- keep per-resource durations and CRUD-only user upload statuses
- centralize spinner lifecycle, tree styling, timing, and non-TTY fallback behavior behind a reusable output helper
- add no new CLI dependencies

## Verification

- pnpm -F @lightdash/cli lint
- pnpm -F @lightdash/cli format
- pnpm -F @lightdash/cli typecheck
- pnpm -F @lightdash/cli test — 273 passed
- pnpm -F @lightdash/cli build
- built CLI organization download smoke test — 34 roles, 9 users, and 40 groups
- built CLI organization upload smoke test — all resources unchanged, zero failures
- verified plain output fallback under TERM=dumb

Relates: PROD-8929