### PR TITLE
feat: change filter operators inline in the guided filter setup

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboardFilterRequiredGroups.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboardFilterRequiredGroups.cy.ts
@@ -209,8 +209,8 @@ describe('Dashboard filter required groups', () => {
         cy.findByTestId('guided-filter-setup').within(() => {
             cy.findByText('1 of 2 set').should('be.visible');
             cy.findByText('Change').should('be.visible');
-            // Both the summary line and the tag input render the value
-            cy.findAllByText('credit_card').first().should('be.visible');
+            // The collapsed summary shows the operator and the value
+            cy.findByText('is credit_card').should('be.visible');
 
             // Open the second rule's input (Order status); its field values
             // load on focus, so pick from the option list instead of typing

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.module.css
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.module.css
@@ -1,3 +1,18 @@
 .summaryRow {
     min-height: 30px;
 }
+
+@keyframes fade-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+/* Stable height + fade so operator changes swap input shapes calmly */
+.valueSwap {
+    min-height: 30px;
+    animation: fade-in 120ms ease;
+}

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.tsx
@@ -5,6 +5,7 @@ import {
     isValuelessDashboardFilterRule,
     type DashboardFilterRule,
     type FilterableItem,
+    type FilterType,
     type WeekDay,
 } from '@lightdash/common';
 import {
@@ -43,6 +44,7 @@ import TruncatedText from '../../../components/common/TruncatedText';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import { hasFilterValueSet } from '../FilterConfiguration/utils';
 import classes from './GuidedFilterSetup.module.css';
+import OperatorPicker from './OperatorPicker';
 import { AndSeparator, OrSeparator } from './RuleSeparators';
 import { useFilterableItemsMap } from './useFilterableItemsMap';
 import { useUpdateDashboardFilterRule } from './useUpdateDashboardFilterRule';
@@ -52,6 +54,16 @@ import {
     isRequirementRuleSatisfied,
     type FilterRequirementRule,
 } from './utils';
+
+const getMemberFilterType = (
+    member: DashboardFilterRule,
+    field: FilterableItem | undefined,
+): FilterType =>
+    field
+        ? getFilterTypeFromItem(field)
+        : getFilterTypeFromItemType(
+              member.target.fallbackType ?? DimensionType.STRING,
+          );
 
 const RuleStatusIcon: FC<{ satisfied: boolean }> = ({ satisfied }) =>
     satisfied ? (
@@ -83,30 +95,44 @@ const MemberInput: FC<MemberInputProps> = ({
     showLabel,
     popoverProps,
     onChange,
-}) => (
-    // Label sits on its own line above a full-width input so long field
-    // names aren't squeezed by the input column
-    <Stack gap={4}>
-        {showLabel && (
-            <TruncatedText maxWidth="100%" fz="xs" c="ldGray.6">
-                {label}
-            </TruncatedText>
-        )}
-        <FilterInputComponent
-            filterType={
-                field
-                    ? getFilterTypeFromItem(field)
-                    : getFilterTypeFromItemType(
-                          member.target.fallbackType ?? DimensionType.STRING,
-                      )
-            }
-            field={field}
-            rule={member}
-            popoverProps={popoverProps}
-            onChange={(newRule) => onChange(newRule as DashboardFilterRule)}
-        />
-    </Stack>
-);
+}) => {
+    const filterType = getMemberFilterType(member, field);
+
+    return (
+        // Label sits on its own line above a full-width input so long field
+        // names aren't squeezed by the input column
+        <Stack gap={4}>
+            {showLabel && (
+                <Group gap={6} wrap="nowrap" align="baseline">
+                    <TruncatedText maxWidth="100%" fz="xs" fw={500}>
+                        {label}
+                    </TruncatedText>
+                    <OperatorPicker
+                        filterType={filterType}
+                        field={field}
+                        member={member}
+                        label={label}
+                        onChange={onChange}
+                        onOpen={popoverProps.onOpen}
+                        onClose={popoverProps.onClose}
+                    />
+                </Group>
+            )}
+            {/* Keyed so a changed operator fades its new input shape in */}
+            <Box key={member.operator} className={classes.valueSwap}>
+                <FilterInputComponent
+                    filterType={filterType}
+                    field={field}
+                    rule={member}
+                    popoverProps={popoverProps}
+                    onChange={(newRule) =>
+                        onChange(newRule as DashboardFilterRule)
+                    }
+                />
+            </Box>
+        </Stack>
+    );
+};
 
 type RuleSummaryProps = {
     rule: FilterRequirementRule;
@@ -123,8 +149,11 @@ const RuleSummary: FC<RuleSummaryProps> = ({ rule, fieldsMap, onChange }) => {
     if (!setMember) return null;
 
     const field = fieldsMap[setMember.target.fieldId];
-    const valueLabel = field
-        ? getConditionalRuleLabelFromItem(setMember, field).value
+    const ruleLabels = field
+        ? getConditionalRuleLabelFromItem(setMember, field)
+        : undefined;
+    const valueLabel = ruleLabels
+        ? [ruleLabels.operator, ruleLabels.value].filter(Boolean).join(' ')
         : undefined;
 
     return (
@@ -288,6 +317,9 @@ const GuidedFilterSetup: FC<Props> = ({
                                 isSatisfied &&
                                 !expandedRuleIds.includes(rule.id);
                             const isMultiMember = rule.members.length > 1;
+                            const firstMember = rule.members[0];
+                            const firstMemberField =
+                                fieldsMap[firstMember.target.fieldId];
 
                             return (
                                 <Fragment key={rule.id}>
@@ -313,19 +345,52 @@ const GuidedFilterSetup: FC<Props> = ({
                                                     <RuleStatusIcon
                                                         satisfied={isSatisfied}
                                                     />
-                                                    <Text
-                                                        size="xs"
-                                                        fw={500}
-                                                        truncate
+                                                    <Group
+                                                        gap={6}
+                                                        wrap="nowrap"
+                                                        align="baseline"
+                                                        miw={0}
                                                     >
-                                                        {isMultiMember
-                                                            ? 'At least one of'
-                                                            : getDashboardFilterRuleLabel(
-                                                                  rule
-                                                                      .members[0],
-                                                                  fieldsMap,
-                                                              )}
-                                                    </Text>
+                                                        <Text
+                                                            size="xs"
+                                                            fw={500}
+                                                            truncate
+                                                        >
+                                                            {isMultiMember
+                                                                ? 'At least one of'
+                                                                : getDashboardFilterRuleLabel(
+                                                                      firstMember,
+                                                                      fieldsMap,
+                                                                  )}
+                                                        </Text>
+                                                        {!isMultiMember && (
+                                                            <OperatorPicker
+                                                                filterType={getMemberFilterType(
+                                                                    firstMember,
+                                                                    firstMemberField,
+                                                                )}
+                                                                field={
+                                                                    firstMemberField
+                                                                }
+                                                                member={
+                                                                    firstMember
+                                                                }
+                                                                label={getDashboardFilterRuleLabel(
+                                                                    firstMember,
+                                                                    fieldsMap,
+                                                                )}
+                                                                onChange={
+                                                                    handleChangeFilterRule
+                                                                }
+                                                                onOpen={
+                                                                    onSubPopoverOpen
+                                                                }
+                                                                onClose={
+                                                                    onSubPopoverClose
+                                                                }
+                                                            />
+                                                        )}
+                                                    </Group>
                                                 </Group>
                                                 <Stack
                                                     gap={6}

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.test.tsx
@@ -1,5 +1,5 @@
 import { FilterOperator, type DashboardFilterRule } from '@lightdash/common';
-import { act, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
@@ -143,6 +143,82 @@ describe('GuidedFilterSetupOverlay', () => {
 
         await userEvent.keyboard('{Escape}');
         expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('changes the rule operator from the inline operator menu', async () => {
+        renderWithProviders(<GuidedFilterSetupOverlay onDismiss={vi.fn()} />);
+
+        const operatorButton = screen.getByRole('button', {
+            name: 'Change operator for customers_first_name',
+        });
+        expect(operatorButton.textContent).toContain('is');
+
+        await userEvent.click(operatorButton);
+        // Mantine renders the dropdown hidden in jsdom, so query and click it directly
+        const option = await screen.findByRole('menuitem', {
+            name: 'starts with',
+            hidden: true,
+        });
+        fireEvent.click(option);
+
+        expect(
+            mockDashboardContext.current.updateDimensionDashboardFilter,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                operator: FilterOperator.STARTS_WITH,
+                disabled: true,
+            }),
+            0,
+            false,
+            false,
+        );
+    });
+
+    it('satisfies the rule immediately when a no-value operator is picked', async () => {
+        renderWithProviders(<GuidedFilterSetupOverlay onDismiss={vi.fn()} />);
+
+        await userEvent.click(
+            screen.getByRole('button', {
+                name: 'Change operator for customers_first_name',
+            }),
+        );
+        fireEvent.click(
+            await screen.findByRole('menuitem', {
+                name: 'is null',
+                hidden: true,
+            }),
+        );
+
+        expect(
+            mockDashboardContext.current.updateDimensionDashboardFilter,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                operator: FilterOperator.NULL,
+                disabled: false,
+            }),
+            0,
+            false,
+            false,
+        );
+    });
+
+    it('does not dismiss on Escape while the operator menu is open', async () => {
+        const onDismiss = vi.fn();
+        renderWithProviders(<GuidedFilterSetupOverlay onDismiss={onDismiss} />);
+
+        await userEvent.click(
+            screen.getByRole('button', {
+                name: 'Change operator for customers_first_name',
+            }),
+        );
+        await screen.findByRole('menuitem', {
+            name: 'starts with',
+            hidden: true,
+        });
+
+        // Without the sub-popover wiring this Escape would close the overlay
+        await userEvent.keyboard('{Escape}');
+        expect(onDismiss).not.toHaveBeenCalled();
     });
 
     it('does not dismiss on Escape while a filter dropdown inside the card is open', async () => {

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/OperatorPicker.module.css
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/OperatorPicker.module.css
@@ -1,0 +1,16 @@
+/* Muted inline text next to the strong field label, mirroring how the
+   toolbar chips render "field ... operator" */
+.operatorButton {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    flex-shrink: 0;
+    font-size: var(--mantine-font-size-xs);
+    color: var(--mantine-color-ldGray-6);
+    white-space: nowrap;
+}
+
+.dropdown {
+    max-height: 280px;
+    overflow-y: auto;
+}

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/OperatorPicker.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/OperatorPicker.tsx
@@ -1,0 +1,106 @@
+import {
+    getFilterRuleWithDefaultValue,
+    type DashboardFilterRule,
+    type FilterableItem,
+    type FilterType,
+} from '@lightdash/common';
+import { Menu, UnstyledButton } from '@mantine-8/core';
+import { IconCheck, IconChevronDown } from '@tabler/icons-react';
+import { useMemo, type FC } from 'react';
+import { getFilterOperatorOptions } from '../../../components/common/Filters/FilterInputs/utils';
+import MantineIcon from '../../../components/common/MantineIcon';
+import classes from './OperatorPicker.module.css';
+
+type Props = {
+    filterType: FilterType;
+    field: FilterableItem | undefined;
+    member: DashboardFilterRule;
+    /** Field label, used for the accessible button name */
+    label: string;
+    onChange: (newRule: DashboardFilterRule) => void;
+    onOpen?: () => void;
+    onClose?: () => void;
+};
+
+/**
+ * Quiet inline operator control for guided setup rows: reads as prose next to
+ * the field label ("Order date [is between]"), opens the same operator list as
+ * the filter-bar chip popover. Changing the operator resets the member's
+ * values to that operator's defaults, exactly like the chip popover does.
+ */
+const OperatorPicker: FC<Props> = ({
+    filterType,
+    field,
+    member,
+    label,
+    onChange,
+    onOpen,
+    onClose,
+}) => {
+    const options = useMemo(
+        () => getFilterOperatorOptions(filterType, field),
+        [filterType, field],
+    );
+    const currentLabel =
+        options.find((option) => option.value === member.operator)?.label ??
+        member.operator;
+
+    return (
+        <Menu
+            withinPortal
+            position="bottom-start"
+            shadow="md"
+            onOpen={onOpen}
+            onClose={onClose}
+        >
+            <Menu.Target>
+                <UnstyledButton
+                    className={classes.operatorButton}
+                    aria-label={`Change operator for ${label}`}
+                >
+                    {currentLabel}
+                    <MantineIcon icon={IconChevronDown} size={12} />
+                </UnstyledButton>
+            </Menu.Target>
+            <Menu.Dropdown className={classes.dropdown}>
+                {options.map((option) => (
+                    <Menu.Item
+                        key={option.value}
+                        fz="xs"
+                        rightSection={
+                            option.value === member.operator ? (
+                                <MantineIcon
+                                    icon={IconCheck}
+                                    size={12}
+                                    color="blue.6"
+                                />
+                            ) : undefined
+                        }
+                        onClick={() => {
+                            if (option.value === member.operator) return;
+                            // Unlike the chip popover there is no Apply step,
+                            // so pass null to clear values instead of seeding
+                            // defaults (a seeded date would instantly satisfy
+                            // the rule with a value the viewer never chose)
+                            onChange(
+                                getFilterRuleWithDefaultValue(
+                                    filterType,
+                                    field,
+                                    {
+                                        ...member,
+                                        operator: option.value,
+                                    },
+                                    null,
+                                ),
+                            );
+                        }}
+                    >
+                        {option.label}
+                    </Menu.Item>
+                ))}
+            </Menu.Dropdown>
+        </Menu>
+    );
+};
+
+export default OperatorPicker;


### PR DESCRIPTION
Adds an operator selector to each filter row in the guided setup modal ("Set filters to load this dashboard"). Viewers could previously only fill in values for the saved operator — e.g. a date filter saved as "is between" couldn't be switched to "is" to load a single day. The filter-bar chip popover already allows changing the operator, so this brings the guided setup to parity.

- New `OperatorPicker`: muted inline text control next to the field label (same operator list as the chip popover), rendered in the rule heading for single-filter rules and on each member row in "at least one of" groups
- Changing the operator swaps the value input and clears values — the modal applies instantly (no Apply step), so seeding defaults would satisfy the rule with a value the viewer never chose; no-value operators (is null / is not null) satisfy the row immediately, matching toolbar behaviour
- Operator changes persist as saved-filter overrides, exactly like chip-popover edits
- Satisfied rows now include the operator in their collapsed summary
- Escape closes the operator menu without dismissing the modal

## Screenshots

<img width="418" height="459" alt="02-light-group" src="https://github.com/user-attachments/assets/710582ba-f009-4eed-9bc7-b8b6d49d301b" />
<img width="1280" height="790" alt="03-light-operator-menu" src="https://github.com/user-attachments/assets/a7b2940f-32b8-47e5-a6f4-b96f180d4661" />
<img width="418" height="459" alt="05-dark-group" src="https://github.com/user-attachments/assets/c4c9bd28-81b4-400b-b1d9-ee9efc27c737" />



Closes: PROD-8971
Closes: #25710
