### PR TITLE
feat(ai): additive viz renderer and query-results plumbing for deep research

### DIFF
--- a/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
+++ b/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
@@ -364,6 +364,21 @@ export class QueryHistoryModel {
         return result ? convertDbQueryHistoryToQueryHistory(result) : undefined;
     }
 
+    async preserveResults(args: {
+        queryUuid: string;
+        projectUuid: string;
+        createdByUserUuid: string;
+    }): Promise<boolean> {
+        const updated = await this.database(QueryHistoryTableName)
+            .where('query_uuid', args.queryUuid)
+            .where('project_uuid', args.projectUuid)
+            .where('created_by_user_uuid', args.createdByUserUuid)
+            .where('status', QueryHistoryStatus.READY)
+            .update({ results_expires_at: null });
+
+        return updated > 0;
+    }
+
     async pollForQueryCompletion({
         queryUuid,
         account,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -74,6 +74,8 @@ type Props = {
     // dashboard path to sync the change back into the query cache.
     onExpandedChartConfigChange?: (config: ChartConfig) => void;
     headerContent?: ReactNode;
+    displayFields?: boolean;
+    displayFilters?: boolean;
 };
 
 export const AiVisualizationRenderer: FC<Props> = ({
@@ -85,6 +87,8 @@ export const AiVisualizationRenderer: FC<Props> = ({
     switcherVariant = 'default',
     onExpandedChartConfigChange,
     headerContent,
+    displayFields = true,
+    displayFilters: displayFiltersProp = true,
 }) => {
     const { data: health } = useHealth();
     const { projectUuid } = useParams<{ projectUuid: string }>();
@@ -166,16 +170,17 @@ export const AiVisualizationRenderer: FC<Props> = ({
         [webAiChartConfig],
     );
 
-    const displayMetricsAndDimensions = shouldDisplayMetricsAndDimensions(
-        vizQueryData.type,
-    );
-    const displayFilters = shouldDisplayVisualizationFilters(
-        metricQuery.filters,
-    );
+    const displayMetricsAndDimensions =
+        displayFields && shouldDisplayMetricsAndDimensions(vizQueryData.type);
+    const displayFilters =
+        displayFiltersProp &&
+        shouldDisplayVisualizationFilters(metricQuery.filters);
     const fieldsCount = displayMetricsAndDimensions
         ? getVisualizationFieldsCount(metricQuery)
         : 0;
-    const filtersCount = getVisualizationFiltersCount(metricQuery.filters);
+    const filtersCount = displayFilters
+        ? getVisualizationFiltersCount(metricQuery.filters)
+        : 0;
     const displayDetails = fieldsCount > 0 || filtersCount > 0;
 
     const defaultChartType: AiAgentChartTypeOption =
@@ -241,7 +246,17 @@ export const AiVisualizationRenderer: FC<Props> = ({
                 onChartConfigChange={handleChartConfigChange}
                 unsavedMetricQuery={metricQuery}
             >
-                <Stack gap="md" h="100%" style={{ minHeight: 0 }}>
+                <Stack
+                    gap="md"
+                    h="100%"
+                    w="100%"
+                    maw="100%"
+                    style={{
+                        minHeight: 0,
+                        minWidth: 0,
+                        overflow: 'hidden',
+                    }}
+                >
                     {headerContent}
                     {webAiChartConfig.type === AiResultType.QUERY_RESULT &&
                         onChartTypeChange && (
@@ -262,6 +277,9 @@ export const AiVisualizationRenderer: FC<Props> = ({
                     <Box
                         flex="1"
                         mih={0}
+                        miw={0}
+                        w="100%"
+                        maw="100%"
                         style={{
                             // Scrolling for tables
                             overflow: 'auto',

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -311,6 +311,7 @@ export type InfiniteQueryResults = Partial<
     isFetchingRows: boolean;
     isFetchingAllPages: boolean;
     fetchMoreRows: () => void;
+    refetchRows: () => Promise<unknown>;
     setFetchAll: (value: boolean) => void;
     fetchAll: boolean;
     hasFetchedAllRows: boolean;
@@ -569,6 +570,7 @@ export const useInfiniteQueryResults = (
             rows: fetchedRows,
             isFetchingRows,
             fetchMoreRows,
+            refetchRows: nextPage.refetch,
             setFetchAll,
             totalClientFetchTimeMs,
             isInitialLoading: isInitialLoading || dependenciesChanged,
@@ -590,6 +592,7 @@ export const useInfiniteQueryResults = (
             fetchedRows,
             isFetchingRows,
             fetchMoreRows,
+            nextPage.refetch,
             totalClientFetchTimeMs,
             isInitialLoading,
             nextPage.error,


### PR DESCRIPTION
## Summary

PR 1 of 5 in the deep research markdown report stack. Adds the shared plumbing the report feature consumes upstack — every change is additive and default-preserving, so no existing caller changes behaviour.

Stacks on: `main`. Consumed by [#25732](https://github.com/lightdash/lightdash/pull/25732) (backend) and [#25733](https://github.com/lightdash/lightdash/pull/25733) (frontend).

## Changes

**Frontend**
- `AiVisualizationRenderer` gains `displayFields` and `displayFilters` props (both default `true`). The report chart tile passes `false` to render a bare visualization; AI chat, artifact panel, and dashboard callers pass nothing and render exactly as before. Also hardens width/overflow so the chart fits narrow containers.
- `useInfiniteQueryResults` returns `refetchRows` (wired to the current page's refetch) for retry affordances.

**Backend**
- `QueryHistoryModel.preserveResults({ queryUuid, projectUuid, createdByUserUuid })` nulls `results_expires_at` on a `READY` row so report chart evidence outlives the normal query-cache TTL. Unused until PR 3.

## Compatibility

```
Caller                      displayFields  displayFilters  behaviour
AiChartVisualization        (unset) true   (unset) true    unchanged
AiArtifactPanel             (unset) true   (unset) true    unchanged
AiDashboardVisualization    (unset) true   (unset) true    unchanged
DeepResearchChartTile (PR4) false          false           bare viz + pills
```

## Test plan

- [x] `pnpm -F backend typecheck:fast` / `pnpm -F frontend typecheck:fast` clean at this level of the stack (rest of tree = main)
- [x] Full backend + frontend unit suites pass at the stack tip
- [x] Manual smoke upstack: AI chat charts still show fields/filters rows; report tiles render bare

🤖 Generated with [Claude Code](https://claude.com/claude-code)