### PR TITLE
feat: support AI hints on field groups

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/getMetadata.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/getMetadata.test.ts
@@ -115,6 +115,30 @@ describe('getMetadata description truncation', () => {
     });
 });
 
+describe('getMetadata group AI hints', () => {
+    it('resolves group hints only when rendering a field for the agent', async () => {
+        const explore = makeExplore({});
+        explore.tables.orders.groupDetails = {
+            settlements: {
+                label: 'Settlements',
+                aiHint: 'Use for zephyr settlement questions.',
+            },
+        };
+        explore.tables.orders.dimensions.status.groups = ['settlements'];
+
+        const result = await execute(explore, [
+            {
+                type: 'field',
+                fields: [{ exploreId: 'sales', fieldId: 'orders_status' }],
+            },
+        ]);
+
+        expect(result.result).toContain(
+            'hint: Use for zephyr settlement questions.',
+        );
+    });
+});
+
 describe('getMetadata explore field listing', () => {
     // The explore summary must list the base table's field ids directly: when
     // field discovery (grep/FTS) misbehaves, this is the agent's ground-truth

--- a/packages/backend/src/ee/services/ai/tools/getMetadata.ts
+++ b/packages/backend/src/ee/services/ai/tools/getMetadata.ts
@@ -1,4 +1,5 @@
 import {
+    getEffectiveFieldAiHints,
     getFilterTypeFromItemType,
     getMetadataToolDefinition,
     isDimension,
@@ -158,7 +159,9 @@ const renderField = (
             `  description: ${collapse(field.description, FIELD_DESCRIPTION_MAX)}`,
         );
     }
-    const hint = flatHint(field.aiHint);
+    const hint = flatHint(
+        getEffectiveFieldAiHints(field, explore.tables[field.table]),
+    );
     if (hint) lines.push(`  hint: ${collapse(hint, FIELD_DESCRIPTION_MAX)}`);
     return lines.join('\n');
 };
@@ -203,7 +206,9 @@ const buildFieldStructuredResult = (
 ): GetMetadataResult['fields'][number] => {
     const { field, isJoined } = found;
     const exploreId = explore.name;
-    const hint = flatHint(field.aiHint);
+    const hint = flatHint(
+        getEffectiveFieldAiHints(field, explore.tables[field.table]),
+    );
     const defaultTimeDimension = getResolvedDefaultTimeDimension(
         explore,
         field,

--- a/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.grepPrecision.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.grepPrecision.test.ts
@@ -37,6 +37,7 @@ type FieldSpec = {
     label?: string;
     description?: string;
     aiHint?: string;
+    groups?: string[];
 };
 
 const makeExplore = (over: {
@@ -45,6 +46,7 @@ const makeExplore = (over: {
     aiHint?: string | string[];
     fields: FieldSpec[];
     requiredFilters?: ModelRequiredFilterRule[];
+    groupDetails?: Explore['tables'][string]['groupDetails'];
 }): Explore => ({
     targetDatabase: SupportedDbtAdapter.POSTGRES,
     name: over.name,
@@ -65,6 +67,7 @@ const makeExplore = (over: {
             uncompiledSqlWhere: undefined,
             description: undefined,
             requiredFilters: over.requiredFilters,
+            groupDetails: over.groupDetails,
             dimensions: Object.fromEntries(
                 over.fields.map((f) => [
                     f.name,
@@ -82,6 +85,7 @@ const makeExplore = (over: {
                         tablesReferences: [over.name],
                         description: f.description,
                         aiHint: f.aiHint,
+                        groups: f.groups,
                     },
                 ]),
             ),
@@ -287,6 +291,31 @@ describe('buildFieldIndex haystack scope', () => {
         expect(compileMatcher('placed')(entry.nameHaystack)).toBe(false);
         expect(compileMatcher('placed')(entry.descHaystack)).toBe(true);
         expect(compileMatcher('self.serve')(entry.hintHaystack)).toBe(true);
+    });
+
+    it('makes group hints greppable without storing them on the field', () => {
+        const groupedExplore = makeExplore({
+            name: 'payments',
+            groupDetails: {
+                settlements: {
+                    label: 'Settlements',
+                    aiHint: 'Use for zephyr settlement questions.',
+                },
+            },
+            fields: [
+                {
+                    name: 'total_revenue',
+                    aiHint: 'Canonical revenue metric.',
+                    groups: ['settlements'],
+                },
+            ],
+        });
+
+        const [entry] = buildFieldIndex([groupedExplore]);
+        expect(entry.aiHint).toBe(
+            'Canonical revenue metric. Use for zephyr settlement questions.',
+        );
+        expect(compileMatcher('zephyr')(entry.hintHaystack)).toBe(true);
     });
 });
 

--- a/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.ts
@@ -1,6 +1,7 @@
 import {
     convertFieldRefToFieldId,
     getDefaultTimeDimension,
+    getEffectiveFieldAiHints,
     getFieldIdForDateDimension,
     getItemId,
     isJoinModelRequiredFilter,
@@ -136,7 +137,9 @@ export const buildFieldIndex = (
                 if (!field.hidden) {
                     const fieldId = `${field.table}_${field.name}`;
                     const description = field.description ?? '';
-                    const aiHint = flatHint(field.aiHint);
+                    const aiHint = flatHint(
+                        getEffectiveFieldAiHints(field, table),
+                    );
                     const nameHaystack = [fieldId, field.label]
                         .filter(Boolean)
                         .join('\n')

--- a/packages/common/src/compiler/translator.mock.ts
+++ b/packages/common/src/compiler/translator.mock.ts
@@ -350,6 +350,10 @@ export const MODEL_WITH_GROUPS_BLOCK: DbtModelNode & { relation_name: string } =
                 revenue: {
                     label: 'Revenue',
                     description: 'Revenue description',
+                    ai_hint: [
+                        'Use revenue fields for billing questions.',
+                        'Prefer revenue metrics over raw dimensions.',
+                    ],
                 },
             },
         },
@@ -437,6 +441,10 @@ export const LIGHTDASH_TABLE_WITH_GROUP_BLOCK: Omit<Table, 'lineageGraph'> = {
         revenue: {
             label: 'Revenue',
             description: 'Revenue description',
+            aiHint: [
+                'Use revenue fields for billing questions.',
+                'Prefer revenue metrics over raw dimensions.',
+            ],
         },
     },
 };

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -42,7 +42,7 @@ import {
     type CustomGranularity,
     type LightdashProjectConfig,
 } from '../types/lightdashProjectConfig';
-import { OrderFieldsByStrategy, type GroupType } from '../types/table';
+import { OrderFieldsByStrategy, type FieldGroupType } from '../types/table';
 import { type TimeFrames } from '../types/timeFrames';
 import { type WarehouseSqlBuilder } from '../types/warehouse';
 import assertUnreachable from '../utils/assertUnreachable';
@@ -921,12 +921,15 @@ export const convertTable = (
         });
     }
 
-    const groupDetails: Record<string, GroupType> = {};
+    const groupDetails: Record<string, FieldGroupType> = {};
     if (meta.group_details) {
         Object.entries(meta.group_details).forEach(([key, data]) => {
             groupDetails[key] = {
                 label: data.label,
                 description: data.description,
+                ...(data.ai_hint
+                    ? { aiHint: convertToAiHints(data.ai_hint) }
+                    : {}),
             };
         });
     }

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -526,6 +526,20 @@
                                 },
                                 "description": {
                                     "type": "string"
+                                },
+                                "ai_hint": {
+                                    "oneOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    ],
+                                    "description": "Hints inherited by fields in this group for AI-powered query generation"
                                 }
                             },
                             "required": ["label"]

--- a/packages/common/src/schemas/json/model-as-code-1.0.json
+++ b/packages/common/src/schemas/json/model-as-code-1.0.json
@@ -193,6 +193,20 @@
                             },
                             "description": {
                                 "type": "string"
+                            },
+                            "ai_hint": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ],
+                                "description": "Hints inherited by fields in this group for AI-powered query generation"
                             }
                         },
                         "required": ["label"]

--- a/packages/common/src/types/dbt.test.ts
+++ b/packages/common/src/types/dbt.test.ts
@@ -1,12 +1,43 @@
 import {
     convertColumnMetric,
     convertModelMetric,
+    getEffectiveFieldAiHints,
     getModelsFromManifest,
     patchPathParts,
     type DbtManifest,
 } from './dbt';
 import { DimensionType, MetricType } from './field';
 import { TimeFrames } from './timeFrames';
+
+describe('getEffectiveFieldAiHints', () => {
+    it('combines field and group hints without changing their source metadata', () => {
+        const field = {
+            aiHint: ['Use as the canonical value.', 'Shared guidance.'],
+            groups: ['settlements', 'missing'],
+        };
+        const table = {
+            groupDetails: {
+                settlements: {
+                    label: 'Settlements',
+                    aiHint: [
+                        'Shared guidance.',
+                        'Use for settlement questions.',
+                    ],
+                },
+            },
+        };
+
+        expect(getEffectiveFieldAiHints(field, table)).toEqual([
+            'Use as the canonical value.',
+            'Shared guidance.',
+            'Use for settlement questions.',
+        ]);
+        expect(field.aiHint).toEqual([
+            'Use as the canonical value.',
+            'Shared guidance.',
+        ]);
+    });
+});
 
 const makeManifest = (nodes: Record<string, object>): DbtManifest =>
     ({

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -18,6 +18,7 @@ import {
     friendlyName,
     getMinMaxBaseDimensionMetadata,
     type CompactOrAlias,
+    type Dimension,
     type DimensionType,
     type FieldUrl,
     type FilterAutocompleteValue,
@@ -29,7 +30,7 @@ import {
 } from './field';
 import { parseFilters, type RequiredFilter } from './filterGrammar';
 import { type LightdashProjectConfig } from './lightdashProjectConfig';
-import { type OrderFieldsByStrategy } from './table';
+import { type OrderFieldsByStrategy, type TableBase } from './table';
 import { type DefaultTimeDimension, type TimeFrames } from './timeFrames';
 
 export enum SupportedDbtAdapter {
@@ -194,6 +195,7 @@ export type DbtModelLightdashConfig = ExploreConfig &
 export type DbtModelGroup = {
     label: string;
     description?: string;
+    ai_hint?: string | string[];
 };
 
 export type DbtModelJoinType = 'inner' | 'full' | 'left' | 'right';
@@ -569,6 +571,21 @@ export const convertToAiHints = (
         return [aiHint];
     }
     return aiHint;
+};
+
+export const getEffectiveFieldAiHints = (
+    field: Pick<Dimension | Metric, 'aiHint' | 'groups'>,
+    table: Pick<TableBase, 'groupDetails'> | undefined,
+): string[] | undefined => {
+    const hints = [
+        ...(convertToAiHints(field.aiHint) ?? []),
+        ...(field.groups ?? []).flatMap(
+            (group) =>
+                convertToAiHints(table?.groupDetails?.[group]?.aiHint) ?? [],
+        ),
+    ];
+
+    return hints.length > 0 ? [...new Set(hints)] : undefined;
 };
 
 export const isDbtRpcRunSqlResults = (

--- a/packages/common/src/types/table.ts
+++ b/packages/common/src/types/table.ts
@@ -12,6 +12,12 @@ export type GroupType = {
     description?: string;
 };
 
+export type FieldGroupType = {
+    label: string;
+    description?: string;
+    aiHint?: string | string[];
+};
+
 export type TableBase = {
     name: string; // Must be sql friendly (a-Z, 0-9, _)
     label: string; // Friendly name
@@ -36,7 +42,7 @@ export type TableBase = {
     hidden?: boolean;
     requiredAttributes?: Record<string, string | string[]>;
     anyAttributes?: Record<string, string | string[]>;
-    groupDetails?: Record<string, GroupType>;
+    groupDetails?: Record<string, FieldGroupType>;
     defaultTimeDimension?: DefaultTimeDimension;
     defaultShowUnderlyingValues?: string[];
     aiHint?: string | string[];


### PR DESCRIPTION
## Summary

- parse AI hints defined on model dimension and metric groups
- keep hints canonical on groups without persisting copied field hints
- resolve group hints only in grep-based field discovery and its metadata tool

## Verification

- common: 2,858 passed, 1 skipped
- backend: 4,465 passed, 1 skipped
- common and backend fast typechecks
- targeted lint and format checks
- browser agent run with group-only cached metadata; catalog field hint columns remained empty

Closes: [PROD-8932](https://linear.app/lightdash/issue/PROD-8932/ai-agent-support-ai-hints-on-dimension-and-metric-groups-within-an)
