### PR TITLE
refactor(frontend): port guided filter setup to MantineModal

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboardFilterRequiredGroups.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboardFilterRequiredGroups.cy.ts
@@ -190,12 +190,13 @@ describe('Dashboard filter required groups', () => {
             );
         });
 
-        // Two rules qualify for the card; the editor note is its subtitle
+        // Two rules qualify for the card; the editor note renders as the
+        // modal description and the progress as its footer, both outside the
+        // rules list testid
         cy.wait('@paymentValuesSearch');
+        cy.findByText(GUIDED_SETUP_NOTE).should('be.visible');
+        cy.findByText('0 of 2 set').should('be.visible');
         cy.findByTestId('guided-filter-setup').within(() => {
-            cy.findByText(GUIDED_SETUP_NOTE).should('be.visible');
-            cy.findByText('0 of 2 set').should('be.visible');
-
             // Set the first rule (Payment method) from the card
             cy.findAllByPlaceholderText('any value')
                 .first()
@@ -206,8 +207,8 @@ describe('Dashboard filter required groups', () => {
         cy.findByRole('option', { name: 'credit_card' }).click();
 
         // The satisfied rule collapses to a summary line with a Change link
+        cy.findByText('1 of 2 set').should('be.visible');
         cy.findByTestId('guided-filter-setup').within(() => {
-            cy.findByText('1 of 2 set').should('be.visible');
             cy.findByText('Change').should('be.visible');
             // The collapsed summary shows the operator and the value
             cy.findByText('is credit_card').should('be.visible');

--- a/packages/frontend/src/components/common/MantineModal/index.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.tsx
@@ -101,11 +101,6 @@ export type MantineModalProps = {
     resourceLabel?: string;
     icon?: IconType;
     /**
-     * aria-label for the header close button.
-     * @default Mantine's default close button label
-     */
-    closeButtonLabel?: string;
-    /**
      * Modal size. Accepts Mantine's built-in sizes ('xs', 'sm', 'md', 'lg', 'xl') or a custom number/string.
      * @default 'lg'
      */
@@ -219,7 +214,6 @@ const MantineModal: React.FC<MantineModalProps> = ({
     resourceType,
     resourceLabel,
     icon,
-    closeButtonLabel,
     size = 'lg',
     fullScreen = false,
     withCloseButton = true,
@@ -350,7 +344,6 @@ const MantineModal: React.FC<MantineModalProps> = ({
                         <Group
                             gap="sm"
                             flex={1}
-                            miw={0}
                             wrap="nowrap"
                             align="flex-start"
                         >
@@ -362,14 +355,7 @@ const MantineModal: React.FC<MantineModalProps> = ({
                                     />
                                 </Paper>
                             ) : null}
-                            <Text
-                                c="ldDark.9"
-                                fw={700}
-                                fz="md"
-                                lh="28px"
-                                miw={0}
-                                lineClamp={2}
-                            >
+                            <Text c="ldDark.9" fw={700} fz="md" lh="28px">
                                 {title}
                             </Text>
                         </Group>
@@ -378,9 +364,7 @@ const MantineModal: React.FC<MantineModalProps> = ({
                                 {headerActions}
                             </Group>
                         ) : null}
-                        {withCloseButton && (
-                            <Modal.CloseButton aria-label={closeButtonLabel} />
-                        )}
+                        {withCloseButton && <Modal.CloseButton />}
                     </Modal.Header>
 
                     {renderBody()}

--- a/packages/frontend/src/components/common/MantineModal/index.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.tsx
@@ -101,6 +101,11 @@ export type MantineModalProps = {
     resourceLabel?: string;
     icon?: IconType;
     /**
+     * aria-label for the header close button.
+     * @default Mantine's default close button label
+     */
+    closeButtonLabel?: string;
+    /**
      * Modal size. Accepts Mantine's built-in sizes ('xs', 'sm', 'md', 'lg', 'xl') or a custom number/string.
      * @default 'lg'
      */
@@ -164,6 +169,12 @@ export type MantineModalProps = {
      */
     headerActions?: React.ReactNode;
     /**
+     * Custom footer content, rendered full-width in place of the default
+     * cancel/confirm button bar. `onConfirm`, `actions`, `leftActions` and
+     * `cancelLabel` are ignored when set.
+     */
+    footer?: React.ReactNode;
+    /**
      * Label for the cancel button. Set to `false` to hide the cancel button.
      * @default "Cancel"
      */
@@ -208,6 +219,7 @@ const MantineModal: React.FC<MantineModalProps> = ({
     resourceType,
     resourceLabel,
     icon,
+    closeButtonLabel,
     size = 'lg',
     fullScreen = false,
     withCloseButton = true,
@@ -220,6 +232,7 @@ const MantineModal: React.FC<MantineModalProps> = ({
     actions,
     leftActions,
     headerActions,
+    footer,
     cancelLabel = 'Cancel',
     cancelDisabled = false,
     onCancel,
@@ -337,6 +350,7 @@ const MantineModal: React.FC<MantineModalProps> = ({
                         <Group
                             gap="sm"
                             flex={1}
+                            miw={0}
                             wrap="nowrap"
                             align="flex-start"
                         >
@@ -348,7 +362,14 @@ const MantineModal: React.FC<MantineModalProps> = ({
                                     />
                                 </Paper>
                             ) : null}
-                            <Text c="ldDark.9" fw={700} fz="md" lh="28px">
+                            <Text
+                                c="ldDark.9"
+                                fw={700}
+                                fz="md"
+                                lh="28px"
+                                miw={0}
+                                lineClamp={2}
+                            >
                                 {title}
                             </Text>
                         </Group>
@@ -357,12 +378,18 @@ const MantineModal: React.FC<MantineModalProps> = ({
                                 {headerActions}
                             </Group>
                         ) : null}
-                        {withCloseButton && <Modal.CloseButton />}
+                        {withCloseButton && (
+                            <Modal.CloseButton aria-label={closeButtonLabel} />
+                        )}
                     </Modal.Header>
 
                     {renderBody()}
 
-                    {(onConfirm || actions || leftActions) && !fullScreen ? (
+                    {footer && !fullScreen ? (
+                        <Box className={classes.actions} px="xl" py="md">
+                            {footer}
+                        </Box>
+                    ) : (onConfirm || actions || leftActions) && !fullScreen ? (
                         <Flex
                             className={classes.actions}
                             px="xl"

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.module.css
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.module.css
@@ -2,6 +2,11 @@
     min-height: 30px;
 }
 
+/* Anchors rendered as <button> don't inherit the body font */
+.buttonAnchor {
+    font-family: inherit;
+}
+
 @keyframes fade-in {
     from {
         opacity: 0;

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.tsx
@@ -159,6 +159,7 @@ const RuleSummary: FC<RuleSummaryProps> = ({ rule, fieldsMap, onChange }) => {
                 component="button"
                 type="button"
                 size="xs"
+                className={classes.buttonAnchor}
                 onClick={onChange}
             >
                 Change
@@ -421,6 +422,7 @@ export const GuidedFilterSetupProgress: FC<GuidedFilterSetupProgressProps> = ({
                 c="ldGray.6"
                 ta="center"
                 mt={4}
+                className={classes.buttonAnchor}
                 onClick={onDismiss}
             >
                 Set filters in the toolbar instead

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetup.tsx
@@ -11,27 +11,18 @@ import {
 import {
     Anchor,
     Box,
-    CloseButton,
     Collapse,
-    Divider,
     Group,
-    Paper,
     Progress,
-    ScrollArea,
     Stack,
     Text,
     ThemeIcon,
 } from '@mantine-8/core';
-import {
-    IconCheck,
-    IconCircleDashed,
-    IconFilterExclamation,
-} from '@tabler/icons-react';
+import { IconCheck, IconCircleDashed } from '@tabler/icons-react';
 import {
     Fragment,
     useCallback,
     useEffect,
-    useMemo,
     useRef,
     useState,
     type FC,
@@ -50,7 +41,6 @@ import { useFilterableItemsMap } from './useFilterableItemsMap';
 import { useUpdateDashboardFilterRule } from './useUpdateDashboardFilterRule';
 import {
     getDashboardFilterRuleLabel,
-    getFilterRequirementRules,
     isRequirementRuleSatisfied,
     type FilterRequirementRule,
 } from './utils';
@@ -178,7 +168,7 @@ const RuleSummary: FC<RuleSummaryProps> = ({ rule, fieldsMap, onChange }) => {
 };
 
 type Props = {
-    onDismiss: () => void;
+    rules: FilterRequirementRule[];
     startOfWeek?: WeekDay;
     /** Report nested filter dropdown state, like the chip popovers do */
     onSubPopoverOpen?: () => void;
@@ -186,20 +176,19 @@ type Props = {
 };
 
 /**
- * Viewer-facing setup card shown over the locked grid while filter
+ * Viewer-facing rule list shown over the locked grid while filter
  * requirements are unmet: every rule gets a real value picker (same state as
  * the filter bar chips), satisfied rules collapse to a summary line, and the
- * dashboard unlocks live once the last rule is met.
+ * dashboard unlocks live once the last rule is met. Rendered as the body of
+ * the guided setup modal (see GuidedFilterSetupOverlay).
  */
 const GuidedFilterSetup: FC<Props> = ({
-    onDismiss,
+    rules,
     startOfWeek,
     onSubPopoverOpen,
     onSubPopoverClose,
 }) => {
     const projectUuid = useDashboardContext((c) => c.projectUuid);
-    const dashboard = useDashboardContext((c) => c.dashboard);
-    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
     const allFilters = useDashboardContext((c) => c.allFilters);
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
     const filterableFieldsByTileUuid = useDashboardContext(
@@ -207,9 +196,6 @@ const GuidedFilterSetup: FC<Props> = ({
     );
     const allFilterableFieldsMap = useDashboardContext(
         (c) => c.allFilterableFieldsMap,
-    );
-    const requiredFiltersNote = useDashboardContext(
-        (c) => c.requiredFiltersNote,
     );
     const activeTab = useDashboardContext((c) => c.activeTab);
     const updateFilterRule = useUpdateDashboardFilterRule({
@@ -222,22 +208,16 @@ const GuidedFilterSetup: FC<Props> = ({
 
     const fieldsMap = useFilterableItemsMap();
 
-    const rules = useMemo(
-        () => getFilterRequirementRules(dashboardFilters),
-        [dashboardFilters],
-    );
-
-    const satisfiedCount = rules.filter(isRequirementRuleSatisfied).length;
-
-    // Keep the first unmet rule in view as the viewer works down the list
-    const viewportRef = useRef<HTMLDivElement>(null);
+    // Keep the first unmet rule in view as the viewer works down the list;
+    // scrollIntoView targets the modal body's scroll area
+    const rootRef = useRef<HTMLDivElement>(null);
     const firstUnmetRule = rules.find(
         (rule) => !isRequirementRuleSatisfied(rule),
     );
     const firstUnmetRuleId = firstUnmetRule?.id;
     useEffect(() => {
-        if (!firstUnmetRuleId || !viewportRef.current) return;
-        const target = viewportRef.current.querySelector(
+        if (!firstUnmetRuleId || !rootRef.current) return;
+        const target = rootRef.current.querySelector(
             `[data-rule-id="${CSS.escape(firstUnmetRuleId)}"]`,
         );
         target?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
@@ -267,231 +247,185 @@ const GuidedFilterSetup: FC<Props> = ({
             filterableFieldsByTileUuid={filterableFieldsByTileUuid}
             activeTabUuid={activeTab?.uuid}
         >
-            <Box data-testid="guided-filter-setup">
-                <Stack gap="xs" px="xl" py="md">
-                    <Group
-                        justify="space-between"
-                        align="flex-start"
-                        wrap="nowrap"
-                    >
-                        <Group gap="sm" wrap="nowrap" miw={0}>
-                            <Paper p="6px" withBorder radius="md">
-                                <MantineIcon
-                                    icon={IconFilterExclamation}
-                                    size="md"
-                                    color="yellow.7"
-                                />
-                            </Paper>
-                            <Text
-                                c="ldDark.9"
-                                fw={700}
-                                fz="md"
-                                lh="28px"
-                                miw={0}
-                                lineClamp={2}
-                            >
-                                Set filters to load{' '}
-                                {dashboard?.name ?? 'this dashboard'}
-                            </Text>
-                        </Group>
-                        <CloseButton
-                            aria-label="Close setup"
-                            onClick={onDismiss}
-                        />
-                    </Group>
-                    <Text size="xs" c="ldGray.6">
-                        {requiredFiltersNote ||
-                            'Data loads automatically once the filters below are set.'}
-                    </Text>
-                </Stack>
-                <Divider />
-                <ScrollArea.Autosize
-                    mah="min(400px, 45vh)"
-                    viewportRef={viewportRef}
-                >
-                    <Stack gap="sm" px="xl" py="md">
-                        {rules.map((rule, ruleIndex) => {
-                            const isSatisfied =
-                                isRequirementRuleSatisfied(rule);
-                            const isCollapsed =
-                                isSatisfied &&
-                                !expandedRuleIds.includes(rule.id);
-                            const isMultiMember = rule.members.length > 1;
-                            const firstMember = rule.members[0];
-                            const firstMemberField =
-                                fieldsMap[firstMember.target.fieldId];
+            <Box data-testid="guided-filter-setup" ref={rootRef}>
+                <Stack gap="sm">
+                    {rules.map((rule, ruleIndex) => {
+                        const isSatisfied = isRequirementRuleSatisfied(rule);
+                        const isCollapsed =
+                            isSatisfied && !expandedRuleIds.includes(rule.id);
+                        const isMultiMember = rule.members.length > 1;
+                        const firstMember = rule.members[0];
+                        const firstMemberField =
+                            fieldsMap[firstMember.target.fieldId];
 
-                            return (
-                                <Fragment key={rule.id}>
-                                    {ruleIndex > 0 && <AndSeparator />}
-                                    <Box data-rule-id={rule.id}>
-                                        <Collapse in={isCollapsed}>
-                                            <RuleSummary
-                                                rule={rule}
-                                                fieldsMap={fieldsMap}
-                                                onChange={() =>
-                                                    setExpandedRuleIds(
-                                                        (previous) => [
-                                                            ...previous,
-                                                            rule.id,
-                                                        ],
-                                                    )
-                                                }
-                                            />
-                                        </Collapse>
-                                        <Collapse in={!isCollapsed}>
-                                            <Stack gap={6}>
-                                                <Group gap={6} wrap="nowrap">
-                                                    <RuleStatusIcon
-                                                        satisfied={isSatisfied}
-                                                    />
-                                                    <Group
-                                                        gap={6}
-                                                        wrap="nowrap"
-                                                        align="baseline"
-                                                        miw={0}
+                        return (
+                            <Fragment key={rule.id}>
+                                {ruleIndex > 0 && <AndSeparator />}
+                                <Box data-rule-id={rule.id}>
+                                    <Collapse in={isCollapsed}>
+                                        <RuleSummary
+                                            rule={rule}
+                                            fieldsMap={fieldsMap}
+                                            onChange={() =>
+                                                setExpandedRuleIds(
+                                                    (previous) => [
+                                                        ...previous,
+                                                        rule.id,
+                                                    ],
+                                                )
+                                            }
+                                        />
+                                    </Collapse>
+                                    <Collapse in={!isCollapsed}>
+                                        <Stack gap={6}>
+                                            <Group gap={6} wrap="nowrap">
+                                                <RuleStatusIcon
+                                                    satisfied={isSatisfied}
+                                                />
+                                                <Group
+                                                    gap={6}
+                                                    wrap="nowrap"
+                                                    align="baseline"
+                                                    miw={0}
+                                                >
+                                                    <Text
+                                                        size="xs"
+                                                        fw={500}
+                                                        truncate
                                                     >
-                                                        <Text
-                                                            size="xs"
-                                                            fw={500}
-                                                            truncate
+                                                        {isMultiMember
+                                                            ? 'At least one of'
+                                                            : getDashboardFilterRuleLabel(
+                                                                  firstMember,
+                                                                  fieldsMap,
+                                                              )}
+                                                    </Text>
+                                                    {!isMultiMember && (
+                                                        <OperatorPicker
+                                                            filterType={getMemberFilterType(
+                                                                firstMember,
+                                                                firstMemberField,
+                                                            )}
+                                                            field={
+                                                                firstMemberField
+                                                            }
+                                                            member={firstMember}
+                                                            label={getDashboardFilterRuleLabel(
+                                                                firstMember,
+                                                                fieldsMap,
+                                                            )}
+                                                            onChange={
+                                                                handleChangeFilterRule
+                                                            }
+                                                            onOpen={
+                                                                onSubPopoverOpen
+                                                            }
+                                                            onClose={
+                                                                onSubPopoverClose
+                                                            }
+                                                        />
+                                                    )}
+                                                </Group>
+                                            </Group>
+                                            <Stack
+                                                gap={6}
+                                                pl={isMultiMember ? 22 : 0}
+                                            >
+                                                {rule.members.map(
+                                                    (member, memberIndex) => (
+                                                        <Fragment
+                                                            key={member.id}
                                                         >
-                                                            {isMultiMember
-                                                                ? 'At least one of'
-                                                                : getDashboardFilterRuleLabel(
-                                                                      firstMember,
-                                                                      fieldsMap,
-                                                                  )}
-                                                        </Text>
-                                                        {!isMultiMember && (
-                                                            <OperatorPicker
-                                                                filterType={getMemberFilterType(
-                                                                    firstMember,
-                                                                    firstMemberField,
-                                                                )}
+                                                            {memberIndex >
+                                                                0 && (
+                                                                <OrSeparator />
+                                                            )}
+                                                            <MemberInput
+                                                                member={member}
                                                                 field={
-                                                                    firstMemberField
-                                                                }
-                                                                member={
-                                                                    firstMember
+                                                                    fieldsMap[
+                                                                        member
+                                                                            .target
+                                                                            .fieldId
+                                                                    ]
                                                                 }
                                                                 label={getDashboardFilterRuleLabel(
-                                                                    firstMember,
+                                                                    member,
                                                                     fieldsMap,
                                                                 )}
+                                                                showLabel={
+                                                                    isMultiMember
+                                                                }
+                                                                popoverProps={{
+                                                                    withinPortal: true,
+                                                                    onOpen: onSubPopoverOpen,
+                                                                    onClose:
+                                                                        onSubPopoverClose,
+                                                                }}
                                                                 onChange={
                                                                     handleChangeFilterRule
                                                                 }
-                                                                onOpen={
-                                                                    onSubPopoverOpen
-                                                                }
-                                                                onClose={
-                                                                    onSubPopoverClose
-                                                                }
                                                             />
-                                                        )}
-                                                    </Group>
-                                                </Group>
-                                                <Stack
-                                                    gap={6}
-                                                    pl={isMultiMember ? 22 : 0}
-                                                >
-                                                    {rule.members.map(
-                                                        (
-                                                            member,
-                                                            memberIndex,
-                                                        ) => (
-                                                            <Fragment
-                                                                key={member.id}
-                                                            >
-                                                                {memberIndex >
-                                                                    0 && (
-                                                                    <OrSeparator />
-                                                                )}
-                                                                <MemberInput
-                                                                    member={
-                                                                        member
-                                                                    }
-                                                                    field={
-                                                                        fieldsMap[
-                                                                            member
-                                                                                .target
-                                                                                .fieldId
-                                                                        ]
-                                                                    }
-                                                                    label={getDashboardFilterRuleLabel(
-                                                                        member,
-                                                                        fieldsMap,
-                                                                    )}
-                                                                    showLabel={
-                                                                        isMultiMember
-                                                                    }
-                                                                    popoverProps={{
-                                                                        withinPortal: true,
-                                                                        onOpen: onSubPopoverOpen,
-                                                                        onClose:
-                                                                            onSubPopoverClose,
-                                                                    }}
-                                                                    onChange={
-                                                                        handleChangeFilterRule
-                                                                    }
-                                                                />
-                                                            </Fragment>
-                                                        ),
-                                                    )}
-                                                </Stack>
+                                                        </Fragment>
+                                                    ),
+                                                )}
                                             </Stack>
-                                        </Collapse>
-                                    </Box>
-                                </Fragment>
-                            );
-                        })}
-                    </Stack>
-                </ScrollArea.Autosize>
-                <Divider />
-                <Stack gap={6} px="xl" py="md">
-                    <Group justify="space-between">
-                        <Text size="xs" c="ldGray.6">
-                            {satisfiedCount} of {rules.length} set
-                        </Text>
-                        <Text
-                            size="xs"
-                            c={
-                                rules.length - satisfiedCount === 0
-                                    ? 'green'
-                                    : 'ldGray.5'
-                            }
-                        >
-                            {rules.length - satisfiedCount === 0
-                                ? 'Loading your dashboard'
-                                : `${rules.length - satisfiedCount} more to go`}
-                        </Text>
-                    </Group>
-                    <Progress
-                        size="xs"
-                        color={
-                            satisfiedCount === rules.length ? 'green' : 'yellow'
-                        }
-                        value={
-                            rules.length > 0
-                                ? (satisfiedCount / rules.length) * 100
-                                : 0
-                        }
-                    />
-                    <Anchor
-                        component="button"
-                        type="button"
-                        size="xs"
-                        c="ldGray.6"
-                        ta="center"
-                        mt={4}
-                        onClick={onDismiss}
-                    >
-                        Set filters in the toolbar instead
-                    </Anchor>
+                                        </Stack>
+                                    </Collapse>
+                                </Box>
+                            </Fragment>
+                        );
+                    })}
                 </Stack>
             </Box>
         </FiltersProvider>
+    );
+};
+
+type GuidedFilterSetupProgressProps = {
+    rules: FilterRequirementRule[];
+    onDismiss: () => void;
+};
+
+/** Progress readout rendered as the guided setup modal's footer */
+export const GuidedFilterSetupProgress: FC<GuidedFilterSetupProgressProps> = ({
+    rules,
+    onDismiss,
+}) => {
+    const satisfiedCount = rules.filter(isRequirementRuleSatisfied).length;
+    const remainingCount = rules.length - satisfiedCount;
+
+    return (
+        <Stack gap={6}>
+            <Group justify="space-between">
+                <Text size="xs" c="ldGray.6">
+                    {satisfiedCount} of {rules.length} set
+                </Text>
+                <Text size="xs" c={remainingCount === 0 ? 'green' : 'ldGray.5'}>
+                    {remainingCount === 0
+                        ? 'Loading your dashboard'
+                        : `${remainingCount} more to go`}
+                </Text>
+            </Group>
+            <Progress
+                size="xs"
+                color={remainingCount === 0 ? 'green' : 'yellow'}
+                value={
+                    rules.length > 0 ? (satisfiedCount / rules.length) * 100 : 0
+                }
+            />
+            <Anchor
+                component="button"
+                type="button"
+                size="xs"
+                c="ldGray.6"
+                ta="center"
+                mt={4}
+                onClick={onDismiss}
+            >
+                Set filters in the toolbar instead
+            </Anchor>
+        </Stack>
     );
 };
 

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.test.tsx
@@ -96,7 +96,7 @@ describe('GuidedFilterSetupOverlay', () => {
 
         expect(screen.getByTestId('guided-filter-setup')).not.toBeNull();
         expect(
-            screen.getByText('Set filters to load Sales dashboard'),
+            screen.getByText('Set filters to load this dashboard'),
         ).not.toBeNull();
         expect(
             screen.getByText('Pick a customer to get started'),

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.test.tsx
@@ -113,9 +113,9 @@ describe('GuidedFilterSetupOverlay', () => {
         await userEvent.click(screen.getByTestId('guided-filter-setup'));
         expect(onDismiss).not.toHaveBeenCalled();
 
-        await userEvent.click(
-            screen.getByRole('button', { name: 'Close setup' }),
-        );
+        const closeButton = document.querySelector('.mantine-8-Modal-close');
+        expect(closeButton).not.toBeNull();
+        await userEvent.click(closeButton as HTMLElement);
         expect(onDismiss).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.tsx
@@ -1,9 +1,13 @@
 import { type WeekDay } from '@lightdash/common';
-import { Modal } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
-import { type FC } from 'react';
+import { IconFilterExclamation } from '@tabler/icons-react';
+import { useMemo, type FC } from 'react';
+import MantineModal from '../../../components/common/MantineModal';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
-import GuidedFilterSetup from './GuidedFilterSetup';
+import GuidedFilterSetup, {
+    GuidedFilterSetupProgress,
+} from './GuidedFilterSetup';
+import { getFilterRequirementRules } from './utils';
 
 type Props = {
     /** Applied to the modal root (embed passes its contract class) */
@@ -12,11 +16,6 @@ type Props = {
     onDismiss: () => void;
 };
 
-/**
- * Composes Modal.Root directly (like SchedulerModal) instead of MantineModal:
- * the footer is a progress readout rather than the cancel/confirm button bar
- * MantineModal hard-codes. The content surface stays stock Modal.Content.
- */
 const GuidedFilterSetupOverlay: FC<Props> = ({
     className,
     startOfWeek,
@@ -31,6 +30,16 @@ const GuidedFilterSetupOverlay: FC<Props> = ({
     const isLoadingDashboardFilters = useDashboardContext(
         (c) => c.isLoadingDashboardFilters,
     );
+    const dashboard = useDashboardContext((c) => c.dashboard);
+    const requiredFiltersNote = useDashboardContext(
+        (c) => c.requiredFiltersNote,
+    );
+    const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
+
+    const rules = useMemo(
+        () => getFilterRequirementRules(dashboardFilters),
+        [dashboardFilters],
+    );
 
     // Until the filterable fields arrive every member resolves an undefined
     // field, so inputs would render as the fallback type with validation
@@ -38,25 +47,42 @@ const GuidedFilterSetupOverlay: FC<Props> = ({
     if (isLoadingDashboardFilters) return null;
 
     return (
-        <Modal.Root
+        <MantineModal
             opened
             onClose={onDismiss}
+            title={`Set filters to load ${dashboard?.name ?? 'this dashboard'}`}
+            description={
+                requiredFiltersNote ||
+                'Data loads automatically once the filters below are set.'
+            }
+            icon={IconFilterExclamation}
+            closeButtonLabel="Close setup"
             size={420}
-            yOffset="max(170px, 20vh)"
-            closeOnEscape={!isSubPopoverOpen}
-            transitionProps={{ duration: 0 }}
-            className={className}
-        >
-            <Modal.Overlay />
-            <Modal.Content aria-label="Set filters to load this dashboard">
-                <GuidedFilterSetup
-                    startOfWeek={startOfWeek}
+            bodyScrollAreaMaxHeight="min(400px, 45vh)"
+            footer={
+                <GuidedFilterSetupProgress
+                    rules={rules}
                     onDismiss={onDismiss}
-                    onSubPopoverOpen={openSubPopover}
-                    onSubPopoverClose={closeSubPopover}
                 />
-            </Modal.Content>
-        </Modal.Root>
+            }
+            modalRootProps={{
+                centered: false,
+                yOffset: 'max(170px, 20vh)',
+                closeOnEscape: !isSubPopoverOpen,
+                transitionProps: { duration: 0 },
+                className,
+            }}
+            modalContentProps={{
+                'aria-label': 'Set filters to load this dashboard',
+            }}
+        >
+            <GuidedFilterSetup
+                rules={rules}
+                startOfWeek={startOfWeek}
+                onSubPopoverOpen={openSubPopover}
+                onSubPopoverClose={closeSubPopover}
+            />
+        </MantineModal>
     );
 };
 

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.tsx
@@ -2,7 +2,6 @@ import { type WeekDay } from '@lightdash/common';
 import { useDisclosure } from '@mantine-8/hooks';
 import { IconFilterExclamation } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
-import Callout from '../../../components/common/Callout';
 import MantineModal from '../../../components/common/MantineModal';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import GuidedFilterSetup, {
@@ -52,6 +51,10 @@ const GuidedFilterSetupOverlay: FC<Props> = ({
             opened
             onClose={onDismiss}
             title={`Set filters to load ${dashboard?.name ?? 'this dashboard'}`}
+            description={
+                requiredFiltersNote ||
+                'Data loads automatically once the filters below are set.'
+            }
             icon={IconFilterExclamation}
             size={420}
             bodyScrollAreaMaxHeight="min(400px, 45vh)"
@@ -72,10 +75,6 @@ const GuidedFilterSetupOverlay: FC<Props> = ({
                 'aria-label': 'Set filters to load this dashboard',
             }}
         >
-            <Callout variant="warning">
-                {requiredFiltersNote ||
-                    'Data loads automatically once the filters below are set.'}
-            </Callout>
             <GuidedFilterSetup
                 rules={rules}
                 startOfWeek={startOfWeek}

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.tsx
@@ -72,7 +72,7 @@ const GuidedFilterSetupOverlay: FC<Props> = ({
                 'aria-label': 'Set filters to load this dashboard',
             }}
         >
-            <Callout variant="info">
+            <Callout variant="warning">
                 {requiredFiltersNote ||
                     'Data loads automatically once the filters below are set.'}
             </Callout>

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.tsx
@@ -2,6 +2,7 @@ import { type WeekDay } from '@lightdash/common';
 import { useDisclosure } from '@mantine-8/hooks';
 import { IconFilterExclamation } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
+import Callout from '../../../components/common/Callout';
 import MantineModal from '../../../components/common/MantineModal';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import GuidedFilterSetup, {
@@ -51,12 +52,7 @@ const GuidedFilterSetupOverlay: FC<Props> = ({
             opened
             onClose={onDismiss}
             title={`Set filters to load ${dashboard?.name ?? 'this dashboard'}`}
-            description={
-                requiredFiltersNote ||
-                'Data loads automatically once the filters below are set.'
-            }
             icon={IconFilterExclamation}
-            closeButtonLabel="Close setup"
             size={420}
             bodyScrollAreaMaxHeight="min(400px, 45vh)"
             footer={
@@ -76,6 +72,10 @@ const GuidedFilterSetupOverlay: FC<Props> = ({
                 'aria-label': 'Set filters to load this dashboard',
             }}
         >
+            <Callout variant="info">
+                {requiredFiltersNote ||
+                    'Data loads automatically once the filters below are set.'}
+            </Callout>
             <GuidedFilterSetup
                 rules={rules}
                 startOfWeek={startOfWeek}

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/GuidedFilterSetupOverlay.tsx
@@ -30,7 +30,6 @@ const GuidedFilterSetupOverlay: FC<Props> = ({
     const isLoadingDashboardFilters = useDashboardContext(
         (c) => c.isLoadingDashboardFilters,
     );
-    const dashboard = useDashboardContext((c) => c.dashboard);
     const requiredFiltersNote = useDashboardContext(
         (c) => c.requiredFiltersNote,
     );
@@ -50,7 +49,7 @@ const GuidedFilterSetupOverlay: FC<Props> = ({
         <MantineModal
             opened
             onClose={onDismiss}
-            title={`Set filters to load ${dashboard?.name ?? 'this dashboard'}`}
+            title="Set filters to load this dashboard"
             description={
                 requiredFiltersNote ||
                 'Data loads automatically once the filters below are set.'

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/RequiredFilterCard.module.css
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/RequiredFilterCard.module.css
@@ -27,3 +27,8 @@
         background-color: alpha(var(--mantine-color-white), 0.04);
     }
 }
+
+/* Anchors rendered as <button> don't inherit the body font */
+.buttonAnchor {
+    font-family: inherit;
+}

--- a/packages/frontend/src/features/dashboardFilters/FilterRequirements/RequiredFilterCard.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterRequirements/RequiredFilterCard.tsx
@@ -178,6 +178,7 @@ const RequiredFilterCard: FC<Props> = ({
                                 component="button"
                                 type="button"
                                 size="xs"
+                                className={classes.buttonAnchor}
                                 onClick={onEditRules}
                             >
                                 Edit rule →


### PR DESCRIPTION
Ports the guided filter setup from a hand-rolled `Modal.Root` composition to the shared `MantineModal` component, so it gets the standard header, body, and styling for free.

- Adds a `footer` prop to `MantineModal` for custom full-width footer content (replaces the default cancel/confirm bar) — this was the blocker for using it here; the only `MantineModal` API change
- The "set filters" note renders as the standard `description`, and the icon uses the stock header styling (no custom color)
- The title is now the static "Set filters to load this dashboard" instead of interpolating the dashboard name, so long names can't blow up the standard header
- Fixes `Anchor component="button"` anchors in the filter setup falling back to the browser default font instead of Inter
- Rescopes the guided setup e2e assertions: the note (modal description) and progress (modal footer) now live outside the rules-list testid
- Net negative: the guided setup's hand-rolled header/dividers/scroll/footer are gone
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/587ec198-fc0f-4f66-b804-6827263dea58" />


Relates: PROD-8971
Relates: #25710
