### PR TITLE
fix(frontend): mantine 8 migration follow-ups from migration guide audit

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
@@ -147,6 +147,7 @@ const GithubLoginForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                     <Avatar
                         src={githubIcon}
                         size="sm"
+                        alt=""
                         classNames={{ image: styles.githubButtonLogo }}
                     />
                 }

--- a/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
@@ -170,6 +170,7 @@ const UpdateProjectConnection: FC<{
                         className={classes.stickyFooter}
                         withBorder
                         shadow="sm"
+                        radius="sm"
                     >
                         <Box>
                             {latestCompilationLog && (

--- a/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
@@ -70,7 +70,7 @@ const GithubSettingsPanel: FC = () => {
         <SettingsGridCard>
             <Box>
                 <Group gap="sm">
-                    <Avatar src={githubIcon} size="md" />
+                    <Avatar src={githubIcon} size="md" alt="" />
                     <Title order={4}>Github</Title>
                 </Group>
             </Box>

--- a/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
@@ -37,7 +37,7 @@ const GitlabSettingsPanel: FC = () => {
         <SettingsGridCard>
             <Box>
                 <Group gap="sm">
-                    <Avatar src={gitlabIcon} size="md" />
+                    <Avatar src={gitlabIcon} size="md" alt="" />
                     <Title order={4}>GitLab</Title>
                 </Group>
             </Box>

--- a/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.tsx
+++ b/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.tsx
@@ -63,7 +63,7 @@ export const SuggestionList = forwardRef<
     }));
 
     return props.items.length > 0 ? (
-        <Card shadow="xs" p={0}>
+        <Card shadow="xs" p={0} withBorder={false} radius="sm">
             <List
                 withPadding={false}
                 listStyleType="none"

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -301,6 +301,7 @@ const Login: FC<{}> = () => {
                                     label="Password"
                                     name="password"
                                     placeholder="Your password"
+                                    autoComplete="current-password"
                                     required
                                     autoFocus
                                     {...form.getInputProps('password')}

--- a/packages/frontend/src/pages/PasswordReset.tsx
+++ b/packages/frontend/src/pages/PasswordReset.tsx
@@ -74,6 +74,7 @@ const PasswordReset: FC = () => {
                                                 label="Password"
                                                 name="password"
                                                 placeholder="Enter a new password"
+                                                autoComplete="new-password"
                                                 disabled={
                                                     passwordResetMutation.isLoading
                                                 }

--- a/packages/frontend/src/stories/FormCard.stories.tsx
+++ b/packages/frontend/src/stories/FormCard.stories.tsx
@@ -18,7 +18,7 @@ export function FormCard({ hasError = false }: FormCardProps) {
     const errorMessage = hasError ? 'This field is required' : undefined;
 
     return (
-        <Card shadow="subtle" radius="md" p="lg">
+        <Card shadow="subtle" radius="md" p="lg" withBorder={false}>
             <Stack>
                 <Title order={4}>This is a form card</Title>
                 <Stack>


### PR DESCRIPTION
### Description:

Follow-up fixes for the Mantine 6→8 component migrations (PasswordInput #25698, Avatar #25699, Card #25703), found by auditing them against the per-component migration guide.

**Password-manager regression (PasswordInput):** Mantine 8's PasswordInput defaults the inner input to `autoComplete="off"`, which stopped browsers/password managers from offering to fill or save passwords on auth screens. Adds `autoComplete="current-password"` to the login field and `autoComplete="new-password"` to the password-reset field. Credential/secret fields (warehouse passwords, tokens) intentionally keep the `off` default.

**Card→Paper theme defaults leak (Card):** v8 Card renders through Paper, so our theme's Paper defaults (`withBorder: true`, `radius="md"`, `shadow="subtle"`) silently applied to migrated Cards that didn't pin those props:
- Comment @mention `SuggestionList`: restores the borderless `sm`-radius popup (`withBorder={false} radius="sm"`)
- Project-connection sticky save bar: restores `radius="sm"` (was drifting to `md`)
- `FormCard` story: pins `withBorder={false}` so the story keeps its current rendered contract

**Decorative avatar a11y (Avatar):** adds `alt=""` to the GitHub/GitLab settings-panel logos and the GitHub sign-in button icon; adjacent visible text already names them.

Verified: frontend typecheck + oxlint clean; sticky bar radius confirmed back to 4px in the running app.

Relates: #25698
Relates: #25699
Relates: #25703

🤖 Generated with [Claude Code](https://claude.com/claude-code)
