### PR TITLE
fix(scripts): serialize shared-services compose startup in dev-fast-start

### DIFF
--- a/scripts/dev-fast-start.sh
+++ b/scripts/dev-fast-start.sh
@@ -277,8 +277,25 @@ fi
 
 # ---------------------------------------------------------------------------
 step "Start Docker services"
-docker compose -p ld-shared -f "$SHARED_COMPOSE" --env-file .env.development up -d \
-    || fail "docker-shared" "could not start shared services (minio/headless-browser/mailpit/nats)"
+# Two instances booting concurrently race inside `compose up` on the shared
+# project (container-name conflicts / vanished-container errors). Serialize
+# with flock where available (Linux); everywhere else a single retry after a
+# short delay resolves the transient race — by then the winner has the
+# services up and this call becomes an idempotent no-op.
+start_shared_services() {
+    docker compose -p ld-shared -f "$SHARED_COMPOSE" --env-file .env.development up -d
+}
+SHARED_LOCK="${HOME}/.lightdash/shared-compose.lock"
+mkdir -p "${HOME}/.lightdash"
+if command -v flock >/dev/null 2>&1; then
+    flock "$SHARED_LOCK" docker compose -p ld-shared -f "$SHARED_COMPOSE" --env-file .env.development up -d \
+        || { sleep 5; start_shared_services; } \
+        || fail "docker-shared" "could not start shared services (minio/headless-browser/mailpit/nats)"
+else
+    start_shared_services \
+        || { sleep 5; start_shared_services; } \
+        || fail "docker-shared" "could not start shared services (minio/headless-browser/mailpit/nats)"
+fi
 docker compose -p "$LD_COMPOSE_PROJECT" -f "$INSTANCE_COMPOSE" --env-file .env.development up -d \
     || fail "docker-instance" "could not start per-instance PostgreSQL"
 


### PR DESCRIPTION
## Summary

Two dev instances booting concurrently race inside `docker compose -p ld-shared up` — one hits a container-name conflict (`ld-shared-minio-1 already in use`), the other tries to start a container the winning invocation just recreated (`No such container`), and both boots fail at the docker-shared step. Reproduced today with two fresh instances started in parallel.

Serialize the shared-services startup with `flock` where available (Linux dev boxes) and fall back to a single retry after a short delay elsewhere (macOS has no flock binary) — by the retry, the winner has the services up and the call is an idempotent no-op. Script contract (STEP/OK/SKIP/FAIL markers, idempotency) unchanged.

## Testing

- `bash -n` clean; re-ran two-instance boot on the dev box after serializing — both reached READY.

Closes: PROD-8995

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBMYi62LyUcXRmHeshAN7y