### PR TITLE
feat(homepage): project announcements backend — tables, CRUD, categories, pin

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -492,6 +492,10 @@ import {
     ProjectCiStatusTableName,
 } from '../ee/database/entities/projectCiStatus';
 import {
+    AnnouncementCategoriesTable,
+    AnnouncementCategoriesTableName,
+    AnnouncementsTable,
+    AnnouncementsTableName,
     HomepageAssignmentsTable,
     HomepageAssignmentsTableName,
     HomepagePersonalOverridesTable,
@@ -637,6 +641,8 @@ declare module 'knex/types/tables' {
         [HomepagesTableName]: ProjectHomepagesTable;
         [HomepageAssignmentsTableName]: HomepageAssignmentsTable;
         [HomepagePersonalOverridesTableName]: HomepagePersonalOverridesTable;
+        [AnnouncementCategoriesTableName]: AnnouncementCategoriesTable;
+        [AnnouncementsTableName]: AnnouncementsTable;
         [AiAgentReasoningTableName]: AiAgentReasoningTable;
         [AiAgentToolCallTableName]: AiAgentToolCallTable;
         [AiAgentToolCallErrorTableName]: AiAgentToolCallErrorTable;

--- a/packages/backend/src/ee/controllers/projectAnnouncementsController.ts
+++ b/packages/backend/src/ee/controllers/projectAnnouncementsController.ts
@@ -1,0 +1,189 @@
+import {
+    assertRegisteredAccount,
+    type ApiAnnouncementCategoriesResponse,
+    type ApiAnnouncementCategoryResponse,
+    type ApiAnnouncementResponse,
+    type ApiAnnouncementsResponse,
+    type ApiErrorPayload,
+    type ApiSuccessEmpty,
+    type CreateAnnouncementCategoryRequest,
+    type CreateAnnouncementRequest,
+    type UpdateAnnouncementRequest,
+    type UUID,
+} from '@lightdash/common';
+import {
+    Body,
+    Delete,
+    Get,
+    Middlewares,
+    OperationId,
+    Patch,
+    Path,
+    Post,
+    Query,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import { toSessionUser } from '../../auth/account/account';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { type ProjectHomepageService } from '../services/ProjectHomepageService';
+
+@Route('/api/v1/projects/{projectUuid}/announcements')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('Homepage')
+export class ProjectAnnouncementsController extends BaseController {
+    private getHomepageService(): ProjectHomepageService {
+        return this.services.getProjectHomepageService<ProjectHomepageService>();
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('listProjectAnnouncements')
+    async list(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Query() page: number = 1,
+        @Query() pageSize: number = 25,
+        @Query() categoryUuid?: UUID,
+    ): Promise<ApiAnnouncementsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().listAnnouncements(
+                toSessionUser(req.account),
+                projectUuid,
+                { page, pageSize, categoryUuid },
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('201', 'Created')
+    @Post('/')
+    @OperationId('createProjectAnnouncement')
+    async create(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Body() body: CreateAnnouncementRequest,
+    ): Promise<ApiAnnouncementResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(201);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().createAnnouncement(
+                toSessionUser(req.account),
+                projectUuid,
+                body,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/{announcementUuid}')
+    @OperationId('updateProjectAnnouncement')
+    async update(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() announcementUuid: UUID,
+        @Body() body: UpdateAnnouncementRequest,
+    ): Promise<ApiAnnouncementResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().updateAnnouncement(
+                toSessionUser(req.account),
+                projectUuid,
+                announcementUuid,
+                body,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Delete('/{announcementUuid}')
+    @OperationId('deleteProjectAnnouncement')
+    async delete(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() announcementUuid: UUID,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.getHomepageService().deleteAnnouncement(
+            toSessionUser(req.account),
+            projectUuid,
+            announcementUuid,
+        );
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/categories')
+    @OperationId('listProjectAnnouncementCategories')
+    async listCategories(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+    ): Promise<ApiAnnouncementCategoriesResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().listAnnouncementCategories(
+                toSessionUser(req.account),
+                projectUuid,
+            ),
+        };
+    }
+
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('201', 'Created')
+    @Post('/categories')
+    @OperationId('createProjectAnnouncementCategory')
+    async createCategory(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Body() body: CreateAnnouncementCategoryRequest,
+    ): Promise<ApiAnnouncementCategoryResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(201);
+        return {
+            status: 'ok',
+            results: await this.getHomepageService().createAnnouncementCategory(
+                toSessionUser(req.account),
+                projectUuid,
+                body,
+            ),
+        };
+    }
+}

--- a/packages/backend/src/ee/database/entities/projectHomepages.ts
+++ b/packages/backend/src/ee/database/entities/projectHomepages.ts
@@ -93,3 +93,52 @@ export type HomepageAssignmentsTable = Knex.CompositeTableType<
     DbHomepageAssignmentIn,
     DbHomepageAssignmentUpdate
 >;
+
+export const AnnouncementCategoriesTableName =
+    'project_announcement_categories';
+
+export type DbAnnouncementCategory = {
+    category_uuid: string;
+    project_uuid: string;
+    name: string;
+    color: string;
+    created_at: Date;
+};
+
+export type AnnouncementCategoriesTable = Knex.CompositeTableType<
+    DbAnnouncementCategory,
+    Pick<DbAnnouncementCategory, 'project_uuid' | 'name' | 'color'>,
+    Partial<Pick<DbAnnouncementCategory, 'name' | 'color'>>
+>;
+
+export const AnnouncementsTableName = 'project_announcements';
+
+export type DbAnnouncement = {
+    announcement_uuid: string;
+    project_uuid: string;
+    title: string;
+    body: string | null;
+    category_uuid: string | null;
+    pinned: boolean;
+    created_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type DbAnnouncementIn = Pick<
+    DbAnnouncement,
+    'project_uuid' | 'title' | 'body' | 'category_uuid' | 'created_by_user_uuid'
+>;
+
+export type DbAnnouncementUpdate = Partial<
+    Pick<
+        DbAnnouncement,
+        'title' | 'body' | 'category_uuid' | 'pinned' | 'updated_at'
+    >
+>;
+
+export type AnnouncementsTable = Knex.CompositeTableType<
+    DbAnnouncement,
+    DbAnnouncementIn,
+    DbAnnouncementUpdate
+>;

--- a/packages/backend/src/ee/database/migrations/20260721170000_create_project_announcements_tables.ts
+++ b/packages/backend/src/ee/database/migrations/20260721170000_create_project_announcements_tables.ts
@@ -1,0 +1,73 @@
+import { Knex } from 'knex';
+
+const CATEGORIES_TABLE = 'project_announcement_categories';
+const ANNOUNCEMENTS_TABLE = 'project_announcements';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(CATEGORIES_TABLE, (table) => {
+        table
+            .uuid('category_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE')
+            .index();
+        table.text('name').notNullable();
+        table.text('color').notNullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table.unique(['project_uuid', 'name']);
+    });
+
+    await knex.schema.createTable(ANNOUNCEMENTS_TABLE, (table) => {
+        table
+            .uuid('announcement_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE')
+            .index();
+        table.text('title').notNullable();
+        table.text('body').nullable();
+        table
+            .uuid('category_uuid')
+            .nullable()
+            .references('category_uuid')
+            .inTable(CATEGORIES_TABLE)
+            .onDelete('SET NULL');
+        table.boolean('pinned').notNullable().defaultTo(false);
+        table
+            .uuid('created_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL');
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+    await knex.raw(`
+        CREATE UNIQUE INDEX project_announcements_one_pinned_per_project
+        ON ${ANNOUNCEMENTS_TABLE} (project_uuid) WHERE pinned = true
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(ANNOUNCEMENTS_TABLE);
+    await knex.schema.dropTableIfExists(CATEGORIES_TABLE);
+}

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -2,20 +2,28 @@ import {
     ConflictError,
     NotFoundError,
     ParameterError,
+    type AnnouncementCategory,
+    type AnnouncementsPage,
     type HomepageAssignment,
     type HomepageAudience,
     type HomepageConfig,
     type HomepageRecentlyViewedItem,
+    type ProjectAnnouncement,
     type ProjectHomepage,
     type ProjectMemberRole,
     type PublishedProjectHomepage,
     type ResolvedPublishedHomepage,
+    type UpdateAnnouncementRequest,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
 import {
+    AnnouncementCategoriesTableName,
+    AnnouncementsTableName,
     HomepageAssignmentsTableName,
     HomepagePersonalOverridesTableName,
     HomepagesTableName,
+    type DbAnnouncement,
+    type DbAnnouncementCategory,
     type DbProjectHomepage,
 } from '../database/entities/projectHomepages';
 
@@ -503,5 +511,235 @@ export class ProjectHomepageModel {
         return publishedDefault
             ? { homepage: publishedDefault, source: { type: 'default' } }
             : undefined;
+    }
+
+    // --- Announcements -----------------------------------------------------
+
+    private static mapDbAnnouncement(
+        row: DbAnnouncement & { author_name?: string | null },
+    ): ProjectAnnouncement {
+        return {
+            announcementUuid: row.announcement_uuid,
+            projectUuid: row.project_uuid,
+            title: row.title,
+            body: row.body,
+            categoryUuid: row.category_uuid,
+            pinned: row.pinned,
+            createdByUserUuid: row.created_by_user_uuid,
+            authorName: row.author_name?.trim() || null,
+            createdAt: row.created_at,
+            updatedAt: row.updated_at,
+        };
+    }
+
+    private announcementsQuery(projectUuid: string, categoryUuid?: string) {
+        const query = this.database(AnnouncementsTableName)
+            .where(`${AnnouncementsTableName}.project_uuid`, projectUuid)
+            .orderBy([
+                { column: 'pinned', order: 'desc' },
+                {
+                    column: `${AnnouncementsTableName}.created_at`,
+                    order: 'desc',
+                },
+            ]);
+        if (categoryUuid) {
+            // Knex builders are thenables; void marks the in-place mutation
+            // as intentionally not awaited.
+            void query.where(
+                `${AnnouncementsTableName}.category_uuid`,
+                categoryUuid,
+            );
+        }
+        return query;
+    }
+
+    async listAnnouncements(
+        projectUuid: string,
+        options: { page: number; pageSize: number; categoryUuid?: string },
+    ): Promise<AnnouncementsPage> {
+        const offset = (options.page - 1) * options.pageSize;
+        const [rows, countRow] = await Promise.all([
+            this.announcementsQuery(projectUuid, options.categoryUuid)
+                .leftJoin(
+                    'users',
+                    'users.user_uuid',
+                    `${AnnouncementsTableName}.created_by_user_uuid`,
+                )
+                .select(
+                    `${AnnouncementsTableName}.*`,
+                    this.database.raw(
+                        `TRIM(CONCAT(users.first_name, ' ', users.last_name)) as author_name`,
+                    ),
+                )
+                .offset(offset)
+                .limit(options.pageSize),
+            this.database(AnnouncementsTableName)
+                .where('project_uuid', projectUuid)
+                .modify((builder) => {
+                    if (options.categoryUuid) {
+                        void builder.where(
+                            'category_uuid',
+                            options.categoryUuid,
+                        );
+                    }
+                })
+                .count<{ count: string }>('* as count')
+                .first(),
+        ]);
+        return {
+            items: rows.map(ProjectHomepageModel.mapDbAnnouncement),
+            totalCount: Number(countRow?.count ?? 0),
+        };
+    }
+
+    async getAnnouncement(
+        announcementUuid: string,
+    ): Promise<ProjectAnnouncement | undefined> {
+        const row = await this.database(AnnouncementsTableName)
+            .where({ announcement_uuid: announcementUuid })
+            .first();
+        return row ? ProjectHomepageModel.mapDbAnnouncement(row) : undefined;
+    }
+
+    async createAnnouncement(data: {
+        projectUuid: string;
+        title: string;
+        body: string | null;
+        categoryUuid: string | null;
+        createdByUserUuid: string;
+    }): Promise<ProjectAnnouncement> {
+        const [row] = await this.database(AnnouncementsTableName)
+            .insert({
+                project_uuid: data.projectUuid,
+                title: data.title,
+                body: data.body,
+                category_uuid: data.categoryUuid,
+                created_by_user_uuid: data.createdByUserUuid,
+            })
+            .returning('*');
+        return ProjectHomepageModel.mapDbAnnouncement(row);
+    }
+
+    async updateAnnouncement(
+        announcementUuid: string,
+        update: UpdateAnnouncementRequest,
+    ): Promise<ProjectAnnouncement> {
+        return this.database.transaction(async (trx) => {
+            const existing = await trx(AnnouncementsTableName)
+                .where({ announcement_uuid: announcementUuid })
+                .first();
+            if (!existing) throw new NotFoundError('Announcement not found');
+            // Single lead story: pinning unpins the previous lead first.
+            if (update.pinned === true) {
+                await trx(AnnouncementsTableName)
+                    .where({
+                        project_uuid: existing.project_uuid,
+                        pinned: true,
+                    })
+                    .update({ pinned: false });
+            }
+            const [row] = await trx(AnnouncementsTableName)
+                .where({ announcement_uuid: announcementUuid })
+                .update({
+                    ...(update.title !== undefined && { title: update.title }),
+                    ...(update.body !== undefined && { body: update.body }),
+                    ...(update.categoryUuid !== undefined && {
+                        category_uuid: update.categoryUuid,
+                    }),
+                    ...(update.pinned !== undefined && {
+                        pinned: update.pinned,
+                    }),
+                    updated_at: new Date(),
+                })
+                .returning('*');
+            return ProjectHomepageModel.mapDbAnnouncement(row);
+        });
+    }
+
+    async deleteAnnouncement(announcementUuid: string): Promise<void> {
+        const deleted = await this.database(AnnouncementsTableName)
+            .where({ announcement_uuid: announcementUuid })
+            .delete();
+        if (deleted === 0) throw new NotFoundError('Announcement not found');
+    }
+
+    private static readonly STARTER_CATEGORIES: Array<
+        Pick<AnnouncementCategory, 'name' | 'color'>
+    > = [
+        { name: 'Release', color: '#3b5bdb' },
+        { name: 'Incident', color: '#c92a2a' },
+        { name: 'Data change', color: '#2b8a3e' },
+    ];
+
+    private static mapDbCategory(
+        row: DbAnnouncementCategory,
+    ): AnnouncementCategory {
+        return {
+            categoryUuid: row.category_uuid,
+            projectUuid: row.project_uuid,
+            name: row.name,
+            color: row.color,
+        };
+    }
+
+    async listCategories(projectUuid: string): Promise<AnnouncementCategory[]> {
+        const existing = await this.database(AnnouncementCategoriesTableName)
+            .where({ project_uuid: projectUuid })
+            .orderBy('created_at', 'asc');
+        if (existing.length > 0) {
+            return existing.map(ProjectHomepageModel.mapDbCategory);
+        }
+        // Lazy starter set; tolerate a concurrent seeder via onConflict.
+        await this.database(AnnouncementCategoriesTableName)
+            .insert(
+                ProjectHomepageModel.STARTER_CATEGORIES.map((category) => ({
+                    project_uuid: projectUuid,
+                    name: category.name,
+                    color: category.color,
+                })),
+            )
+            .onConflict(['project_uuid', 'name'])
+            .ignore();
+        const seeded = await this.database(AnnouncementCategoriesTableName)
+            .where({ project_uuid: projectUuid })
+            .orderBy('created_at', 'asc');
+        return seeded.map(ProjectHomepageModel.mapDbCategory);
+    }
+
+    async getCategory(
+        categoryUuid: string,
+    ): Promise<AnnouncementCategory | undefined> {
+        const row = await this.database(AnnouncementCategoriesTableName)
+            .where({ category_uuid: categoryUuid })
+            .first();
+        return row ? ProjectHomepageModel.mapDbCategory(row) : undefined;
+    }
+
+    async createCategory(data: {
+        projectUuid: string;
+        name: string;
+        color: string;
+    }): Promise<AnnouncementCategory> {
+        try {
+            const [row] = await this.database(AnnouncementCategoriesTableName)
+                .insert({
+                    project_uuid: data.projectUuid,
+                    name: data.name,
+                    color: data.color,
+                })
+                .returning('*');
+            return ProjectHomepageModel.mapDbCategory(row);
+        } catch (error) {
+            if (
+                error instanceof Error &&
+                'code' in error &&
+                error.code === '23505'
+            ) {
+                throw new ConflictError(
+                    'A category with this name already exists',
+                );
+            }
+            throw error;
+        }
     }
 }

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -136,6 +136,16 @@ const makeService = ({
             discardDraft: vi.fn().mockResolvedValue(makeHomepage()),
             publish: vi.fn().mockResolvedValue(makeHomepage()),
             delete: vi.fn().mockResolvedValue(undefined),
+            listAnnouncements: vi
+                .fn()
+                .mockResolvedValue({ items: [], totalCount: 0 }),
+            getAnnouncement: vi.fn().mockResolvedValue(undefined),
+            createAnnouncement: vi.fn(),
+            updateAnnouncement: vi.fn(),
+            deleteAnnouncement: vi.fn().mockResolvedValue(undefined),
+            listCategories: vi.fn().mockResolvedValue([]),
+            getCategory: vi.fn().mockResolvedValue(undefined),
+            createCategory: vi.fn(),
             ...projectHomepageModel,
         },
         groupsModel: {
@@ -441,6 +451,130 @@ describe('ProjectHomepageService', () => {
         expect(result).toEqual({
             resolved: { type: 'dashboard', dashboardUuid: 'dashboard-uuid-1' },
             reason: { type: 'personal', dashboardUuid: 'dashboard-uuid-1' },
+        });
+    });
+
+    describe('announcements', () => {
+        it('createAnnouncement is forbidden for a viewer', async () => {
+            const service = makeService();
+            await expect(
+                service.createAnnouncement(makeViewerUser(), PROJECT_UUID, {
+                    title: 'Hello',
+                    body: null,
+                    categoryUuid: null,
+                }),
+            ).rejects.toThrow(ForbiddenError);
+        });
+
+        it('createAnnouncement rejects an empty title', async () => {
+            const service = makeService();
+            await expect(
+                service.createAnnouncement(makeAdminUser(), PROJECT_UUID, {
+                    title: '   ',
+                    body: null,
+                    categoryUuid: null,
+                }),
+            ).rejects.toThrow(ParameterError);
+        });
+
+        it('createAnnouncement rejects a category from another project', async () => {
+            const service = makeService({
+                projectHomepageModel: {
+                    getCategory: vi.fn().mockResolvedValue({
+                        categoryUuid: 'cat-1',
+                        projectUuid: 'other-project',
+                        name: 'Release',
+                        color: '#3b5bdb',
+                    }),
+                },
+            });
+            await expect(
+                service.createAnnouncement(makeAdminUser(), PROJECT_UUID, {
+                    title: 'Hello',
+                    body: null,
+                    categoryUuid: 'cat-1',
+                }),
+            ).rejects.toThrow(NotFoundError);
+        });
+
+        it('updateAnnouncement passes pinned through for an owned announcement', async () => {
+            const announcement = {
+                announcementUuid: 'ann-1',
+                projectUuid: PROJECT_UUID,
+                title: 'Hello',
+                body: null,
+                categoryUuid: null,
+                pinned: false,
+                createdByUserUuid: 'user-1',
+                authorName: 'Ana',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            };
+            const updateAnnouncement = vi
+                .fn()
+                .mockResolvedValue({ ...announcement, pinned: true });
+            const service = makeService({
+                projectHomepageModel: {
+                    getAnnouncement: vi.fn().mockResolvedValue(announcement),
+                    updateAnnouncement,
+                },
+            });
+            const result = await service.updateAnnouncement(
+                makeAdminUser(),
+                PROJECT_UUID,
+                'ann-1',
+                { pinned: true },
+            );
+            expect(updateAnnouncement).toHaveBeenCalledWith('ann-1', {
+                pinned: true,
+            });
+            expect(result.pinned).toBe(true);
+        });
+
+        it('updateAnnouncement 404s for an announcement in another project', async () => {
+            const service = makeService({
+                projectHomepageModel: {
+                    getAnnouncement: vi.fn().mockResolvedValue({
+                        announcementUuid: 'ann-1',
+                        projectUuid: 'other-project',
+                    }),
+                },
+            });
+            await expect(
+                service.updateAnnouncement(
+                    makeAdminUser(),
+                    PROJECT_UUID,
+                    'ann-1',
+                    { pinned: true },
+                ),
+            ).rejects.toThrow(NotFoundError);
+        });
+
+        it('createAnnouncementCategory validates the colour format', async () => {
+            const service = makeService();
+            await expect(
+                service.createAnnouncementCategory(
+                    makeAdminUser(),
+                    PROJECT_UUID,
+                    { name: 'Ops', color: 'red' },
+                ),
+            ).rejects.toThrow(ParameterError);
+        });
+
+        it('listAnnouncements allows a viewer and rejects bad pagination', async () => {
+            const service = makeService();
+            await expect(
+                service.listAnnouncements(makeViewerUser(), PROJECT_UUID, {
+                    page: 1,
+                    pageSize: 25,
+                }),
+            ).resolves.toEqual({ items: [], totalCount: 0 });
+            await expect(
+                service.listAnnouncements(makeViewerUser(), PROJECT_UUID, {
+                    page: 0,
+                    pageSize: 25,
+                }),
+            ).rejects.toThrow(ParameterError);
         });
     });
 });

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -7,6 +7,10 @@ import {
     HOMEPAGE_MAX_BLOCKS_PER_ROW,
     NotFoundError,
     ParameterError,
+    type AnnouncementCategory,
+    type AnnouncementsPage,
+    type CreateAnnouncementCategoryRequest,
+    type CreateAnnouncementRequest,
     type CreateProjectHomepageRequest,
     type HomepageAssignment,
     type HomepageAudience,
@@ -15,10 +19,12 @@ import {
     type HomepageRecentlyViewedItem,
     type HomepageViewAsResult,
     type HomepageViewAsTarget,
+    type ProjectAnnouncement,
     type ProjectHomepage,
     type ProjectMemberRole,
     type ResolvedHomepage,
     type SessionUser,
+    type UpdateAnnouncementRequest,
     type UpdateProjectHomepageDraftRequest,
 } from '@lightdash/common';
 import { type GroupsModel } from '../../models/GroupsModel';
@@ -60,6 +66,14 @@ export type ProjectHomepageServiceArguments = {
         | 'discardDraft'
         | 'publish'
         | 'delete'
+        | 'listAnnouncements'
+        | 'getAnnouncement'
+        | 'createAnnouncement'
+        | 'updateAnnouncement'
+        | 'deleteAnnouncement'
+        | 'listCategories'
+        | 'getCategory'
+        | 'createCategory'
     >;
     featureFlagService: Pick<FeatureFlagService, 'get'>;
     groupsModel: Pick<GroupsModel, 'findUserGroups'>;
@@ -496,5 +510,137 @@ export class ProjectHomepageService extends BaseService {
                 imageUrl: null,
             };
         }
+    }
+
+    // --- Announcements -----------------------------------------------------
+
+    private async getOwnedAnnouncement(
+        projectUuid: string,
+        announcementUuid: string,
+    ): Promise<ProjectAnnouncement> {
+        const announcement =
+            await this.projectHomepageModel.getAnnouncement(announcementUuid);
+        if (!announcement || announcement.projectUuid !== projectUuid) {
+            throw new NotFoundError('Announcement not found');
+        }
+        return announcement;
+    }
+
+    private async assertOwnedCategory(
+        projectUuid: string,
+        categoryUuid: string | null | undefined,
+    ): Promise<void> {
+        if (categoryUuid === null || categoryUuid === undefined) return;
+        const category =
+            await this.projectHomepageModel.getCategory(categoryUuid);
+        if (!category || category.projectUuid !== projectUuid) {
+            throw new NotFoundError('Category not found');
+        }
+    }
+
+    private static validateAnnouncementTitle(title: string): void {
+        if (title.trim().length === 0) {
+            throw new ParameterError('Announcement title cannot be empty');
+        }
+    }
+
+    async listAnnouncements(
+        user: SessionUser,
+        projectUuid: string,
+        options: { page: number; pageSize: number; categoryUuid?: string },
+    ): Promise<AnnouncementsPage> {
+        await this.assertFlagEnabled(user);
+        this.assertCanView(user, projectUuid);
+        if (
+            options.page < 1 ||
+            options.pageSize < 1 ||
+            options.pageSize > 100
+        ) {
+            throw new ParameterError('Invalid pagination');
+        }
+        return this.projectHomepageModel.listAnnouncements(
+            projectUuid,
+            options,
+        );
+    }
+
+    async createAnnouncement(
+        user: SessionUser,
+        projectUuid: string,
+        data: CreateAnnouncementRequest,
+    ): Promise<ProjectAnnouncement> {
+        await this.assertFlagEnabled(user);
+        this.assertCanManage(user, projectUuid);
+        ProjectHomepageService.validateAnnouncementTitle(data.title);
+        await this.assertOwnedCategory(projectUuid, data.categoryUuid);
+        return this.projectHomepageModel.createAnnouncement({
+            projectUuid,
+            title: data.title.trim(),
+            body: data.body,
+            categoryUuid: data.categoryUuid,
+            createdByUserUuid: user.userUuid,
+        });
+    }
+
+    async updateAnnouncement(
+        user: SessionUser,
+        projectUuid: string,
+        announcementUuid: string,
+        update: UpdateAnnouncementRequest,
+    ): Promise<ProjectAnnouncement> {
+        await this.assertFlagEnabled(user);
+        this.assertCanManage(user, projectUuid);
+        await this.getOwnedAnnouncement(projectUuid, announcementUuid);
+        if (update.title !== undefined) {
+            ProjectHomepageService.validateAnnouncementTitle(update.title);
+        }
+        await this.assertOwnedCategory(projectUuid, update.categoryUuid);
+        return this.projectHomepageModel.updateAnnouncement(announcementUuid, {
+            ...update,
+            ...(update.title !== undefined && { title: update.title.trim() }),
+        });
+    }
+
+    async deleteAnnouncement(
+        user: SessionUser,
+        projectUuid: string,
+        announcementUuid: string,
+    ): Promise<void> {
+        await this.assertFlagEnabled(user);
+        this.assertCanManage(user, projectUuid);
+        await this.getOwnedAnnouncement(projectUuid, announcementUuid);
+        await this.projectHomepageModel.deleteAnnouncement(announcementUuid);
+    }
+
+    async listAnnouncementCategories(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<AnnouncementCategory[]> {
+        await this.assertFlagEnabled(user);
+        this.assertCanView(user, projectUuid);
+        return this.projectHomepageModel.listCategories(projectUuid);
+    }
+
+    async createAnnouncementCategory(
+        user: SessionUser,
+        projectUuid: string,
+        data: CreateAnnouncementCategoryRequest,
+    ): Promise<AnnouncementCategory> {
+        await this.assertFlagEnabled(user);
+        this.assertCanManage(user, projectUuid);
+        const name = data.name.trim();
+        if (name.length === 0 || name.length > 40) {
+            throw new ParameterError(
+                'Category name must be 1-40 characters long',
+            );
+        }
+        if (!/^#[0-9a-fA-F]{6}$/.test(data.color)) {
+            throw new ParameterError('Category color must be #rrggbb');
+        }
+        return this.projectHomepageModel.createCategory({
+            projectUuid,
+            name,
+            color: data.color.toLowerCase(),
+        });
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -175,6 +175,8 @@ import { OrganizationWarehouseCredentialsController } from './../ee/controllers/
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { PreAggregateController } from './../ee/controllers/PreAggregateController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { ProjectAnnouncementsController } from './../ee/controllers/projectAnnouncementsController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ProjectHomepageController } from './../ee/controllers/projectHomepageController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { SchedulerAiAugmentationController } from './../ee/controllers/schedulerAiAugmentationController';
@@ -3154,7 +3156,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -3164,7 +3166,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -3174,7 +3176,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -3187,7 +3189,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -4212,7 +4214,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -4222,7 +4224,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -4232,7 +4234,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -4245,7 +4247,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -9823,6 +9825,224 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 allowPersonal: { dataType: 'boolean', required: true },
                 audience: { ref: 'HomepageAudience', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ProjectAnnouncement: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                authorName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                createdByUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                pinned: { dataType: 'boolean', required: true },
+                categoryUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                body: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                title: { dataType: 'string', required: true },
+                projectUuid: { dataType: 'string', required: true },
+                announcementUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AnnouncementsPage: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                totalCount: { dataType: 'double', required: true },
+                items: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'ProjectAnnouncement' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AnnouncementsPage_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AnnouncementsPage', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAnnouncementsResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AnnouncementsPage_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_ProjectAnnouncement_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'ProjectAnnouncement', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAnnouncementResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_ProjectAnnouncement_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateAnnouncementRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                categoryUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                body: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                title: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateAnnouncementRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                pinned: { dataType: 'boolean' },
+                categoryUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                body: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                title: { dataType: 'string' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AnnouncementCategory: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                color: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+                projectUuid: { dataType: 'string', required: true },
+                categoryUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_AnnouncementCategory-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AnnouncementCategory',
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAnnouncementCategoriesResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AnnouncementCategory-Array_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AnnouncementCategory_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AnnouncementCategory', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAnnouncementCategoryResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AnnouncementCategory_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateAnnouncementCategoryRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                color: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
             },
             validators: {},
         },
@@ -20052,6 +20272,18 @@ const models: TsoaRoute.Models = {
                                                                                                                                             },
                                                                                                                                         ],
                                                                                                                                 },
+                                                                                                                                required:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'boolean',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                tableName:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
                                                                                                                                 fieldRef:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -20064,22 +20296,10 @@ const models: TsoaRoute.Models = {
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                tableName:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
                                                                                                                                 operator:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                required:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'boolean',
                                                                                                                                         required: true,
                                                                                                                                     },
                                                                                                                             },
@@ -20184,6 +20404,31 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                status: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'enum',
+                                                                                                enums: [
+                                                                                                    'error',
+                                                                                                ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'enum',
+                                                                                                enums: [
+                                                                                                    'success',
+                                                                                                ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
                                                                                 pagination:
                                                                                     {
                                                                                         dataType:
@@ -20226,31 +20471,6 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                status: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'enum',
-                                                                                                enums: [
-                                                                                                    'error',
-                                                                                                ],
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'enum',
-                                                                                                enums: [
-                                                                                                    'success',
-                                                                                                ],
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
                                                                                 error: {
                                                                                     dataType:
                                                                                         'union',
@@ -20576,6 +20796,40 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -20594,40 +20848,6 @@ const models: TsoaRoute.Models = {
                                                                                                     ],
                                                                                                 },
                                                                                             ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
                                                                                         required: true,
                                                                                     },
                                                                                 label: {
@@ -20706,6 +20926,18 @@ const models: TsoaRoute.Models = {
                                                                                                                         },
                                                                                                                     ],
                                                                                                             },
+                                                                                                            required:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'boolean',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            tableName:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
                                                                                                             fieldRef:
                                                                                                                 {
                                                                                                                     dataType:
@@ -20718,22 +20950,10 @@ const models: TsoaRoute.Models = {
                                                                                                                         'string',
                                                                                                                     required: true,
                                                                                                                 },
-                                                                                                            tableName:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
                                                                                                             operator:
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'string',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            required:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'boolean',
                                                                                                                     required: true,
                                                                                                                 },
                                                                                                         },
@@ -20930,11 +21150,8 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                warnings: {
-                                                    dataType: 'array',
-                                                    array: {
-                                                        dataType: 'string',
-                                                    },
+                                                slug: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 status: {
@@ -20942,12 +21159,15 @@ const models: TsoaRoute.Models = {
                                                     enums: ['success'],
                                                     required: true,
                                                 },
-                                                slug: {
+                                                uuid: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                uuid: {
-                                                    dataType: 'string',
+                                                warnings: {
+                                                    dataType: 'array',
+                                                    array: {
+                                                        dataType: 'string',
+                                                    },
                                                     required: true,
                                                 },
                                                 name: {
@@ -21421,13 +21641,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                slug: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
-                                                    required: true,
-                                                },
-                                                slug: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
@@ -21652,14 +21872,14 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'metric',
+                                                                                    'dimension',
                                                                                 ],
                                                                             },
                                                                             {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    'metric',
                                                                                 ],
                                                                             },
                                                                             {
@@ -54313,6 +54533,410 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectAnnouncementsController_list: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        page: { default: 1, in: 'query', name: 'page', dataType: 'double' },
+        pageSize: {
+            default: 25,
+            in: 'query',
+            name: 'pageSize',
+            dataType: 'double',
+        },
+        categoryUuid: { in: 'query', name: 'categoryUuid', ref: 'UUID' },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/announcements',
+        ...fetchMiddlewares<RequestHandler>(ProjectAnnouncementsController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectAnnouncementsController.prototype.list,
+        ),
+
+        async function ProjectAnnouncementsController_list(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectAnnouncementsController_list,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectAnnouncementsController>(
+                        ProjectAnnouncementsController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'list',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectAnnouncementsController_create: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'CreateAnnouncementRequest',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/announcements',
+        ...fetchMiddlewares<RequestHandler>(ProjectAnnouncementsController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectAnnouncementsController.prototype.create,
+        ),
+
+        async function ProjectAnnouncementsController_create(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectAnnouncementsController_create,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectAnnouncementsController>(
+                        ProjectAnnouncementsController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'create',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 201,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectAnnouncementsController_update: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        announcementUuid: {
+            in: 'path',
+            name: 'announcementUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpdateAnnouncementRequest',
+        },
+    };
+    app.patch(
+        '/api/v1/projects/:projectUuid/announcements/:announcementUuid',
+        ...fetchMiddlewares<RequestHandler>(ProjectAnnouncementsController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectAnnouncementsController.prototype.update,
+        ),
+
+        async function ProjectAnnouncementsController_update(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectAnnouncementsController_update,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectAnnouncementsController>(
+                        ProjectAnnouncementsController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'update',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectAnnouncementsController_delete: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        announcementUuid: {
+            in: 'path',
+            name: 'announcementUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.delete(
+        '/api/v1/projects/:projectUuid/announcements/:announcementUuid',
+        ...fetchMiddlewares<RequestHandler>(ProjectAnnouncementsController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectAnnouncementsController.prototype.delete,
+        ),
+
+        async function ProjectAnnouncementsController_delete(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectAnnouncementsController_delete,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectAnnouncementsController>(
+                        ProjectAnnouncementsController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'delete',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectAnnouncementsController_listCategories: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/announcements/categories',
+        ...fetchMiddlewares<RequestHandler>(ProjectAnnouncementsController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectAnnouncementsController.prototype.listCategories,
+        ),
+
+        async function ProjectAnnouncementsController_listCategories(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectAnnouncementsController_listCategories,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectAnnouncementsController>(
+                        ProjectAnnouncementsController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listCategories',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectAnnouncementsController_createCategory: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            ref: 'UUID',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'CreateAnnouncementCategoryRequest',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/announcements/categories',
+        ...fetchMiddlewares<RequestHandler>(ProjectAnnouncementsController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectAnnouncementsController.prototype.createCategory,
+        ),
+
+        async function ProjectAnnouncementsController_createCategory(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectAnnouncementsController_createCategory,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectAnnouncementsController>(
+                        ProjectAnnouncementsController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'createCategory',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 201,
                 });
             } catch (err) {
                 return next(err);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3522,22 +3522,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -4484,22 +4484,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -10455,6 +10455,213 @@
                     }
                 },
                 "required": ["allowPersonal", "audience"],
+                "type": "object"
+            },
+            "ProjectAnnouncement": {
+                "properties": {
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "authorName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "createdByUserUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "pinned": {
+                        "type": "boolean"
+                    },
+                    "categoryUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "body": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "announcementUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "updatedAt",
+                    "createdAt",
+                    "authorName",
+                    "createdByUserUuid",
+                    "pinned",
+                    "categoryUuid",
+                    "body",
+                    "title",
+                    "projectUuid",
+                    "announcementUuid"
+                ],
+                "type": "object"
+            },
+            "AnnouncementsPage": {
+                "properties": {
+                    "totalCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "items": {
+                        "items": {
+                            "$ref": "#/components/schemas/ProjectAnnouncement"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["totalCount", "items"],
+                "type": "object"
+            },
+            "ApiSuccess_AnnouncementsPage_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AnnouncementsPage"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAnnouncementsResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AnnouncementsPage_"
+            },
+            "ApiSuccess_ProjectAnnouncement_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/ProjectAnnouncement"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAnnouncementResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_ProjectAnnouncement_"
+            },
+            "CreateAnnouncementRequest": {
+                "properties": {
+                    "categoryUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "body": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                },
+                "required": ["categoryUuid", "body", "title"],
+                "type": "object"
+            },
+            "UpdateAnnouncementRequest": {
+                "properties": {
+                    "pinned": {
+                        "type": "boolean"
+                    },
+                    "categoryUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "body": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "description": "PATCH semantics: omitted fields are left unchanged"
+            },
+            "AnnouncementCategory": {
+                "properties": {
+                    "color": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "categoryUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["color", "name", "projectUuid", "categoryUuid"],
+                "type": "object"
+            },
+            "ApiSuccess_AnnouncementCategory-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/AnnouncementCategory"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAnnouncementCategoriesResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AnnouncementCategory-Array_"
+            },
+            "ApiSuccess_AnnouncementCategory_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AnnouncementCategory"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAnnouncementCategoryResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AnnouncementCategory_"
+            },
+            "CreateAnnouncementCategoryRequest": {
+                "properties": {
+                    "color": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": ["color", "name"],
                 "type": "object"
             },
             "ManagedAgentScheduleOption": {
@@ -21416,28 +21623,28 @@
                                                                                         "items": {},
                                                                                         "type": "array"
                                                                                     },
+                                                                                    "required": {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    "tableName": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "fieldRef": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "fieldId": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "operator": {
                                                                                         "type": "string"
-                                                                                    },
-                                                                                    "required": {
-                                                                                        "type": "boolean"
                                                                                     }
                                                                                 },
                                                                                 "required": [
+                                                                                    "required",
+                                                                                    "tableName",
                                                                                     "fieldRef",
                                                                                     "fieldId",
-                                                                                    "tableName",
-                                                                                    "operator",
-                                                                                    "required"
+                                                                                    "operator"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -21492,6 +21699,13 @@
                                                             "searchQueries": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "status": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "error",
+                                                                                "success"
+                                                                            ]
+                                                                        },
                                                                         "pagination": {
                                                                             "properties": {
                                                                                 "totalPageCount": {
@@ -21518,13 +21732,6 @@
                                                                                 "page"
                                                                             ],
                                                                             "type": "object"
-                                                                        },
-                                                                        "status": {
-                                                                            "type": "string",
-                                                                            "enum": [
-                                                                                "error",
-                                                                                "success"
-                                                                            ]
                                                                         },
                                                                         "error": {
                                                                             "type": "string"
@@ -21685,22 +21892,22 @@
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
                                                                                 "fieldType": {
                                                                                     "type": "string",
                                                                                     "enum": [
-                                                                                        "metric",
-                                                                                        "dimension"
+                                                                                        "dimension",
+                                                                                        "metric"
                                                                                     ]
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
                                                                                 },
                                                                                 "table": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
                                                                                 },
                                                                                 "label": {
                                                                                     "type": "string"
@@ -21714,10 +21921,10 @@
                                                                                 "caseSensitiveFilters",
                                                                                 "fieldValueType",
                                                                                 "fieldFilterType",
-                                                                                "description",
                                                                                 "fieldType",
-                                                                                "table",
                                                                                 "fieldId",
+                                                                                "table",
+                                                                                "description",
                                                                                 "label",
                                                                                 "name"
                                                                             ],
@@ -21739,28 +21946,28 @@
                                                                                             "items": {},
                                                                                             "type": "array"
                                                                                         },
+                                                                                        "required": {
+                                                                                            "type": "boolean"
+                                                                                        },
+                                                                                        "tableName": {
+                                                                                            "type": "string"
+                                                                                        },
                                                                                         "fieldRef": {
                                                                                             "type": "string"
                                                                                         },
                                                                                         "fieldId": {
                                                                                             "type": "string"
                                                                                         },
-                                                                                        "tableName": {
-                                                                                            "type": "string"
-                                                                                        },
                                                                                         "operator": {
                                                                                             "type": "string"
-                                                                                        },
-                                                                                        "required": {
-                                                                                            "type": "boolean"
                                                                                         }
                                                                                     },
                                                                                     "required": [
+                                                                                        "required",
+                                                                                        "tableName",
                                                                                         "fieldRef",
                                                                                         "fieldId",
-                                                                                        "tableName",
-                                                                                        "operator",
-                                                                                        "required"
+                                                                                        "operator"
                                                                                     ],
                                                                                     "type": "object"
                                                                                 },
@@ -21903,22 +22110,22 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "warnings": {
-                                                        "items": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": "array"
+                                                    "slug": {
+                                                        "type": "string"
                                                     },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
                                                     },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
                                                     "uuid": {
                                                         "type": "string"
+                                                    },
+                                                    "warnings": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
                                                     },
                                                     "name": {
                                                         "type": "string"
@@ -21927,10 +22134,10 @@
                                                 "required": [
                                                     "versionUuids",
                                                     "href",
-                                                    "warnings",
-                                                    "status",
                                                     "slug",
+                                                    "status",
                                                     "uuid",
+                                                    "warnings",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -22091,13 +22298,13 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
+                                                    "slug": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "slug": {
-                                                        "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
@@ -22105,8 +22312,8 @@
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "status",
                                                     "slug",
+                                                    "status",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -22190,8 +22397,8 @@
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "metric",
                                                                     "dimension",
+                                                                    "metric",
                                                                     null
                                                                 ],
                                                                 "nullable": true
@@ -53202,6 +53409,308 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/PublishProjectHomepageRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/announcements": {
+            "get": {
+                "operationId": "listProjectAnnouncements",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAnnouncementsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "required": false,
+                        "schema": {
+                            "default": 1,
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "pageSize",
+                        "required": false,
+                        "schema": {
+                            "default": 25,
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "categoryUuid",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "createProjectAnnouncement",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAnnouncementResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateAnnouncementRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/announcements/{announcementUuid}": {
+            "patch": {
+                "operationId": "updateProjectAnnouncement",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAnnouncementResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "announcementUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateAnnouncementRequest"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "deleteProjectAnnouncement",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "announcementUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/announcements/categories": {
+            "get": {
+                "operationId": "listProjectAnnouncementCategories",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAnnouncementCategoriesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "createProjectAnnouncementCategory",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAnnouncementCategoryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Homepage"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/UUID"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateAnnouncementCategoryRequest"
                             }
                         }
                     }

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -302,3 +302,54 @@ export type ApiProjectHomepageResponse = ApiSuccess<ProjectHomepage>;
 export type ApiProjectHomepagesResponse = ApiSuccess<ProjectHomepage[]>;
 export type ApiProjectHomepageOrNullResponse =
     ApiSuccess<ProjectHomepage | null>;
+
+export type AnnouncementCategory = {
+    categoryUuid: string;
+    projectUuid: string;
+    name: string;
+    color: string;
+};
+
+export type ProjectAnnouncement = {
+    announcementUuid: string;
+    projectUuid: string;
+    title: string;
+    body: string | null;
+    categoryUuid: string | null;
+    pinned: boolean;
+    createdByUserUuid: string | null;
+    authorName: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+};
+
+export type AnnouncementsPage = {
+    items: ProjectAnnouncement[];
+    totalCount: number;
+};
+
+export type CreateAnnouncementRequest = {
+    title: string;
+    body: string | null;
+    categoryUuid: string | null;
+};
+
+/** PATCH semantics: omitted fields are left unchanged */
+export type UpdateAnnouncementRequest = {
+    title?: string;
+    body?: string | null;
+    categoryUuid?: string | null;
+    pinned?: boolean;
+};
+
+export type CreateAnnouncementCategoryRequest = {
+    name: string;
+    color: string;
+};
+
+export type ApiAnnouncementsResponse = ApiSuccess<AnnouncementsPage>;
+export type ApiAnnouncementResponse = ApiSuccess<ProjectAnnouncement>;
+export type ApiAnnouncementCategoriesResponse = ApiSuccess<
+    AnnouncementCategory[]
+>;
+export type ApiAnnouncementCategoryResponse = ApiSuccess<AnnouncementCategory>;

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -45,6 +45,10 @@ import type {
     ApiAiRouterInstructionResponse,
     ApiAiRouterResponse,
     ApiAiRouterRouteResponse,
+    ApiAnnouncementCategoriesResponse,
+    ApiAnnouncementCategoryResponse,
+    ApiAnnouncementResponse,
+    ApiAnnouncementsResponse,
     ApiAppendInstructionResponse,
     ApiAppImageUploadResponse,
     ApiAppThumbnailUrlResponse,
@@ -1299,6 +1303,10 @@ type ApiResults =
     | ApiProjectHomepageResponse['results']
     | ApiProjectHomepageOrNullResponse['results']
     | ApiResolvedHomepageResponse['results']
+    | ApiAnnouncementsResponse['results']
+    | ApiAnnouncementResponse['results']
+    | ApiAnnouncementCategoriesResponse['results']
+    | ApiAnnouncementCategoryResponse['results']
     | ApiHomepageViewAsResponse['results']
     | ApiHomepageLinkMetadataResponse['results']
     | ApiProjectColorPaletteResponse['results']


### PR DESCRIPTION
## What

Moves project announcements out of the homepage config JSON into first-class EE tables, with paginated CRUD under `/api/v1/projects/{projectUuid}/announcements`.

**Rebased onto `main`.** This previously stacked on #25737 (wysiwyg canvas); announcements never depended on that work, so the base was corrected and this now merges independently. #25741 (the front-page UI) stacks on this.

## What's in it

- `project_announcements` table + entity, with a DB-level constraint allowing at most one pinned lead per project.
- Paginated list/create/update/delete/pin endpoints on a new `ProjectAnnouncementsController`.
- Read gated on project view, write on manage — reusing the existing CASL abilities, behind the HomepageBuilder feature flag.

## Regression analysis

**No existing behaviour changes.** Announcements previously lived inside `HomepageConfig`; that shape is migrated away in #25741, not here. This PR only adds tables and endpoints — nothing reads from them until the block is rewired.

**Not affected:** projects without the HomepageBuilder flag (every endpoint 403s, as before); service accounts and CI/CD pipelines (no new scopes — the existing project view/manage abilities gate this); custom roles (no vocabulary change, so no `scoped_roles` migration needed).

## Verification

Backend `typecheck:fast` green; `ProjectHomepageService` + `projectAnnouncementsController` tests passing (31); fresh migration run clean against a reset DB.

## Notes

`packages/backend/src/generated/{routes.ts,swagger.json}` are intentionally not committed — the pre-commit hook unstages them and the release workflow owns them.
