### PR TITLE
fix(frontend): reset client state when the authenticated user changes [1/4]

### DIFF
--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -10,14 +10,35 @@ import { useParams } from 'react-router';
 import { useOrganization } from './organization/useOrganization';
 import { useProject } from './useProject';
 import { useProjects } from './useProjects';
+import { useAccount } from './user/useAccount';
 
-const LAST_PROJECT_KEY = 'lastProject';
+export const LAST_PROJECT_KEY = 'lastProject';
+export const LAST_USER_KEY = 'lastAuthenticatedUserUuid';
 
 export const useActiveProject = () => {
+    const { data: account } = useAccount();
+    const userUuid =
+        account && 'userUuid' in account.user ? account.user.userUuid : null;
+
     return useQuery<string | null>(
-        ['activeProject'],
-        () => Promise.resolve(localStorage.getItem(LAST_PROJECT_KEY) || null),
+        ['activeProject', userUuid],
+        () => {
+            // lastProject persists across full-page reloads, so it may belong
+            // to a previously signed-in user. Only hand it out once it
+            // provably belongs to the current user (a missing marker means a
+            // browser from before the marker existed and is trusted).
+            if (userUuid) {
+                const storedIdentity = localStorage.getItem(LAST_USER_KEY);
+                if (storedIdentity !== null && storedIdentity !== userUuid) {
+                    return Promise.resolve(null);
+                }
+            }
+            return Promise.resolve(
+                localStorage.getItem(LAST_PROJECT_KEY) || null,
+            );
+        },
         {
+            enabled: account !== undefined,
             cacheTime: 0,
             refetchOnWindowFocus: false,
             refetchOnMount: false,

--- a/packages/frontend/src/providers/App/AppProvider.tsx
+++ b/packages/frontend/src/providers/App/AppProvider.tsx
@@ -1,11 +1,60 @@
-import { type FC } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef, type FC } from 'react';
 import useHealth from '../../hooks/health/useHealth';
+import { LAST_PROJECT_KEY, LAST_USER_KEY } from '../../hooks/useActiveProject';
 import useUser from '../../hooks/user/useUser';
 import AppProviderContext from './context';
 
 const AppProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
     const health = useHealth();
     const user = useUser(!!health?.data?.isAuthenticated);
+    const queryClient = useQueryClient();
+
+    // Central identity-change detector: never let one user's client state leak
+    // into another user's session. Two kinds of staleness are handled
+    // separately. The in-memory query cache only ever holds the previous
+    // user's data on a same-page identity change (tracked with a ref), where
+    // it is cleared. localStorage also survives full reloads — which most auth
+    // flows (login, register, SSO) trigger via window.location — so
+    // auth-scoped keys like lastProject are cleared whenever the resolved user
+    // differs from the persisted previous one; leaving them would make the
+    // new session request the old user's project (403s). Hooking here rather
+    // than each auth mutation covers every path.
+    const sessionIdentityRef = useRef<string | null | undefined>(undefined);
+    useEffect(() => {
+        // undefined => identity not yet resolved (health or user still loading)
+        let currentIdentity: string | null | undefined;
+        if (health.data) {
+            currentIdentity = health.data.isAuthenticated
+                ? user.data?.userUuid
+                : null;
+        }
+        if (currentIdentity === undefined) return;
+
+        const previousSessionIdentity = sessionIdentityRef.current;
+        sessionIdentityRef.current = currentIdentity;
+
+        if (
+            previousSessionIdentity != null &&
+            previousSessionIdentity !== currentIdentity
+        ) {
+            // Same-page transition away from a signed-in user (account switch,
+            // logout, session expiry): drop their cached data. lastProject is
+            // intentionally kept on transition to logged-out so that the same
+            // user logging back in returns to their project; a different user
+            // is handled below.
+            queryClient.clear();
+        }
+
+        if (currentIdentity !== null) {
+            const storedIdentity = localStorage.getItem(LAST_USER_KEY);
+            if (storedIdentity !== null && storedIdentity !== currentIdentity) {
+                localStorage.removeItem(LAST_PROJECT_KEY);
+                void queryClient.invalidateQueries(['activeProject']);
+            }
+            localStorage.setItem(LAST_USER_KEY, currentIdentity);
+        }
+    }, [health.data, user.data?.userUuid, queryClient]);
 
     const value = {
         health,


### PR DESCRIPTION
Part 1 of 4 — a stacked split of #25752 (onboarding polish).

**Reset client state when the authenticated user changes.** Prevents one user's cached client state from leaking into the next session: a same-page identity transition clears the React Query cache; `lastProject` in localStorage (which survives the full reloads login/register/SSO trigger) is dropped when the resolved user differs from the persisted previous one, and `useActiveProject` verifies ownership before handing it out so early project queries can't refetch the previous user's project (403 storms).

Flag-independent and self-contained — safe to review and merge first.

Stack: **① this** → ② new-onboarding flag + signup/org-setup → ③ warehouse-connect → ④ homepage/AI polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
