### PR TITLE
fix: stop TSOA intersection validation emptying BigQuery keyfileContents

### DIFF
--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -57,7 +57,9 @@ export type CreateBigqueryCredentials = {
     timeoutSeconds: number | undefined;
     priority: 'interactive' | 'batch' | undefined;
     authenticationType?: BigqueryAuthenticationType;
-    keyfileContents: Record<string, string>; // used for both sso and private key
+    // Index signature (not Record) so tsoa generates additionalProperties and
+    // intersection-body validation preserves the keyfile fields.
+    keyfileContents: { [key: string]: string }; // used for both sso and private key
     requireUserCredentials?: boolean;
     retries: number | undefined;
     location: string | undefined;


### PR DESCRIPTION
## Summary

**Fixes the `E2E: API (Vitest)` job currently failing on every backend-touching PR.**

Creating a BigQuery project via `POST /api/v1/org/projects` stores `keyfileContents` as an **empty object**, so every subsequent BigQuery operation fails with `The incoming JSON object does not contain a client_email field` (project refresh, sqlRunner, async queries — the exact failures in recent E2E runs).

Three interlocking causes:
1. The endpoint's body is an intersection type (`CreateProjectOptionalCredentials = Omit<CreateProject, ...> & {...}`), and TSOA's `validateIntersection` hard-codes `silently-remove-extras` regardless of the configured mode (`@tsoa/runtime` `templateHelpers` — inner validators are always strict).
2. TSOA generation recently degraded `Record<string, string>` to a model with **no `additionalProperties`** (a July-16 checkout generates `additionalProperties: {dataType: 'string'}`; current main generates none — no lockfile or tsoa-config change; source-type-change trigger still being bisected). Empty declared properties + forced silent-remove = every keyfile field deleted server-side before the controller runs.
3. The E2E API job is path-skipped on frontend-only PRs, so the breakage sailed through recent merges unnoticed.

## Fix

Type `keyfileContents` as an index signature — `{ [key: string]: string }` — which tsoa reliably generates **with** `additionalProperties`, so intersection cleaning preserves all fields.

## Verification

- Regenerated routes show the healthy inline model for `keyfileContents` in all credential schemas.
- Live end-to-end on a dev instance: created a BigQuery project via the API, decrypted the stored `warehouse_credentials` — full keyfile retained (previously `{}`); the BigQuery client now receives complete credentials.
- The E2E API job on THIS PR is the definitive regression test — it exercises exactly the broken path.

Follow-up (tracked in the ticket): identify the commit that degraded `Record` generation — other `Record<string, X>`-typed body fields inside intersection bodies remain exposed to the same class of stripping.

Closes: PROD-8998

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBMYi62LyUcXRmHeshAN7y