### PR TITLE
feat: new-onboarding flag, passwordless signup & full-page org setup [2/4]

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -525,6 +525,10 @@ EMAIL_SMTP_SENDER_EMAIL=noreply@lightdash.local
 # Dev API access (auto-provisioned PAT from seed data)
 LIGHTDASH_API_URL=http://localhost:${PORT}
 LDPAT=ldpat_deadbeefdeadbeefdeadbeefdeadbeef
+
+# Allow registering fresh users/orgs (signup flow testing). Always on by default
+# in dev — without it, POST /api/v1/user 403s once the seed org exists.
+ALLOW_MULTIPLE_ORGS=true
 EOF
 echo "DBT_DEMO_DIR=$(pwd)/examples/full-jaffle-shop-demo" >> .env.development.local
 ```

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
@@ -150,7 +150,7 @@ describe('provisionOnboardingHomepage', () => {
         const mocks = buildArguments();
         mocks.getFeatureFlag.mockImplementation(async ({ featureFlagId }) => ({
             id: featureFlagId,
-            enabled: featureFlagId !== FeatureFlags.OrganizationSetupPage,
+            enabled: featureFlagId !== FeatureFlags.NewOnboarding,
         }));
 
         await provisionOnboardingHomepage(mocks.args);
@@ -192,7 +192,7 @@ describe('provisionOnboardingHomepage', () => {
 
         expect(mocks.getFeatureFlag).toHaveBeenCalledWith({
             user,
-            featureFlagId: FeatureFlags.OrganizationSetupPage,
+            featureFlagId: FeatureFlags.NewOnboarding,
         });
         expect(mocks.getFeatureFlag).toHaveBeenCalledWith({
             user,

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
@@ -36,7 +36,7 @@ export const provisionOnboardingHomepage = async ({
     const [orgSetupPageFlag, homepageBuilderFlag] = await Promise.all([
         featureFlagService.get({
             user,
-            featureFlagId: FeatureFlags.OrganizationSetupPage,
+            featureFlagId: FeatureFlags.NewOnboarding,
         }),
         featureFlagService.get({
             user,

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -34,6 +34,7 @@ import {
     ParameterError,
     SaveOrganizationBrandRequest,
     SessionUser,
+    TooManyRequestsError,
     UnexpectedServerError,
     UpdateAllowedEmailDomains,
     UpdateColorPalette,
@@ -374,6 +375,15 @@ export class OrganizationService extends BaseService {
         if (response.status === 404) {
             throw new NotFoundError(
                 `No brand found for domain "${normalizedDomain}"`,
+            );
+        }
+        if (response.status === 429) {
+            this.logger.warn('Brandfetch rate limit reached', {
+                organizationUuid,
+                domain: normalizedDomain,
+            });
+            throw new TooManyRequestsError(
+                'Brand lookup is rate limited right now — try again shortly',
             );
         }
         if (!response.ok) {

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -192,7 +192,7 @@ const createUserService = (
                 get: vi.fn<FeatureFlagModel['get']>(
                     async ({ featureFlagId }) => ({
                         id: featureFlagId,
-                        enabled: featureFlagId !== FeatureFlags.EmailOnlySignup,
+                        enabled: featureFlagId !== FeatureFlags.NewOnboarding,
                     }),
                 ),
             } as unknown as FeatureFlagModel),
@@ -299,7 +299,7 @@ describe('UserService', () => {
 
             expect(featureFlagModel.get).toHaveBeenCalledWith({
                 user: undefined,
-                featureFlagId: FeatureFlags.EmailOnlySignup,
+                featureFlagId: FeatureFlags.NewOnboarding,
             });
             expect(userModel.createUser).toHaveBeenCalledWith({
                 firstName: '',
@@ -384,17 +384,18 @@ describe('UserService', () => {
         };
 
         describe('requestEmailOtpLogin', () => {
-            test('rejects when the feature flag is disabled', async () => {
+            test('sends an OTP for a passwordless account even when the feature flag is disabled', async () => {
                 const service = createUserService(lightdashConfigMock, {
                     featureFlagModel: createFeatureFlagModel(false),
                 });
+                userModel.findUserByEmail.mockResolvedValueOnce(sessionUser);
+                userModel.hasPassword.mockResolvedValueOnce(false);
+                userModel.hasOpenIdIdentity.mockResolvedValueOnce(false);
 
-                await expect(
-                    service.requestEmailOtpLogin('email'),
-                ).rejects.toThrow(
-                    new ForbiddenError('Email OTP login is not enabled'),
-                );
-                expect(userModel.findUserByEmail).not.toHaveBeenCalled();
+                await service.requestEmailOtpLogin('email');
+
+                expect(emailModel.createPrimaryEmailOtp).toHaveBeenCalled();
+                expect(emailClient.sendOneTimePasscodeEmail).toHaveBeenCalled();
             });
 
             test('does not create or send an OTP for a passworded account', async () => {
@@ -583,16 +584,27 @@ describe('UserService', () => {
                 );
             });
 
-            test('rejects before account lookup when the feature is disabled', async () => {
+            test('signs in a passwordless account even when the feature is disabled', async () => {
                 const service = createUserService(lightdashConfigMock, {
                     featureFlagModel: createFeatureFlagModel(false),
                 });
+                const emailStatus = activeOtp();
+                userModel.findUserByEmail.mockResolvedValueOnce(sessionUser);
+                userModel.hasPassword.mockResolvedValueOnce(false);
+                userModel.hasOpenIdIdentity.mockResolvedValueOnce(false);
+                emailModel.getPrimaryEmailStatus.mockResolvedValueOnce(
+                    emailStatus,
+                );
+                emailModel.getPrimaryEmailStatusByUserAndOtp.mockResolvedValueOnce(
+                    emailStatus,
+                );
+                emailModel.verifyUserEmailIfExists.mockResolvedValueOnce([
+                    { email: emailStatus.email },
+                ]);
 
                 await expect(
-                    service.loginWithEmailOtp('email', '123456'),
-                ).rejects.toThrow(
-                    new ForbiddenError('Email OTP login is not enabled'),
-                );
+                    service.loginWithEmailOtp('EMAIL', '123456'),
+                ).resolves.toBe(sessionUser);
             });
         });
     });
@@ -656,13 +668,9 @@ describe('UserService', () => {
                 redirectUri: undefined,
                 showOptions: ['emailOtp'],
             });
-            expect(featureFlagModel.get).toHaveBeenCalledWith({
-                user: undefined,
-                featureFlagId: FeatureFlags.EmailOnlySignup,
-            });
         });
 
-        test('keeps email unchanged when the feature is disabled', async () => {
+        test('still shows email OTP for a passwordless user when the feature is disabled', async () => {
             const service = createUserService(lightdashConfigMock, {
                 featureFlagModel: createFeatureFlagModel(false),
             });
@@ -673,7 +681,7 @@ describe('UserService', () => {
             await expect(service.getLoginOptions('email')).resolves.toEqual({
                 forceRedirect: false,
                 redirectUri: undefined,
-                showOptions: ['email'],
+                showOptions: ['emailOtp'],
             });
         });
 

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1579,7 +1579,7 @@ export class UserService extends BaseService {
         } else {
             const emailOnlySignupFlag = await this.featureFlagModel.get({
                 user: undefined,
-                featureFlagId: FeatureFlags.EmailOnlySignup,
+                featureFlagId: FeatureFlags.NewOnboarding,
             });
             if (!emailOnlySignupFlag.enabled) {
                 throw new ForbiddenError('Email-only signup is not enabled');
@@ -1877,16 +1877,6 @@ export class UserService extends BaseService {
         };
     }
 
-    private async assertEmailOtpLoginEnabled(): Promise<void> {
-        const featureFlag = await this.featureFlagModel.get({
-            user: undefined,
-            featureFlagId: FeatureFlags.EmailOnlySignup,
-        });
-        if (!featureFlag.enabled) {
-            throw new ForbiddenError('Email OTP login is not enabled');
-        }
-    }
-
     private async isStrictlyPasswordlessUser(
         user: LightdashUser,
         email: string,
@@ -1900,8 +1890,10 @@ export class UserService extends BaseService {
         return !hasPassword && !hasOpenIdIdentity && isEmailLoginAllowed;
     }
 
+    // OTP login is deliberately NOT gated on the NewOnboarding flag: accounts
+    // enrolled as strictly passwordless have no other way to sign in, so a
+    // flag rollback must not strand them. The flag gates enrollment only.
     async requestEmailOtpLogin(email: string): Promise<void> {
-        await this.assertEmailOtpLoginEnabled();
         const normalizedEmail = email.toLowerCase();
         const user = await this.userModel.findUserByEmail(normalizedEmail);
         if (
@@ -1919,7 +1911,6 @@ export class UserService extends BaseService {
         passcode: string,
         context?: AuthAuditContext,
     ): Promise<SessionUser> {
-        await this.assertEmailOtpLoginEnabled();
         const normalizedEmail = email.toLowerCase();
         const invalidCode = () => {
             emitAuthAuditEvent({
@@ -3255,27 +3246,21 @@ export class UserService extends BaseService {
 
         const openIdIssuers = await this.userModel.getOpenIdIssuers(email);
         const hasPassword = await this.userModel.hasPasswordByEmail(email);
+        // Not gated on the NewOnboarding flag: an enrolled passwordless
+        // account must keep its only sign-in path across a flag rollback.
         let shouldShowEmailOtp = false;
         if (existingUser && !hasPassword) {
-            const [
-                featureFlag,
-                hasPasswordLogin,
-                hasOpenIdIdentity,
-                isEmailLoginAllowed,
-            ] = await Promise.all([
-                this.featureFlagModel.get({
-                    user: undefined,
-                    featureFlagId: FeatureFlags.EmailOnlySignup,
-                }),
-                this.userModel.hasPassword(existingUser.userUuid),
-                this.userModel.hasOpenIdIdentity(existingUser.userUuid),
-                this.isLoginMethodAllowed(email, LocalIssuerTypes.EMAIL_OTP),
-            ]);
+            const [hasPasswordLogin, hasOpenIdIdentity, isEmailLoginAllowed] =
+                await Promise.all([
+                    this.userModel.hasPassword(existingUser.userUuid),
+                    this.userModel.hasOpenIdIdentity(existingUser.userUuid),
+                    this.isLoginMethodAllowed(
+                        email,
+                        LocalIssuerTypes.EMAIL_OTP,
+                    ),
+                ]);
             shouldShowEmailOtp =
-                featureFlag.enabled &&
-                !hasPasswordLogin &&
-                !hasOpenIdIdentity &&
-                isEmailLoginAllowed;
+                !hasPasswordLogin && !hasOpenIdIdentity && isEmailLoginAllowed;
         }
         const applyEmailOtpOption = (options: LoginOptionTypes[]) =>
             shouldShowEmailOtp && options.includes(LocalIssuerTypes.EMAIL)

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -286,11 +286,24 @@ export enum FeatureFlags {
     OrgAiProviderApiKeys = 'org-ai-provider-api-keys',
 
     /**
-     * Gate the dbt-less "connect to your warehouse" onboarding path and the
-     * Snowflake "connect via CLI (SSO)" auth method in project creation.
-     * Off by default; enable per-org for gradual rollout.
+     * Gate the whole new onboarding experience as one unit: email-only
+     * signup (register collects only an email; ownership proven via email
+     * OTP), the full-page organization setup experience shown after
+     * registration, and the dbt-less "connect to your warehouse" onboarding
+     * path including the Snowflake "connect via CLI (SSO)" auth method in
+     * project creation. Off by default. Note: the register page evaluates
+     * this flag anonymously, so per-org overrides do not apply there —
+     * enable instance-wide (or for everyone in posthog) to turn on signup.
+     */
+    NewOnboarding = 'new-onboarding',
+
+    /**
+     * @deprecated Temporary shims kept only so this stacked slice compiles
+     * before the warehouse slice converts its consumers; removed there.
      */
     WarehouseConnectOnboarding = 'warehouse-connect-onboarding',
+    OrganizationSetupPage = 'organization-setup-page',
+    EmailOnlySignup = 'email-only-signup',
 
     /**
      * Cloud-only: let an organization send report/notification emails from
@@ -301,23 +314,6 @@ export enum FeatureFlags {
      * default; enable per-org.
      */
     EmailWhitelabel = 'email-whitelabel',
-
-    /**
-     * Replaces the user-completion modal with a full-page organization setup
-     * experience (name your organization, pick a theme colour, and tell us
-     * about yourself) shown after registration. Off by default.
-     */
-    OrganizationSetupPage = 'organization-setup-page',
-
-    /**
-     * Allow self-serve signup with just an email address: the register page
-     * collects only an email, the account is created without a password or
-     * names, and ownership is proven via the existing email OTP verification.
-     * Users can set a password later (settings or password reset). Off by
-     * default; instance-wide toggle (evaluated anonymously, so per-org
-     * overrides don't apply).
-     */
-    EmailOnlySignup = 'email-only-signup',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -153,9 +153,12 @@ const PUBLIC_ROUTES: RouteObject[] = [
             );
             return {
                 Component: () => (
-                    <TrackPage name={PageName.ORGANIZATION_SETUP}>
-                        <OrganizationSetup />
-                    </TrackPage>
+                    <>
+                        <NavBar />
+                        <TrackPage name={PageName.ORGANIZATION_SETUP}>
+                            <OrganizationSetup />
+                        </TrackPage>
+                    </>
                 ),
             };
         },
@@ -797,9 +800,14 @@ const PRIVATE_ROUTES: RouteObject[] = [
                     );
                     return {
                         Component: () => (
-                            <TrackPage name={PageName.ONBOARDING_DATA_SOURCE}>
-                                <OnboardingDataSource />
-                            </TrackPage>
+                            <>
+                                <NavBar />
+                                <TrackPage
+                                    name={PageName.ONBOARDING_DATA_SOURCE}
+                                >
+                                    <OnboardingDataSource />
+                                </TrackPage>
+                            </>
                         ),
                     };
                 },
@@ -814,9 +822,14 @@ const PRIVATE_ROUTES: RouteObject[] = [
                     );
                     return {
                         Component: () => (
-                            <TrackPage name={PageName.ONBOARDING_PROJECT_READY}>
-                                <OnboardingProjectReady />
-                            </TrackPage>
+                            <>
+                                <NavBar />
+                                <TrackPage
+                                    name={PageName.ONBOARDING_PROJECT_READY}
+                                >
+                                    <OnboardingProjectReady />
+                                </TrackPage>
+                            </>
                         ),
                     };
                 },

--- a/packages/frontend/src/components/AppRoute.tsx
+++ b/packages/frontend/src/components/AppRoute.tsx
@@ -13,9 +13,7 @@ const AppRoute: FC<React.PropsWithChildren> = ({ children }) => {
     const location = useLocation();
     const orgRequest = useOrganization();
     const homepageBuilderFlag = useHomepageBuilderFlag();
-    const orgSetupPageFlag = useServerFeatureFlag(
-        FeatureFlags.OrganizationSetupPage,
-    );
+    const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
 
     if (health.isInitialLoading || orgRequest.isInitialLoading) {
         return <PageSpinner />;

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
@@ -179,9 +179,7 @@ const UserCompletionModal: FC = () => {
 const UserCompletionModalWithUser = () => {
     const { user, health } = useApp();
     const location = useLocation();
-    const orgSetupPageFlag = useServerFeatureFlag(
-        FeatureFlags.OrganizationSetupPage,
-    );
+    const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
 
     if (orgSetupPageFlag.isLoading) {
         return null;

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandAppearanceSettings.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandAppearanceSettings.tsx
@@ -302,7 +302,6 @@ const BrandAppearanceForm: FC<{ brand: OrganizationBrand | null }> = ({
                         Preview
                     </Text>
                     <BrandPreview
-                        domain={form.values.domain}
                         name={form.values.name}
                         logos={form.values.logos}
                         colors={form.values.colors}

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandPreview.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandPreview.tsx
@@ -83,7 +83,6 @@ const linePath = (points: number[]): string => {
 };
 
 type BrandPreviewProps = {
-    domain: string;
     name: string | null;
     logos: OrganizationBrandLogo[];
     colors: OrganizationBrandColor[];
@@ -92,7 +91,6 @@ type BrandPreviewProps = {
 };
 
 export const BrandPreview: FC<BrandPreviewProps> = ({
-    domain,
     name,
     logos,
     colors,
@@ -102,7 +100,6 @@ export const BrandPreview: FC<BrandPreviewProps> = ({
     const primary = pickPrimaryColor(colors);
     const navLogo = pickNavLogo(logos);
     const displayName = name ?? 'Your company';
-    const displayDomain = domain.trim() || 'yourcompany.com';
     const barColors = [primary, `${primary}59`];
 
     // Apply a brand font family only when we can actually load it, otherwise
@@ -123,7 +120,7 @@ export const BrandPreview: FC<BrandPreviewProps> = ({
                 </Group>
                 <Box className={classes.urlBar}>
                     <Text size="xs" c="dimmed">
-                        app.{displayDomain}
+                        {window.location.host}
                     </Text>
                 </Box>
             </Group>

--- a/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.tsx
@@ -15,9 +15,7 @@ import layout from './homepageLayout.module.css';
 const NoProjectHomepage: FC = () => {
     const { user } = useApp();
     const { data: organization, isInitialLoading } = useOrganization();
-    const orgSetupPageFlag = useServerFeatureFlag(
-        FeatureFlags.OrganizationSetupPage,
-    );
+    const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
     const actions = useRecommendedActions(null);
 
     if (isInitialLoading || orgSetupPageFlag.isLoading) {

--- a/packages/frontend/src/hooks/organization/useOrganizationBrand.ts
+++ b/packages/frontend/src/hooks/organization/useOrganizationBrand.ts
@@ -61,6 +61,7 @@ export const useDetectOrganizationBrand = (domain: string, enabled: boolean) =>
         queryFn: () => fetchOrganizationBrand({ domain }),
         enabled: enabled && domain.length > 0,
         retry: false,
+        retryOnMount: false,
         staleTime: Infinity,
         refetchOnWindowFocus: false,
     });

--- a/packages/frontend/src/hooks/useEmailVerification.ts
+++ b/packages/frontend/src/hooks/useEmailVerification.ts
@@ -68,7 +68,7 @@ export const useVerifyEmail = () => {
     const queryClient = useQueryClient();
     const { showToastSuccess } = useToaster();
     const emailOnlySignupFlag = useServerFeatureFlag(
-        FeatureFlags.EmailOnlySignup,
+        FeatureFlags.NewOnboarding,
     );
     return useMutation<EmailStatusExpiring, ApiError, string>(
         (code) => verifyOTPQuery(code),

--- a/packages/frontend/src/hooks/useOnboardingPageGuard.tsx
+++ b/packages/frontend/src/hooks/useOnboardingPageGuard.tsx
@@ -12,9 +12,7 @@ type OnboardingPageGuardResult =
 
 export const useOnboardingPageGuard = (): OnboardingPageGuardResult => {
     const { health, user } = useApp();
-    const orgSetupPageFlag = useServerFeatureFlag(
-        FeatureFlags.OrganizationSetupPage,
-    );
+    const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
 
     if (health.isInitialLoading || health.error) {
         return { status: 'blocked', element: <PageSpinner /> };

--- a/packages/frontend/src/pages/OnboardingDataSource.module.css
+++ b/packages/frontend/src/pages/OnboardingDataSource.module.css
@@ -1,11 +1,12 @@
 .page {
-    min-height: 100vh;
+    min-height: calc(100vh - var(--navbar-height));
     background-color: var(--mantine-color-white);
     display: flex;
     flex-direction: column;
 }
 
 .column {
+    flex: 1;
     width: 100%;
     max-width: 1140px;
     margin: 0 auto;
@@ -75,6 +76,7 @@
 }
 
 .connectColumn {
+    flex: 1;
     width: 100%;
     max-width: 62rem;
     margin: 0 auto;

--- a/packages/frontend/src/pages/OnboardingDataSource.tsx
+++ b/packages/frontend/src/pages/OnboardingDataSource.tsx
@@ -17,6 +17,7 @@ import {
 } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
+import AboutFooter from '../components/AboutFooter';
 import { DocumentTitle } from '../components/common/DocumentTitle';
 import ErrorState from '../components/common/ErrorState';
 import MantineIcon from '../components/common/MantineIcon';
@@ -114,8 +115,7 @@ const DataSourcePicker: FC = () => {
                     Add a data source
                 </Title>
                 <Text size="md" c="dimmed" ta="center">
-                    Connecting a warehouse is the main event — it's what makes
-                    Aurora useful.
+                    Connect your warehouse so your agents can query your data.
                 </Text>
             </Stack>
 
@@ -252,6 +252,8 @@ const OnboardingDataSourceContent: FC = () => {
             ) : (
                 <DataSourcePicker />
             )}
+
+            <AboutFooter />
         </Box>
     );
 };

--- a/packages/frontend/src/pages/OnboardingProjectReady.module.css
+++ b/packages/frontend/src/pages/OnboardingProjectReady.module.css
@@ -1,9 +1,12 @@
 .page {
-    min-height: 100vh;
+    min-height: calc(100vh - var(--navbar-height));
     background-color: var(--mantine-color-white);
+    display: flex;
+    flex-direction: column;
 }
 
 .column {
+    flex: 1;
     width: 100%;
     max-width: 580px;
     margin: 0 auto;

--- a/packages/frontend/src/pages/OnboardingProjectReady.tsx
+++ b/packages/frontend/src/pages/OnboardingProjectReady.tsx
@@ -12,6 +12,7 @@ import { IconCheck } from '@tabler/icons-react';
 import confetti from 'canvas-confetti';
 import { useEffect, useMemo, useRef, useState, type FC } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
+import AboutFooter from '../components/AboutFooter';
 import { DocumentTitle } from '../components/common/DocumentTitle';
 import MantineIcon from '../components/common/MantineIcon';
 import { useTables } from '../features/sqlRunner/hooks/useTables';
@@ -135,7 +136,7 @@ const OnboardingProjectReadyContent: FC<{ projectUuid: string }> = ({
                         We're getting your project ready
                     </Title>
                     <Text c="dimmed" size="lg" ta="center">
-                        Aurora now understands your data.
+                        Your agents now understand your data.
                     </Text>
                 </Stack>
 
@@ -201,6 +202,8 @@ const OnboardingProjectReadyContent: FC<{ projectUuid: string }> = ({
                     </Button>
                 )}
             </Box>
+
+            <AboutFooter />
         </Box>
     );
 };

--- a/packages/frontend/src/pages/OrganizationSetup.module.css
+++ b/packages/frontend/src/pages/OrganizationSetup.module.css
@@ -1,32 +1,26 @@
 .page {
-    min-height: 100vh;
+    min-height: calc(100vh - var(--navbar-height));
     display: flex;
     flex-direction: column;
     background-color: var(--mantine-color-ldGray-0);
 }
 
-.topBar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: var(--mantine-spacing-lg) var(--mantine-spacing-xl);
-    flex-shrink: 0;
-}
-
 .body {
     flex: 1;
     display: flex;
-    align-items: stretch;
+    align-items: center;
+    justify-content: center;
+    gap: 5rem;
+    width: 100%;
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: var(--mantine-spacing-xl) 3rem;
     min-height: 0;
 }
 
 .leftPane {
     flex: 4;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    padding: var(--mantine-spacing-xl) 4rem;
-    max-width: 640px;
+    max-width: 560px;
 }
 
 .rightPane {
@@ -34,9 +28,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: var(--mantine-spacing-xl) 3rem;
-    background-color: var(--mantine-color-white);
-    border-left: 1px solid var(--mantine-color-ldGray-2);
 }
 
 .heading {
@@ -124,17 +115,17 @@
 @media (max-width: 992px) {
     .body {
         flex-direction: column;
+        gap: var(--mantine-spacing-xl);
     }
 
     .leftPane {
         flex: none;
         max-width: none;
-        padding: var(--mantine-spacing-xl);
+        width: 100%;
     }
 
     .rightPane {
         flex: none;
-        border-left: none;
-        border-top: 1px solid var(--mantine-color-ldGray-2);
+        width: 100%;
     }
 }

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -24,8 +24,8 @@ import { useForm } from '@mantine/form';
 import { zodResolver } from 'mantine-form-zod-resolver';
 import { useEffect, useRef, useState, type FC } from 'react';
 import { Navigate, useNavigate } from 'react-router';
+import AboutFooter from '../components/AboutFooter';
 import { DocumentTitle } from '../components/common/DocumentTitle';
-import LightdashLogo from '../components/LightdashLogo/LightdashLogo';
 import PageSpinner from '../components/PageSpinner';
 import { jobTitles } from '../components/UserCompletionModal/jobTitles';
 import {
@@ -184,8 +184,6 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
         selectedColor,
         detectedBrand?.colors ?? [],
     );
-    const previewDomain =
-        detectedBrand?.domain ?? (isCompanyDomain ? emailDomain : '');
     const titleFont =
         detectedBrand?.fonts.find((font) => font.type === 'title') ?? null;
     const bodyFont =
@@ -224,14 +222,22 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
             });
         }
 
-        if (detectedBrand) {
+        const brandDomain =
+            detectedBrand?.domain ?? (isCompanyDomain ? emailDomain : null);
+        if (brandDomain) {
             saveBrand.mutate({
-                domain: detectedBrand.domain,
-                name: detectedBrand.name,
-                description: detectedBrand.description,
-                logos: detectedBrand.logos,
-                colors: buildBrandColors(selectedColor, detectedBrand.colors),
-                fonts: detectedBrand.fonts,
+                domain: brandDomain,
+                name:
+                    values.organizationName.trim() ||
+                    detectedBrand?.name ||
+                    null,
+                description: detectedBrand?.description ?? null,
+                logos: detectedBrand?.logos ?? [],
+                colors: buildBrandColors(
+                    selectedColor,
+                    detectedBrand?.colors ?? [],
+                ),
+                fonts: detectedBrand?.fonts ?? [],
             });
         }
     });
@@ -243,12 +249,6 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
     return (
         <Box className={classes.page}>
             <DocumentTitle title="Set up your organization" />
-            <Box className={classes.topBar}>
-                <LightdashLogo />
-                <Text size="sm" c="dimmed">
-                    Step {displayStep} of {totalSteps} · {stepLabel}
-                </Text>
-            </Box>
 
             <Box className={classes.body}>
                 <Box className={classes.leftPane}>
@@ -256,6 +256,10 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                         {isWorkspaceStep ? (
                             <Stack gap="lg">
                                 <Stack gap="xs">
+                                    <Text size="sm" c="dimmed">
+                                        Step {displayStep} of {totalSteps} ·{' '}
+                                        {stepLabel}
+                                    </Text>
                                     <Title
                                         order={1}
                                         fz={44}
@@ -291,38 +295,38 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                                         </Text>
                                     </Group>
 
-                                    <Group gap="lg" align="flex-start">
-                                        <Box
-                                            className={classes.logoTile}
-                                            bg={
-                                                detectedLogoUrl
-                                                    ? 'var(--mantine-color-ldGray-0)'
-                                                    : selectedColor
-                                            }
-                                        >
-                                            {detectedLogoUrl ? (
-                                                <img
-                                                    src={detectedLogoUrl}
-                                                    alt=""
-                                                    className={
-                                                        classes.logoTileImage
-                                                    }
-                                                />
-                                            ) : (
-                                                <Text
-                                                    fw={700}
-                                                    fz={20}
-                                                    c="white"
-                                                >
-                                                    {logoTileInitial}
-                                                </Text>
-                                            )}
-                                        </Box>
+                                    <Stack gap="xs">
+                                        <Text size="sm" fw={500}>
+                                            Theme color
+                                        </Text>
+                                        <Group gap="lg" align="center">
+                                            <Box
+                                                className={classes.logoTile}
+                                                bg={
+                                                    detectedLogoUrl
+                                                        ? 'var(--mantine-color-ldGray-0)'
+                                                        : selectedColor
+                                                }
+                                            >
+                                                {detectedLogoUrl ? (
+                                                    <img
+                                                        src={detectedLogoUrl}
+                                                        alt=""
+                                                        className={
+                                                            classes.logoTileImage
+                                                        }
+                                                    />
+                                                ) : (
+                                                    <Text
+                                                        fw={700}
+                                                        fz={20}
+                                                        c="white"
+                                                    >
+                                                        {logoTileInitial}
+                                                    </Text>
+                                                )}
+                                            </Box>
 
-                                        <Stack gap="xs">
-                                            <Text size="sm" fw={500}>
-                                                Theme color
-                                            </Text>
                                             <Box className={classes.swatchRow}>
                                                 {swatches.map((color) => (
                                                     <Box
@@ -346,8 +350,8 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                                                     />
                                                 ))}
                                             </Box>
-                                        </Stack>
-                                    </Group>
+                                        </Group>
+                                    </Stack>
                                 </Stack>
 
                                 <Group>
@@ -366,6 +370,10 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                         ) : (
                             <Stack gap="lg">
                                 <Stack gap="xs">
+                                    <Text size="sm" c="dimmed">
+                                        Step {displayStep} of {totalSteps} ·{' '}
+                                        {stepLabel}
+                                    </Text>
                                     <Title
                                         order={1}
                                         fz={44}
@@ -446,7 +454,6 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
 
                 <Box className={classes.rightPane}>
                     <OrganizationSetupPreview
-                        domain={previewDomain}
                         name={form.values.organizationName || null}
                         logos={detectedBrand?.logos ?? []}
                         colors={previewColors}
@@ -457,6 +464,8 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                     />
                 </Box>
             </Box>
+
+            <AboutFooter />
         </Box>
     );
 };
@@ -464,9 +473,7 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
 const OrganizationSetup: FC = () => {
     const { health, user } = useApp();
     const navigate = useNavigate();
-    const orgSetupPageFlag = useServerFeatureFlag(
-        FeatureFlags.OrganizationSetupPage,
-    );
+    const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
     const completeMutation = useUserCompleteMutation({
         onSuccess: () => void navigate('/'),
     });

--- a/packages/frontend/src/pages/OrganizationSetupPreview.tsx
+++ b/packages/frontend/src/pages/OrganizationSetupPreview.tsx
@@ -9,7 +9,6 @@ import { BrandPreview } from '../components/UserSettings/AppearanceSettingsPanel
 import classes from './OrganizationSetup.module.css';
 
 type OrganizationSetupPreviewProps = {
-    domain: string;
     name: string | null;
     logos: OrganizationBrandLogo[];
     colors: OrganizationBrandColor[];
@@ -20,7 +19,6 @@ type OrganizationSetupPreviewProps = {
 };
 
 const OrganizationSetupPreview: FC<OrganizationSetupPreviewProps> = ({
-    domain,
     name,
     logos,
     colors,
@@ -50,7 +48,6 @@ const OrganizationSetupPreview: FC<OrganizationSetupPreviewProps> = ({
         )}
 
         <BrandPreview
-            domain={domain}
             name={name}
             logos={logos}
             colors={colors}

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -55,7 +55,7 @@ const Register: FC = () => {
     const allowPasswordAuthentication =
         !health.data?.auth.disablePasswordAuthentication;
     const emailOnlySignupFlag = useServerFeatureFlag(
-        FeatureFlags.EmailOnlySignup,
+        FeatureFlags.NewOnboarding,
         { retry: 3 },
     );
     const { identify } = useTracking();

--- a/packages/frontend/src/pages/VerifyEmail.tsx
+++ b/packages/frontend/src/pages/VerifyEmail.tsx
@@ -71,7 +71,7 @@ const VerifyEmailPage: FC = () => {
     const { show: showIntercom } = useIntercom();
     const navigate = useNavigate();
     const emailOnlySignupFlag = useServerFeatureFlag(
-        FeatureFlags.EmailOnlySignup,
+        FeatureFlags.NewOnboarding,
     );
 
     if (

--- a/scripts/dev-fast-start.sh
+++ b/scripts/dev-fast-start.sh
@@ -182,6 +182,12 @@ if test -f .env.development.local; then
     reconcile_env EMAIL_SMTP_PORT 1025
     reconcile_env LDPAT ldpat_deadbeefdeadbeefdeadbeefdeadbeef
     reconcile_env DBT_DEMO_DIR "$(pwd)/examples/full-jaffle-shop-demo"
+    # Default-on (append only, never overwrite): fresh-user signup testing needs
+    # multi-org registration, else POST /api/v1/user 403s once the seed org exists.
+    if ! grep -q "^ALLOW_MULTIPLE_ORGS=" .env.development.local; then
+        echo "ALLOW_MULTIPLE_ORGS=true" >> .env.development.local
+        ENV_PORTS_CHANGED=1
+    fi
     if [ "$ENV_PORTS_CHANGED" = 1 ]; then
         echo "OK: env file reconciled to slot ports (PGPORT=${LD_PG_PORT} PORT=${PORT} FE_PORT=${FE_PORT})"
     else
@@ -218,6 +224,9 @@ EMAIL_SMTP_SENDER_EMAIL=noreply@lightdash.local
 # Dev API access (auto-provisioned PAT from seed data)
 LIGHTDASH_API_URL=http://localhost:${PORT}
 LDPAT=ldpat_deadbeefdeadbeefdeadbeefdeadbeef
+
+# Allow registering fresh users/orgs (signup flow testing)
+ALLOW_MULTIPLE_ORGS=true
 EOF
     echo "DBT_DEMO_DIR=$(pwd)/examples/full-jaffle-shop-demo" >> .env.development.local
     echo "OK: env file created"

--- a/scripts/dev-profiles.json
+++ b/scripts/dev-profiles.json
@@ -1,41 +1,68 @@
 {
-  "$comment": "Instance capabilities for /docker-dev. The AI tier is just Core vs EE: all AI features (agents, writeback, reviews classifier) are bundled into the `ee` profile. GitHub and Slack are integrations (extra credentials / a tunnel), kept as their own toggles. EE requires `github` because AI writeback opens PRs through it, so an EE instance is turnkey for writeback. The start-time multi-select composes these; each pulls in its `requires` transitively, then the union of secrets/flags/env/orgSettings is applied, `reconcile` steps run, and `verify` checks confirm it. `secrets` are keys in scripts/dev-secrets.manifest.json. Addressable by name: `/docker-dev start ee` or `/docker-dev start ee,slack`; no profile = a plain Core instance.",
-  "profiles": {
-    "github": {
-      "label": "GitHub integration (dbt-over-GitHub)",
-      "description": "Connect a project's dbt over the dev GitHub App. Usable standalone on Core (dbt-over-GitHub without AI); also required by EE for writeback PRs.",
-      "secrets": ["GITHUB_APP"],
-      "reconcile": ["github-app-installation", "github-dbt-repo"],
-      "verify": ["github-repos-list"]
+    "$comment": "Instance capabilities for /docker-dev. The AI tier is just Core vs EE: all AI features (agents, writeback, reviews classifier) are bundled into the `ee` profile. GitHub and Slack are integrations (extra credentials / a tunnel), kept as their own toggles. EE requires `github` because AI writeback opens PRs through it, so an EE instance is turnkey for writeback. The start-time multi-select composes these; each pulls in its `requires` transitively, then the union of secrets/flags/env/orgSettings is applied, `reconcile` steps run, and `verify` checks confirm it. `secrets` are keys in scripts/dev-secrets.manifest.json. Addressable by name: `/docker-dev start ee` or `/docker-dev start ee,slack`; no profile = a plain Core instance.",
+    "profiles": {
+        "github": {
+            "label": "GitHub integration (dbt-over-GitHub)",
+            "description": "Connect a project's dbt over the dev GitHub App. Usable standalone on Core (dbt-over-GitHub without AI); also required by EE for writeback PRs.",
+            "secrets": [
+                "GITHUB_APP"
+            ],
+            "reconcile": [
+                "github-app-installation",
+                "github-dbt-repo"
+            ],
+            "verify": [
+                "github-repos-list"
+            ]
+        },
+        "ee": {
+            "label": "Enterprise Edition \u2014 license + all AI (agents, writeback, reviews)",
+            "description": "EE license plus every AI feature: Copilot/agents, AI writeback (opens PRs via GitHub), and the reviews classifier. Bootstraps from the EE base snapshot. Requires the GitHub integration so writeback is turnkey. AI sandboxes default to the LOCAL Docker provider (SANDBOX_PROVIDER=docker) \u2014 no E2B account needed locally; build the images per the Sandboxes section of docker-dev.md.",
+            "ee": true,
+            "requires": [
+                "github"
+            ],
+            "secrets": [
+                "LIGHTDASH_LICENSE_KEY",
+                "ANTHROPIC_API_KEY",
+                "AUTH_GOOGLE_OAUTH2_CLIENT_ID",
+                "AUTH_GOOGLE_OAUTH2_CLIENT_SECRET"
+            ],
+            "env": {
+                "AI_COPILOT_ENABLED": "true",
+                "AI_DEFAULT_PROVIDER": "anthropic",
+                "SANDBOX_PROVIDER": "docker"
+            },
+            "flags": [
+                "ai-writeback",
+                "github-mcp-one-click",
+                "ai-preview-deploy-setup",
+                "homepage-builder"
+            ],
+            "orgSettings": {
+                "ai_agent_reviews_enabled": true
+            },
+            "verify": [
+                "agents-200",
+                "writeback-token"
+            ],
+            "notes": "Sandboxes default to SANDBOX_PROVIDER=docker (local containers). Build the two local images (lightdash-sandbox:local, lightdash-ai-writeback:local) via sandboxes/*/build-local-image.sh before running writeback or data-app generation \u2014 see the Sandboxes section of docker-dev.md. To use E2B instead, add E2B_API_KEY and set SANDBOX_PROVIDER=e2b."
+        },
+        "slack": {
+            "label": "Slack bot (optional add-on)",
+            "description": "Slack app for @mention agent chat. Needs a public tunnel; see the slack-bot-local-setup notes. Not bundled into EE because the tunnel step can't be automated.",
+            "requires": [
+                "ee"
+            ],
+            "secrets": [
+                "SLACK_APP"
+            ],
+            "notes": "SLACK_APP is not yet in the secrets manifest \u2014 confirm the 1Password item name before enabling."
+        }
     },
-    "ee": {
-      "label": "Enterprise Edition — license + all AI (agents, writeback, reviews)",
-      "description": "EE license plus every AI feature: Copilot/agents, AI writeback (opens PRs via GitHub), and the reviews classifier. Bootstraps from the EE base snapshot. Requires the GitHub integration so writeback is turnkey. AI sandboxes default to the LOCAL Docker provider (SANDBOX_PROVIDER=docker) — no E2B account needed locally; build the images per the Sandboxes section of docker-dev.md.",
-      "ee": true,
-      "requires": ["github"],
-      "secrets": [
-        "LIGHTDASH_LICENSE_KEY",
-        "ANTHROPIC_API_KEY",
-        "AUTH_GOOGLE_OAUTH2_CLIENT_ID",
-        "AUTH_GOOGLE_OAUTH2_CLIENT_SECRET"
-      ],
-      "env": { "AI_COPILOT_ENABLED": "true", "AI_DEFAULT_PROVIDER": "anthropic", "SANDBOX_PROVIDER": "docker" },
-      "flags": ["ai-writeback", "github-mcp-one-click", "ai-preview-deploy-setup"],
-      "orgSettings": { "ai_agent_reviews_enabled": true },
-      "verify": ["agents-200", "writeback-token"],
-      "notes": "Sandboxes default to SANDBOX_PROVIDER=docker (local containers). Build the two local images (lightdash-sandbox:local, lightdash-ai-writeback:local) via sandboxes/*/build-local-image.sh before running writeback or data-app generation — see the Sandboxes section of docker-dev.md. To use E2B instead, add E2B_API_KEY and set SANDBOX_PROVIDER=e2b."
-    },
-    "slack": {
-      "label": "Slack bot (optional add-on)",
-      "description": "Slack app for @mention agent chat. Needs a public tunnel; see the slack-bot-local-setup notes. Not bundled into EE because the tunnel step can't be automated.",
-      "requires": ["ee"],
-      "secrets": ["SLACK_APP"],
-      "notes": "SLACK_APP is not yet in the secrets manifest — confirm the 1Password item name before enabling."
+    "snapshots": {
+        "$comment": "Preferred base snapshot per tier, so common instances skip the migrate pass / reconcile. Maintained by dev-fast-start.sh.",
+        "core": "ld-shared_postgres_base",
+        "ee": "ld-shared_postgres_base_ee"
     }
-  },
-  "snapshots": {
-    "$comment": "Preferred base snapshot per tier, so common instances skip the migrate pass / reconcile. Maintained by dev-fast-start.sh.",
-    "core": "ld-shared_postgres_base",
-    "ee": "ld-shared_postgres_base_ee"
-  }
 }


### PR DESCRIPTION
Part 2 of 4 — stacked split of #25752. Base: `stack/01-auth-reset`.

Introduces the single **`new-onboarding`** feature flag and the signup/org-setup experience behind it:
- One consolidated flag replaces the three earlier onboarding flags.
- Email-only (passwordless) signup + full-page organization setup, gated on the flag. OTP **login** is deliberately *not* gated, so a flag rollback never strands already-enrolled passwordless accounts (enrollment is gated, login is not).
- Provisioned onboarding homepage + no-project homepage, dev-provisioning defaults, brand lookup during org setup (429 handled, no refetch storm).

Note: three now-unused enum members are carried as temporary `@deprecated` shims and removed in Part 3, where their last consumers convert — this keeps every slice independently compilable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
