### PR TITLE
fix: prevent old homepage flashing before homepage-builder flag resolves

### DIFF
--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -52,8 +52,10 @@ const Home: FC = () => {
 
     const { user } = useApp();
     const isAiAgentsEnabled = useAiAgentButtonVisibility();
-    const { isEnabled: isHomepageBuilderFlagEnabled } =
-        useHomepageBuilderFlag();
+    const {
+        isEnabled: isHomepageBuilderFlagEnabled,
+        isLoading: isHomepageBuilderFlagLoading,
+    } = useHomepageBuilderFlag();
     const { isCopilotEnabled, isLoading: isCopilotLoading } =
         useIsCopilotEnabled();
     // The builder's centerpiece is the AI hero, so without copilot it is a
@@ -71,7 +73,9 @@ const Home: FC = () => {
         isMostPopularAndRecentlyUpdatedLoading ||
         pinnedItems.isInitialLoading ||
         favorites.isInitialLoading ||
-        isCopilotLoading;
+        isCopilotLoading ||
+        isHomepageBuilderFlagLoading ||
+        resolvedHomepage.isInitialLoading;
 
     const error = onboarding.error || project.error;
 


### PR DESCRIPTION
The `homepage-builder` feature flag is checked asynchronously in `Home.tsx`, but its loading state was ignored when deciding old-vs-new homepage. On first render the flag resolves to disabled, so the classic homepage renders briefly before the flag comes back enabled and the page re-renders into the new homepage — the reported flicker.

Fix: include the flag's `isLoading` and the resolved-homepage query's `isInitialLoading` in the page's `isLoading` gate, so the spinner shows until both resolve instead of falling through to the classic homepage. `resolvedHomepage.isInitialLoading` is `false` while the query is disabled (flag off), so the classic homepage still renders immediately for users without the flag.