### PR TITLE
feat: persist invalid AI tool-call attempts for debugging

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -340,6 +340,8 @@ import {
     WarehouseCredentialTableName,
 } from '../database/entities/warehouseCredentials';
 import {
+    AiAgentToolCallErrorTable,
+    AiAgentToolCallErrorTableName,
     AiAgentToolCallTable,
     AiAgentToolCallTableName,
     AiAgentToolResultTable,
@@ -632,6 +634,7 @@ declare module 'knex/types/tables' {
         [HomepagePersonalOverridesTableName]: HomepagePersonalOverridesTable;
         [AiAgentReasoningTableName]: AiAgentReasoningTable;
         [AiAgentToolCallTableName]: AiAgentToolCallTable;
+        [AiAgentToolCallErrorTableName]: AiAgentToolCallErrorTable;
         [AiAgentToolResultTableName]: AiAgentToolResultTable;
         [McpToolCallTableName]: McpToolCallTable;
         [McpClientInfoTableName]: McpClientInfoTable;

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -366,6 +366,34 @@ export type AiAgentToolCallTable = Knex.CompositeTableType<
     never
 >;
 
+export const AiAgentToolCallErrorTableName = 'ai_agent_tool_call_error';
+
+// Debugging aid: schema-invalid tool-call attempts dropped by the AI SDK before
+// execution. Kept separate from ai_agent_tool_call, whose rows are replayed
+// into UI/history reconstruction.
+export type DbAiAgentToolCallError = {
+    ai_agent_tool_call_error_uuid: string;
+    ai_prompt_uuid: string;
+    tool_call_id: string;
+    tool_name: string;
+    error_message: string;
+    raw_args: string | null;
+    created_at: Date;
+};
+
+export type AiAgentToolCallErrorTable = Knex.CompositeTableType<
+    DbAiAgentToolCallError,
+    Pick<
+        DbAiAgentToolCallError,
+        | 'ai_prompt_uuid'
+        | 'tool_call_id'
+        | 'tool_name'
+        | 'error_message'
+        | 'raw_args'
+    >,
+    never
+>;
+
 export const AiAgentToolResultTableName = 'ai_agent_tool_result';
 
 export type DbAiAgentToolResult = {

--- a/packages/backend/src/ee/database/migrations/20260717121817_ai_agent_tool_call_error.ts
+++ b/packages/backend/src/ee/database/migrations/20260717121817_ai_agent_tool_call_error.ts
@@ -1,0 +1,32 @@
+import { Knex } from 'knex';
+
+const AiAgentToolCallErrorTableName = 'ai_agent_tool_call_error';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(AiAgentToolCallErrorTableName, (table) => {
+        table
+            .uuid('ai_agent_tool_call_error_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table.uuid('ai_prompt_uuid').notNullable();
+        table.text('tool_call_id').notNullable();
+        table.text('tool_name').notNullable();
+        table.text('error_message').notNullable();
+        // text, not jsonb — one failure mode is args that aren't valid JSON
+        table.text('raw_args').nullable();
+        table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable();
+
+        // When a prompt is deleted, all its tool call errors should also be deleted
+        table
+            .foreign('ai_prompt_uuid')
+            .references('ai_prompt_uuid')
+            .inTable('ai_prompt')
+            .onDelete('CASCADE');
+
+        table.index('ai_prompt_uuid');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(AiAgentToolCallErrorTableName);
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -104,6 +104,7 @@ import Logger from '../../logging/logger';
 import { wrapSentryTransaction } from '../../utils';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import {
+    AiAgentToolCallErrorTableName,
     AiAgentToolCallTableName,
     AiAgentToolResultTableName,
     AiPromptContextEntityType,
@@ -334,6 +335,9 @@ const toAiPromptSteer = (row: AiPromptSteerRow): AiPromptSteer => ({
 });
 
 export class AiAgentModel {
+    // Cap stored raw args of invalid tool calls (they can be arbitrarily large)
+    private static readonly MAX_TOOL_CALL_ERROR_RAW_ARGS_LENGTH = 65536;
+
     private database: Knex;
 
     private lightdashConfig: LightdashConfig;
@@ -5963,6 +5967,30 @@ export class AiAgentModel {
             .returning('ai_agent_tool_call_uuid');
 
         return toolCall.ai_agent_tool_call_uuid;
+    }
+
+    // Debugging aid: tool-call attempts the AI SDK rejected before execution
+    // (schema-invalid args, unparsable JSON). Not replayed into UI/history.
+    async createToolCallError(data: {
+        promptUuid: string;
+        toolCallId: string;
+        toolName: string;
+        errorMessage: string;
+        rawArgs: string | null;
+    }): Promise<void> {
+        await this.database(AiAgentToolCallErrorTableName).insert({
+            ai_prompt_uuid: data.promptUuid,
+            tool_call_id: data.toolCallId,
+            tool_name: data.toolName,
+            error_message: data.errorMessage,
+            raw_args:
+                data.rawArgs !== null
+                    ? data.rawArgs.slice(
+                          0,
+                          AiAgentModel.MAX_TOOL_CALL_ERROR_RAW_ARGS_LENGTH,
+                      )
+                    : null,
+        });
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -293,6 +293,7 @@ import {
     SendFileFn,
     SendSlackBlocksFn,
     StoreReasoningFn,
+    StoreToolCallErrorFn,
     StoreToolCallFn,
     StoreToolResultsFn,
     UpdateProgressFn,
@@ -7474,6 +7475,18 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             );
         };
 
+        const storeToolCallError: StoreToolCallErrorFn = async (args) => {
+            await wrapSentryTransaction(
+                'AiAgent.storeToolCallError',
+                {
+                    promptUuid: args.promptUuid,
+                    toolCallId: args.toolCallId,
+                    toolName: args.toolName,
+                },
+                () => this.aiAgentModel.createToolCallError(args),
+            );
+        };
+
         const storeToolResults: StoreToolResultsFn = async (args) => {
             void wrapSentryTransaction(
                 'AiAgent.storeToolResults',
@@ -7936,6 +7949,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             sendSlackBlocks,
             updateSlackMessage,
             storeToolCall,
+            storeToolCallError,
             storeToolResults,
             storeReasoning,
             isPromptInterrupted: (promptUuid: string) =>
@@ -8125,6 +8139,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             sendSlackBlocks,
             updateSlackMessage,
             storeToolCall,
+            storeToolCallError,
             storeToolResults,
             storeReasoning,
             isPromptInterrupted,
@@ -8598,6 +8613,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             sendSlackBlocks,
             updateSlackMessage,
             storeToolCall,
+            storeToolCallError,
             storeToolResults,
             storeReasoning,
             isPromptInterrupted,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -201,6 +201,20 @@ export const normalizeToolOutput = (
     }
 };
 
+// Raw args of an invalid tool call: may be a parsed object or, when JSON
+// parsing itself failed, the raw string the model produced.
+const serializeRawToolArgs = (input: unknown): string | null => {
+    if (input === undefined) return null;
+    if (typeof input === 'string') return input;
+    try {
+        return JSON.stringify(input) ?? null;
+    } catch {
+        return String(input);
+    }
+};
+
+const QUERY_RETRY_CAP_TOOL_NAME = '__query_retry_cap';
+
 export const defaultAgentOptions = {
     toolChoice: 'auto' as const,
     stopWhen: stepCountIs(STEP_CAP),
@@ -235,6 +249,7 @@ const buildPrepareStep = ({
     logger: ReturnType<typeof createAiAgentLogger>;
 }) => {
     const forcedFirstStep = buildForcedFirstStep(args, tools);
+    let retryCapPersisted = false;
 
     return async ({
         stepNumber,
@@ -264,6 +279,25 @@ const buildPrepareStep = ({
                 'Prepare Step',
                 `Query retry cap tripped for prompt UUID: ${args.promptUuid}`,
             );
+            // Once per prompt: leave a debugging trail that the query tools
+            // were removed this turn (the cap stays tripped on later steps).
+            if (!retryCapPersisted) {
+                retryCapPersisted = true;
+                void dependencies
+                    .storeToolCallError({
+                        promptUuid: args.promptUuid,
+                        toolCallId: `${QUERY_RETRY_CAP_TOOL_NAME}-${args.promptUuid}`,
+                        toolName: QUERY_RETRY_CAP_TOOL_NAME,
+                        errorMessage: retryOverride.nudge,
+                        rawArgs: null,
+                    })
+                    .catch((error) => {
+                        Logger.error(
+                            '[AiAgent][Prepare Step] Failed to store query retry cap marker',
+                            error,
+                        );
+                    });
+            }
         }
 
         const steers = await dependencies.consumePromptSteers({
@@ -916,6 +950,39 @@ export const generateAgentResponse = async ({
                                     },
                                 });
 
+                                // Same handling as the streaming path: keep
+                                // invalid attempts out of ai_agent_tool_call
+                                // (replayed into UI/history) and persist them
+                                // in the error table instead.
+                                if (toolCall.invalid) {
+                                    Sentry.captureException(toolCall.error, {
+                                        tags: {
+                                            errorType: 'AiAgentToolCallInvalid',
+                                            'ai.model': modelName,
+                                        },
+                                    });
+                                    void dependencies
+                                        .storeToolCallError({
+                                            promptUuid: args.promptUuid,
+                                            toolCallId: toolCall.toolCallId,
+                                            toolName: toolCall.toolName,
+                                            errorMessage:
+                                                toolCall.error instanceof Error
+                                                    ? toolCall.error.message
+                                                    : String(toolCall.error),
+                                            rawArgs: serializeRawToolArgs(
+                                                toolCall.input,
+                                            ),
+                                        })
+                                        .catch((error) => {
+                                            Logger.error(
+                                                '[AiAgent][On Step Finish] Failed to store invalid tool call',
+                                                error,
+                                            );
+                                        });
+                                    return;
+                                }
+
                                 // in_progress is emitted at execute start by withEarlyToolProgress; re-emitting here double-sends it.
 
                                 await dependencies.storeToolCall({
@@ -1184,6 +1251,30 @@ export const streamAgentResponse = async ({
                                     'ai.model': modelName,
                                 },
                             });
+
+                            // Invalid calls are excluded from
+                            // ai_agent_tool_call (those rows are replayed into
+                            // UI/history), but persist them separately so the
+                            // thread doesn't silently lose failed attempts.
+                            void dependencies
+                                .storeToolCallError({
+                                    promptUuid: args.promptUuid,
+                                    toolCallId: event.chunk.toolCallId,
+                                    toolName: event.chunk.toolName,
+                                    errorMessage:
+                                        event.chunk.error instanceof Error
+                                            ? event.chunk.error.message
+                                            : String(event.chunk.error),
+                                    rawArgs: serializeRawToolArgs(
+                                        event.chunk.input,
+                                    ),
+                                })
+                                .catch((error) => {
+                                    Logger.error(
+                                        '[AiAgent][Chunk Tool Call] Failed to store invalid tool call',
+                                        error,
+                                    );
+                                });
                             break;
                         }
 

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -60,6 +60,7 @@ import {
     SendSlackBlocksFn,
     SetupPreviewDeployFn,
     StoreReasoningFn,
+    StoreToolCallErrorFn,
     StoreToolCallFn,
     StoreToolResultsFn,
     SyncDbtProjectFn,
@@ -217,6 +218,7 @@ export type AiAgentDependencies = {
     updatePrompt: UpdatePromptFn;
     updateProgress: UpdateProgressFn;
     storeToolCall: StoreToolCallFn;
+    storeToolCallError: StoreToolCallErrorFn;
     storeToolResults: StoreToolResultsFn;
     storeReasoning: StoreReasoningFn;
     isPromptInterrupted: IsPromptInterruptedFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -419,6 +419,16 @@ export type StoreToolCallFn = (data: {
     parentToolCallId: string | null;
 }) => Promise<void>;
 
+// Persists tool-call attempts the AI SDK rejected before execution
+// (schema-invalid args, unparsable JSON) — debugging aid, not shown in UI.
+export type StoreToolCallErrorFn = (data: {
+    promptUuid: string;
+    toolCallId: string;
+    toolName: string;
+    errorMessage: string;
+    rawArgs: string | null;
+}) => Promise<void>;
+
 export type StoreToolResultsFn = (
     data: Array<{
         promptUuid: string;


### PR DESCRIPTION
## Problem

When the model emits a tool call whose args fail schema validation (zod) or aren't valid JSON at all, the AI SDK rejects it before execution and `streamAgentResponse` only captures the error to Sentry — nothing is persisted. Threads then show **zero** tool calls for turns that actually made several invalid attempts; after repeated failures the query retry cap removes the query tools and the model emits a give-up response, which is stored as a normal successful reply. Debugging such turns from the DB is impossible.

## Change (observability slice only)

- New EE table `ai_agent_tool_call_error` (uuid PK, `ai_prompt_uuid` FK cascade delete, `tool_call_id`, `tool_name`, `error_message`, `raw_args`, `created_at`).
  - `raw_args` is `text`, not `jsonb` — one failure mode is args that aren't valid JSON; stored as-is (object args serialized), capped at 64k chars.
  - Deliberately **not** added to `ai_agent_tool_call`: those rows are replayed into UI/history reconstruction.
- `agentV2.ts` onChunk `invalid` branch now persists the attempt via a new `storeToolCallError` dependency (fire-and-forget with `.catch` + log, mirroring the neighboring `storeToolCall`). Sentry capture unchanged.
- Same handling added to the generate (non-stream) path's `onStepFinish`, which previously stored invalid calls **into** `ai_agent_tool_call` (replayed into UI/history) — they now go to the error table instead.
- Secondary: when the query retry cap trips (query tools removed after repeated failures), a single synthetic `__query_retry_cap` row is persisted per prompt with the nudge message, so the "tools were stripped this turn" event is also visible.
- DB-only debugging aid — no API/UI exposure. The model-behavior half of the issue stays open.

## Testing

- `invalidToolCallPersistence.test.ts`: deterministic `MockLanguageModelV3` harness driving the real `streamAgentResponse`:
  - unparsable-JSON args → `storeToolCallError` called with raw string args; sibling valid call still goes through `storeToolCall`
  - valid-JSON-but-fails-zod args → persisted with serialized args, `storeToolCall` untouched
  - retry-cap history → exactly one `__query_retry_cap` marker across multiple steps
  - generate (non-stream) path → invalid call persisted to the error table, valid sibling still stored in `ai_agent_tool_call`
- Migration verified up → rollback → up on local dev DB; insert/cascade checked via psql.
- `queryRetryCap.test.ts`, `agentV2.test.ts`, backend `typecheck:fast`, lint — all green.

Part of #25724
Part of: PROD-8982

🤖 Generated with [Claude Code](https://claude.com/claude-code)
