### PR TITLE
refactor: rename data-app viewer URL from `/preview` to `/view`

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -281,7 +281,7 @@ review rules):**
   when one of the invalidation conditions becomes true, not on every refetch.
 
 This is read-only — pinning an older version is preview-only and does **not** mutate `app_versions` or change which
-version is served outside the generation page (the public `/preview` route still shows the latest ready version). A
+version is served outside the generation page (the public `/view` route still shows the latest ready version). A
 true "restore this version as v_next" flow is a separate, later step ([GLITCH-443](https://linear.app/lightdash/issue/GLITCH-443)).
 
 ### Deletion
@@ -945,8 +945,11 @@ If the org design linked to the app has more than **30 asset files**, the theme 
 | `/projects/:projectUuid/apps`                                    | `SavedApps.tsx`      | Browse all data apps (content section)    |
 | `/projects/:projectUuid/apps/generate`                           | `AppGenerate.tsx`    | New app creation (split-panel chat UI)    |
 | `/projects/:projectUuid/apps/:appUuid`                           | `AppGenerate.tsx`    | Edit existing app (loads version history) |
-| `/projects/:projectUuid/apps/:appUuid/versions/:version/preview` | `AppPreviewTest.tsx` | Standalone preview                        |
-| `/projects/:projectUuid/apps/:appUuid/preview`                   | `AppPreviewTest.tsx` | Preview latest ready version              |
+| `/projects/:projectUuid/apps/:appUuid/versions/:version/view`    | `AppPreviewTest.tsx` | View a specific version                   |
+| `/projects/:projectUuid/apps/:appUuid/view`                      | `AppPreviewTest.tsx` | View latest ready version                 |
+
+The `.../view` routes previously lived at `.../preview`; the old paths are kept as client-side redirects
+(`LegacyAppPreviewRedirect.tsx`) so bookmarked links keep working.
 
 ### Key Hooks
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -5335,7 +5335,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         // ChatMessageContent) back to the preview version it came from, for
         // provenance.
         const sourceDisplayName = sourceApp.name || 'untitled app';
-        const sourcePreviewPath = `/projects/${projectUuid}/apps/${sourceApp.app_id}/versions/${sourceVersion.version}/preview`;
+        const sourcePreviewPath = `/projects/${projectUuid}/apps/${sourceApp.app_id}/versions/${sourceVersion.version}/view`;
         const prompt = `Promote [${sourceDisplayName}](${sourcePreviewPath})`;
         const { client: s3Client, bucket } = this.getS3Client();
 
@@ -5627,7 +5627,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         // app" with a markdown link to the source's preview at the version
         // we forked from, and a static assistant reply confirming success.
         const sourceDisplayName = sourceApp.name || 'untitled app';
-        const sourcePreviewPath = `/projects/${projectUuid}/apps/${sourceApp.app_id}/versions/${sourceVersion.version}/preview`;
+        const sourcePreviewPath = `/projects/${projectUuid}/apps/${sourceApp.app_id}/versions/${sourceVersion.version}/view`;
         const duplicatePrompt = `Duplicate [${sourceDisplayName}](${sourcePreviewPath})`;
 
         try {
@@ -5860,7 +5860,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         const newVersion = 1;
 
         const sourceDisplayName = sourceApp.name || 'untitled app';
-        const sourcePreviewPath = `/projects/${sourceProjectUuid}/apps/${sourceApp.app_id}/versions/${sourceVersion.version}/preview`;
+        const sourcePreviewPath = `/projects/${sourceProjectUuid}/apps/${sourceApp.app_id}/versions/${sourceVersion.version}/view`;
         const prompt = `Duplicate [${sourceDisplayName}](${sourcePreviewPath})`;
 
         // Keep the S3 copy inside the try so an S3 failure is per-app (logged

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -510,7 +510,7 @@ export default class SchedulerTask {
                 throw new Error(`App not found: ${appUuid}`);
             }
             return {
-                url: `${this.lightdashConfig.siteUrl}/projects/${app.project_uuid}/apps/${appUuid}/preview`,
+                url: `${this.lightdashConfig.siteUrl}/projects/${app.project_uuid}/apps/${appUuid}/view`,
                 minimalUrl: `${this.lightdashConfig.headlessBrowser.internalLightdashHost}/minimal/projects/${app.project_uuid}/apps/${appUuid}`,
                 details: {
                     name: app.name,
@@ -653,7 +653,7 @@ export default class SchedulerTask {
         );
         let deliveryUrl: string;
         if (appUuid) {
-            deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/apps/${appUuid}/preview?${schedulerUuidParam}`;
+            deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/apps/${appUuid}/view?${schedulerUuidParam}`;
         } else if (savedChartUuid) {
             deliveryUrl = `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/saved/${savedChartUuid}/view?${schedulerUuidParam}`;
         } else {

--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -36,6 +36,7 @@ import ProjectSwitcher from './components/NavBar/ProjectSwitcher';
 import { ThemeSwitcher } from './components/NavBar/ThemeSwitcher';
 import PrivateRoute from './components/PrivateRoute';
 import ProjectRoute from './components/ProjectRoute';
+import LegacyAppPreviewRedirect from './features/apps/LegacyAppPreviewRedirect';
 import { loadLazyRouteDefault } from './features/chunkErrorHandler';
 import { useActiveProjectUuid } from './hooks/useActiveProject';
 import useLogoutMutation from './hooks/user/useUserLogoutMutation';
@@ -441,7 +442,7 @@ const APP_ROUTES: RouteObject[] = [
                         },
                     },
                     {
-                        path: '/projects/:projectUuid/apps/:appUuid/preview',
+                        path: '/projects/:projectUuid/apps/:appUuid/view',
                         lazy: async () => {
                             const AppPreviewTest = await loadLazyRouteDefault(
                                 './pages/AppPreviewTest',
@@ -451,7 +452,7 @@ const APP_ROUTES: RouteObject[] = [
                         },
                     },
                     {
-                        path: '/projects/:projectUuid/apps/:appUuid/versions/:version/preview',
+                        path: '/projects/:projectUuid/apps/:appUuid/versions/:version/view',
                         lazy: async () => {
                             const AppPreviewTest = await loadLazyRouteDefault(
                                 './pages/AppPreviewTest',
@@ -459,6 +460,14 @@ const APP_ROUTES: RouteObject[] = [
                             );
                             return { Component: AppPreviewTest };
                         },
+                    },
+                    {
+                        path: '/projects/:projectUuid/apps/:appUuid/preview',
+                        element: <LegacyAppPreviewRedirect />,
+                    },
+                    {
+                        path: '/projects/:projectUuid/apps/:appUuid/versions/:version/preview',
+                        element: <LegacyAppPreviewRedirect />,
                     },
                 ],
             },

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -10,6 +10,7 @@ import PrivateRoute from './components/PrivateRoute';
 import ProjectRoute from './components/ProjectRoute';
 import CreateProjectSettings from './components/Settings/CreateProjectSettings';
 import UserCompletionModal from './components/UserCompletionModal';
+import LegacyAppPreviewRedirect from './features/apps/LegacyAppPreviewRedirect';
 import { loadLazyRouteDefault } from './features/chunkErrorHandler';
 import { MetricCatalogView } from './features/metricsCatalog/types';
 import { TrackPage } from './providers/Tracking/TrackingProvider';
@@ -637,7 +638,7 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
         },
     },
     {
-        path: 'apps/:appUuid/versions/:version/preview',
+        path: 'apps/:appUuid/versions/:version/view',
         handle: { hideAILauncher: true },
         lazy: async () => {
             const AppPreviewTest = await loadLazyRouteDefault(
@@ -648,7 +649,7 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
         },
     },
     {
-        path: 'apps/:appUuid/preview',
+        path: 'apps/:appUuid/view',
         handle: { hideAILauncher: true },
         lazy: async () => {
             const AppPreviewTest = await loadLazyRouteDefault(
@@ -657,6 +658,14 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
             );
             return { Component: AppPreviewTest };
         },
+    },
+    {
+        path: 'apps/:appUuid/versions/:version/preview',
+        element: <LegacyAppPreviewRedirect />,
+    },
+    {
+        path: 'apps/:appUuid/preview',
+        element: <LegacyAppPreviewRedirect />,
     },
     {
         path: 'user-activity',

--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -52,7 +52,7 @@ const getFavoriteItemUrl = (projectUuid: string, item: ResourceViewItem) => {
         case ResourceViewItemType.SPACE:
             return `/projects/${projectUuid}/spaces/${item.data.uuid}`;
         case ResourceViewItemType.DATA_APP:
-            return `/projects/${projectUuid}/apps/${item.data.uuid}/preview`;
+            return `/projects/${projectUuid}/apps/${item.data.uuid}/view`;
         default:
             return assertUnreachable(item, `Unknown favorite item type`);
     }

--- a/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewUtils.tsx
@@ -191,7 +191,7 @@ export const getSchedulerLink = (
                 resourcePath = `/projects/${projectUuid}/dashboards/${item.resourceUuid}/view`;
                 break;
             case SchedulerResourceType.APP:
-                resourcePath = `/projects/${projectUuid}/apps/${item.resourceUuid}/preview`;
+                resourcePath = `/projects/${projectUuid}/apps/${item.resourceUuid}/view`;
                 break;
             default:
                 assertUnreachable(

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -338,7 +338,7 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
                                 {hasReadyVersion(app) && (
                                     <Menu.Item
                                         component={Link}
-                                        to={`/projects/${app.projectUuid}/apps/${app.appUuid}/preview`}
+                                        to={`/projects/${app.projectUuid}/apps/${app.appUuid}/view`}
                                         target="_blank"
                                         leftSection={
                                             <MantineIcon

--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -87,7 +87,7 @@ export const getResourceUrl = (projectUuid: string, item: ResourceViewItem) => {
         case ResourceViewItemType.SPACE:
             return `/projects/${projectUuid}/spaces/${item.data.uuid}`;
         case ResourceViewItemType.DATA_APP:
-            return `/projects/${projectUuid}/apps/${item.data.uuid}/preview`;
+            return `/projects/${projectUuid}/apps/${item.data.uuid}/view`;
         default:
             return assertUnreachable(item, `Can't get URL for ${itemType}`);
     }

--- a/packages/frontend/src/features/apps/LegacyAppPreviewRedirect.tsx
+++ b/packages/frontend/src/features/apps/LegacyAppPreviewRedirect.tsx
@@ -1,0 +1,23 @@
+import { Navigate, useLocation, useParams } from 'react-router';
+
+// The app viewer used to live at `/preview`; old bookmarked links must keep working.
+const LegacyAppPreviewRedirect = () => {
+    const { projectUuid, appUuid, version } = useParams();
+    const location = useLocation();
+    const basePath = `/projects/${projectUuid}/apps/${appUuid}`;
+
+    return (
+        <Navigate
+            to={{
+                pathname: version
+                    ? `${basePath}/versions/${version}/view`
+                    : `${basePath}/view`,
+                search: location.search,
+                hash: location.hash,
+            }}
+            replace
+        />
+    );
+};
+
+export default LegacyAppPreviewRedirect;

--- a/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
+++ b/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
@@ -157,7 +157,7 @@ export const getSearchItemMap = (
         item: item,
         searchRank: item.search_rank,
         location: {
-            pathname: `/projects/${projectUuid}/apps/${item.uuid}/preview`,
+            pathname: `/projects/${projectUuid}/apps/${item.uuid}/view`,
         },
     }));
 

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -3049,7 +3049,7 @@ const AppGenerate: FC = () => {
                                                 previewApp ? (
                                                     <Menu.Item
                                                         component={Link}
-                                                        to={`/projects/${projectUuid}/apps/${previewApp.appUuid}/preview`}
+                                                        to={`/projects/${projectUuid}/apps/${previewApp.appUuid}/view`}
                                                         target="_blank"
                                                         leftSection={
                                                             <MantineIcon


### PR DESCRIPTION
### Description:
The `/preview` route was a relic of early data-app versions and confused customers into thinking it was an ephemeral endpoint, when it's the canonical viewer for the latest ready version. Renamed to /view to match the dashboard/chart viewer convention:

- `/projects/:projectUuid/apps/:appUuid/view` (latest ready version)
- `/projects/:projectUuid/apps/:appUuid/versions/:version/view` (pinned)

Old `/preview` links (e.g. bookmarks) still work: the legacy paths render LegacyAppPreviewRedirect, which replace-redirects to /view preserving query string and hash (e.g. ?schedulerUuid=).

Updated all link generators: resource views, browse menu, omnibar, schedulers view, My Apps panel, builder preview link, scheduled-delivery URLs (SchedulerTask), and promote/duplicate chat links (AppGenerateService). The preview-token API endpoints and the token-based iframe serving path (/api/apps/...) are unrelated and unchanged.