### PR TITLE
fix: support EKS Pod Identity when S3_USE_CREDENTIALS_FROM includes ecs

### DIFF
--- a/packages/backend/src/clients/Aws/S3BaseClient.test.ts
+++ b/packages/backend/src/clients/Aws/S3BaseClient.test.ts
@@ -35,6 +35,7 @@ const s3Mocks = vi.hoisted(() => {
         mockFromContainerMetadata: vi.fn(() => ({
             __type: 'container_metadata',
         })),
+        mockFromHttp: vi.fn(() => ({ __type: 'container_http' })),
         mockFromInstanceMetadata: vi.fn(() => ({
             __type: 'instance_metadata',
         })),
@@ -53,6 +54,7 @@ vi.mock('@aws-sdk/credential-providers', () => ({
     fromIni: () => s3Mocks.mockFromIni(),
     fromContainerMetadata: () => s3Mocks.mockFromContainerMetadata(),
     fromInstanceMetadata: () => s3Mocks.mockFromInstanceMetadata(),
+    fromHttp: () => s3Mocks.mockFromHttp(),
 }));
 
 vi.mock('@aws-sdk/client-s3', () => ({
@@ -78,6 +80,8 @@ describe('S3BaseClient', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         s3Mocks.state.capturedProviders = undefined;
+        delete process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI;
+        delete process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI;
     });
 
     const baseConfig: S3BaseConfiguration = {
@@ -161,6 +165,34 @@ describe('S3BaseClient', () => {
         expect(Logger.debug).toHaveBeenCalledWith(
             expect.stringContaining('credential chain'),
         );
+    });
+
+    it('chains fromHttp before fromContainerMetadata for ecs when container credentials env vars are set', () => {
+        process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI =
+            'http://169.254.170.23/v1/credentials';
+        const client = new TestableS3Client({
+            ...baseConfig,
+            useCredentialsFrom: ['ecs'],
+        });
+        expect(client.getS3()).toBeInstanceOf(s3Mocks.FakeS3);
+        expect(s3Mocks.state.capturedProviders?.map((p) => p.__type)).toEqual([
+            'container_http',
+            'container_metadata',
+        ]);
+    });
+
+    it('omits fromHttp for ecs when container credentials env vars are not set', () => {
+        // fromHttp throws at construction without these env vars, so including it
+        // unconditionally would crash client creation
+        const client = new TestableS3Client({
+            ...baseConfig,
+            useCredentialsFrom: ['ecs'],
+        });
+        expect(client.getS3()).toBeInstanceOf(s3Mocks.FakeS3);
+        expect(s3Mocks.mockFromHttp).not.toHaveBeenCalled();
+        expect(s3Mocks.state.capturedProviders?.map((p) => p.__type)).toEqual([
+            'container_metadata',
+        ]);
     });
 
     it('ignores unknown providers and falls back to default credential resolution when none are valid', () => {

--- a/packages/backend/src/clients/Aws/S3BaseClient.ts
+++ b/packages/backend/src/clients/Aws/S3BaseClient.ts
@@ -3,6 +3,7 @@ import {
     createCredentialChain,
     fromContainerMetadata,
     fromEnv,
+    fromHttp,
     fromIni,
     fromInstanceMetadata,
     fromTokenFile,
@@ -69,6 +70,17 @@ export function resolveS3Credentials(config: {
                     break;
                 case 'container_metadata':
                 case 'ecs':
+                    // Mirror the SDK's default remoteProvider: fromHttp supports the
+                    // EKS Pod Identity endpoint, which fromContainerMetadata rejects.
+                    // Gated on the env vars because fromHttp throws at construction
+                    // when neither is set.
+                    if (
+                        process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI ||
+                        process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI
+                    ) {
+                        providers.push(fromHttp({}));
+                        providerLabels.push('container_http');
+                    }
                     providers.push(fromContainerMetadata());
                     providerLabels.push('container_metadata');
                     break;


### PR DESCRIPTION
## Problem

On EKS with Pod Identity, setting `S3_USE_CREDENTIALS_FROM=ecs` (as the self-host docs recommend for IAM-role setups) fails S3 credential resolution with:

```
169.254.170.23 is not a valid container metadata service hostname
```

The `ecs`/`container_metadata` case of `resolveS3Credentials` only pushes the legacy `fromContainerMetadata()` provider, whose hostname allowlist doesn't include the EKS Pod Identity endpoints. The Pod-Identity-aware `fromHttp` provider never runs on that path (it does run when `S3_USE_CREDENTIALS_FROM` is unset, via SDK default resolution).

## Fix

Chain `fromHttp()` before `fromContainerMetadata()` in the `ecs`/`container_metadata` case, mirroring the AWS SDK's own `remoteProvider` in `@aws-sdk/credential-provider-node`.

The `fromHttp` provider is gated on `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`/`AWS_CONTAINER_CREDENTIALS_FULL_URI` being present — exactly as the SDK gates it — because `fromHttp` **throws synchronously at construction** when neither env var is set. Pushing it unconditionally would turn today's lazy request-time credential failure into a crash at S3 client construction for instances that set `S3_USE_CREDENTIALS_FROM=ecs` outside a container-credentials environment.

## Verification

Ran the real SDK providers locally (no mocks) to confirm:

- **Bug repro**: `fromContainerMetadata()` with `AWS_CONTAINER_CREDENTIALS_FULL_URI=http://169.254.170.23/...` fails with the exact hostname error from the issue.
- **Fixed chain resolves Pod-Identity-shaped credentials**: `chain(fromHttp, fromContainerMetadata)` against a local stub serving a `FULL_URI` endpoint resolves credentials via `fromHttp`.
- **No regression on classic ECS**: `fromHttp` handles `RELATIVE_URI` against the same `169.254.170.2` endpoint, and on failure its error is chainable (`tryNextLink=true`), so the chain still falls through to `fromContainerMetadata`.
- **Construction-crash guard**: confirmed `fromHttp({})` throws synchronously with neither env var set, hence the gate.

Unit tests cover both branches of the gate (provider order with env vars set; `fromHttp` omitted without them).

Closes: PROD-8931
Closes: #25618

🤖 Generated with [Claude Code](https://claude.com/claude-code)