### PR TITLE
fix(homepage): only show "Revert to published" when the draft diverges

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -55,7 +55,8 @@ import {
     IconTrash,
     IconUsers,
 } from '@tabler/icons-react';
-import { Fragment, useEffect, useRef, useState, type FC } from 'react';
+import isEqual from 'lodash/isEqual';
+import { Fragment, useEffect, useMemo, useRef, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
@@ -578,6 +579,18 @@ export const HomepageEditor: FC<Props> = ({
 
     const isDirty = draft !== lastSavedRef.current || updateMutation.isLoading;
 
+    // Only offer a revert when the draft actually diverges from what's live —
+    // reverting to an identical published version is a no-op.
+    const publishedConfig = useMemo(
+        () =>
+            homepage.publishedConfig
+                ? migrateHomepageConfig(homepage.publishedConfig)
+                : null,
+        [homepage.publishedConfig],
+    );
+    const canRevertToPublished =
+        publishedConfig !== null && !isEqual(draft, publishedConfig);
+
     const sensors = useSensors(
         useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     );
@@ -790,7 +803,7 @@ export const HomepageEditor: FC<Props> = ({
                         Draft saved
                     </span>
                 )}
-                {homepage.publishedConfig !== null && (
+                {canRevertToPublished && (
                     <button
                         type="button"
                         className={classes.tbBtn}


### PR DESCRIPTION
## What & why

The **Revert to published** button (shipped in #25718) appeared whenever a homepage had *ever* been published (`publishedConfig !== null`) — regardless of whether the draft actually differed from it. So when the draft already matched the published version, it offered a **no-op revert**, which is confusing noise.

This gates the button on a real comparison: it only shows when the **live editor draft diverges from the published config**.

## Change

One file, `HomepageEditor.tsx`:
- `canRevertToPublished = publishedConfig !== null && !isEqual(draft, migrateHomepageConfig(publishedConfig))` — deep-equality via `lodash/isEqual` (the established frontend pattern), `migrateHomepageConfig` on the published side so both are normalized to the current format before comparing.
- Compares the **live `draft`** (not the saved server draft), so the button appears the moment you diverge and disappears as soon as the draft matches published again — including right after a revert.

## Testing

Verified live (Chrome DevTools): on a homepage whose draft equals its published version, the button is now **hidden**; it reappears once the draft is edited to differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)