### PR TITLE
feat: create custom metrics from existing explore metrics

### DIFF
--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -11,6 +11,10 @@
                     "$ref": "#/$defs/FieldId",
                     "description": "For PoP-generated metrics, the base metric id that this metric is derived from."
                 },
+                "baseMetricName": {
+                    "description": "Name of the explore metric this metric was cloned from",
+                    "type": "string"
+                },
                 "compact": {
                     "$ref": "#/$defs/CompactOrAlias",
                     "description": "Compact format for large numbers"
@@ -2402,11 +2406,11 @@
                 }
             },
             "required": [
-                "limit",
                 "exploreName",
                 "dimensions",
                 "metrics",
                 "sorts",
+                "limit",
                 "tableCalculations"
             ],
             "type": "object"
@@ -2611,9 +2615,6 @@
             "type": "object"
         },
         "Record_string.string_": {
-            "additionalProperties": {
-                "type": "string"
-            },
             "description": "Construct a type with a set of properties K of type T",
             "properties": {},
             "type": "object"
@@ -3643,9 +3644,9 @@
     },
     "required": [
         "name",
-        "slug",
-        "chartConfig",
         "tableName",
+        "chartConfig",
+        "slug",
         "spaceSlug",
         "version",
         "metricQuery"

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -11,10 +11,6 @@
                     "$ref": "#/$defs/FieldId",
                     "description": "For PoP-generated metrics, the base metric id that this metric is derived from."
                 },
-                "baseMetricName": {
-                    "description": "Name of the explore metric this metric was cloned from",
-                    "type": "string"
-                },
                 "compact": {
                     "$ref": "#/$defs/CompactOrAlias",
                     "description": "Compact format for large numbers"
@@ -2406,11 +2402,11 @@
                 }
             },
             "required": [
+                "limit",
                 "exploreName",
                 "dimensions",
                 "metrics",
                 "sorts",
-                "limit",
                 "tableCalculations"
             ],
             "type": "object"
@@ -2615,6 +2611,9 @@
             "type": "object"
         },
         "Record_string.string_": {
+            "additionalProperties": {
+                "type": "string"
+            },
             "description": "Construct a type with a set of properties K of type T",
             "properties": {},
             "type": "object"
@@ -3644,9 +3643,9 @@
     },
     "required": [
         "name",
-        "tableName",
-        "chartConfig",
         "slug",
+        "chartConfig",
+        "tableName",
         "spaceSlug",
         "version",
         "metricQuery"

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -11,6 +11,10 @@
                     "$ref": "#/$defs/FieldId",
                     "description": "For PoP-generated metrics, the base metric id that this metric is derived from."
                 },
+                "baseMetricName": {
+                    "description": "Name of the explore metric this metric was cloned from",
+                    "type": "string"
+                },
                 "compact": {
                     "$ref": "#/$defs/CompactOrAlias",
                     "description": "Compact format for large numbers"

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -586,17 +586,6 @@
             "required": ["w", "h", "y", "x", "type"],
             "type": "object"
         },
-        "DashboardTileTarget": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/DashboardFieldTarget"
-                },
-                {
-                    "enum": [false],
-                    "type": "boolean"
-                }
-            ]
-        },
         "DashboardTileTypes": {
             "enum": [
                 "saved_chart",
@@ -902,9 +891,6 @@
             "type": "object"
         },
         "Record_string.DashboardTileTarget_": {
-            "additionalProperties": {
-                "$ref": "#/$defs/DashboardTileTarget"
-            },
             "description": "Construct a type with a set of properties K of type T",
             "properties": {},
             "type": "object"

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -586,6 +586,17 @@
             "required": ["w", "h", "y", "x", "type"],
             "type": "object"
         },
+        "DashboardTileTarget": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/DashboardFieldTarget"
+                },
+                {
+                    "enum": [false],
+                    "type": "boolean"
+                }
+            ]
+        },
         "DashboardTileTypes": {
             "enum": [
                 "saved_chart",
@@ -891,6 +902,9 @@
             "type": "object"
         },
         "Record_string.DashboardTileTarget_": {
+            "additionalProperties": {
+                "$ref": "#/$defs/DashboardTileTarget"
+            },
             "description": "Construct a type with a set of properties K of type T",
             "properties": {},
             "type": "object"

--- a/packages/common/src/types/metricQuery.ts
+++ b/packages/common/src/types/metricQuery.ts
@@ -55,6 +55,8 @@ export interface AdditionalMetric {
     filters?: MetricFilterRule[];
     /** Name of the base dimension/column this metric aggregates */
     baseDimensionName?: string;
+    /** Name of the explore metric this metric was cloned from */
+    baseMetricName?: string;
     /** Unique identifier for the metric */
     uuid?: string | null;
     /** Percentile value for percentile metrics */

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -443,8 +443,12 @@ export const CustomMetricModal = memo(() => {
 
     const defaultFilterRuleFieldId = useMemo(() => {
         if (item) {
-            // A metric is not a valid filter target; let the form fall back
-            if (isMetric(item)) return undefined;
+            // For metric-derived customs, default new filters to the metric's
+            // underlying dimension (joined explores can have same-named fields)
+            if (isMetric(item)) return item.dimensionReference;
+            if (isMetricDerived && sourceMetric) {
+                return sourceMetric.dimensionReference;
+            }
             if (!isEditing) return getItemId(item);
 
             if (
@@ -455,7 +459,7 @@ export const CustomMetricModal = memo(() => {
                 return `${item.table}_${item.baseDimensionName}`;
             }
         }
-    }, [isEditing, item]);
+    }, [isEditing, item, isMetricDerived, sourceMetric]);
 
     const getFormatInputProps = (path: keyof CustomFormat) =>
         form.getInputProps(`format.${path}`);

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -3,7 +3,6 @@ import {
     CustomFormatType,
     DimensionType,
     friendlyName,
-    getCustomFormatFromLegacy,
     getCustomMetricType,
     getFilterableDimensionsFromItemsMap,
     getItemId,
@@ -56,6 +55,7 @@ import {
     addFieldIdToMetricFilterRule,
     getCustomMetricName,
     getFilterRulesFromMetricBaseFilters,
+    getFormatFromBaseMetric,
     prepareCustomMetricData,
 } from './utils';
 
@@ -348,17 +348,9 @@ export const CustomMetricModal = memo(() => {
                     setFieldValue('percentile', item.percentile);
 
                 // Carry the base metric's formatting into the clone
-                if (item.formatOptions) {
-                    setFieldValue('format', { ...item.formatOptions });
-                } else if (item.format || item.round !== undefined) {
-                    setFieldValue(
-                        'format',
-                        getCustomFormatFromLegacy({
-                            format: item.format,
-                            round: item.round,
-                            compact: item.compact,
-                        }),
-                    );
+                const baseFormat = getFormatFromBaseMetric(item);
+                if (baseFormat) {
+                    setFieldValue('format', baseFormat);
                 }
             }
         },

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -1,6 +1,7 @@
 import {
     canApplyFormattingToCustomMetric,
     CustomFormatType,
+    DimensionType,
     friendlyName,
     getCustomFormatFromLegacy,
     getCustomMetricType,
@@ -183,6 +184,22 @@ export const CustomMetricModal = memo(() => {
         if (!customMetricType) return false;
         // Metric-derived custom metrics have no base dimension to check
         if (isMetricDerived) {
+            // MIN/MAX-of-date clones are date-valued; numeric formats don't apply
+            const isDateValued =
+                sourceMetric?.baseDimensionType === DimensionType.DATE ||
+                sourceMetric?.baseDimensionType === DimensionType.TIMESTAMP ||
+                (isAdditionalMetric(item) &&
+                    item.formatOptions &&
+                    [
+                        CustomFormatType.DATE,
+                        CustomFormatType.TIMESTAMP,
+                    ].includes(item.formatOptions.type));
+            if (
+                isDateValued &&
+                [MetricType.MIN, MetricType.MAX].includes(customMetricType)
+            ) {
+                return false;
+            }
             return (
                 isNumericItem(item) ||
                 [MetricType.COUNT, MetricType.COUNT_DISTINCT].includes(
@@ -194,7 +211,13 @@ export const CustomMetricModal = memo(() => {
             !!dimensionToCheck &&
             canApplyFormattingToCustomMetric(dimensionToCheck, customMetricType)
         );
-    }, [dimensionToCheck, customMetricType, isMetricDerived, item]);
+    }, [
+        dimensionToCheck,
+        customMetricType,
+        isMetricDerived,
+        item,
+        sourceMetric,
+    ]);
 
     const form = useForm<
         Pick<AdditionalMetric, 'percentile'> & {

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -2,6 +2,7 @@ import {
     canApplyFormattingToCustomMetric,
     CustomFormatType,
     friendlyName,
+    getCustomFormatFromLegacy,
     getCustomMetricType,
     getFilterableDimensionsFromItemsMap,
     getItemId,
@@ -9,7 +10,9 @@ import {
     isAdditionalMetric,
     isCustomDimension,
     isDimension,
+    isMetric,
     isNonAggregateMetricType,
+    isNumericItem,
     MetricType,
     NumberSeparator,
     type AdditionalMetric,
@@ -51,6 +54,7 @@ import { useDataForFiltersProvider } from './hooks/useDataForFiltersProvider';
 import {
     addFieldIdToMetricFilterRule,
     getCustomMetricName,
+    getFilterRulesFromMetricBaseFilters,
     prepareCustomMetricData,
 } from './utils';
 
@@ -86,6 +90,25 @@ export const CustomMetricModal = memo(() => {
         dimensionToCheck =
             exploreData?.tables[item.table]?.dimensions[item.baseDimensionName];
     }
+
+    // Creating a clone of an explore metric, or editing such a clone
+    const isMetricDerived =
+        (!isEditing && isMetric(item)) ||
+        (isEditing && isAdditionalMetric(item) && !!item.baseMetricName);
+
+    const sourceMetric = useMemo(() => {
+        if (!isEditing && isMetric(item)) return item;
+        if (isEditing && isAdditionalMetric(item) && item.baseMetricName) {
+            return exploreData?.tables[item.table]?.metrics[
+                item.baseMetricName
+            ];
+        }
+        return undefined;
+    }, [isEditing, item, exploreData]);
+
+    const sourceMetricLabel =
+        sourceMetric?.label ??
+        (isAdditionalMetric(item) ? item.baseMetricName : undefined);
 
     const originalBaseDimensionName = useMemo(() => {
         if (isEditing && isAdditionalMetric(item) && item.baseDimensionName) {
@@ -156,16 +179,22 @@ export const CustomMetricModal = memo(() => {
         );
     };
 
-    const canApplyFormatting = useMemo(
-        () =>
-            dimensionToCheck &&
-            customMetricType &&
-            canApplyFormattingToCustomMetric(
-                dimensionToCheck,
-                customMetricType,
-            ),
-        [dimensionToCheck, customMetricType],
-    );
+    const canApplyFormatting = useMemo(() => {
+        if (!customMetricType) return false;
+        // Metric-derived custom metrics have no base dimension to check
+        if (isMetricDerived) {
+            return (
+                isNumericItem(item) ||
+                [MetricType.COUNT, MetricType.COUNT_DISTINCT].includes(
+                    customMetricType,
+                )
+            );
+        }
+        return (
+            !!dimensionToCheck &&
+            canApplyFormattingToCustomMetric(dimensionToCheck, customMetricType)
+        );
+    }, [dimensionToCheck, customMetricType, isMetricDerived, item]);
 
     const form = useForm<
         Pick<AdditionalMetric, 'percentile'> & {
@@ -197,11 +226,10 @@ export const CustomMetricModal = memo(() => {
                 const metricName = getCustomMetricName(
                     item.table,
                     label,
-                    isEditing &&
-                        isAdditionalMetric(item) &&
-                        'baseDimensionName' in item &&
-                        item.baseDimensionName
-                        ? item.baseDimensionName
+                    isEditing && isAdditionalMetric(item)
+                        ? (item.baseDimensionName ??
+                              item.baseMetricName ??
+                              item.name)
                         : item.name,
                 );
 
@@ -245,15 +273,23 @@ export const CustomMetricModal = memo(() => {
                 'customMetricLabel',
                 isEditing
                     ? label
-                    : customMetricType
-                      ? `${friendlyName(customMetricType)} of ${label}`
-                      : '',
+                    : isMetric(item)
+                      ? `Copy of ${label}`
+                      : customMetricType
+                        ? `${friendlyName(customMetricType)} of ${label}`
+                        : '',
             );
         }
     }, [setFieldValue, item, customMetricType, isEditing]);
 
     const initialCustomMetricFiltersWithIds = useMemo(() => {
-        if (!isEditing) return [];
+        if (!isEditing) {
+            // Cloning an explore metric starts from its own filters so the
+            // numbers match the base metric until the user tweaks them
+            return isMetric(item)
+                ? getFilterRulesFromMetricBaseFilters(item)
+                : [];
+        }
 
         return isAdditionalMetric(item)
             ? item.filters?.map((filterRule) =>
@@ -282,6 +318,24 @@ export const CustomMetricModal = memo(() => {
                         // This spread is intentional to avoid @mantine/form mutating the enum object `item.formatOptions.type`
                         ...item.formatOptions,
                     });
+                }
+            }
+            if (!isEditing && isMetric(item)) {
+                if (item.percentile)
+                    setFieldValue('percentile', item.percentile);
+
+                // Carry the base metric's formatting into the clone
+                if (item.formatOptions) {
+                    setFieldValue('format', { ...item.formatOptions });
+                } else if (item.format || item.round !== undefined) {
+                    setFieldValue(
+                        'format',
+                        getCustomFormatFromLegacy({
+                            format: item.format,
+                            round: item.round,
+                            compact: item.compact,
+                        }),
+                    );
                 }
             }
         },
@@ -349,6 +403,17 @@ export const CustomMetricModal = memo(() => {
                               }`
                             : 'Custom metric edited successfully',
                 });
+            } else if (isMetric(item)) {
+                dispatch(
+                    explorerActions.addAdditionalMetric({
+                        uuid: uuidv4(),
+                        baseMetricName: item.name,
+                        ...data,
+                    }),
+                );
+                showToastSuccess({
+                    title: 'Custom metric added successfully',
+                });
             } else if (isDimension(item) && form.values.customMetricLabel) {
                 dispatch(
                     explorerActions.addAdditionalMetric({
@@ -378,6 +443,8 @@ export const CustomMetricModal = memo(() => {
 
     const defaultFilterRuleFieldId = useMemo(() => {
         if (item) {
+            // A metric is not a valid filter target; let the form fall back
+            if (isMetric(item)) return undefined;
             if (!isEditing) return getItemId(item);
 
             if (
@@ -479,6 +546,19 @@ export const CustomMetricModal = memo(() => {
                             ) : null}
                         </Stack>
                     )}
+                    {isMetricDerived && sourceMetricLabel && (
+                        <TextInput
+                            label="Source metric"
+                            value={sourceMetricLabel}
+                            readOnly
+                            description="The metric this custom metric is based on."
+                            leftSection={
+                                sourceMetric ? (
+                                    <FieldIcon item={sourceMetric} size="sm" />
+                                ) : null
+                            }
+                        />
+                    )}
                     {customMetricType && (
                         <TextInput
                             label="Type"
@@ -487,6 +567,16 @@ export const CustomMetricModal = memo(() => {
                             description="Metric type"
                         />
                     )}
+                    {isMetricDerived &&
+                        (isMetric(item) || isAdditionalMetric(item)) &&
+                        item.sql && (
+                            <TextInput
+                                label="SQL"
+                                value={item.sql}
+                                readOnly
+                                description="SQL this metric aggregates"
+                            />
+                        )}
                     {isEditing &&
                         isAdditionalMetric(item) &&
                         item.sql &&

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.test.ts
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.test.ts
@@ -1,0 +1,115 @@
+import {
+    FieldType,
+    FilterOperator,
+    MetricType,
+    type Metric,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    getFilterRulesFromMetricBaseFilters,
+    prepareCustomMetricData,
+} from '.';
+
+const baseMetric: Metric = {
+    fieldType: FieldType.METRIC,
+    type: MetricType.SUM,
+    name: 'total_revenue',
+    label: 'Total revenue',
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: '${TABLE}.revenue',
+    hidden: false,
+    filters: [
+        {
+            id: 'yaml-filter-id',
+            target: { fieldRef: 'status' },
+            operator: FilterOperator.EQUALS,
+            values: ['completed'],
+        },
+        {
+            id: 'yaml-filter-id-2',
+            target: { fieldRef: 'customers.country' },
+            operator: FilterOperator.EQUALS,
+            values: ['GB'],
+        },
+    ],
+};
+
+describe('getFilterRulesFromMetricBaseFilters', () => {
+    it('qualifies bare fieldRefs with the metric table and derives fieldIds', () => {
+        const rules = getFilterRulesFromMetricBaseFilters(baseMetric);
+
+        expect(rules).toHaveLength(2);
+        expect(rules[0].target).toEqual({
+            fieldRef: 'orders.status',
+            fieldId: 'orders_status',
+        });
+        expect(rules[1].target).toEqual({
+            fieldRef: 'customers.country',
+            fieldId: 'customers_country',
+        });
+    });
+
+    it('assigns fresh rule ids so clones do not share ids with the base metric', () => {
+        const rules = getFilterRulesFromMetricBaseFilters(baseMetric);
+
+        expect(rules[0].id).not.toBe('yaml-filter-id');
+        expect(rules[1].id).not.toBe('yaml-filter-id-2');
+    });
+
+    it('returns an empty list for metrics without filters', () => {
+        expect(
+            getFilterRulesFromMetricBaseFilters({
+                ...baseMetric,
+                filters: undefined,
+            }),
+        ).toEqual([]);
+    });
+});
+
+describe('prepareCustomMetricData from an explore metric', () => {
+    it('clones sql and type and derives the name from the base metric name', () => {
+        const data = prepareCustomMetricData({
+            item: baseMetric,
+            type: baseMetric.type,
+            customMetricLabel: 'Copy of Total revenue',
+            customMetricFiltersWithIds:
+                getFilterRulesFromMetricBaseFilters(baseMetric),
+            isEditingCustomMetric: false,
+        });
+
+        expect(data).toEqual(
+            expect.objectContaining({
+                table: 'orders',
+                sql: '${TABLE}.revenue',
+                type: MetricType.SUM,
+                label: 'Copy of Total revenue',
+                name: 'total_revenue_copy_of_total_revenue',
+                description: expect.stringContaining('Sum of Total revenue'),
+            }),
+        );
+        expect(data.filters).toHaveLength(2);
+        expect(data.filters?.[0].target).toEqual({
+            fieldRef: 'orders.status',
+        });
+    });
+
+    it('keeps the name derived from baseMetricName when editing a clone', () => {
+        const data = prepareCustomMetricData({
+            item: {
+                table: 'orders',
+                name: 'total_revenue_copy_of_total_revenue',
+                label: 'Copy of Total revenue',
+                type: MetricType.SUM,
+                sql: '${TABLE}.revenue',
+                baseMetricName: 'total_revenue',
+            },
+            type: MetricType.SUM,
+            customMetricLabel: 'Revenue Gb',
+            customMetricFiltersWithIds: [],
+            isEditingCustomMetric: true,
+        });
+
+        expect(data.name).toBe('total_revenue_revenue_gb');
+    });
+});

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.test.ts
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.test.ts
@@ -1,15 +1,18 @@
 import {
+    Compact,
     CustomFormatType,
     DimensionType,
     FieldType,
     FilterOperator,
     MetricType,
+    NumberSeparator,
     TimeFrames,
     type Metric,
 } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
 import {
     getFilterRulesFromMetricBaseFilters,
+    getFormatFromBaseMetric,
     prepareCustomMetricData,
 } from '.';
 
@@ -67,6 +70,70 @@ describe('getFilterRulesFromMetricBaseFilters', () => {
                 filters: undefined,
             }),
         ).toEqual([]);
+    });
+});
+
+describe('getFormatFromBaseMetric', () => {
+    it('converts a compact-only legacy format', () => {
+        expect(
+            getFormatFromBaseMetric({
+                ...baseMetric,
+                compact: Compact.THOUSANDS,
+            }),
+        ).toEqual({
+            type: CustomFormatType.NUMBER,
+            compact: Compact.THOUSANDS,
+            round: undefined,
+        });
+    });
+
+    it('carries the field-level separator alongside a legacy format', () => {
+        expect(
+            getFormatFromBaseMetric({
+                ...baseMetric,
+                format: 'usd',
+                round: 2,
+                separator: NumberSeparator.COMMA_PERIOD,
+            }),
+        ).toEqual({
+            type: CustomFormatType.CURRENCY,
+            currency: 'USD',
+            round: 2,
+            compact: undefined,
+            separator: NumberSeparator.COMMA_PERIOD,
+        });
+    });
+
+    it('carries the field-level separator alongside structured formatOptions', () => {
+        expect(
+            getFormatFromBaseMetric({
+                ...baseMetric,
+                formatOptions: { type: CustomFormatType.NUMBER, round: 1 },
+                separator: NumberSeparator.PERIOD_COMMA,
+            }),
+        ).toEqual({
+            type: CustomFormatType.NUMBER,
+            round: 1,
+            separator: NumberSeparator.PERIOD_COMMA,
+        });
+    });
+
+    it('converts a separator-only metric', () => {
+        expect(
+            getFormatFromBaseMetric({
+                ...baseMetric,
+                separator: NumberSeparator.SPACE_PERIOD,
+            }),
+        ).toEqual({
+            type: CustomFormatType.NUMBER,
+            round: undefined,
+            compact: undefined,
+            separator: NumberSeparator.SPACE_PERIOD,
+        });
+    });
+
+    it('returns undefined when the base metric has no formatting', () => {
+        expect(getFormatFromBaseMetric(baseMetric)).toBeUndefined();
     });
 });
 

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.test.ts
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.test.ts
@@ -1,7 +1,10 @@
 import {
+    CustomFormatType,
+    DimensionType,
     FieldType,
     FilterOperator,
     MetricType,
+    TimeFrames,
     type Metric,
 } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
@@ -91,6 +94,30 @@ describe('prepareCustomMetricData from an explore metric', () => {
         expect(data.filters).toHaveLength(2);
         expect(data.filters?.[0].target).toEqual({
             fieldRef: 'orders.status',
+        });
+    });
+
+    it('keeps date formatting when cloning a MIN-of-timestamp metric', () => {
+        const data = prepareCustomMetricData({
+            item: {
+                ...baseMetric,
+                name: 'date_of_first_order',
+                label: 'Date of first order',
+                type: MetricType.MIN,
+                sql: '${TABLE}.created',
+                filters: undefined,
+                baseDimensionType: DimensionType.TIMESTAMP,
+                baseDimensionTimeInterval: TimeFrames.DAY,
+            },
+            type: MetricType.MIN,
+            customMetricLabel: 'Copy of Date of first order',
+            customMetricFiltersWithIds: [],
+            isEditingCustomMetric: false,
+        });
+
+        expect(data.formatOptions).toEqual({
+            type: CustomFormatType.TIMESTAMP,
+            timeInterval: TimeFrames.DAY,
         });
     });
 

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
@@ -6,6 +6,7 @@ import {
     isCustomBinDimension,
     isCustomDimension,
     isDimension,
+    isMetric,
     MetricType,
     snakeCaseName,
     type AdditionalMetric,
@@ -15,8 +16,10 @@ import {
     type Explore,
     type FilterRule,
     type getFilterableDimensionsFromItemsMap,
+    type Metric,
     type MetricFilterRule,
 } from '@lightdash/common';
+import { v4 as uuidv4 } from 'uuid';
 import { type MetricFilterRuleWithFieldId } from '../FilterForm';
 
 export const addFieldRefToFilterRule = (
@@ -44,6 +47,22 @@ export const addFieldIdToMetricFilterRule = (
         }`,
     },
 });
+
+// YAML metric filters may use bare fieldRefs (relative to the metric's table);
+// the filter form requires fully qualified `table.field` refs.
+export const getFilterRulesFromMetricBaseFilters = (
+    metric: Metric,
+): MetricFilterRuleWithFieldId[] =>
+    (metric.filters ?? []).map((filterRule) => {
+        const fieldRef = filterRule.target.fieldRef.includes('.')
+            ? filterRule.target.fieldRef
+            : `${metric.table}.${filterRule.target.fieldRef}`;
+        return addFieldIdToMetricFilterRule({
+            ...filterRule,
+            id: uuidv4(),
+            target: { ...filterRule.target, fieldRef },
+        });
+    });
 
 export const getCustomMetricName = (
     table: string,
@@ -78,7 +97,7 @@ const getCustomMetricDescription = (
     }`;
 
 const getTypeOverridesForAdditionalMetric = (
-    item: Dimension | AdditionalMetric | CustomDimension,
+    item: Dimension | AdditionalMetric | CustomDimension | Metric,
     type: MetricType,
 ): Partial<AdditionalMetric> | undefined => {
     if (!isDimension(item)) return;
@@ -119,7 +138,7 @@ export const prepareCustomMetricData = ({
     percentile: metricPercentile,
     formatOptions,
 }: {
-    item: Dimension | AdditionalMetric | CustomDimension;
+    item: Dimension | AdditionalMetric | CustomDimension | Metric;
     type: MetricType;
     customMetricLabel: string;
     customMetricFiltersWithIds: MetricFilterRuleWithFieldId[];
@@ -184,11 +203,8 @@ export const prepareCustomMetricData = ({
         name: getCustomMetricName(
             item.table,
             customMetricLabel,
-            isEditingCustomMetric &&
-                isAdditionalMetric(item) &&
-                'baseDimensionName' in item &&
-                item.baseDimensionName
-                ? item.baseDimensionName
+            isEditingCustomMetric && isAdditionalMetric(item)
+                ? (item.baseDimensionName ?? item.baseMetricName ?? item.name)
                 : isCustomDimension(item)
                   ? item.id // Custom dimensions have ids instead of names
                   : item.name,
@@ -204,7 +220,7 @@ export const prepareCustomMetricData = ({
                 ),
             }),
         ...(!isEditingCustomMetric &&
-            isDimension(item) && {
+            (isDimension(item) || isMetric(item)) && {
                 description: getCustomMetricDescription(
                     type,
                     item.label,

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
@@ -100,29 +100,47 @@ const getTypeOverridesForAdditionalMetric = (
     item: Dimension | AdditionalMetric | CustomDimension | Metric,
     type: MetricType,
 ): Partial<AdditionalMetric> | undefined => {
+    if (type !== MetricType.MIN && type !== MetricType.MAX) return;
+
+    // Clones of MIN/MAX-of-date metrics keep the base metric's date formatting
+    if (isMetric(item)) {
+        switch (item.baseDimensionType) {
+            case DimensionType.DATE:
+                return {
+                    formatOptions: {
+                        type: CustomFormatType.DATE,
+                        timeInterval: item.baseDimensionTimeInterval,
+                    },
+                };
+            case DimensionType.TIMESTAMP:
+                return {
+                    formatOptions: {
+                        type: CustomFormatType.TIMESTAMP,
+                        timeInterval: item.baseDimensionTimeInterval,
+                    },
+                };
+            default:
+                return;
+        }
+    }
+
     if (!isDimension(item)) return;
 
-    switch (type) {
-        case MetricType.MIN:
-        case MetricType.MAX:
-            switch (item.type) {
-                case DimensionType.DATE:
-                    return {
-                        formatOptions: {
-                            type: CustomFormatType.DATE,
-                            timeInterval: item.timeInterval,
-                        },
-                    };
-                case DimensionType.TIMESTAMP:
-                    return {
-                        formatOptions: {
-                            type: CustomFormatType.TIMESTAMP,
-                            timeInterval: item.timeInterval,
-                        },
-                    };
-                default:
-                    return;
-            }
+    switch (item.type) {
+        case DimensionType.DATE:
+            return {
+                formatOptions: {
+                    type: CustomFormatType.DATE,
+                    timeInterval: item.timeInterval,
+                },
+            };
+        case DimensionType.TIMESTAMP:
+            return {
+                formatOptions: {
+                    type: CustomFormatType.TIMESTAMP,
+                    timeInterval: item.timeInterval,
+                },
+            };
         default:
             return;
     }

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/utils/index.ts
@@ -2,6 +2,7 @@ import {
     CustomFormatType,
     DimensionType,
     friendlyName,
+    getCustomFormatFromLegacy,
     isAdditionalMetric,
     isCustomBinDimension,
     isCustomDimension,
@@ -63,6 +64,34 @@ export const getFilterRulesFromMetricBaseFilters = (
             target: { ...filterRule.target, fieldRef },
         });
     });
+
+// Formatting the clone should inherit: structured formatOptions when present,
+// otherwise any combination of legacy format/round/compact. The field-level
+// separator composes with both shapes, so it carries over in either case.
+export const getFormatFromBaseMetric = (
+    metric: Metric,
+): CustomFormat | undefined => {
+    const hasLegacyFormat =
+        metric.format !== undefined ||
+        metric.round !== undefined ||
+        metric.compact !== undefined;
+
+    const base = metric.formatOptions
+        ? { ...metric.formatOptions }
+        : hasLegacyFormat || metric.separator !== undefined
+          ? getCustomFormatFromLegacy({
+                format: metric.format,
+                round: metric.round,
+                compact: metric.compact,
+            })
+          : undefined;
+
+    if (!base) return undefined;
+    if (metric.separator && !base.separator) {
+        return { ...base, separator: metric.separator };
+    }
+    return base;
+};
 
 export const getCustomMetricName = (
     table: string,

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -5,10 +5,12 @@ import {
     getCustomMetricType,
     getItemId,
     isAdditionalMetric,
+    isAggregateMetricType,
     isCustomDimension,
     isCustomSqlDimension,
     isDimension,
     isFilterableField,
+    isMetric,
     type AdditionalMetric,
     type CustomDimension,
     type Dimension,
@@ -154,6 +156,28 @@ const TreeSingleNodeActions: FC<Props> = ({
                     </Menu.Item>
                 ) : null}
 
+                {isMetric(item) && isAggregateMetricType(item.type) ? (
+                    <Menu.Item
+                        component="button"
+                        leftSection={<MantineIcon icon={IconCopy} />}
+                        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                            e.stopPropagation();
+                            track({
+                                name: EventName.ADD_CUSTOM_METRIC_CLICKED,
+                            });
+                            dispatch(
+                                explorerActions.toggleAdditionalMetricModal({
+                                    type: item.type,
+                                    item,
+                                    isEditing: false,
+                                }),
+                            );
+                        }}
+                    >
+                        Create custom metric
+                    </Menu.Item>
+                ) : null}
+
                 {isAdditionalMetric(item) ? (
                     <>
                         <Menu.Item
@@ -195,37 +219,40 @@ const TreeSingleNodeActions: FC<Props> = ({
                             Duplicate custom metric
                         </Menu.Item>
 
-                        <Menu.Item
-                            component="button"
-                            leftSection={<MantineIcon icon={IconCode} />}
-                            onClick={(
-                                e: React.MouseEvent<HTMLButtonElement>,
-                            ) => {
-                                e.stopPropagation();
-                                if (
-                                    projectUuid &&
-                                    user.data?.organizationUuid
-                                ) {
-                                    track({
-                                        name: EventName.WRITE_BACK_FROM_CUSTOM_METRIC_CLICKED,
-                                        properties: {
-                                            userId: user.data.userUuid,
-                                            projectId: projectUuid,
-                                            organizationId:
-                                                user.data.organizationUuid,
-                                            customMetricsCount: 1,
-                                        },
-                                    });
-                                }
-                                dispatch(
-                                    explorerActions.toggleWriteBackModal({
-                                        items: [item],
-                                    }),
-                                );
-                            }}
-                        >
-                            Write back to dbt
-                        </Menu.Item>
+                        {/* Write-back requires a base dimension column to attach the metric to in YAML */}
+                        {item.baseDimensionName ? (
+                            <Menu.Item
+                                component="button"
+                                leftSection={<MantineIcon icon={IconCode} />}
+                                onClick={(
+                                    e: React.MouseEvent<HTMLButtonElement>,
+                                ) => {
+                                    e.stopPropagation();
+                                    if (
+                                        projectUuid &&
+                                        user.data?.organizationUuid
+                                    ) {
+                                        track({
+                                            name: EventName.WRITE_BACK_FROM_CUSTOM_METRIC_CLICKED,
+                                            properties: {
+                                                userId: user.data.userUuid,
+                                                projectId: projectUuid,
+                                                organizationId:
+                                                    user.data.organizationUuid,
+                                                customMetricsCount: 1,
+                                            },
+                                        });
+                                    }
+                                    dispatch(
+                                        explorerActions.toggleWriteBackModal({
+                                            items: [item],
+                                        }),
+                                    );
+                                }}
+                            >
+                                Write back to dbt
+                            </Menu.Item>
+                        ) : null}
 
                         <Menu.Item
                             color="red"

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -38,8 +38,14 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
     const dispatch = useExplorerDispatch();
 
     // Get all custom metrics and dimensions for write-back
-    const allAdditionalMetrics = useExplorerSelector(selectAdditionalMetrics);
+    const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
     const allCustomDimensions = useExplorerSelector(selectCustomDimensions);
+
+    // Write-back requires a base dimension column to attach the metric to in YAML
+    const allAdditionalMetrics = useMemo(
+        () => additionalMetrics?.filter((metric) => metric.baseDimensionName),
+        [additionalMetrics],
+    );
 
     // Feature flag for bin dimensions write-back
     const { data: writeBackCustomBinDimensionsFlag } = useServerFeatureFlag(

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -3,6 +3,7 @@ import {
     getItemId,
     getItemLabelWithoutTableName,
     getItemMap,
+    isAggregateMetricType,
     isCustomDimension,
     isCustomSqlDimension,
     isDimension,
@@ -19,6 +20,7 @@ import {
 } from '@lightdash/common';
 import { ActionIcon, Box, Group, Menu, Text } from '@mantine-8/core';
 import {
+    IconCopy,
     IconDots,
     IconFilter,
     IconPencil,
@@ -150,6 +152,29 @@ const ContextMenu: FC<ContextMenuProps> = ({
                         >
                             Add period comparison
                         </Menu.Item>
+
+                        {!isItemAdditionalMetric &&
+                        isAggregateMetricType(item.type) ? (
+                            <Menu.Item
+                                leftSection={<MantineIcon icon={IconCopy} />}
+                                onClick={() => {
+                                    track({
+                                        name: EventName.ADD_CUSTOM_METRIC_CLICKED,
+                                    });
+                                    dispatch(
+                                        explorerActions.toggleAdditionalMetricModal(
+                                            {
+                                                type: item.type,
+                                                item,
+                                                isEditing: false,
+                                            },
+                                        ),
+                                    );
+                                }}
+                            >
+                                Create custom metric
+                            </Menu.Item>
+                        ) : null}
 
                         <Menu.Divider />
                     </>

--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -339,7 +339,11 @@ const explorerSlice = createSlice({
             action: PayloadAction<
                 | {
                       type?: MetricType;
-                      item?: Dimension | AdditionalMetric | CustomDimension;
+                      item?:
+                          | Dimension
+                          | AdditionalMetric
+                          | CustomDimension
+                          | Metric;
                       isEditing: boolean;
                   }
                 | undefined

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -283,7 +283,7 @@ export interface ExplorerReduceState {
         additionalMetric: {
             isOpen: boolean;
             isEditing?: boolean;
-            item?: Dimension | AdditionalMetric | CustomDimension;
+            item?: Dimension | AdditionalMetric | CustomDimension | Metric;
             type?: MetricType;
         };
         customDimension: {


### PR DESCRIPTION
## Description

Adds a **"Create custom metric"** action on existing explore (YAML) metrics, so users can create ad-hoc filtered/tweaked variants of a metric in the UI instead of rebuilding it from the underlying dimension or adding one-time-use metrics to YAML. This is the "filtered measures" workflow several customers have asked for.

### How it works

- **Entry points**: the metric's `⋯` menu in the explorer field tree, and the results-table column-header menu (next to "Add period comparison"). Offered on **aggregate** metrics only (`sum`, `count`, `count_distinct`, `min`, `max`, `average`, `median`, `percentile`) — non-aggregate/derived metrics can't take per-metric filters, and `sum_distinct`/`average_distinct` are excluded.
- **Clone-the-definition**: the modal opens prefilled with the base metric's `sql`, type, percentile, formatting (structured `formatOptions`, or legacy `format`/`round`/`compact` converted via `getCustomFormatFromLegacy`), and its YAML `filters` as editable rules — so the clone matches the base until tweaked. Bare filter `fieldRef`s are qualified with the metric's table. This is compile-safe by construction: an aggregate metric's SQL may only reference dimensions, which is exactly what additional metrics allow — no compiler changes.
- **Provenance**: new optional `AdditionalMetric.baseMetricName` field. Edit mode shows the source metric and keeps the generated name stable across label changes.
- New filter rules in the modal default to the base metric's underlying column (`dimensionReference`) — joined explores can have same-named fields (e.g. two "Amount" columns) and the previous fallback picked the first dimension in the explore, silently targeting the wrong table.
- Clones of MIN/MAX metrics over date/timestamp columns inherit DATE/TIMESTAMP `formatOptions` from the base's `baseDimensionType`, and the numeric Format section is hidden for them.
- **Write-back gating fix**: "Write back to dbt" is now hidden for custom metrics without a `baseDimensionName` (single-item menu and bulk section-header action) — `DbtSchemaEditor.addCustomMetrics` throws without one, a pre-existing crash path for custom-dimension-based metrics too.

### Out of scope (follow-ups)

Clone re-sync when the base YAML metric changes (provenance is stored to enable it), AI-agent schema support, non-aggregate metrics.

## Testing

- Unit tests for the prepare/normalize logic (filter qualification, name/provenance, date-format carry-over).
- Verified end-to-end in the dev app: cloning a filtered YAML metric compiles to byte-identical `SUM(CASE WHEN … )` SQL as the base and renders with identical formatting; sorts and query-level filters keep the per-metric filter; entry points gate correctly for YAML vs custom vs non-aggregate metrics; saved-chart round-trip and edit-clone flows work.

Closes: PROD-622
Closes: #16873

🤖 Generated with [Claude Code](https://claude.com/claude-code)
