### PR TITLE
feat(ai): link deep research runs to agent threads

### DIFF
--- a/packages/backend/src/ee/controllers/AiDeepResearchController.ts
+++ b/packages/backend/src/ee/controllers/AiDeepResearchController.ts
@@ -3,6 +3,7 @@ import {
     type AiDeepResearchRequestBody,
     type ApiAiAgentThreadMessageVizQueryResponse,
     type ApiAiDeepResearchEventsResponse,
+    type ApiAiDeepResearchRunListResponse,
     type ApiAiDeepResearchRunResponse,
     type ApiErrorPayload,
     type UUID,
@@ -59,7 +60,34 @@ export class AiDeepResearchController extends BaseController {
                 projectUuid,
                 prompt: body.prompt,
                 effort: body.effort,
+                aiThreadUuid: body.threadUuid,
+                promptUuid: body.promptUuid,
             }),
+        };
+    }
+
+    /**
+     * List the caller's Deep Research runs attached to an agent thread.
+     * @summary List Deep Research runs
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('listAiDeepResearchRuns')
+    async listRuns(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Query() threadUuid: UUID,
+    ): Promise<ApiAiDeepResearchRunListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiDeepResearchService().listRunsForThread(
+                toSessionUser(req.account),
+                projectUuid,
+                threadUuid,
+            ),
         };
     }
 

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -160,6 +160,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
 
                 return new AiDeepResearchService({
                     aiDeepResearchRunModel,
+                    aiAgentModel: models.getAiAgentModel<AiAgentModel>(),
                     projectModel: models.getProjectModel(),
                     featureFlagModel: models.getFeatureFlagModel(),
                     schedulerClient:

--- a/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
+++ b/packages/backend/src/ee/models/AiDeepResearchRunModel.ts
@@ -116,6 +116,22 @@ export class AiDeepResearchRunModel {
             .first();
     }
 
+    async findByThreadScoped(args: {
+        aiThreadUuid: string;
+        organizationUuid: string;
+        projectUuid: string;
+        createdByUserUuid: string;
+    }): Promise<DbAiDeepResearchRun[]> {
+        return this.database<AiDeepResearchRunsTable>(
+            AiDeepResearchRunsTableName,
+        )
+            .where('ai_thread_uuid', args.aiThreadUuid)
+            .where('organization_uuid', args.organizationUuid)
+            .where('project_uuid', args.projectUuid)
+            .where('created_by_user_uuid', args.createdByUserUuid)
+            .orderBy('created_at', 'asc');
+    }
+
     async claimQueuedRun(
         aiDeepResearchRunUuid: string,
     ): Promise<DbAiDeepResearchRun | undefined> {

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -152,6 +152,7 @@ const runRow = (overrides: Record<string, unknown> = {}) => ({
 const buildService = (
     overrides: {
         model?: Record<string, unknown>;
+        aiAgentModel?: Record<string, unknown>;
         projectModel?: Record<string, unknown>;
         featureFlagModel?: Record<string, unknown>;
         schedulerClient?: Record<string, unknown>;
@@ -182,8 +183,18 @@ const buildService = (
         appendProgressEvent: vi.fn().mockResolvedValue(true),
         setClaudeSessionId: vi.fn().mockResolvedValue(true),
         touch: vi.fn().mockResolvedValue(true),
+        findByThreadScoped: vi.fn().mockResolvedValue([]),
         markStaleRunsAsFailed: vi.fn().mockResolvedValue([]),
         ...overrides.model,
+    };
+    const aiAgentModel = {
+        findThreadOwnership: vi.fn().mockResolvedValue({
+            threadUuid: 'thread-1',
+            projectUuid: 'project-1',
+            agentUuid: null,
+            ownerUserUuid: 'user-1',
+        }),
+        ...overrides.aiAgentModel,
     };
     const projectModel = {
         getSummary: vi.fn().mockResolvedValue({ organizationUuid: 'org-1' }),
@@ -218,6 +229,7 @@ const buildService = (
         });
     const service = new AiDeepResearchService({
         aiDeepResearchRunModel: model as AnyType,
+        aiAgentModel: aiAgentModel as AnyType,
         projectModel: projectModel as AnyType,
         featureFlagModel: featureFlagModel as AnyType,
         schedulerClient: schedulerClient as AnyType,
@@ -228,6 +240,7 @@ const buildService = (
     return {
         service,
         model,
+        aiAgentModel,
         projectModel,
         featureFlagModel,
         schedulerClient,
@@ -272,6 +285,105 @@ describe('AiDeepResearchService', () => {
             });
             expect(run.status).toBe('queued');
         });
+
+        it('persists the thread link when the caller owns the thread', async () => {
+            const { service, model, aiAgentModel } = buildService();
+
+            await service.createRun({
+                user: userWithProjectAccess(),
+                projectUuid: 'project-1',
+                prompt: 'Investigate revenue',
+                budget,
+                aiThreadUuid: 'thread-1',
+            });
+
+            expect(aiAgentModel.findThreadOwnership).toHaveBeenCalledWith({
+                organizationUuid: 'org-1',
+                threadUuid: 'thread-1',
+            });
+            expect(model.create).toHaveBeenCalledWith(
+                expect.objectContaining({ aiThreadUuid: 'thread-1' }),
+            );
+        });
+
+        it('persists the prompt link alongside its thread', async () => {
+            const { service, model } = buildService();
+
+            await service.createRun({
+                user: userWithProjectAccess(),
+                projectUuid: 'project-1',
+                prompt: 'Investigate revenue',
+                budget,
+                aiThreadUuid: 'thread-1',
+                promptUuid: 'prompt-1',
+            });
+
+            expect(model.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    aiThreadUuid: 'thread-1',
+                    promptUuid: 'prompt-1',
+                }),
+            );
+        });
+
+        it('rejects a prompt link without its thread', async () => {
+            const { service, model } = buildService();
+
+            await expect(
+                service.createRun({
+                    user: userWithProjectAccess(),
+                    projectUuid: 'project-1',
+                    prompt: 'Investigate revenue',
+                    budget,
+                    promptUuid: 'prompt-1',
+                }),
+            ).rejects.toBeInstanceOf(ParameterError);
+            expect(model.create).not.toHaveBeenCalled();
+        });
+
+        it.each([
+            ['missing', undefined],
+            [
+                'owned by another user',
+                {
+                    threadUuid: 'thread-1',
+                    projectUuid: 'project-1',
+                    agentUuid: null,
+                    ownerUserUuid: 'user-2',
+                },
+            ],
+            [
+                'in another project',
+                {
+                    threadUuid: 'thread-1',
+                    projectUuid: 'project-2',
+                    agentUuid: null,
+                    ownerUserUuid: 'user-1',
+                },
+            ],
+        ] as const)(
+            'rejects a thread link that is %s',
+            async (_case, ownership) => {
+                const { service, model } = buildService({
+                    aiAgentModel: {
+                        findThreadOwnership: vi
+                            .fn()
+                            .mockResolvedValue(ownership),
+                    },
+                });
+
+                await expect(
+                    service.createRun({
+                        user: userWithProjectAccess(),
+                        projectUuid: 'project-1',
+                        prompt: 'Investigate revenue',
+                        budget,
+                        aiThreadUuid: 'thread-1',
+                    }),
+                ).rejects.toBeInstanceOf(NotFoundError);
+                expect(model.create).not.toHaveBeenCalled();
+            },
+        );
 
         it('uses the server-owned default budget when none is provided', async () => {
             const { service, model } = buildService();
@@ -608,6 +720,36 @@ describe('AiDeepResearchService', () => {
                 ),
             ).rejects.toBeInstanceOf(NotFoundError);
             expect(model.requestCancellation).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('listRunsForThread', () => {
+        it('lists only the callers runs for the thread, scoped to org and project', async () => {
+            const { service, model } = buildService({
+                model: {
+                    findByThreadScoped: vi
+                        .fn()
+                        .mockResolvedValue([
+                            runRow({ ai_thread_uuid: 'thread-1' }),
+                        ]),
+                },
+            });
+
+            const runs = await service.listRunsForThread(
+                userWithProjectAccess(),
+                'project-1',
+                'thread-1',
+            );
+
+            expect(model.findByThreadScoped).toHaveBeenCalledWith({
+                aiThreadUuid: 'thread-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'project-1',
+                createdByUserUuid: 'user-1',
+            });
+            expect(runs).toHaveLength(1);
+            expect(runs[0].aiThreadUuid).toBe('thread-1');
+            expect(runs[0].prompt).toBe('Investigate revenue');
         });
     });
 

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.ts
@@ -37,6 +37,7 @@ import {
     type DbAiDeepResearchEvent,
     type DbAiDeepResearchRun,
 } from '../../database/entities/aiDeepResearch';
+import { type AiAgentModel } from '../../models/AiAgentModel';
 import {
     type AiDeepResearchRunModel,
     type DbAiDeepResearchEventWithCursor,
@@ -114,6 +115,7 @@ export type AiDeepResearchExecutor = (
 
 type Dependencies = {
     aiDeepResearchRunModel: AiDeepResearchRunModel;
+    aiAgentModel: Pick<AiAgentModel, 'findThreadOwnership'>;
     projectModel: ProjectModel;
     featureFlagModel: FeatureFlagModel;
     schedulerClient: CommercialSchedulerClient;
@@ -133,6 +135,9 @@ type EventCursorPayload = {
 const toRun = (row: DbAiDeepResearchRun): AiDeepResearchRun => ({
     aiDeepResearchRunUuid: row.ai_deep_research_run_uuid,
     projectUuid: row.project_uuid,
+    aiThreadUuid: row.ai_thread_uuid,
+    promptUuid: row.prompt_uuid,
+    prompt: row.prompt,
     status: row.status,
     resultMarkdown: row.result_markdown,
     budget: row.budget_snapshot,
@@ -292,6 +297,8 @@ const assertValidBudget = (budget: AiDeepResearchBudget): void => {
 export class AiDeepResearchService extends BaseService {
     private readonly aiDeepResearchRunModel: AiDeepResearchRunModel;
 
+    private readonly aiAgentModel: Pick<AiAgentModel, 'findThreadOwnership'>;
+
     private readonly projectModel: ProjectModel;
 
     private readonly featureFlagModel: FeatureFlagModel;
@@ -309,6 +316,7 @@ export class AiDeepResearchService extends BaseService {
 
     constructor({
         aiDeepResearchRunModel,
+        aiAgentModel,
         projectModel,
         featureFlagModel,
         schedulerClient,
@@ -318,6 +326,7 @@ export class AiDeepResearchService extends BaseService {
     }: Dependencies) {
         super();
         this.aiDeepResearchRunModel = aiDeepResearchRunModel;
+        this.aiAgentModel = aiAgentModel;
         this.projectModel = projectModel;
         this.featureFlagModel = featureFlagModel;
         this.schedulerClient = schedulerClient;
@@ -434,6 +443,27 @@ export class AiDeepResearchService extends BaseService {
             throw new ForbiddenError('Deep Research is not enabled');
         }
 
+        if (args.promptUuid && !args.aiThreadUuid) {
+            throw new ParameterError(
+                'A Deep Research prompt link requires its thread',
+            );
+        }
+        if (args.aiThreadUuid) {
+            const ownership = await this.aiAgentModel.findThreadOwnership({
+                organizationUuid: args.user.organizationUuid,
+                threadUuid: args.aiThreadUuid,
+            });
+            if (
+                !ownership ||
+                ownership.projectUuid !== args.projectUuid ||
+                ownership.ownerUserUuid !== args.user.userUuid
+            ) {
+                throw new NotFoundError(
+                    `AI thread ${args.aiThreadUuid} not found`,
+                );
+            }
+        }
+
         const run = await this.aiDeepResearchRunModel.create({
             organizationUuid: args.user.organizationUuid,
             projectUuid: args.projectUuid,
@@ -478,6 +508,25 @@ export class AiDeepResearchService extends BaseService {
                 aiDeepResearchRunUuid,
             ),
         );
+    }
+
+    async listRunsForThread(
+        user: SessionUser,
+        projectUuid: string,
+        aiThreadUuid: string,
+    ): Promise<AiDeepResearchRun[]> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        await this.assertCanViewProject(user, projectUuid);
+
+        const runs = await this.aiDeepResearchRunModel.findByThreadScoped({
+            aiThreadUuid,
+            organizationUuid: user.organizationUuid,
+            projectUuid,
+            createdByUserUuid: user.userUuid,
+        });
+        return runs.map(toRun);
     }
 
     async getChartVizQuery(args: {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -28201,6 +28201,23 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 status: { ref: 'AiDeepResearchRunStatus', required: true },
+                prompt: { dataType: 'string', required: true },
+                promptUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                aiThreadUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 projectUuid: { dataType: 'string', required: true },
                 aiDeepResearchRunUuid: { dataType: 'string', required: true },
             },
@@ -28244,11 +28261,34 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                promptUuid: { dataType: 'string' },
+                threadUuid: { dataType: 'string' },
                 effort: { ref: 'AiDeepResearchEffort' },
                 prompt: { dataType: 'string', required: true },
             },
             validators: {},
         },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_AiDeepResearchRun-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'AiDeepResearchRun' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiDeepResearchRunListResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiDeepResearchRun-Array_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Record_string.never_': {
@@ -67910,6 +67950,73 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: 202,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiDeepResearchController_listRuns: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        threadUuid: {
+            in: 'query',
+            name: 'threadUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.get(
+        '/api/v1/ee/projects/:projectUuid/ai-deep-research',
+        ...fetchMiddlewares<RequestHandler>(AiDeepResearchController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiDeepResearchController.prototype.listRuns,
+        ),
+
+        async function AiDeepResearchController_listRuns(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiDeepResearchController_listRuns,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiDeepResearchController>(
+                        AiDeepResearchController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listRuns',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
                 });
             } catch (err) {
                 return next(err);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -28456,6 +28456,17 @@
                     "status": {
                         "$ref": "#/components/schemas/AiDeepResearchRunStatus"
                     },
+                    "prompt": {
+                        "type": "string"
+                    },
+                    "promptUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "aiThreadUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "projectUuid": {
                         "type": "string"
                     },
@@ -28473,6 +28484,9 @@
                     "budget",
                     "resultMarkdown",
                     "status",
+                    "prompt",
+                    "promptUuid",
+                    "aiThreadUuid",
                     "projectUuid",
                     "aiDeepResearchRunUuid"
                 ],
@@ -28501,6 +28515,14 @@
             },
             "AiDeepResearchRequestBody": {
                 "properties": {
+                    "promptUuid": {
+                        "type": "string",
+                        "description": "Thread message that captured this prompt. Requires threadUuid."
+                    },
+                    "threadUuid": {
+                        "type": "string",
+                        "description": "Agent thread to attach the run to. Must be owned by the caller."
+                    },
                     "effort": {
                         "$ref": "#/components/schemas/AiDeepResearchEffort",
                         "description": "Server-owned execution budget tier. Defaults to medium."
@@ -28511,6 +28533,26 @@
                 },
                 "required": ["prompt"],
                 "type": "object"
+            },
+            "ApiSuccess_AiDeepResearchRun-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiDeepResearchRun"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiDeepResearchRunListResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiDeepResearchRun-Array_"
             },
             "Record_string.never_": {
                 "properties": {},
@@ -59246,6 +59288,52 @@
                         }
                     }
                 }
+            },
+            "get": {
+                "operationId": "listAiDeepResearchRuns",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiDeepResearchRunListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "List the caller's Deep Research runs attached to an agent thread.",
+                "summary": "List Deep Research runs",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "threadUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/ee/projects/{projectUuid}/ai-deep-research/{aiDeepResearchRunUuid}": {

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -50,6 +50,10 @@ export type AiDeepResearchRequestBody = {
     prompt: string;
     /** Server-owned execution budget tier. Defaults to medium. */
     effort?: AiDeepResearchEffort;
+    /** Agent thread to attach the run to. Must be owned by the caller. */
+    threadUuid?: string;
+    /** Thread message that captured this prompt. Requires threadUuid. */
+    promptUuid?: string;
 };
 
 export const AI_DEEP_RESEARCH_CONFIDENCE_LEVELS = [
@@ -157,6 +161,9 @@ export type AiDeepResearchEvent =
 export type AiDeepResearchRun = {
     aiDeepResearchRunUuid: string;
     projectUuid: string;
+    aiThreadUuid: string | null;
+    promptUuid: string | null;
+    prompt: string;
     status: AiDeepResearchRunStatus;
     /** The report as a single markdown document with embedded chart blocks. */
     resultMarkdown: string | null;
@@ -175,6 +182,8 @@ export type AiDeepResearchEventsPage = {
 };
 
 export type ApiAiDeepResearchRunResponse = ApiSuccess<AiDeepResearchRun>;
+
+export type ApiAiDeepResearchRunListResponse = ApiSuccess<AiDeepResearchRun[]>;
 
 export type ApiAiDeepResearchEventsResponse =
     ApiSuccess<AiDeepResearchEventsPage>;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -11,12 +11,14 @@ import {
 import { IconCrop, IconInfoCircle } from '@tabler/icons-react';
 import {
     Fragment,
+    useMemo,
     useRef,
     useState,
     type FC,
     type PropsWithChildren,
 } from 'react';
 import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
+import { useDeepResearchThreadRuns } from '../../hooks/useDeepResearch';
 import { useAgentAiMcpServers } from '../../hooks/useProjectAiMcpServers';
 import { AddToEvalModal } from '../Admin/AddToEvalModal';
 import { DeepResearchThreadRuns } from '../DeepResearch/DeepResearchThreadRuns';
@@ -107,6 +109,22 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
     const [addToEvalsPromptUuid, setAddToEvalsPromptUuid] = useState<
         string | null
     >(null);
+    // Deep research prompts never receive a chat response — the run card is
+    // the response — so their assistant bubbles must not render (they would
+    // show as failed generations).
+    const deepResearchRuns = useDeepResearchThreadRuns(
+        projectUuid,
+        thread.uuid,
+    );
+    const deepResearchPromptUuids = useMemo(
+        () =>
+            new Set(
+                (deepResearchRuns.data ?? []).flatMap((run) =>
+                    run.promptUuid ? [run.promptUuid] : [],
+                ),
+            ),
+        [deepResearchRuns.data],
+    );
     const compactionsByTriggeringPromptUuid = new Map(
         thread.compactions.map((compaction) => [
             compaction.triggeringPromptUuid,
@@ -142,6 +160,12 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
                                     !(
                                         message.role === 'user' &&
                                         message.hidden
+                                    ) &&
+                                    !(
+                                        message.role === 'assistant' &&
+                                        deepResearchPromptUuids.has(
+                                            message.uuid,
+                                        )
                                     ),
                             )
                             .map((message, i, xs) => (

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.tsx
@@ -1,10 +1,13 @@
 import { Alert, Button, Paper, Skeleton, Stack, Text } from '@mantine-8/core';
+import { useMemo } from 'react';
 import useUser from '../../../../../hooks/user/useUser';
 import { useDeepResearchRunsForThread } from '../../deepResearch/deepResearchRegistry';
+import { toDeepResearchRegistration } from '../../deepResearch/runProgress';
 import { type DeepResearchRunRegistration } from '../../deepResearch/types';
 import {
     useContinueDeepResearchMutation,
     useDeepResearchRun,
+    useDeepResearchThreadRuns,
 } from '../../hooks/useDeepResearch';
 import { DeepResearchRunCard } from './DeepResearchRunCard';
 
@@ -107,11 +110,34 @@ export const DeepResearchThreadRuns = ({
     threadUuid: string;
 }) => {
     const user = useUser(true);
-    const registrations = useDeepResearchRunsForThread(
+    const userUuid = user.data?.userUuid;
+    // Server is the source of truth; the local registry only contributes
+    // optimistic entries (starting / start_failed / just-started runs the
+    // list has not caught up with yet).
+    const serverRuns = useDeepResearchThreadRuns(projectUuid, threadUuid);
+    const localRegistrations = useDeepResearchRunsForThread(
         projectUuid,
         threadUuid,
-        user.data?.userUuid,
+        userUuid,
     );
+    const registrations = useMemo(() => {
+        const fromServer = (serverRuns.data ?? []).map((run) =>
+            toDeepResearchRegistration(run, {
+                threadUuid,
+                userUuid: userUuid ?? '',
+            }),
+        );
+        const serverRunUuids = new Set(
+            fromServer.map((registration) => registration.runUuid),
+        );
+        return [
+            ...fromServer,
+            ...localRegistrations.filter(
+                (registration) => !serverRunUuids.has(registration.runUuid),
+            ),
+        ];
+    }, [serverRuns.data, localRegistrations, threadUuid, userUuid]);
+
     if (!registrations.length) {
         return null;
     }

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/runProgress.ts
@@ -2,12 +2,14 @@ import {
     assertUnreachable,
     countDeepResearchFindings,
     type AiDeepResearchActivity,
+    type AiDeepResearchBudget,
     type AiDeepResearchEffort,
     type AiDeepResearchEvent,
     type AiDeepResearchPhase,
     type AiDeepResearchRun,
 } from '@lightdash/common';
 import {
+    DEEP_RESEARCH_DEPTHS,
     type DeepResearchDepth,
     type DeepResearchRunRegistration,
     type DeepResearchRunStatus,
@@ -122,6 +124,29 @@ export const isDeepResearchRunTerminal = (
         'waiting_for_permission',
         'waiting_for_reconnection',
     ].includes(status);
+
+/** The budget is a pure function of depth, so it round-trips a run's depth. */
+const getDepthFromBudget = (budget: AiDeepResearchBudget): DeepResearchDepth =>
+    DEEP_RESEARCH_DEPTHS.find(
+        (depth) =>
+            DEEP_RESEARCH_DEPTH_CONFIG[depth].warehouseQueries ===
+            budget.maxWarehouseQueries,
+    ) ?? 'standard';
+
+/** A registration equivalent for a run loaded from the server. */
+export const toDeepResearchRegistration = (
+    run: AiDeepResearchRun,
+    args: { threadUuid: string; userUuid: string },
+): DeepResearchRunRegistration => ({
+    runUuid: run.aiDeepResearchRunUuid,
+    projectUuid: run.projectUuid,
+    threadUuid: args.threadUuid,
+    userUuid: args.userUuid,
+    question: run.prompt,
+    depth: getDepthFromBudget(run.budget),
+    createdAt: run.createdAt,
+    state: 'started',
+});
 
 /** Plain-text intro of the report markdown, for compact previews. */
 export const getDeepResearchReportPreview = (markdown: string): string =>

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useDeepResearch.ts
@@ -4,6 +4,7 @@ import {
     type AiDeepResearchRequestBody,
     type AiDeepResearchRun,
     type ApiAiDeepResearchEventsResponse,
+    type ApiAiDeepResearchRunListResponse,
     type ApiAiDeepResearchRunResponse,
     type ApiAiAgentThreadMessageVizQuery,
     type ApiAiAgentThreadMessageVizQueryResponse,
@@ -53,6 +54,14 @@ const getDeepResearchRun = (projectUuid: string, runUuid: string) =>
         method: 'GET',
         body: undefined,
     }) as Promise<ApiAiDeepResearchRunResponse['results']>;
+
+const listDeepResearchRuns = (projectUuid: string, threadUuid: string) =>
+    lightdashApi<AnyType>({
+        version: 'v1',
+        url: `${getBaseUrl(projectUuid)}?threadUuid=${threadUuid}`,
+        method: 'GET',
+        body: undefined,
+    }) as Promise<ApiAiDeepResearchRunListResponse['results']>;
 
 const getDeepResearchEventsPage = (
     projectUuid: string,
@@ -124,7 +133,7 @@ export const useStartDeepResearchMutation = ({
     return useMutation<
         AiDeepResearchRun,
         ApiError,
-        StartDeepResearchArgs,
+        StartDeepResearchArgs & { promptUuid?: string },
         { optimisticRunUuid: string; createdAt: string }
     >({
         onMutate: (variables) => {
@@ -142,10 +151,12 @@ export const useStartDeepResearchMutation = ({
             });
             return { optimisticRunUuid, createdAt };
         },
-        mutationFn: ({ question, depth }) =>
+        mutationFn: ({ question, depth, promptUuid }) =>
             startDeepResearch(projectUuid, {
                 prompt: question,
                 effort: DEEP_RESEARCH_DEPTH_CONFIG[depth].effort,
+                threadUuid,
+                promptUuid,
             }),
         onSuccess: (run, variables, context) => {
             replaceDeepResearchRun(context?.optimisticRunUuid ?? '', {
@@ -180,7 +191,7 @@ export const useStartDeepResearchForThreadMutation = (projectUuid: string) => {
     return useMutation<
         AiDeepResearchRun,
         ApiError,
-        StartDeepResearchArgs & { threadUuid: string },
+        StartDeepResearchArgs & { threadUuid: string; promptUuid?: string },
         { optimisticRunUuid: string; createdAt: string }
     >({
         onMutate: (variables) => {
@@ -198,10 +209,12 @@ export const useStartDeepResearchForThreadMutation = (projectUuid: string) => {
             });
             return { optimisticRunUuid, createdAt };
         },
-        mutationFn: ({ question, depth }) =>
+        mutationFn: ({ question, depth, threadUuid, promptUuid }) =>
             startDeepResearch(projectUuid, {
                 prompt: question,
                 effort: DEEP_RESEARCH_DEPTH_CONFIG[depth].effort,
+                threadUuid,
+                promptUuid,
             }),
         onSuccess: (run, variables, context) => {
             replaceDeepResearchRun(context?.optimisticRunUuid ?? '', {
@@ -229,6 +242,16 @@ export const useStartDeepResearchForThreadMutation = (projectUuid: string) => {
         },
     });
 };
+
+export const useDeepResearchThreadRuns = (
+    projectUuid: string | undefined,
+    threadUuid: string,
+) =>
+    useQuery<AiDeepResearchRun[], ApiError>({
+        queryKey: [DEEP_RESEARCH_QUERY_KEY, projectUuid, 'thread', threadUuid],
+        queryFn: () => listDeepResearchRuns(projectUuid ?? '', threadUuid),
+        enabled: !!projectUuid,
+    });
 
 export const useDeepResearchRun = (
     registration: DeepResearchRunRegistration,

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -291,14 +291,18 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         question,
         depth,
     }: Parameters<typeof startDeepResearch.mutateAsync>[0]) => {
-        await createAgentThreadMessage({
+        const message = await createAgentThreadMessage({
             prompt: question,
             modelConfig: threadModelConfig ?? undefined,
             context: pageContextInput,
             optimisticContext: pagePreviewItems,
             skipAgentResponse: true,
         });
-        await startDeepResearch.mutateAsync({ question, depth });
+        await startDeepResearch.mutateAsync({
+            question,
+            depth,
+            promptUuid: message.uuid,
+        });
     };
     const isBusy = Boolean(isCreatingMessage || isStreaming || isPending);
     const retryPrompt = reviewItem?.remediation?.retryPrompt ?? null;

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -217,6 +217,7 @@ const AiAgentNewThreadPage: FC = () => {
                 question,
                 depth,
                 threadUuid: thread.uuid,
+                promptUuid: thread.firstMessage.uuid,
             });
         },
         [


### PR DESCRIPTION
## Summary

PR 5 of 5 in the deep research markdown report stack, and the only one that changes chat behaviour. Deep research runs persist which thread and prompt they belong to, run cards render from a server listing instead of localStorage, and the false "Something went wrong" bubble on deep research prompts is gone.

Stacks on: [#25733](https://github.com/lightdash/lightdash/pull/25733).

Before this PR the run↔thread link existed only in the starting browser's localStorage: opening the same thread from another browser (or clearing storage) lost the run card and made the report unreachable, and the response-less prompt row tripped the 5-minute stale-generation heuristic into rendering a failed-response bubble.

## Changes

**Backend**
- `POST /ai-deep-research` accepts `threadUuid` + `promptUuid`; `createRun` validates thread ownership via `AiAgentModel.findThreadOwnership` (must exist, same project, owned by caller — 404 otherwise; `promptUuid` requires `threadUuid`). This is the deep research service's only AI-agent dependency, introduced here.
- New `GET /ai-deep-research?threadUuid=` (`listAiDeepResearchRuns`) returns the caller's runs for a thread, scoped by org/project/creator. Run responses now include `prompt`, `aiThreadUuid`, `promptUuid`.

**Frontend**
- Both start flows send the linkage (`thread.firstMessage.uuid` on new conversations, the created message uuid mid-thread).
- `DeepResearchThreadRuns` renders from the server list; the localStorage registry only contributes optimistic starting/failed entries, deduped against it. Depth round-trips from the run's budget tier.
- `AgentChatDisplay` suppresses the assistant bubble for messages matching a run's `promptUuid` — the run card is the response, so the stale-generation heuristic never misfires.

## Who sees what

```
Before:  starting browser        → card + report
         same user, new browser  → no card, error bubble after 5 min
After:   any browser, creator    → card + report from server
         optimistic states       → registry only (starting / start_failed)
```

## Test plan

- [x] `pnpm -F common|backend|frontend typecheck:fast` clean; `pnpm generate-api` regenerated
- [x] Backend tests: thread-ownership rejection matrix (missing / other user / other project), prompt-without-thread rejection, scoped listing
- [x] Frontend suite green (registry merge, run card, suppression paths)
- [x] Manual: fresh browser profile with empty localStorage renders the run card and report from the server; thread shows question → run card with no error bubble; a user-initiated run persisted both links in the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)