### PR TITLE
feat(ai): deep research markdown report model and lint

### DIFF
--- a/packages/common/src/ee/aiDeepResearch/markdown.test.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.test.ts
@@ -1,0 +1,323 @@
+import {
+    countDeepResearchFindings,
+    extractDeepResearchCharts,
+    findDeepResearchChartBlocks,
+    lintDeepResearchReportMarkdown,
+    spliceDeepResearchChartBlocks,
+} from './markdown';
+
+const chartJson = (queryUuid: string, title = 'Revenue by month') =>
+    JSON.stringify({
+        queryUuid,
+        title,
+        chartConfig: {
+            defaultVizType: 'bar',
+            xAxisDimension: 'orders_month',
+            yAxisMetrics: ['orders_total_revenue'],
+            groupBy: null,
+            xAxisType: 'time',
+            stackBars: null,
+            lineType: null,
+            funnelDataInput: null,
+            xAxisLabel: 'Month',
+            yAxisLabel: 'Revenue',
+            secondaryYAxisMetric: null,
+            secondaryYAxisLabel: null,
+        },
+    });
+
+const UUID_A = '11111111-1111-4111-8111-111111111111';
+const UUID_B = '22222222-2222-4222-8222-222222222222';
+
+const chartFence = (queryUuid: string, title?: string) =>
+    `\`\`\`chart\n${chartJson(queryUuid, title)}\n\`\`\``;
+
+const validReport = `The seasonal dip is driven by B2B churn, with high confidence overall.
+
+## Baseline revenue trend
+
+<confidence level="high">Complete order history since 2022.</confidence>
+
+Revenue grew steadily until spring.
+
+${chartFence(UUID_A)}
+
+The dip aligns with contract renewals.
+
+## Conclusion
+
+- B2B churn explains the dip.
+- Renewal timing is the main driver.
+`;
+
+describe('findDeepResearchChartBlocks', () => {
+    it('finds a backtick chart block with offsets covering the fences', () => {
+        const markdown = `intro\n\n${chartFence(UUID_A)}\n\nafter`;
+        const matches = findDeepResearchChartBlocks(markdown);
+        expect(matches).toHaveLength(1);
+        expect(matches[0].block?.queryUuid).toBe(UUID_A);
+        expect(matches[0].error).toBeNull();
+        expect(markdown.slice(matches[0].start, matches[0].end)).toBe(
+            `${chartFence(UUID_A)}\n`,
+        );
+    });
+
+    it('finds tilde-fenced chart blocks', () => {
+        const markdown = `~~~chart\n${chartJson(UUID_A)}\n~~~`;
+        const matches = findDeepResearchChartBlocks(markdown);
+        expect(matches).toHaveLength(1);
+        expect(matches[0].block?.queryUuid).toBe(UUID_A);
+    });
+
+    it('ignores a chart fence nested inside a longer fence', () => {
+        const markdown = `\`\`\`\`md\n${chartFence(UUID_A)}\n\`\`\`\`\n`;
+        expect(findDeepResearchChartBlocks(markdown)).toHaveLength(0);
+    });
+
+    it('ignores non-chart fences', () => {
+        const markdown = '```sql\nSELECT 1;\n```';
+        expect(findDeepResearchChartBlocks(markdown)).toHaveLength(0);
+    });
+
+    it('captures an unclosed chart fence at end of document', () => {
+        const markdown = `text\n\n\`\`\`chart\n${chartJson(UUID_A)}`;
+        const matches = findDeepResearchChartBlocks(markdown);
+        expect(matches).toHaveLength(1);
+        expect(matches[0].end).toBe(markdown.length);
+        expect(matches[0].block?.queryUuid).toBe(UUID_A);
+    });
+
+    it('reports invalid JSON with an actionable error', () => {
+        const matches = findDeepResearchChartBlocks(
+            '```chart\n{not json}\n```',
+        );
+        expect(matches).toHaveLength(1);
+        expect(matches[0].block).toBeNull();
+        expect(matches[0].error).toContain('not valid JSON');
+    });
+
+    it('rejects grouped charts with an actionable error', () => {
+        const grouped = JSON.parse(chartJson(UUID_A));
+        grouped.chartConfig.groupBy = ['orders_status'];
+        const matches = findDeepResearchChartBlocks(
+            `\`\`\`chart\n${JSON.stringify(grouped)}\n\`\`\``,
+        );
+        expect(matches[0].block).toBeNull();
+        expect(matches[0].error).toContain('groupBy is not supported');
+    });
+
+    it('reports schema violations with the offending path', () => {
+        const matches = findDeepResearchChartBlocks(
+            `\`\`\`chart\n${JSON.stringify({
+                queryUuid: 'not-a-uuid',
+                title: 'x',
+                chartConfig: null,
+            })}\n\`\`\``,
+        );
+        expect(matches[0].block).toBeNull();
+        expect(matches[0].error).toContain('queryUuid');
+    });
+});
+
+describe('extractDeepResearchCharts', () => {
+    it('returns parsed blocks only', () => {
+        const markdown = `${chartFence(UUID_A)}\n\n\`\`\`chart\noops\n\`\`\``;
+        const charts = extractDeepResearchCharts(markdown);
+        expect(charts).toHaveLength(1);
+        expect(charts[0].queryUuid).toBe(UUID_A);
+    });
+});
+
+describe('spliceDeepResearchChartBlocks', () => {
+    it('replaces multiple blocks without invalidating offsets', () => {
+        const markdown = `a\n\n${chartFence(UUID_A)}\n\nb\n\n${chartFence(
+            UUID_B,
+        )}\n\nc`;
+        const matches = findDeepResearchChartBlocks(markdown);
+        const result = spliceDeepResearchChartBlocks(
+            markdown,
+            matches.map((match, i) => ({
+                match,
+                replacement: `[removed ${i}]`,
+            })),
+        );
+        expect(result).toContain('[removed 0]');
+        expect(result).toContain('[removed 1]');
+        expect(result).not.toContain('```chart');
+        expect(result).toContain('a\n');
+        expect(result).toContain('b\n');
+        expect(result).toContain('c');
+    });
+});
+
+describe('countDeepResearchFindings', () => {
+    it('counts confidence tags outside code fences', () => {
+        const markdown = `## A\n\n<confidence level="high">ok</confidence>\n\n\`\`\`md\n<confidence level="low">not me</confidence>\n\`\`\`\n\n## B\n\n<confidence level="low">meh</confidence>`;
+        expect(countDeepResearchFindings(markdown)).toBe(2);
+    });
+});
+
+describe('lintDeepResearchReportMarkdown', () => {
+    it('accepts a valid report', () => {
+        expect(lintDeepResearchReportMarkdown(validReport)).toEqual([]);
+    });
+
+    it('requires intro prose before the first heading', () => {
+        const errors = lintDeepResearchReportMarkdown(
+            validReport.replace(/^.*\n\n## Baseline/, '## Baseline'),
+        );
+        expect(errors.some((e) => e.includes('introduction'))).toBe(true);
+    });
+
+    it('requires a conclusion section', () => {
+        const errors = lintDeepResearchReportMarkdown(
+            validReport.replace('## Conclusion', '## Wrap up'),
+        );
+        expect(errors.some((e) => e.includes('## Conclusion'))).toBe(true);
+    });
+
+    it('requires at least one finding section', () => {
+        const errors = lintDeepResearchReportMarkdown(
+            'Intro only.\n\n## Conclusion\n\n- done',
+        );
+        expect(errors.some((e) => e.includes('finding section'))).toBe(true);
+    });
+
+    it('requires exactly one confidence tag per finding section', () => {
+        const errors = lintDeepResearchReportMarkdown(
+            validReport.replace(
+                '<confidence level="high">Complete order history since 2022.</confidence>\n\n',
+                '',
+            ),
+        );
+        expect(
+            errors.some(
+                (e) => e.includes('Baseline revenue trend') && e.includes('0'),
+            ),
+        ).toBe(true);
+    });
+
+    it('rejects invalid confidence levels', () => {
+        const errors = lintDeepResearchReportMarkdown(
+            validReport.replace('level="high"', 'level="certain"'),
+        );
+        expect(errors.some((e) => e.includes('invalid level'))).toBe(true);
+    });
+
+    it('rejects disallowed html tags', () => {
+        const errors = lintDeepResearchReportMarkdown(
+            `${validReport}\n<script>alert(1)</script>\n`,
+        );
+        expect(errors.some((e) => e.includes('script'))).toBe(true);
+    });
+
+    it('does not flag autolinks as html tags', () => {
+        const errors = lintDeepResearchReportMarkdown(
+            validReport.replace(
+                'Revenue grew steadily until spring.',
+                'Revenue grew steadily until spring, see <https://example.com>.',
+            ),
+        );
+        expect(errors).toEqual([]);
+    });
+
+    it('rejects unbalanced tags', () => {
+        const errors = lintDeepResearchReportMarkdown(
+            validReport.replace(
+                'The dip aligns with contract renewals.',
+                '<note>\n\nThe dip aligns with contract renewals.',
+            ),
+        );
+        expect(errors.some((e) => e.includes('Unbalanced <note>'))).toBe(true);
+    });
+
+    it('rejects more than one chart in a finding section', () => {
+        const errors = lintDeepResearchReportMarkdown(
+            validReport.replace(
+                'The dip aligns with contract renewals.',
+                `The dip aligns with contract renewals.\n\n${chartFence(
+                    UUID_B,
+                    'Second chart',
+                )}`,
+            ),
+        );
+        expect(
+            errors.some(
+                (e) =>
+                    e.includes('Baseline revenue trend') &&
+                    e.includes('at most one chart per finding'),
+            ),
+        ).toBe(true);
+    });
+
+    it('accepts one chart in each of two finding sections', () => {
+        const errors = lintDeepResearchReportMarkdown(
+            validReport.replace(
+                '## Conclusion',
+                `## Second finding\n\n<confidence level="medium">ok</confidence>\n\nMore prose.\n\n${chartFence(
+                    UUID_B,
+                    'Second chart',
+                )}\n\n## Conclusion`,
+            ),
+        );
+        expect(errors).toEqual([]);
+    });
+
+    it('rejects duplicate chart queryUuids', () => {
+        const errors = lintDeepResearchReportMarkdown(
+            validReport.replace(
+                'The dip aligns with contract renewals.',
+                `The dip aligns with contract renewals.\n\n${chartFence(
+                    UUID_A,
+                    'Duplicate',
+                )}`,
+            ),
+        );
+        expect(
+            errors.some((e) => e.includes('more than one chart block')),
+        ).toBe(true);
+    });
+
+    it('rejects more than the maximum number of charts', () => {
+        const manyCharts = Array.from({ length: 9 }, (_, i) =>
+            chartFence(`33333333-3333-4333-8333-33333333333${i}`, `Chart ${i}`),
+        ).join('\n\n');
+        const errors = lintDeepResearchReportMarkdown(
+            validReport.replace(chartFence(UUID_A), manyCharts),
+        );
+        expect(errors.some((e) => e.includes('at most 8'))).toBe(true);
+    });
+
+    it('surfaces chart block json errors', () => {
+        const errors = lintDeepResearchReportMarkdown(
+            validReport.replace(chartFence(UUID_A), '```chart\n{broken\n```'),
+        );
+        expect(
+            errors.some(
+                (e) =>
+                    e.includes('Chart block 1 is invalid') &&
+                    e.includes('not valid JSON'),
+            ),
+        ).toBe(true);
+    });
+
+    it('requires a sources section when citations are used', () => {
+        const errors = lintDeepResearchReportMarkdown(
+            validReport.replace(
+                'The dip aligns with contract renewals.',
+                'The dip aligns with contract renewals [1].',
+            ),
+        );
+        expect(errors.some((e) => e.includes('## Sources'))).toBe(true);
+    });
+
+    it('accepts citations when a sources section exists', () => {
+        const errors = lintDeepResearchReportMarkdown(
+            `${validReport.replace(
+                'The dip aligns with contract renewals.',
+                'The dip aligns with contract renewals [1].',
+            )}\n## Sources\n\n1. [SaaS churn benchmarks](https://example.com) — industry baseline\n`,
+        );
+        expect(errors).toEqual([]);
+    });
+});

--- a/packages/common/src/ee/aiDeepResearch/markdown.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.ts
@@ -1,0 +1,417 @@
+import { z } from 'zod';
+import { getErrorMessage } from '../../types/errors';
+import {
+    AI_DEEP_RESEARCH_CONFIDENCE_LEVELS,
+    type AiDeepResearchChartConfig,
+} from './types';
+
+export const AI_DEEP_RESEARCH_CHART_LANGUAGE = 'chart';
+export const AI_DEEP_RESEARCH_MAX_CHARTS = 8;
+
+/**
+ * Whitelisted HTML tags allowed in report markdown, mapped to their allowed
+ * attributes. Single source for the frontend sanitizer (streamdown
+ * `allowedTags`) and the backend markdown lint.
+ */
+export const AI_DEEP_RESEARCH_MARKDOWN_TAGS: Record<string, string[]> = {
+    note: ['title'],
+    warning: ['title'],
+    info: ['title'],
+    tip: ['title'],
+    confidence: ['level'],
+};
+
+const chartConfigSchema: z.ZodType<AiDeepResearchChartConfig> = z.object({
+    defaultVizType: z.enum([
+        'table',
+        'bar',
+        'horizontal',
+        'line',
+        'scatter',
+        'pie',
+        'funnel',
+    ]),
+    xAxisDimension: z.string().nullable(),
+    yAxisMetrics: z.array(z.string()).nullable(),
+    groupBy: z.array(z.string()).nullable(),
+    xAxisType: z.enum(['category', 'time']).nullable(),
+    stackBars: z.boolean().nullable(),
+    lineType: z.enum(['line', 'area']).nullable(),
+    funnelDataInput: z.enum(['row', 'column']).nullable(),
+    xAxisLabel: z.string(),
+    yAxisLabel: z.string(),
+    secondaryYAxisMetric: z.string().nullable(),
+    secondaryYAxisLabel: z.string().nullable(),
+});
+
+export const aiDeepResearchChartBlockSchema = z
+    .object({
+        queryUuid: z.string().uuid(),
+        /** Metadata only (accessibility, error messages) — not rendered. */
+        title: z.string().min(1),
+        chartConfig: chartConfigSchema,
+    })
+    .superRefine((block, context) => {
+        // Grouped charts need a pivoted query execution, which report charts
+        // do not have — they replay the exact preserved research query.
+        if (block.chartConfig.groupBy?.length) {
+            context.addIssue({
+                code: 'custom',
+                path: ['chartConfig', 'groupBy'],
+                message:
+                    'groupBy is not supported in report charts; set it to null and use a separate chart per breakdown instead.',
+            });
+        }
+    });
+
+export type AiDeepResearchChartBlock = z.infer<
+    typeof aiDeepResearchChartBlockSchema
+>;
+
+export type AiDeepResearchChartBlockMatch = {
+    /** Char offset of the opening fence line. */
+    start: number;
+    /** Char offset just past the closing fence line (or end of document). */
+    end: number;
+    raw: string;
+    block: AiDeepResearchChartBlock | null;
+    error: string | null;
+};
+
+type FencedBlock = {
+    start: number;
+    end: number;
+    lang: string;
+    body: string;
+};
+
+const parseFenceLine = (
+    line: string,
+): { marker: string; info: string } | null => {
+    const match = line.match(/^ {0,3}(`{3,}|~{3,})[ \t]*(.*)$/);
+    if (!match) return null;
+    const [, marker, rest] = match;
+    // CommonMark: a backtick fence's info string cannot contain backticks
+    if (marker.startsWith('`') && rest.includes('`')) return null;
+    return { marker, info: rest.trim() };
+};
+
+const scanFencedBlocks = (markdown: string): FencedBlock[] => {
+    const blocks: FencedBlock[] = [];
+    const lines = markdown.split('\n');
+    let offset = 0;
+    let open: {
+        marker: string;
+        lang: string;
+        start: number;
+        body: string[];
+    } | null = null;
+
+    for (const line of lines) {
+        const lineEnd = Math.min(offset + line.length + 1, markdown.length);
+        const fence = parseFenceLine(line);
+        if (open) {
+            const closes =
+                fence !== null &&
+                fence.info === '' &&
+                fence.marker[0] === open.marker[0] &&
+                fence.marker.length >= open.marker.length;
+            if (closes) {
+                blocks.push({
+                    start: open.start,
+                    end: lineEnd,
+                    lang: open.lang,
+                    body: open.body.join('\n'),
+                });
+                open = null;
+            } else {
+                open.body.push(line);
+            }
+        } else if (fence) {
+            const lang = fence.info.split(/\s+/)[0] ?? '';
+            open = { marker: fence.marker, lang, start: offset, body: [] };
+        }
+        offset += line.length + 1;
+    }
+
+    if (open) {
+        blocks.push({
+            start: open.start,
+            end: markdown.length,
+            lang: open.lang,
+            body: open.body.join('\n'),
+        });
+    }
+
+    return blocks;
+};
+
+const toChartBlockMatch = (
+    markdown: string,
+    { start, end, body }: FencedBlock,
+): AiDeepResearchChartBlockMatch => {
+    const raw = markdown.slice(start, end);
+    let parsedJson: unknown;
+    try {
+        parsedJson = JSON.parse(body);
+    } catch (e) {
+        return {
+            start,
+            end,
+            raw,
+            block: null,
+            error: `Chart block is not valid JSON: ${getErrorMessage(e)}`,
+        };
+    }
+    const result = aiDeepResearchChartBlockSchema.safeParse(parsedJson);
+    if (!result.success) {
+        return {
+            start,
+            end,
+            raw,
+            block: null,
+            error: result.error.issues
+                .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+                .join('; '),
+        };
+    }
+    return { start, end, raw, block: result.data, error: null };
+};
+
+export const findDeepResearchChartBlocks = (
+    markdown: string,
+): AiDeepResearchChartBlockMatch[] =>
+    scanFencedBlocks(markdown)
+        .filter((block) => block.lang === AI_DEEP_RESEARCH_CHART_LANGUAGE)
+        .map((block) => toChartBlockMatch(markdown, block));
+
+export const extractDeepResearchCharts = (
+    markdown: string,
+): AiDeepResearchChartBlock[] =>
+    findDeepResearchChartBlocks(markdown).flatMap((match) =>
+        match.block ? [match.block] : [],
+    );
+
+export const spliceDeepResearchChartBlocks = (
+    markdown: string,
+    replacements: Array<{
+        match: Pick<AiDeepResearchChartBlockMatch, 'start' | 'end'>;
+        replacement: string;
+    }>,
+): string =>
+    [...replacements]
+        .sort((a, b) => b.match.start - a.match.start)
+        .reduce(
+            (doc, { match, replacement }) =>
+                `${doc.slice(0, match.start)}${replacement}\n${doc.slice(
+                    match.end,
+                )}`,
+            markdown,
+        );
+
+/** Replaces fenced code blocks with blank lines so tag/heading scans skip them. */
+const maskFencedBlocks = (markdown: string): string => {
+    const blocks = scanFencedBlocks(markdown);
+    return blocks.reduceRight(
+        (doc, { start, end }) =>
+            `${doc.slice(0, start)}${doc
+                .slice(start, end)
+                .replace(/[^\n]/g, ' ')}${doc.slice(end)}`,
+        markdown,
+    );
+};
+
+const CONFIDENCE_TAG_RE = /<confidence\b[^>]*>/g;
+
+export const countDeepResearchFindings = (markdown: string): number =>
+    maskFencedBlocks(markdown).match(CONFIDENCE_TAG_RE)?.length ?? 0;
+
+const STRUCTURAL_SECTIONS = new Set(['conclusion', 'sources', 'caveats']);
+
+type MarkdownSection = {
+    title: string;
+    content: string;
+    /** Char range of the whole section (heading line to next heading). */
+    start: number;
+    end: number;
+};
+
+const splitSections = (
+    masked: string,
+): { preamble: string; sections: MarkdownSection[] } => {
+    const lines = masked.split('\n');
+    const sections: MarkdownSection[] = [];
+    const preambleLines: string[] = [];
+    let current: { title: string; lines: string[]; start: number } | null =
+        null;
+    let offset = 0;
+
+    const closeCurrent = (end: number) => {
+        if (current) {
+            sections.push({
+                title: current.title,
+                content: current.lines.join('\n'),
+                start: current.start,
+                end,
+            });
+        }
+    };
+
+    for (const line of lines) {
+        const heading = line.match(/^## +(.+?)\s*$/);
+        if (heading) {
+            closeCurrent(offset);
+            current = { title: heading[1], lines: [], start: offset };
+        } else if (current) {
+            current.lines.push(line);
+        } else {
+            preambleLines.push(line);
+        }
+        offset += line.length + 1;
+    }
+    closeCurrent(masked.length);
+    return { preamble: preambleLines.join('\n'), sections };
+};
+
+const lintHtmlTags = (masked: string): string[] => {
+    const errors: string[] = [];
+    const allowedTags = new Set([
+        ...Object.keys(AI_DEEP_RESEARCH_MARKDOWN_TAGS),
+        'br',
+    ]);
+    const tagCounts = new Map<string, { open: number; close: number }>();
+    const disallowed = new Set<string>();
+
+    const tagRe = /<(\/?)([a-zA-Z][a-zA-Z-]*)(?=[\s/>])/g;
+    for (
+        let match = tagRe.exec(masked);
+        match !== null;
+        match = tagRe.exec(masked)
+    ) {
+        const [, slash, rawName] = match;
+        const name = rawName.toLowerCase();
+        if (!allowedTags.has(name)) {
+            disallowed.add(rawName);
+        } else if (name !== 'br') {
+            const counts = tagCounts.get(name) ?? { open: 0, close: 0 };
+            if (slash) counts.close += 1;
+            else counts.open += 1;
+            tagCounts.set(name, counts);
+        }
+    }
+
+    if (disallowed.size > 0) {
+        errors.push(
+            `Disallowed HTML tag(s): ${[...disallowed].join(
+                ', ',
+            )}. Only ${Object.keys(AI_DEEP_RESEARCH_MARKDOWN_TAGS)
+                .map((tag) => `<${tag}>`)
+                .join(', ')} are supported; any other HTML is stripped.`,
+        );
+    }
+
+    tagCounts.forEach(({ open, close }, name) => {
+        if (open !== close) {
+            errors.push(
+                `Unbalanced <${name}> tags: ${open} opening vs ${close} closing. Use paired tags (self-closing tags are not supported), e.g. <${name} ...>content</${name}>.`,
+            );
+        }
+    });
+
+    return errors;
+};
+
+export const lintDeepResearchReportMarkdown = (markdown: string): string[] => {
+    const errors: string[] = [];
+    const masked = maskFencedBlocks(markdown);
+    const { preamble, sections } = splitSections(masked);
+
+    if (!/\S/.test(preamble.replace(/^#{1,6} .*$/gm, ''))) {
+        errors.push(
+            'Start the report with a short introduction (2-4 sentences of prose) before the first "## " heading.',
+        );
+    }
+
+    const findingSections = sections.filter(
+        ({ title }) => !STRUCTURAL_SECTIONS.has(title.trim().toLowerCase()),
+    );
+    if (findingSections.length === 0) {
+        errors.push(
+            'The report must contain at least one "## " finding section between the introduction and the conclusion.',
+        );
+    }
+    if (
+        !sections.some(
+            ({ title }) => title.trim().toLowerCase() === 'conclusion',
+        )
+    ) {
+        errors.push('The report must end with a "## Conclusion" section.');
+    }
+
+    findingSections.forEach(({ title, content }) => {
+        const confidenceTags = content.match(CONFIDENCE_TAG_RE) ?? [];
+        if (confidenceTags.length !== 1) {
+            errors.push(
+                `Finding section "${title}" must contain exactly one <confidence level="low|medium|high">...</confidence> tag right after its heading (found ${confidenceTags.length}).`,
+            );
+        }
+        confidenceTags.forEach((tag) => {
+            const level = tag.match(/level="([^"]*)"/)?.[1];
+            if (
+                !AI_DEEP_RESEARCH_CONFIDENCE_LEVELS.includes(
+                    level as (typeof AI_DEEP_RESEARCH_CONFIDENCE_LEVELS)[number],
+                )
+            ) {
+                errors.push(
+                    `Finding section "${title}" has a <confidence> tag with an invalid level; use level="low", "medium" or "high".`,
+                );
+            }
+        });
+    });
+
+    const chartMatches = findDeepResearchChartBlocks(markdown);
+    chartMatches.forEach((match, index) => {
+        if (match.error) {
+            errors.push(`Chart block ${index + 1} is invalid: ${match.error}`);
+        }
+    });
+    findingSections.forEach(({ title, start, end }) => {
+        const chartsInSection = chartMatches.filter(
+            (match) => match.start >= start && match.start < end,
+        ).length;
+        if (chartsInSection > 1) {
+            errors.push(
+                `Finding section "${title}" embeds ${chartsInSection} chart blocks; embed at most one chart per finding and split additional charts into their own finding sections.`,
+            );
+        }
+    });
+    if (chartMatches.length > AI_DEEP_RESEARCH_MAX_CHARTS) {
+        errors.push(
+            `The report contains ${chartMatches.length} chart blocks; use at most ${AI_DEEP_RESEARCH_MAX_CHARTS}.`,
+        );
+    }
+    const seenQueryUuids = new Set<string>();
+    chartMatches.forEach((match) => {
+        if (!match.block) return;
+        if (seenQueryUuids.has(match.block.queryUuid)) {
+            errors.push(
+                `Chart queryUuid ${match.block.queryUuid} is used by more than one chart block; each completed query may be embedded once.`,
+            );
+        }
+        seenQueryUuids.add(match.block.queryUuid);
+    });
+
+    errors.push(...lintHtmlTags(masked));
+
+    const hasCitations = /\[\d+\]/.test(masked);
+    const hasSourcesSection = sections.some(
+        ({ title }) => title.trim().toLowerCase() === 'sources',
+    );
+    if (hasCitations && !hasSourcesSection) {
+        errors.push(
+            'The report uses [n] citation markers but has no "## Sources" section; list every cited source there as a numbered list.',
+        );
+    }
+
+    return errors;
+};

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -52,7 +52,36 @@ export type AiDeepResearchRequestBody = {
     effort?: AiDeepResearchEffort;
 };
 
-export type AiDeepResearchConfidence = 'low' | 'medium' | 'high';
+export const AI_DEEP_RESEARCH_CONFIDENCE_LEVELS = [
+    'low',
+    'medium',
+    'high',
+] as const;
+
+export type AiDeepResearchConfidence =
+    (typeof AI_DEEP_RESEARCH_CONFIDENCE_LEVELS)[number];
+
+export type AiDeepResearchChartConfig = {
+    defaultVizType:
+        | 'table'
+        | 'bar'
+        | 'horizontal'
+        | 'line'
+        | 'scatter'
+        | 'pie'
+        | 'funnel';
+    xAxisDimension: string | null;
+    yAxisMetrics: string[] | null;
+    groupBy: string[] | null;
+    xAxisType: 'category' | 'time' | null;
+    stackBars: boolean | null;
+    lineType: 'line' | 'area' | null;
+    funnelDataInput: 'row' | 'column' | null;
+    xAxisLabel: string;
+    yAxisLabel: string;
+    secondaryYAxisMetric: string | null;
+    secondaryYAxisLabel: string | null;
+};
 
 export type AiDeepResearchEvidence = {
     title: string;

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -1,4 +1,5 @@
 export * from './AiAgent';
+export * from './aiDeepResearch/markdown';
 export * from './aiDeepResearch/types';
 export * from './aiWriteback/types';
 export * from './externalConnections/types';


### PR DESCRIPTION
## Summary

PR 2 of 5 in the deep research markdown report stack. Adds the shared report model in `@lightdash/common`: a deep research report becomes one markdown document with embedded ` ```chart ` fences, and this module is the single source of truth for parsing and validating it. Nothing consumes it yet — the backend adopts it in [#25732](https://github.com/lightdash/lightdash/pull/25732), the frontend in [#25733](https://github.com/lightdash/lightdash/pull/25733).

Stacks on: [#25730](https://github.com/lightdash/lightdash/pull/25730).

## Changes

- `ee/aiDeepResearch/markdown.ts`:
  - `findDeepResearchChartBlocks` — CommonMark-correct fence scanner (line-based open-fence state, not a single regex; handles `~~~` fences, 4+-backtick wrappers, unclosed fences) returning char ranges + parsed blocks.
  - `aiDeepResearchChartBlockSchema` — zod schema for `{ queryUuid, title, chartConfig }`; `groupBy` is rejected with an actionable message (grouped charts need a pivoted execution the preserved research query doesn't have); `title` is metadata only.
  - `spliceDeepResearchChartBlocks` — back-to-front range replacement, used to drop unverifiable charts.
  - `lintDeepResearchReportMarkdown` — actionable errors the agent self-corrects from: intro before the first `##`, at least one finding section plus `## Conclusion`, exactly one `<confidence level>` per finding, at most one chart per finding, ≤8 chart blocks with unique queryUuids, whitelisted balanced HTML tags only, `## Sources` required when `[n]` citations appear.
  - `AI_DEEP_RESEARCH_MARKDOWN_TAGS` — the callout/confidence tag whitelist shared by this lint and the frontend sanitizer.
- `types.ts`: adds `AiDeepResearchChartConfig` and `AI_DEEP_RESEARCH_CONFIDENCE_LEVELS`; existing structured report types are untouched here (removed with their consumers in PR 3).

## Report document shape

```
intro prose (answers the question, states confidence)
## Finding section            × 2–5
  <confidence level="…">caveat</confidence>
  setup prose
  ```chart {json}```          ≤ 1 per finding
  interpretation prose
## Caveats (optional)
## Conclusion (bullets)
## Sources (when [n] cited)
```

## Test plan

- [x] `pnpm -F common typecheck:fast` clean
- [x] `pnpm -F common test` — new `markdown.test.ts` covers fence edge cases (nested/tilde/unclosed/wrapped), invalid JSON, duplicate uuids, groupBy rejection, and every lint rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)