### PR TITLE
feat: warehouse-connect onboarding — Snowflake CLI-SSO & BigQuery SSO [3/4]

### DIFF
--- a/packages/backend/src/controllers/bigquerySSOController.ts
+++ b/packages/backend/src/controllers/bigquerySSOController.ts
@@ -1,5 +1,6 @@
 import {
     ApiBigqueryDatasets,
+    ApiBigqueryProjectRecommendation,
     ApiBigqueryProjects,
     ApiErrorPayload,
     ApiSuccessEmpty,
@@ -69,6 +70,29 @@ export class BigquerySSOController extends BaseController {
         return {
             status: 'ok',
             results: projects,
+        };
+    }
+
+    /**
+     * Get the recommended BigQuery project based on dataset size
+     * @summary Get BigQuery project recommendation
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/projects/recommendation')
+    @OperationId('GetBigQueryProjectRecommendation')
+    async getBigQueryProjectRecommendation(
+        @Request() req: express.Request,
+    ): Promise<ApiBigqueryProjectRecommendation> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const recommendation = await this.services
+            .getProjectService()
+            .getBigqueryProjectRecommendation(toSessionUser(req.account));
+
+        return {
+            status: 'ok',
+            results: recommendation,
         };
     }
 

--- a/packages/backend/src/models/WarehouseConnectCodeModel.test.ts
+++ b/packages/backend/src/models/WarehouseConnectCodeModel.test.ts
@@ -19,12 +19,14 @@ const dbRow = {
 };
 
 describe('WarehouseConnectCodeModel', () => {
-    it('deletes all prior codes for the user when creating a code', async () => {
+    it('deletes prior codes for the user and expired codes when creating a code', async () => {
         const deleteBuilder = {
             where: vi.fn(),
+            orWhere: vi.fn(),
             delete: vi.fn(async () => 1),
         };
         deleteBuilder.where.mockReturnValue(deleteBuilder);
+        deleteBuilder.orWhere.mockReturnValue(deleteBuilder);
         const insert = vi.fn(async () => [dbRow]);
         const trx = vi
             .fn()
@@ -35,6 +37,7 @@ describe('WarehouseConnectCodeModel', () => {
                 async (callback: (value: typeof trx) => unknown) =>
                     callback(trx),
             ),
+            fn: { now: vi.fn(() => 'database-now') },
         } as unknown as Knex;
         const model = new WarehouseConnectCodeModel({ database });
 
@@ -48,6 +51,11 @@ describe('WarehouseConnectCodeModel', () => {
         expect(deleteBuilder.where).toHaveBeenCalledWith(
             'created_by_user_uuid',
             userUuid,
+        );
+        expect(deleteBuilder.orWhere).toHaveBeenCalledWith(
+            'expires_at',
+            '<=',
+            'database-now',
         );
         expect(deleteBuilder.delete).toHaveBeenCalledOnce();
         expect(insert).toHaveBeenCalledWith({
@@ -152,44 +160,5 @@ describe('WarehouseConnectCodeModel', () => {
             '>',
             'database-now',
         );
-    });
-
-    it('deletes and returns deposited credentials for the creator only once', async () => {
-        const builder = {
-            where: vi.fn(),
-            whereNotNull: vi.fn(),
-            delete: vi.fn(),
-            returning: vi.fn(async () => [dbRow]),
-        };
-        builder.where.mockReturnValue(builder);
-        builder.whereNotNull.mockReturnValue(builder);
-        builder.delete.mockReturnValue(builder);
-        const database = Object.assign(
-            vi.fn(() => builder),
-            {
-                fn: { now: vi.fn(() => 'database-now') },
-            },
-        ) as unknown as Knex;
-        const model = new WarehouseConnectCodeModel({ database });
-
-        await expect(
-            model.deleteDepositedForClaim('hashed-code', userUuid),
-        ).resolves.toEqual({
-            organizationUuid,
-            createdByUserUuid: userUuid,
-            expiresAt,
-            usedAt,
-            encryptedCredentials,
-        });
-        expect(builder.where).toHaveBeenCalledWith(
-            'created_by_user_uuid',
-            userUuid,
-        );
-        expect(builder.whereNotNull).toHaveBeenCalledWith('used_at');
-        expect(builder.whereNotNull).toHaveBeenCalledWith(
-            'encrypted_credentials',
-        );
-        expect(builder.delete).toHaveBeenCalledOnce();
-        expect(builder.returning).toHaveBeenCalledWith('*');
     });
 });

--- a/packages/backend/src/models/WarehouseConnectCodeModel.ts
+++ b/packages/backend/src/models/WarehouseConnectCodeModel.ts
@@ -46,6 +46,7 @@ export class WarehouseConnectCodeModel {
         await this.database.transaction(async (trx) => {
             await trx(WarehouseConnectCodeTableName)
                 .where('created_by_user_uuid', data.createdByUserUuid)
+                .orWhere('expires_at', '<=', this.database.fn.now())
                 .delete();
             await trx(WarehouseConnectCodeTableName).insert({
                 code_hash: data.codeHash,
@@ -79,21 +80,6 @@ export class WarehouseConnectCodeModel {
             .where('code_hash', codeHash)
             .where('expires_at', '>', this.database.fn.now())
             .first();
-        return row ? WarehouseConnectCodeModel.convertRow(row) : null;
-    }
-
-    async deleteDepositedForClaim(
-        codeHash: string,
-        createdByUserUuid: string,
-    ): Promise<WarehouseConnectCodeRecord | null> {
-        const [row] = await this.database(WarehouseConnectCodeTableName)
-            .where('code_hash', codeHash)
-            .where('created_by_user_uuid', createdByUserUuid)
-            .whereNotNull('used_at')
-            .whereNotNull('encrypted_credentials')
-            .where('expires_at', '>', this.database.fn.now())
-            .delete()
-            .returning('*');
         return row ? WarehouseConnectCodeModel.convertRow(row) : null;
     }
 }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -9830,6 +9830,42 @@ export class ProjectService extends BaseService {
         }
     }
 
+    async getBigqueryProjectRecommendation(user: SessionUser) {
+        // At this point, there might not be any projects
+        // so we can't check any permissions here.
+        // Bigquery will handle the permissions
+        const refreshToken = await this.userModel.getRefreshToken(
+            user.userUuid,
+            OpenIdIdentityIssuerType.GOOGLE,
+        );
+        const accessToken = await UserService.generateGoogleAccessToken(
+            refreshToken,
+            'bigquery',
+        );
+
+        try {
+            const projects =
+                await BigqueryWarehouseClient.getProjects(accessToken);
+            return await BigqueryWarehouseClient.getProjectRecommendation(
+                projects,
+                refreshToken,
+            );
+        } catch (error) {
+            this.logger.error(
+                `getBigqueryProjectRecommendation error: ${JSON.stringify(error)}`,
+            );
+
+            if (BigqueryWarehouseClient.isBigqueryError(error)) {
+                throw new WarehouseConnectionError(
+                    'Failed to get a project recommendation from BigQuery',
+                );
+            }
+            throw new UnexpectedServerError(
+                'Failed to get a project recommendation',
+            );
+        }
+    }
+
     // eslint-disable-next-line class-methods-use-this
     getUserQueryTags(account: Account) {
         if (account.isJwtUser()) {

--- a/packages/backend/src/services/WarehouseConnectService/WarehouseConnectService.test.ts
+++ b/packages/backend/src/services/WarehouseConnectService/WarehouseConnectService.test.ts
@@ -57,8 +57,6 @@ const createModelMock = () => ({
     consumeForDeposit: vi.fn<WarehouseConnectCodeModel['consumeForDeposit']>(),
     findDepositedForClaim:
         vi.fn<WarehouseConnectCodeModel['findDepositedForClaim']>(),
-    deleteDepositedForClaim:
-        vi.fn<WarehouseConnectCodeModel['deleteDepositedForClaim']>(),
 });
 
 const testInventory = {
@@ -262,7 +260,6 @@ describe('WarehouseConnectService', () => {
         await expect(service.claim(otherUser, code)).rejects.toThrow(
             NotFoundError,
         );
-        expect(model.deleteDepositedForClaim).not.toHaveBeenCalled();
     });
 
     it('returns pending before credentials are deposited', async () => {
@@ -277,15 +274,11 @@ describe('WarehouseConnectService', () => {
         await expect(service.claim(createUser(), code)).resolves.toEqual({
             status: 'pending',
         });
-        expect(model.deleteDepositedForClaim).not.toHaveBeenCalled();
     });
 
-    it('returns deposited credentials once and then returns NotFound', async () => {
+    it('returns deposited credentials repeatedly until the code expires', async () => {
         const model = createModelMock();
-        model.findDepositedForClaim
-            .mockResolvedValueOnce(depositedRecord)
-            .mockResolvedValueOnce(null);
-        model.deleteDepositedForClaim.mockResolvedValue(depositedRecord);
+        model.findDepositedForClaim.mockResolvedValue(depositedRecord);
         const encryptionUtil = createEncryptionUtilMock();
         const analytics = createAnalyticsMock();
         const service = new WarehouseConnectService({
@@ -295,15 +288,19 @@ describe('WarehouseConnectService', () => {
         });
         const user = createUser();
 
-        await expect(service.claim(user, code)).resolves.toEqual({
+        const expectedResult = {
             status: 'deposited',
             credentials,
             inventory: testInventory,
-        });
-        await expect(service.claim(user, code)).rejects.toThrow(NotFoundError);
-        expect(model.deleteDepositedForClaim).toHaveBeenCalledWith(
+        };
+        await expect(service.claim(user, code)).resolves.toEqual(
+            expectedResult,
+        );
+        await expect(service.claim(user, code)).resolves.toEqual(
+            expectedResult,
+        );
+        expect(model.findDepositedForClaim).toHaveBeenCalledWith(
             hashWarehouseConnectCode(code),
-            user.userUuid,
         );
         expect(encryptionUtil.decrypt).toHaveBeenCalledWith(
             encryptedCredentials,

--- a/packages/backend/src/services/WarehouseConnectService/WarehouseConnectService.ts
+++ b/packages/backend/src/services/WarehouseConnectService/WarehouseConnectService.ts
@@ -40,10 +40,7 @@ const isDurableSnowflakeCredential = (
 
 type WarehouseConnectCodeModelMethods = Pick<
     WarehouseConnectCodeModel,
-    | 'create'
-    | 'consumeForDeposit'
-    | 'findDepositedForClaim'
-    | 'deleteDepositedForClaim'
+    'create' | 'consumeForDeposit' | 'findDepositedForClaim'
 >;
 
 type EncryptionUtilMethods = Pick<EncryptionUtil, 'encrypt' | 'decrypt'>;
@@ -184,27 +181,18 @@ export class WarehouseConnectService extends BaseService {
             return { status: 'pending' };
         }
 
-        const claimed =
-            await this.warehouseConnectCodeModel.deleteDepositedForClaim(
-                codeHash,
-                user.userUuid,
-            );
-        if (claimed === null || claimed.encryptedCredentials === null) {
-            throw new NotFoundError('Warehouse connect code not found');
-        }
-
         try {
             const deposit = JSON.parse(
-                this.encryptionUtil.decrypt(claimed.encryptedCredentials),
+                this.encryptionUtil.decrypt(connectCode.encryptedCredentials),
             ) as {
                 credentials: DepositSnowflakeCredentials;
                 inventory: WarehouseConnectInventory | null;
             };
             this.analytics.track({
-                userId: claimed.createdByUserUuid,
+                userId: connectCode.createdByUserUuid,
                 event: 'warehouse_connect.claimed',
                 properties: {
-                    organizationId: claimed.organizationUuid,
+                    organizationId: connectCode.organizationUuid,
                 },
             });
             return {

--- a/packages/cli/src/handlers/connectSnowflake.test.ts
+++ b/packages/cli/src/handlers/connectSnowflake.test.ts
@@ -39,6 +39,7 @@ const discovery: SnowflakeSessionDiscovery = {
                 name: 'analytics',
                 comment: 'Analytics data',
                 kind: 'STANDARD',
+                sizeBytes: 1234,
             },
         ],
         warehouses: [
@@ -112,7 +113,9 @@ const getDependencies = () => ({
 });
 
 const depositInventory = {
-    databases: [{ name: 'analytics', comment: 'Analytics data' }],
+    databases: [
+        { name: 'analytics', comment: 'Analytics data', sizeBytes: 1234 },
+    ],
     warehouses: [{ name: 'lightdash_wh', size: 'X-Small', state: 'STARTED' }],
     roles: [
         { name: 'lightdash_role', isDefault: true },
@@ -264,6 +267,7 @@ describe('connectSnowflakeHandler', () => {
                     name,
                     comment: null,
                     kind: null,
+                    sizeBytes: null,
                 })),
                 warehouses: inventoryNames.map((name) => ({
                     name,
@@ -294,7 +298,7 @@ describe('connectSnowflakeHandler', () => {
         expect(request.inventory).toEqual({
             databases: inventoryNames
                 .slice(0, 100)
-                .map((name) => ({ name, comment: null })),
+                .map((name) => ({ name, comment: null, sizeBytes: null })),
             warehouses: inventoryNames
                 .slice(0, 100)
                 .map((name) => ({ name, size: null, state: null })),

--- a/packages/cli/src/handlers/connectSnowflake.ts
+++ b/packages/cli/src/handlers/connectSnowflake.ts
@@ -184,7 +184,11 @@ const buildInventory = (
     }
     return {
         databases: discovery.inventory.databases
-            .map(({ name, comment }) => ({ name, comment }))
+            .map(({ name, comment, sizeBytes }) => ({
+                name,
+                comment,
+                sizeBytes,
+            }))
             .slice(0, 100),
         warehouses: discovery.inventory.warehouses
             .map(({ name, size, state }) => ({ name, size, state }))

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -101,6 +101,7 @@ import {
 import { type ApiGetSpotlightTableConfig } from './api/spotlight';
 import { type ApiSuccessEmpty } from './api/success';
 import { type Account } from './auth';
+import { type BigqueryProjectRecommendation } from './bigQuerySSO';
 import {
     type ApiCatalogAnalyticsResults,
     type ApiCatalogMetadataResults,
@@ -1025,6 +1026,7 @@ export type ProjectSavedChartStatus = boolean;
 export type ApiFlashResults = Record<string, string[]>;
 
 type ApiResults =
+    | BigqueryProjectRecommendation
     | ApiWarehouseConnectCodeResponse['results']
     | ApiWarehouseConnectCodeClaimResponse['results']
     | ApiQueryResults

--- a/packages/common/src/types/bigQuerySSO.ts
+++ b/packages/common/src/types/bigQuerySSO.ts
@@ -2,6 +2,7 @@ export type BigqueryDataset = {
     projectId: string;
     location: string | undefined;
     datasetId: string;
+    sizeBytes?: number | null;
 };
 
 export type ApiBigqueryDatasets = {
@@ -17,4 +18,13 @@ export type BigqueryProject = {
 export type ApiBigqueryProjects = {
     status: 'ok';
     results: BigqueryProject[];
+};
+
+export type BigqueryProjectRecommendation = {
+    projectId: string | null;
+};
+
+export type ApiBigqueryProjectRecommendation = {
+    status: 'ok';
+    results: BigqueryProjectRecommendation;
 };

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -298,14 +298,6 @@ export enum FeatureFlags {
     NewOnboarding = 'new-onboarding',
 
     /**
-     * @deprecated Temporary shims kept only so this stacked slice compiles
-     * before the warehouse slice converts its consumers; removed there.
-     */
-    WarehouseConnectOnboarding = 'warehouse-connect-onboarding',
-    OrganizationSetupPage = 'organization-setup-page',
-    EmailOnlySignup = 'email-only-signup',
-
-    /**
      * Cloud-only: let an organization send report/notification emails from
      * their own verified domain (email whitelabelling) instead of the
      * Lightdash address. Gates both the setup UI and the admin API. Requires a

--- a/packages/common/src/types/warehouseConnectCode.ts
+++ b/packages/common/src/types/warehouseConnectCode.ts
@@ -19,7 +19,11 @@ export type DepositSnowflakeCredentials = Omit<
     >;
 
 export type WarehouseConnectInventory = {
-    databases: { name: string; comment: string | null }[];
+    databases: {
+        name: string;
+        comment: string | null;
+        sizeBytes?: number | null;
+    }[];
     warehouses: {
         name: string;
         size: string | null;

--- a/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
@@ -40,7 +40,9 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
     const { user, health } = useApp();
     const [createProjectJobId, setCreateProjectJobId] = useState<string>();
     const { activeJobIsRunning, activeJobId, activeJob } = useActiveJob();
-    const { isLoading: isSaving, mutateAsync } = useCreateMutation();
+    const { isLoading: isSaving, mutateAsync } = useCreateMutation({
+        quietJobToast: warehouseOnly,
+    });
     const onProjectError = useOnProjectError();
 
     const warehouseType = selectedWarehouse ?? WarehouseTypes.BIGQUERY;

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectConnectMethod.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectConnectMethod.tsx
@@ -35,7 +35,7 @@ const SelectConnectMethod: FC<SelectConnectMethodProps> = ({
     const { track } = useTracking();
 
     const warehouseConnectFlag = useServerFeatureFlag(
-        FeatureFlags.WarehouseConnectOnboarding,
+        FeatureFlags.NewOnboarding,
     );
     const isWarehouseConnectEnabled =
         warehouseConnectFlag.data?.enabled ?? false;

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -1,8 +1,13 @@
-import { BigqueryAuthenticationType, WarehouseTypes } from '@lightdash/common';
+import {
+    BigqueryAuthenticationType,
+    FeatureFlags,
+    WarehouseTypes,
+} from '@lightdash/common';
 import {
     TextInput,
     Anchor,
     Autocomplete,
+    Badge,
     Button,
     FileInput,
     Group,
@@ -17,15 +22,24 @@ import {
 import { NumberInput, Tooltip } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconCheck, IconExclamationCircle } from '@tabler/icons-react';
-import { useState, type ChangeEvent, type FC, type ReactNode } from 'react';
+import {
+    useEffect,
+    useRef,
+    useState,
+    type ChangeEvent,
+    type FC,
+    type ReactNode,
+} from 'react';
 import { useToggle } from 'react-use';
 import { useGoogleLoginPopup } from '../../../hooks/gdrive/useGdrive';
 import useHealth from '../../../hooks/health/useHealth';
 import {
     useBigqueryDatasets,
+    useBigqueryProjectRecommendation,
     useBigqueryProjects,
     useIsBigQueryAuthenticated,
 } from '../../../hooks/useBigquerySSO';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../../common/MantineIcon';
 import DocumentationHelpButton from '../../DocumentationHelpButton';
 import FormCollapseButton from '../FormCollapseButton';
@@ -34,6 +48,7 @@ import FormSection from '../Inputs/FormSection';
 import StartOfWeekSelect from '../Inputs/StartOfWeekSelect';
 import { useProjectFormContext } from '../useProjectFormContext';
 import classes from './BigQueryForm.module.css';
+import { largestDatasetName } from './bigQuerySso';
 import DataTimezoneField from './DataTimezoneField';
 import { BigQueryDefaultValues } from './defaultValues';
 
@@ -78,6 +93,39 @@ export const BigQuerySchemaInput: FC<{
     const datasetField = form.getInputProps('warehouse.dataset');
     const hasProject =
         typeof debouncedProject === 'string' && debouncedProject.length > 0;
+    const recommendedDataset = largestDatasetName(datasets ?? []);
+    const hasAppliedRecommendation = useRef(false);
+
+    useEffect(() => {
+        hasAppliedRecommendation.current = false;
+    }, [debouncedProject]);
+
+    useEffect(() => {
+        if (
+            hasAppliedRecommendation.current ||
+            !isSso ||
+            !isAuthenticated ||
+            datasetField.value ||
+            !recommendedDataset
+        ) {
+            return;
+        }
+        hasAppliedRecommendation.current = true;
+        const selectedDataset = datasets?.find(
+            (dataset) => dataset.datasetId === recommendedDataset,
+        );
+        form.setFieldValue('warehouse.dataset', recommendedDataset);
+        if (selectedDataset?.location) {
+            form.setFieldValue('warehouse.location', selectedDataset.location);
+        }
+    }, [
+        datasetField.value,
+        datasets,
+        form,
+        isAuthenticated,
+        isSso,
+        recommendedDataset,
+    ]);
 
     if (!isSso || !isAuthenticated) {
         return (
@@ -120,6 +168,23 @@ export const BigQuerySchemaInput: FC<{
             }}
             disabled={disabled || !hasProject}
             data={datasets?.map((dataset) => dataset.datasetId) ?? []}
+            renderOption={({ option }) => (
+                <Group justify="space-between" wrap="nowrap" gap="xs" w="100%">
+                    <Text size="sm" truncate="end">
+                        {option.value}
+                    </Text>
+                    {option.value === recommendedDataset ? (
+                        <Badge
+                            size="xs"
+                            color="green"
+                            variant="light"
+                            radius="sm"
+                        >
+                            Recommended · largest
+                        </Badge>
+                    ) : null}
+                </Group>
+            )}
             maxDropdownHeight={220}
             rightSectionPointerEvents={datasetsError ? 'all' : 'none'}
             rightSection={
@@ -183,7 +248,9 @@ const BigQueryForm: FC<{
     const isAuthenticated = data !== undefined && bigqueryAuthError === null;
     const form = useFormContext();
     const project = form.getInputProps('warehouse.project');
+    const hasAppliedProjectRecommendation = useRef(false);
     const [debouncedProject] = useDebouncedValue(project.value, 300);
+    const { savedProject } = useProjectFormContext();
     const health = useHealth();
     const isAdcEnabled = health.data?.auth.google?.enableGCloudADC;
     // Fetching databases can only happen if user is authenticated
@@ -203,9 +270,17 @@ const BigQueryForm: FC<{
         isLoading: isLoadingProjects,
         error: projectsError,
     } = useBigqueryProjects(isAuthenticated && isSso);
+    const shouldFetchProjectRecommendation =
+        isAuthenticated &&
+        isSso &&
+        !savedProject &&
+        !project.value &&
+        !hasAppliedProjectRecommendation.current;
+    const { data: projectRecommendation } = useBigqueryProjectRecommendation(
+        shouldFetchProjectRecommendation,
+    );
     const [isOpen, toggleOpen] = useToggle(false);
     const [temporaryFile, setTemporaryFile] = useState<File | null>(null);
-    const { savedProject } = useProjectFormContext();
     const requireSecrets: boolean = !(
         savedProject?.warehouseConnection?.type === WarehouseTypes.BIGQUERY &&
         savedProject?.warehouseConnection?.authenticationType ===
@@ -222,6 +297,46 @@ const BigQueryForm: FC<{
 
     // savedProject might not be loaded when the form is rendered, so we need to set the defaultValue also on a hook
     const defaultAuthenticationType = BigqueryAuthenticationType.SSO;
+
+    const warehouseConnectFlag = useServerFeatureFlag(
+        FeatureFlags.NewOnboarding,
+    );
+    const shouldDefaultToSso =
+        !savedProject && (warehouseConnectFlag.data?.enabled ?? false);
+    useEffect(() => {
+        if (shouldDefaultToSso && !form.isTouched()) {
+            form.setFieldValue(
+                'warehouse.authenticationType',
+                BigqueryAuthenticationType.SSO,
+            );
+        }
+    }, [shouldDefaultToSso, form]);
+
+    useEffect(() => {
+        if (
+            hasAppliedProjectRecommendation.current ||
+            !isAuthenticated ||
+            !isSso ||
+            savedProject ||
+            projectRecommendation === undefined
+        ) {
+            return;
+        }
+        hasAppliedProjectRecommendation.current = true;
+        if (!project.value && projectRecommendation.projectId) {
+            form.setFieldValue(
+                'warehouse.project',
+                projectRecommendation.projectId,
+            );
+        }
+    }, [
+        form,
+        isAuthenticated,
+        isSso,
+        project.value,
+        projectRecommendation,
+        savedProject,
+    ]);
 
     const { mutate: openLoginPopup } = useGoogleLoginPopup(
         'bigquery',
@@ -333,7 +448,11 @@ const BigQueryForm: FC<{
                                     : 'Type or select a project'
                             }
                             required
-                            {...form.getInputProps('warehouse.project')}
+                            {...project}
+                            onChange={(value) => {
+                                hasAppliedProjectRecommendation.current = true;
+                                project.onChange(value);
+                            }}
                             disabled={disabled}
                             labelProps={{ style: { marginTop: '8px' } }}
                             w={hasDatasets ? '90%' : '100%'}
@@ -345,9 +464,31 @@ const BigQueryForm: FC<{
                                         projectItem.projectId === option.value,
                                 );
 
-                                return projectOption?.friendlyName
-                                    ? `${projectOption.friendlyName} (${projectOption.projectId})`
-                                    : option.value;
+                                return (
+                                    <Group
+                                        justify="space-between"
+                                        wrap="nowrap"
+                                        gap="xs"
+                                        w="100%"
+                                    >
+                                        <Text size="sm" truncate="end">
+                                            {projectOption?.friendlyName
+                                                ? `${projectOption.friendlyName} (${projectOption.projectId})`
+                                                : option.value}
+                                        </Text>
+                                        {option.value ===
+                                        projectRecommendation?.projectId ? (
+                                            <Badge
+                                                size="xs"
+                                                color="green"
+                                                variant="light"
+                                                radius="sm"
+                                            >
+                                                Recommended · largest
+                                            </Badge>
+                                        ) : null}
+                                    </Group>
+                                );
                             }}
                             rightSectionPointerEvents={
                                 projectsError ? 'all' : 'none'

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoModeContext.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoModeContext.ts
@@ -1,0 +1,9 @@
+import { createContext, useContext } from 'react';
+
+export const CliSsoModeContext = createContext(false);
+export const SetCliSsoModeContext = createContext<(value: boolean) => void>(
+    () => {},
+);
+
+export const useSnowflakeCliSsoMode = () => useContext(CliSsoModeContext);
+export const useSetSnowflakeCliSsoMode = () => useContext(SetCliSsoModeContext);

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoModeProvider.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoModeProvider.tsx
@@ -1,0 +1,18 @@
+import { useState, type FC, type PropsWithChildren } from 'react';
+import {
+    CliSsoModeContext,
+    SetCliSsoModeContext,
+} from './SnowflakeCliSsoModeContext';
+
+export const SnowflakeCliSsoModeProvider: FC<PropsWithChildren> = ({
+    children,
+}) => {
+    const [isCliSsoMode, setIsCliSsoMode] = useState(false);
+    return (
+        <SetCliSsoModeContext.Provider value={setIsCliSsoMode}>
+            <CliSsoModeContext.Provider value={isCliSsoMode}>
+                {children}
+            </CliSsoModeContext.Provider>
+        </SetCliSsoModeContext.Provider>
+    );
+};

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoPanel.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoPanel.tsx
@@ -31,10 +31,46 @@ import MantineIcon from '../../common/MantineIcon';
 import { useFormContext } from '../formContext';
 import {
     buildSnowflakeConnectCommand,
+    largestDatabaseName,
     recommendedWarehouseName,
     SNOWFLAKE_CLI_INSTALL_COMMAND,
     warehouseSecondaryText,
 } from './snowflakeCliSso';
+
+const STORED_CODE_KEY = 'snowflakeCliSsoConnectCode';
+
+const readStoredCode = (): { code: string; expiresAt: string } | null => {
+    try {
+        const raw = sessionStorage.getItem(STORED_CODE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        if (
+            typeof parsed?.code === 'string' &&
+            typeof parsed?.expiresAt === 'string'
+        ) {
+            return parsed;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+};
+
+const readValidStoredCode = (): {
+    code: string;
+    secondsRemaining: number;
+} | null => {
+    const stored = readStoredCode();
+    if (!stored) return null;
+    const secondsRemaining = Math.round(
+        (new Date(stored.expiresAt).getTime() - Date.now()) / 1000,
+    );
+    if (secondsRemaining <= 0) {
+        sessionStorage.removeItem(STORED_CODE_KEY);
+        return null;
+    }
+    return { code: stored.code, secondsRemaining };
+};
 
 const CopyableCommand: FC<{ command: string }> = ({ command }) => (
     <Group gap="xs" align="flex-start" wrap="nowrap">
@@ -104,9 +140,12 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
     const form = useFormContext();
     const siteUrl = health.data?.siteUrl ?? '';
     const mint = useMintWarehouseConnectCode();
-    const [code, setCode] = useState<string | null>(null);
+    const [storedCode] = useState(() =>
+        connectedCredentials === null ? readValidStoredCode() : null,
+    );
+    const [code, setCode] = useState<string | null>(storedCode?.code ?? null);
     const [secondsRemaining, setSecondsRemaining] = useState<number | null>(
-        null,
+        storedCode?.secondsRemaining ?? null,
     );
     const [claimed, setClaimed] = useState(false);
     const [inventory, setInventory] =
@@ -123,8 +162,42 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
             setClaimed(true);
             setInventory(claim.data.inventory);
             onDeposited(claim.data.credentials);
+            const depositedInventory = claim.data.inventory;
+            const selectedDatabase =
+                claim.data.credentials.database ??
+                largestDatabaseName(depositedInventory?.databases ?? []) ??
+                undefined;
+            if (!claim.data.credentials.database && selectedDatabase) {
+                form.setFieldValue('warehouse.database', selectedDatabase);
+            }
+            if (!claim.data.credentials.warehouse) {
+                const recommended = recommendedWarehouseName(
+                    depositedInventory?.warehouses ?? [],
+                );
+                if (recommended) {
+                    form.setFieldValue('warehouse.warehouse', recommended);
+                }
+            }
+            if (!claim.data.credentials.schema) {
+                const firstSchema = (depositedInventory?.schemas ?? []).find(
+                    (schema) =>
+                        !selectedDatabase ||
+                        schema.database === selectedDatabase,
+                )?.name;
+                if (firstSchema) {
+                    form.setFieldValue('warehouse.schema', firstSchema);
+                }
+            }
         }
-    }, [claimed, claim.data, onDeposited]);
+    }, [claimed, claim.data, onDeposited, form]);
+
+    useEffect(() => {
+        if (claim.error) {
+            sessionStorage.removeItem(STORED_CODE_KEY);
+            setCode(null);
+            setSecondsRemaining(null);
+        }
+    }, [claim.error]);
 
     useEffect(() => {
         if (secondsRemaining === null || secondsRemaining <= 0)
@@ -141,6 +214,17 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
         const result = await mint.mutateAsync();
         setClaimed(false);
         setCode(result.code);
+        try {
+            sessionStorage.setItem(
+                STORED_CODE_KEY,
+                JSON.stringify({
+                    code: result.code,
+                    expiresAt: result.expiresAt,
+                }),
+            );
+        } catch {
+            // best-effort persistence; refresh recovery just won't apply
+        }
         const expiry = new Date(result.expiresAt).getTime();
         setSecondsRemaining(
             Math.max(0, Math.round((expiry - Date.now()) / 1000)),
@@ -171,6 +255,9 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
         const recommendedWarehouse = recommendedWarehouseName(
             inventory?.warehouses ?? [],
         );
+        const recommendedDatabase = largestDatabaseName(
+            inventory?.databases ?? [],
+        );
         const schemaOptions = [
             ...new Set(
                 (inventory?.schemas ?? [])
@@ -186,9 +273,13 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
             twoLineOption(
                 option.label,
                 databaseMeta.get(option.value)?.comment ?? null,
-                option.value === connectedCredentials.database
-                    ? defaultBadge
-                    : null,
+                option.value === connectedCredentials.database ? (
+                    defaultBadge
+                ) : option.value === recommendedDatabase ? (
+                    <Badge size="xs" color="green" variant="light" radius="sm">
+                        Recommended · largest
+                    </Badge>
+                ) : null,
             );
         const renderWarehouseOption = ({
             option,

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -47,6 +47,10 @@ import { getWarehouseIcon } from '../ProjectConnectFlow/utils';
 import { useProjectFormContext } from '../useProjectFormContext';
 import DataTimezoneField from './DataTimezoneField';
 import { SnowflakeDefaultValues } from './defaultValues';
+import {
+    useSetSnowflakeCliSsoMode,
+    useSnowflakeCliSsoMode,
+} from './SnowflakeCliSsoModeContext';
 import SnowflakeCliSsoPanel from './SnowflakeCliSsoPanel';
 import {
     CLI_SSO_LABEL,
@@ -65,6 +69,10 @@ export const SnowflakeSchemaInput: FC<{
     description?: ReactNode;
 }> = ({ disabled, description }) => {
     const form = useFormContext();
+    const isCliSsoMode = useSnowflakeCliSsoMode();
+    if (isCliSsoMode) {
+        return null;
+    }
     return (
         <TextInput
             name="warehouse.schema"
@@ -146,11 +154,12 @@ const SnowflakeForm: FC<{
     const isEditMode = !!savedProject;
 
     const warehouseConnectFlag = useServerFeatureFlag(
-        FeatureFlags.WarehouseConnectOnboarding,
+        FeatureFlags.NewOnboarding,
     );
     const isCliSsoEnabled =
         !savedProject && (warehouseConnectFlag.data?.enabled ?? false);
-    const [isCliSsoMode, setIsCliSsoMode] = useState(false);
+    const isCliSsoMode = useSnowflakeCliSsoMode();
+    const setIsCliSsoMode = useSetSnowflakeCliSsoMode();
     const userSelectedAuthType = useRef(false);
     const [cliSsoCredentials, setCliSsoCredentials] =
         useState<DepositSnowflakeCredentials | null>(null);
@@ -186,7 +195,7 @@ const SnowflakeForm: FC<{
         if (isCliSsoEnabled && !userSelectedAuthType.current) {
             setIsCliSsoMode(true);
         }
-    }, [isCliSsoEnabled]);
+    }, [isCliSsoEnabled, setIsCliSsoMode]);
     const authenticationType: SnowflakeAuthenticationType =
         form.values.warehouse.authenticationType ?? defaultAuthType;
 
@@ -329,7 +338,7 @@ const SnowflakeForm: FC<{
                         <TextInput
                             name="warehouse.account"
                             label="Account"
-                            placeholder="AAA99827"
+                            placeholder="xy12345.eu-west-2.aws"
                             description={
                                 isCliSsoMode && cliSsoCredentials !== null
                                     ? 'Your CLI SSO connection is bound to this account.'

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/bigQuerySso.test.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/bigQuerySso.test.ts
@@ -1,0 +1,47 @@
+import { largestDatasetName } from './bigQuerySso';
+
+describe('largestDatasetName', () => {
+    it('returns the largest dataset with a positive known size', () => {
+        expect(
+            largestDatasetName([
+                {
+                    projectId: 'project',
+                    datasetId: 'unknown',
+                    location: 'EU',
+                    sizeBytes: null,
+                },
+                {
+                    projectId: 'project',
+                    datasetId: 'largest',
+                    location: 'EU',
+                    sizeBytes: 200,
+                },
+                {
+                    projectId: 'project',
+                    datasetId: 'smaller',
+                    location: 'EU',
+                    sizeBytes: 100,
+                },
+            ]),
+        ).toBe('largest');
+    });
+
+    it('returns null when no positive size is known', () => {
+        expect(
+            largestDatasetName([
+                {
+                    projectId: 'project',
+                    datasetId: 'unknown',
+                    location: 'EU',
+                    sizeBytes: null,
+                },
+                {
+                    projectId: 'project',
+                    datasetId: 'empty',
+                    location: 'EU',
+                    sizeBytes: 0,
+                },
+            ]),
+        ).toBeNull();
+    });
+});

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/bigQuerySso.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/bigQuerySso.ts
@@ -1,0 +1,16 @@
+import { type BigqueryDataset } from '@lightdash/common';
+
+export const largestDatasetName = (
+    datasets: BigqueryDataset[],
+): string | null => {
+    let largestName: string | null = null;
+    let largestSize = 0;
+    datasets.forEach((dataset) => {
+        const size = dataset.sizeBytes ?? 0;
+        if (size > largestSize) {
+            largestName = dataset.datasetId;
+            largestSize = size;
+        }
+    });
+    return largestName;
+};

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/snowflakeCliSso.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/snowflakeCliSso.ts
@@ -61,6 +61,22 @@ export const recommendedWarehouseName = (
         : (best as WarehouseConnectInventory['warehouses'][number]).name;
 };
 
+export const largestDatabaseName = (
+    databases: WarehouseConnectInventory['databases'],
+): string | null => {
+    let best: WarehouseConnectInventory['databases'][number] | null = null;
+    databases.forEach((database) => {
+        const size = database.sizeBytes ?? 0;
+        if (size <= 0) return;
+        if (best === null || size > (best.sizeBytes ?? 0)) {
+            best = database;
+        }
+    });
+    return best === null
+        ? null
+        : (best as WarehouseConnectInventory['databases'][number]).name;
+};
+
 export const buildSnowflakeConnectCommand = ({
     siteUrl,
     code,

--- a/packages/frontend/src/components/ProjectConnection/WarehouseSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseSettingsForm.tsx
@@ -1,5 +1,5 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { Select } from '@mantine-8/core';
+import { Select, Stack } from '@mantine-8/core';
 import { type FC, type ReactNode } from 'react';
 import { useFormContext } from './formContext';
 import AthenaForm from './WarehouseForms/AthenaForm';
@@ -10,6 +10,7 @@ import { warehouseDefaultValues } from './WarehouseForms/defaultValues';
 import DuckdbForm from './WarehouseForms/DuckdbForm';
 import PostgresForm from './WarehouseForms/PostgresForm';
 import RedshiftForm from './WarehouseForms/RedshiftForm';
+import { SnowflakeCliSsoModeProvider } from './WarehouseForms/SnowflakeCliSsoModeProvider';
 import SnowflakeForm from './WarehouseForms/SnowflakeForm';
 import TrinoForm from './WarehouseForms/TrinoForm';
 
@@ -56,37 +57,38 @@ const WarehouseSettingsForm: FC<WarehouseSettingsFormProps> = ({
     const WarehouseForm = WarehouseTypeForms[warehouseType];
 
     return (
-        <div
-            style={{ height: '100%', display: 'flex', flexDirection: 'column' }}
-        >
-            {isProjectUpdate && (
-                <Select
-                    allowDeselect={false}
-                    defaultValue={WarehouseTypes.BIGQUERY}
-                    label="Type"
-                    data={Object.entries(WarehouseTypeLabels).map(
-                        ([value, label]) => ({
-                            value,
-                            label,
-                        }),
-                    )}
-                    required
-                    {...form.getInputProps('warehouse.type')}
-                    onChange={(value) => {
-                        if (!value) return;
-                        const warehouseType = value as WarehouseTypes;
+        <SnowflakeCliSsoModeProvider>
+            <Stack h="100%" gap={0}>
+                {isProjectUpdate && (
+                    <Select
+                        allowDeselect={false}
+                        defaultValue={WarehouseTypes.BIGQUERY}
+                        label="Type"
+                        data={Object.entries(WarehouseTypeLabels).map(
+                            ([value, label]) => ({
+                                value,
+                                label,
+                            }),
+                        )}
+                        required
+                        {...form.getInputProps('warehouse.type')}
+                        onChange={(value) => {
+                            if (!value) return;
+                            const warehouseType = value as WarehouseTypes;
 
-                        form.setValues({
-                            warehouse: warehouseDefaultValues[warehouseType],
-                        });
-                    }}
-                    disabled={disabled}
-                />
-            )}
+                            form.setValues({
+                                warehouse:
+                                    warehouseDefaultValues[warehouseType],
+                            });
+                        }}
+                        disabled={disabled}
+                    />
+                )}
 
-            <WarehouseForm disabled={disabled} />
-            {children}
-        </div>
+                <WarehouseForm disabled={disabled} />
+                {children}
+            </Stack>
+        </SnowflakeCliSsoModeProvider>
     );
 };
 

--- a/packages/frontend/src/hooks/useBigquerySSO.ts
+++ b/packages/frontend/src/hooks/useBigquerySSO.ts
@@ -1,5 +1,6 @@
 import {
     type ApiBigqueryDatasets,
+    type ApiBigqueryProjectRecommendation,
     type ApiBigqueryProjects,
     type ApiError,
     type ApiSuccessEmpty,
@@ -33,6 +34,21 @@ export const useBigqueryProjects = (isAuthenticated: boolean) => {
         queryKey: ['bigquery-projects'],
         queryFn: getProjects,
         enabled: isAuthenticated,
+    });
+};
+
+const getProjectRecommendation = async () =>
+    lightdashApi<ApiBigqueryProjectRecommendation['results']>({
+        url: `/bigquery/sso/projects/recommendation`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useBigqueryProjectRecommendation = (enabled: boolean) => {
+    return useQuery<ApiBigqueryProjectRecommendation['results'], ApiError>({
+        queryKey: ['bigquery-project-recommendation'],
+        queryFn: getProjectRecommendation,
+        enabled,
     });
 };
 

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -123,8 +123,8 @@ export const useUpdateMutation = (uuid: string) => {
     );
 };
 
-export const useCreateMutation = () => {
-    const { setActiveJobId } = useActiveJob();
+export const useCreateMutation = (options?: { quietJobToast?: boolean }) => {
+    const { setActiveJobId, setQuietActiveJobId } = useActiveJob();
     const { showToastApiError } = useToaster();
     return useMutation<ApiJobStartedResults, ApiError, CreateProject>(
         (data) => createProject(data),
@@ -132,7 +132,11 @@ export const useCreateMutation = () => {
             mutationKey: ['project_create'],
             retry: 3,
             onSuccess: (data) => {
-                setActiveJobId(data.jobUuid);
+                if (options?.quietJobToast) {
+                    setQuietActiveJobId(data.jobUuid);
+                } else {
+                    setActiveJobId(data.jobUuid);
+                }
             },
             onError: ({ error }) => {
                 showToastApiError({

--- a/packages/frontend/src/providers/ActiveJob/ActiveJobProvider.tsx
+++ b/packages/frontend/src/providers/ActiveJob/ActiveJobProvider.tsx
@@ -7,7 +7,13 @@ import {
 import { notifications } from '@mantine/notifications';
 import { IconArrowRight } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useState, type FC } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useState,
+    type FC,
+    type SetStateAction,
+} from 'react';
 import useToaster from '../../hooks/toaster/useToaster';
 import {
     jobStatusLabel,
@@ -19,9 +25,23 @@ import Context from './context';
 
 const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
     const [isJobsDrawerOpen, setIsJobsDrawerOpen] = useState(false);
-    const [activeJobId, setActiveJobId] = useState();
+    const [activeJobId, setActiveJobIdState] = useState<string | undefined>();
+    const [isQuietJob, setIsQuietJob] = useState(false);
     const queryClient = useQueryClient();
     const { showToastSuccess, showToastApiError, showToastInfo } = useToaster();
+
+    const setActiveJobId = useCallback(
+        (jobId: SetStateAction<string | undefined>) => {
+            setIsQuietJob(false);
+            setActiveJobIdState(jobId);
+        },
+        [],
+    );
+
+    const setQuietActiveJobId = useCallback((jobId: string) => {
+        setIsQuietJob(true);
+        setActiveJobIdState(jobId);
+    }, []);
 
     const toastJobStatus = useCallback(
         async (job: Job | undefined) => {
@@ -40,12 +60,14 @@ const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
                         await queryClient.invalidateQueries(['organization']);
                     }
                     await queryClient.invalidateQueries(['parameters']);
+                    if (isQuietJob) break;
                     showToastSuccess({
                         key: TOAST_KEY_FOR_REFRESH_JOB,
                         title: toastTitle,
                     });
                     break;
                 case 'RUNNING':
+                    if (isQuietJob) break;
                     showToastInfo({
                         key: TOAST_KEY_FOR_REFRESH_JOB,
                         title: toastTitle,
@@ -68,7 +90,13 @@ const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
                     setIsJobsDrawerOpen(true);
             }
         },
-        [showToastInfo, showToastSuccess, queryClient, isJobsDrawerOpen],
+        [
+            showToastInfo,
+            showToastSuccess,
+            queryClient,
+            isJobsDrawerOpen,
+            isQuietJob,
+        ],
     );
 
     const toastJobError = ({ error }: ApiError) => {
@@ -111,6 +139,7 @@ const ActiveJobProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {
                 setIsJobsDrawerOpen,
                 activeJobId,
                 setActiveJobId,
+                setQuietActiveJobId,
                 activeJob,
                 activeJobIsRunning,
             }}

--- a/packages/frontend/src/providers/ActiveJob/types.ts
+++ b/packages/frontend/src/providers/ActiveJob/types.ts
@@ -5,7 +5,8 @@ export interface ContextType {
     isJobsDrawerOpen: boolean;
     setIsJobsDrawerOpen: Dispatch<SetStateAction<boolean>>;
     activeJobId: string | undefined;
-    setActiveJobId: Dispatch<SetStateAction<any>>;
+    setActiveJobId: Dispatch<SetStateAction<string | undefined>>;
+    setQuietActiveJobId: (jobId: string) => void;
     activeJob: Job | undefined;
     activeJobIsRunning: boolean | undefined;
 }

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -1,4 +1,10 @@
-import { Dataset } from '@google-cloud/bigquery';
+import {
+    BigQuery,
+    Dataset,
+    type DatasetsResponse,
+    type QueryRowsResponse,
+} from '@google-cloud/bigquery';
+import { type BigqueryProject } from '@lightdash/common';
 import type { Mock, MockInstance } from 'vitest';
 import {
     BigquerySqlBuilder,
@@ -75,6 +81,285 @@ describe('BigqueryWarehouseClient', () => {
         );
         expect(getTableMock).toHaveBeenCalledTimes(1);
         expect(getTableResponse.getMetadata).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('BigqueryWarehouseClient.getDatabases', () => {
+    const createDataset = (datasetId: string) =>
+        new Dataset(new BigQuery({ projectId: 'test-project' }), datasetId, {
+            location: 'EU',
+        });
+    const createClient = (
+        datasets: Dataset[],
+        query: (sql: string) => Promise<QueryRowsResponse>,
+    ) => ({
+        getDatasets: vi
+            .fn<() => Promise<DatasetsResponse>>()
+            .mockResolvedValue([datasets]),
+        query: vi.fn(query),
+    });
+
+    it('includes the stored size for each dataset', async () => {
+        const datasets = [createDataset('small'), createDataset('large')];
+        const queryMock = vi
+            .fn<(sql: string) => Promise<QueryRowsResponse>>()
+            .mockResolvedValueOnce([[{ sizeBytes: 100 }]])
+            .mockResolvedValueOnce([[{ sizeBytes: 500 }]]);
+        const client = createClient(datasets, queryMock);
+
+        await expect(
+            BigqueryWarehouseClient.getDatabases(
+                'test-project',
+                'refresh-token',
+                client,
+            ),
+        ).resolves.toEqual([
+            {
+                projectId: 'test-project',
+                datasetId: 'small',
+                location: 'EU',
+                sizeBytes: 100,
+            },
+            {
+                projectId: 'test-project',
+                datasetId: 'large',
+                location: 'EU',
+                sizeBytes: 500,
+            },
+        ]);
+        expect(queryMock).toHaveBeenNthCalledWith(
+            1,
+            'SELECT SUM(size_bytes) AS sizeBytes FROM `test-project.small.__TABLES__`',
+        );
+    });
+
+    it('returns null when an individual dataset size query fails', async () => {
+        const datasets = [createDataset('unavailable'), createDataset('ok')];
+        const queryMock = vi
+            .fn<(sql: string) => Promise<QueryRowsResponse>>()
+            .mockRejectedValueOnce(new Error('permission denied'))
+            .mockResolvedValueOnce([[{ sizeBytes: 500 }]]);
+        const client = createClient(datasets, queryMock);
+
+        const result = await BigqueryWarehouseClient.getDatabases(
+            'test-project',
+            'refresh-token',
+            client,
+        );
+
+        expect(
+            result.map(({ datasetId, sizeBytes }) => ({
+                datasetId,
+                sizeBytes,
+            })),
+        ).toEqual([
+            { datasetId: 'unavailable', sizeBytes: null },
+            { datasetId: 'ok', sizeBytes: 500 },
+        ]);
+    });
+
+    it('only queries sizes for the first 25 datasets', async () => {
+        const datasets = Array.from({ length: 30 }, (_, index) =>
+            createDataset(`dataset_${index}`),
+        );
+        const queryMock = vi
+            .fn<(sql: string) => Promise<QueryRowsResponse>>()
+            .mockResolvedValue([[{ sizeBytes: 100 }]]);
+        const client = createClient(datasets, queryMock);
+
+        const result = await BigqueryWarehouseClient.getDatabases(
+            'test-project',
+            'refresh-token',
+            client,
+        );
+
+        expect(queryMock).toHaveBeenCalledTimes(25);
+        expect(
+            result.slice(0, 25).every(({ sizeBytes }) => sizeBytes === 100),
+        ).toBe(true);
+        expect(
+            result.slice(25).every(({ sizeBytes }) => sizeBytes === null),
+        ).toBe(true);
+    });
+});
+
+describe('BigqueryWarehouseClient.getProjectRecommendation', () => {
+    type RecommendationQuery = (options: {
+        query: string;
+        location: string;
+    }) => Promise<QueryRowsResponse>;
+
+    const createDataset = (
+        projectId: string,
+        datasetId: string,
+        location: string,
+    ) =>
+        new Dataset(new BigQuery({ projectId }), datasetId, {
+            location,
+        });
+
+    const createClient = (
+        projectId: string,
+        locations: string[],
+        queryImplementation: RecommendationQuery,
+    ) => {
+        const datasets = locations.map((location, index) =>
+            createDataset(projectId, `dataset_${index}`, location),
+        );
+        const getDatasets = vi.fn<() => Promise<DatasetsResponse>>();
+        vi.mocked(getDatasets).mockResolvedValue([datasets]);
+        const query = vi.fn<RecommendationQuery>();
+        vi.mocked(query).mockImplementation(queryImplementation);
+        return { getDatasets, query };
+    };
+
+    it('ranks projects by their largest dataset across distinct regions', async () => {
+        const firstClient = createClient(
+            'first-project',
+            ['EU', 'US', 'EU'],
+            async ({ location }) =>
+                location === 'US'
+                    ? [[{ table_schema: 'largest', total_bytes: 1200 }]]
+                    : [[{ table_schema: 'smaller', total_bytes: 500 }]],
+        );
+        const secondClient = createClient(
+            'second-project',
+            ['EU'],
+            async () => [
+                [
+                    { table_schema: 'small', total_bytes: 100 },
+                    { table_schema: 'large', total_bytes: 900 },
+                ],
+            ],
+        );
+        const clients = new Map([
+            ['first-project', firstClient],
+            ['second-project', secondClient],
+        ]);
+        const clientFactory = vi.fn((projectId: string) => {
+            const client = clients.get(projectId);
+            if (!client) throw new Error('Unexpected project');
+            return client;
+        });
+        const projects: BigqueryProject[] = [
+            { projectId: 'first-project', friendlyName: null },
+            { projectId: 'second-project', friendlyName: null },
+        ];
+
+        await expect(
+            BigqueryWarehouseClient.getProjectRecommendation(
+                projects,
+                'refresh-token',
+                clientFactory,
+            ),
+        ).resolves.toEqual({ projectId: 'first-project' });
+        expect(vi.mocked(firstClient.getDatasets)).toHaveBeenCalledWith({
+            autoPaginate: false,
+            maxResults: 1000,
+        });
+        expect(vi.mocked(firstClient.query)).toHaveBeenCalledTimes(2);
+        expect(vi.mocked(firstClient.query)).toHaveBeenCalledWith({
+            query: 'SELECT table_schema, SUM(total_logical_bytes) AS total_bytes FROM `first-project`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE GROUP BY table_schema',
+            location: 'US',
+        });
+    });
+
+    it('skips a project when any of its region queries errors', async () => {
+        const failingClient = createClient(
+            'failing-project',
+            ['EU', 'US'],
+            async ({ location }) => {
+                if (location === 'US') throw new Error('permission denied');
+                return [[{ table_schema: 'largest', total_bytes: 5000 }]];
+            },
+        );
+        const healthyClient = createClient(
+            'healthy-project',
+            ['EU'],
+            async () => [[{ table_schema: 'available', total_bytes: 100 }]],
+        );
+        const clients = new Map([
+            ['failing-project', failingClient],
+            ['healthy-project', healthyClient],
+        ]);
+        const clientFactory = vi.fn((projectId: string) => {
+            const client = clients.get(projectId);
+            if (!client) throw new Error('Unexpected project');
+            return client;
+        });
+
+        await expect(
+            BigqueryWarehouseClient.getProjectRecommendation(
+                [
+                    { projectId: 'failing-project', friendlyName: null },
+                    { projectId: 'healthy-project', friendlyName: null },
+                ],
+                'refresh-token',
+                clientFactory,
+            ),
+        ).resolves.toEqual({ projectId: 'healthy-project' });
+    });
+
+    it('returns no recommendation when every project score is unavailable', async () => {
+        const client = createClient('unavailable-project', ['EU'], async () => {
+            throw new Error('permission denied');
+        });
+        const clientFactory = vi.fn<(projectId: string) => typeof client>();
+        vi.mocked(clientFactory).mockReturnValue(client);
+
+        await expect(
+            BigqueryWarehouseClient.getProjectRecommendation(
+                [{ projectId: 'unavailable-project', friendlyName: null }],
+                'refresh-token',
+                clientFactory,
+            ),
+        ).resolves.toEqual({ projectId: null });
+    });
+
+    it('caps ranking at eight projects and three regions per project', async () => {
+        const projects: BigqueryProject[] = Array.from(
+            { length: 10 },
+            (_, index) => ({
+                projectId: `project-${index}`,
+                friendlyName: null,
+            }),
+        );
+        const clients = new Map(
+            projects.map(({ projectId }, index) => [
+                projectId,
+                createClient(
+                    projectId,
+                    ['EU', 'US', 'asia-east1', 'us-west1'],
+                    async () => [
+                        [{ table_schema: 'dataset', total_bytes: index }],
+                    ],
+                ),
+            ]),
+        );
+        const clientFactory = vi.fn((projectId: string) => {
+            const client = clients.get(projectId);
+            if (!client) throw new Error('Unexpected project');
+            return client;
+        });
+
+        await expect(
+            BigqueryWarehouseClient.getProjectRecommendation(
+                projects,
+                'refresh-token',
+                clientFactory,
+            ),
+        ).resolves.toEqual({ projectId: 'project-7' });
+        expect(vi.mocked(clientFactory)).toHaveBeenCalledTimes(8);
+        projects.forEach(({ projectId }, index) => {
+            const client = clients.get(projectId);
+            if (!client) throw new Error('Unexpected project');
+            expect(vi.mocked(client.getDatasets)).toHaveBeenCalledTimes(
+                index < 8 ? 1 : 0,
+            );
+            expect(vi.mocked(client.query)).toHaveBeenCalledTimes(
+                index < 8 ? 3 : 0,
+            );
+        });
     });
 });
 

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -5,6 +5,8 @@ import {
     BigQueryTime,
     BigQueryTimestamp,
     Dataset,
+    DatasetsResponse,
+    GetDatasetsOptions,
     Job,
     QueryResultsOptions,
     QueryRowsResponse,
@@ -15,6 +17,7 @@ import {
     BigqueryAuthenticationType,
     BigqueryDataset,
     BigqueryProject,
+    BigqueryProjectRecommendation,
     CreateBigqueryCredentials,
     DimensionType,
     getErrorMessage,
@@ -46,6 +49,9 @@ import {
 import { normalizeUnicode } from '../utils/sql';
 import WarehouseBaseClient from './WarehouseBaseClient';
 import WarehouseBaseSqlBuilder from './WarehouseBaseSqlBuilder';
+
+const MAX_RECOMMENDATION_PROJECTS = 8;
+const MAX_RECOMMENDATION_REGIONS_PER_PROJECT = 3;
 
 export enum BigqueryFieldType {
     STRING = 'STRING',
@@ -775,8 +781,10 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
     static async getDatabases(
         projectId: string,
         refresh_token: string,
-    ): Promise<BigqueryDataset[]> {
-        const bigqueryClient = new BigQuery({
+        bigqueryClient: {
+            getDatasets: () => Promise<DatasetsResponse>;
+            query: (query: string) => Promise<QueryRowsResponse>;
+        } = new BigQuery({
             projectId,
             credentials: {
                 type: 'authorized_user',
@@ -784,15 +792,149 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                 client_secret: process.env.AUTH_GOOGLE_OAUTH2_CLIENT_SECRET,
                 refresh_token,
             },
-        });
-
+        }),
+    ): Promise<BigqueryDataset[]> {
         const datasets = await bigqueryClient.getDatasets();
-        const databases = datasets[0].map((d) => ({
-            projectId: d.projectId,
-            location: d.location,
-            datasetId: d.id!,
-        }));
+        const databases = await Promise.all(
+            datasets[0].map(async (dataset, index) => {
+                let sizeBytes: number | null = null;
+                if (index < 25) {
+                    try {
+                        const [rows] = await bigqueryClient.query(
+                            `SELECT SUM(size_bytes) AS sizeBytes FROM \`${dataset.projectId}.${dataset.id}.__TABLES__\``,
+                        );
+                        const size = Number(rows[0]?.sizeBytes);
+                        sizeBytes = Number.isFinite(size) ? size : null;
+                    } catch {
+                        sizeBytes = null;
+                    }
+                }
+
+                return {
+                    projectId: dataset.projectId,
+                    location: dataset.location,
+                    datasetId: dataset.id!,
+                    sizeBytes,
+                };
+            }),
+        );
         return databases;
+    }
+
+    static async getProjectRecommendation(
+        projects: BigqueryProject[],
+        refreshToken: string,
+        bigqueryClientFactory: (projectId: string) => {
+            getDatasets: (
+                options: GetDatasetsOptions,
+            ) => Promise<DatasetsResponse>;
+            query: (options: {
+                query: string;
+                location: string;
+            }) => Promise<QueryRowsResponse>;
+        } = (projectId) => {
+            const client = new BigQuery({
+                projectId,
+                credentials: {
+                    type: 'authorized_user',
+                    client_id: process.env.AUTH_GOOGLE_OAUTH2_CLIENT_ID,
+                    client_secret: process.env.AUTH_GOOGLE_OAUTH2_CLIENT_SECRET,
+                    refresh_token: refreshToken,
+                },
+            });
+            return {
+                getDatasets: (options) => client.getDatasets(options),
+                query: (options) =>
+                    client.query(options.query, { location: options.location }),
+            };
+        },
+    ): Promise<BigqueryProjectRecommendation> {
+        const projectScores = await Promise.all(
+            projects
+                .slice(0, MAX_RECOMMENDATION_PROJECTS)
+                .map(async ({ projectId }) => {
+                    try {
+                        const client = bigqueryClientFactory(projectId);
+                        const [datasets] = await client.getDatasets({
+                            autoPaginate: false,
+                            maxResults: 1000,
+                        });
+                        const locationsByQualifier = new Map<string, string>();
+                        datasets.forEach((dataset) => {
+                            if (dataset.location) {
+                                locationsByQualifier.set(
+                                    dataset.location.toLowerCase(),
+                                    dataset.location,
+                                );
+                            }
+                        });
+                        const locations = Array.from(
+                            locationsByQualifier.entries(),
+                        ).slice(0, MAX_RECOMMENDATION_REGIONS_PER_PROJECT);
+
+                        const regionScores = await Promise.all(
+                            locations.map(async ([qualifier, location]) => {
+                                try {
+                                    const [rows] = await client.query({
+                                        query: `SELECT table_schema, SUM(total_logical_bytes) AS total_bytes FROM \`${projectId}\`.\`region-${qualifier}\`.INFORMATION_SCHEMA.TABLE_STORAGE GROUP BY table_schema`,
+                                        location,
+                                    });
+                                    let largestDatasetSize: number | null =
+                                        null;
+                                    rows.forEach((row) => {
+                                        const size = Number(row.total_bytes);
+                                        if (
+                                            Number.isFinite(size) &&
+                                            (largestDatasetSize === null ||
+                                                size > largestDatasetSize)
+                                        ) {
+                                            largestDatasetSize = size;
+                                        }
+                                    });
+                                    return {
+                                        error: false,
+                                        sizeBytes: largestDatasetSize,
+                                    };
+                                } catch {
+                                    return { error: true, sizeBytes: null };
+                                }
+                            }),
+                        );
+
+                        if (regionScores.some(({ error }) => error)) {
+                            return { projectId, sizeBytes: null };
+                        }
+
+                        const sizeBytes = regionScores.reduce<number | null>(
+                            (largestSize, regionScore) =>
+                                regionScore.sizeBytes !== null &&
+                                (largestSize === null ||
+                                    regionScore.sizeBytes > largestSize)
+                                    ? regionScore.sizeBytes
+                                    : largestSize,
+                            null,
+                        );
+                        return { projectId, sizeBytes };
+                    } catch {
+                        return { projectId, sizeBytes: null };
+                    }
+                }),
+        );
+
+        const recommendation = projectScores.reduce<{
+            projectId: string | null;
+            sizeBytes: number | null;
+        }>(
+            (largestProject, projectScore) =>
+                projectScore.sizeBytes !== null &&
+                (largestProject.sizeBytes === null ||
+                    projectScore.sizeBytes > largestProject.sizeBytes)
+                    ? projectScore
+                    : largestProject,
+            { projectId: null, sizeBytes: null },
+        );
+
+        return { projectId: recommendation.projectId };
     }
 
     static async getProjects(accessToken: string): Promise<BigqueryProject[]> {

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
@@ -536,6 +536,14 @@ describe('SnowflakeWarehouseClient', () => {
                             database_name: 'ANALYTICS',
                         },
                     ];
+                } else if (sqlText.startsWith('SELECT SUM(bytes)')) {
+                    if (sqlText.includes('DATABASE_0.')) {
+                        rows = [{ total_bytes: 1250 }];
+                    } else if (sqlText.includes('DATABASE_1.')) {
+                        rows = [{ total_bytes: 500 }];
+                    } else {
+                        rows = [{ total_bytes: null }];
+                    }
                 }
                 complete(
                     undefined,
@@ -568,6 +576,7 @@ describe('SnowflakeWarehouseClient', () => {
                     name: `DATABASE_${index}`,
                     comment: index === 0 ? 'Primary analytics' : null,
                     kind: index === 1 ? 'IMPORTED DATABASE' : 'STANDARD',
+                    sizeBytes: [1250, 500][index] ?? null,
                 })),
                 warehouses: [
                     {
@@ -595,8 +604,89 @@ describe('SnowflakeWarehouseClient', () => {
         );
         expect(execute).toHaveBeenCalledWith(
             expect.objectContaining({
+                sqlText: `SELECT SUM(bytes) AS "total_bytes" FROM DATABASE_0.INFORMATION_SCHEMA.TABLES WHERE table_type = 'BASE TABLE'`,
+            }),
+        );
+        expect(
+            execute.mock.calls.filter(([statement]) =>
+                statement.sqlText.startsWith('SELECT SUM(bytes)'),
+            ),
+        ).toHaveLength(25);
+        expect(
+            execute.mock.calls.some(([statement]) =>
+                statement.sqlText.startsWith('USE WAREHOUSE'),
+            ),
+        ).toBe(false);
+        expect(execute).toHaveBeenCalledWith(
+            expect.objectContaining({
                 sqlText:
                     'SHOW GRANTS TO USER "user.name@example.com" LIMIT 100',
+            }),
+        );
+    });
+
+    it('returns null database sizes when size discovery fails', async () => {
+        const execute = vi.fn(
+            ({
+                sqlText,
+                complete,
+            }: {
+                sqlText: string;
+                complete: (
+                    error: Error | undefined,
+                    statement: { getColumns: () => typeof queryColumnsMock },
+                    rows: Record<string, AnyType>[],
+                ) => void;
+            }) => {
+                if (sqlText.startsWith('SELECT SUM(bytes)')) {
+                    complete(
+                        new Error('Insufficient privileges'),
+                        { getColumns: () => queryColumnsMock },
+                        [],
+                    );
+                    return;
+                }
+                let rows: Record<string, AnyType>[] = [];
+                if (sqlText.startsWith('SELECT CURRENT_USER')) {
+                    rows = [{ USER: 'test-user' }];
+                } else if (sqlText.startsWith('SHOW DATABASES')) {
+                    rows = [{ name: 'ANALYTICS' }, { name: 'RAW' }];
+                } else if (sqlText.startsWith('SHOW WAREHOUSES')) {
+                    rows = [
+                        { name: 'WH_BIG', size: 'Large', state: 'SUSPENDED' },
+                        {
+                            name: 'WH_SMALL',
+                            size: 'X-Small',
+                            state: 'STARTED',
+                        },
+                    ];
+                }
+                complete(
+                    undefined,
+                    { getColumns: () => queryColumnsMock },
+                    rows,
+                );
+            },
+        );
+        vi.mocked(createConnection).mockImplementationOnce(() =>
+            interactiveConnectionMock(execute),
+        );
+        const warehouse = new SnowflakeWarehouseClient(credentials);
+
+        const discovery = await warehouse.getSessionDiscovery('test-user');
+
+        expect(discovery.inventory.databases).toEqual([
+            {
+                name: 'ANALYTICS',
+                comment: null,
+                kind: null,
+                sizeBytes: null,
+            },
+            { name: 'RAW', comment: null, kind: null, sizeBytes: null },
+        ]);
+        expect(execute).toHaveBeenCalledWith(
+            expect.objectContaining({
+                sqlText: 'USE WAREHOUSE WH_SMALL',
             }),
         );
     });

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -98,6 +98,7 @@ const EXTERNAL_BROWSER_AUTHENTICATOR = 'EXTERNALBROWSER';
 const OAUTH_AUTHORIZATION_CODE_AUTHENTICATOR = 'OAUTH_AUTHORIZATION_CODE';
 const SESSION_DISCOVERY_LIMIT = 100;
 const SESSION_SCHEMA_DISCOVERY_LIMIT = 1000;
+const SESSION_DATABASE_SIZE_LIMIT = 25;
 // Minimum allowed by Snowflake (range 16-160, default 160)
 const SNOWFLAKE_RESULT_CHUNK_SIZE_MB = 16;
 
@@ -202,6 +203,7 @@ export type SnowflakeSessionInventory = {
         name: string;
         comment: string | null;
         kind: string | null;
+        sizeBytes: number | null;
     }[];
     warehouses: {
         name: string;
@@ -290,6 +292,7 @@ const listSnowflakeSchemas = (
 
 const listSnowflakeDatabases = (
     rows: AnyType[],
+    databaseSizes: Map<string, number>,
 ): SnowflakeSessionInventory['databases'] =>
     rows
         .flatMap((rawRow) => {
@@ -306,6 +309,7 @@ const listSnowflakeDatabases = (
                             ? null
                             : getSnowflakeRowValue(row, 'comment'),
                     kind: getSnowflakeRowValue(row, 'kind'),
+                    sizeBytes: databaseSizes.get(name) ?? null,
                 },
             ];
         })
@@ -334,6 +338,56 @@ const listSnowflakeWarehouses = (
             ];
         })
         .slice(0, SESSION_DISCOVERY_LIMIT);
+
+const WAREHOUSE_SIZE_ORDER = [
+    'X-Small',
+    'Small',
+    'Medium',
+    'Large',
+    'X-Large',
+    '2X-Large',
+    '3X-Large',
+    '4X-Large',
+    '5X-Large',
+    '6X-Large',
+];
+
+const warehouseSizeRank = (size: string | null): number => {
+    const index = WAREHOUSE_SIZE_ORDER.findIndex(
+        (candidate) =>
+            candidate.toLowerCase() === (size ?? '').trim().toLowerCase(),
+    );
+    return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+};
+
+const pickSizeDiscoveryWarehouse = (rows: AnyType[]): string | null => {
+    const warehouses = rows
+        .map((rawRow) => {
+            const row = rawRow as Record<string, AnyType>;
+            return {
+                name: getSnowflakeRowValue(row, 'name'),
+                size: getSnowflakeRowValue(row, 'size'),
+                state: (getSnowflakeRowValue(row, 'state') ?? '')
+                    .trim()
+                    .toUpperCase(),
+            };
+        })
+        .filter((warehouse) => Boolean(warehouse.name));
+    const started = warehouses.filter(
+        (warehouse) => warehouse.state === 'STARTED',
+    );
+    const pool = started.length > 0 ? started : warehouses;
+    const best = pool.reduce<(typeof pool)[number] | null>(
+        (currentBest, candidate) =>
+            currentBest === null ||
+            warehouseSizeRank(candidate.size) <
+                warehouseSizeRank(currentBest.size)
+                ? candidate
+                : currentBest,
+        null,
+    );
+    return best?.name ?? null;
+};
 
 export const snowflakeIdentifier = (value: string): string =>
     /^[A-Za-z_][A-Za-z0-9_$]*$/.test(value)
@@ -868,6 +922,62 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         } catch {
             schemaRows = [];
         }
+        const databaseSizes = new Map<string, number>();
+        const sizeCandidates = databasesResult.rows
+            .map((rawRow) =>
+                getSnowflakeRowValue(rawRow as Record<string, AnyType>, 'name'),
+            )
+            .filter((name): name is string => Boolean(name))
+            .slice(0, SESSION_DATABASE_SIZE_LIMIT);
+        // INFORMATION_SCHEMA aggregation needs an active warehouse; without a
+        // session default, activate one (prefer already-running, then smallest)
+        if (sizeCandidates.length > 0) {
+            const sessionWarehouseName = getSnowflakeRowValue(
+                defaultsRow,
+                'warehouse',
+            );
+            const sizeWarehouseName =
+                sessionWarehouseName ??
+                pickSizeDiscoveryWarehouse(warehousesResult.rows);
+            if (!sessionWarehouseName && sizeWarehouseName) {
+                try {
+                    await this.executeStatements(
+                        connection,
+                        `USE WAREHOUSE ${snowflakeIdentifier(
+                            sizeWarehouseName,
+                        )}`,
+                    );
+                } catch {
+                    /* size queries will fail and sizes stay null */
+                }
+            }
+        }
+        await sizeCandidates.reduce(
+            (previous, databaseName) =>
+                previous.then(async () => {
+                    try {
+                        const sizeResult = await this.executeStatements(
+                            connection,
+                            `SELECT SUM(bytes) AS "total_bytes" FROM ${snowflakeIdentifier(
+                                databaseName,
+                            )}.INFORMATION_SCHEMA.TABLES WHERE table_type = 'BASE TABLE'`,
+                        );
+                        const totalBytes = getSnowflakeRowNumber(
+                            (sizeResult.rows[0] ?? {}) as Record<
+                                string,
+                                AnyType
+                            >,
+                            'total_bytes',
+                        );
+                        if (totalBytes !== null && totalBytes > 0) {
+                            databaseSizes.set(databaseName, totalBytes);
+                        }
+                    } catch {
+                        /* size stays null for this database */
+                    }
+                }),
+            Promise.resolve(),
+        );
         const defaultRole = getSnowflakeRowValue(defaultsRow, 'role');
         const grantedRoles = [
             ...new Set([
@@ -897,7 +1007,10 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                 schema: getSnowflakeRowValue(defaultsRow, 'schema'),
             },
             inventory: {
-                databases: listSnowflakeDatabases(databasesResult.rows),
+                databases: listSnowflakeDatabases(
+                    databasesResult.rows,
+                    databaseSizes,
+                ),
                 warehouses: listSnowflakeWarehouses(warehousesResult.rows),
                 roles,
                 schemas: listSnowflakeSchemas(schemaRows),


### PR DESCRIPTION
Part 3 of 4 — stacked split of #25752. Base: `stack/02-flag-signup-orgsetup`.

**Warehouse-connect onboarding**, gated on `new-onboarding`:
- Snowflake CLI-SSO: re-claimable connect codes (survive refresh), database-size discovery, auto-selected smart defaults (largest DB, recommended warehouse, first schema), sessionStorage persistence.
- BigQuery SSO: default to Sign-in-with-Google in onboarding, and a project/dataset recommendation ranked by largest dataset.
- Quiet job-toast suppression in the warehouse-only flow (job drawer still opens on ERROR).
- Removes the temporary flag shims from Part 2 (last consumers convert here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
