### PR TITLE
feat: warehouse-connect onboarding polish — smart defaults, quiet toasts, schema-grounded AI suggestions

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -525,6 +525,10 @@ EMAIL_SMTP_SENDER_EMAIL=noreply@lightdash.local
 # Dev API access (auto-provisioned PAT from seed data)
 LIGHTDASH_API_URL=http://localhost:${PORT}
 LDPAT=ldpat_deadbeefdeadbeefdeadbeefdeadbeef
+
+# Allow registering fresh users/orgs (signup flow testing). Always on by default
+# in dev — without it, POST /api/v1/user 403s once the seed org exists.
+ALLOW_MULTIPLE_ORGS=true
 EOF
 echo "DBT_DEMO_DIR=$(pwd)/examples/full-jaffle-shop-demo" >> .env.development.local
 ```

--- a/packages/backend/src/controllers/bigquerySSOController.ts
+++ b/packages/backend/src/controllers/bigquerySSOController.ts
@@ -1,5 +1,6 @@
 import {
     ApiBigqueryDatasets,
+    ApiBigqueryProjectRecommendation,
     ApiBigqueryProjects,
     ApiErrorPayload,
     ApiSuccessEmpty,
@@ -69,6 +70,29 @@ export class BigquerySSOController extends BaseController {
         return {
             status: 'ok',
             results: projects,
+        };
+    }
+
+    /**
+     * Get the recommended BigQuery project based on dataset size
+     * @summary Get BigQuery project recommendation
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/projects/recommendation')
+    @OperationId('GetBigQueryProjectRecommendation')
+    async getBigQueryProjectRecommendation(
+        @Request() req: express.Request,
+    ): Promise<ApiBigqueryProjectRecommendation> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const recommendation = await this.services
+            .getProjectService()
+            .getBigqueryProjectRecommendation(toSessionUser(req.account));
+
+        return {
+            status: 'ok',
+            results: recommendation,
         };
     }
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -1664,6 +1664,13 @@ export class AiAgentService extends BaseService {
             };
         });
 
+        // Semantic-layer-less projects (dbt-less / NONE) have no explores, so
+        // ground empty-state chips in the indexed warehouse schema instead.
+        const warehouseTables =
+            explores.length === 0 && canRunSql
+                ? await this.getSuggestionWarehouseTables(user, projectUuid)
+                : [];
+
         const verifiedQuestionsData =
             await this.aiAgentModel.getVerifiedQuestions(agentUuid);
         const verifiedQuestions = verifiedQuestionsData
@@ -1720,6 +1727,7 @@ export class AiAgentService extends BaseService {
                     canManageContent: agent.enableContentTools,
                     enabledTools,
                     explores,
+                    warehouseTables,
                     verifiedQuestions,
                     verifiedContentTags: agent.tags ?? [],
                     verifiedContent,
@@ -1813,6 +1821,37 @@ export class AiAgentService extends BaseService {
         });
 
         return { chips };
+    }
+
+    // Flattens the cached warehouse catalog to up to 50 `database.schema.table`
+    // names; returns [] on any failure so suggestion generation still proceeds.
+    private async getSuggestionWarehouseTables(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<string[]> {
+        try {
+            const catalog = await this.projectService.getWarehouseTables(
+                user,
+                projectUuid,
+            );
+            const tables: string[] = [];
+            for (const [database, schemas] of Object.entries(catalog)) {
+                for (const [schema, schemaTables] of Object.entries(schemas)) {
+                    for (const table of Object.keys(schemaTables)) {
+                        tables.push(`${database}.${schema}.${table}`);
+                        if (tables.length >= 50) return tables;
+                    }
+                }
+            }
+            return tables;
+        } catch (error) {
+            Logger.warn(
+                `[AiAgentService] Failed to read warehouse tables for suggestions: ${String(
+                    error,
+                )}`,
+            );
+            return [];
+        }
     }
 
     private async buildSuggestionsThreadContext({

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
@@ -150,7 +150,7 @@ describe('provisionOnboardingHomepage', () => {
         const mocks = buildArguments();
         mocks.getFeatureFlag.mockImplementation(async ({ featureFlagId }) => ({
             id: featureFlagId,
-            enabled: featureFlagId !== FeatureFlags.OrganizationSetupPage,
+            enabled: featureFlagId !== FeatureFlags.NewOnboarding,
         }));
 
         await provisionOnboardingHomepage(mocks.args);
@@ -192,7 +192,7 @@ describe('provisionOnboardingHomepage', () => {
 
         expect(mocks.getFeatureFlag).toHaveBeenCalledWith({
             user,
-            featureFlagId: FeatureFlags.OrganizationSetupPage,
+            featureFlagId: FeatureFlags.NewOnboarding,
         });
         expect(mocks.getFeatureFlag).toHaveBeenCalledWith({
             user,

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
@@ -36,7 +36,7 @@ export const provisionOnboardingHomepage = async ({
     const [orgSetupPageFlag, homepageBuilderFlag] = await Promise.all([
         featureFlagService.get({
             user,
-            featureFlagId: FeatureFlags.OrganizationSetupPage,
+            featureFlagId: FeatureFlags.NewOnboarding,
         }),
         featureFlagService.get({
             user,

--- a/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
@@ -37,6 +37,7 @@ How to use the context (PROMPT chips):
 - verifiedContent: TOPIC SIGNAL. If there's a "Revenue Summary" verified chart, propose a fresh angle on revenue ("Break down revenue by month").
 - verifiedQuestions: these ARE complete prompts. Use them verbatim as prompt chips when they fit — they're the highest-quality chip you can produce.
 - explores: catalog-driven question chips when no curated signal applies.
+- warehouseTables: RAW SCHEMA SIGNAL for projects with no semantic layer yet. Each entry is a fully-qualified \`database.schema.table\` name. When <explores> is empty but <warehouseTables> is present, write prompt chips grounded in these real table names using the \`runSql\` tool (e.g. "Count orders per month in analytics.public.orders"). Only reference table names that appear verbatim in <warehouseTables>; never invent columns — keep chips about whole tables, row counts, recency, and simple groupings the agent can express in SQL.
 
 Tool guide (PROMPT chips):
 - \`generateVisualization\`: factual data questions answerable from the semantic layer.
@@ -44,7 +45,7 @@ Tool guide (PROMPT chips):
 - \`generateDashboard\`: multi-chart overview ("Build me an executive summary").
 - \`findContent\`: "Is there already a chart for monthly revenue?" — locates existing saved content.
 
-If the project has zero explores AND no verified questions AND no recent conversations, return three generic prompt chips that nudge the user to set up data.`;
+If the project has zero explores, no warehouseTables, no verified questions AND no recent conversations, return three generic prompt chips that nudge the user to set up data.`;
 
 const POST_RESPONSE_PROMPT = `You write 2-5 chips that appear above the chat input AFTER the agent has just replied. Each chip is what the user is most likely to click NEXT in this conversation.
 
@@ -171,6 +172,9 @@ export type SuggestionPromptContext = {
     verifiedQuestions: string[];
     verifiedContentTags: string[];
     verifiedContent: VerifiedContentItem[];
+    // Fully-qualified `database.schema.table` names — only set for
+    // semantic-layer-less projects with no explores, to ground chips via runSql.
+    warehouseTables?: string[];
     // Only set when generating empty-state chips. Lets the LLM pick up where
     // the user left off.
     recentUserConversations?: RecentUserConversation[];
@@ -217,6 +221,7 @@ export async function generateAgentSuggestions(
             },
             enabledTools: context.enabledTools,
             explores: context.explores,
+            warehouseTables: context.warehouseTables ?? null,
             verifiedQuestions: context.verifiedQuestions,
             verifiedContentTags: context.verifiedContentTags,
             verifiedContent: context.verifiedContent,

--- a/packages/backend/src/models/WarehouseConnectCodeModel.test.ts
+++ b/packages/backend/src/models/WarehouseConnectCodeModel.test.ts
@@ -19,12 +19,14 @@ const dbRow = {
 };
 
 describe('WarehouseConnectCodeModel', () => {
-    it('deletes all prior codes for the user when creating a code', async () => {
+    it('deletes prior codes for the user and expired codes when creating a code', async () => {
         const deleteBuilder = {
             where: vi.fn(),
+            orWhere: vi.fn(),
             delete: vi.fn(async () => 1),
         };
         deleteBuilder.where.mockReturnValue(deleteBuilder);
+        deleteBuilder.orWhere.mockReturnValue(deleteBuilder);
         const insert = vi.fn(async () => [dbRow]);
         const trx = vi
             .fn()
@@ -35,6 +37,7 @@ describe('WarehouseConnectCodeModel', () => {
                 async (callback: (value: typeof trx) => unknown) =>
                     callback(trx),
             ),
+            fn: { now: vi.fn(() => 'database-now') },
         } as unknown as Knex;
         const model = new WarehouseConnectCodeModel({ database });
 
@@ -48,6 +51,11 @@ describe('WarehouseConnectCodeModel', () => {
         expect(deleteBuilder.where).toHaveBeenCalledWith(
             'created_by_user_uuid',
             userUuid,
+        );
+        expect(deleteBuilder.orWhere).toHaveBeenCalledWith(
+            'expires_at',
+            '<=',
+            'database-now',
         );
         expect(deleteBuilder.delete).toHaveBeenCalledOnce();
         expect(insert).toHaveBeenCalledWith({
@@ -152,44 +160,5 @@ describe('WarehouseConnectCodeModel', () => {
             '>',
             'database-now',
         );
-    });
-
-    it('deletes and returns deposited credentials for the creator only once', async () => {
-        const builder = {
-            where: vi.fn(),
-            whereNotNull: vi.fn(),
-            delete: vi.fn(),
-            returning: vi.fn(async () => [dbRow]),
-        };
-        builder.where.mockReturnValue(builder);
-        builder.whereNotNull.mockReturnValue(builder);
-        builder.delete.mockReturnValue(builder);
-        const database = Object.assign(
-            vi.fn(() => builder),
-            {
-                fn: { now: vi.fn(() => 'database-now') },
-            },
-        ) as unknown as Knex;
-        const model = new WarehouseConnectCodeModel({ database });
-
-        await expect(
-            model.deleteDepositedForClaim('hashed-code', userUuid),
-        ).resolves.toEqual({
-            organizationUuid,
-            createdByUserUuid: userUuid,
-            expiresAt,
-            usedAt,
-            encryptedCredentials,
-        });
-        expect(builder.where).toHaveBeenCalledWith(
-            'created_by_user_uuid',
-            userUuid,
-        );
-        expect(builder.whereNotNull).toHaveBeenCalledWith('used_at');
-        expect(builder.whereNotNull).toHaveBeenCalledWith(
-            'encrypted_credentials',
-        );
-        expect(builder.delete).toHaveBeenCalledOnce();
-        expect(builder.returning).toHaveBeenCalledWith('*');
     });
 });

--- a/packages/backend/src/models/WarehouseConnectCodeModel.ts
+++ b/packages/backend/src/models/WarehouseConnectCodeModel.ts
@@ -46,6 +46,7 @@ export class WarehouseConnectCodeModel {
         await this.database.transaction(async (trx) => {
             await trx(WarehouseConnectCodeTableName)
                 .where('created_by_user_uuid', data.createdByUserUuid)
+                .orWhere('expires_at', '<=', this.database.fn.now())
                 .delete();
             await trx(WarehouseConnectCodeTableName).insert({
                 code_hash: data.codeHash,
@@ -79,21 +80,6 @@ export class WarehouseConnectCodeModel {
             .where('code_hash', codeHash)
             .where('expires_at', '>', this.database.fn.now())
             .first();
-        return row ? WarehouseConnectCodeModel.convertRow(row) : null;
-    }
-
-    async deleteDepositedForClaim(
-        codeHash: string,
-        createdByUserUuid: string,
-    ): Promise<WarehouseConnectCodeRecord | null> {
-        const [row] = await this.database(WarehouseConnectCodeTableName)
-            .where('code_hash', codeHash)
-            .where('created_by_user_uuid', createdByUserUuid)
-            .whereNotNull('used_at')
-            .whereNotNull('encrypted_credentials')
-            .where('expires_at', '>', this.database.fn.now())
-            .delete()
-            .returning('*');
         return row ? WarehouseConnectCodeModel.convertRow(row) : null;
     }
 }

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -34,6 +34,7 @@ import {
     ParameterError,
     SaveOrganizationBrandRequest,
     SessionUser,
+    TooManyRequestsError,
     UnexpectedServerError,
     UpdateAllowedEmailDomains,
     UpdateColorPalette,
@@ -374,6 +375,15 @@ export class OrganizationService extends BaseService {
         if (response.status === 404) {
             throw new NotFoundError(
                 `No brand found for domain "${normalizedDomain}"`,
+            );
+        }
+        if (response.status === 429) {
+            this.logger.warn('Brandfetch rate limit reached', {
+                organizationUuid,
+                domain: normalizedDomain,
+            });
+            throw new TooManyRequestsError(
+                'Brand lookup is rate limited right now — try again shortly',
             );
         }
         if (!response.ok) {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -9830,6 +9830,39 @@ export class ProjectService extends BaseService {
         }
     }
 
+    async getBigqueryProjectRecommendation(user: SessionUser) {
+        const refreshToken = await this.userModel.getRefreshToken(
+            user.userUuid,
+            OpenIdIdentityIssuerType.GOOGLE,
+        );
+        const accessToken = await UserService.generateGoogleAccessToken(
+            refreshToken,
+            'bigquery',
+        );
+
+        try {
+            const projects =
+                await BigqueryWarehouseClient.getProjects(accessToken);
+            return await BigqueryWarehouseClient.getProjectRecommendation(
+                projects,
+                refreshToken,
+            );
+        } catch (error) {
+            this.logger.error(
+                `getBigqueryProjectRecommendation error: ${JSON.stringify(error)}`,
+            );
+
+            if (BigqueryWarehouseClient.isBigqueryError(error)) {
+                throw new WarehouseConnectionError(
+                    'Failed to get a project recommendation from BigQuery',
+                );
+            }
+            throw new UnexpectedServerError(
+                'Failed to get a project recommendation',
+            );
+        }
+    }
+
     // eslint-disable-next-line class-methods-use-this
     getUserQueryTags(account: Account) {
         if (account.isJwtUser()) {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -9831,6 +9831,9 @@ export class ProjectService extends BaseService {
     }
 
     async getBigqueryProjectRecommendation(user: SessionUser) {
+        // At this point, there might not be any projects
+        // so we can't check any permissions here.
+        // Bigquery will handle the permissions
         const refreshToken = await this.userModel.getRefreshToken(
             user.userUuid,
             OpenIdIdentityIssuerType.GOOGLE,

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -192,7 +192,7 @@ const createUserService = (
                 get: vi.fn<FeatureFlagModel['get']>(
                     async ({ featureFlagId }) => ({
                         id: featureFlagId,
-                        enabled: featureFlagId !== FeatureFlags.EmailOnlySignup,
+                        enabled: featureFlagId !== FeatureFlags.NewOnboarding,
                     }),
                 ),
             } as unknown as FeatureFlagModel),
@@ -299,7 +299,7 @@ describe('UserService', () => {
 
             expect(featureFlagModel.get).toHaveBeenCalledWith({
                 user: undefined,
-                featureFlagId: FeatureFlags.EmailOnlySignup,
+                featureFlagId: FeatureFlags.NewOnboarding,
             });
             expect(userModel.createUser).toHaveBeenCalledWith({
                 firstName: '',
@@ -658,7 +658,7 @@ describe('UserService', () => {
             });
             expect(featureFlagModel.get).toHaveBeenCalledWith({
                 user: undefined,
-                featureFlagId: FeatureFlags.EmailOnlySignup,
+                featureFlagId: FeatureFlags.NewOnboarding,
             });
         });
 

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -384,17 +384,18 @@ describe('UserService', () => {
         };
 
         describe('requestEmailOtpLogin', () => {
-            test('rejects when the feature flag is disabled', async () => {
+            test('sends an OTP for a passwordless account even when the feature flag is disabled', async () => {
                 const service = createUserService(lightdashConfigMock, {
                     featureFlagModel: createFeatureFlagModel(false),
                 });
+                userModel.findUserByEmail.mockResolvedValueOnce(sessionUser);
+                userModel.hasPassword.mockResolvedValueOnce(false);
+                userModel.hasOpenIdIdentity.mockResolvedValueOnce(false);
 
-                await expect(
-                    service.requestEmailOtpLogin('email'),
-                ).rejects.toThrow(
-                    new ForbiddenError('Email OTP login is not enabled'),
-                );
-                expect(userModel.findUserByEmail).not.toHaveBeenCalled();
+                await service.requestEmailOtpLogin('email');
+
+                expect(emailModel.createPrimaryEmailOtp).toHaveBeenCalled();
+                expect(emailClient.sendOneTimePasscodeEmail).toHaveBeenCalled();
             });
 
             test('does not create or send an OTP for a passworded account', async () => {
@@ -583,16 +584,27 @@ describe('UserService', () => {
                 );
             });
 
-            test('rejects before account lookup when the feature is disabled', async () => {
+            test('signs in a passwordless account even when the feature is disabled', async () => {
                 const service = createUserService(lightdashConfigMock, {
                     featureFlagModel: createFeatureFlagModel(false),
                 });
+                const emailStatus = activeOtp();
+                userModel.findUserByEmail.mockResolvedValueOnce(sessionUser);
+                userModel.hasPassword.mockResolvedValueOnce(false);
+                userModel.hasOpenIdIdentity.mockResolvedValueOnce(false);
+                emailModel.getPrimaryEmailStatus.mockResolvedValueOnce(
+                    emailStatus,
+                );
+                emailModel.getPrimaryEmailStatusByUserAndOtp.mockResolvedValueOnce(
+                    emailStatus,
+                );
+                emailModel.verifyUserEmailIfExists.mockResolvedValueOnce([
+                    { email: emailStatus.email },
+                ]);
 
                 await expect(
-                    service.loginWithEmailOtp('email', '123456'),
-                ).rejects.toThrow(
-                    new ForbiddenError('Email OTP login is not enabled'),
-                );
+                    service.loginWithEmailOtp('EMAIL', '123456'),
+                ).resolves.toBe(sessionUser);
             });
         });
     });
@@ -656,13 +668,9 @@ describe('UserService', () => {
                 redirectUri: undefined,
                 showOptions: ['emailOtp'],
             });
-            expect(featureFlagModel.get).toHaveBeenCalledWith({
-                user: undefined,
-                featureFlagId: FeatureFlags.NewOnboarding,
-            });
         });
 
-        test('keeps email unchanged when the feature is disabled', async () => {
+        test('still shows email OTP for a passwordless user when the feature is disabled', async () => {
             const service = createUserService(lightdashConfigMock, {
                 featureFlagModel: createFeatureFlagModel(false),
             });
@@ -673,7 +681,7 @@ describe('UserService', () => {
             await expect(service.getLoginOptions('email')).resolves.toEqual({
                 forceRedirect: false,
                 redirectUri: undefined,
-                showOptions: ['email'],
+                showOptions: ['emailOtp'],
             });
         });
 

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1579,7 +1579,7 @@ export class UserService extends BaseService {
         } else {
             const emailOnlySignupFlag = await this.featureFlagModel.get({
                 user: undefined,
-                featureFlagId: FeatureFlags.EmailOnlySignup,
+                featureFlagId: FeatureFlags.NewOnboarding,
             });
             if (!emailOnlySignupFlag.enabled) {
                 throw new ForbiddenError('Email-only signup is not enabled');
@@ -1880,7 +1880,7 @@ export class UserService extends BaseService {
     private async assertEmailOtpLoginEnabled(): Promise<void> {
         const featureFlag = await this.featureFlagModel.get({
             user: undefined,
-            featureFlagId: FeatureFlags.EmailOnlySignup,
+            featureFlagId: FeatureFlags.NewOnboarding,
         });
         if (!featureFlag.enabled) {
             throw new ForbiddenError('Email OTP login is not enabled');
@@ -3265,7 +3265,7 @@ export class UserService extends BaseService {
             ] = await Promise.all([
                 this.featureFlagModel.get({
                     user: undefined,
-                    featureFlagId: FeatureFlags.EmailOnlySignup,
+                    featureFlagId: FeatureFlags.NewOnboarding,
                 }),
                 this.userModel.hasPassword(existingUser.userUuid),
                 this.userModel.hasOpenIdIdentity(existingUser.userUuid),

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1877,16 +1877,6 @@ export class UserService extends BaseService {
         };
     }
 
-    private async assertEmailOtpLoginEnabled(): Promise<void> {
-        const featureFlag = await this.featureFlagModel.get({
-            user: undefined,
-            featureFlagId: FeatureFlags.NewOnboarding,
-        });
-        if (!featureFlag.enabled) {
-            throw new ForbiddenError('Email OTP login is not enabled');
-        }
-    }
-
     private async isStrictlyPasswordlessUser(
         user: LightdashUser,
         email: string,
@@ -1900,8 +1890,10 @@ export class UserService extends BaseService {
         return !hasPassword && !hasOpenIdIdentity && isEmailLoginAllowed;
     }
 
+    // OTP login is deliberately NOT gated on the NewOnboarding flag: accounts
+    // enrolled as strictly passwordless have no other way to sign in, so a
+    // flag rollback must not strand them. The flag gates enrollment only.
     async requestEmailOtpLogin(email: string): Promise<void> {
-        await this.assertEmailOtpLoginEnabled();
         const normalizedEmail = email.toLowerCase();
         const user = await this.userModel.findUserByEmail(normalizedEmail);
         if (
@@ -1919,7 +1911,6 @@ export class UserService extends BaseService {
         passcode: string,
         context?: AuthAuditContext,
     ): Promise<SessionUser> {
-        await this.assertEmailOtpLoginEnabled();
         const normalizedEmail = email.toLowerCase();
         const invalidCode = () => {
             emitAuthAuditEvent({
@@ -3255,27 +3246,21 @@ export class UserService extends BaseService {
 
         const openIdIssuers = await this.userModel.getOpenIdIssuers(email);
         const hasPassword = await this.userModel.hasPasswordByEmail(email);
+        // Not gated on the NewOnboarding flag: an enrolled passwordless
+        // account must keep its only sign-in path across a flag rollback.
         let shouldShowEmailOtp = false;
         if (existingUser && !hasPassword) {
-            const [
-                featureFlag,
-                hasPasswordLogin,
-                hasOpenIdIdentity,
-                isEmailLoginAllowed,
-            ] = await Promise.all([
-                this.featureFlagModel.get({
-                    user: undefined,
-                    featureFlagId: FeatureFlags.NewOnboarding,
-                }),
-                this.userModel.hasPassword(existingUser.userUuid),
-                this.userModel.hasOpenIdIdentity(existingUser.userUuid),
-                this.isLoginMethodAllowed(email, LocalIssuerTypes.EMAIL_OTP),
-            ]);
+            const [hasPasswordLogin, hasOpenIdIdentity, isEmailLoginAllowed] =
+                await Promise.all([
+                    this.userModel.hasPassword(existingUser.userUuid),
+                    this.userModel.hasOpenIdIdentity(existingUser.userUuid),
+                    this.isLoginMethodAllowed(
+                        email,
+                        LocalIssuerTypes.EMAIL_OTP,
+                    ),
+                ]);
             shouldShowEmailOtp =
-                featureFlag.enabled &&
-                !hasPasswordLogin &&
-                !hasOpenIdIdentity &&
-                isEmailLoginAllowed;
+                !hasPasswordLogin && !hasOpenIdIdentity && isEmailLoginAllowed;
         }
         const applyEmailOtpOption = (options: LoginOptionTypes[]) =>
             shouldShowEmailOtp && options.includes(LocalIssuerTypes.EMAIL)

--- a/packages/backend/src/services/WarehouseConnectService/WarehouseConnectService.test.ts
+++ b/packages/backend/src/services/WarehouseConnectService/WarehouseConnectService.test.ts
@@ -57,8 +57,6 @@ const createModelMock = () => ({
     consumeForDeposit: vi.fn<WarehouseConnectCodeModel['consumeForDeposit']>(),
     findDepositedForClaim:
         vi.fn<WarehouseConnectCodeModel['findDepositedForClaim']>(),
-    deleteDepositedForClaim:
-        vi.fn<WarehouseConnectCodeModel['deleteDepositedForClaim']>(),
 });
 
 const testInventory = {
@@ -262,7 +260,6 @@ describe('WarehouseConnectService', () => {
         await expect(service.claim(otherUser, code)).rejects.toThrow(
             NotFoundError,
         );
-        expect(model.deleteDepositedForClaim).not.toHaveBeenCalled();
     });
 
     it('returns pending before credentials are deposited', async () => {
@@ -277,15 +274,11 @@ describe('WarehouseConnectService', () => {
         await expect(service.claim(createUser(), code)).resolves.toEqual({
             status: 'pending',
         });
-        expect(model.deleteDepositedForClaim).not.toHaveBeenCalled();
     });
 
-    it('returns deposited credentials once and then returns NotFound', async () => {
+    it('returns deposited credentials repeatedly until the code expires', async () => {
         const model = createModelMock();
-        model.findDepositedForClaim
-            .mockResolvedValueOnce(depositedRecord)
-            .mockResolvedValueOnce(null);
-        model.deleteDepositedForClaim.mockResolvedValue(depositedRecord);
+        model.findDepositedForClaim.mockResolvedValue(depositedRecord);
         const encryptionUtil = createEncryptionUtilMock();
         const analytics = createAnalyticsMock();
         const service = new WarehouseConnectService({
@@ -295,15 +288,19 @@ describe('WarehouseConnectService', () => {
         });
         const user = createUser();
 
-        await expect(service.claim(user, code)).resolves.toEqual({
+        const expectedResult = {
             status: 'deposited',
             credentials,
             inventory: testInventory,
-        });
-        await expect(service.claim(user, code)).rejects.toThrow(NotFoundError);
-        expect(model.deleteDepositedForClaim).toHaveBeenCalledWith(
+        };
+        await expect(service.claim(user, code)).resolves.toEqual(
+            expectedResult,
+        );
+        await expect(service.claim(user, code)).resolves.toEqual(
+            expectedResult,
+        );
+        expect(model.findDepositedForClaim).toHaveBeenCalledWith(
             hashWarehouseConnectCode(code),
-            user.userUuid,
         );
         expect(encryptionUtil.decrypt).toHaveBeenCalledWith(
             encryptedCredentials,

--- a/packages/backend/src/services/WarehouseConnectService/WarehouseConnectService.ts
+++ b/packages/backend/src/services/WarehouseConnectService/WarehouseConnectService.ts
@@ -40,10 +40,7 @@ const isDurableSnowflakeCredential = (
 
 type WarehouseConnectCodeModelMethods = Pick<
     WarehouseConnectCodeModel,
-    | 'create'
-    | 'consumeForDeposit'
-    | 'findDepositedForClaim'
-    | 'deleteDepositedForClaim'
+    'create' | 'consumeForDeposit' | 'findDepositedForClaim'
 >;
 
 type EncryptionUtilMethods = Pick<EncryptionUtil, 'encrypt' | 'decrypt'>;
@@ -184,27 +181,18 @@ export class WarehouseConnectService extends BaseService {
             return { status: 'pending' };
         }
 
-        const claimed =
-            await this.warehouseConnectCodeModel.deleteDepositedForClaim(
-                codeHash,
-                user.userUuid,
-            );
-        if (claimed === null || claimed.encryptedCredentials === null) {
-            throw new NotFoundError('Warehouse connect code not found');
-        }
-
         try {
             const deposit = JSON.parse(
-                this.encryptionUtil.decrypt(claimed.encryptedCredentials),
+                this.encryptionUtil.decrypt(connectCode.encryptedCredentials),
             ) as {
                 credentials: DepositSnowflakeCredentials;
                 inventory: WarehouseConnectInventory | null;
             };
             this.analytics.track({
-                userId: claimed.createdByUserUuid,
+                userId: connectCode.createdByUserUuid,
                 event: 'warehouse_connect.claimed',
                 properties: {
-                    organizationId: claimed.organizationUuid,
+                    organizationId: connectCode.organizationUuid,
                 },
             });
             return {

--- a/packages/cli/src/handlers/connectSnowflake.test.ts
+++ b/packages/cli/src/handlers/connectSnowflake.test.ts
@@ -39,6 +39,7 @@ const discovery: SnowflakeSessionDiscovery = {
                 name: 'analytics',
                 comment: 'Analytics data',
                 kind: 'STANDARD',
+                sizeBytes: 1234,
             },
         ],
         warehouses: [
@@ -112,7 +113,9 @@ const getDependencies = () => ({
 });
 
 const depositInventory = {
-    databases: [{ name: 'analytics', comment: 'Analytics data' }],
+    databases: [
+        { name: 'analytics', comment: 'Analytics data', sizeBytes: 1234 },
+    ],
     warehouses: [{ name: 'lightdash_wh', size: 'X-Small', state: 'STARTED' }],
     roles: [
         { name: 'lightdash_role', isDefault: true },
@@ -264,6 +267,7 @@ describe('connectSnowflakeHandler', () => {
                     name,
                     comment: null,
                     kind: null,
+                    sizeBytes: null,
                 })),
                 warehouses: inventoryNames.map((name) => ({
                     name,
@@ -294,7 +298,7 @@ describe('connectSnowflakeHandler', () => {
         expect(request.inventory).toEqual({
             databases: inventoryNames
                 .slice(0, 100)
-                .map((name) => ({ name, comment: null })),
+                .map((name) => ({ name, comment: null, sizeBytes: null })),
             warehouses: inventoryNames
                 .slice(0, 100)
                 .map((name) => ({ name, size: null, state: null })),

--- a/packages/cli/src/handlers/connectSnowflake.ts
+++ b/packages/cli/src/handlers/connectSnowflake.ts
@@ -184,7 +184,11 @@ const buildInventory = (
     }
     return {
         databases: discovery.inventory.databases
-            .map(({ name, comment }) => ({ name, comment }))
+            .map(({ name, comment, sizeBytes }) => ({
+                name,
+                comment,
+                sizeBytes,
+            }))
             .slice(0, 100),
         warehouses: discovery.inventory.warehouses
             .map(({ name, size, state }) => ({ name, size, state }))

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -101,6 +101,7 @@ import {
 import { type ApiGetSpotlightTableConfig } from './api/spotlight';
 import { type ApiSuccessEmpty } from './api/success';
 import { type Account } from './auth';
+import { type BigqueryProjectRecommendation } from './bigQuerySSO';
 import {
     type ApiCatalogAnalyticsResults,
     type ApiCatalogMetadataResults,
@@ -1025,6 +1026,7 @@ export type ProjectSavedChartStatus = boolean;
 export type ApiFlashResults = Record<string, string[]>;
 
 type ApiResults =
+    | BigqueryProjectRecommendation
     | ApiWarehouseConnectCodeResponse['results']
     | ApiWarehouseConnectCodeClaimResponse['results']
     | ApiQueryResults

--- a/packages/common/src/types/bigQuerySSO.ts
+++ b/packages/common/src/types/bigQuerySSO.ts
@@ -2,6 +2,7 @@ export type BigqueryDataset = {
     projectId: string;
     location: string | undefined;
     datasetId: string;
+    sizeBytes?: number | null;
 };
 
 export type ApiBigqueryDatasets = {
@@ -17,4 +18,13 @@ export type BigqueryProject = {
 export type ApiBigqueryProjects = {
     status: 'ok';
     results: BigqueryProject[];
+};
+
+export type BigqueryProjectRecommendation = {
+    projectId: string | null;
+};
+
+export type ApiBigqueryProjectRecommendation = {
+    status: 'ok';
+    results: BigqueryProjectRecommendation;
 };

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -286,11 +286,16 @@ export enum FeatureFlags {
     OrgAiProviderApiKeys = 'org-ai-provider-api-keys',
 
     /**
-     * Gate the dbt-less "connect to your warehouse" onboarding path and the
-     * Snowflake "connect via CLI (SSO)" auth method in project creation.
-     * Off by default; enable per-org for gradual rollout.
+     * Gate the whole new onboarding experience as one unit: email-only
+     * signup (register collects only an email; ownership proven via email
+     * OTP), the full-page organization setup experience shown after
+     * registration, and the dbt-less "connect to your warehouse" onboarding
+     * path including the Snowflake "connect via CLI (SSO)" auth method in
+     * project creation. Off by default. Note: the register page evaluates
+     * this flag anonymously, so per-org overrides do not apply there —
+     * enable instance-wide (or for everyone in posthog) to turn on signup.
      */
-    WarehouseConnectOnboarding = 'warehouse-connect-onboarding',
+    NewOnboarding = 'new-onboarding',
 
     /**
      * Cloud-only: let an organization send report/notification emails from
@@ -301,23 +306,6 @@ export enum FeatureFlags {
      * default; enable per-org.
      */
     EmailWhitelabel = 'email-whitelabel',
-
-    /**
-     * Replaces the user-completion modal with a full-page organization setup
-     * experience (name your organization, pick a theme colour, and tell us
-     * about yourself) shown after registration. Off by default.
-     */
-    OrganizationSetupPage = 'organization-setup-page',
-
-    /**
-     * Allow self-serve signup with just an email address: the register page
-     * collects only an email, the account is created without a password or
-     * names, and ownership is proven via the existing email OTP verification.
-     * Users can set a password later (settings or password reset). Off by
-     * default; instance-wide toggle (evaluated anonymously, so per-org
-     * overrides don't apply).
-     */
-    EmailOnlySignup = 'email-only-signup',
 }
 
 export type FeatureFlag = {

--- a/packages/common/src/types/warehouseConnectCode.ts
+++ b/packages/common/src/types/warehouseConnectCode.ts
@@ -19,7 +19,11 @@ export type DepositSnowflakeCredentials = Omit<
     >;
 
 export type WarehouseConnectInventory = {
-    databases: { name: string; comment: string | null }[];
+    databases: {
+        name: string;
+        comment: string | null;
+        sizeBytes?: number | null;
+    }[];
     warehouses: {
         name: string;
         size: string | null;

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -153,9 +153,12 @@ const PUBLIC_ROUTES: RouteObject[] = [
             );
             return {
                 Component: () => (
-                    <TrackPage name={PageName.ORGANIZATION_SETUP}>
-                        <OrganizationSetup />
-                    </TrackPage>
+                    <>
+                        <NavBar />
+                        <TrackPage name={PageName.ORGANIZATION_SETUP}>
+                            <OrganizationSetup />
+                        </TrackPage>
+                    </>
                 ),
             };
         },
@@ -797,9 +800,14 @@ const PRIVATE_ROUTES: RouteObject[] = [
                     );
                     return {
                         Component: () => (
-                            <TrackPage name={PageName.ONBOARDING_DATA_SOURCE}>
-                                <OnboardingDataSource />
-                            </TrackPage>
+                            <>
+                                <NavBar />
+                                <TrackPage
+                                    name={PageName.ONBOARDING_DATA_SOURCE}
+                                >
+                                    <OnboardingDataSource />
+                                </TrackPage>
+                            </>
                         ),
                     };
                 },
@@ -814,9 +822,14 @@ const PRIVATE_ROUTES: RouteObject[] = [
                     );
                     return {
                         Component: () => (
-                            <TrackPage name={PageName.ONBOARDING_PROJECT_READY}>
-                                <OnboardingProjectReady />
-                            </TrackPage>
+                            <>
+                                <NavBar />
+                                <TrackPage
+                                    name={PageName.ONBOARDING_PROJECT_READY}
+                                >
+                                    <OnboardingProjectReady />
+                                </TrackPage>
+                            </>
                         ),
                     };
                 },

--- a/packages/frontend/src/components/AppRoute.tsx
+++ b/packages/frontend/src/components/AppRoute.tsx
@@ -13,9 +13,7 @@ const AppRoute: FC<React.PropsWithChildren> = ({ children }) => {
     const location = useLocation();
     const orgRequest = useOrganization();
     const homepageBuilderFlag = useHomepageBuilderFlag();
-    const orgSetupPageFlag = useServerFeatureFlag(
-        FeatureFlags.OrganizationSetupPage,
-    );
+    const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
 
     if (health.isInitialLoading || orgRequest.isInitialLoading) {
         return <PageSpinner />;

--- a/packages/frontend/src/components/NavBar/UserMenu.tsx
+++ b/packages/frontend/src/components/NavBar/UserMenu.tsx
@@ -33,16 +33,19 @@ const UserMenu: FC = () => {
             <Menu.Dropdown>
                 <ThemeSwitcherMenuItem />
 
-                <Menu.Item
-                    role="menuitem"
-                    component={Link}
-                    to="/generalSettings"
-                    leftSection={<MantineIcon icon={IconUserCircle} />}
-                >
-                    User settings
-                </Menu.Item>
+                {user.data?.isSetupComplete ? (
+                    <Menu.Item
+                        role="menuitem"
+                        component={Link}
+                        to="/generalSettings"
+                        leftSection={<MantineIcon icon={IconUserCircle} />}
+                    >
+                        User settings
+                    </Menu.Item>
+                ) : null}
 
-                {user.data?.ability?.can('create', 'InviteLink') ? (
+                {user.data?.isSetupComplete &&
+                user.data?.ability?.can('create', 'InviteLink') ? (
                     <Menu.Item
                         role="menuitem"
                         component={Link}

--- a/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
@@ -40,7 +40,9 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
     const { user, health } = useApp();
     const [createProjectJobId, setCreateProjectJobId] = useState<string>();
     const { activeJobIsRunning, activeJobId, activeJob } = useActiveJob();
-    const { isLoading: isSaving, mutateAsync } = useCreateMutation();
+    const { isLoading: isSaving, mutateAsync } = useCreateMutation({
+        quietJobToast: warehouseOnly,
+    });
     const onProjectError = useOnProjectError();
 
     const warehouseType = selectedWarehouse ?? WarehouseTypes.BIGQUERY;

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectConnectMethod.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectConnectMethod.tsx
@@ -35,7 +35,7 @@ const SelectConnectMethod: FC<SelectConnectMethodProps> = ({
     const { track } = useTracking();
 
     const warehouseConnectFlag = useServerFeatureFlag(
-        FeatureFlags.WarehouseConnectOnboarding,
+        FeatureFlags.NewOnboarding,
     );
     const isWarehouseConnectEnabled =
         warehouseConnectFlag.data?.enabled ?? false;

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -299,7 +299,7 @@ const BigQueryForm: FC<{
     const defaultAuthenticationType = BigqueryAuthenticationType.SSO;
 
     const warehouseConnectFlag = useServerFeatureFlag(
-        FeatureFlags.WarehouseConnectOnboarding,
+        FeatureFlags.NewOnboarding,
     );
     const shouldDefaultToSso =
         !savedProject && (warehouseConnectFlag.data?.enabled ?? false);

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -310,8 +310,7 @@ const BigQueryForm: FC<{
                 BigqueryAuthenticationType.SSO,
             );
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [shouldDefaultToSso]);
+    }, [shouldDefaultToSso, form]);
 
     useEffect(() => {
         if (

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -1,8 +1,13 @@
-import { BigqueryAuthenticationType, WarehouseTypes } from '@lightdash/common';
+import {
+    BigqueryAuthenticationType,
+    FeatureFlags,
+    WarehouseTypes,
+} from '@lightdash/common';
 import {
     TextInput,
     Anchor,
     Autocomplete,
+    Badge,
     Button,
     FileInput,
     Group,
@@ -17,15 +22,24 @@ import {
 import { NumberInput, Tooltip } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconCheck, IconExclamationCircle } from '@tabler/icons-react';
-import { useState, type ChangeEvent, type FC, type ReactNode } from 'react';
+import {
+    useEffect,
+    useRef,
+    useState,
+    type ChangeEvent,
+    type FC,
+    type ReactNode,
+} from 'react';
 import { useToggle } from 'react-use';
 import { useGoogleLoginPopup } from '../../../hooks/gdrive/useGdrive';
 import useHealth from '../../../hooks/health/useHealth';
 import {
     useBigqueryDatasets,
+    useBigqueryProjectRecommendation,
     useBigqueryProjects,
     useIsBigQueryAuthenticated,
 } from '../../../hooks/useBigquerySSO';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../../common/MantineIcon';
 import DocumentationHelpButton from '../../DocumentationHelpButton';
 import FormCollapseButton from '../FormCollapseButton';
@@ -34,6 +48,7 @@ import FormSection from '../Inputs/FormSection';
 import StartOfWeekSelect from '../Inputs/StartOfWeekSelect';
 import { useProjectFormContext } from '../useProjectFormContext';
 import classes from './BigQueryForm.module.css';
+import { largestDatasetName } from './bigQuerySso';
 import DataTimezoneField from './DataTimezoneField';
 import { BigQueryDefaultValues } from './defaultValues';
 
@@ -78,6 +93,39 @@ export const BigQuerySchemaInput: FC<{
     const datasetField = form.getInputProps('warehouse.dataset');
     const hasProject =
         typeof debouncedProject === 'string' && debouncedProject.length > 0;
+    const recommendedDataset = largestDatasetName(datasets ?? []);
+    const hasAppliedRecommendation = useRef(false);
+
+    useEffect(() => {
+        hasAppliedRecommendation.current = false;
+    }, [debouncedProject]);
+
+    useEffect(() => {
+        if (
+            hasAppliedRecommendation.current ||
+            !isSso ||
+            !isAuthenticated ||
+            datasetField.value ||
+            !recommendedDataset
+        ) {
+            return;
+        }
+        hasAppliedRecommendation.current = true;
+        const selectedDataset = datasets?.find(
+            (dataset) => dataset.datasetId === recommendedDataset,
+        );
+        form.setFieldValue('warehouse.dataset', recommendedDataset);
+        if (selectedDataset?.location) {
+            form.setFieldValue('warehouse.location', selectedDataset.location);
+        }
+    }, [
+        datasetField.value,
+        datasets,
+        form,
+        isAuthenticated,
+        isSso,
+        recommendedDataset,
+    ]);
 
     if (!isSso || !isAuthenticated) {
         return (
@@ -120,6 +168,23 @@ export const BigQuerySchemaInput: FC<{
             }}
             disabled={disabled || !hasProject}
             data={datasets?.map((dataset) => dataset.datasetId) ?? []}
+            renderOption={({ option }) => (
+                <Group justify="space-between" wrap="nowrap" gap="xs" w="100%">
+                    <Text size="sm" truncate="end">
+                        {option.value}
+                    </Text>
+                    {option.value === recommendedDataset ? (
+                        <Badge
+                            size="xs"
+                            color="green"
+                            variant="light"
+                            radius="sm"
+                        >
+                            Recommended · largest
+                        </Badge>
+                    ) : null}
+                </Group>
+            )}
             maxDropdownHeight={220}
             rightSectionPointerEvents={datasetsError ? 'all' : 'none'}
             rightSection={
@@ -183,7 +248,9 @@ const BigQueryForm: FC<{
     const isAuthenticated = data !== undefined && bigqueryAuthError === null;
     const form = useFormContext();
     const project = form.getInputProps('warehouse.project');
+    const hasAppliedProjectRecommendation = useRef(false);
     const [debouncedProject] = useDebouncedValue(project.value, 300);
+    const { savedProject } = useProjectFormContext();
     const health = useHealth();
     const isAdcEnabled = health.data?.auth.google?.enableGCloudADC;
     // Fetching databases can only happen if user is authenticated
@@ -203,9 +270,17 @@ const BigQueryForm: FC<{
         isLoading: isLoadingProjects,
         error: projectsError,
     } = useBigqueryProjects(isAuthenticated && isSso);
+    const shouldFetchProjectRecommendation =
+        isAuthenticated &&
+        isSso &&
+        !savedProject &&
+        !project.value &&
+        !hasAppliedProjectRecommendation.current;
+    const { data: projectRecommendation } = useBigqueryProjectRecommendation(
+        shouldFetchProjectRecommendation,
+    );
     const [isOpen, toggleOpen] = useToggle(false);
     const [temporaryFile, setTemporaryFile] = useState<File | null>(null);
-    const { savedProject } = useProjectFormContext();
     const requireSecrets: boolean = !(
         savedProject?.warehouseConnection?.type === WarehouseTypes.BIGQUERY &&
         savedProject?.warehouseConnection?.authenticationType ===
@@ -222,6 +297,47 @@ const BigQueryForm: FC<{
 
     // savedProject might not be loaded when the form is rendered, so we need to set the defaultValue also on a hook
     const defaultAuthenticationType = BigqueryAuthenticationType.SSO;
+
+    const warehouseConnectFlag = useServerFeatureFlag(
+        FeatureFlags.WarehouseConnectOnboarding,
+    );
+    const shouldDefaultToSso =
+        !savedProject && (warehouseConnectFlag.data?.enabled ?? false);
+    useEffect(() => {
+        if (shouldDefaultToSso && !form.isTouched()) {
+            form.setFieldValue(
+                'warehouse.authenticationType',
+                BigqueryAuthenticationType.SSO,
+            );
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [shouldDefaultToSso]);
+
+    useEffect(() => {
+        if (
+            hasAppliedProjectRecommendation.current ||
+            !isAuthenticated ||
+            !isSso ||
+            savedProject ||
+            projectRecommendation === undefined
+        ) {
+            return;
+        }
+        hasAppliedProjectRecommendation.current = true;
+        if (!project.value && projectRecommendation.projectId) {
+            form.setFieldValue(
+                'warehouse.project',
+                projectRecommendation.projectId,
+            );
+        }
+    }, [
+        form,
+        isAuthenticated,
+        isSso,
+        project.value,
+        projectRecommendation,
+        savedProject,
+    ]);
 
     const { mutate: openLoginPopup } = useGoogleLoginPopup(
         'bigquery',
@@ -333,7 +449,11 @@ const BigQueryForm: FC<{
                                     : 'Type or select a project'
                             }
                             required
-                            {...form.getInputProps('warehouse.project')}
+                            {...project}
+                            onChange={(value) => {
+                                hasAppliedProjectRecommendation.current = true;
+                                project.onChange(value);
+                            }}
                             disabled={disabled}
                             labelProps={{ style: { marginTop: '8px' } }}
                             w={hasDatasets ? '90%' : '100%'}
@@ -345,9 +465,31 @@ const BigQueryForm: FC<{
                                         projectItem.projectId === option.value,
                                 );
 
-                                return projectOption?.friendlyName
-                                    ? `${projectOption.friendlyName} (${projectOption.projectId})`
-                                    : option.value;
+                                return (
+                                    <Group
+                                        justify="space-between"
+                                        wrap="nowrap"
+                                        gap="xs"
+                                        w="100%"
+                                    >
+                                        <Text size="sm" truncate="end">
+                                            {projectOption?.friendlyName
+                                                ? `${projectOption.friendlyName} (${projectOption.projectId})`
+                                                : option.value}
+                                        </Text>
+                                        {option.value ===
+                                        projectRecommendation?.projectId ? (
+                                            <Badge
+                                                size="xs"
+                                                color="green"
+                                                variant="light"
+                                                radius="sm"
+                                            >
+                                                Recommended · largest
+                                            </Badge>
+                                        ) : null}
+                                    </Group>
+                                );
                             }}
                             rightSectionPointerEvents={
                                 projectsError ? 'all' : 'none'

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoModeContext.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoModeContext.ts
@@ -1,0 +1,9 @@
+import { createContext, useContext } from 'react';
+
+export const CliSsoModeContext = createContext(false);
+export const SetCliSsoModeContext = createContext<(value: boolean) => void>(
+    () => {},
+);
+
+export const useSnowflakeCliSsoMode = () => useContext(CliSsoModeContext);
+export const useSetSnowflakeCliSsoMode = () => useContext(SetCliSsoModeContext);

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoModeProvider.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoModeProvider.tsx
@@ -1,0 +1,18 @@
+import { useState, type FC, type PropsWithChildren } from 'react';
+import {
+    CliSsoModeContext,
+    SetCliSsoModeContext,
+} from './SnowflakeCliSsoModeContext';
+
+export const SnowflakeCliSsoModeProvider: FC<PropsWithChildren> = ({
+    children,
+}) => {
+    const [isCliSsoMode, setIsCliSsoMode] = useState(false);
+    return (
+        <SetCliSsoModeContext.Provider value={setIsCliSsoMode}>
+            <CliSsoModeContext.Provider value={isCliSsoMode}>
+                {children}
+            </CliSsoModeContext.Provider>
+        </SetCliSsoModeContext.Provider>
+    );
+};

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoPanel.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoPanel.tsx
@@ -56,6 +56,22 @@ const readStoredCode = (): { code: string; expiresAt: string } | null => {
     }
 };
 
+const readValidStoredCode = (): {
+    code: string;
+    secondsRemaining: number;
+} | null => {
+    const stored = readStoredCode();
+    if (!stored) return null;
+    const secondsRemaining = Math.round(
+        (new Date(stored.expiresAt).getTime() - Date.now()) / 1000,
+    );
+    if (secondsRemaining <= 0) {
+        sessionStorage.removeItem(STORED_CODE_KEY);
+        return null;
+    }
+    return { code: stored.code, secondsRemaining };
+};
+
 const CopyableCommand: FC<{ command: string }> = ({ command }) => (
     <Group gap="xs" align="flex-start" wrap="nowrap">
         <Code block flex={1} miw={0}>
@@ -124,9 +140,12 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
     const form = useFormContext();
     const siteUrl = health.data?.siteUrl ?? '';
     const mint = useMintWarehouseConnectCode();
-    const [code, setCode] = useState<string | null>(null);
+    const [storedCode] = useState(() =>
+        connectedCredentials === null ? readValidStoredCode() : null,
+    );
+    const [code, setCode] = useState<string | null>(storedCode?.code ?? null);
     const [secondsRemaining, setSecondsRemaining] = useState<number | null>(
-        null,
+        storedCode?.secondsRemaining ?? null,
     );
     const [claimed, setClaimed] = useState(false);
     const [inventory, setInventory] =
@@ -137,22 +156,6 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
     const isPolling = !!code && !claimed && !isConnected && !isExpired;
 
     const claim = useWarehouseConnectCodeClaim(code, isPolling);
-
-    useEffect(() => {
-        if (isConnected || code) return;
-        const stored = readStoredCode();
-        if (!stored) return;
-        const remaining = Math.round(
-            (new Date(stored.expiresAt).getTime() - Date.now()) / 1000,
-        );
-        if (remaining <= 0) {
-            sessionStorage.removeItem(STORED_CODE_KEY);
-            return;
-        }
-        setCode(stored.code);
-        setSecondsRemaining(remaining);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
 
     useEffect(() => {
         if (!claimed && claim.data?.status === 'deposited') {

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoPanel.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoPanel.tsx
@@ -31,10 +31,30 @@ import MantineIcon from '../../common/MantineIcon';
 import { useFormContext } from '../formContext';
 import {
     buildSnowflakeConnectCommand,
+    largestDatabaseName,
     recommendedWarehouseName,
     SNOWFLAKE_CLI_INSTALL_COMMAND,
     warehouseSecondaryText,
 } from './snowflakeCliSso';
+
+const STORED_CODE_KEY = 'snowflakeCliSsoConnectCode';
+
+const readStoredCode = (): { code: string; expiresAt: string } | null => {
+    try {
+        const raw = sessionStorage.getItem(STORED_CODE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        if (
+            typeof parsed?.code === 'string' &&
+            typeof parsed?.expiresAt === 'string'
+        ) {
+            return parsed;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+};
 
 const CopyableCommand: FC<{ command: string }> = ({ command }) => (
     <Group gap="xs" align="flex-start" wrap="nowrap">
@@ -119,12 +139,62 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
     const claim = useWarehouseConnectCodeClaim(code, isPolling);
 
     useEffect(() => {
+        if (isConnected || code) return;
+        const stored = readStoredCode();
+        if (!stored) return;
+        const remaining = Math.round(
+            (new Date(stored.expiresAt).getTime() - Date.now()) / 1000,
+        );
+        if (remaining <= 0) {
+            sessionStorage.removeItem(STORED_CODE_KEY);
+            return;
+        }
+        setCode(stored.code);
+        setSecondsRemaining(remaining);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
         if (!claimed && claim.data?.status === 'deposited') {
             setClaimed(true);
             setInventory(claim.data.inventory);
             onDeposited(claim.data.credentials);
+            const depositedInventory = claim.data.inventory;
+            const selectedDatabase =
+                claim.data.credentials.database ??
+                largestDatabaseName(depositedInventory?.databases ?? []) ??
+                undefined;
+            if (!claim.data.credentials.database && selectedDatabase) {
+                form.setFieldValue('warehouse.database', selectedDatabase);
+            }
+            if (!claim.data.credentials.warehouse) {
+                const recommended = recommendedWarehouseName(
+                    depositedInventory?.warehouses ?? [],
+                );
+                if (recommended) {
+                    form.setFieldValue('warehouse.warehouse', recommended);
+                }
+            }
+            if (!claim.data.credentials.schema) {
+                const firstSchema = (depositedInventory?.schemas ?? []).find(
+                    (schema) =>
+                        !selectedDatabase ||
+                        schema.database === selectedDatabase,
+                )?.name;
+                if (firstSchema) {
+                    form.setFieldValue('warehouse.schema', firstSchema);
+                }
+            }
         }
-    }, [claimed, claim.data, onDeposited]);
+    }, [claimed, claim.data, onDeposited, form]);
+
+    useEffect(() => {
+        if (claim.error) {
+            sessionStorage.removeItem(STORED_CODE_KEY);
+            setCode(null);
+            setSecondsRemaining(null);
+        }
+    }, [claim.error]);
 
     useEffect(() => {
         if (secondsRemaining === null || secondsRemaining <= 0)
@@ -141,6 +211,17 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
         const result = await mint.mutateAsync();
         setClaimed(false);
         setCode(result.code);
+        try {
+            sessionStorage.setItem(
+                STORED_CODE_KEY,
+                JSON.stringify({
+                    code: result.code,
+                    expiresAt: result.expiresAt,
+                }),
+            );
+        } catch {
+            // best-effort persistence; refresh recovery just won't apply
+        }
         const expiry = new Date(result.expiresAt).getTime();
         setSecondsRemaining(
             Math.max(0, Math.round((expiry - Date.now()) / 1000)),
@@ -171,6 +252,9 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
         const recommendedWarehouse = recommendedWarehouseName(
             inventory?.warehouses ?? [],
         );
+        const recommendedDatabase = largestDatabaseName(
+            inventory?.databases ?? [],
+        );
         const schemaOptions = [
             ...new Set(
                 (inventory?.schemas ?? [])
@@ -186,9 +270,13 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
             twoLineOption(
                 option.label,
                 databaseMeta.get(option.value)?.comment ?? null,
-                option.value === connectedCredentials.database
-                    ? defaultBadge
-                    : null,
+                option.value === connectedCredentials.database ? (
+                    defaultBadge
+                ) : option.value === recommendedDatabase ? (
+                    <Badge size="xs" color="green" variant="light" radius="sm">
+                        Recommended · largest
+                    </Badge>
+                ) : null,
             );
         const renderWarehouseOption = ({
             option,

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -154,7 +154,7 @@ const SnowflakeForm: FC<{
     const isEditMode = !!savedProject;
 
     const warehouseConnectFlag = useServerFeatureFlag(
-        FeatureFlags.WarehouseConnectOnboarding,
+        FeatureFlags.NewOnboarding,
     );
     const isCliSsoEnabled =
         !savedProject && (warehouseConnectFlag.data?.enabled ?? false);

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -47,6 +47,10 @@ import { getWarehouseIcon } from '../ProjectConnectFlow/utils';
 import { useProjectFormContext } from '../useProjectFormContext';
 import DataTimezoneField from './DataTimezoneField';
 import { SnowflakeDefaultValues } from './defaultValues';
+import {
+    useSetSnowflakeCliSsoMode,
+    useSnowflakeCliSsoMode,
+} from './SnowflakeCliSsoModeContext';
 import SnowflakeCliSsoPanel from './SnowflakeCliSsoPanel';
 import {
     CLI_SSO_LABEL,
@@ -65,6 +69,10 @@ export const SnowflakeSchemaInput: FC<{
     description?: ReactNode;
 }> = ({ disabled, description }) => {
     const form = useFormContext();
+    const isCliSsoMode = useSnowflakeCliSsoMode();
+    if (isCliSsoMode) {
+        return null;
+    }
     return (
         <TextInput
             name="warehouse.schema"
@@ -150,7 +158,8 @@ const SnowflakeForm: FC<{
     );
     const isCliSsoEnabled =
         !savedProject && (warehouseConnectFlag.data?.enabled ?? false);
-    const [isCliSsoMode, setIsCliSsoMode] = useState(false);
+    const isCliSsoMode = useSnowflakeCliSsoMode();
+    const setIsCliSsoMode = useSetSnowflakeCliSsoMode();
     const userSelectedAuthType = useRef(false);
     const [cliSsoCredentials, setCliSsoCredentials] =
         useState<DepositSnowflakeCredentials | null>(null);
@@ -186,7 +195,7 @@ const SnowflakeForm: FC<{
         if (isCliSsoEnabled && !userSelectedAuthType.current) {
             setIsCliSsoMode(true);
         }
-    }, [isCliSsoEnabled]);
+    }, [isCliSsoEnabled, setIsCliSsoMode]);
     const authenticationType: SnowflakeAuthenticationType =
         form.values.warehouse.authenticationType ?? defaultAuthType;
 
@@ -329,7 +338,7 @@ const SnowflakeForm: FC<{
                         <TextInput
                             name="warehouse.account"
                             label="Account"
-                            placeholder="AAA99827"
+                            placeholder="xy12345.eu-west-2.aws"
                             description={
                                 isCliSsoMode && cliSsoCredentials !== null
                                     ? 'Your CLI SSO connection is bound to this account.'

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/bigQuerySso.test.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/bigQuerySso.test.ts
@@ -1,0 +1,47 @@
+import { largestDatasetName } from './bigQuerySso';
+
+describe('largestDatasetName', () => {
+    it('returns the largest dataset with a positive known size', () => {
+        expect(
+            largestDatasetName([
+                {
+                    projectId: 'project',
+                    datasetId: 'unknown',
+                    location: 'EU',
+                    sizeBytes: null,
+                },
+                {
+                    projectId: 'project',
+                    datasetId: 'largest',
+                    location: 'EU',
+                    sizeBytes: 200,
+                },
+                {
+                    projectId: 'project',
+                    datasetId: 'smaller',
+                    location: 'EU',
+                    sizeBytes: 100,
+                },
+            ]),
+        ).toBe('largest');
+    });
+
+    it('returns null when no positive size is known', () => {
+        expect(
+            largestDatasetName([
+                {
+                    projectId: 'project',
+                    datasetId: 'unknown',
+                    location: 'EU',
+                    sizeBytes: null,
+                },
+                {
+                    projectId: 'project',
+                    datasetId: 'empty',
+                    location: 'EU',
+                    sizeBytes: 0,
+                },
+            ]),
+        ).toBeNull();
+    });
+});

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/bigQuerySso.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/bigQuerySso.ts
@@ -1,0 +1,16 @@
+import { type BigqueryDataset } from '@lightdash/common';
+
+export const largestDatasetName = (
+    datasets: BigqueryDataset[],
+): string | null => {
+    let largestName: string | null = null;
+    let largestSize = 0;
+    datasets.forEach((dataset) => {
+        const size = dataset.sizeBytes ?? 0;
+        if (size > largestSize) {
+            largestName = dataset.datasetId;
+            largestSize = size;
+        }
+    });
+    return largestName;
+};

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/snowflakeCliSso.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/snowflakeCliSso.ts
@@ -61,6 +61,22 @@ export const recommendedWarehouseName = (
         : (best as WarehouseConnectInventory['warehouses'][number]).name;
 };
 
+export const largestDatabaseName = (
+    databases: WarehouseConnectInventory['databases'],
+): string | null => {
+    let best: WarehouseConnectInventory['databases'][number] | null = null;
+    databases.forEach((database) => {
+        const size = database.sizeBytes ?? 0;
+        if (size <= 0) return;
+        if (best === null || size > (best.sizeBytes ?? 0)) {
+            best = database;
+        }
+    });
+    return best === null
+        ? null
+        : (best as WarehouseConnectInventory['databases'][number]).name;
+};
+
 export const buildSnowflakeConnectCommand = ({
     siteUrl,
     code,

--- a/packages/frontend/src/components/ProjectConnection/WarehouseSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseSettingsForm.tsx
@@ -1,5 +1,5 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { Select } from '@mantine-8/core';
+import { Select, Stack } from '@mantine-8/core';
 import { type FC, type ReactNode } from 'react';
 import { useFormContext } from './formContext';
 import AthenaForm from './WarehouseForms/AthenaForm';
@@ -58,13 +58,7 @@ const WarehouseSettingsForm: FC<WarehouseSettingsFormProps> = ({
 
     return (
         <SnowflakeCliSsoModeProvider>
-            <div
-                style={{
-                    height: '100%',
-                    display: 'flex',
-                    flexDirection: 'column',
-                }}
-            >
+            <Stack h="100%" gap={0}>
                 {isProjectUpdate && (
                     <Select
                         allowDeselect={false}
@@ -93,7 +87,7 @@ const WarehouseSettingsForm: FC<WarehouseSettingsFormProps> = ({
 
                 <WarehouseForm disabled={disabled} />
                 {children}
-            </div>
+            </Stack>
         </SnowflakeCliSsoModeProvider>
     );
 };

--- a/packages/frontend/src/components/ProjectConnection/WarehouseSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseSettingsForm.tsx
@@ -10,6 +10,7 @@ import { warehouseDefaultValues } from './WarehouseForms/defaultValues';
 import DuckdbForm from './WarehouseForms/DuckdbForm';
 import PostgresForm from './WarehouseForms/PostgresForm';
 import RedshiftForm from './WarehouseForms/RedshiftForm';
+import { SnowflakeCliSsoModeProvider } from './WarehouseForms/SnowflakeCliSsoModeProvider';
 import SnowflakeForm from './WarehouseForms/SnowflakeForm';
 import TrinoForm from './WarehouseForms/TrinoForm';
 
@@ -56,37 +57,44 @@ const WarehouseSettingsForm: FC<WarehouseSettingsFormProps> = ({
     const WarehouseForm = WarehouseTypeForms[warehouseType];
 
     return (
-        <div
-            style={{ height: '100%', display: 'flex', flexDirection: 'column' }}
-        >
-            {isProjectUpdate && (
-                <Select
-                    allowDeselect={false}
-                    defaultValue={WarehouseTypes.BIGQUERY}
-                    label="Type"
-                    data={Object.entries(WarehouseTypeLabels).map(
-                        ([value, label]) => ({
-                            value,
-                            label,
-                        }),
-                    )}
-                    required
-                    {...form.getInputProps('warehouse.type')}
-                    onChange={(value) => {
-                        if (!value) return;
-                        const warehouseType = value as WarehouseTypes;
+        <SnowflakeCliSsoModeProvider>
+            <div
+                style={{
+                    height: '100%',
+                    display: 'flex',
+                    flexDirection: 'column',
+                }}
+            >
+                {isProjectUpdate && (
+                    <Select
+                        allowDeselect={false}
+                        defaultValue={WarehouseTypes.BIGQUERY}
+                        label="Type"
+                        data={Object.entries(WarehouseTypeLabels).map(
+                            ([value, label]) => ({
+                                value,
+                                label,
+                            }),
+                        )}
+                        required
+                        {...form.getInputProps('warehouse.type')}
+                        onChange={(value) => {
+                            if (!value) return;
+                            const warehouseType = value as WarehouseTypes;
 
-                        form.setValues({
-                            warehouse: warehouseDefaultValues[warehouseType],
-                        });
-                    }}
-                    disabled={disabled}
-                />
-            )}
+                            form.setValues({
+                                warehouse:
+                                    warehouseDefaultValues[warehouseType],
+                            });
+                        }}
+                        disabled={disabled}
+                    />
+                )}
 
-            <WarehouseForm disabled={disabled} />
-            {children}
-        </div>
+                <WarehouseForm disabled={disabled} />
+                {children}
+            </div>
+        </SnowflakeCliSsoModeProvider>
     );
 };
 

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
@@ -179,9 +179,7 @@ const UserCompletionModal: FC = () => {
 const UserCompletionModalWithUser = () => {
     const { user, health } = useApp();
     const location = useLocation();
-    const orgSetupPageFlag = useServerFeatureFlag(
-        FeatureFlags.OrganizationSetupPage,
-    );
+    const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
 
     if (orgSetupPageFlag.isLoading) {
         return null;

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandAppearanceSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandAppearanceSettings.tsx
@@ -302,7 +302,6 @@ const BrandAppearanceForm: FC<{ brand: OrganizationBrand | null }> = ({
                         Preview
                     </Text>
                     <BrandPreview
-                        domain={form.values.domain}
                         name={form.values.name}
                         logos={form.values.logos}
                         colors={form.values.colors}

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandPreview.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandPreview.tsx
@@ -83,7 +83,6 @@ const linePath = (points: number[]): string => {
 };
 
 type BrandPreviewProps = {
-    domain: string;
     name: string | null;
     logos: OrganizationBrandLogo[];
     colors: OrganizationBrandColor[];
@@ -92,7 +91,6 @@ type BrandPreviewProps = {
 };
 
 export const BrandPreview: FC<BrandPreviewProps> = ({
-    domain,
     name,
     logos,
     colors,
@@ -102,7 +100,6 @@ export const BrandPreview: FC<BrandPreviewProps> = ({
     const primary = pickPrimaryColor(colors);
     const navLogo = pickNavLogo(logos);
     const displayName = name ?? 'Your company';
-    const displayDomain = domain.trim() || 'yourcompany.com';
     const barColors = [primary, `${primary}59`];
 
     // Apply a brand font family only when we can actually load it, otherwise
@@ -123,7 +120,7 @@ export const BrandPreview: FC<BrandPreviewProps> = ({
                 </Group>
                 <Box className={classes.urlBar}>
                     <Text size="xs" c="dimmed">
-                        app.{displayDomain}
+                        {window.location.host}
                     </Text>
                 </Box>
             </Group>

--- a/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.tsx
@@ -15,9 +15,7 @@ import layout from './homepageLayout.module.css';
 const NoProjectHomepage: FC = () => {
     const { user } = useApp();
     const { data: organization, isInitialLoading } = useOrganization();
-    const orgSetupPageFlag = useServerFeatureFlag(
-        FeatureFlags.OrganizationSetupPage,
-    );
+    const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
     const actions = useRecommendedActions(null);
 
     if (isInitialLoading || orgSetupPageFlag.isLoading) {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
@@ -27,8 +27,6 @@ export const AskAiHero: FC<{
 }) => {
     const { user } = useApp();
     const actions = useRecommendedActions(projectUuid);
-    // Once everything is done or skipped the checklist retires and the
-    // prompt suggestions take its place
     const showChecklist = showRecommendedActions && actions.hasPendingActions;
     return (
         <Stack gap={16} align="center" w="100%">
@@ -47,11 +45,7 @@ export const AskAiHero: FC<{
                 </Text>
             )}
             <Box w="100%">
-                <DayOneAskInput
-                    projectUuid={projectUuid}
-                    preview={preview}
-                    hideSuggestions={showChecklist}
-                />
+                <DayOneAskInput projectUuid={projectUuid} preview={preview} />
             </Box>
             {showChecklist && (
                 <RecommendedActionsChecklist

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
@@ -13,7 +13,7 @@ import {
     IconX,
     type Icon,
 } from '@tabler/icons-react';
-import { useCallback, useState, type FC } from 'react';
+import { useCallback, useEffect, useState, type FC } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import useTracking from '../../../../providers/Tracking/useTracking';
@@ -61,6 +61,8 @@ const ACTION_DEFINITIONS: Record<
         subtitle: 'Ask Aurora from your channels',
     },
 };
+
+const AUTO_ROTATE_INTERVAL_MS = 10_000;
 
 const POSITION_CLASSES = [styles.pos0, styles.pos1, styles.pos2, styles.pos3];
 const STACK_HEIGHT_CLASSES = [
@@ -205,6 +207,7 @@ export const RecommendedActionsChecklist: FC<{
     const { statuses, skippedActions, setSkippedActions, visibleActions } =
         actions;
     const [carouselIndex, setCarouselIndex] = useState(0);
+    const [isStackHovered, setIsStackHovered] = useState(false);
 
     const handleSkip = useCallback(
         (actionKey: HomepageRecommendedActionKey) => {
@@ -263,8 +266,6 @@ export const RecommendedActionsChecklist: FC<{
         [projectUuid, statuses, setSkippedActions],
     );
 
-    if (visibleActions.length === 0) return null;
-
     const isSkipped = (key: HomepageRecommendedActionKey) =>
         skippedActions.includes(key) && !statuses[key].isComplete;
     const doneActions = visibleActions.filter(
@@ -290,6 +291,18 @@ export const RecommendedActionsChecklist: FC<{
         ...orderedAll.slice(activeIndex),
         ...orderedAll.slice(0, activeIndex),
     ];
+
+    const rotatableCount = incompleteActions.length;
+
+    useEffect(() => {
+        if (isStackHovered || rotatableCount <= 1) return;
+        const timeout = setTimeout(() => {
+            setCarouselIndex((activeIndex + 1) % rotatableCount);
+        }, AUTO_ROTATE_INTERVAL_MS);
+        return () => clearTimeout(timeout);
+    }, [activeIndex, isStackHovered, rotatableCount]);
+
+    if (visibleActions.length === 0) return null;
 
     return (
         <Stack gap={8} className={styles.checklistRoot}>
@@ -333,6 +346,8 @@ export const RecommendedActionsChecklist: FC<{
                 className={`${styles.cardStack} ${stackHeightClass(
                     orderedAll.length,
                 )}`}
+                onMouseEnter={() => setIsStackHovered(true)}
+                onMouseLeave={() => setIsStackHovered(false)}
             >
                 {/* Fixed render order keeps DOM nodes put; depth classes do the shuffling */}
                 {visibleActions.map((key) => {

--- a/packages/frontend/src/hooks/organization/useOrganizationBrand.ts
+++ b/packages/frontend/src/hooks/organization/useOrganizationBrand.ts
@@ -61,6 +61,7 @@ export const useDetectOrganizationBrand = (domain: string, enabled: boolean) =>
         queryFn: () => fetchOrganizationBrand({ domain }),
         enabled: enabled && domain.length > 0,
         retry: false,
+        retryOnMount: false,
         staleTime: Infinity,
         refetchOnWindowFocus: false,
     });

--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -10,14 +10,35 @@ import { useParams } from 'react-router';
 import { useOrganization } from './organization/useOrganization';
 import { useProject } from './useProject';
 import { useProjects } from './useProjects';
+import { useAccount } from './user/useAccount';
 
-const LAST_PROJECT_KEY = 'lastProject';
+export const LAST_PROJECT_KEY = 'lastProject';
+export const LAST_USER_KEY = 'lastAuthenticatedUserUuid';
 
 export const useActiveProject = () => {
+    const { data: account } = useAccount();
+    const userUuid =
+        account && 'userUuid' in account.user ? account.user.userUuid : null;
+
     return useQuery<string | null>(
-        ['activeProject'],
-        () => Promise.resolve(localStorage.getItem(LAST_PROJECT_KEY) || null),
+        ['activeProject', userUuid],
+        () => {
+            // lastProject persists across full-page reloads, so it may belong
+            // to a previously signed-in user. Only hand it out once it
+            // provably belongs to the current user (a missing marker means a
+            // browser from before the marker existed and is trusted).
+            if (userUuid) {
+                const storedIdentity = localStorage.getItem(LAST_USER_KEY);
+                if (storedIdentity !== null && storedIdentity !== userUuid) {
+                    return Promise.resolve(null);
+                }
+            }
+            return Promise.resolve(
+                localStorage.getItem(LAST_PROJECT_KEY) || null,
+            );
+        },
         {
+            enabled: account !== undefined,
             cacheTime: 0,
             refetchOnWindowFocus: false,
             refetchOnMount: false,

--- a/packages/frontend/src/hooks/useBigquerySSO.ts
+++ b/packages/frontend/src/hooks/useBigquerySSO.ts
@@ -1,5 +1,6 @@
 import {
     type ApiBigqueryDatasets,
+    type ApiBigqueryProjectRecommendation,
     type ApiBigqueryProjects,
     type ApiError,
     type ApiSuccessEmpty,
@@ -33,6 +34,21 @@ export const useBigqueryProjects = (isAuthenticated: boolean) => {
         queryKey: ['bigquery-projects'],
         queryFn: getProjects,
         enabled: isAuthenticated,
+    });
+};
+
+const getProjectRecommendation = async () =>
+    lightdashApi<ApiBigqueryProjectRecommendation['results']>({
+        url: `/bigquery/sso/projects/recommendation`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useBigqueryProjectRecommendation = (enabled: boolean) => {
+    return useQuery<ApiBigqueryProjectRecommendation['results'], ApiError>({
+        queryKey: ['bigquery-project-recommendation'],
+        queryFn: getProjectRecommendation,
+        enabled,
     });
 };
 

--- a/packages/frontend/src/hooks/useEmailVerification.ts
+++ b/packages/frontend/src/hooks/useEmailVerification.ts
@@ -68,7 +68,7 @@ export const useVerifyEmail = () => {
     const queryClient = useQueryClient();
     const { showToastSuccess } = useToaster();
     const emailOnlySignupFlag = useServerFeatureFlag(
-        FeatureFlags.EmailOnlySignup,
+        FeatureFlags.NewOnboarding,
     );
     return useMutation<EmailStatusExpiring, ApiError, string>(
         (code) => verifyOTPQuery(code),

--- a/packages/frontend/src/hooks/useOnboardingPageGuard.tsx
+++ b/packages/frontend/src/hooks/useOnboardingPageGuard.tsx
@@ -12,9 +12,7 @@ type OnboardingPageGuardResult =
 
 export const useOnboardingPageGuard = (): OnboardingPageGuardResult => {
     const { health, user } = useApp();
-    const orgSetupPageFlag = useServerFeatureFlag(
-        FeatureFlags.OrganizationSetupPage,
-    );
+    const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
 
     if (health.isInitialLoading || health.error) {
         return { status: 'blocked', element: <PageSpinner /> };

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -123,8 +123,8 @@ export const useUpdateMutation = (uuid: string) => {
     );
 };
 
-export const useCreateMutation = () => {
-    const { setActiveJobId } = useActiveJob();
+export const useCreateMutation = (options?: { quietJobToast?: boolean }) => {
+    const { setActiveJobId, setQuietActiveJobId } = useActiveJob();
     const { showToastApiError } = useToaster();
     return useMutation<ApiJobStartedResults, ApiError, CreateProject>(
         (data) => createProject(data),
@@ -132,7 +132,11 @@ export const useCreateMutation = () => {
             mutationKey: ['project_create'],
             retry: 3,
             onSuccess: (data) => {
-                setActiveJobId(data.jobUuid);
+                if (options?.quietJobToast) {
+                    setQuietActiveJobId(data.jobUuid);
+                } else {
+                    setActiveJobId(data.jobUuid);
+                }
             },
             onError: ({ error }) => {
                 showToastApiError({

--- a/packages/frontend/src/pages/OnboardingDataSource.module.css
+++ b/packages/frontend/src/pages/OnboardingDataSource.module.css
@@ -1,11 +1,12 @@
 .page {
-    min-height: 100vh;
+    min-height: calc(100vh - var(--navbar-height));
     background-color: var(--mantine-color-white);
     display: flex;
     flex-direction: column;
 }
 
 .column {
+    flex: 1;
     width: 100%;
     max-width: 1140px;
     margin: 0 auto;
@@ -75,6 +76,7 @@
 }
 
 .connectColumn {
+    flex: 1;
     width: 100%;
     max-width: 62rem;
     margin: 0 auto;

--- a/packages/frontend/src/pages/OnboardingDataSource.tsx
+++ b/packages/frontend/src/pages/OnboardingDataSource.tsx
@@ -17,6 +17,7 @@ import {
 } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
+import AboutFooter from '../components/AboutFooter';
 import { DocumentTitle } from '../components/common/DocumentTitle';
 import ErrorState from '../components/common/ErrorState';
 import MantineIcon from '../components/common/MantineIcon';
@@ -114,8 +115,7 @@ const DataSourcePicker: FC = () => {
                     Add a data source
                 </Title>
                 <Text size="md" c="dimmed" ta="center">
-                    Connecting a warehouse is the main event — it's what makes
-                    Aurora useful.
+                    Connect your warehouse so your agents can query your data.
                 </Text>
             </Stack>
 
@@ -252,6 +252,8 @@ const OnboardingDataSourceContent: FC = () => {
             ) : (
                 <DataSourcePicker />
             )}
+
+            <AboutFooter />
         </Box>
     );
 };

--- a/packages/frontend/src/pages/OnboardingProjectReady.module.css
+++ b/packages/frontend/src/pages/OnboardingProjectReady.module.css
@@ -1,9 +1,12 @@
 .page {
-    min-height: 100vh;
+    min-height: calc(100vh - var(--navbar-height));
     background-color: var(--mantine-color-white);
+    display: flex;
+    flex-direction: column;
 }
 
 .column {
+    flex: 1;
     width: 100%;
     max-width: 580px;
     margin: 0 auto;

--- a/packages/frontend/src/pages/OnboardingProjectReady.tsx
+++ b/packages/frontend/src/pages/OnboardingProjectReady.tsx
@@ -12,6 +12,7 @@ import { IconCheck } from '@tabler/icons-react';
 import confetti from 'canvas-confetti';
 import { useEffect, useMemo, useRef, useState, type FC } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
+import AboutFooter from '../components/AboutFooter';
 import { DocumentTitle } from '../components/common/DocumentTitle';
 import MantineIcon from '../components/common/MantineIcon';
 import { useTables } from '../features/sqlRunner/hooks/useTables';
@@ -135,7 +136,7 @@ const OnboardingProjectReadyContent: FC<{ projectUuid: string }> = ({
                         We're getting your project ready
                     </Title>
                     <Text c="dimmed" size="lg" ta="center">
-                        Aurora now understands your data.
+                        Your agents now understand your data.
                     </Text>
                 </Stack>
 
@@ -201,6 +202,8 @@ const OnboardingProjectReadyContent: FC<{ projectUuid: string }> = ({
                     </Button>
                 )}
             </Box>
+
+            <AboutFooter />
         </Box>
     );
 };

--- a/packages/frontend/src/pages/OrganizationSetup.module.css
+++ b/packages/frontend/src/pages/OrganizationSetup.module.css
@@ -1,32 +1,26 @@
 .page {
-    min-height: 100vh;
+    min-height: calc(100vh - var(--navbar-height));
     display: flex;
     flex-direction: column;
     background-color: var(--mantine-color-ldGray-0);
 }
 
-.topBar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: var(--mantine-spacing-lg) var(--mantine-spacing-xl);
-    flex-shrink: 0;
-}
-
 .body {
     flex: 1;
     display: flex;
-    align-items: stretch;
+    align-items: center;
+    justify-content: center;
+    gap: 5rem;
+    width: 100%;
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: var(--mantine-spacing-xl) 3rem;
     min-height: 0;
 }
 
 .leftPane {
     flex: 4;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    padding: var(--mantine-spacing-xl) 4rem;
-    max-width: 640px;
+    max-width: 560px;
 }
 
 .rightPane {
@@ -34,9 +28,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: var(--mantine-spacing-xl) 3rem;
-    background-color: var(--mantine-color-white);
-    border-left: 1px solid var(--mantine-color-ldGray-2);
 }
 
 .heading {
@@ -124,17 +115,17 @@
 @media (max-width: 992px) {
     .body {
         flex-direction: column;
+        gap: var(--mantine-spacing-xl);
     }
 
     .leftPane {
         flex: none;
         max-width: none;
-        padding: var(--mantine-spacing-xl);
+        width: 100%;
     }
 
     .rightPane {
         flex: none;
-        border-left: none;
-        border-top: 1px solid var(--mantine-color-ldGray-2);
+        width: 100%;
     }
 }

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -24,8 +24,8 @@ import { useForm } from '@mantine/form';
 import { zodResolver } from 'mantine-form-zod-resolver';
 import { useEffect, useRef, useState, type FC } from 'react';
 import { Navigate, useNavigate } from 'react-router';
+import AboutFooter from '../components/AboutFooter';
 import { DocumentTitle } from '../components/common/DocumentTitle';
-import LightdashLogo from '../components/LightdashLogo/LightdashLogo';
 import PageSpinner from '../components/PageSpinner';
 import { jobTitles } from '../components/UserCompletionModal/jobTitles';
 import {
@@ -184,8 +184,6 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
         selectedColor,
         detectedBrand?.colors ?? [],
     );
-    const previewDomain =
-        detectedBrand?.domain ?? (isCompanyDomain ? emailDomain : '');
     const titleFont =
         detectedBrand?.fonts.find((font) => font.type === 'title') ?? null;
     const bodyFont =
@@ -224,14 +222,22 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
             });
         }
 
-        if (detectedBrand) {
+        const brandDomain =
+            detectedBrand?.domain ?? (isCompanyDomain ? emailDomain : null);
+        if (brandDomain) {
             saveBrand.mutate({
-                domain: detectedBrand.domain,
-                name: detectedBrand.name,
-                description: detectedBrand.description,
-                logos: detectedBrand.logos,
-                colors: buildBrandColors(selectedColor, detectedBrand.colors),
-                fonts: detectedBrand.fonts,
+                domain: brandDomain,
+                name:
+                    values.organizationName.trim() ||
+                    detectedBrand?.name ||
+                    null,
+                description: detectedBrand?.description ?? null,
+                logos: detectedBrand?.logos ?? [],
+                colors: buildBrandColors(
+                    selectedColor,
+                    detectedBrand?.colors ?? [],
+                ),
+                fonts: detectedBrand?.fonts ?? [],
             });
         }
     });
@@ -243,12 +249,6 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
     return (
         <Box className={classes.page}>
             <DocumentTitle title="Set up your organization" />
-            <Box className={classes.topBar}>
-                <LightdashLogo />
-                <Text size="sm" c="dimmed">
-                    Step {displayStep} of {totalSteps} · {stepLabel}
-                </Text>
-            </Box>
 
             <Box className={classes.body}>
                 <Box className={classes.leftPane}>
@@ -256,6 +256,10 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                         {isWorkspaceStep ? (
                             <Stack gap="lg">
                                 <Stack gap="xs">
+                                    <Text size="sm" c="dimmed">
+                                        Step {displayStep} of {totalSteps} ·{' '}
+                                        {stepLabel}
+                                    </Text>
                                     <Title
                                         order={1}
                                         fz={44}
@@ -291,38 +295,38 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                                         </Text>
                                     </Group>
 
-                                    <Group gap="lg" align="flex-start">
-                                        <Box
-                                            className={classes.logoTile}
-                                            bg={
-                                                detectedLogoUrl
-                                                    ? 'var(--mantine-color-ldGray-0)'
-                                                    : selectedColor
-                                            }
-                                        >
-                                            {detectedLogoUrl ? (
-                                                <img
-                                                    src={detectedLogoUrl}
-                                                    alt=""
-                                                    className={
-                                                        classes.logoTileImage
-                                                    }
-                                                />
-                                            ) : (
-                                                <Text
-                                                    fw={700}
-                                                    fz={20}
-                                                    c="white"
-                                                >
-                                                    {logoTileInitial}
-                                                </Text>
-                                            )}
-                                        </Box>
+                                    <Stack gap="xs">
+                                        <Text size="sm" fw={500}>
+                                            Theme color
+                                        </Text>
+                                        <Group gap="lg" align="center">
+                                            <Box
+                                                className={classes.logoTile}
+                                                bg={
+                                                    detectedLogoUrl
+                                                        ? 'var(--mantine-color-ldGray-0)'
+                                                        : selectedColor
+                                                }
+                                            >
+                                                {detectedLogoUrl ? (
+                                                    <img
+                                                        src={detectedLogoUrl}
+                                                        alt=""
+                                                        className={
+                                                            classes.logoTileImage
+                                                        }
+                                                    />
+                                                ) : (
+                                                    <Text
+                                                        fw={700}
+                                                        fz={20}
+                                                        c="white"
+                                                    >
+                                                        {logoTileInitial}
+                                                    </Text>
+                                                )}
+                                            </Box>
 
-                                        <Stack gap="xs">
-                                            <Text size="sm" fw={500}>
-                                                Theme color
-                                            </Text>
                                             <Box className={classes.swatchRow}>
                                                 {swatches.map((color) => (
                                                     <Box
@@ -346,8 +350,8 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                                                     />
                                                 ))}
                                             </Box>
-                                        </Stack>
-                                    </Group>
+                                        </Group>
+                                    </Stack>
                                 </Stack>
 
                                 <Group>
@@ -366,6 +370,10 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                         ) : (
                             <Stack gap="lg">
                                 <Stack gap="xs">
+                                    <Text size="sm" c="dimmed">
+                                        Step {displayStep} of {totalSteps} ·{' '}
+                                        {stepLabel}
+                                    </Text>
                                     <Title
                                         order={1}
                                         fz={44}
@@ -446,7 +454,6 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
 
                 <Box className={classes.rightPane}>
                     <OrganizationSetupPreview
-                        domain={previewDomain}
                         name={form.values.organizationName || null}
                         logos={detectedBrand?.logos ?? []}
                         colors={previewColors}
@@ -457,6 +464,8 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                     />
                 </Box>
             </Box>
+
+            <AboutFooter />
         </Box>
     );
 };

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -473,9 +473,7 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
 const OrganizationSetup: FC = () => {
     const { health, user } = useApp();
     const navigate = useNavigate();
-    const orgSetupPageFlag = useServerFeatureFlag(
-        FeatureFlags.OrganizationSetupPage,
-    );
+    const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
     const completeMutation = useUserCompleteMutation({
         onSuccess: () => void navigate('/'),
     });

--- a/packages/frontend/src/pages/OrganizationSetupPreview.tsx
+++ b/packages/frontend/src/pages/OrganizationSetupPreview.tsx
@@ -9,7 +9,6 @@ import { BrandPreview } from '../components/UserSettings/AppearanceSettingsPanel
 import classes from './OrganizationSetup.module.css';
 
 type OrganizationSetupPreviewProps = {
-    domain: string;
     name: string | null;
     logos: OrganizationBrandLogo[];
     colors: OrganizationBrandColor[];
@@ -20,7 +19,6 @@ type OrganizationSetupPreviewProps = {
 };
 
 const OrganizationSetupPreview: FC<OrganizationSetupPreviewProps> = ({
-    domain,
     name,
     logos,
     colors,
@@ -50,7 +48,6 @@ const OrganizationSetupPreview: FC<OrganizationSetupPreviewProps> = ({
         )}
 
         <BrandPreview
-            domain={domain}
             name={name}
             logos={logos}
             colors={colors}

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -55,7 +55,7 @@ const Register: FC = () => {
     const allowPasswordAuthentication =
         !health.data?.auth.disablePasswordAuthentication;
     const emailOnlySignupFlag = useServerFeatureFlag(
-        FeatureFlags.EmailOnlySignup,
+        FeatureFlags.NewOnboarding,
         { retry: 3 },
     );
     const { identify } = useTracking();

--- a/packages/frontend/src/pages/VerifyEmail.tsx
+++ b/packages/frontend/src/pages/VerifyEmail.tsx
@@ -71,7 +71,7 @@ const VerifyEmailPage: FC = () => {
     const { show: showIntercom } = useIntercom();
     const navigate = useNavigate();
     const emailOnlySignupFlag = useServerFeatureFlag(
-        FeatureFlags.EmailOnlySignup,
+        FeatureFlags.NewOnboarding,
     );
 
     if (

--- a/packages/frontend/src/providers/ActiveJob/ActiveJobProvider.tsx
+++ b/packages/frontend/src/providers/ActiveJob/ActiveJobProvider.tsx
@@ -25,19 +25,22 @@ import Context from './context';
 
 const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
     const [isJobsDrawerOpen, setIsJobsDrawerOpen] = useState(false);
-    const [activeJobId, setActiveJobIdState] = useState();
+    const [activeJobId, setActiveJobIdState] = useState<string | undefined>();
     const [isQuietJob, setIsQuietJob] = useState(false);
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastApiError, showToastInfo } = useToaster();
 
-    const setActiveJobId = useCallback((jobId: SetStateAction<any>) => {
-        setIsQuietJob(false);
-        setActiveJobIdState(jobId);
-    }, []);
+    const setActiveJobId = useCallback(
+        (jobId: SetStateAction<string | undefined>) => {
+            setIsQuietJob(false);
+            setActiveJobIdState(jobId);
+        },
+        [],
+    );
 
     const setQuietActiveJobId = useCallback((jobId: string) => {
         setIsQuietJob(true);
-        setActiveJobIdState(jobId as any);
+        setActiveJobIdState(jobId);
     }, []);
 
     const toastJobStatus = useCallback(

--- a/packages/frontend/src/providers/ActiveJob/ActiveJobProvider.tsx
+++ b/packages/frontend/src/providers/ActiveJob/ActiveJobProvider.tsx
@@ -7,7 +7,13 @@ import {
 import { notifications } from '@mantine/notifications';
 import { IconArrowRight } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useState, type FC } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useState,
+    type FC,
+    type SetStateAction,
+} from 'react';
 import useToaster from '../../hooks/toaster/useToaster';
 import {
     jobStatusLabel,
@@ -19,9 +25,20 @@ import Context from './context';
 
 const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
     const [isJobsDrawerOpen, setIsJobsDrawerOpen] = useState(false);
-    const [activeJobId, setActiveJobId] = useState();
+    const [activeJobId, setActiveJobIdState] = useState();
+    const [isQuietJob, setIsQuietJob] = useState(false);
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastApiError, showToastInfo } = useToaster();
+
+    const setActiveJobId = useCallback((jobId: SetStateAction<any>) => {
+        setIsQuietJob(false);
+        setActiveJobIdState(jobId);
+    }, []);
+
+    const setQuietActiveJobId = useCallback((jobId: string) => {
+        setIsQuietJob(true);
+        setActiveJobIdState(jobId as any);
+    }, []);
 
     const toastJobStatus = useCallback(
         async (job: Job | undefined) => {
@@ -40,12 +57,14 @@ const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
                         await queryClient.invalidateQueries(['organization']);
                     }
                     await queryClient.invalidateQueries(['parameters']);
+                    if (isQuietJob) break;
                     showToastSuccess({
                         key: TOAST_KEY_FOR_REFRESH_JOB,
                         title: toastTitle,
                     });
                     break;
                 case 'RUNNING':
+                    if (isQuietJob) break;
                     showToastInfo({
                         key: TOAST_KEY_FOR_REFRESH_JOB,
                         title: toastTitle,
@@ -68,7 +87,13 @@ const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
                     setIsJobsDrawerOpen(true);
             }
         },
-        [showToastInfo, showToastSuccess, queryClient, isJobsDrawerOpen],
+        [
+            showToastInfo,
+            showToastSuccess,
+            queryClient,
+            isJobsDrawerOpen,
+            isQuietJob,
+        ],
     );
 
     const toastJobError = ({ error }: ApiError) => {
@@ -111,6 +136,7 @@ const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
                 setIsJobsDrawerOpen,
                 activeJobId,
                 setActiveJobId,
+                setQuietActiveJobId,
                 activeJob,
                 activeJobIsRunning,
             }}

--- a/packages/frontend/src/providers/ActiveJob/types.ts
+++ b/packages/frontend/src/providers/ActiveJob/types.ts
@@ -5,7 +5,7 @@ export interface ContextType {
     isJobsDrawerOpen: boolean;
     setIsJobsDrawerOpen: Dispatch<SetStateAction<boolean>>;
     activeJobId: string | undefined;
-    setActiveJobId: Dispatch<SetStateAction<any>>;
+    setActiveJobId: Dispatch<SetStateAction<string | undefined>>;
     setQuietActiveJobId: (jobId: string) => void;
     activeJob: Job | undefined;
     activeJobIsRunning: boolean | undefined;

--- a/packages/frontend/src/providers/ActiveJob/types.ts
+++ b/packages/frontend/src/providers/ActiveJob/types.ts
@@ -6,6 +6,7 @@ export interface ContextType {
     setIsJobsDrawerOpen: Dispatch<SetStateAction<boolean>>;
     activeJobId: string | undefined;
     setActiveJobId: Dispatch<SetStateAction<any>>;
+    setQuietActiveJobId: (jobId: string) => void;
     activeJob: Job | undefined;
     activeJobIsRunning: boolean | undefined;
 }

--- a/packages/frontend/src/providers/App/AppProvider.tsx
+++ b/packages/frontend/src/providers/App/AppProvider.tsx
@@ -1,11 +1,60 @@
-import { type FC } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef, type FC } from 'react';
 import useHealth from '../../hooks/health/useHealth';
+import { LAST_PROJECT_KEY, LAST_USER_KEY } from '../../hooks/useActiveProject';
 import useUser from '../../hooks/user/useUser';
 import AppProviderContext from './context';
 
 const AppProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
     const health = useHealth();
     const user = useUser(!!health?.data?.isAuthenticated);
+    const queryClient = useQueryClient();
+
+    // Central identity-change detector: never let one user's client state leak
+    // into another user's session. Two kinds of staleness are handled
+    // separately. The in-memory query cache only ever holds the previous
+    // user's data on a same-page identity change (tracked with a ref), where
+    // it is cleared. localStorage also survives full reloads — which most auth
+    // flows (login, register, SSO) trigger via window.location — so
+    // auth-scoped keys like lastProject are cleared whenever the resolved user
+    // differs from the persisted previous one; leaving them would make the
+    // new session request the old user's project (403s). Hooking here rather
+    // than each auth mutation covers every path.
+    const sessionIdentityRef = useRef<string | null | undefined>(undefined);
+    useEffect(() => {
+        // undefined => identity not yet resolved (health or user still loading)
+        let currentIdentity: string | null | undefined;
+        if (health.data) {
+            currentIdentity = health.data.isAuthenticated
+                ? user.data?.userUuid
+                : null;
+        }
+        if (currentIdentity === undefined) return;
+
+        const previousSessionIdentity = sessionIdentityRef.current;
+        sessionIdentityRef.current = currentIdentity;
+
+        if (
+            previousSessionIdentity != null &&
+            previousSessionIdentity !== currentIdentity
+        ) {
+            // Same-page transition away from a signed-in user (account switch,
+            // logout, session expiry): drop their cached data. lastProject is
+            // intentionally kept on transition to logged-out so that the same
+            // user logging back in returns to their project; a different user
+            // is handled below.
+            queryClient.clear();
+        }
+
+        if (currentIdentity !== null) {
+            const storedIdentity = localStorage.getItem(LAST_USER_KEY);
+            if (storedIdentity !== null && storedIdentity !== currentIdentity) {
+                localStorage.removeItem(LAST_PROJECT_KEY);
+                void queryClient.invalidateQueries(['activeProject']);
+            }
+            localStorage.setItem(LAST_USER_KEY, currentIdentity);
+        }
+    }, [health.data, user.data?.userUuid, queryClient]);
 
     const value = {
         health,

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -1,4 +1,10 @@
-import { Dataset } from '@google-cloud/bigquery';
+import {
+    BigQuery,
+    Dataset,
+    type DatasetsResponse,
+    type QueryRowsResponse,
+} from '@google-cloud/bigquery';
+import { type BigqueryProject } from '@lightdash/common';
 import type { Mock, MockInstance } from 'vitest';
 import {
     BigquerySqlBuilder,
@@ -75,6 +81,285 @@ describe('BigqueryWarehouseClient', () => {
         );
         expect(getTableMock).toHaveBeenCalledTimes(1);
         expect(getTableResponse.getMetadata).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('BigqueryWarehouseClient.getDatabases', () => {
+    const createDataset = (datasetId: string) =>
+        new Dataset(new BigQuery({ projectId: 'test-project' }), datasetId, {
+            location: 'EU',
+        });
+    const createClient = (
+        datasets: Dataset[],
+        query: (sql: string) => Promise<QueryRowsResponse>,
+    ) => ({
+        getDatasets: vi
+            .fn<() => Promise<DatasetsResponse>>()
+            .mockResolvedValue([datasets]),
+        query: vi.fn(query),
+    });
+
+    it('includes the stored size for each dataset', async () => {
+        const datasets = [createDataset('small'), createDataset('large')];
+        const queryMock = vi
+            .fn<(sql: string) => Promise<QueryRowsResponse>>()
+            .mockResolvedValueOnce([[{ sizeBytes: 100 }]])
+            .mockResolvedValueOnce([[{ sizeBytes: 500 }]]);
+        const client = createClient(datasets, queryMock);
+
+        await expect(
+            BigqueryWarehouseClient.getDatabases(
+                'test-project',
+                'refresh-token',
+                client,
+            ),
+        ).resolves.toEqual([
+            {
+                projectId: 'test-project',
+                datasetId: 'small',
+                location: 'EU',
+                sizeBytes: 100,
+            },
+            {
+                projectId: 'test-project',
+                datasetId: 'large',
+                location: 'EU',
+                sizeBytes: 500,
+            },
+        ]);
+        expect(queryMock).toHaveBeenNthCalledWith(
+            1,
+            'SELECT SUM(size_bytes) AS sizeBytes FROM `test-project.small.__TABLES__`',
+        );
+    });
+
+    it('returns null when an individual dataset size query fails', async () => {
+        const datasets = [createDataset('unavailable'), createDataset('ok')];
+        const queryMock = vi
+            .fn<(sql: string) => Promise<QueryRowsResponse>>()
+            .mockRejectedValueOnce(new Error('permission denied'))
+            .mockResolvedValueOnce([[{ sizeBytes: 500 }]]);
+        const client = createClient(datasets, queryMock);
+
+        const result = await BigqueryWarehouseClient.getDatabases(
+            'test-project',
+            'refresh-token',
+            client,
+        );
+
+        expect(
+            result.map(({ datasetId, sizeBytes }) => ({
+                datasetId,
+                sizeBytes,
+            })),
+        ).toEqual([
+            { datasetId: 'unavailable', sizeBytes: null },
+            { datasetId: 'ok', sizeBytes: 500 },
+        ]);
+    });
+
+    it('only queries sizes for the first 25 datasets', async () => {
+        const datasets = Array.from({ length: 30 }, (_, index) =>
+            createDataset(`dataset_${index}`),
+        );
+        const queryMock = vi
+            .fn<(sql: string) => Promise<QueryRowsResponse>>()
+            .mockResolvedValue([[{ sizeBytes: 100 }]]);
+        const client = createClient(datasets, queryMock);
+
+        const result = await BigqueryWarehouseClient.getDatabases(
+            'test-project',
+            'refresh-token',
+            client,
+        );
+
+        expect(queryMock).toHaveBeenCalledTimes(25);
+        expect(
+            result.slice(0, 25).every(({ sizeBytes }) => sizeBytes === 100),
+        ).toBe(true);
+        expect(
+            result.slice(25).every(({ sizeBytes }) => sizeBytes === null),
+        ).toBe(true);
+    });
+});
+
+describe('BigqueryWarehouseClient.getProjectRecommendation', () => {
+    type RecommendationQuery = (options: {
+        query: string;
+        location: string;
+    }) => Promise<QueryRowsResponse>;
+
+    const createDataset = (
+        projectId: string,
+        datasetId: string,
+        location: string,
+    ) =>
+        new Dataset(new BigQuery({ projectId }), datasetId, {
+            location,
+        });
+
+    const createClient = (
+        projectId: string,
+        locations: string[],
+        queryImplementation: RecommendationQuery,
+    ) => {
+        const datasets = locations.map((location, index) =>
+            createDataset(projectId, `dataset_${index}`, location),
+        );
+        const getDatasets = vi.fn<() => Promise<DatasetsResponse>>();
+        vi.mocked(getDatasets).mockResolvedValue([datasets]);
+        const query = vi.fn<RecommendationQuery>();
+        vi.mocked(query).mockImplementation(queryImplementation);
+        return { getDatasets, query };
+    };
+
+    it('ranks projects by their largest dataset across distinct regions', async () => {
+        const firstClient = createClient(
+            'first-project',
+            ['EU', 'US', 'EU'],
+            async ({ location }) =>
+                location === 'US'
+                    ? [[{ table_schema: 'largest', total_bytes: 1200 }]]
+                    : [[{ table_schema: 'smaller', total_bytes: 500 }]],
+        );
+        const secondClient = createClient(
+            'second-project',
+            ['EU'],
+            async () => [
+                [
+                    { table_schema: 'small', total_bytes: 100 },
+                    { table_schema: 'large', total_bytes: 900 },
+                ],
+            ],
+        );
+        const clients = new Map([
+            ['first-project', firstClient],
+            ['second-project', secondClient],
+        ]);
+        const clientFactory = vi.fn((projectId: string) => {
+            const client = clients.get(projectId);
+            if (!client) throw new Error('Unexpected project');
+            return client;
+        });
+        const projects: BigqueryProject[] = [
+            { projectId: 'first-project', friendlyName: null },
+            { projectId: 'second-project', friendlyName: null },
+        ];
+
+        await expect(
+            BigqueryWarehouseClient.getProjectRecommendation(
+                projects,
+                'refresh-token',
+                clientFactory,
+            ),
+        ).resolves.toEqual({ projectId: 'first-project' });
+        expect(vi.mocked(firstClient.getDatasets)).toHaveBeenCalledWith({
+            autoPaginate: false,
+            maxResults: 1000,
+        });
+        expect(vi.mocked(firstClient.query)).toHaveBeenCalledTimes(2);
+        expect(vi.mocked(firstClient.query)).toHaveBeenCalledWith({
+            query: 'SELECT table_schema, SUM(total_logical_bytes) AS total_bytes FROM `first-project`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE GROUP BY table_schema',
+            location: 'US',
+        });
+    });
+
+    it('skips a project when any of its region queries errors', async () => {
+        const failingClient = createClient(
+            'failing-project',
+            ['EU', 'US'],
+            async ({ location }) => {
+                if (location === 'US') throw new Error('permission denied');
+                return [[{ table_schema: 'largest', total_bytes: 5000 }]];
+            },
+        );
+        const healthyClient = createClient(
+            'healthy-project',
+            ['EU'],
+            async () => [[{ table_schema: 'available', total_bytes: 100 }]],
+        );
+        const clients = new Map([
+            ['failing-project', failingClient],
+            ['healthy-project', healthyClient],
+        ]);
+        const clientFactory = vi.fn((projectId: string) => {
+            const client = clients.get(projectId);
+            if (!client) throw new Error('Unexpected project');
+            return client;
+        });
+
+        await expect(
+            BigqueryWarehouseClient.getProjectRecommendation(
+                [
+                    { projectId: 'failing-project', friendlyName: null },
+                    { projectId: 'healthy-project', friendlyName: null },
+                ],
+                'refresh-token',
+                clientFactory,
+            ),
+        ).resolves.toEqual({ projectId: 'healthy-project' });
+    });
+
+    it('returns no recommendation when every project score is unavailable', async () => {
+        const client = createClient('unavailable-project', ['EU'], async () => {
+            throw new Error('permission denied');
+        });
+        const clientFactory = vi.fn<(projectId: string) => typeof client>();
+        vi.mocked(clientFactory).mockReturnValue(client);
+
+        await expect(
+            BigqueryWarehouseClient.getProjectRecommendation(
+                [{ projectId: 'unavailable-project', friendlyName: null }],
+                'refresh-token',
+                clientFactory,
+            ),
+        ).resolves.toEqual({ projectId: null });
+    });
+
+    it('caps ranking at eight projects and three regions per project', async () => {
+        const projects: BigqueryProject[] = Array.from(
+            { length: 10 },
+            (_, index) => ({
+                projectId: `project-${index}`,
+                friendlyName: null,
+            }),
+        );
+        const clients = new Map(
+            projects.map(({ projectId }, index) => [
+                projectId,
+                createClient(
+                    projectId,
+                    ['EU', 'US', 'asia-east1', 'us-west1'],
+                    async () => [
+                        [{ table_schema: 'dataset', total_bytes: index }],
+                    ],
+                ),
+            ]),
+        );
+        const clientFactory = vi.fn((projectId: string) => {
+            const client = clients.get(projectId);
+            if (!client) throw new Error('Unexpected project');
+            return client;
+        });
+
+        await expect(
+            BigqueryWarehouseClient.getProjectRecommendation(
+                projects,
+                'refresh-token',
+                clientFactory,
+            ),
+        ).resolves.toEqual({ projectId: 'project-7' });
+        expect(vi.mocked(clientFactory)).toHaveBeenCalledTimes(8);
+        projects.forEach(({ projectId }, index) => {
+            const client = clients.get(projectId);
+            if (!client) throw new Error('Unexpected project');
+            expect(vi.mocked(client.getDatasets)).toHaveBeenCalledTimes(
+                index < 8 ? 1 : 0,
+            );
+            expect(vi.mocked(client.query)).toHaveBeenCalledTimes(
+                index < 8 ? 3 : 0,
+            );
+        });
     });
 });
 

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -5,6 +5,8 @@ import {
     BigQueryTime,
     BigQueryTimestamp,
     Dataset,
+    DatasetsResponse,
+    GetDatasetsOptions,
     Job,
     QueryResultsOptions,
     QueryRowsResponse,
@@ -15,6 +17,7 @@ import {
     BigqueryAuthenticationType,
     BigqueryDataset,
     BigqueryProject,
+    BigqueryProjectRecommendation,
     CreateBigqueryCredentials,
     DimensionType,
     getErrorMessage,
@@ -46,6 +49,9 @@ import {
 import { normalizeUnicode } from '../utils/sql';
 import WarehouseBaseClient from './WarehouseBaseClient';
 import WarehouseBaseSqlBuilder from './WarehouseBaseSqlBuilder';
+
+const MAX_RECOMMENDATION_PROJECTS = 8;
+const MAX_RECOMMENDATION_REGIONS_PER_PROJECT = 3;
 
 export enum BigqueryFieldType {
     STRING = 'STRING',
@@ -775,8 +781,10 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
     static async getDatabases(
         projectId: string,
         refresh_token: string,
-    ): Promise<BigqueryDataset[]> {
-        const bigqueryClient = new BigQuery({
+        bigqueryClient: {
+            getDatasets: () => Promise<DatasetsResponse>;
+            query: (query: string) => Promise<QueryRowsResponse>;
+        } = new BigQuery({
             projectId,
             credentials: {
                 type: 'authorized_user',
@@ -784,15 +792,149 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                 client_secret: process.env.AUTH_GOOGLE_OAUTH2_CLIENT_SECRET,
                 refresh_token,
             },
-        });
-
+        }),
+    ): Promise<BigqueryDataset[]> {
         const datasets = await bigqueryClient.getDatasets();
-        const databases = datasets[0].map((d) => ({
-            projectId: d.projectId,
-            location: d.location,
-            datasetId: d.id!,
-        }));
+        const databases = await Promise.all(
+            datasets[0].map(async (dataset, index) => {
+                let sizeBytes: number | null = null;
+                if (index < 25) {
+                    try {
+                        const [rows] = await bigqueryClient.query(
+                            `SELECT SUM(size_bytes) AS sizeBytes FROM \`${dataset.projectId}.${dataset.id}.__TABLES__\``,
+                        );
+                        const size = Number(rows[0]?.sizeBytes);
+                        sizeBytes = Number.isFinite(size) ? size : null;
+                    } catch {
+                        sizeBytes = null;
+                    }
+                }
+
+                return {
+                    projectId: dataset.projectId,
+                    location: dataset.location,
+                    datasetId: dataset.id!,
+                    sizeBytes,
+                };
+            }),
+        );
         return databases;
+    }
+
+    static async getProjectRecommendation(
+        projects: BigqueryProject[],
+        refreshToken: string,
+        bigqueryClientFactory: (projectId: string) => {
+            getDatasets: (
+                options: GetDatasetsOptions,
+            ) => Promise<DatasetsResponse>;
+            query: (options: {
+                query: string;
+                location: string;
+            }) => Promise<QueryRowsResponse>;
+        } = (projectId) => {
+            const client = new BigQuery({
+                projectId,
+                credentials: {
+                    type: 'authorized_user',
+                    client_id: process.env.AUTH_GOOGLE_OAUTH2_CLIENT_ID,
+                    client_secret: process.env.AUTH_GOOGLE_OAUTH2_CLIENT_SECRET,
+                    refresh_token: refreshToken,
+                },
+            });
+            return {
+                getDatasets: (options) => client.getDatasets(options),
+                query: (options) =>
+                    client.query(options.query, { location: options.location }),
+            };
+        },
+    ): Promise<BigqueryProjectRecommendation> {
+        const projectScores = await Promise.all(
+            projects
+                .slice(0, MAX_RECOMMENDATION_PROJECTS)
+                .map(async ({ projectId }) => {
+                    try {
+                        const client = bigqueryClientFactory(projectId);
+                        const [datasets] = await client.getDatasets({
+                            autoPaginate: false,
+                            maxResults: 1000,
+                        });
+                        const locationsByQualifier = new Map<string, string>();
+                        datasets.forEach((dataset) => {
+                            if (dataset.location) {
+                                locationsByQualifier.set(
+                                    dataset.location.toLowerCase(),
+                                    dataset.location,
+                                );
+                            }
+                        });
+                        const locations = Array.from(
+                            locationsByQualifier.entries(),
+                        ).slice(0, MAX_RECOMMENDATION_REGIONS_PER_PROJECT);
+
+                        const regionScores = await Promise.all(
+                            locations.map(async ([qualifier, location]) => {
+                                try {
+                                    const [rows] = await client.query({
+                                        query: `SELECT table_schema, SUM(total_logical_bytes) AS total_bytes FROM \`${projectId}\`.\`region-${qualifier}\`.INFORMATION_SCHEMA.TABLE_STORAGE GROUP BY table_schema`,
+                                        location,
+                                    });
+                                    let largestDatasetSize: number | null =
+                                        null;
+                                    rows.forEach((row) => {
+                                        const size = Number(row.total_bytes);
+                                        if (
+                                            Number.isFinite(size) &&
+                                            (largestDatasetSize === null ||
+                                                size > largestDatasetSize)
+                                        ) {
+                                            largestDatasetSize = size;
+                                        }
+                                    });
+                                    return {
+                                        error: false,
+                                        sizeBytes: largestDatasetSize,
+                                    };
+                                } catch {
+                                    return { error: true, sizeBytes: null };
+                                }
+                            }),
+                        );
+
+                        if (regionScores.some(({ error }) => error)) {
+                            return { projectId, sizeBytes: null };
+                        }
+
+                        const sizeBytes = regionScores.reduce<number | null>(
+                            (largestSize, regionScore) =>
+                                regionScore.sizeBytes !== null &&
+                                (largestSize === null ||
+                                    regionScore.sizeBytes > largestSize)
+                                    ? regionScore.sizeBytes
+                                    : largestSize,
+                            null,
+                        );
+                        return { projectId, sizeBytes };
+                    } catch {
+                        return { projectId, sizeBytes: null };
+                    }
+                }),
+        );
+
+        const recommendation = projectScores.reduce<{
+            projectId: string | null;
+            sizeBytes: number | null;
+        }>(
+            (largestProject, projectScore) =>
+                projectScore.sizeBytes !== null &&
+                (largestProject.sizeBytes === null ||
+                    projectScore.sizeBytes > largestProject.sizeBytes)
+                    ? projectScore
+                    : largestProject,
+            { projectId: null, sizeBytes: null },
+        );
+
+        return { projectId: recommendation.projectId };
     }
 
     static async getProjects(accessToken: string): Promise<BigqueryProject[]> {

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
@@ -536,6 +536,14 @@ describe('SnowflakeWarehouseClient', () => {
                             database_name: 'ANALYTICS',
                         },
                     ];
+                } else if (sqlText.startsWith('SELECT SUM(bytes)')) {
+                    if (sqlText.includes('DATABASE_0.')) {
+                        rows = [{ total_bytes: 1250 }];
+                    } else if (sqlText.includes('DATABASE_1.')) {
+                        rows = [{ total_bytes: 500 }];
+                    } else {
+                        rows = [{ total_bytes: null }];
+                    }
                 }
                 complete(
                     undefined,
@@ -568,6 +576,7 @@ describe('SnowflakeWarehouseClient', () => {
                     name: `DATABASE_${index}`,
                     comment: index === 0 ? 'Primary analytics' : null,
                     kind: index === 1 ? 'IMPORTED DATABASE' : 'STANDARD',
+                    sizeBytes: [1250, 500][index] ?? null,
                 })),
                 warehouses: [
                     {
@@ -595,8 +604,89 @@ describe('SnowflakeWarehouseClient', () => {
         );
         expect(execute).toHaveBeenCalledWith(
             expect.objectContaining({
+                sqlText: `SELECT SUM(bytes) AS "total_bytes" FROM DATABASE_0.INFORMATION_SCHEMA.TABLES WHERE table_type = 'BASE TABLE'`,
+            }),
+        );
+        expect(
+            execute.mock.calls.filter(([statement]) =>
+                statement.sqlText.startsWith('SELECT SUM(bytes)'),
+            ),
+        ).toHaveLength(25);
+        expect(
+            execute.mock.calls.some(([statement]) =>
+                statement.sqlText.startsWith('USE WAREHOUSE'),
+            ),
+        ).toBe(false);
+        expect(execute).toHaveBeenCalledWith(
+            expect.objectContaining({
                 sqlText:
                     'SHOW GRANTS TO USER "user.name@example.com" LIMIT 100',
+            }),
+        );
+    });
+
+    it('returns null database sizes when size discovery fails', async () => {
+        const execute = vi.fn(
+            ({
+                sqlText,
+                complete,
+            }: {
+                sqlText: string;
+                complete: (
+                    error: Error | undefined,
+                    statement: { getColumns: () => typeof queryColumnsMock },
+                    rows: Record<string, AnyType>[],
+                ) => void;
+            }) => {
+                if (sqlText.startsWith('SELECT SUM(bytes)')) {
+                    complete(
+                        new Error('Insufficient privileges'),
+                        { getColumns: () => queryColumnsMock },
+                        [],
+                    );
+                    return;
+                }
+                let rows: Record<string, AnyType>[] = [];
+                if (sqlText.startsWith('SELECT CURRENT_USER')) {
+                    rows = [{ USER: 'test-user' }];
+                } else if (sqlText.startsWith('SHOW DATABASES')) {
+                    rows = [{ name: 'ANALYTICS' }, { name: 'RAW' }];
+                } else if (sqlText.startsWith('SHOW WAREHOUSES')) {
+                    rows = [
+                        { name: 'WH_BIG', size: 'Large', state: 'SUSPENDED' },
+                        {
+                            name: 'WH_SMALL',
+                            size: 'X-Small',
+                            state: 'STARTED',
+                        },
+                    ];
+                }
+                complete(
+                    undefined,
+                    { getColumns: () => queryColumnsMock },
+                    rows,
+                );
+            },
+        );
+        vi.mocked(createConnection).mockImplementationOnce(() =>
+            interactiveConnectionMock(execute),
+        );
+        const warehouse = new SnowflakeWarehouseClient(credentials);
+
+        const discovery = await warehouse.getSessionDiscovery('test-user');
+
+        expect(discovery.inventory.databases).toEqual([
+            {
+                name: 'ANALYTICS',
+                comment: null,
+                kind: null,
+                sizeBytes: null,
+            },
+            { name: 'RAW', comment: null, kind: null, sizeBytes: null },
+        ]);
+        expect(execute).toHaveBeenCalledWith(
+            expect.objectContaining({
+                sqlText: 'USE WAREHOUSE WH_SMALL',
             }),
         );
     });

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -98,6 +98,7 @@ const EXTERNAL_BROWSER_AUTHENTICATOR = 'EXTERNALBROWSER';
 const OAUTH_AUTHORIZATION_CODE_AUTHENTICATOR = 'OAUTH_AUTHORIZATION_CODE';
 const SESSION_DISCOVERY_LIMIT = 100;
 const SESSION_SCHEMA_DISCOVERY_LIMIT = 1000;
+const SESSION_DATABASE_SIZE_LIMIT = 25;
 // Minimum allowed by Snowflake (range 16-160, default 160)
 const SNOWFLAKE_RESULT_CHUNK_SIZE_MB = 16;
 
@@ -202,6 +203,7 @@ export type SnowflakeSessionInventory = {
         name: string;
         comment: string | null;
         kind: string | null;
+        sizeBytes: number | null;
     }[];
     warehouses: {
         name: string;
@@ -290,6 +292,7 @@ const listSnowflakeSchemas = (
 
 const listSnowflakeDatabases = (
     rows: AnyType[],
+    databaseSizes: Map<string, number>,
 ): SnowflakeSessionInventory['databases'] =>
     rows
         .flatMap((rawRow) => {
@@ -306,6 +309,7 @@ const listSnowflakeDatabases = (
                             ? null
                             : getSnowflakeRowValue(row, 'comment'),
                     kind: getSnowflakeRowValue(row, 'kind'),
+                    sizeBytes: databaseSizes.get(name) ?? null,
                 },
             ];
         })
@@ -334,6 +338,56 @@ const listSnowflakeWarehouses = (
             ];
         })
         .slice(0, SESSION_DISCOVERY_LIMIT);
+
+const WAREHOUSE_SIZE_ORDER = [
+    'X-Small',
+    'Small',
+    'Medium',
+    'Large',
+    'X-Large',
+    '2X-Large',
+    '3X-Large',
+    '4X-Large',
+    '5X-Large',
+    '6X-Large',
+];
+
+const warehouseSizeRank = (size: string | null): number => {
+    const index = WAREHOUSE_SIZE_ORDER.findIndex(
+        (candidate) =>
+            candidate.toLowerCase() === (size ?? '').trim().toLowerCase(),
+    );
+    return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+};
+
+const pickSizeDiscoveryWarehouse = (rows: AnyType[]): string | null => {
+    const warehouses = rows
+        .map((rawRow) => {
+            const row = rawRow as Record<string, AnyType>;
+            return {
+                name: getSnowflakeRowValue(row, 'name'),
+                size: getSnowflakeRowValue(row, 'size'),
+                state: (getSnowflakeRowValue(row, 'state') ?? '')
+                    .trim()
+                    .toUpperCase(),
+            };
+        })
+        .filter((warehouse) => Boolean(warehouse.name));
+    const started = warehouses.filter(
+        (warehouse) => warehouse.state === 'STARTED',
+    );
+    const pool = started.length > 0 ? started : warehouses;
+    const best = pool.reduce<(typeof pool)[number] | null>(
+        (currentBest, candidate) =>
+            currentBest === null ||
+            warehouseSizeRank(candidate.size) <
+                warehouseSizeRank(currentBest.size)
+                ? candidate
+                : currentBest,
+        null,
+    );
+    return best?.name ?? null;
+};
 
 export const snowflakeIdentifier = (value: string): string =>
     /^[A-Za-z_][A-Za-z0-9_$]*$/.test(value)
@@ -868,6 +922,62 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         } catch {
             schemaRows = [];
         }
+        const databaseSizes = new Map<string, number>();
+        const sizeCandidates = databasesResult.rows
+            .map((rawRow) =>
+                getSnowflakeRowValue(rawRow as Record<string, AnyType>, 'name'),
+            )
+            .filter((name): name is string => Boolean(name))
+            .slice(0, SESSION_DATABASE_SIZE_LIMIT);
+        // INFORMATION_SCHEMA aggregation needs an active warehouse; without a
+        // session default, activate one (prefer already-running, then smallest)
+        if (sizeCandidates.length > 0) {
+            const sessionWarehouseName = getSnowflakeRowValue(
+                defaultsRow,
+                'warehouse',
+            );
+            const sizeWarehouseName =
+                sessionWarehouseName ??
+                pickSizeDiscoveryWarehouse(warehousesResult.rows);
+            if (!sessionWarehouseName && sizeWarehouseName) {
+                try {
+                    await this.executeStatements(
+                        connection,
+                        `USE WAREHOUSE ${snowflakeIdentifier(
+                            sizeWarehouseName,
+                        )}`,
+                    );
+                } catch {
+                    /* size queries will fail and sizes stay null */
+                }
+            }
+        }
+        await sizeCandidates.reduce(
+            (previous, databaseName) =>
+                previous.then(async () => {
+                    try {
+                        const sizeResult = await this.executeStatements(
+                            connection,
+                            `SELECT SUM(bytes) AS "total_bytes" FROM ${snowflakeIdentifier(
+                                databaseName,
+                            )}.INFORMATION_SCHEMA.TABLES WHERE table_type = 'BASE TABLE'`,
+                        );
+                        const totalBytes = getSnowflakeRowNumber(
+                            (sizeResult.rows[0] ?? {}) as Record<
+                                string,
+                                AnyType
+                            >,
+                            'total_bytes',
+                        );
+                        if (totalBytes !== null && totalBytes > 0) {
+                            databaseSizes.set(databaseName, totalBytes);
+                        }
+                    } catch {
+                        /* size stays null for this database */
+                    }
+                }),
+            Promise.resolve(),
+        );
         const defaultRole = getSnowflakeRowValue(defaultsRow, 'role');
         const grantedRoles = [
             ...new Set([
@@ -897,7 +1007,10 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                 schema: getSnowflakeRowValue(defaultsRow, 'schema'),
             },
             inventory: {
-                databases: listSnowflakeDatabases(databasesResult.rows),
+                databases: listSnowflakeDatabases(
+                    databasesResult.rows,
+                    databaseSizes,
+                ),
                 warehouses: listSnowflakeWarehouses(warehousesResult.rows),
                 roles,
                 schemas: listSnowflakeSchemas(schemaRows),

--- a/scripts/dev-fast-start.sh
+++ b/scripts/dev-fast-start.sh
@@ -182,6 +182,12 @@ if test -f .env.development.local; then
     reconcile_env EMAIL_SMTP_PORT 1025
     reconcile_env LDPAT ldpat_deadbeefdeadbeefdeadbeefdeadbeef
     reconcile_env DBT_DEMO_DIR "$(pwd)/examples/full-jaffle-shop-demo"
+    # Default-on (append only, never overwrite): fresh-user signup testing needs
+    # multi-org registration, else POST /api/v1/user 403s once the seed org exists.
+    if ! grep -q "^ALLOW_MULTIPLE_ORGS=" .env.development.local; then
+        echo "ALLOW_MULTIPLE_ORGS=true" >> .env.development.local
+        ENV_PORTS_CHANGED=1
+    fi
     if [ "$ENV_PORTS_CHANGED" = 1 ]; then
         echo "OK: env file reconciled to slot ports (PGPORT=${LD_PG_PORT} PORT=${PORT} FE_PORT=${FE_PORT})"
     else
@@ -218,6 +224,9 @@ EMAIL_SMTP_SENDER_EMAIL=noreply@lightdash.local
 # Dev API access (auto-provisioned PAT from seed data)
 LIGHTDASH_API_URL=http://localhost:${PORT}
 LDPAT=ldpat_deadbeefdeadbeefdeadbeefdeadbeef
+
+# Allow registering fresh users/orgs (signup flow testing)
+ALLOW_MULTIPLE_ORGS=true
 EOF
     echo "DBT_DEMO_DIR=$(pwd)/examples/full-jaffle-shop-demo" >> .env.development.local
     echo "OK: env file created"

--- a/scripts/dev-profiles.json
+++ b/scripts/dev-profiles.json
@@ -1,41 +1,68 @@
 {
-  "$comment": "Instance capabilities for /docker-dev. The AI tier is just Core vs EE: all AI features (agents, writeback, reviews classifier) are bundled into the `ee` profile. GitHub and Slack are integrations (extra credentials / a tunnel), kept as their own toggles. EE requires `github` because AI writeback opens PRs through it, so an EE instance is turnkey for writeback. The start-time multi-select composes these; each pulls in its `requires` transitively, then the union of secrets/flags/env/orgSettings is applied, `reconcile` steps run, and `verify` checks confirm it. `secrets` are keys in scripts/dev-secrets.manifest.json. Addressable by name: `/docker-dev start ee` or `/docker-dev start ee,slack`; no profile = a plain Core instance.",
-  "profiles": {
-    "github": {
-      "label": "GitHub integration (dbt-over-GitHub)",
-      "description": "Connect a project's dbt over the dev GitHub App. Usable standalone on Core (dbt-over-GitHub without AI); also required by EE for writeback PRs.",
-      "secrets": ["GITHUB_APP"],
-      "reconcile": ["github-app-installation", "github-dbt-repo"],
-      "verify": ["github-repos-list"]
+    "$comment": "Instance capabilities for /docker-dev. The AI tier is just Core vs EE: all AI features (agents, writeback, reviews classifier) are bundled into the `ee` profile. GitHub and Slack are integrations (extra credentials / a tunnel), kept as their own toggles. EE requires `github` because AI writeback opens PRs through it, so an EE instance is turnkey for writeback. The start-time multi-select composes these; each pulls in its `requires` transitively, then the union of secrets/flags/env/orgSettings is applied, `reconcile` steps run, and `verify` checks confirm it. `secrets` are keys in scripts/dev-secrets.manifest.json. Addressable by name: `/docker-dev start ee` or `/docker-dev start ee,slack`; no profile = a plain Core instance.",
+    "profiles": {
+        "github": {
+            "label": "GitHub integration (dbt-over-GitHub)",
+            "description": "Connect a project's dbt over the dev GitHub App. Usable standalone on Core (dbt-over-GitHub without AI); also required by EE for writeback PRs.",
+            "secrets": [
+                "GITHUB_APP"
+            ],
+            "reconcile": [
+                "github-app-installation",
+                "github-dbt-repo"
+            ],
+            "verify": [
+                "github-repos-list"
+            ]
+        },
+        "ee": {
+            "label": "Enterprise Edition \u2014 license + all AI (agents, writeback, reviews)",
+            "description": "EE license plus every AI feature: Copilot/agents, AI writeback (opens PRs via GitHub), and the reviews classifier. Bootstraps from the EE base snapshot. Requires the GitHub integration so writeback is turnkey. AI sandboxes default to the LOCAL Docker provider (SANDBOX_PROVIDER=docker) \u2014 no E2B account needed locally; build the images per the Sandboxes section of docker-dev.md.",
+            "ee": true,
+            "requires": [
+                "github"
+            ],
+            "secrets": [
+                "LIGHTDASH_LICENSE_KEY",
+                "ANTHROPIC_API_KEY",
+                "AUTH_GOOGLE_OAUTH2_CLIENT_ID",
+                "AUTH_GOOGLE_OAUTH2_CLIENT_SECRET"
+            ],
+            "env": {
+                "AI_COPILOT_ENABLED": "true",
+                "AI_DEFAULT_PROVIDER": "anthropic",
+                "SANDBOX_PROVIDER": "docker"
+            },
+            "flags": [
+                "ai-writeback",
+                "github-mcp-one-click",
+                "ai-preview-deploy-setup",
+                "homepage-builder"
+            ],
+            "orgSettings": {
+                "ai_agent_reviews_enabled": true
+            },
+            "verify": [
+                "agents-200",
+                "writeback-token"
+            ],
+            "notes": "Sandboxes default to SANDBOX_PROVIDER=docker (local containers). Build the two local images (lightdash-sandbox:local, lightdash-ai-writeback:local) via sandboxes/*/build-local-image.sh before running writeback or data-app generation \u2014 see the Sandboxes section of docker-dev.md. To use E2B instead, add E2B_API_KEY and set SANDBOX_PROVIDER=e2b."
+        },
+        "slack": {
+            "label": "Slack bot (optional add-on)",
+            "description": "Slack app for @mention agent chat. Needs a public tunnel; see the slack-bot-local-setup notes. Not bundled into EE because the tunnel step can't be automated.",
+            "requires": [
+                "ee"
+            ],
+            "secrets": [
+                "SLACK_APP"
+            ],
+            "notes": "SLACK_APP is not yet in the secrets manifest \u2014 confirm the 1Password item name before enabling."
+        }
     },
-    "ee": {
-      "label": "Enterprise Edition — license + all AI (agents, writeback, reviews)",
-      "description": "EE license plus every AI feature: Copilot/agents, AI writeback (opens PRs via GitHub), and the reviews classifier. Bootstraps from the EE base snapshot. Requires the GitHub integration so writeback is turnkey. AI sandboxes default to the LOCAL Docker provider (SANDBOX_PROVIDER=docker) — no E2B account needed locally; build the images per the Sandboxes section of docker-dev.md.",
-      "ee": true,
-      "requires": ["github"],
-      "secrets": [
-        "LIGHTDASH_LICENSE_KEY",
-        "ANTHROPIC_API_KEY",
-        "AUTH_GOOGLE_OAUTH2_CLIENT_ID",
-        "AUTH_GOOGLE_OAUTH2_CLIENT_SECRET"
-      ],
-      "env": { "AI_COPILOT_ENABLED": "true", "AI_DEFAULT_PROVIDER": "anthropic", "SANDBOX_PROVIDER": "docker" },
-      "flags": ["ai-writeback", "github-mcp-one-click", "ai-preview-deploy-setup"],
-      "orgSettings": { "ai_agent_reviews_enabled": true },
-      "verify": ["agents-200", "writeback-token"],
-      "notes": "Sandboxes default to SANDBOX_PROVIDER=docker (local containers). Build the two local images (lightdash-sandbox:local, lightdash-ai-writeback:local) via sandboxes/*/build-local-image.sh before running writeback or data-app generation — see the Sandboxes section of docker-dev.md. To use E2B instead, add E2B_API_KEY and set SANDBOX_PROVIDER=e2b."
-    },
-    "slack": {
-      "label": "Slack bot (optional add-on)",
-      "description": "Slack app for @mention agent chat. Needs a public tunnel; see the slack-bot-local-setup notes. Not bundled into EE because the tunnel step can't be automated.",
-      "requires": ["ee"],
-      "secrets": ["SLACK_APP"],
-      "notes": "SLACK_APP is not yet in the secrets manifest — confirm the 1Password item name before enabling."
+    "snapshots": {
+        "$comment": "Preferred base snapshot per tier, so common instances skip the migrate pass / reconcile. Maintained by dev-fast-start.sh.",
+        "core": "ld-shared_postgres_base",
+        "ee": "ld-shared_postgres_base_ee"
     }
-  },
-  "snapshots": {
-    "$comment": "Preferred base snapshot per tier, so common instances skip the migrate pass / reconcile. Maintained by dev-fast-start.sh.",
-    "core": "ld-shared_postgres_base",
-    "ee": "ld-shared_postgres_base_ee"
-  }
 }


### PR DESCRIPTION
Closes: <!-- no linked issue -->

### Description

A batch of onboarding-flow improvements for the warehouse-connect (dbt-less) journey, plus supporting warehouse-client work. Each concern is a self-contained commit.

**Snowflake CLI-SSO connect**
- Connect codes are now **re-claimable until expiry** — a browser refresh before "Test & save" no longer loses the connection and forces the whole CLI SSO flow to be redone (expired codes are swept on the next mint).
- Discover approximate **database sizes** during connect (best-effort `INFORMATION_SCHEMA.TABLES` sums, capped, each query isolated; activates a warehouse first when the session has none, since the metadata aggregation needs compute).
- The panel **auto-selects** the largest database, the recommended warehouse, and the first schema when the session didn't already carry them, and **persists the connect code** (never credentials) in `sessionStorage` to restore state across a refresh.

**BigQuery SSO onboarding**
- Defaults the auth type to **"Sign in with Google"** in this flow.
- After sign-in, a **separate async endpoint** ranks accessible projects by their largest dataset and the form auto-selects the winning project, then the largest dataset within it. Both apply once via a ref guard (clearing an input never snaps the value back), with a "Recommended · largest" badge. The projects-list endpoint is untouched so the picker stays fast.

**Homepage**
- The "Finish setting up" cards **auto-rotate** every 10s (hover-pauses, resets on manual navigation).
- **Schema-grounded AI question suggestions**: for projects with **no semantic layer** (zero explores) that can run SQL, the homepage's AI chips are grounded in up to 50 real `database.schema.table` names from the indexed catalog, so the agent proposes concrete SQL-answerable questions instead of generic nudges. Projects with a semantic layer are unaffected. Chips now render alongside the checklist rather than only after it's dismissed.

**Onboarding toasts**
- Suppresses the redundant "Testing adaptor" / "project created" job toasts in the warehouse-only flow (which already has a progress screen). Job polling, redirect, and error handling are unchanged; all other flows keep their toasts.

**Auth-change client-state reset** (found while testing this flow)
- When the authenticated user changes, the previous user's client state no longer leaks into the new session. A same-page identity transition clears the React Query cache; `lastProject` in localStorage (which survives the full reloads that login/register/SSO trigger) is dropped whenever the resolved user differs from the persisted previous one, and `useActiveProject` verifies ownership before handing it out so races against early project queries can't refetch the previous user's project. Before: a fresh signup after another user's session fired `ForbiddenError` 403s for the previous user's project on every load and could briefly render their project in the switcher. After: zero cross-user requests across the whole signup flow (verified in-browser against backend logs); a same-user re-login keeps the remembered project, and existing browsers keep theirs across the upgrade.

### Notes
- Generated API artifacts (`routes.ts`/`swagger.json`) are intentionally left out — the repo's pre-commit hook unstages them since the release workflow owns them.
- Verified: all package typechecks, touched-path lint, and 91 unit tests (warehouse clients, connect service/model, BigQuery helper, CLI) pass. Manually exercised the Snowflake connect (db preselect + refresh persistence) and the homepage AI suggestions end-to-end in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
