### PR TITLE
feat(navbar): add Autopilot cell next to Ask AI

### DIFF
--- a/packages/frontend/src/components/NavBar/AutopilotNavButton.module.css
+++ b/packages/frontend/src/components/NavBar/AutopilotNavButton.module.css
@@ -1,28 +1,10 @@
-/* Tighten padding so the collapsed state reads as an icon cell, not a wide button. */
-.cell {
-    padding-left: 10px;
-    padding-right: 10px;
-    /* Let the corner status dot poke past the icon without being clipped. */
-    overflow: visible;
-}
-
-/* Mantine's Button label clips overflow by default — allow the dot to show. */
-.labelSlot {
-    overflow: visible;
-}
-
-.inner {
-    display: inline-flex;
-    align-items: center;
-}
-
 .iconWrap {
     position: relative;
     display: inline-flex;
     align-items: center;
 }
 
-/* Corner status dot on the icon while collapsed; fades out on hover. */
+/* Corner status dot on the icon. */
 .dotCorner {
     position: absolute;
     top: -3px;
@@ -31,51 +13,6 @@
     height: 6px;
     border-radius: 50%;
     box-shadow: 0 0 0 1.5px var(--mantine-color-body);
-    transition: opacity 140ms ease;
-}
-
-.cell:hover .dotCorner {
-    opacity: 0;
-}
-
-/* Label expands in on hover. */
-.label {
-    max-width: 0;
-    margin-left: 0;
-    overflow: hidden;
-    white-space: nowrap;
-    opacity: 0;
-    font-weight: 500;
-    transition:
-        max-width 200ms ease,
-        margin-left 200ms ease,
-        opacity 160ms ease;
-}
-
-.cell:hover .label {
-    max-width: 140px;
-    margin-left: 8px;
-    opacity: 1;
-}
-
-/* Inline status dot appears alongside the label on hover. */
-.dotInline {
-    width: 0;
-    height: 7px;
-    margin-left: 0;
-    border-radius: 50%;
-    overflow: hidden;
-    opacity: 0;
-    transition:
-        width 180ms ease,
-        margin-left 180ms ease,
-        opacity 160ms ease;
-}
-
-.cell:hover .dotInline {
-    width: 7px;
-    margin-left: 8px;
-    opacity: 1;
 }
 
 .dotActive {
@@ -180,12 +117,4 @@
 
 .promoCta:hover {
     background: #ffffff;
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .label,
-    .dotInline,
-    .dotCorner {
-        transition: none;
-    }
 }

--- a/packages/frontend/src/components/NavBar/AutopilotNavButton.module.css
+++ b/packages/frontend/src/components/NavBar/AutopilotNavButton.module.css
@@ -1,0 +1,191 @@
+/* Tighten padding so the collapsed state reads as an icon cell, not a wide button. */
+.cell {
+    padding-left: 10px;
+    padding-right: 10px;
+    /* Let the corner status dot poke past the icon without being clipped. */
+    overflow: visible;
+}
+
+/* Mantine's Button label clips overflow by default — allow the dot to show. */
+.labelSlot {
+    overflow: visible;
+}
+
+.inner {
+    display: inline-flex;
+    align-items: center;
+}
+
+.iconWrap {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+}
+
+/* Corner status dot on the icon while collapsed; fades out on hover. */
+.dotCorner {
+    position: absolute;
+    top: -3px;
+    right: -4px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    box-shadow: 0 0 0 1.5px var(--mantine-color-body);
+    transition: opacity 140ms ease;
+}
+
+.cell:hover .dotCorner {
+    opacity: 0;
+}
+
+/* Label expands in on hover. */
+.label {
+    max-width: 0;
+    margin-left: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    opacity: 0;
+    font-weight: 500;
+    transition:
+        max-width 200ms ease,
+        margin-left 200ms ease,
+        opacity 160ms ease;
+}
+
+.cell:hover .label {
+    max-width: 140px;
+    margin-left: 8px;
+    opacity: 1;
+}
+
+/* Inline status dot appears alongside the label on hover. */
+.dotInline {
+    width: 0;
+    height: 7px;
+    margin-left: 0;
+    border-radius: 50%;
+    overflow: hidden;
+    opacity: 0;
+    transition:
+        width 180ms ease,
+        margin-left 180ms ease,
+        opacity 160ms ease;
+}
+
+.cell:hover .dotInline {
+    width: 7px;
+    margin-left: 8px;
+    opacity: 1;
+}
+
+.dotActive {
+    background: var(--mantine-color-green-6);
+}
+
+.dotFailed {
+    background: var(--mantine-color-red-6);
+}
+
+/* --- Promo hovercard (deliberately dark in both themes) --- */
+.promoDropdown {
+    padding: 0;
+    border: none;
+    background: transparent;
+    overflow: visible;
+}
+
+.promo {
+    position: relative;
+    overflow: hidden;
+    padding: 15px 15px 14px;
+    border-radius: 12px;
+    color: #ededed;
+    background: #141414;
+    box-shadow:
+        0 14px 40px rgba(0, 0, 0, 0.46),
+        inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+        inset 0 1px 0 0 rgba(255, 255, 255, 0.05);
+}
+
+.promoHeader {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    margin-bottom: 14px;
+}
+
+.promoOrb {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    border-radius: 8px;
+    flex-shrink: 0;
+    color: #d0d0d0;
+    background: rgba(255, 255, 255, 0.06);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+
+.promoTitle {
+    font-size: 13.5px;
+    font-weight: 650;
+    letter-spacing: -0.01em;
+}
+
+.promoTagline {
+    font-size: 11.5px;
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.promoFeatures {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-top: 13px;
+    margin-bottom: 15px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.promoFeature {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 12.5px;
+    color: rgba(255, 255, 255, 0.74);
+}
+
+.promoFeatureIcon {
+    color: rgba(255, 255, 255, 0.46);
+    flex-shrink: 0;
+}
+
+.promoCta {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    width: 100%;
+    padding: 8px 12px;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    color: #141414;
+    font-size: 12.5px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    background: #f2f2f2;
+    transition: background-color 140ms ease;
+}
+
+.promoCta:hover {
+    background: #ffffff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .label,
+    .dotInline,
+    .dotCorner {
+        transition: none;
+    }
+}

--- a/packages/frontend/src/components/NavBar/AutopilotNavButton.module.css
+++ b/packages/frontend/src/components/NavBar/AutopilotNavButton.module.css
@@ -1,3 +1,14 @@
+/* Let the corner status dot poke past the icon without being clipped.
+ * Mantine's Button clips overflow on both the root AND its inner label
+ * span by default — both need to be opted back into visible. */
+.cell {
+    overflow: visible;
+}
+
+.cellLabel {
+    overflow: visible;
+}
+
 .iconWrap {
     position: relative;
     display: inline-flex;
@@ -46,22 +57,9 @@
 
 .promoHeader {
     display: flex;
-    align-items: center;
-    gap: 9px;
+    flex-direction: column;
+    gap: 2px;
     margin-bottom: 14px;
-}
-
-.promoOrb {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 26px;
-    height: 26px;
-    border-radius: 8px;
-    flex-shrink: 0;
-    color: #d0d0d0;
-    background: rgba(255, 255, 255, 0.06);
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
 }
 
 .promoTitle {
@@ -117,4 +115,58 @@
 
 .promoCta:hover {
     background: #ffffff;
+}
+
+/* --- Mini hovercard for the active/live state --- */
+.miniCard {
+    display: block;
+    width: 100%;
+    padding: 13px 14px;
+    border: none;
+    border-radius: 12px;
+    cursor: pointer;
+    text-align: left;
+    color: #ededed;
+    background: #141414;
+    box-shadow:
+        0 14px 40px rgba(0, 0, 0, 0.46),
+        inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+        inset 0 1px 0 0 rgba(255, 255, 255, 0.05);
+}
+
+.miniHeaderText {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+
+.miniStatusDot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.miniStatus {
+    font-size: 12.5px;
+    color: rgba(255, 255, 255, 0.74);
+}
+
+.miniSummary {
+    margin-top: 4px;
+    font-size: 11.5px;
+    color: rgba(255, 255, 255, 0.46);
+}
+
+.miniFooter {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    font-size: 11.5px;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.6);
 }

--- a/packages/frontend/src/components/NavBar/AutopilotNavButton.tsx
+++ b/packages/frontend/src/components/NavBar/AutopilotNavButton.tsx
@@ -1,0 +1,174 @@
+import { subject } from '@casl/ability';
+import { FeatureFlags, ManagedAgentRunStatus } from '@lightdash/common';
+import { Button, HoverCard, Text } from '@mantine-8/core';
+import {
+    IconArrowRight,
+    IconChartBar,
+    IconShieldCheck,
+    IconTarget,
+    IconTrendingUp,
+} from '@tabler/icons-react';
+import { useNavigate } from 'react-router';
+import { useManagedAgentLatestRun } from '../../ee/features/managedAgent/hooks/useManagedAgentLatestRun';
+import { useManagedAgentSettings } from '../../ee/features/managedAgent/hooks/useManagedAgentSettings';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../providers/App/useApp';
+import MantineIcon from '../common/MantineIcon';
+import classes from './AutopilotNavButton.module.css';
+
+type Props = {
+    projectUuid: string;
+};
+
+const CAPABILITIES = [
+    { icon: IconShieldCheck, label: 'Fixes broken charts' },
+    { icon: IconTrendingUp, label: 'Flags stale content' },
+    { icon: IconChartBar, label: 'Creates fresh visualizations' },
+];
+
+/**
+ * Autopilot cell in the primary nav group, right after Ask AI. Icon-only (target
+ * glyph + status dot) until hovered, then it expands to reveal the label —
+ * present but quiet. Managers only, gated on the AiAutopilot flag. When it isn't
+ * set up yet, hovering opens a promo card; the cell and its CTA both lead to the
+ * /autopilot page, where setup happens inline.
+ */
+export const AutopilotNavButton = ({ projectUuid }: Props) => {
+    const navigate = useNavigate();
+    const { user } = useApp();
+    const canManage =
+        user.data?.ability?.can(
+            'manage',
+            subject('AiAgent', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+            }),
+        ) ?? false;
+    const { data: aiAutopilotFlag } = useServerFeatureFlag(
+        FeatureFlags.AiAutopilot,
+    );
+    const active = !!aiAutopilotFlag?.enabled && canManage;
+
+    const { data: settings } = useManagedAgentSettings({ enabled: active });
+    const isEnabled = settings?.enabled ?? false;
+    const { data: latestRun } = useManagedAgentLatestRun({
+        enabled: active && isEnabled,
+    });
+
+    const goToAutopilot = () =>
+        void navigate(`/projects/${projectUuid}/autopilot`);
+
+    if (!active) return null;
+
+    if (!isEnabled) {
+        return (
+            <HoverCard
+                width={280}
+                shadow="xl"
+                position="bottom-start"
+                offset={8}
+                openDelay={120}
+                closeDelay={80}
+                withinPortal
+                portalProps={{ target: '#navbar-header' }}
+            >
+                <HoverCard.Target>
+                    <Button
+                        size="xs"
+                        variant="default"
+                        classNames={{
+                            root: classes.cell,
+                            label: classes.labelSlot,
+                        }}
+                        onClick={goToAutopilot}
+                        aria-label="Autopilot"
+                    >
+                        <span className={classes.inner}>
+                            <span className={classes.iconWrap}>
+                                <MantineIcon
+                                    icon={IconTarget}
+                                    size={16}
+                                    color="dimmed"
+                                />
+                            </span>
+                            <Text span className={classes.label} size="sm">
+                                Autopilot
+                            </Text>
+                        </span>
+                    </Button>
+                </HoverCard.Target>
+                <HoverCard.Dropdown className={classes.promoDropdown}>
+                    <div className={classes.promo}>
+                        <div className={classes.promoHeader}>
+                            <span className={classes.promoOrb}>
+                                <MantineIcon icon={IconTarget} size={18} />
+                            </span>
+                            <div>
+                                <div className={classes.promoTitle}>
+                                    Autopilot
+                                </div>
+                                <div className={classes.promoTagline}>
+                                    Your project, kept sharp and current.
+                                </div>
+                            </div>
+                        </div>
+                        <div className={classes.promoFeatures}>
+                            {CAPABILITIES.map((feature) => (
+                                <div
+                                    key={feature.label}
+                                    className={classes.promoFeature}
+                                >
+                                    <MantineIcon
+                                        icon={feature.icon}
+                                        size={15}
+                                        className={classes.promoFeatureIcon}
+                                    />
+                                    <span>{feature.label}</span>
+                                </div>
+                            ))}
+                        </div>
+                        <button
+                            type="button"
+                            className={classes.promoCta}
+                            onClick={goToAutopilot}
+                        >
+                            Set up Autopilot
+                            <MantineIcon icon={IconArrowRight} size={14} />
+                        </button>
+                    </div>
+                </HoverCard.Dropdown>
+            </HoverCard>
+        );
+    }
+
+    const failed = latestRun?.status === ManagedAgentRunStatus.ERROR;
+    const dotClass = failed ? classes.dotFailed : classes.dotActive;
+
+    return (
+        <Button
+            size="xs"
+            variant="default"
+            classNames={{ root: classes.cell, label: classes.labelSlot }}
+            onClick={goToAutopilot}
+            aria-label="Autopilot"
+            title={`Autopilot · ${failed ? 'run failed' : 'active'}`}
+        >
+            <span className={classes.inner}>
+                <span className={classes.iconWrap}>
+                    <MantineIcon icon={IconTarget} size={16} />
+                    <span
+                        className={`${classes.dotCorner} ${dotClass}`}
+                        aria-hidden="true"
+                    />
+                </span>
+                <Text span className={classes.label} size="sm">
+                    Autopilot
+                </Text>
+                <span
+                    className={`${classes.dotInline} ${dotClass}`}
+                    aria-hidden="true"
+                />
+            </span>
+        </Button>
+    );
+};

--- a/packages/frontend/src/components/NavBar/AutopilotNavButton.tsx
+++ b/packages/frontend/src/components/NavBar/AutopilotNavButton.tsx
@@ -1,5 +1,10 @@
 import { subject } from '@casl/ability';
-import { FeatureFlags, ManagedAgentRunStatus } from '@lightdash/common';
+import {
+    FeatureFlags,
+    ManagedAgentActionType,
+    ManagedAgentRunStatus,
+    type ManagedAgentRun,
+} from '@lightdash/common';
 import { Button, HoverCard } from '@mantine-8/core';
 import {
     IconArrowRight,
@@ -8,8 +13,10 @@ import {
     IconTarget,
     IconTrendingUp,
 } from '@tabler/icons-react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useNavigate } from 'react-router';
+import { lightdashApi } from '../../api';
 import { useManagedAgentLatestRun } from '../../ee/features/managedAgent/hooks/useManagedAgentLatestRun';
 import { useManagedAgentSettings } from '../../ee/features/managedAgent/hooks/useManagedAgentSettings';
 import { ManagedAgentSetupModal } from '../../ee/features/managedAgent/ManagedAgentSetupModal';
@@ -18,8 +25,41 @@ import useApp from '../../providers/App/useApp';
 import MantineIcon from '../common/MantineIcon';
 import classes from './AutopilotNavButton.module.css';
 
+const resumeSettings = async (projectUuid: string, schedule: string) =>
+    lightdashApi({
+        url: `/projects/${projectUuid}/managed-agent/settings`,
+        method: 'PATCH',
+        body: JSON.stringify({ enabled: true, schedule }),
+    });
+
 type Props = {
     projectUuid: string;
+};
+
+const formatRelative = (dateInput: Date | string) => {
+    const diff = Date.now() - new Date(dateInput).getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    return `${Math.floor(hours / 24)}d ago`;
+};
+
+const summarizeActionCounts = (
+    counts: ManagedAgentRun['actionCountsByType'] | undefined,
+): string | null => {
+    if (!counts) return null;
+    const parts: string[] = [];
+    if (counts[ManagedAgentActionType.FIXED_BROKEN])
+        parts.push(`${counts[ManagedAgentActionType.FIXED_BROKEN]} fixed`);
+    if (counts[ManagedAgentActionType.CREATED_CONTENT])
+        parts.push(`${counts[ManagedAgentActionType.CREATED_CONTENT]} created`);
+    if (counts[ManagedAgentActionType.FLAGGED_STALE])
+        parts.push(`${counts[ManagedAgentActionType.FLAGGED_STALE]} flagged`);
+    if (counts[ManagedAgentActionType.SOFT_DELETED])
+        parts.push(`${counts[ManagedAgentActionType.SOFT_DELETED]} deleted`);
+    return parts.length > 0 ? parts.join(' · ') : null;
 };
 
 const CAPABILITIES = [
@@ -29,15 +69,21 @@ const CAPABILITIES = [
 ];
 
 /**
- * Autopilot cell in the primary nav group, right after Ask AI. Icon-only (target
- * glyph + status dot) until hovered, then it expands to reveal the label —
- * present but quiet. Managers only, gated on the AiAutopilot flag. When it isn't
- * set up yet, hovering opens a promo card explaining what it does; clicking opens
- * the setup modal directly (first time) or jumps to /autopilot to resume (a
- * settings row already exists, just switched off).
+ * Autopilot cell in the primary nav group, right after Ask AI. Always a plain
+ * icon button (no hover-expand) — the hovercards below carry the explanation
+ * instead. Managers only, gated on the AiAutopilot flag.
+ *
+ * - Never configured: hovering opens a promo card; clicking opens the setup
+ *   modal.
+ * - Configured but disabled: same card, but clicking resumes it directly
+ *   (PATCHes the existing settings row back to enabled) rather than
+ *   navigating away.
+ * - Active: hovering opens a compact status card (status, last-run action
+ *   summary, link to the full activity page).
  */
 export const AutopilotNavButton = ({ projectUuid }: Props) => {
     const navigate = useNavigate();
+    const queryClient = useQueryClient();
     const { user } = useApp();
     const canManage =
         user.data?.ability?.can(
@@ -63,15 +109,24 @@ export const AutopilotNavButton = ({ projectUuid }: Props) => {
     const goToAutopilot = () =>
         void navigate(`/projects/${projectUuid}/autopilot`);
 
+    const resumeMutation = useMutation({
+        mutationFn: () => resumeSettings(projectUuid, settings!.schedule),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({
+                queryKey: ['managed-agent-settings', projectUuid],
+            });
+        },
+    });
+
     if (!active) return null;
 
     if (!isEnabled) {
         // A settings row already exists (it was configured before, just
-        // switched off) — resuming just needs the toggle on /autopilot.
-        // No row yet — walk them through the setup modal first.
+        // switched off) — resume it directly. No row yet — walk them
+        // through the setup modal first.
         const hasExistingSettings = !!settings;
         const handleCellClick = hasExistingSettings
-            ? goToAutopilot
+            ? () => resumeMutation.mutate()
             : () => setSetupOpen(true);
 
         return (
@@ -89,30 +144,31 @@ export const AutopilotNavButton = ({ projectUuid }: Props) => {
                     <Button
                         size="xs"
                         variant="default"
-                        px={10}
+                        classNames={{
+                            root: classes.cell,
+                            label: classes.cellLabel,
+                        }}
                         onClick={handleCellClick}
+                        loading={resumeMutation.isLoading}
                         aria-label={
                             hasExistingSettings
                                 ? 'Resume Autopilot'
                                 : 'Set up Autopilot'
                         }
                     >
-                        <MantineIcon icon={IconTarget} size={16} color="dimmed" />
+                        <MantineIcon
+                            icon={IconTarget}
+                            size={16}
+                            color="dimmed"
+                        />
                     </Button>
                 </HoverCard.Target>
                 <HoverCard.Dropdown className={classes.promoDropdown}>
                     <div className={classes.promo}>
                         <div className={classes.promoHeader}>
-                            <span className={classes.promoOrb}>
-                                <MantineIcon icon={IconTarget} size={18} />
-                            </span>
-                            <div>
-                                <div className={classes.promoTitle}>
-                                    Autopilot
-                                </div>
-                                <div className={classes.promoTagline}>
-                                    Your project, kept sharp and current.
-                                </div>
+                            <div className={classes.promoTitle}>Autopilot</div>
+                            <div className={classes.promoTagline}>
+                                Your project, kept sharp and current.
                             </div>
                         </div>
                         <div className={classes.promoFeatures}>
@@ -134,10 +190,13 @@ export const AutopilotNavButton = ({ projectUuid }: Props) => {
                             type="button"
                             className={classes.promoCta}
                             onClick={handleCellClick}
+                            disabled={resumeMutation.isLoading}
                         >
-                            {hasExistingSettings
-                                ? 'Resume Autopilot'
-                                : 'Set up Autopilot'}
+                            {resumeMutation.isLoading
+                                ? 'Resuming…'
+                                : hasExistingSettings
+                                  ? 'Resume Autopilot'
+                                  : 'Set up Autopilot'}
                             <MantineIcon icon={IconArrowRight} size={14} />
                         </button>
                     </div>
@@ -155,25 +214,82 @@ export const AutopilotNavButton = ({ projectUuid }: Props) => {
         );
     }
 
+    const running = latestRun?.status === ManagedAgentRunStatus.STARTED;
     const failed = latestRun?.status === ManagedAgentRunStatus.ERROR;
     const dotClass = failed ? classes.dotFailed : classes.dotActive;
 
+    let statusText: string;
+    if (running) {
+        statusText = latestRun?.currentActivity ?? 'Working…';
+    } else if (failed) {
+        statusText = 'Last run failed';
+    } else if (latestRun) {
+        const count = latestRun.actionCount;
+        statusText = `${count} action${count === 1 ? '' : 's'} · ${formatRelative(
+            latestRun.finishedAt ?? latestRun.startedAt,
+        )}`;
+    } else {
+        statusText = 'Monitoring your project';
+    }
+
+    const actionSummary = summarizeActionCounts(latestRun?.actionCountsByType);
+
     return (
-        <Button
-            size="xs"
-            variant="default"
-            px={10}
-            onClick={goToAutopilot}
-            aria-label="Autopilot"
-            title={`Autopilot · ${failed ? 'run failed' : 'active'}`}
+        <HoverCard
+            width={240}
+            shadow="xl"
+            position="bottom-start"
+            offset={8}
+            openDelay={120}
+            closeDelay={80}
+            withinPortal
+            portalProps={{ target: '#navbar-header' }}
         >
-            <span className={classes.iconWrap}>
-                <MantineIcon icon={IconTarget} size={16} />
-                <span
-                    className={`${classes.dotCorner} ${dotClass}`}
-                    aria-hidden="true"
-                />
-            </span>
-        </Button>
+            <HoverCard.Target>
+                <Button
+                    size="xs"
+                    variant="default"
+                    classNames={{
+                        root: classes.cell,
+                        label: classes.cellLabel,
+                    }}
+                    onClick={goToAutopilot}
+                    aria-label="Autopilot"
+                >
+                    <span className={classes.iconWrap}>
+                        <MantineIcon icon={IconTarget} size={16} />
+                        <span
+                            className={`${classes.dotCorner} ${dotClass}`}
+                            aria-hidden="true"
+                        />
+                    </span>
+                </Button>
+            </HoverCard.Target>
+            <HoverCard.Dropdown className={classes.promoDropdown}>
+                <button
+                    type="button"
+                    className={classes.miniCard}
+                    onClick={goToAutopilot}
+                >
+                    <div className={classes.miniHeaderText}>
+                        <span className={classes.promoTitle}>Autopilot</span>
+                        <span
+                            className={`${classes.miniStatusDot} ${dotClass}`}
+                            aria-hidden="true"
+                        />
+                    </div>
+                    <div className={classes.miniStatus}>{statusText}</div>
+                    {actionSummary && !running && (
+                        <div className={classes.miniSummary}>
+                            {actionSummary}
+                        </div>
+                    )}
+                    <div className={classes.miniFooter}>
+                        View activity
+                        <MantineIcon icon={IconArrowRight} size={12} />
+                    </div>
+                </button>
+            </HoverCard.Dropdown>
+        </HoverCard>
     );
 };

--- a/packages/frontend/src/components/NavBar/AutopilotNavButton.tsx
+++ b/packages/frontend/src/components/NavBar/AutopilotNavButton.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import { FeatureFlags, ManagedAgentRunStatus } from '@lightdash/common';
-import { Button, HoverCard, Text } from '@mantine-8/core';
+import { Button, HoverCard } from '@mantine-8/core';
 import {
     IconArrowRight,
     IconChartBar,
@@ -8,9 +8,11 @@ import {
     IconTarget,
     IconTrendingUp,
 } from '@tabler/icons-react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router';
 import { useManagedAgentLatestRun } from '../../ee/features/managedAgent/hooks/useManagedAgentLatestRun';
 import { useManagedAgentSettings } from '../../ee/features/managedAgent/hooks/useManagedAgentSettings';
+import { ManagedAgentSetupModal } from '../../ee/features/managedAgent/ManagedAgentSetupModal';
 import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../providers/App/useApp';
 import MantineIcon from '../common/MantineIcon';
@@ -30,8 +32,9 @@ const CAPABILITIES = [
  * Autopilot cell in the primary nav group, right after Ask AI. Icon-only (target
  * glyph + status dot) until hovered, then it expands to reveal the label —
  * present but quiet. Managers only, gated on the AiAutopilot flag. When it isn't
- * set up yet, hovering opens a promo card; the cell and its CTA both lead to the
- * /autopilot page, where setup happens inline.
+ * set up yet, hovering opens a promo card explaining what it does; clicking opens
+ * the setup modal directly (first time) or jumps to /autopilot to resume (a
+ * settings row already exists, just switched off).
  */
 export const AutopilotNavButton = ({ projectUuid }: Props) => {
     const navigate = useNavigate();
@@ -55,12 +58,22 @@ export const AutopilotNavButton = ({ projectUuid }: Props) => {
         enabled: active && isEnabled,
     });
 
+    const [setupOpen, setSetupOpen] = useState(false);
+
     const goToAutopilot = () =>
         void navigate(`/projects/${projectUuid}/autopilot`);
 
     if (!active) return null;
 
     if (!isEnabled) {
+        // A settings row already exists (it was configured before, just
+        // switched off) — resuming just needs the toggle on /autopilot.
+        // No row yet — walk them through the setup modal first.
+        const hasExistingSettings = !!settings;
+        const handleCellClick = hasExistingSettings
+            ? goToAutopilot
+            : () => setSetupOpen(true);
+
         return (
             <HoverCard
                 width={280}
@@ -76,25 +89,15 @@ export const AutopilotNavButton = ({ projectUuid }: Props) => {
                     <Button
                         size="xs"
                         variant="default"
-                        classNames={{
-                            root: classes.cell,
-                            label: classes.labelSlot,
-                        }}
-                        onClick={goToAutopilot}
-                        aria-label="Autopilot"
+                        px={10}
+                        onClick={handleCellClick}
+                        aria-label={
+                            hasExistingSettings
+                                ? 'Resume Autopilot'
+                                : 'Set up Autopilot'
+                        }
                     >
-                        <span className={classes.inner}>
-                            <span className={classes.iconWrap}>
-                                <MantineIcon
-                                    icon={IconTarget}
-                                    size={16}
-                                    color="dimmed"
-                                />
-                            </span>
-                            <Text span className={classes.label} size="sm">
-                                Autopilot
-                            </Text>
-                        </span>
+                        <MantineIcon icon={IconTarget} size={16} color="dimmed" />
                     </Button>
                 </HoverCard.Target>
                 <HoverCard.Dropdown className={classes.promoDropdown}>
@@ -130,13 +133,24 @@ export const AutopilotNavButton = ({ projectUuid }: Props) => {
                         <button
                             type="button"
                             className={classes.promoCta}
-                            onClick={goToAutopilot}
+                            onClick={handleCellClick}
                         >
-                            Set up Autopilot
+                            {hasExistingSettings
+                                ? 'Resume Autopilot'
+                                : 'Set up Autopilot'}
                             <MantineIcon icon={IconArrowRight} size={14} />
                         </button>
                     </div>
                 </HoverCard.Dropdown>
+                <ManagedAgentSetupModal
+                    projectUuid={projectUuid}
+                    opened={setupOpen}
+                    onClose={() => setSetupOpen(false)}
+                    onEnabled={() => {
+                        setSetupOpen(false);
+                        goToAutopilot();
+                    }}
+                />
             </HoverCard>
         );
     }
@@ -148,24 +162,15 @@ export const AutopilotNavButton = ({ projectUuid }: Props) => {
         <Button
             size="xs"
             variant="default"
-            classNames={{ root: classes.cell, label: classes.labelSlot }}
+            px={10}
             onClick={goToAutopilot}
             aria-label="Autopilot"
             title={`Autopilot · ${failed ? 'run failed' : 'active'}`}
         >
-            <span className={classes.inner}>
-                <span className={classes.iconWrap}>
-                    <MantineIcon icon={IconTarget} size={16} />
-                    <span
-                        className={`${classes.dotCorner} ${dotClass}`}
-                        aria-hidden="true"
-                    />
-                </span>
-                <Text span className={classes.label} size="sm">
-                    Autopilot
-                </Text>
+            <span className={classes.iconWrap}>
+                <MantineIcon icon={IconTarget} size={16} />
                 <span
-                    className={`${classes.dotInline} ${dotClass}`}
+                    className={`${classes.dotCorner} ${dotClass}`}
                     aria-hidden="true"
                 />
             </span>

--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -5,6 +5,7 @@ import { useHasMetricsInCatalog } from '../../features/metricsCatalog/hooks/useM
 import Omnibar from '../../features/omnibar';
 import useApp from '../../providers/App/useApp';
 import Logo from '../../svgs/logo-icon.svg?react';
+import { AutopilotNavButton } from './AutopilotNavButton';
 import BrowseMenu from './BrowseMenu';
 import ExploreMenu from './ExploreMenu';
 import HeadwayMenuItem from './HeadwayMenuItem';
@@ -66,6 +67,9 @@ export const MainNavBarContent: FC<Props> = ({
                                     projectUuid={activeProjectUuid}
                                 />
                             </Suspense>
+                            <AutopilotNavButton
+                                projectUuid={activeProjectUuid}
+                            />
                         </Button.Group>
                         <Omnibar projectUuid={activeProjectUuid} />
                     </>

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
@@ -448,12 +448,15 @@
     align-items: center;
     justify-content: center;
     background-color: light-dark(
-        var(--mantine-color-violet-0),
-        var(--mantine-color-violet-9)
+        var(--mantine-color-gray-1),
+        var(--mantine-color-dark-6)
     );
     border: 1px solid
-        light-dark(var(--mantine-color-violet-1), var(--mantine-color-violet-7));
-    color: var(--mantine-color-violet-5);
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+    color: light-dark(
+        var(--mantine-color-violet-6),
+        var(--mantine-color-violet-4)
+    );
 }
 
 .activeBadge {

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -597,8 +597,8 @@ const FixedBrokenDiff: FC<{
                 </Stack>
             ) : (
                 <Text fz="xs" c="dimmed" lh={1.6}>
-                    This fix touched fields not surfaced in this view, see
-                    chart history for details.
+                    This fix touched fields not surfaced in this view, see chart
+                    history for details.
                 </Text>
             )}
             {historyLink}
@@ -1341,8 +1341,8 @@ const SettingsSidebar: FC<{
                                         />
                                         <Text fz="xs" c="dimmed">
                                             Please invite Lightdash to this
-                                            channel, we can&apos;t post
-                                            messages until you do. (
+                                            channel, we can&apos;t post messages
+                                            until you do. (
                                             <Text
                                                 component="span"
                                                 inherit
@@ -2067,8 +2067,8 @@ export const ManagedAgentActivityPage: FC = () => {
                                         No activity yet
                                     </Text>
                                     <Text fz="xs" c="dimmed">
-                                        The agent runs on a schedule, check
-                                        back soon.
+                                        The agent runs on a schedule, check back
+                                        soon.
                                     </Text>
                                 </Box>
                             ) : (

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -35,7 +35,6 @@ import {
 import {
     IconAlertTriangle,
     IconArrowBackUp,
-    IconBolt,
     IconBrandSlack,
     IconChartBar,
     IconChevronRight,
@@ -1510,9 +1509,9 @@ const ActionRow: FC<{
 
 // --- Run row ---
 
-const BoltPulseLoader: FC<{ size?: number }> = ({ size = 12 }) => (
+const TargetPulseLoader: FC<{ size?: number }> = ({ size = 12 }) => (
     <Box className={classes.boltPulseLoader} aria-label="Running">
-        <IconBolt size={size} fill="currentColor" stroke={0} />
+        <IconTarget size={size} stroke={2.5} />
     </Box>
 );
 
@@ -1564,7 +1563,7 @@ const RunHeaderRow: FC<{
                         <Box w={12} />
                     )}
                     {variant === 'live' ? (
-                        <BoltPulseLoader size={12} />
+                        <TargetPulseLoader size={12} />
                     ) : variant === 'errored' ? (
                         <IconAlertTriangle
                             size={12}

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -51,6 +51,7 @@ import {
     IconPlayerPlay,
     IconSelector,
     IconSettings,
+    IconTarget,
     IconTool,
     IconTrash,
     IconX,
@@ -183,7 +184,7 @@ const SetupSection: FC<{
                 <Stack gap={0}>
                     <Group gap="sm" align="center">
                         <Box className={classes.setupOrb}>
-                            <IconBolt size={16} />
+                            <IconTarget size={16} />
                         </Box>
                         <Title order={4} fw={700}>
                             Autopilot
@@ -520,7 +521,7 @@ const FixedBrokenDiff: FC<{
             <Stack gap="sm">
                 <MetadataLabel label="Changes applied" />
                 <Text fz="xs" c="dimmed" lh={1.6}>
-                    Diff unavailable for this fix — see chart history for
+                    Diff unavailable for this fix, see chart history for
                     details.
                 </Text>
                 {historyLink}
@@ -597,7 +598,7 @@ const FixedBrokenDiff: FC<{
                 </Stack>
             ) : (
                 <Text fz="xs" c="dimmed" lh={1.6}>
-                    This fix touched fields not surfaced in this view — see
+                    This fix touched fields not surfaced in this view, see
                     chart history for details.
                 </Text>
             )}
@@ -775,7 +776,7 @@ const DetailSidebar: FC<{
                 showRestoreBanner && error?.statusCode === 404;
             showToastApiError({
                 title: isHardDeleted
-                    ? 'Could not restore — the original was permanently deleted'
+                    ? 'Could not restore. The original was permanently deleted'
                     : category === 'undo'
                       ? 'Could not undo action'
                       : 'Could not dismiss action',
@@ -1066,7 +1067,7 @@ const DetailSidebar: FC<{
                         </Button>
                     ) : (
                         <Tooltip
-                            label="This fix was recorded before revert support — restore manually via chart history."
+                            label="This fix was recorded before revert support. Restore manually via chart history."
                             withinPortal
                             multiline
                             w={240}
@@ -1341,7 +1342,7 @@ const SettingsSidebar: FC<{
                                         />
                                         <Text fz="xs" c="dimmed">
                                             Please invite Lightdash to this
-                                            channel — we can&apos;t post
+                                            channel, we can&apos;t post
                                             messages until you do. (
                                             <Text
                                                 component="span"
@@ -2067,7 +2068,7 @@ export const ManagedAgentActivityPage: FC = () => {
                                         No activity yet
                                     </Text>
                                     <Text fz="xs" c="dimmed">
-                                        The agent runs on a schedule — check
+                                        The agent runs on a schedule, check
                                         back soon.
                                     </Text>
                                 </Box>

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
@@ -14,9 +14,9 @@ import {
 } from '@mantine-8/core';
 import {
     IconArrowRight,
-    IconBolt,
     IconChartBar,
     IconShieldCheck,
+    IconTarget,
     IconTrendingUp,
 } from '@tabler/icons-react';
 import {
@@ -189,7 +189,7 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
                 <Stack gap="md">
                     <Group gap="md" align="center">
                         <Box className={classes.orbActive}>
-                            <IconBolt size={18} />
+                            <IconTarget size={18} />
                         </Box>
                         <Stack gap={4}>
                             <Group gap={8} align="center">
@@ -241,7 +241,7 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
                 <Stack gap="md">
                     <Group gap="md" align="center">
                         <Box className={classes.orb}>
-                            <IconBolt size={18} />
+                            <IconTarget size={18} />
                         </Box>
                         <Stack gap={4}>
                             <Group gap={8} align="center">

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentSetupModal.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentSetupModal.tsx
@@ -98,7 +98,7 @@ export const ManagedAgentSetupModal: FC<{
                 {/* Description */}
                 <Text fz="sm" c="dimmed">
                     An AI agent that monitors your project&apos;s health
-                    automatically — cleaning up stale content, fixing broken
+                    automatically, cleaning up stale content, fixing broken
                     charts, and surfacing insights. All actions are logged and
                     reversible.
                 </Text>

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentSetupModal.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentSetupModal.tsx
@@ -1,9 +1,9 @@
 import { ManagedAgentScheduleOption } from '@lightdash/common';
 import { Box, Group, Select, Stack, Text } from '@mantine-8/core';
 import {
-    IconBolt,
     IconChartBar,
     IconClock,
+    IconTarget,
     IconTool,
     IconTrendingUp,
 } from '@tabler/icons-react';
@@ -89,10 +89,12 @@ export const ManagedAgentSetupModal: FC<{
             opened={opened}
             onClose={onClose}
             title="Enable Autopilot"
-            icon={IconBolt}
+            icon={IconTarget}
             size="lg"
             onConfirm={() => mutation.mutate()}
             confirmLabel="Enable"
+            confirmLoading={mutation.isLoading}
+            cancelDisabled={mutation.isLoading}
         >
             <Stack gap="xl">
                 {/* Description */}

--- a/packages/frontend/src/ee/features/managedAgent/ToolActivityBadge.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ToolActivityBadge.tsx
@@ -2,7 +2,6 @@ import { Box, Text } from '@mantine-8/core';
 import {
     IconAlertTriangle,
     IconArrowBackUp,
-    IconBolt,
     IconBulb,
     IconChartBar,
     IconClock,
@@ -15,6 +14,7 @@ import {
     IconMessageQuestion,
     IconPlus,
     IconStar,
+    IconTarget,
     IconTool,
     IconTrash,
 } from '@tabler/icons-react';
@@ -23,8 +23,8 @@ import classes from './ToolActivityBadge.module.css';
 
 // Mirrors backend FRIENDLY_TOOL_LABELS values from
 // packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts.
-// Out-of-map labels fall back to IconBolt.
-const ACTIVITY_ICON: Record<string, typeof IconBolt> = {
+// Out-of-map labels fall back to IconTarget.
+const ACTIVITY_ICON: Record<string, typeof IconTarget> = {
     'Reviewing recent activity': IconHistory,
     'Looking for stale charts': IconChartBar,
     'Looking for stale dashboards': IconLayoutDashboard,
@@ -43,7 +43,7 @@ const ACTIVITY_ICON: Record<string, typeof IconBolt> = {
     'Reverting earlier change': IconArrowBackUp,
 };
 
-const iconFor = (label: string) => ACTIVITY_ICON[label] ?? IconBolt;
+const iconFor = (label: string) => ACTIVITY_ICON[label] ?? IconTarget;
 
 const FALLBACK_LABEL = 'Autopilot is working';
 
@@ -115,7 +115,7 @@ export const ToolActivityBadge: FC<{ currentActivity: string | null }> = ({
         };
     }, [currentActivity]);
 
-    const ActiveIcon = currentActivity ? iconFor(currentActivity) : IconBolt;
+    const ActiveIcon = currentActivity ? iconFor(currentActivity) : IconTarget;
     const label =
         thinkingVerb ??
         stripTrailingEllipsis(currentActivity ?? FALLBACK_LABEL);


### PR DESCRIPTION
Closes: ZAP-640

## What & why

Autopilot's only entry point was a card on the legacy home page. That card doesn't render at all once a project uses a custom builder homepage (`PublishedHomepage`), so switching to a custom homepage silently removed Autopilot's only visible entry point.

This adds a permanent navbar cell instead, right after Ask AI, so Autopilot is reachable regardless of which homepage a project uses.

## Design

Designed collaboratively (mockups iterated live, credit to Joao's design work with Claude on the concept). Always a plain icon button — no hover-expand-to-label — with hovercards carrying the explanation instead. Deliberately monochrome; the target-glyph icon carries the only accent color.

## Changes

**`AutopilotNavButton`** — new segmented-group cell in `MainNavBarContent`, right after `AiAgentsButton`. Gated on `FeatureFlags.AiAutopilot` + `can('manage', 'AiAgent')`, same access rule the old home card used. Three states:
- **Never configured**: hovering opens a dark promo card (capabilities + CTA) explaining what Autopilot does. Clicking opens the setup modal.
- **Configured but disabled**: same promo card, but the CTA reads "Resume Autopilot" and PATCHes the existing settings row back to `enabled: true` directly (reusing its saved schedule) — no navigation, no re-running setup.
- **Active**: target glyph + corner status dot (green = active, red = latest run failed). Hovering opens a compact status card: current status line (idle summary / live activity text / failure), the last-run action-type breakdown carried over from the old home card (e.g. "3 fixed · 2 created"), and a link to the full activity page.

**Other fixes bundled in:**
- Fixed the setup modal's "Enable" button giving no feedback while its request was in flight (missing `confirmLoading`/`cancelDisabled`) — read as unresponsive and allowed duplicate submits.
- Fixed the status dot clipping — Mantine's `Button` clips overflow on both its root *and* an inner label span; both needed the override.
- Replaced every remaining `IconBolt` across the Autopilot surfaces (setup modal header, activity-page running-run pulse loader, legacy home card, tool-activity fallback icon) with the same target glyph, and toned the activity page's icon chip down to a subtle neutral background (icon itself stays violet).
- Removed em dashes from the Autopilot-related copy.

## Testing

Verified live end-to-end (Chrome DevTools) across every state: not-configured → promo → modal-open, configured-but-disabled → "Resume" → actually flips to active in place, and the active cell → hovercard → click-through to `/autopilot`. `typecheck:fast` and oxlint clean throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)