### PR TITLE
feat(homepage): resolver build surface — same layout math, nothing hidden

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.module.css
@@ -177,8 +177,10 @@
     overflow-y: auto;
 }
 
+/* Same content width as the published page (tierFull 1160) so the canvas
+ * shows real proportions instead of a compressed approximation. */
 .canvasInner {
-    max-width: 960px;
+    max-width: 1224px;
     margin: 0 auto;
     padding: 32px 32px 120px;
 }

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -61,7 +61,7 @@ import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import { useAiAgentButtonVisibility } from '../aiCopilot/hooks/useAiAgentsButtonVisibility';
-import { traitFor } from './blockLayout';
+import { TIER_CLASS, traitFor } from './blockLayout';
 import { IconSquare } from './blocks/BlockShell';
 import {
     blockLibrary,
@@ -85,6 +85,7 @@ import {
     type DropTarget,
 } from './configOps';
 import classes from './HomepageEditor.module.css';
+import layout from './homepageLayout.module.css';
 import {
     useDeleteHomepage,
     useDiscardHomepageDraft,
@@ -97,6 +98,7 @@ import {
     type HomepageViewType,
 } from './PreviewPane';
 import { PublishModal } from './PublishModal';
+import { resolveHomepageLayout } from './resolveHomepageLayout';
 
 type DragSource =
     | { kind: 'new'; definition: BlockDefinition }
@@ -497,6 +499,13 @@ export const HomepageEditor: FC<Props> = ({
     const lastSavedRef = useRef<HomepageConfig>(draft);
     // Compare-and-set token so a stale editor can never clobber newer state
     const baseUpdatedAtRef = useRef<Date>(homepage.updatedAt);
+
+    // WYSIWYG: the canvas adopts the published layout's geometry. Build
+    // surface keeps rows/blocks 1:1 with the draft, so indexes line up.
+    const resolvedRows = useMemo(
+        () => resolveHomepageLayout(draft, { surface: 'build' }).rows,
+        [draft],
+    );
 
     const [activeDrag, setActiveDrag] = useState<DragSource | null>(null);
     // Where the drop will land, shown as an insertion indicator. The real
@@ -966,8 +975,18 @@ export const HomepageEditor: FC<Props> = ({
                                                     gap="md"
                                                     align="stretch"
                                                     wrap="nowrap"
-                                                    className={
+                                                    className={`${
                                                         classes.rowColumns
+                                                    } ${layout.row} ${
+                                                        TIER_CLASS[
+                                                            resolvedRows[
+                                                                rowIndex
+                                                            ].widthTier
+                                                        ]
+                                                    }`}
+                                                    data-fit={
+                                                        resolvedRows[rowIndex]
+                                                            .fit
                                                     }
                                                 >
                                                     {row.blocks.map(
@@ -992,86 +1011,111 @@ export const HomepageEditor: FC<Props> = ({
                                                                             )}
                                                                         />
                                                                     )}
-                                                                    <BlockCard
-                                                                        block={
-                                                                            block
+                                                                    <div
+                                                                        className={
+                                                                            layout.col
                                                                         }
-                                                                        definition={
-                                                                            definition
+                                                                        data-weight={
+                                                                            resolvedRows[
+                                                                                rowIndex
+                                                                            ]
+                                                                                .columns[
+                                                                                blockIndex
+                                                                            ]
+                                                                                .weight
                                                                         }
-                                                                        justPlaced={
-                                                                            block.id ===
-                                                                            justPlacedId
+                                                                        data-hug-units={
+                                                                            resolvedRows[
+                                                                                rowIndex
+                                                                            ]
+                                                                                .columns[
+                                                                                blockIndex
+                                                                            ]
+                                                                                .hugUnits ??
+                                                                            undefined
                                                                         }
-                                                                        projectUuid={
-                                                                            projectUuid
-                                                                        }
-                                                                        canUp={canMoveUp(
-                                                                            draft,
-                                                                            block.id,
-                                                                        )}
-                                                                        canDown={canMoveDown(
-                                                                            draft,
-                                                                            block.id,
-                                                                        )}
-                                                                        onUp={() =>
-                                                                            setDraft(
-                                                                                (
-                                                                                    prev,
-                                                                                ) =>
-                                                                                    moveBlockUp(
+                                                                    >
+                                                                        <BlockCard
+                                                                            block={
+                                                                                block
+                                                                            }
+                                                                            definition={
+                                                                                definition
+                                                                            }
+                                                                            justPlaced={
+                                                                                block.id ===
+                                                                                justPlacedId
+                                                                            }
+                                                                            projectUuid={
+                                                                                projectUuid
+                                                                            }
+                                                                            canUp={canMoveUp(
+                                                                                draft,
+                                                                                block.id,
+                                                                            )}
+                                                                            canDown={canMoveDown(
+                                                                                draft,
+                                                                                block.id,
+                                                                            )}
+                                                                            onUp={() =>
+                                                                                setDraft(
+                                                                                    (
                                                                                         prev,
-                                                                                        block.id,
-                                                                                    ),
-                                                                            )
-                                                                        }
-                                                                        onDown={() =>
-                                                                            setDraft(
-                                                                                (
-                                                                                    prev,
-                                                                                ) =>
-                                                                                    moveBlockDown(
+                                                                                    ) =>
+                                                                                        moveBlockUp(
+                                                                                            prev,
+                                                                                            block.id,
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                            onDown={() =>
+                                                                                setDraft(
+                                                                                    (
                                                                                         prev,
-                                                                                        block.id,
-                                                                                    ),
-                                                                            )
-                                                                        }
-                                                                        onDuplicate={() =>
-                                                                            setDraft(
-                                                                                (
-                                                                                    prev,
-                                                                                ) =>
-                                                                                    duplicateBlock(
+                                                                                    ) =>
+                                                                                        moveBlockDown(
+                                                                                            prev,
+                                                                                            block.id,
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                            onDuplicate={() =>
+                                                                                setDraft(
+                                                                                    (
                                                                                         prev,
-                                                                                        block.id,
-                                                                                    ),
-                                                                            )
-                                                                        }
-                                                                        onRemove={() =>
-                                                                            setDraft(
-                                                                                (
-                                                                                    prev,
-                                                                                ) =>
-                                                                                    removeBlock(
+                                                                                    ) =>
+                                                                                        duplicateBlock(
+                                                                                            prev,
+                                                                                            block.id,
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                            onRemove={() =>
+                                                                                setDraft(
+                                                                                    (
                                                                                         prev,
-                                                                                        block.id,
-                                                                                    ),
-                                                                            )
-                                                                        }
-                                                                        onChange={(
-                                                                            updated,
-                                                                        ) =>
-                                                                            setDraft(
-                                                                                (
-                                                                                    prev,
-                                                                                ) =>
-                                                                                    replaceBlock(
+                                                                                    ) =>
+                                                                                        removeBlock(
+                                                                                            prev,
+                                                                                            block.id,
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                            onChange={(
+                                                                                updated,
+                                                                            ) =>
+                                                                                setDraft(
+                                                                                    (
                                                                                         prev,
-                                                                                        updated,
-                                                                                    ),
-                                                                            )
-                                                                        }
-                                                                    />
+                                                                                    ) =>
+                                                                                        replaceBlock(
+                                                                                            prev,
+                                                                                            updated,
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                        />
+                                                                    </div>
                                                                 </Fragment>
                                                             );
                                                         },

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -5,7 +5,7 @@ import {
 } from '@lightdash/common';
 import { Box, Paper, Text } from '@mantine-8/core';
 import { type FC, type ReactNode } from 'react';
-import { type BlockWidthTier } from './blockLayout';
+import { TIER_CLASS } from './blockLayout';
 import { getBlockDefinition } from './blocks/registry';
 import { type BlockPresentation } from './blocks/types';
 import layout from './homepageLayout.module.css';
@@ -15,13 +15,6 @@ import {
 } from './resolveHomepageLayout';
 
 const PERSONAL_BLOCK_TYPES: HomepageBlock['type'][] = ['favorites', 'recent'];
-
-const TIER_CLASS: Record<BlockWidthTier, string> = {
-    reading: layout.tierReading,
-    composer: layout.tierComposer,
-    content: layout.tierContent,
-    full: layout.tierFull,
-};
 
 // Unknown block types render nothing so newer configs degrade gracefully
 const BlockRenderer: FC<{

--- a/packages/frontend/src/ee/features/homepageBuilder/blockLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blockLayout.ts
@@ -1,4 +1,5 @@
 import { type HomepageBlock } from '@lightdash/common';
+import layout from './homepageLayout.module.css';
 
 // How wide a single-block row of this type should render. Formalises the
 // magic widths that used to live as ad-hoc maps in PublishedHomepage.
@@ -79,3 +80,11 @@ const blockLayoutTraits: Record<HomepageBlock['type'], BlockLayoutTrait> = {
 
 export const traitFor = (type: HomepageBlock['type']): BlockLayoutTrait =>
     blockLayoutTraits[type];
+
+// Width tier → shared layout class, used by both render surfaces.
+export const TIER_CLASS: Record<BlockWidthTier, string> = {
+    reading: layout.tierReading,
+    composer: layout.tierComposer,
+    content: layout.tierContent,
+    full: layout.tierFull,
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
@@ -309,6 +309,61 @@ describe('resolveHomepageLayout', () => {
         });
     });
 
+    describe('build surface', () => {
+        it('keeps config-empty blocks and rows 1:1 with the config', () => {
+            const config = makeConfig([
+                [emptyBlock('ann', 'announcements')],
+                [emptyBlock('r', 'resources'), block('f', 'favorites')],
+                [block('c', 'collection')],
+            ]);
+            const { rows } = resolveHomepageLayout(config, {
+                surface: 'build',
+            });
+            expect(rows.map((r) => r.id)).toEqual([
+                'row-0',
+                'row-1',
+                'row-2',
+            ]);
+            expect(rows[1].columns.map((c) => c.block.id)).toEqual([
+                'r',
+                'f',
+            ]);
+        });
+
+        it('never hoists a hero — the ask-ai row stays in flow at composer width', () => {
+            const config = makeConfig([
+                [block('a', 'ask-ai-hero')],
+                [block('c', 'collection')],
+            ]);
+            const { hero, rows } = resolveHomepageLayout(config, {
+                surface: 'build',
+            });
+            expect(hero).toBeNull();
+            expect(rows.map((r) => r.id)).toEqual(['row-0', 'row-1']);
+            expect(rows[0].widthTier).toBe('composer');
+        });
+
+        it('applies the same fit and width math as view for visible content', () => {
+            const config = makeConfig([
+                [block('m', 'metrics'), block('f', 'favorites')],
+                [block('c', 'collection')],
+            ]);
+            const view = resolveHomepageLayout(config);
+            const build = resolveHomepageLayout(config, {
+                surface: 'build',
+            });
+            expect(build.rows.map((r) => r.fit)).toEqual(
+                view.rows.map((r) => r.fit),
+            );
+            expect(build.rows.map((r) => r.widthTier)).toEqual(
+                view.rows.map((r) => r.widthTier),
+            );
+            expect(
+                build.rows[0].columns.map((c) => c.hugUnits),
+            ).toEqual(view.rows[0].columns.map((c) => c.hugUnits));
+        });
+    });
+
     describe('hug fit', () => {
         it('multi-column rows hug', () => {
             const config = makeConfig([

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -195,10 +195,18 @@ const applyIntroRole = (rows: ResolvedRow[]): ResolvedRow[] => {
     ];
 };
 
+// 'view' hides config-empty blocks and hoists the leading hero; 'build' keeps
+// every config row/block 1:1 (empty blocks stay editable) and leaves the hero
+// in flow, while sharing all width/fit/hug math — so the edit canvas and the
+// published page cannot drift.
+export type LayoutSurface = 'view' | 'build';
+
 export const resolveHomepageLayout = (
     config: HomepageConfig,
+    opts: { surface: LayoutSurface } = { surface: 'view' },
 ): ResolvedLayout => {
-    const visibleRows = toVisibleRows(config.rows);
+    const isBuild = opts.surface === 'build';
+    const visibleRows = isBuild ? config.rows : toVisibleRows(config.rows);
     // Leading chrome rows join the hero rather than demoting it: the composer
     // is still "leading" with a quick-actions strip above it.
     const composerIdx = visibleRows.findIndex(
@@ -206,7 +214,8 @@ export const resolveHomepageLayout = (
             !row.blocks.every((b) => HERO_COMPANION_TYPES.includes(b.type)),
     );
     const composerRow = composerIdx >= 0 ? visibleRows[composerIdx] : undefined;
-    const hasLeadingHero = !!composerRow && isLeadingHero(composerRow.blocks);
+    const hasLeadingHero =
+        !isBuild && !!composerRow && isLeadingHero(composerRow.blocks);
     const bodyRows = hasLeadingHero
         ? visibleRows.slice(composerIdx + 1)
         : visibleRows;


### PR DESCRIPTION
## Homepage v2 — WYSIWYG builder canvas

Stacked on #25736. Second slice of the homepage-v2 layout sweep: what you build is what renders.

### Resolver `surface` option
`resolveHomepageLayout(config, { surface: 'view' | 'build' })`:
- `view` (default, unchanged): config-empty blocks hidden, leading hero hoisted + viewport-centred.
- `build`: every config row/block kept 1:1 (empty blocks stay editable) and the hero stays in flow at composer width — while sharing **all** width/fit/hug math with `view`. One layout brain, two surfaces; the builder ≠ published drift can't reopen.

### Canvas renders through the resolver
- The canvas row containers adopt the shared layout classes: width tier (`reading`/`composer`/`content`/`full`), `data-fit` hug clustering, and per-column `data-weight`/`data-hug-units` — the same CSS the published page uses. DnD structure (SortableContext, row gaps, gutters, block chrome) is untouched.
- `canvasInner` widened 960 → 1224 so the canvas shows the published page's real 1160 content width instead of a compressed approximation.
- Hero vertical viewport-centring stays preview-only, deliberately: rows must remain in flow for drag-and-drop; the Preview toggle is the exact published render.

### Testing
- 3 new resolver tests (build keeps rows 1:1, never hoists, same fit/tier/hug as view); 84 homepage-builder tests green.
- Live QA on a scratch draft homepage: canvas vs Preview measured — identical fit sequence and tier widths (composer row 720 on both); drag-and-drop verified working across resolved rows (block relocation re-resolves layout live). Content-hugged columns hug their (bigger) build-mode forms, which is expected — unit-based columns match exactly.

### Who's affected
EE homepage builder only (feature-flagged, unreleased). No API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoJHV5NJ5SSajknBVpaG4C
