### PR TITLE
feat: setup invites — hand warehouse connect to a teammate with one-click passwordless accept

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.test.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.test.ts
@@ -1,3 +1,4 @@
+import { InviteLinkPurpose } from '@lightdash/common';
 import * as nodemailer from 'nodemailer';
 import type SMTPConnection from 'nodemailer/lib/smtp-connection';
 import EmailClient from './EmailClient';
@@ -86,6 +87,46 @@ describe('EmailClient', () => {
             });
             await client.sendPasswordRecoveryEmail(passwordResetLinkMock);
             expect(client.transporter?.sendMail).toHaveBeenCalledTimes(1);
+        });
+
+        test('should use the setup invitation template for setup invites', async () => {
+            const client = new EmailClient({
+                lightdashConfig: lightdashConfigWithBasicSMTP,
+            });
+
+            await client.sendInviteEmail(
+                {
+                    firstName: 'Taylor',
+                    lastName: 'Smith',
+                    organizationName: 'Acme',
+                },
+                {
+                    email: 'expert@example.com',
+                    expiresAt: new Date('2026-07-21T00:00:00Z'),
+                    inviteCode: 'invite-code',
+                    inviteUrl: 'https://example.com/invite/invite-code',
+                    organizationUuid: 'organization-uuid',
+                    userUuid: 'user-uuid',
+                    purpose: InviteLinkPurpose.Setup,
+                },
+            );
+
+            expect(
+                vi.mocked(client.transporter!.sendMail),
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    to: 'expert@example.com',
+                    subject:
+                        'Taylor Smith needs your help setting up Lightdash for Acme',
+                    template: 'setupInvitation',
+                    context: expect.objectContaining({
+                        inviterName: 'Taylor Smith',
+                        orgName: 'Acme',
+                        inviteUrl:
+                            'https://example.com/invite/invite-code?from=email',
+                    }),
+                }),
+            );
         });
 
         test('should retry email sending on ECONNRESET error', async () => {

--- a/packages/backend/src/clients/EmailClient/EmailClient.test.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.test.ts
@@ -98,6 +98,7 @@ describe('EmailClient', () => {
                 {
                     firstName: 'Taylor',
                     lastName: 'Smith',
+                    email: 'taylor@example.com',
                     organizationName: 'Acme',
                 },
                 {

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -644,7 +644,7 @@ export default class EmailClient {
                         inviteUrl,
                         host: this.lightdashConfig.siteUrl,
                     },
-                    text: `${inviterName} is setting up Lightdash for ${userThatInvited.organizationName} and needs someone with data-warehouse access to connect their data. It takes about 5 minutes. This link is valid for the next 72 hours. ${inviteUrl}`,
+                    text: `${inviterName} is setting up Lightdash for ${userThatInvited.organizationName} and needs someone with data-warehouse access to connect their data. Lightdash is the Agentic BI platform for modern data teams — build and manage analytics straight from the tools you already use, with AI handling the busywork. Built on dbt. Loved by developers. Actually used by businesses. Accept the invite and we'll take you straight to connecting ${userThatInvited.organizationName}'s data warehouse — the last step before your team can start asking questions of their data. This link is valid for the next 72 hours. ${inviteUrl}`,
                 });
             }
             default:

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -611,7 +611,7 @@ export default class EmailClient {
     public async sendInviteEmail(
         userThatInvited: Pick<
             SessionUser,
-            'firstName' | 'lastName' | 'organizationName'
+            'firstName' | 'lastName' | 'email' | 'organizationName'
         >,
         invite: InviteLink,
     ) {
@@ -631,7 +631,9 @@ export default class EmailClient {
                 });
             case InviteLinkPurpose.Setup: {
                 const inviterName =
-                    `${userThatInvited.firstName} ${userThatInvited.lastName}`.trim();
+                    `${userThatInvited.firstName} ${userThatInvited.lastName}`.trim() ||
+                    userThatInvited.email ||
+                    'A teammate';
                 return this.sendEmail({
                     to: invite.email,
                     subject: `${inviterName} needs your help setting up Lightdash for ${userThatInvited.organizationName}`,

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -1,10 +1,12 @@
 import {
     AdminNotificationPayload,
     AdminNotificationType,
+    assertUnreachable,
     CreateProjectMember,
     EmailSenderIdentity,
     getErrorMessage,
     InviteLink,
+    InviteLinkPurpose,
     MissingConfigError,
     PasswordResetLink,
     ProjectMemberRole,
@@ -613,17 +615,42 @@ export default class EmailClient {
         >,
         invite: InviteLink,
     ) {
-        return this.sendEmail({
-            to: invite.email,
-            subject: `You've been invited to join Lightdash`,
-            template: 'invitation',
-            context: {
-                orgName: userThatInvited.organizationName,
-                inviteUrl: `${invite.inviteUrl}?from=email`,
-                host: this.lightdashConfig.siteUrl,
-            },
-            text: `Your teammates at ${userThatInvited.organizationName} are using Lightdash to discover and share data insights. Click on the link below within the next 72 hours to join your team and start exploring your data! ${invite.inviteUrl}?from=email`,
-        });
+        const inviteUrl = `${invite.inviteUrl}?from=email`;
+        switch (invite.purpose) {
+            case InviteLinkPurpose.Member:
+                return this.sendEmail({
+                    to: invite.email,
+                    subject: `You've been invited to join Lightdash`,
+                    template: 'invitation',
+                    context: {
+                        orgName: userThatInvited.organizationName,
+                        inviteUrl,
+                        host: this.lightdashConfig.siteUrl,
+                    },
+                    text: `Your teammates at ${userThatInvited.organizationName} are using Lightdash to discover and share data insights. Click on the link below within the next 72 hours to join your team and start exploring your data! ${inviteUrl}`,
+                });
+            case InviteLinkPurpose.Setup: {
+                const inviterName =
+                    `${userThatInvited.firstName} ${userThatInvited.lastName}`.trim();
+                return this.sendEmail({
+                    to: invite.email,
+                    subject: `${inviterName} needs your help setting up Lightdash for ${userThatInvited.organizationName}`,
+                    template: 'setupInvitation',
+                    context: {
+                        inviterName,
+                        orgName: userThatInvited.organizationName,
+                        inviteUrl,
+                        host: this.lightdashConfig.siteUrl,
+                    },
+                    text: `${inviterName} is setting up Lightdash for ${userThatInvited.organizationName} and needs someone with data-warehouse access to connect their data. It takes about 5 minutes. This link is valid for the next 72 hours. ${inviteUrl}`,
+                });
+            }
+            default:
+                return assertUnreachable(
+                    invite.purpose,
+                    `Unknown invite link purpose: ${invite.purpose}`,
+                );
+        }
     }
 
     public async sendProjectAccessEmail(

--- a/packages/backend/src/clients/EmailClient/templates/setupInvitation.html
+++ b/packages/backend/src/clients/EmailClient/templates/setupInvitation.html
@@ -1,35 +1,708 @@
-{{> _emailHead}}
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:v="urn:schemas-microsoft-com:vml"
+    xmlns:o="urn:schemas-microsoft-com:office:office"
+    lang="en"
+>
+    <head>
+        <meta name="x-apple-disable-message-reformatting" />
+        <meta http-equiv="X-UA-Compatible" />
+        <meta charset="utf-8" />
+        <meta name="viewport" content="target-densitydpi=device-dpi" />
+        <meta content="true" name="HandheldFriendly" />
+        <meta content="width=device-width" name="viewport" />
+        <style type="text/css">
+            table {
+                border-collapse: separate;
+                table-layout: fixed;
+                mso-table-lspace: 0pt;
+                mso-table-rspace: 0pt;
+            }
+
+            table td {
+                border-collapse: collapse;
+            }
+
+            .ExternalClass {
+                width: 100%;
+            }
+
+            .ExternalClass,
+            .ExternalClass p,
+            .ExternalClass span,
+            .ExternalClass font,
+            .ExternalClass td,
+            .ExternalClass div {
+                line-height: 100%;
+            }
+
+            * {
+                line-height: inherit;
+                text-size-adjust: 100%;
+                -ms-text-size-adjust: 100%;
+                -moz-text-size-adjust: 100%;
+                -o-text-size-adjust: 100%;
+                -webkit-text-size-adjust: 100%;
+                -webkit-font-smoothing: antialiased;
+                -moz-osx-font-smoothing: grayscale;
+            }
+
+            html {
+                -webkit-text-size-adjust: none !important;
+            }
+
+            img + div {
+                display: none;
+                display: none !important;
+            }
+
+            img {
+                margin: 0;
+                padding: 0;
+                -ms-interpolation-mode: bicubic;
+            }
+
+            h1,
+            h2,
+            h3,
+            p,
+            a {
+                line-height: 1;
+                overflow-wrap: normal;
+                white-space: normal;
+                word-break: break-word;
+            }
+
+            a {
+                text-decoration: none;
+            }
+
+            h1,
+            h2,
+            h3,
+            p {
+                min-width: 100% !important;
+                width: 100% !important;
+                max-width: 100% !important;
+                display: inline-block !important;
+                border: 0;
+                padding: 0;
+                margin: 0;
+            }
+
+            a[x-apple-data-detectors] {
+                color: inherit !important;
+                text-decoration: none !important;
+                font-size: inherit !important;
+                font-family: inherit !important;
+                font-weight: inherit !important;
+                line-height: inherit !important;
+            }
+
+            a[href^='mailto'],
+            a[href^='tel'],
+            a[href^='sms'] {
+                color: inherit !important;
+                text-decoration: none !important;
+            }
+
+            @media only screen and (min-width: 481px) {
+                .hd {
+                    display: none !important;
+                }
+            }
+
+            @media only screen and (max-width: 480px) {
+                .hm {
+                    display: none !important;
+                }
+            }
+
+            [style*='Roboto'] {
+                font-family:
+                    'Roboto',
+                    BlinkMacSystemFont,
+                    Segoe UI,
+                    Helvetica Neue,
+                    Arial,
+                    sans-serif !important;
+            }
+
+            [style*='Albert Sans'] {
+                font-family:
+                    'Albert Sans',
+                    BlinkMacSystemFont,
+                    Segoe UI,
+                    Helvetica Neue,
+                    Arial,
+                    sans-serif !important;
+            }
+
+            @media only screen and (min-width: 481px) {
+                .t3,
+                .t4 {
+                    mso-line-height-alt: 60px !important;
+                    line-height: 60px !important;
+                    display: block !important;
+                }
+
+                .t9 {
+                    padding-left: 20px !important;
+                    padding-right: 20px !important;
+                }
+
+                .t11 {
+                    padding-left: 20px !important;
+                    padding-right: 20px !important;
+                    width: 560px !important;
+                }
+
+                .t14 {
+                    margin-left: 0px !important;
+                }
+
+                .t15 {
+                    padding: 26px 40px !important;
+                    border-top-left-radius: 14px !important;
+                    border-top-right-radius: 14px !important;
+                    width: 720px !important;
+                }
+
+                .t20 {
+                    border-top-left-radius: 14px !important;
+                    border-top-right-radius: 14px !important;
+                    padding: 26px 40px !important;
+                }
+
+                .t28 {
+                    border-bottom-right-radius: 14px !important;
+                    border-bottom-left-radius: 14px !important;
+                    padding: 40px !important;
+                }
+
+                .t30 {
+                    padding: 40px !important;
+                    border-bottom-right-radius: 14px !important;
+                    border-bottom-left-radius: 14px !important;
+                    width: 720px !important;
+                }
+
+                .t36 {
+                    max-width: 122px !important;
+                }
+
+                .t41 {
+                    mso-line-height-alt: 0px !important;
+                    line-height: 0 !important;
+                    display: none !important;
+                }
+
+                .t50 {
+                    font-size: 20px !important;
+                }
+
+                .t57 {
+                    padding: 48px 50px 2px !important;
+                }
+
+                .t59 {
+                    padding: 48px 50px 2px !important;
+                    width: 500px !important;
+                }
+
+                .t63,
+                .t68 {
+                    padding-bottom: 40px !important;
+                }
+
+                .t75,
+                .t85,
+                .t95 {
+                    max-width: 44px !important;
+                }
+
+                .t123 {
+                    mso-line-height-alt: 33px !important;
+                    line-height: 33px !important;
+                }
+
+                .t132 {
+                    line-height: 25px !important;
+                    font-size: 16px !important;
+                    color: #95959e !important;
+                    mso-text-raise: 3px !important;
+                }
+
+                .t133 {
+                    mso-line-height-alt: 33px !important;
+                    line-height: 33px !important;
+                }
+
+                .t142 {
+                    line-height: 25px !important;
+                    font-size: 38px !important;
+                    mso-text-raise: -4px !important;
+                }
+
+                .t143 {
+                    mso-line-height-alt: 33px !important;
+                    line-height: 33px !important;
+                }
+
+                .t152 {
+                    line-height: 25px !important;
+                    font-size: 16px !important;
+                    color: #95959e !important;
+                    mso-text-raise: 3px !important;
+                }
+            }
+        </style>
+        <!--[if !mso]><!-->
+        <link
+            href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&family=Albert+Sans:wght@500;700&display=swap"
+            rel="stylesheet"
+            type="text/css"
+        />
+        <!--<![endif]-->
+        <!--[if mso]>
+            <style type="text/css">
+                div.t3,
+                div.t4 {
+                    mso-line-height-alt: 60px !important;
+                    line-height: 60px !important;
+                    display: block !important;
+                }
+
+                td.t9 {
+                    padding-left: 20px !important;
+                    padding-right: 20px !important;
+                }
+
+                td.t11 {
+                    padding-left: 20px !important;
+                    padding-right: 20px !important;
+                    width: 600px !important;
+                }
+
+                table.t14 {
+                    margin-left: 0px !important;
+                }
+
+                td.t15 {
+                    padding: 26px 40px !important;
+                    border-top-left-radius: 14px !important;
+                    border-top-right-radius: 14px !important;
+                    width: 800px !important;
+                }
+
+                td.t20 {
+                    border-top-left-radius: 14px !important;
+                    border-top-right-radius: 14px !important;
+                    padding: 26px 40px !important;
+                }
+
+                td.t28 {
+                    border-bottom-right-radius: 14px !important;
+                    border-bottom-left-radius: 14px !important;
+                    padding: 40px !important;
+                }
+
+                td.t30 {
+                    padding: 40px !important;
+                    border-bottom-right-radius: 14px !important;
+                    border-bottom-left-radius: 14px !important;
+                    width: 800px !important;
+                }
+
+                td.t34 {
+                    width: 122px !important;
+                }
+
+                div.t36 {
+                    max-width: 122px !important;
+                }
+
+                div.t41 {
+                    mso-line-height-alt: 0px !important;
+                    line-height: 0 !important;
+                    display: none !important;
+                }
+
+                h1.t50 {
+                    font-size: 20px !important;
+                }
+
+                td.t57,
+                td.t59 {
+                    padding: 48px 50px 2px !important;
+                }
+
+                td.t63,
+                td.t68 {
+                    padding-bottom: 40px !important;
+                }
+
+                td.t73 {
+                    width: 24px !important;
+                }
+
+                div.t75 {
+                    max-width: 44px !important;
+                }
+
+                td.t83 {
+                    width: 24px !important;
+                }
+
+                div.t85 {
+                    max-width: 44px !important;
+                }
+
+                td.t93 {
+                    width: 24px !important;
+                }
+
+                div.t95 {
+                    max-width: 44px !important;
+                }
+
+                div.t123 {
+                    mso-line-height-alt: 33px !important;
+                    line-height: 33px !important;
+                }
+
+                p.t132 {
+                    line-height: 25px !important;
+                    font-size: 16px !important;
+                    color: #95959e !important;
+                    mso-text-raise: 3px !important;
+                }
+
+                div.t133 {
+                    mso-line-height-alt: 33px !important;
+                    line-height: 33px !important;
+                }
+
+                p.t142 {
+                    line-height: 25px !important;
+                    font-size: 38px !important;
+                    mso-text-raise: -4px !important;
+                }
+
+                div.t143 {
+                    mso-line-height-alt: 33px !important;
+                    line-height: 33px !important;
+                }
+
+                p.t152 {
+                    line-height: 25px !important;
+                    font-size: 16px !important;
+                    color: #95959e !important;
+                    mso-text-raise: 3px !important;
+                }
+            </style>
+        <![endif]-->
+        <!--[if mso]>
+            <xml>
+                <o:OfficeDocumentSettings>
+                    <o:AllowPNG />
+                    <o:PixelsPerInch>96</o:PixelsPerInch>
+                </o:OfficeDocumentSettings>
+            </xml>
+        <![endif]-->
+    </head>
+    <body
+        class="t0"
+        style="
+            min-width: 100%;
+            margin: 0px;
+            padding: 0px;
+            background-color: #292929;
+        "
+    >
+        <div class="t1" style="background-color: #292929">
+            <table
+                role="presentation"
+                width="100%"
+                cellpadding="0"
+                cellspacing="0"
+                border="0"
+                align="center"
+            >
+                <tr>
+                    <td
+                        class="t154"
+                        style="
+                            font-size: 0;
+                            line-height: 0;
+                            mso-line-height-rule: exactly;
+                        "
+                        valign="top"
+                        align="center"
+                    >
+                        <!--[if mso]>
+                            <v:background
+                                xmlns:v="urn:schemas-microsoft-com:vml"
+                                fill="true"
+                                stroke="false"
+                            >
+                                <v:fill color="#292929" />
+                            </v:background>
+                        <![endif]-->
+                        <table
+                            role="presentation"
+                            width="100%"
+                            cellpadding="0"
+                            cellspacing="0"
+                            border="0"
+                            align="center"
+                        >
+                            <tr>
+                                <td>
+                                    <div
+                                        class="t3"
+                                        style="
+                                            mso-line-height-rule: exactly;
+                                            font-size: 1px;
+                                            display: none;
+                                        "
+                                    >
+                                        &nbsp;
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <table
+                                        class="t10"
+                                        role="presentation"
+                                        cellpadding="0"
+                                        cellspacing="0"
+                                        align="center"
+                                    >
+                                        <tr>
+                                            <!--[if !mso]><!-->
+                                            <td
+                                                class="t11"
+                                                style="
+                                                    overflow: hidden;
+                                                    width: 435px;
+                                                "
+                                            >
+                                                <!--<![endif]-->
+                                                <!--[if mso]>
+                    <td class="t11" style="overflow:hidden;width:435px;"><![endif]-->
+                                                <table
+                                                    role="presentation"
+                                                    width="100%"
+                                                    cellpadding="0"
+                                                    cellspacing="0"
+                                                >
+                                                    <tr>
+                                                        <td>
+                                                            <!--[if !mso]><!-->
+                                                            <table
+                                                                class="t14"
+                                                                role="presentation"
+                                                                cellpadding="0"
+                                                                cellspacing="0"
+                                                                style="
+                                                                    margin-left: auto;
+                                                                    margin-right: auto;
+                                                                "
+                                                            >
+                                                                <!--<![endif]-->
+                                                                <!--[if mso]>
+                            <table class="t14" role="presentation" cellpadding="0" cellspacing="0" align="left">
+                            <![endif]-->
+                                                                <tr>
+                                                                    <!--[if !mso]><!-->
+                                                                    <td
+                                                                        class="t15"
+                                                                        style="background-color:#7262FF;background-image:url({{host}}/banner.jpg);background-repeat:no-repeat;background-size:contain;background-position:right top;overflow:hidden;width:331px;padding:16px 14px 16px 14px;border-radius:4px 4px 0 0;"
+                                                                    >
+                                                                        <!--<![endif]-->
+                                                                        <!--[if mso]>
+                                <td class="t15"
+                                    style="background-color:#7262FF;background-image:url({{host}}/banner.jpg);background-repeat:no-repeat;background-size:contain;background-position:right top;overflow:hidden;width:359px;padding:16px 14px 16px 14px;border-radius:4px 4px 0 0;">
+                                <![endif]-->
+                                                                        <div
+                                                                            class="t21"
+                                                                            style="
+                                                                                display: inline-table;
+                                                                                width: 100%;
+                                                                                text-align: left;
+                                                                                vertical-align: top;
+                                                                            "
+                                                                        >
+                                                                            <!--[if mso]>
+                                  <table role="presentation" cellpadding="0" cellspacing="0" align="left" valign="top">
+                                    <tr>
+                                      <td width="122" valign="top"><![endif]-->
+                                                                            <div
+                                                                                class="t36"
+                                                                                style="
+                                                                                    display: inline-table;
+                                                                                    text-align: initial;
+                                                                                    vertical-align: inherit;
+                                                                                    width: 100%;
+                                                                                    max-width: 92px;
+                                                                                "
+                                                                            >
+                                                                                <table
+                                                                                    role="presentation"
+                                                                                    width="100%"
+                                                                                    cellpadding="0"
+                                                                                    cellspacing="0"
+                                                                                    class="t38"
+                                                                                >
+                                                                                    <tr>
+                                                                                        <td
+                                                                                            class="t39"
+                                                                                        >
+                                                                                            <div
+                                                                                                style="
+                                                                                                    font-size: 0px;
+                                                                                                "
+                                                                                            >
+                                                                                                <img
+                                                                                                    class="t40"
+                                                                                                    style="
+                                                                                                        display: block;
+                                                                                                        border: 0;
+                                                                                                        height: auto;
+                                                                                                        width: 100%;
+                                                                                                        margin: 0;
+                                                                                                        max-width: 100%;
+                                                                                                    "
+                                                                                                    width="122"
+                                                                                                    src="{{logoSrc}}"
+                                                                                                />
+                                                                                            </div>
+                                                                                        </td>
+                                                                                    </tr>
+                                                                                </table>
+                                                                            </div>
+                                                                            <!--[if mso]>
+                                  </td>
+                                  </tr></table>
+                                  <![endif]-->
+                                                                        </div>
+                                                                    </td>
+                                                                </tr>
+                                                            </table>
+                                                        </td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td>
+                                                            <table
+                                                                class="t29"
+                                                                role="presentation"
+                                                                cellpadding="0"
+                                                                cellspacing="0"
+                                                                align="center"
+                                                            >
+                                                                <tr>
+                                                                    <!--[if !mso]><!-->
+                                                                    <td
+                                                                        class="t30"
+                                                                        style="
+                                                                            background-color: #f7f7f9;
+                                                                            overflow: hidden;
+                                                                            width: 353px;
+                                                                            padding: 16px
+                                                                                16px
+                                                                                48px
+                                                                                16px;
+                                                                            border-radius: 0
+                                                                                0
+                                                                                4px
+                                                                                4px;
+                                                                        "
+                                                                    >
+                                                                        <!--<![endif]-->
+                                                                        <!--[if mso]>
+                                <td class="t30"
+                                    style="background-color:#F7F7F9;overflow:hidden;width:385px;padding:16px 16px 48px 16px;border-radius:0 0 4px 4px;">
+                                <![endif]-->
+                                                                        <table
+                                                                            role="presentation"
+                                                                            width="100%"
+                                                                            cellpadding="0"
+                                                                            cellspacing="0"
+                                                                        >
+                                                                            <!--[if !mso]><!-->
+                                                                            <tr>
+                                                                                <td>
+                                                                                    <div
+                                                                                        class="t41"
+                                                                                        style="
+                                                                                            mso-line-height-rule: exactly;
+                                                                                            mso-line-height-alt: 16px;
+                                                                                            line-height: 16px;
+                                                                                            font-size: 1px;
+                                                                                            display: block;
+                                                                                        "
+                                                                                    >
+                                                                                        &nbsp;
+                                                                                    </div>
+                                                                                </td>
+                                                                            </tr>
+                                                                            <!--<![endif]-->
                                                                             <tr>
                                                                                 <td>
                                                                                     <table
+                                                                                        class="t43"
                                                                                         role="presentation"
                                                                                         cellpadding="0"
                                                                                         cellspacing="0"
-                                                                                        align="center"
+                                                                                        align="left"
                                                                                     >
                                                                                         <tr>
+                                                                                            <!--[if !mso]><!-->
                                                                                             <td
+                                                                                                class="t44"
                                                                                                 style="
-                                                                                                    width: 600px;
+                                                                                                    width: 678px;
                                                                                                 "
                                                                                             >
+                                                                                                <!--<![endif]-->
+                                                                                                <!--[if mso]>
+                                            <td class="t44" style="width:678px;"><![endif]-->
                                                                                                 <h1
+                                                                                                    class="t50"
                                                                                                     style="
-                                                                                                        font-family: BlinkMacSystemFont,
-                                                                                                            Segoe UI,
-                                                                                                            Helvetica Neue,
+                                                                                                        font-family:
+                                                                                                            BlinkMacSystemFont,
+                                                                                                            Segoe
+                                                                                                                UI,
+                                                                                                            Helvetica
+                                                                                                                Neue,
                                                                                                             Arial,
                                                                                                             sans-serif,
                                                                                                             'Roboto';
-                                                                                                        line-height: 28px;
+                                                                                                        line-height: 20px;
                                                                                                         font-weight: 500;
-                                                                                                        font-size: 24px;
+                                                                                                        font-style: normal;
+                                                                                                        font-size: 16px;
+                                                                                                        text-decoration: none;
+                                                                                                        text-transform: none;
+                                                                                                        direction: ltr;
                                                                                                         color: #121212;
                                                                                                         text-align: center;
-                                                                                                        margin-bottom: 20px;
+                                                                                                        mso-line-height-rule: exactly;
+                                                                                                        mso-text-raise: 1px;
                                                                                                     "
                                                                                                 >
-                                                                                                    You've been asked to help set up {{orgName}}
+                                                                                                    You&#39;ve
+                                                                                                    been
+                                                                                                    asked
+                                                                                                    to
+                                                                                                    help
+                                                                                                    set
+                                                                                                    up
+                                                                                                    {{orgName}}
                                                                                                 </h1>
                                                                                             </td>
                                                                                         </tr>
@@ -38,38 +711,157 @@
                                                                             </tr>
                                                                             <tr>
                                                                                 <td>
+                                                                                    <div
+                                                                                        class="t133"
+                                                                                        style="
+                                                                                            mso-line-height-rule: exactly;
+                                                                                            mso-line-height-alt: 25px;
+                                                                                            line-height: 25px;
+                                                                                            font-size: 1px;
+                                                                                            display: block;
+                                                                                        "
+                                                                                    >
+                                                                                        &nbsp;
+                                                                                    </div>
+                                                                                </td>
+                                                                            </tr>
+                                                                            <tr>
+                                                                                <td>
                                                                                     <table
+                                                                                        class="t125"
                                                                                         role="presentation"
                                                                                         cellpadding="0"
                                                                                         cellspacing="0"
                                                                                         align="center"
                                                                                     >
                                                                                         <tr>
+                                                                                            <!--[if !mso]><!-->
                                                                                             <td
+                                                                                                class="t126"
                                                                                                 style="
-                                                                                                    width: 600px;
+                                                                                                    width: 966px;
                                                                                                 "
                                                                                             >
+                                                                                                <!--<![endif]-->
+                                                                                                <!--[if mso]>
+                                            <td class="t126" style="width:966px;"><![endif]-->
                                                                                                 <p
+                                                                                                    class="t132"
                                                                                                     style="
-                                                                                                        font-family: BlinkMacSystemFont,
-                                                                                                            Segoe UI,
-                                                                                                            Helvetica Neue,
+                                                                                                        font-family:
+                                                                                                            BlinkMacSystemFont,
+                                                                                                            Segoe
+                                                                                                                UI,
+                                                                                                            Helvetica
+                                                                                                                Neue,
                                                                                                             Arial,
                                                                                                             sans-serif,
                                                                                                             'Roboto';
-                                                                                                        line-height: 20px;
+                                                                                                        line-height: 22px;
                                                                                                         font-weight: 400;
+                                                                                                        font-style: normal;
                                                                                                         font-size: 14px;
+                                                                                                        text-decoration: none;
+                                                                                                        text-transform: none;
+                                                                                                        direction: ltr;
                                                                                                         color: #8c8182;
                                                                                                         text-align: center;
+                                                                                                        mso-line-height-rule: exactly;
+                                                                                                        mso-text-raise: 2px;
                                                                                                     "
                                                                                                 >
-                                                                                                    {{inviterName}} is setting up Lightdash for {{orgName}} and needs someone with data-warehouse access to connect their data.
+                                                                                                    {{inviterName}}
+                                                                                                    is
+                                                                                                    setting
+                                                                                                    up
+                                                                                                    Lightdash
+                                                                                                    for
+                                                                                                    {{orgName}}
+                                                                                                    and
+                                                                                                    needs
+                                                                                                    someone
+                                                                                                    with
+                                                                                                    data-warehouse
+                                                                                                    access
+                                                                                                    to
+                                                                                                    connect
+                                                                                                    their
+                                                                                                    data.
                                                                                                     <br /><br />
-                                                                                                    Lightdash is the Agentic BI platform for modern data teams &mdash; build and manage analytics straight from the tools you already use, with AI handling the busywork. Built on dbt. Loved by developers. Actually used by businesses.
+                                                                                                    Lightdash
+                                                                                                    is
+                                                                                                    the
+                                                                                                    Agentic
+                                                                                                    BI
+                                                                                                    platform
+                                                                                                    for
+                                                                                                    modern
+                                                                                                    data
+                                                                                                    teams
+                                                                                                    &mdash;
+                                                                                                    build
+                                                                                                    and
+                                                                                                    manage
+                                                                                                    analytics
+                                                                                                    straight
+                                                                                                    from
+                                                                                                    the
+                                                                                                    tools
+                                                                                                    you
+                                                                                                    already
+                                                                                                    use,
+                                                                                                    with
+                                                                                                    AI
+                                                                                                    handling
+                                                                                                    the
+                                                                                                    busywork.
+                                                                                                    Built
+                                                                                                    on
+                                                                                                    dbt.
+                                                                                                    Loved
+                                                                                                    by
+                                                                                                    developers.
+                                                                                                    Actually
+                                                                                                    used
+                                                                                                    by
+                                                                                                    businesses.
                                                                                                     <br /><br />
-                                                                                                    Accept the invite and we&rsquo;ll take you straight to connecting {{orgName}}&rsquo;s data warehouse &mdash; the last step before your team can start asking questions of their data. This link is valid for the next 72 hours.
+                                                                                                    Accept
+                                                                                                    the
+                                                                                                    invite
+                                                                                                    and
+                                                                                                    we&rsquo;ll
+                                                                                                    take
+                                                                                                    you
+                                                                                                    straight
+                                                                                                    to
+                                                                                                    connecting
+                                                                                                    {{orgName}}&rsquo;s
+                                                                                                    data
+                                                                                                    warehouse
+                                                                                                    &mdash;
+                                                                                                    the
+                                                                                                    last
+                                                                                                    step
+                                                                                                    before
+                                                                                                    your
+                                                                                                    team
+                                                                                                    can
+                                                                                                    start
+                                                                                                    asking
+                                                                                                    questions
+                                                                                                    of
+                                                                                                    their
+                                                                                                    data.
+                                                                                                    This
+                                                                                                    link
+                                                                                                    is
+                                                                                                    valid
+                                                                                                    for
+                                                                                                    the
+                                                                                                    next
+                                                                                                    72
+                                                                                                    hours.
                                                                                                 </p>
                                                                                             </td>
                                                                                         </tr>
@@ -77,51 +869,533 @@
                                                                                 </td>
                                                                             </tr>
                                                                             <tr>
-                                                                                <td style="height: 25px;">&nbsp;</td>
+                                                                                <td>
+                                                                                    <div
+                                                                                        class="t143"
+                                                                                        style="
+                                                                                            mso-line-height-rule: exactly;
+                                                                                            mso-line-height-alt: 30px;
+                                                                                            line-height: 30px;
+                                                                                            font-size: 1px;
+                                                                                            display: block;
+                                                                                        "
+                                                                                    >
+                                                                                        &nbsp;
+                                                                                    </div>
+                                                                                </td>
                                                                             </tr>
                                                                             <tr>
                                                                                 <td>
                                                                                     <table
+                                                                                        class="t145"
                                                                                         role="presentation"
                                                                                         cellpadding="0"
                                                                                         cellspacing="0"
                                                                                         align="center"
                                                                                     >
                                                                                         <tr>
+                                                                                            <!--[if !mso]><!-->
                                                                                             <td
+                                                                                                class="t146"
                                                                                                 style="
                                                                                                     background-color: #7262ff;
                                                                                                     overflow: hidden;
                                                                                                     text-align: center;
                                                                                                     line-height: 40px;
-                                                                                                    padding: 4px;
-                                                                                                    border-radius: 3px;
+                                                                                                    mso-line-height-rule: exactly;
+                                                                                                    mso-text-raise: 8px;
+                                                                                                    padding: 4px
+                                                                                                        4px
+                                                                                                        4px
+                                                                                                        4px;
+                                                                                                    border-radius: 3px
+                                                                                                        3px
+                                                                                                        3px
+                                                                                                        3px;
                                                                                                 "
                                                                                             >
+                                                                                                <!--<![endif]-->
+                                                                                                <!--[if mso]>
+                                            <td class="t146"
+                                                style="background-color:#7262FF;overflow:hidden;text-align:center;line-height:40px;mso-line-height-rule:exactly;mso-text-raise:8px;padding:4px 4px 4px 4px;border-radius:3px 3px 3px 3px;">
+                                            <![endif]-->
                                                                                                 <a
-                                                                                                    href="{{inviteUrl}}"
-                                                                                                    target="_blank"
+                                                                                                    class="t152"
                                                                                                     style="
                                                                                                         display: block;
-                                                                                                        font-family: BlinkMacSystemFont,
-                                                                                                            Segoe UI,
-                                                                                                            Helvetica Neue,
+                                                                                                        font-family:
+                                                                                                            BlinkMacSystemFont,
+                                                                                                            Segoe
+                                                                                                                UI,
+                                                                                                            Helvetica
+                                                                                                                Neue,
                                                                                                             Arial,
                                                                                                             sans-serif,
                                                                                                             'Roboto';
                                                                                                         line-height: 40px;
                                                                                                         font-weight: 600;
+                                                                                                        font-style: normal;
                                                                                                         font-size: 14px;
                                                                                                         text-decoration: none;
+                                                                                                        direction: ltr;
                                                                                                         color: #ffffff;
                                                                                                         text-align: center;
-                                                                                                        padding: 0 20px;
+                                                                                                        mso-line-height-rule: exactly;
+                                                                                                        mso-text-raise: 8px;
+                                                                                                        padding: 0
+                                                                                                            20px
+                                                                                                            0
+                                                                                                            20px;
                                                                                                     "
-                                                                                                    >Help set up {{orgName}}</a
+                                                                                                    href="{{inviteUrl}}"
+                                                                                                    target="_blank"
+                                                                                                    >Help
+                                                                                                    set
+                                                                                                    up
+                                                                                                    {{orgName}}</a
                                                                                                 >
                                                                                             </td>
                                                                                         </tr>
                                                                                     </table>
                                                                                 </td>
                                                                             </tr>
-{{> _emailFoot}}
+                                                                        </table>
+                                                                    </td>
+                                                                </tr>
+                                                            </table>
+                                                        </td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td>
+                                                            <table
+                                                                class="t58"
+                                                                role="presentation"
+                                                                cellpadding="0"
+                                                                cellspacing="0"
+                                                                align="center"
+                                                            >
+                                                                <tr>
+                                                                    <!--[if !mso]><!-->
+                                                                    <td
+                                                                        class="t59"
+                                                                        style="
+                                                                            overflow: hidden;
+                                                                            width: 540px;
+                                                                            padding: 40px
+                                                                                30px
+                                                                                40px
+                                                                                30px;
+                                                                        "
+                                                                    >
+                                                                        <!--<![endif]-->
+                                                                        <!--[if mso]>
+                                <td class="t59" style="overflow:hidden;width:600px;padding:40px 30px 40px 30px;">
+                                <![endif]-->
+                                                                        <table
+                                                                            role="presentation"
+                                                                            width="100%"
+                                                                            cellpadding="0"
+                                                                            cellspacing="0"
+                                                                        >
+                                                                            <tr>
+                                                                                <td>
+                                                                                    <table
+                                                                                        class="t62"
+                                                                                        role="presentation"
+                                                                                        cellpadding="0"
+                                                                                        cellspacing="0"
+                                                                                        align="center"
+                                                                                    >
+                                                                                        <tr>
+                                                                                            <!--[if !mso]><!-->
+                                                                                            <td
+                                                                                                class="t63"
+                                                                                                style="
+                                                                                                    overflow: hidden;
+                                                                                                    width: 800px;
+                                                                                                    padding: 10px
+                                                                                                        0
+                                                                                                        21px
+                                                                                                        0;
+                                                                                                "
+                                                                                            >
+                                                                                                <!--<![endif]-->
+                                                                                                <!--[if mso]>
+                                            <td class="t63" style="overflow:hidden;width:800px;padding:10px 0 21px 0;">
+                                            <![endif]-->
+                                                                                                <div
+                                                                                                    class="t69"
+                                                                                                    style="
+                                                                                                        display: inline-table;
+                                                                                                        width: 100%;
+                                                                                                        text-align: center;
+                                                                                                        vertical-align: top;
+                                                                                                    "
+                                                                                                >
+                                                                                                    <!--[if mso]>
+                                              <table role="presentation" cellpadding="0" cellspacing="0" align="center"
+                                                     valign="top">
+                                                <tr>
+                                                  <td class="t74" style="width:10px;" width="10"></td>
+                                                  <td width="24" valign="top"><![endif]-->
+                                                                                                    <div
+                                                                                                        class="t75"
+                                                                                                        style="
+                                                                                                            display: inline-table;
+                                                                                                            text-align: initial;
+                                                                                                            vertical-align: inherit;
+                                                                                                            width: 33.33333%;
+                                                                                                            max-width: 40px;
+                                                                                                        "
+                                                                                                    >
+                                                                                                        <div
+                                                                                                            class="t76"
+                                                                                                            style="
+                                                                                                                padding: 0
+                                                                                                                    10px
+                                                                                                                    0
+                                                                                                                    10px;
+                                                                                                            "
+                                                                                                        >
+                                                                                                            <table
+                                                                                                                role="presentation"
+                                                                                                                width="100%"
+                                                                                                                cellpadding="0"
+                                                                                                                cellspacing="0"
+                                                                                                                class="t77"
+                                                                                                            >
+                                                                                                                <tr>
+                                                                                                                    <td
+                                                                                                                        class="t78"
+                                                                                                                    >
+                                                                                                                        <a
+                                                                                                                            href="https://twitter.com/lightdash_devs"
+                                                                                                                            style="
+                                                                                                                                font-size: 0px;
+                                                                                                                            "
+                                                                                                                            ><img
+                                                                                                                                class="t79"
+                                                                                                                                style="
+                                                                                                                                    display: block;
+                                                                                                                                    border: 0;
+                                                                                                                                    height: auto;
+                                                                                                                                    width: 100%;
+                                                                                                                                    margin: 0;
+                                                                                                                                    max-width: 100%;
+                                                                                                                                "
+                                                                                                                                width="24"
+                                                                                                                                src="{{twitterSrc}}"
+                                                                                                                        /></a>
+                                                                                                                    </td>
+                                                                                                                </tr>
+                                                                                                            </table>
+                                                                                                        </div>
+                                                                                                    </div>
+                                                                                                    <!--[if mso]>
+                                              </td>
+                                              <td class="t74" style="width:10px;" width="10"></td>
+                                              <td class="t84" style="width:10px;" width="10"></td>
+                                              <td width="24" valign="top"><![endif]-->
+                                                                                                    <div
+                                                                                                        class="t85"
+                                                                                                        style="
+                                                                                                            display: inline-table;
+                                                                                                            text-align: initial;
+                                                                                                            vertical-align: inherit;
+                                                                                                            width: 33.33333%;
+                                                                                                            max-width: 40px;
+                                                                                                        "
+                                                                                                    >
+                                                                                                        <div
+                                                                                                            class="t86"
+                                                                                                            style="
+                                                                                                                padding: 0
+                                                                                                                    10px
+                                                                                                                    0
+                                                                                                                    10px;
+                                                                                                            "
+                                                                                                        >
+                                                                                                            <table
+                                                                                                                role="presentation"
+                                                                                                                width="100%"
+                                                                                                                cellpadding="0"
+                                                                                                                cellspacing="0"
+                                                                                                                class="t87"
+                                                                                                            >
+                                                                                                                <tr>
+                                                                                                                    <td
+                                                                                                                        class="t88"
+                                                                                                                    >
+                                                                                                                        <a
+                                                                                                                            href="https://github.com/lightdash/lightdash"
+                                                                                                                            style="
+                                                                                                                                font-size: 0px;
+                                                                                                                            "
+                                                                                                                            ><img
+                                                                                                                                class="t89"
+                                                                                                                                style="
+                                                                                                                                    display: block;
+                                                                                                                                    border: 0;
+                                                                                                                                    height: auto;
+                                                                                                                                    width: 100%;
+                                                                                                                                    margin: 0;
+                                                                                                                                    max-width: 100%;
+                                                                                                                                "
+                                                                                                                                width="24"
+                                                                                                                                src="{{githubSrc}}"
+                                                                                                                        /></a>
+                                                                                                                    </td>
+                                                                                                                </tr>
+                                                                                                            </table>
+                                                                                                        </div>
+                                                                                                    </div>
+                                                                                                    <!--[if mso]>
+                                              </td>
+                                              <td class="t84" style="width:10px;" width="10"></td>
+                                              <td class="t94" style="width:10px;" width="10"></td>
+                                              <td width="24" valign="top"><![endif]-->
+                                                                                                    <div
+                                                                                                        class="t95"
+                                                                                                        style="
+                                                                                                            display: inline-table;
+                                                                                                            text-align: initial;
+                                                                                                            vertical-align: inherit;
+                                                                                                            width: 33.33333%;
+                                                                                                            max-width: 40px;
+                                                                                                        "
+                                                                                                    >
+                                                                                                        <div
+                                                                                                            class="t96"
+                                                                                                            style="
+                                                                                                                padding: 0
+                                                                                                                    10px
+                                                                                                                    0
+                                                                                                                    10px;
+                                                                                                            "
+                                                                                                        >
+                                                                                                            <table
+                                                                                                                role="presentation"
+                                                                                                                width="100%"
+                                                                                                                cellpadding="0"
+                                                                                                                cellspacing="0"
+                                                                                                                class="t97"
+                                                                                                            >
+                                                                                                                <tr>
+                                                                                                                    <td
+                                                                                                                        class="t98"
+                                                                                                                    >
+                                                                                                                        <a
+                                                                                                                            href="https://www.linkedin.com/company/lightdash"
+                                                                                                                            style="
+                                                                                                                                font-size: 0px;
+                                                                                                                            "
+                                                                                                                            ><img
+                                                                                                                                class="t99"
+                                                                                                                                style="
+                                                                                                                                    display: block;
+                                                                                                                                    border: 0;
+                                                                                                                                    height: auto;
+                                                                                                                                    width: 100%;
+                                                                                                                                    margin: 0;
+                                                                                                                                    max-width: 100%;
+                                                                                                                                "
+                                                                                                                                width="24"
+                                                                                                                                src="{{linkedinSrc}}"
+                                                                                                                        /></a>
+                                                                                                                    </td>
+                                                                                                                </tr>
+                                                                                                            </table>
+                                                                                                        </div>
+                                                                                                    </div>
+                                                                                                    <!--[if mso]>
+                                              </td>
+                                              <td class="t94" style="width:10px;" width="10"></td>
+                                              </tr></table>
+                                              <![endif]-->
+                                                                                                </div>
+                                                                                            </td>
+                                                                                        </tr>
+                                                                                    </table>
+                                                                                </td>
+                                                                            </tr>
+                                                                            <tr>
+                                                                                <td>
+                                                                                    <table
+                                                                                        class="t114"
+                                                                                        role="presentation"
+                                                                                        cellpadding="0"
+                                                                                        cellspacing="0"
+                                                                                        align="center"
+                                                                                    >
+                                                                                        <tr>
+                                                                                            <!--[if !mso]><!-->
+                                                                                            <td
+                                                                                                class="t115"
+                                                                                                style="
+                                                                                                    width: 600px;
+                                                                                                "
+                                                                                            >
+                                                                                                <!--<![endif]-->
+                                                                                                <!--[if mso]>
+                                            <td class="t115" style="width:600px;"><![endif]-->
+                                                                                                <p
+                                                                                                    class="t121"
+                                                                                                    style="
+                                                                                                        font-family:
+                                                                                                            BlinkMacSystemFont,
+                                                                                                            Segoe
+                                                                                                                UI,
+                                                                                                            Helvetica
+                                                                                                                Neue,
+                                                                                                            Arial,
+                                                                                                            sans-serif,
+                                                                                                            'Albert Sans';
+                                                                                                        line-height: 22px;
+                                                                                                        font-weight: 500;
+                                                                                                        font-style: normal;
+                                                                                                        font-size: 12px;
+                                                                                                        text-decoration: none;
+                                                                                                        text-transform: none;
+                                                                                                        direction: ltr;
+                                                                                                        color: #888888;
+                                                                                                        text-align: center;
+                                                                                                        mso-line-height-rule: exactly;
+                                                                                                        mso-text-raise: 3px;
+                                                                                                    "
+                                                                                                >
+                                                                                                      <a
+                                                                                                        class="t122"
+                                                                                                        href="https://www.lightdash.com/"
+                                                                                                        style="
+                                                                                                            font-weight: 700;
+                                                                                                            font-style: normal;
+                                                                                                            text-decoration: none;
+                                                                                                            direction: ltr;
+                                                                                                            color: #878787;
+                                                                                                            mso-line-height-rule: exactly;
+                                                                                                        "
+                                                                                                        target="_blank"
+                                                                                                        >Lightdash</a
+                                                                                                    >
+                                                                                                </p>
+                                                                                            </td>
+                                                                                        </tr>
+                                                                                    </table>
+                                                                                </td>
+                                                                            </tr>
+                                                                            <tr>
+                                                                                <td>
+                                                                                    <table
+                                                                                        class="t102"
+                                                                                        role="presentation"
+                                                                                        cellpadding="0"
+                                                                                        cellspacing="0"
+                                                                                        align="center"
+                                                                                    >
+                                                                                        <tr>
+                                                                                            <!--[if !mso]><!-->
+                                                                                            <td
+                                                                                                class="t103"
+                                                                                                style="
+                                                                                                    width: 600px;
+                                                                                                "
+                                                                                            >
+                                                                                                <!--<![endif]-->
+                                                                                                <!--[if mso]>
+                                            <td class="t103" style="width:600px;"><![endif]-->
+                                                                                                <p
+                                                                                                    class="t109"
+                                                                                                    style="
+                                                                                                        font-family:
+                                                                                                            BlinkMacSystemFont,
+                                                                                                            Segoe
+                                                                                                                UI,
+                                                                                                            Helvetica
+                                                                                                                Neue,
+                                                                                                            Arial,
+                                                                                                            sans-serif,
+                                                                                                            'Albert Sans';
+                                                                                                        line-height: 22px;
+                                                                                                        font-weight: 500;
+                                                                                                        font-style: normal;
+                                                                                                        font-size: 12px;
+                                                                                                        text-decoration: none;
+                                                                                                        text-transform: none;
+                                                                                                        direction: ltr;
+                                                                                                        color: #888888;
+                                                                                                        text-align: center;
+                                                                                                        mso-line-height-rule: exactly;
+                                                                                                        mso-text-raise: 3px;
+                                                                                                    "
+                                                                                                >
+                                                                                                      
+                                                                                                     <a
+                                                                                                        class="t110"
+                                                                                                        href="https://www.lightdash.com/privacy-policy"
+                                                                                                        style="
+                                                                                                            font-weight: 700;
+                                                                                                            font-style: normal;
+                                                                                                            text-decoration: none;
+                                                                                                            direction: ltr;
+                                                                                                            color: #888888;
+                                                                                                            mso-line-height-rule: exactly;
+                                                                                                        "
+                                                                                                        target="_blank"
+                                                                                                        >Privacy
+                                                                                                        policy</a
+                                                                                                    >  •
+                                                                                                     <a
+                                                                                                        class="t111"
+                                                                                                        href="https://lightdash-community.slack.com/ssb/redirect"
+                                                                                                        style="
+                                                                                                            font-weight: 700;
+                                                                                                            font-style: normal;
+                                                                                                            text-decoration: none;
+                                                                                                            direction: ltr;
+                                                                                                            color: #878787;
+                                                                                                            mso-line-height-rule: exactly;
+                                                                                                        "
+                                                                                                        target="_blank"
+                                                                                                        >Join
+                                                                                                        our
+                                                                                                        community</a
+                                                                                                    >
+                                                                                                </p>
+                                                                                            </td>
+                                                                                        </tr>
+                                                                                    </table>
+                                                                                </td>
+                                                                            </tr>
+                                                                        </table>
+                                                                    </td>
+                                                                </tr>
+                                                            </table>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <div
+                                        class="t4"
+                                        style="
+                                            mso-line-height-rule: exactly;
+                                            font-size: 1px;
+                                            display: none;
+                                        "
+                                    >
+                                        &nbsp;
+                                    </div>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </div>
+    </body>
+</html>

--- a/packages/backend/src/clients/EmailClient/templates/setupInvitation.html
+++ b/packages/backend/src/clients/EmailClient/templates/setupInvitation.html
@@ -1,0 +1,123 @@
+{{> _emailHead}}
+                                                                            <tr>
+                                                                                <td>
+                                                                                    <table
+                                                                                        role="presentation"
+                                                                                        cellpadding="0"
+                                                                                        cellspacing="0"
+                                                                                        align="center"
+                                                                                    >
+                                                                                        <tr>
+                                                                                            <td
+                                                                                                style="
+                                                                                                    width: 600px;
+                                                                                                "
+                                                                                            >
+                                                                                                <h1
+                                                                                                    style="
+                                                                                                        font-family: BlinkMacSystemFont,
+                                                                                                            Segoe UI,
+                                                                                                            Helvetica Neue,
+                                                                                                            Arial,
+                                                                                                            sans-serif,
+                                                                                                            'Roboto';
+                                                                                                        line-height: 28px;
+                                                                                                        font-weight: 500;
+                                                                                                        font-size: 24px;
+                                                                                                        color: #121212;
+                                                                                                        text-align: center;
+                                                                                                        margin-bottom: 20px;
+                                                                                                    "
+                                                                                                >
+                                                                                                    You've been asked to help set up {{orgName}}
+                                                                                                </h1>
+                                                                                            </td>
+                                                                                        </tr>
+                                                                                    </table>
+                                                                                </td>
+                                                                            </tr>
+                                                                            <tr>
+                                                                                <td>
+                                                                                    <table
+                                                                                        role="presentation"
+                                                                                        cellpadding="0"
+                                                                                        cellspacing="0"
+                                                                                        align="center"
+                                                                                    >
+                                                                                        <tr>
+                                                                                            <td
+                                                                                                style="
+                                                                                                    width: 600px;
+                                                                                                "
+                                                                                            >
+                                                                                                <p
+                                                                                                    style="
+                                                                                                        font-family: BlinkMacSystemFont,
+                                                                                                            Segoe UI,
+                                                                                                            Helvetica Neue,
+                                                                                                            Arial,
+                                                                                                            sans-serif,
+                                                                                                            'Roboto';
+                                                                                                        line-height: 20px;
+                                                                                                        font-weight: 400;
+                                                                                                        font-size: 14px;
+                                                                                                        color: #8c8182;
+                                                                                                        text-align: center;
+                                                                                                    "
+                                                                                                >
+                                                                                                    {{inviterName}} is setting up Lightdash for {{orgName}} and needs someone with data-warehouse access to connect their data. It takes about 5 minutes. This link is valid for the next 72 hours.
+                                                                                                </p>
+                                                                                            </td>
+                                                                                        </tr>
+                                                                                    </table>
+                                                                                </td>
+                                                                            </tr>
+                                                                            <tr>
+                                                                                <td style="height: 25px;">&nbsp;</td>
+                                                                            </tr>
+                                                                            <tr>
+                                                                                <td>
+                                                                                    <table
+                                                                                        role="presentation"
+                                                                                        cellpadding="0"
+                                                                                        cellspacing="0"
+                                                                                        align="center"
+                                                                                    >
+                                                                                        <tr>
+                                                                                            <td
+                                                                                                style="
+                                                                                                    background-color: #7262ff;
+                                                                                                    overflow: hidden;
+                                                                                                    text-align: center;
+                                                                                                    line-height: 40px;
+                                                                                                    padding: 4px;
+                                                                                                    border-radius: 3px;
+                                                                                                "
+                                                                                            >
+                                                                                                <a
+                                                                                                    href="{{inviteUrl}}"
+                                                                                                    target="_blank"
+                                                                                                    style="
+                                                                                                        display: block;
+                                                                                                        font-family: BlinkMacSystemFont,
+                                                                                                            Segoe UI,
+                                                                                                            Helvetica Neue,
+                                                                                                            Arial,
+                                                                                                            sans-serif,
+                                                                                                            'Roboto';
+                                                                                                        line-height: 40px;
+                                                                                                        font-weight: 600;
+                                                                                                        font-size: 14px;
+                                                                                                        text-decoration: none;
+                                                                                                        color: #ffffff;
+                                                                                                        text-align: center;
+                                                                                                        padding: 0 20px;
+                                                                                                    "
+                                                                                                    >Help set up {{orgName}}</a
+                                                                                                >
+                                                                                            </td>
+                                                                                        </tr>
+                                                                                    </table>
+                                                                                </td>
+                                                                            </tr>
+{{> _emailFoot}}

--- a/packages/backend/src/clients/EmailClient/templates/setupInvitation.html
+++ b/packages/backend/src/clients/EmailClient/templates/setupInvitation.html
@@ -65,7 +65,11 @@
                                                                                                         text-align: center;
                                                                                                     "
                                                                                                 >
-                                                                                                    {{inviterName}} is setting up Lightdash for {{orgName}} and needs someone with data-warehouse access to connect their data. It takes about 5 minutes. This link is valid for the next 72 hours.
+                                                                                                    {{inviterName}} is setting up Lightdash for {{orgName}} and needs someone with data-warehouse access to connect their data.
+                                                                                                    <br /><br />
+                                                                                                    Lightdash is the Agentic BI platform for modern data teams &mdash; build and manage analytics straight from the tools you already use, with AI handling the busywork. Built on dbt. Loved by developers. Actually used by businesses.
+                                                                                                    <br /><br />
+                                                                                                    Accept the invite and we&rsquo;ll take you straight to connecting {{orgName}}&rsquo;s data warehouse &mdash; the last step before your team can start asking questions of their data. This link is valid for the next 72 hours.
                                                                                                 </p>
                                                                                             </td>
                                                                                         </tr>

--- a/packages/backend/src/controllers/inviteLinksController.test.ts
+++ b/packages/backend/src/controllers/inviteLinksController.test.ts
@@ -1,0 +1,36 @@
+import { type SessionUser } from '@lightdash/common';
+import express from 'express';
+import { type ServiceRepository } from '../services/ServiceRepository';
+import { sessionUser } from '../services/UserService.mock';
+import { InviteLinksController } from './inviteLinksController';
+
+describe('InviteLinksController', () => {
+    test('activates an invite, logs in the session, and returns the registration response shape', async () => {
+        const activateUserFromInviteWithoutPassword = vi.fn(
+            async () => sessionUser,
+        );
+        const services = {
+            getUserService: () => ({
+                activateUserFromInviteWithoutPassword,
+            }),
+        } as unknown as ServiceRepository;
+        const login = vi.fn(
+            (user: SessionUser, done: (error?: Error | null) => void) => done(),
+        );
+        const req = { login } as unknown as express.Request;
+        const controller = new InviteLinksController(services);
+
+        await expect(
+            controller.activateInviteLink(req, 'invite-code'),
+        ).resolves.toEqual({
+            status: 'ok',
+            results: sessionUser,
+        });
+
+        expect(activateUserFromInviteWithoutPassword).toHaveBeenCalledWith(
+            'invite-code',
+        );
+        expect(login).toHaveBeenCalledWith(sessionUser, expect.any(Function));
+        expect(controller.getStatus()).toBe(200);
+    });
+});

--- a/packages/backend/src/controllers/inviteLinksController.ts
+++ b/packages/backend/src/controllers/inviteLinksController.ts
@@ -1,6 +1,7 @@
 import {
     ApiErrorPayload,
     ApiInviteLinkResponse,
+    ApiRegisterUserResponse,
     ApiSuccessEmpty,
     assertRegisteredAccount,
     CreateInviteLink,
@@ -53,6 +54,31 @@ export class InviteLinksController extends BaseController {
             status: 'ok',
             results: inviteLink,
         };
+    }
+
+    @Middlewares([unauthorisedInDemo])
+    @SuccessResponse('200', 'Success')
+    @Post('{inviteCode}/activate')
+    @OperationId('ActivateInviteLink')
+    async activateInviteLink(
+        @Request() req: express.Request,
+        @Path() inviteCode: string,
+    ): Promise<ApiRegisterUserResponse> {
+        const sessionUser = await this.services
+            .getUserService()
+            .activateUserFromInviteWithoutPassword(inviteCode);
+        return new Promise((resolve, reject) => {
+            req.login(sessionUser, (err) => {
+                if (err) {
+                    reject(err);
+                }
+                this.setStatus(200);
+                resolve({
+                    status: 'ok',
+                    results: sessionUser,
+                });
+            });
+        });
     }
 
     /**

--- a/packages/backend/src/database/entities/inviteLinks.ts
+++ b/packages/backend/src/database/entities/inviteLinks.ts
@@ -1,3 +1,4 @@
+import { InviteLinkPurpose } from '@lightdash/common';
 import { Knex } from 'knex';
 
 export type DbInviteLink = {
@@ -6,11 +7,16 @@ export type DbInviteLink = {
     user_uuid: string;
     created_at: Date;
     expires_at: Date;
+    purpose: InviteLinkPurpose;
 };
 
 type DbInviteLinkInsert = Pick<
     DbInviteLink,
-    'organization_id' | 'invite_code_hash' | 'expires_at' | 'user_uuid'
+    | 'organization_id'
+    | 'invite_code_hash'
+    | 'expires_at'
+    | 'user_uuid'
+    | 'purpose'
 >;
 type DbInviteLinkUpdate = {};
 

--- a/packages/backend/src/database/migrations/20260718114940_add_invite_links_purpose.ts
+++ b/packages/backend/src/database/migrations/20260718114940_add_invite_links_purpose.ts
@@ -1,0 +1,16 @@
+import { InviteLinkPurpose } from '@lightdash/common';
+import { Knex } from 'knex';
+
+const InviteLinksTableName = 'invite_links';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(InviteLinksTableName, (table) => {
+        table.text('purpose').notNullable().defaultTo(InviteLinkPurpose.Member);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(InviteLinksTableName, (table) => {
+        table.dropColumn('purpose');
+    });
+}

--- a/packages/backend/src/models/InviteLinkModel.ts
+++ b/packages/backend/src/models/InviteLinkModel.ts
@@ -1,4 +1,9 @@
-import { InviteLink, NotFoundError } from '@lightdash/common';
+import {
+    InviteLink,
+    InviteLinkPurpose,
+    NotFoundError,
+    ParameterError,
+} from '@lightdash/common';
 import * as crypto from 'crypto';
 import { Knex } from 'knex';
 import { URL } from 'url';
@@ -40,7 +45,18 @@ export class InviteLinkModel {
             organizationUuid: data.organization_uuid,
             userUuid: data.user_uuid,
             email: data.email,
+            purpose: InviteLinkModel.parsePurpose(data.purpose),
         };
+    }
+
+    private static parsePurpose(purpose: string): InviteLinkPurpose {
+        if (purpose === InviteLinkPurpose.Member) {
+            return InviteLinkPurpose.Member;
+        }
+        if (purpose === InviteLinkPurpose.Setup) {
+            return InviteLinkPurpose.Setup;
+        }
+        throw new ParameterError(`Invalid invite link purpose: ${purpose}`);
     }
 
     private transformInviteCodeToUrl(code: string): string {
@@ -89,6 +105,7 @@ export class InviteLinkModel {
         expiresAt: Date,
         organizationUuid: string,
         userUuid: string,
+        purpose: InviteLinkPurpose,
     ): Promise<InviteLink> {
         const inviteCodeHash = InviteLinkModel._hash(inviteCode);
         const orgs = await this.database('organizations')
@@ -104,6 +121,7 @@ export class InviteLinkModel {
                 invite_code_hash: inviteCodeHash,
                 expires_at: expiresAt,
                 user_uuid: userUuid,
+                purpose,
             })
             .onConflict('user_uuid')
             .merge();

--- a/packages/backend/src/models/UserModel.test.ts
+++ b/packages/backend/src/models/UserModel.test.ts
@@ -272,6 +272,55 @@ describe('UserModel', () => {
         expect(merge).toHaveBeenCalledOnce();
     });
 
+    it('activates an invited user without creating a password login', async () => {
+        const update = vi.fn(() => ({
+            returning: vi.fn(async () => [{ user_id: 1 }]),
+        }));
+        const where = vi.fn(() => ({ update }));
+        const transactionClient = vi.fn((tableName: string) => {
+            if (tableName === UserTableName) {
+                return { where };
+            }
+            throw new Error(`Unexpected table ${tableName}`);
+        }) as unknown as Knex.Transaction;
+        const database = Object.assign(vi.fn(), {
+            transaction: vi.fn(
+                async (callback: (trx: Knex.Transaction) => Promise<unknown>) =>
+                    callback(transactionClient),
+            ),
+        }) as unknown as Knex;
+        const model = new UserModel({
+            database,
+            lightdashConfig,
+            featureFlagModel,
+        });
+        const activatedUser = mapDbUserDetailsToLightdashUser(
+            {
+                ...userDetails,
+                first_name: '',
+                last_name: '',
+            },
+            false,
+        );
+        vi.spyOn(model, 'getUserDetailsByUuid').mockResolvedValue(
+            activatedUser,
+        );
+
+        await expect(
+            model.activateUserWithoutPassword(userDetails.user_uuid),
+        ).resolves.toEqual(activatedUser);
+
+        expect(activatedUser.isActive).toBe(true);
+        expect(update).toHaveBeenCalledWith({
+            first_name: '',
+            last_name: '',
+            updated_at: expect.any(Date),
+        });
+        expect(transactionClient).not.toHaveBeenCalledWith(
+            PasswordLoginTableName,
+        );
+    });
+
     it('collapses legacy service account project membership rules before returning the ability builder', async () => {
         const model = createUserModel();
 

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -1070,6 +1070,25 @@ export class UserModel {
         ) {
             throw new ParameterError("Password doesn't meet requirements");
         }
+        return this.activateInvitedUser(userUuid, activateUser);
+    }
+
+    async activateUserWithoutPassword(
+        userUuid: string,
+    ): Promise<LightdashUser> {
+        return this.activateInvitedUser(userUuid, {
+            firstName: '',
+            lastName: '',
+        });
+    }
+
+    private async activateInvitedUser(
+        userUuid: string,
+        activateUser:
+            | ActivateUser
+            | OpenIdUser
+            | Pick<ActivateUser, 'firstName' | 'lastName'>,
+    ): Promise<LightdashUser> {
         await this.database.transaction(async (trx) => {
             const [user] = await trx(UserTableName)
                 .where('user_uuid', userUuid)
@@ -1084,7 +1103,7 @@ export class UserModel {
                 })
                 .returning('*');
 
-            if (!isOpenIdUser(activateUser)) {
+            if (!isOpenIdUser(activateUser) && 'password' in activateUser) {
                 await UserModel.createPasswordLogin(trx, {
                     user_id: user.user_id,
                     password_hash: await bcrypt.hash(
@@ -1092,7 +1111,7 @@ export class UserModel {
                         await bcrypt.genSalt(),
                     ),
                 });
-            } else {
+            } else if (isOpenIdUser(activateUser)) {
                 await trx(OpenIdIdentitiesTableName)
                     .insert({
                         issuer_type: activateUser.openId.issuerType,

--- a/packages/backend/src/services/RolesService/RolesService.test.ts
+++ b/packages/backend/src/services/RolesService/RolesService.test.ts
@@ -4,6 +4,7 @@ import {
     defineUserAbility,
     ForbiddenError,
     getSystemRoles,
+    InviteLinkPurpose,
     NotFoundError,
     OrganizationMemberRole,
     ParameterError,
@@ -450,6 +451,7 @@ describe('RolesService', () => {
                 organizationUuid: 'test-org-uuid',
                 userUuid: pendingUser.userUuid,
                 email: pendingUser.email,
+                purpose: InviteLinkPurpose.Member,
             });
 
             await expect(

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -736,6 +736,7 @@ export class RolesService extends BaseService {
                 {
                     firstName: account.user.firstName,
                     lastName: account.user.lastName,
+                    email: account.user.email,
                     organizationName: account.organization.name,
                 },
                 inviteLink,

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -9,6 +9,7 @@ import {
     CustomRoleAsCode,
     ForbiddenError,
     getAllScopeMap,
+    InviteLinkPurpose,
     isOrganizationMemberRole,
     isScopeAssignableAtLevel,
     isSystemRole,
@@ -728,6 +729,7 @@ export class RolesService extends BaseService {
             new Date(Date.now() + 3 * 24 * 60 * 60 * 1000),
             organizationUuid,
             userUuid,
+            InviteLinkPurpose.Member,
         );
         try {
             await this.emailClient.sendInviteEmail(

--- a/packages/backend/src/services/UserService.mock.ts
+++ b/packages/backend/src/services/UserService.mock.ts
@@ -3,6 +3,7 @@ import {
     AnyType,
     CreateInviteLink,
     InviteLink,
+    InviteLinkPurpose,
     LightdashUser,
     OpenIdIdentity,
     OpenIdIdentityIssuerType,
@@ -76,6 +77,7 @@ export const inviteLink: InviteLink = {
     inviteUrl: 'inviteUrl',
     organizationUuid: 'organizationUuid',
     userUuid: 'userUuid',
+    purpose: InviteLinkPurpose.Member,
 };
 
 export const inviteUser: CreateInviteLink = {

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -2,6 +2,7 @@ import {
     AuthorizationError,
     defineUserAbility,
     EmailStatus,
+    ExpiredError,
     FeatureFlags,
     ForbiddenError,
     InviteLinkPurpose,
@@ -68,6 +69,8 @@ const userModel = {
     })),
     createUser: vi.fn<UserModel['createUser']>(async () => sessionUser),
     activateUser: vi.fn(async () => sessionUser),
+    activateUserWithoutPassword: vi.fn(async () => sessionUser),
+    addProjectMemberships: vi.fn(async () => undefined),
     getOrganizationsForUser: vi.fn(async () => [sessionUser]),
     findUserByEmail: vi.fn<UserModel['findUserByEmail']>(async () => undefined),
     createPendingUser: vi.fn(async () => newUser),
@@ -158,8 +161,16 @@ const organizationSettingsModel = {
     update: vi.fn(),
 };
 
+const organizationAllowedEmailDomainsModel = {
+    findAllowedEmailDomains: vi.fn(async () => undefined),
+};
+
 type UserServiceTestOverrides = {
     featureFlagModel?: Pick<FeatureFlagModel, 'get'>;
+    organizationAllowedEmailDomainsModel?: Pick<
+        OrganizationAllowedEmailDomainsModel,
+        'findAllowedEmailDomains'
+    >;
     passwordResetLinkModel?: Pick<
         PasswordResetLinkModel,
         'getByCode' | 'deleteByCode'
@@ -190,7 +201,8 @@ const createUserService = (
         organizationModel: organizationModel as unknown as OrganizationModel,
         personalAccessTokenModel: {} as PersonalAccessTokenModel,
         organizationAllowedEmailDomainsModel:
-            {} as OrganizationAllowedEmailDomainsModel,
+            (overrides.organizationAllowedEmailDomainsModel as OrganizationAllowedEmailDomainsModel) ??
+            (organizationAllowedEmailDomainsModel as unknown as OrganizationAllowedEmailDomainsModel),
         organizationSsoModel:
             organizationSsoModel as unknown as OrganizationSsoModel,
         organizationSettingsModel:
@@ -410,6 +422,237 @@ describe('UserService', () => {
                 password: 'password1!',
             });
             expect(sendOneTimePasscodeSpy).toHaveBeenCalledWith(sessionUser);
+        });
+    });
+
+    describe('activateUserFromInviteWithoutPassword', () => {
+        const validInviteLink = {
+            ...inviteLink,
+            email: 'invitee@example.com',
+            expiresAt: new Date('2099-01-01'),
+        };
+        const memberUser = {
+            ...sessionUser,
+            userUuid: validInviteLink.userUuid,
+            email: validInviteLink.email,
+            role: OrganizationMemberRole.MEMBER,
+        };
+
+        test('activates the invited user without a password and consumes the invite', async () => {
+            vi.mocked(inviteLinkModel.getByCode).mockResolvedValueOnce(
+                validInviteLink,
+            );
+            vi.mocked(
+                userModel.activateUserWithoutPassword,
+            ).mockResolvedValueOnce(memberUser);
+            vi.mocked(userModel.findSessionUserByUUID).mockResolvedValueOnce(
+                memberUser,
+            );
+            const service = createUserService(lightdashConfigMock);
+            const loginMethodAllowedSpy = vi
+                .spyOn(service, 'isLoginMethodAllowed')
+                .mockResolvedValue(true);
+
+            await expect(
+                service.activateUserFromInviteWithoutPassword(
+                    validInviteLink.inviteCode,
+                ),
+            ).resolves.toEqual(memberUser);
+
+            expect(loginMethodAllowedSpy).toHaveBeenCalledWith(
+                validInviteLink.email,
+                'email',
+            );
+            expect(userModel.activateUserWithoutPassword).toHaveBeenCalledWith(
+                validInviteLink.userUuid,
+            );
+            expect(inviteLinkModel.deleteByCode).toHaveBeenCalledWith(
+                validInviteLink.inviteCode,
+            );
+            expect(emailClient.sendOneTimePasscodeEmail).not.toHaveBeenCalled();
+            expect(analyticsMock.track).toHaveBeenCalledWith({
+                event: 'user.created',
+                userId: memberUser.userUuid,
+                properties: {
+                    context: 'accept_invite',
+                    createdUserId: memberUser.userUuid,
+                    organizationId: memberUser.organizationUuid,
+                    userConnectionType: 'email_only',
+                },
+            });
+        });
+
+        test('rejects and consumes an expired invite without activating the user', async () => {
+            vi.mocked(inviteLinkModel.getByCode).mockResolvedValueOnce({
+                ...validInviteLink,
+                expiresAt: new Date('2000-01-01'),
+            });
+            const service = createUserService(lightdashConfigMock);
+
+            await expect(
+                service.activateUserFromInviteWithoutPassword(
+                    validInviteLink.inviteCode,
+                ),
+            ).rejects.toThrow(new ExpiredError('Invite link expired'));
+
+            expect(inviteLinkModel.deleteByCode).toHaveBeenCalledWith(
+                validInviteLink.inviteCode,
+            );
+            expect(
+                userModel.activateUserWithoutPassword,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('returns not found for an unknown invite without activating the user', async () => {
+            vi.mocked(inviteLinkModel.getByCode).mockRejectedValueOnce(
+                new NotFoundError('No invite link found'),
+            );
+            const service = createUserService(lightdashConfigMock);
+
+            await expect(
+                service.activateUserFromInviteWithoutPassword('unknown'),
+            ).rejects.toThrow(new NotFoundError('No invite link found'));
+
+            expect(
+                userModel.activateUserWithoutPassword,
+            ).not.toHaveBeenCalled();
+            expect(inviteLinkModel.deleteByCode).not.toHaveBeenCalled();
+        });
+
+        test('returns not found when the same invite is consumed again', async () => {
+            vi.mocked(inviteLinkModel.getByCode)
+                .mockResolvedValueOnce(validInviteLink)
+                .mockRejectedValueOnce(
+                    new NotFoundError('No invite link found'),
+                );
+            vi.mocked(
+                userModel.activateUserWithoutPassword,
+            ).mockResolvedValueOnce(memberUser);
+            const service = createUserService(lightdashConfigMock);
+            vi.spyOn(service, 'isLoginMethodAllowed').mockResolvedValue(true);
+
+            await service.activateUserFromInviteWithoutPassword(
+                validInviteLink.inviteCode,
+            );
+            await expect(
+                service.activateUserFromInviteWithoutPassword(
+                    validInviteLink.inviteCode,
+                ),
+            ).rejects.toThrow(new NotFoundError('No invite link found'));
+
+            expect(userModel.activateUserWithoutPassword).toHaveBeenCalledTimes(
+                1,
+            );
+        });
+
+        test('applies allowed-domain project memberships for a member invite', async () => {
+            const allowedEmailDomainsModel: Pick<
+                OrganizationAllowedEmailDomainsModel,
+                'findAllowedEmailDomains'
+            > = {
+                findAllowedEmailDomains: vi.fn<
+                    OrganizationAllowedEmailDomainsModel['findAllowedEmailDomains']
+                >(async () => ({
+                    organizationUuid: memberUser.organizationUuid!,
+                    emailDomains: ['example.com'],
+                    role: OrganizationMemberRole.MEMBER,
+                    projects: [
+                        {
+                            projectUuid: 'project-uuid',
+                            role: ProjectMemberRole.VIEWER,
+                        },
+                    ],
+                })),
+            };
+            vi.mocked(inviteLinkModel.getByCode).mockResolvedValueOnce(
+                validInviteLink,
+            );
+            vi.mocked(
+                userModel.activateUserWithoutPassword,
+            ).mockResolvedValueOnce(memberUser);
+            const service = createUserService(lightdashConfigMock, {
+                organizationAllowedEmailDomainsModel: allowedEmailDomainsModel,
+            });
+            vi.spyOn(service, 'isLoginMethodAllowed').mockResolvedValue(true);
+
+            await service.activateUserFromInviteWithoutPassword(
+                validInviteLink.inviteCode,
+            );
+
+            expect(userModel.addProjectMemberships).toHaveBeenCalledWith(
+                memberUser.userUuid,
+                { 'project-uuid': ProjectMemberRole.VIEWER },
+            );
+        });
+
+        test('preserves an admin invite role without applying member defaults', async () => {
+            const adminUser = {
+                ...memberUser,
+                role: OrganizationMemberRole.ADMIN,
+            };
+            vi.mocked(inviteLinkModel.getByCode).mockResolvedValueOnce(
+                validInviteLink,
+            );
+            vi.mocked(
+                userModel.activateUserWithoutPassword,
+            ).mockResolvedValueOnce(adminUser);
+            vi.mocked(userModel.findSessionUserByUUID).mockResolvedValueOnce(
+                adminUser,
+            );
+            const service = createUserService(lightdashConfigMock);
+            vi.spyOn(service, 'isLoginMethodAllowed').mockResolvedValue(true);
+
+            await expect(
+                service.activateUserFromInviteWithoutPassword(
+                    validInviteLink.inviteCode,
+                ),
+            ).resolves.toMatchObject({ role: OrganizationMemberRole.ADMIN });
+
+            expect(
+                organizationAllowedEmailDomainsModel.findAllowedEmailDomains,
+            ).not.toHaveBeenCalled();
+            expect(userModel.addProjectMemberships).not.toHaveBeenCalled();
+        });
+    });
+
+    test('keeps password-based invite activation unchanged', async () => {
+        vi.mocked(inviteLinkModel.getByCode).mockResolvedValueOnce({
+            ...inviteLink,
+            expiresAt: new Date('2099-01-01'),
+        });
+        const service = createUserService(lightdashConfigMock);
+        vi.spyOn(service, 'isLoginMethodAllowed').mockResolvedValue(true);
+        vi.spyOn(
+            service,
+            'sendOneTimePasscodeToPrimaryEmail',
+        ).mockResolvedValue({
+            email: inviteLink.email,
+            isVerified: false,
+        });
+        const activation = {
+            firstName: 'Invite',
+            lastName: 'User',
+            password: 'password1!',
+        };
+
+        await service.activateUserFromInvite(inviteLink.inviteCode, activation);
+
+        expect(userModel.activateUser).toHaveBeenCalledWith(
+            inviteLink.userUuid,
+            activation,
+        );
+        expect(service.sendOneTimePasscodeToPrimaryEmail).toHaveBeenCalledWith(
+            sessionUser,
+        );
+        expect(analyticsMock.track).toHaveBeenCalledWith({
+            event: 'user.created',
+            userId: sessionUser.userUuid,
+            properties: {
+                context: 'accept_invite',
+                createdUserId: sessionUser.userUuid,
+                organizationId: sessionUser.organizationUuid,
+                userConnectionType: 'password',
+            },
         });
     });
 

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -4,6 +4,7 @@ import {
     EmailStatus,
     FeatureFlags,
     ForbiddenError,
+    InviteLinkPurpose,
     NotFoundError,
     OpenIdIdentityIssuerType,
     OrganizationMemberRole,
@@ -2241,6 +2242,85 @@ describe('UserService', () => {
             expect(
                 inviteLinkModel.upsert as import('vitest').Mock,
             ).toHaveBeenCalledTimes(1);
+        });
+        test('should default the purpose to member', async () => {
+            await userService.createPendingUserAndInviteLink(
+                sessionUser,
+                inviteUser,
+            );
+
+            expect(vi.mocked(inviteLinkModel.upsert)).toHaveBeenCalledWith(
+                expect.any(String),
+                inviteUser.expiresAt,
+                sessionUser.organizationUuid,
+                newUser.userUuid,
+                InviteLinkPurpose.Member,
+            );
+        });
+        test('should force setup invites to use the admin role', async () => {
+            const adminUser = {
+                ...sessionUser,
+                ability: defineUserAbility(
+                    {
+                        userUuid: sessionUser.userUuid,
+                        role: OrganizationMemberRole.ADMIN,
+                        organizationUuid: sessionUser.organizationUuid,
+                        roleUuid: undefined,
+                    },
+                    [],
+                ),
+            };
+            const setupInviteLink = {
+                ...inviteLink,
+                purpose: InviteLinkPurpose.Setup,
+            };
+            vi.mocked(inviteLinkModel.upsert).mockResolvedValueOnce(
+                setupInviteLink,
+            );
+
+            await userService.createPendingUserAndInviteLink(adminUser, {
+                ...inviteUser,
+                role: OrganizationMemberRole.MEMBER,
+                purpose: InviteLinkPurpose.Setup,
+            });
+
+            expect(vi.mocked(userModel.createPendingUser)).toHaveBeenCalledWith(
+                sessionUser.organizationUuid,
+                {
+                    email: inviteUser.email,
+                    firstName: '',
+                    lastName: '',
+                    role: OrganizationMemberRole.ADMIN,
+                },
+            );
+            expect(vi.mocked(inviteLinkModel.upsert)).toHaveBeenCalledWith(
+                expect.any(String),
+                inviteUser.expiresAt,
+                sessionUser.organizationUuid,
+                newUser.userUuid,
+                InviteLinkPurpose.Setup,
+            );
+            expect(vi.mocked(emailClient.sendInviteEmail)).toHaveBeenCalledWith(
+                adminUser,
+                setupInviteLink,
+            );
+        });
+        test('should reject setup invites when the caller cannot grant roles', async () => {
+            await expect(
+                userService.createPendingUserAndInviteLink(sessionUser, {
+                    ...inviteUser,
+                    purpose: InviteLinkPurpose.Setup,
+                }),
+            ).rejects.toThrowError(
+                new ForbiddenError(
+                    'A setup invite requires permission to grant the admin role',
+                ),
+            );
+
+            expect(
+                vi.mocked(userModel.createPendingUser),
+            ).not.toHaveBeenCalled();
+            expect(vi.mocked(inviteLinkModel.upsert)).not.toHaveBeenCalled();
         });
         test('should send invite when email belongs to user without org', async () => {
             (

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -30,6 +30,7 @@ import {
     hasInviteCode,
     hasProperty,
     InviteLink,
+    InviteLinkPurpose,
     isOpenIdIdentityIssuerType,
     isOpenIdUser,
     isUserAvatarColorValue,
@@ -590,6 +591,7 @@ export class UserService extends BaseService {
             throw new ForbiddenError();
         }
         const { email, role } = createInviteLink;
+        const purpose = createInviteLink.purpose ?? InviteLinkPurpose.Member;
         // Same default expiry as the invite modal in the frontend
         const expiresAt =
             createInviteLink.expiresAt ??
@@ -614,12 +616,31 @@ export class UserService extends BaseService {
         }
 
         let userUuid: string;
-        const userRole = auditedAbility.can(
+        const canGrantRoles = auditedAbility.can(
             'manage',
             subject('OrganizationMemberProfile', { organizationUuid }),
-        )
-            ? role || OrganizationMemberRole.MEMBER
-            : OrganizationMemberRole.MEMBER;
+        );
+        let userRole: OrganizationMemberRole;
+        switch (purpose) {
+            case InviteLinkPurpose.Member:
+                userRole = canGrantRoles
+                    ? role || OrganizationMemberRole.MEMBER
+                    : OrganizationMemberRole.MEMBER;
+                break;
+            case InviteLinkPurpose.Setup:
+                if (!canGrantRoles) {
+                    throw new ForbiddenError(
+                        'A setup invite requires permission to grant the admin role',
+                    );
+                }
+                userRole = OrganizationMemberRole.ADMIN;
+                break;
+            default:
+                return assertUnreachable(
+                    purpose,
+                    `Unknown invite link purpose: ${purpose}`,
+                );
+        }
         if (!existingUserWithEmail) {
             const pendingUser = await this.userModel.createPendingUser(
                 organizationUuid,
@@ -645,6 +666,15 @@ export class UserService extends BaseService {
                 userRole,
                 undefined,
             );
+        } else if (
+            existingUserWithEmail &&
+            purpose === InviteLinkPurpose.Setup
+        ) {
+            await this.organizationMemberProfileModel.updateOrganizationMember(
+                organizationUuid,
+                existingUserWithEmail.userUuid,
+                { role: OrganizationMemberRole.ADMIN },
+            );
         }
 
         const inviteLink = await this.inviteLinkModel.upsert(
@@ -652,6 +682,7 @@ export class UserService extends BaseService {
             expiresAt,
             organizationUuid,
             userUuid,
+            purpose,
         );
         await this.emailClient.sendInviteEmail(user, inviteLink);
         this.analytics.track({

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -382,11 +382,30 @@ export class UserService extends BaseService {
         activateUser: ActivateUser | OpenIdUser,
     ): Promise<LightdashUser> {
         const inviteLink = await this.inviteLinkModel.getByCode(inviteCode);
-        const userEmail = isOpenIdUser(activateUser)
-            ? activateUser.openId.email
-            : inviteLink.email;
+        return this.activateUserFromInviteLink(inviteLink, activateUser);
+    }
 
-        if (isOpenIdUser(activateUser)) {
+    async activateUserFromInviteWithoutPassword(
+        inviteCode: string,
+    ): Promise<SessionUser> {
+        const inviteLink = await this.getInviteLink(inviteCode);
+        const user = await this.activateUserFromInviteLink(inviteLink);
+        // The invite link was delivered to this address, so opening it proves
+        // mailbox ownership — same trust as OpenID email verification.
+        await this.tryVerifyUserEmail(user, inviteLink.email);
+        return this.userModel.findSessionUserByUUID(user.userUuid);
+    }
+
+    private async activateUserFromInviteLink(
+        inviteLink: InviteLink,
+        activateUser?: ActivateUser | OpenIdUser,
+    ): Promise<LightdashUser> {
+        const userEmail =
+            activateUser && isOpenIdUser(activateUser)
+                ? activateUser.openId.email
+                : inviteLink.email;
+
+        if (activateUser && isOpenIdUser(activateUser)) {
             if (
                 (await this.isLoginMethodAllowed(
                     userEmail,
@@ -416,10 +435,14 @@ export class UserService extends BaseService {
                 `Provided email ${userEmail} does not match the invited email.`,
             );
         }
-        const user = await this.userModel.activateUser(
-            inviteLink.userUuid,
-            activateUser,
-        );
+        const user = activateUser
+            ? await this.userModel.activateUser(
+                  inviteLink.userUuid,
+                  activateUser,
+              )
+            : await this.userModel.activateUserWithoutPassword(
+                  inviteLink.userUuid,
+              );
         await this.inviteLinkModel.deleteByCode(inviteLink.inviteCode);
 
         // Apply default project memberships from allowed email domains config.
@@ -466,6 +489,17 @@ export class UserService extends BaseService {
         }
 
         this.identifyUser(user);
+        let userConnectionType:
+            | 'email_only'
+            | 'password'
+            | OpenIdIdentityIssuerType;
+        if (!activateUser) {
+            userConnectionType = 'email_only';
+        } else if (isOpenIdUser(activateUser)) {
+            userConnectionType = activateUser.openId.issuerType;
+        } else {
+            userConnectionType = 'password';
+        }
         this.analytics.track({
             event: 'user.created',
             userId: user.userUuid,
@@ -473,10 +507,10 @@ export class UserService extends BaseService {
                 context: 'accept_invite',
                 createdUserId: user.userUuid,
                 organizationId: user.organizationUuid,
-                userConnectionType: 'password',
+                userConnectionType,
             },
         });
-        if (!isOpenIdUser(activateUser)) {
+        if (activateUser && !isOpenIdUser(activateUser)) {
             await this.sendOneTimePasscodeToPrimaryEmail(user);
         }
         return user;

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -996,6 +996,10 @@ export type PasswordReset = {
 };
 
 export type ApiHealthResults = HealthState;
+export enum InviteLinkPurpose {
+    Member = 'member',
+    Setup = 'setup',
+}
 export type InviteLink = {
     expiresAt: Date;
     inviteCode: string;
@@ -1003,11 +1007,13 @@ export type InviteLink = {
     organizationUuid: string;
     userUuid: string;
     email: string;
+    purpose: InviteLinkPurpose;
 };
 export type CreateInviteLink = {
     email: string;
     expiresAt?: Date;
     role?: OrganizationMemberRole;
+    purpose?: InviteLinkPurpose;
 };
 
 export type ApiInviteLinkResponse = {

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/InviteExpertFooter.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/InviteExpertFooter.tsx
@@ -1,15 +1,23 @@
 import { Anchor, Text } from '@mantine-8/core';
+import { useDisclosure } from '@mantine/hooks';
 import { type FC } from 'react';
-import { Link } from 'react-router';
+import SetupInviteModal from './SetupInviteModal';
 
-const InviteExpertFooter: FC = () => (
-    <Text c="dimmed" w={420} mx="auto" ta="center">
-        This step is best carried out by your organization’s analytics experts.
-        If this is not you,{' '}
-        <Anchor component={Link} to="/generalSettings/userManagement?to=invite">
-            invite them to Lightdash!
-        </Anchor>
-    </Text>
-);
+const InviteExpertFooter: FC = () => {
+    const [opened, { open, close }] = useDisclosure(false);
+
+    return (
+        <>
+            <Text c="dimmed" w={420} mx="auto" ta="center">
+                This step is best carried out by your organization’s analytics
+                experts. If this is not you,{' '}
+                <Anchor component="button" type="button" onClick={open}>
+                    invite them to help you set up.
+                </Anchor>
+            </Text>
+            <SetupInviteModal opened={opened} onClose={close} />
+        </>
+    );
+};
 
 export default InviteExpertFooter;

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SetupInviteModal.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SetupInviteModal.tsx
@@ -8,6 +8,7 @@ import {
     Alert,
     Button,
     CopyButton,
+    Group,
     Stack,
     Text,
     TextInput,
@@ -18,11 +19,14 @@ import { IconCheck, IconCopy, IconUserPlus } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { z } from 'zod';
 import { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
+import { useUserUpdateMutation } from '../../../hooks/user/useUserUpdateMutation';
 import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
 
 type SetupInviteFormValues = {
+    firstName: string;
+    lastName: string;
     email: string;
 };
 
@@ -30,13 +34,25 @@ const SetupInviteModal: FC<{
     opened: boolean;
     onClose: () => void;
 }> = ({ opened, onClose }) => {
-    const { health } = useApp();
+    const { health, user } = useApp();
+    const existingFirstName = user.data?.firstName ?? '';
+    const existingLastName = user.data?.lastName ?? '';
+    const needsName = !existingFirstName.trim() || !existingLastName.trim();
+
     const form = useForm<SetupInviteFormValues>({
         initialValues: {
+            firstName: existingFirstName,
+            lastName: existingLastName,
             email: '',
         },
         validate: zodResolver(
             z.object({
+                firstName: needsName
+                    ? z.string().trim().min(1, 'Required')
+                    : z.string(),
+                lastName: needsName
+                    ? z.string().trim().min(1, 'Required')
+                    : z.string(),
                 email: getEmailSchema(),
             }),
         ),
@@ -47,6 +63,8 @@ const SetupInviteModal: FC<{
         reset,
         isLoading,
     } = useCreateInviteLinkMutation();
+    const { mutateAsync: updateUserAsync, isLoading: isUpdatingUser } =
+        useUserUpdateMutation();
 
     const handleClose = () => {
         form.reset();
@@ -55,12 +73,20 @@ const SetupInviteModal: FC<{
     };
 
     const handleSubmit = async (values: SetupInviteFormValues) => {
+        if (needsName) {
+            await updateUserAsync({
+                firstName: values.firstName.trim(),
+                lastName: values.lastName.trim(),
+            });
+        }
         await mutateAsync({
             email: values.email,
             role: OrganizationMemberRole.ADMIN,
             purpose: InviteLinkPurpose.Setup,
         });
     };
+
+    const isSubmitting = isLoading || isUpdatingUser;
 
     return (
         <MantineModal
@@ -75,7 +101,7 @@ const SetupInviteModal: FC<{
                     <Button onClick={handleClose}>Done</Button>
                 ) : (
                     <Button
-                        disabled={isLoading}
+                        loading={isSubmitting}
                         type="submit"
                         form="setup_invite"
                     >
@@ -139,17 +165,40 @@ const SetupInviteModal: FC<{
                     onSubmit={form.onSubmit((values) => handleSubmit(values))}
                 >
                     <Stack gap="sm">
+                        {needsName && (
+                            <>
+                                <Group grow gap="sm">
+                                    <TextInput
+                                        name="firstName"
+                                        label="Your first name"
+                                        required
+                                        disabled={isSubmitting}
+                                        {...form.getInputProps('firstName')}
+                                    />
+                                    <TextInput
+                                        name="lastName"
+                                        label="Your last name"
+                                        required
+                                        disabled={isSubmitting}
+                                        {...form.getInputProps('lastName')}
+                                    />
+                                </Group>
+                                <Text size="sm" c="dimmed">
+                                    We'll include your name in the invite so
+                                    they know who's asking.
+                                </Text>
+                            </>
+                        )}
                         <TextInput
                             name="email"
                             label="Their email address"
                             placeholder="example@company.com"
                             required
-                            disabled={isLoading}
+                            disabled={isSubmitting}
                             {...form.getInputProps('email')}
                         />
                         <Text size="sm" c="dimmed">
-                            We'll ask them to connect your data warehouse —
-                            takes about 5 minutes.
+                            We'll ask them to connect your data warehouse.
                         </Text>
                     </Stack>
                 </form>

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SetupInviteModal.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SetupInviteModal.tsx
@@ -1,0 +1,161 @@
+import {
+    getEmailSchema,
+    InviteLinkPurpose,
+    OrganizationMemberRole,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Alert,
+    Button,
+    CopyButton,
+    Stack,
+    Text,
+    TextInput,
+    Tooltip,
+} from '@mantine-8/core';
+import { useForm, zodResolver } from '@mantine/form';
+import { IconCheck, IconCopy, IconUserPlus } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { z } from 'zod';
+import { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
+import useApp from '../../../providers/App/useApp';
+import MantineIcon from '../../common/MantineIcon';
+import MantineModal from '../../common/MantineModal';
+
+type SetupInviteFormValues = {
+    email: string;
+};
+
+const SetupInviteModal: FC<{
+    opened: boolean;
+    onClose: () => void;
+}> = ({ opened, onClose }) => {
+    const { health } = useApp();
+    const form = useForm<SetupInviteFormValues>({
+        initialValues: {
+            email: '',
+        },
+        validate: zodResolver(
+            z.object({
+                email: getEmailSchema(),
+            }),
+        ),
+    });
+    const {
+        data: inviteLink,
+        mutateAsync,
+        reset,
+        isLoading,
+    } = useCreateInviteLinkMutation();
+
+    const handleClose = () => {
+        form.reset();
+        reset();
+        onClose();
+    };
+
+    const handleSubmit = async (values: SetupInviteFormValues) => {
+        await mutateAsync({
+            email: values.email,
+            role: OrganizationMemberRole.ADMIN,
+            purpose: InviteLinkPurpose.Setup,
+        });
+    };
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={handleClose}
+            title="Invite someone to set this up"
+            icon={IconUserPlus}
+            size="lg"
+            cancelLabel={inviteLink ? false : 'Cancel'}
+            actions={
+                inviteLink ? (
+                    <Button onClick={handleClose}>Done</Button>
+                ) : (
+                    <Button
+                        disabled={isLoading}
+                        type="submit"
+                        form="setup_invite"
+                    >
+                        Send invite
+                    </Button>
+                )
+            }
+        >
+            {inviteLink ? (
+                <Alert icon={<IconCheck />} color="green" title="Invite ready">
+                    <Stack gap="sm">
+                        <Text size="sm">
+                            {health.data?.hasEmailClient ? (
+                                <>
+                                    Invite sent to <b>{inviteLink.email}</b> —
+                                    we'll take them straight to warehouse setup.
+                                </>
+                            ) : (
+                                <>
+                                    Share this link with{' '}
+                                    <b>{inviteLink.email}</b> to take them
+                                    straight to warehouse setup.
+                                </>
+                            )}
+                        </Text>
+                        <TextInput
+                            readOnly
+                            className="sentry-block ph-no-capture"
+                            value={inviteLink.inviteUrl}
+                            rightSection={
+                                <CopyButton value={inviteLink.inviteUrl}>
+                                    {({ copied, copy }) => (
+                                        <Tooltip
+                                            label={copied ? 'Copied' : 'Copy'}
+                                            withArrow
+                                            position="right"
+                                        >
+                                            <ActionIcon
+                                                color={copied ? 'teal' : 'gray'}
+                                                onClick={copy}
+                                            >
+                                                <MantineIcon
+                                                    icon={
+                                                        copied
+                                                            ? IconCheck
+                                                            : IconCopy
+                                                    }
+                                                />
+                                            </ActionIcon>
+                                        </Tooltip>
+                                    )}
+                                </CopyButton>
+                            }
+                        />
+                    </Stack>
+                </Alert>
+            ) : (
+                <form
+                    id="setup_invite"
+                    name="setup_invite"
+                    onSubmit={form.onSubmit((values) => handleSubmit(values))}
+                >
+                    <Stack gap="sm">
+                        <TextInput
+                            name="email"
+                            label="Their email address"
+                            placeholder="example@company.com"
+                            required
+                            disabled={isLoading}
+                            {...form.getInputProps('email')}
+                        />
+                        <Text size="sm" c="dimmed">
+                            We'll ask them to connect your data warehouse —
+                            takes about 5 minutes.
+                        </Text>
+                    </Stack>
+                </form>
+            )}
+        </MantineModal>
+    );
+};
+
+export default SetupInviteModal;

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
@@ -194,7 +194,16 @@ const UserCompletionModalWithUser = () => {
         // redirect (e.g. AppRoute's needsProject -> /createProject) wins the
         // same render commit.
         return shouldSetup ? (
-            <Navigate key={location.pathname} to="/organization-setup" />
+            <Navigate
+                key={location.pathname}
+                to={
+                    location.pathname && location.pathname !== '/'
+                        ? `/organization-setup?redirect=${encodeURIComponent(
+                              location.pathname,
+                          )}`
+                        : '/organization-setup'
+                }
+            />
         ) : null;
     }
 

--- a/packages/frontend/src/hooks/useInviteLink.tsx
+++ b/packages/frontend/src/hooks/useInviteLink.tsx
@@ -2,6 +2,7 @@ import {
     type ApiError,
     type CreateInviteLink,
     type InviteLink,
+    type LightdashUser,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
@@ -45,6 +46,35 @@ export const useInviteLink = (inviteCode: string | undefined) =>
         queryFn: () => inviteLinkQuery(inviteCode!),
         enabled: inviteCode !== undefined,
     });
+
+const activateInviteLinkQuery = async (inviteCode: string) =>
+    lightdashApi<LightdashUser>({
+        url: `/invite-links/${inviteCode}/activate`,
+        method: 'POST',
+        body: undefined,
+    });
+
+export const useActivateInviteLinkMutation = (
+    inviteCode: string | undefined,
+    redirectUrl: string,
+) => {
+    const { showToastApiError } = useToaster();
+    return useMutation<LightdashUser, ApiError>(
+        () => activateInviteLinkQuery(inviteCode!),
+        {
+            mutationKey: ['activate_invite_link', inviteCode],
+            onSuccess: () => {
+                window.location.href = redirectUrl;
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to accept invite',
+                    apiError: error,
+                });
+            },
+        },
+    );
+};
 
 export const useCreateInviteLinkMutation = () => {
     const queryClient = useQueryClient();

--- a/packages/frontend/src/pages/Invite.tsx
+++ b/packages/frontend/src/pages/Invite.tsx
@@ -1,4 +1,5 @@
 import {
+    FeatureFlags,
     InviteLinkPurpose,
     OpenIdIdentityIssuerType,
     type ActivateUserWithInviteCode,
@@ -28,7 +29,11 @@ import CreateUserForm from '../components/RegisterForms/CreateUserForm';
 import { useOrganization } from '../hooks/organization/useOrganization';
 import useToaster from '../hooks/toaster/useToaster';
 import { useFlashMessages } from '../hooks/useFlashMessages';
-import { useInviteLink } from '../hooks/useInviteLink';
+import {
+    useActivateInviteLinkMutation,
+    useInviteLink,
+} from '../hooks/useInviteLink';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import useApp from '../providers/App/useApp';
 import useTracking from '../providers/Tracking/useTracking';
 
@@ -88,6 +93,63 @@ const ErrorCard: FC<{ title: string }> = ({ title }) => {
     );
 };
 
+const PrivacyTermsFootnote: FC = () => (
+    <Text c="ldGray.6" ta="center" fz="sm" fw={500}>
+        By creating an account, you agree to
+        <br />
+        our{' '}
+        <Anchor
+            href="https://www.lightdash.com/privacy-policy"
+            target="_blank"
+            fz="sm"
+            fw={500}
+        >
+            Privacy Policy
+        </Anchor>{' '}
+        and our{' '}
+        <Anchor
+            href="https://www.lightdash.com/terms-of-service"
+            target="_blank"
+            fz="sm"
+            fw={500}
+        >
+            Terms of Service.
+        </Anchor>
+    </Text>
+);
+
+interface OneClickCardProps {
+    email: string;
+    isSetupInvite: boolean;
+    isLoading: boolean;
+    onActivate: () => void;
+}
+
+const OneClickCard: FC<OneClickCardProps> = ({
+    email,
+    isSetupInvite,
+    isLoading,
+    onActivate,
+}) => (
+    <Card p="xl" withBorder shadow="subtle" data-cy="one-click-invite">
+        <Stack gap="md" align="center">
+            <Title order={3} ta="center">
+                {isSetupInvite
+                    ? 'You’ve been asked to help with setup'
+                    : 'You’ve been invited to Lightdash'}
+            </Title>
+            <Text c="ldGray.6" ta="center">
+                {isSetupInvite
+                    ? 'One click and we’ll take you straight to connecting the data warehouse.'
+                    : 'One click to join your team.'}
+            </Text>
+            <Button fullWidth loading={isLoading} onClick={onActivate}>
+                Continue as {email}
+            </Button>
+        </Stack>
+    </Card>
+);
+
 const createUserQuery = async (data: ActivateUserWithInviteCode) =>
     lightdashApi<LightdashUser>({
         url: `/user`,
@@ -118,6 +180,14 @@ const Invite: FC = () => {
         inviteLinkQuery.data?.purpose === InviteLinkPurpose.Setup;
     const redirectUrl = isSetupInvite ? '/onboarding/data-source' : '/';
 
+    const newOnboardingFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding, {
+        retry: 3,
+    });
+    const activateInvite = useActivateInviteLinkMutation(
+        inviteCode,
+        redirectUrl,
+    );
+
     const { isLoading, mutate, isSuccess } = useMutation<
         LightdashUser,
         ApiError,
@@ -138,6 +208,9 @@ const Invite: FC = () => {
 
     const allowPasswordAuthentication =
         !health.data?.auth.disablePasswordAuthentication;
+    const isNewOnboarding = newOnboardingFlag.data?.enabled ?? false;
+    const showOneClick =
+        isNewOnboarding && allowPasswordAuthentication && Boolean(inviteCode);
 
     useEffect(() => {
         const searchParams = new URLSearchParams(search);
@@ -147,7 +220,11 @@ const Invite: FC = () => {
         }
     }, [search]);
 
-    if (health.isInitialLoading || inviteLinkQuery.isInitialLoading) {
+    if (
+        health.isInitialLoading ||
+        inviteLinkQuery.isInitialLoading ||
+        newOnboardingFlag.isInitialLoading
+    ) {
         return <PageSpinner />;
     }
 
@@ -220,6 +297,19 @@ const Invite: FC = () => {
                                 : inviteLinkQuery.error.error.message
                         }
                     />
+                ) : showOneClick && inviteLinkQuery.data ? (
+                    <>
+                        <OneClickCard
+                            email={inviteLinkQuery.data.email}
+                            isSetupInvite={isSetupInvite}
+                            isLoading={
+                                activateInvite.isLoading ||
+                                activateInvite.isSuccess
+                            }
+                            onActivate={() => activateInvite.mutate()}
+                        />
+                        <PrivacyTermsFootnote />
+                    </>
                 ) : isLinkFromEmail || isSetupInvite ? (
                     <>
                         <Card p="xl" withBorder shadow="subtle">
@@ -236,28 +326,7 @@ const Invite: FC = () => {
                             )}
                             {logins}
                         </Card>
-                        <Text c="ldGray.6" ta="center" fz="sm" fw={500}>
-                            By creating an account, you agree to
-                            <br />
-                            our{' '}
-                            <Anchor
-                                href="https://www.lightdash.com/privacy-policy"
-                                target="_blank"
-                                fz="sm"
-                                fw={500}
-                            >
-                                Privacy Policy
-                            </Anchor>{' '}
-                            and our{' '}
-                            <Anchor
-                                href="https://www.lightdash.com/terms-of-service"
-                                target="_blank"
-                                fz="sm"
-                                fw={500}
-                            >
-                                Terms of Service.
-                            </Anchor>
-                        </Text>
+                        <PrivacyTermsFootnote />
                     </>
                 ) : (
                     <WelcomeCard

--- a/packages/frontend/src/pages/Invite.tsx
+++ b/packages/frontend/src/pages/Invite.tsx
@@ -1,4 +1,5 @@
 import {
+    InviteLinkPurpose,
     OpenIdIdentityIssuerType,
     type ActivateUserWithInviteCode,
     type ApiError,
@@ -110,8 +111,13 @@ const Invite: FC = () => {
     }, [flashMessages.data, showToastError]);
     const { search } = useLocation();
     const { identify } = useTracking();
-    const redirectUrl = '/';
     const [isLinkFromEmail, setIsLinkFromEmail] = useState<boolean>(false);
+    const inviteLinkQuery = useInviteLink(inviteCode);
+
+    const isSetupInvite =
+        inviteLinkQuery.data?.purpose === InviteLinkPurpose.Setup;
+    const redirectUrl = isSetupInvite ? '/onboarding/data-source' : '/';
+
     const { isLoading, mutate, isSuccess } = useMutation<
         LightdashUser,
         ApiError,
@@ -129,7 +135,6 @@ const Invite: FC = () => {
             });
         },
     });
-    const inviteLinkQuery = useInviteLink(inviteCode);
 
     const allowPasswordAuthentication =
         !health.data?.auth.disablePasswordAuthentication;
@@ -215,12 +220,20 @@ const Invite: FC = () => {
                                 : inviteLinkQuery.error.error.message
                         }
                     />
-                ) : isLinkFromEmail ? (
+                ) : isLinkFromEmail || isSetupInvite ? (
                     <>
                         <Card p="xl" withBorder shadow="subtle">
                             <Title order={3} ta="center" mb="md">
-                                Sign up
+                                {isSetupInvite
+                                    ? 'You’ve been asked to help with setup'
+                                    : 'Sign up'}
                             </Title>
+                            {isSetupInvite && (
+                                <Text c="ldGray.6" ta="center" mb="md">
+                                    Create your account and we’ll take you
+                                    straight to warehouse setup.
+                                </Text>
+                            )}
                             {logins}
                         </Card>
                         <Text c="ldGray.6" ta="center" fz="sm" fw={500}>

--- a/packages/frontend/src/pages/OnboardingDataSource.module.css
+++ b/packages/frontend/src/pages/OnboardingDataSource.module.css
@@ -10,7 +10,7 @@
     width: 100%;
     max-width: 1140px;
     margin: 0 auto;
-    padding: 56px var(--mantine-spacing-sm) var(--mantine-spacing-xl);
+    padding: 56px var(--mantine-spacing-xxl) var(--mantine-spacing-xl);
     display: flex;
     flex-direction: column;
     gap: var(--mantine-spacing-xl);

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -23,7 +23,7 @@ import {
 import { useForm } from '@mantine/form';
 import { zodResolver } from 'mantine-form-zod-resolver';
 import { useEffect, useRef, useState, type FC } from 'react';
-import { Navigate, useNavigate } from 'react-router';
+import { Navigate, useNavigate, useSearchParams } from 'react-router';
 import AboutFooter from '../components/AboutFooter';
 import { DocumentTitle } from '../components/common/DocumentTitle';
 import PageSpinner from '../components/PageSpinner';
@@ -473,9 +473,17 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
 const OrganizationSetup: FC = () => {
     const { health, user } = useApp();
     const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+    const redirectParam = searchParams.get('redirect');
+    const redirectTo =
+        redirectParam &&
+        redirectParam.startsWith('/') &&
+        !redirectParam.startsWith('//')
+            ? redirectParam
+            : '/';
     const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
     const completeMutation = useUserCompleteMutation({
-        onSuccess: () => void navigate('/'),
+        onSuccess: () => void navigate(redirectTo),
     });
     const isCompletingSetup =
         completeMutation.isLoading || completeMutation.isSuccess;


### PR DESCRIPTION
## Summary

> Stacked on #25762.

A founder mid-onboarding often isn't the person with warehouse credentials. This makes "invite an expert" a first-class handoff:

- **Purpose-carrying invite links** (`member`/`setup`): setup invites grant the admin role (required to create the first project) and throw instead of silently downgrading when the inviter can't grant it.
- **In-place invite modal** on the data-source screen, replacing the dead `?to=invite` settings deep-link. When the inviter has no first/last name (passwordless signup never collects it), the modal captures it and saves it to their profile before sending.
- **Task-framed invitation email** rebuilt on the current template system, using current positioning copy: who's asking, what Lightdash is, and that accepting leads straight to connecting the warehouse. Inviter name falls back to their email.
- **One-click passwordless accept**: `POST /api/v1/invite-links/{code}/activate` provisions the pending user with no password, forms, or OTP — the emailed single-use link is the credential (same trust level as the legacy accept flow). The email is marked verified on activation (opening the link proves mailbox ownership, mirroring OpenID verification), the invite is consumed, the session is logged in. Activation is a click-triggered POST so mail-scanner link prefetch can't consume the invite.
- **Destination preserved end-to-end**: the accept page is a single "Continue as {email}" card; setup invitees land directly on the warehouse connect screen, with the user-setup interstitial threading the destination via a `redirect` param. Legacy signup flow kept for flag-off environments and SSO-only instances.

## Testing

- Backend: activation endpoint unit + controller tests (single-use, expiry, role, no password row); full suite green.
- Live-verified end-to-end in a browser: invite modal → styled email in Mailpit → one click → about-you step → warehouse connect screen, as an admin in the inviter's org with verified email.

Closes: PROD-8993

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBMYi62LyUcXRmHeshAN7y