### PR TITLE
fix: derive inherited space role from org-level custom role scopes

### DIFF
--- a/packages/backend/src/models/SpacePermissionModel.ts
+++ b/packages/backend/src/models/SpacePermissionModel.ts
@@ -59,6 +59,14 @@ export type ProjectSpaceAccessWithCustomRole = ProjectSpaceAccess & {
     roleUuid: string | null;
 };
 
+/**
+ * Org-level custom-role assignments persist a placeholder `member` in
+ * `organization_memberships.role`; the real role lives in `role_uuid`.
+ */
+export type OrganizationSpaceAccessWithCustomRole = OrganizationSpaceAccess & {
+    roleUuid: string | null;
+};
+
 export class SpacePermissionModel {
     constructor(private readonly database: Knex) {}
 
@@ -504,17 +512,18 @@ export class SpacePermissionModel {
         spaceUuids: string[],
         filters?: { userUuid?: string },
         { trx = this.database }: { trx?: Knex } = {},
-    ): Promise<Record<string, OrganizationSpaceAccess[]>> {
+    ): Promise<Record<string, OrganizationSpaceAccessWithCustomRole[]>> {
         return wrapSentryTransaction(
             'SpaceModel.getOrganizationSpaceAccess',
             { spaceUuidsCount: spaceUuids.length },
             async () => {
-                const organizationSpacesAccess: OrganizationSpaceAccess[] =
+                const organizationSpacesAccess: OrganizationSpaceAccessWithCustomRole[] =
                     await trx(SpaceTableName)
                         .select({
                             userUuid: `${UserTableName}.user_uuid`,
                             spaceUuid: `${SpaceTableName}.space_uuid`,
                             role: `${OrganizationMembershipsTableName}.role`,
+                            roleUuid: `${OrganizationMembershipsTableName}.role_uuid`,
                         })
                         .innerJoin(
                             ProjectTableName,
@@ -547,7 +556,7 @@ export class SpacePermissionModel {
                         });
 
                 return organizationSpacesAccess.reduce<
-                    Record<string, OrganizationSpaceAccess[]>
+                    Record<string, OrganizationSpaceAccessWithCustomRole[]>
                 >((acc, organizationSpaceAccess) => {
                     if (!acc[organizationSpaceAccess.spaceUuid]) {
                         acc[organizationSpaceAccess.spaceUuid] = [];

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -6,7 +6,6 @@ import {
     SpaceMemberRole,
     type DirectSpaceAccess,
     type OrganizationMemberRole,
-    type OrganizationSpaceAccess,
     type PossibleAbilities,
     type ProjectMemberRole,
     type SessionUser,
@@ -16,6 +15,7 @@ import { type Knex } from 'knex';
 import { SpaceModel } from '../../models/SpaceModel';
 import {
     SpacePermissionModel,
+    type OrganizationSpaceAccessWithCustomRole,
     type ProjectSpaceAccessWithCustomRole,
 } from '../../models/SpacePermissionModel';
 import { SpacePermissionService } from './SpacePermissionService';
@@ -57,7 +57,9 @@ const createMockSpacePermissionModel = () => ({
                 spaceUuids: string[],
                 filters?: { userUuid?: string },
                 options?: { trx?: Knex },
-            ) => Promise<Record<string, OrganizationSpaceAccess[]>>
+            ) => Promise<
+                Record<string, OrganizationSpaceAccessWithCustomRole[]>
+            >
         >(),
     getSpaceInfo:
         vi.fn<
@@ -205,6 +207,7 @@ describe('SpacePermissionService', () => {
                         userUuid,
                         spaceUuid: 'root-space',
                         role: 'member' as OrganizationMemberRole,
+                        roleUuid: null,
                     },
                 ],
             });
@@ -269,6 +272,7 @@ describe('SpacePermissionService', () => {
                         userUuid,
                         spaceUuid: 'root-space',
                         role: 'member' as OrganizationMemberRole,
+                        roleUuid: null,
                     },
                 ],
             });
@@ -290,6 +294,64 @@ describe('SpacePermissionService', () => {
 
             expect(mockPermissionModel.getRoleScopes).toHaveBeenCalledWith(
                 [customRoleUuid],
+                { trx: undefined },
+            );
+            expect(result.access).toEqual([
+                expect.objectContaining({
+                    userUuid,
+                    role: SpaceMemberRole.EDITOR,
+                }),
+            ]);
+        });
+
+        test('org-level custom-role holders get the space role derived from their scopes, not the member placeholder', async () => {
+            const spaceUuid = 'root-space';
+            const orgCustomRoleUuid = 'org-custom-role-uuid';
+
+            mockPermissionModel.getInheritanceChains.mockResolvedValue({
+                'root-space': {
+                    chain: [
+                        {
+                            spaceUuid: 'root-space',
+                            spaceName: 'Root',
+                            inheritParentPermissions: true,
+                        },
+                    ],
+                    inheritsFromOrgOrProject: true,
+                },
+            });
+            mockPermissionModel.getDirectSpaceAccess.mockResolvedValue({});
+            // No project membership — access comes from the org layer only
+            mockPermissionModel.getProjectSpaceAccess.mockResolvedValue({});
+            // Org custom-role assignments persist `role: member` as a placeholder
+            mockPermissionModel.getOrganizationSpaceAccess.mockResolvedValue({
+                'root-space': [
+                    {
+                        userUuid,
+                        spaceUuid: 'root-space',
+                        role: 'member' as OrganizationMemberRole,
+                        roleUuid: orgCustomRoleUuid,
+                    },
+                ],
+            });
+            mockPermissionModel.getSpaceInfo.mockResolvedValue({
+                [spaceUuid]: {
+                    projectUuid,
+                    organizationUuid,
+                },
+            });
+            mockPermissionModel.getRoleScopes.mockResolvedValue({
+                [orgCustomRoleUuid]: [
+                    'manage:Space@public',
+                    'manage:Dashboard@space',
+                    'manage:SavedChart@space',
+                ],
+            });
+
+            const result = await service.getAllSpaceAccessContext(spaceUuid);
+
+            expect(mockPermissionModel.getRoleScopes).toHaveBeenCalledWith(
+                [orgCustomRoleUuid],
                 { trx: undefined },
             );
             expect(result.access).toEqual([
@@ -351,6 +413,7 @@ describe('SpacePermissionService', () => {
                         userUuid,
                         spaceUuid: 'private-space',
                         role: 'member' as OrganizationMemberRole,
+                        roleUuid: null,
                     },
                 ],
             });
@@ -405,6 +468,7 @@ describe('SpacePermissionService', () => {
                         userUuid: adminUuid,
                         spaceUuid: 'private-space',
                         role: 'admin' as OrganizationMemberRole,
+                        roleUuid: null,
                     },
                 ],
             });
@@ -774,16 +838,19 @@ describe('SpacePermissionService', () => {
                         userUuid: 'org-admin',
                         spaceUuid,
                         role: 'admin' as OrganizationMemberRole,
+                        roleUuid: null,
                     },
                     {
                         userUuid: 'dual-admin',
                         spaceUuid,
                         role: 'admin' as OrganizationMemberRole,
+                        roleUuid: null,
                     },
                     {
                         userUuid: 'org-member',
                         spaceUuid,
                         role: 'member' as OrganizationMemberRole,
+                        roleUuid: null,
                     },
                 ],
             });
@@ -1211,6 +1278,7 @@ describe('SpacePermissionService', () => {
                         userUuid,
                         spaceUuid,
                         role: 'viewer' as OrganizationMemberRole,
+                        roleUuid: null,
                     },
                 ],
             });
@@ -1255,6 +1323,7 @@ describe('SpacePermissionService', () => {
                         userUuid,
                         spaceUuid,
                         role: 'viewer' as OrganizationMemberRole,
+                        roleUuid: null,
                     },
                 ],
             });

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     getHighestSpaceRole,
+    getOrganizationRoleForSpaceAccess,
     getProjectRoleForSpaceAccess,
     NotFoundError,
     OrganizationMemberRole,
@@ -18,6 +19,7 @@ import { Knex } from 'knex';
 import { SpaceModel } from '../../models/SpaceModel';
 import {
     SpacePermissionModel,
+    type OrganizationSpaceAccessWithCustomRole,
     type ProjectSpaceAccessWithCustomRole,
 } from '../../models/SpacePermissionModel';
 import { BaseService } from '../BaseService';
@@ -176,26 +178,35 @@ export class SpacePermissionService extends BaseService {
     }
 
     /**
-     * Custom-role project/group assignments persist a placeholder `viewer` in
-     * the legacy `role` column (the real role lives in `role_uuid`). Replace
-     * the placeholder with the role derived from the custom role's scopes so
-     * inherited space access reflects what the role actually grants.
+     * Custom-role assignments persist a placeholder in the legacy `role`
+     * column (`viewer` on project/group access, `member` on org memberships)
+     * with the real role in `role_uuid`. Replace the placeholder with the
+     * role derived from the custom role's scopes so inherited space access
+     * reflects what the role actually grants.
      */
-    private async resolveCustomRoleProjectAccess(
+    private async resolveCustomRoleAccess(
         projectAccessMap: Record<string, ProjectSpaceAccessWithCustomRole[]>,
+        organizationAccessMap: Record<
+            string,
+            OrganizationSpaceAccessWithCustomRole[]
+        >,
         { trx }: { trx?: Knex } = {},
-    ): Promise<Record<string, ProjectSpaceAccess[]>> {
+    ): Promise<{
+        projectAccessMap: Record<string, ProjectSpaceAccess[]>;
+        organizationAccessMap: Record<string, OrganizationSpaceAccess[]>;
+    }> {
         const customRoleUuids = [
             ...new Set(
-                Object.values(projectAccessMap)
-                    .flat()
-                    .flatMap((access) =>
-                        access.roleUuid ? [access.roleUuid] : [],
-                    ),
+                [
+                    ...Object.values(projectAccessMap).flat(),
+                    ...Object.values(organizationAccessMap).flat(),
+                ].flatMap((access) =>
+                    access.roleUuid ? [access.roleUuid] : [],
+                ),
             ),
         ];
         if (customRoleUuids.length === 0) {
-            return projectAccessMap;
+            return { projectAccessMap, organizationAccessMap };
         }
 
         const scopesByRole = await this.spacePermissionModel.getRoleScopes(
@@ -203,21 +214,42 @@ export class SpacePermissionService extends BaseService {
             { trx },
         );
 
-        return Object.fromEntries(
-            Object.entries(projectAccessMap).map(([spaceUuid, accessList]) => [
-                spaceUuid,
-                accessList.map(({ roleUuid, ...access }) =>
-                    roleUuid
-                        ? {
-                              ...access,
-                              role: getProjectRoleForSpaceAccess(
-                                  scopesByRole[roleUuid] ?? [],
-                              ),
-                          }
-                        : access,
+        return {
+            projectAccessMap: Object.fromEntries(
+                Object.entries(projectAccessMap).map(
+                    ([spaceUuid, accessList]) => [
+                        spaceUuid,
+                        accessList.map(({ roleUuid, ...access }) =>
+                            roleUuid
+                                ? {
+                                      ...access,
+                                      role: getProjectRoleForSpaceAccess(
+                                          scopesByRole[roleUuid] ?? [],
+                                      ),
+                                  }
+                                : access,
+                        ),
+                    ],
                 ),
-            ]),
-        );
+            ),
+            organizationAccessMap: Object.fromEntries(
+                Object.entries(organizationAccessMap).map(
+                    ([spaceUuid, accessList]) => [
+                        spaceUuid,
+                        accessList.map(({ roleUuid, ...access }) =>
+                            roleUuid
+                                ? {
+                                      ...access,
+                                      role: getOrganizationRoleForSpaceAccess(
+                                          scopesByRole[roleUuid] ?? [],
+                                      ),
+                                  }
+                                : access,
+                        ),
+                    ],
+                ),
+            ),
+        };
     }
 
     /**
@@ -270,41 +302,50 @@ export class SpacePermissionService extends BaseService {
         ];
 
         // Batch-fetch access data
-        const [directAccessMap, projectAccessMap, orgAccessMap, spaceInfo] =
-            await Promise.all([
-                this.spacePermissionModel.getDirectSpaceAccess(
-                    allChainSpaceUuids,
-                    filters,
-                    { trx },
-                ),
-                allChainsRootSpaceUuids.length > 0
-                    ? this.spacePermissionModel
-                          .getProjectSpaceAccess(
-                              allChainsRootSpaceUuids,
-                              filters,
-                              { trx },
-                          )
-                          .then((access) =>
-                              this.resolveCustomRoleProjectAccess(access, {
-                                  trx,
-                              }),
-                          )
-                    : Promise.resolve(
-                          {} as Record<string, ProjectSpaceAccess[]>,
-                      ),
-                allChainsRootSpaceUuids.length > 0
-                    ? this.spacePermissionModel.getOrganizationSpaceAccess(
-                          allChainsRootSpaceUuids,
-                          filters,
-                          { trx },
-                      )
-                    : Promise.resolve(
-                          {} as Record<string, OrganizationSpaceAccess[]>,
-                      ),
-                this.spacePermissionModel.getSpaceInfo(uniqueSpaceUuids, {
-                    trx,
-                }),
-            ]);
+        const [
+            directAccessMap,
+            rawProjectAccessMap,
+            rawOrgAccessMap,
+            spaceInfo,
+        ] = await Promise.all([
+            this.spacePermissionModel.getDirectSpaceAccess(
+                allChainSpaceUuids,
+                filters,
+                { trx },
+            ),
+            allChainsRootSpaceUuids.length > 0
+                ? this.spacePermissionModel.getProjectSpaceAccess(
+                      allChainsRootSpaceUuids,
+                      filters,
+                      { trx },
+                  )
+                : Promise.resolve(
+                      {} as Record<string, ProjectSpaceAccessWithCustomRole[]>,
+                  ),
+            allChainsRootSpaceUuids.length > 0
+                ? this.spacePermissionModel.getOrganizationSpaceAccess(
+                      allChainsRootSpaceUuids,
+                      filters,
+                      { trx },
+                  )
+                : Promise.resolve(
+                      {} as Record<
+                          string,
+                          OrganizationSpaceAccessWithCustomRole[]
+                      >,
+                  ),
+            this.spacePermissionModel.getSpaceInfo(uniqueSpaceUuids, {
+                trx,
+            }),
+        ]);
+
+        // Substitute scope-derived roles for custom-role placeholder rows
+        const { projectAccessMap, organizationAccessMap: orgAccessMap } =
+            await this.resolveCustomRoleAccess(
+                rawProjectAccessMap,
+                rawOrgAccessMap,
+                { trx },
+            );
 
         // For each requested space, aggregate access from its chain
         const result: Record<string, SpaceAccessContextForCasl> = {};

--- a/packages/common/src/authorization/space/customRoleProjectRole.test.ts
+++ b/packages/common/src/authorization/space/customRoleProjectRole.test.ts
@@ -1,7 +1,13 @@
 import { ProjectMemberRole } from '../../types/projectMemberRole';
-import { convertProjectRoleToSpaceRole } from '../../utils/projectMemberRole';
+import {
+    convertOrganizationRoleToProjectRole,
+    convertProjectRoleToSpaceRole,
+} from '../../utils/projectMemberRole';
 import { PROJECT_ROLE_TO_SCOPES_MAP } from '../roleToScopeMapping';
-import { getProjectRoleForSpaceAccess } from './customRoleProjectRole';
+import {
+    getOrganizationRoleForSpaceAccess,
+    getProjectRoleForSpaceAccess,
+} from './customRoleProjectRole';
 
 describe('getProjectRoleForSpaceAccess', () => {
     it.each(Object.values(ProjectMemberRole))(
@@ -13,6 +19,20 @@ describe('getProjectRoleForSpaceAccess', () => {
             expect(convertProjectRoleToSpaceRole(derivedRole)).toEqual(
                 convertProjectRoleToSpaceRole(role),
             );
+        },
+    );
+});
+
+describe('getOrganizationRoleForSpaceAccess', () => {
+    it.each(Object.values(ProjectMemberRole))(
+        'org derivation converts to the same project role as the direct derivation for %s scopes',
+        (role) => {
+            const scopes = [...PROJECT_ROLE_TO_SCOPES_MAP[role]];
+            expect(
+                convertOrganizationRoleToProjectRole(
+                    getOrganizationRoleForSpaceAccess(scopes),
+                ),
+            ).toEqual(getProjectRoleForSpaceAccess(scopes));
         },
     );
 });

--- a/packages/common/src/authorization/space/customRoleProjectRole.ts
+++ b/packages/common/src/authorization/space/customRoleProjectRole.ts
@@ -1,3 +1,4 @@
+import { OrganizationMemberRole } from '../../types/organizationMemberProfile';
 import { ProjectMemberRole } from '../../types/projectMemberRole';
 
 /**
@@ -20,4 +21,23 @@ export const getProjectRoleForSpaceAccess = (
         return ProjectMemberRole.EDITOR;
     }
     return ProjectMemberRole.VIEWER;
+};
+
+/**
+ * Organization-role equivalent of a custom role for space-access resolution.
+ * Same derivation as `getProjectRoleForSpaceAccess` — org-level custom-role
+ * assignments persist a placeholder `member` in `organization_memberships`,
+ * which would otherwise grant no inherited space access at all.
+ */
+export const getOrganizationRoleForSpaceAccess = (
+    scopes: string[],
+): OrganizationMemberRole => {
+    switch (getProjectRoleForSpaceAccess(scopes)) {
+        case ProjectMemberRole.ADMIN:
+            return OrganizationMemberRole.ADMIN;
+        case ProjectMemberRole.EDITOR:
+            return OrganizationMemberRole.EDITOR;
+        default:
+            return OrganizationMemberRole.VIEWER;
+    }
 };


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8976/org-level-custom-role-users-get-no-inherited-space-access

### Description:
Org-level custom-role assignments persist a placeholder 'member' in organization_memberships.role (the real role lives in role_uuid), and space access resolution read only the role column. Since 'member' converts to no project role, org-custom-role holders (including service accounts) got no inherited space access at all.

Applies the same scope derivation as the project-level fix (#25680) to the organization layer: getOrganizationSpaceAccess now surfaces role_uuid, and SpacePermissionService substitutes the scope-derived role for both layers with a single scoped_roles lookup.
