### PR TITLE
fix(frontend): relabel Snowflake key-pair auth option

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -58,7 +58,7 @@ import {
     getSsoLabel,
     NONE_LABEL,
     PASSWORD_LABEL,
-    PRIVATE_KEY_LABEL,
+    SNOWFLAKE_KEY_PAIR_LABEL,
 } from './util';
 import styles from './WarehouseButtons.module.css';
 
@@ -210,7 +210,7 @@ const SnowflakeForm: FC<{
               },
               {
                   value: SnowflakeAuthenticationType.PRIVATE_KEY,
-                  label: PRIVATE_KEY_LABEL,
+                  label: SNOWFLAKE_KEY_PAIR_LABEL,
               },
               {
                   value: SnowflakeAuthenticationType.PASSWORD,
@@ -220,7 +220,7 @@ const SnowflakeForm: FC<{
         : [
               {
                   value: SnowflakeAuthenticationType.PRIVATE_KEY,
-                  label: PRIVATE_KEY_LABEL,
+                  label: SNOWFLAKE_KEY_PAIR_LABEL,
               },
               {
                   value: SnowflakeAuthenticationType.PASSWORD,

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/util.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/util.ts
@@ -2,7 +2,7 @@ import { capitalize, type WarehouseTypes } from '@lightdash/common';
 
 export const getSsoLabel = (warehouse: WarehouseTypes, provider?: string) =>
     `User Account (Sign in with ${provider ?? capitalize(warehouse)})`;
-export const PRIVATE_KEY_LABEL = `Service Account (JSON key file)`;
+export const SNOWFLAKE_KEY_PAIR_LABEL = `Key Pair (private key file)`;
 export const PASSWORD_LABEL = `Password`;
 export const EXTERNAL_BROWSER_LABEL = `External Browser`;
 export const PERSONAL_ACCESS_TOKEN_LABEL = `Personal Access Token`;


### PR DESCRIPTION
Closes: #25767

### Description

The Snowflake project connection form labelled the key-pair authentication option as **"Service Account (JSON key file)"**, which is BigQuery terminology. Snowflake key-pair auth uses a `.p8` private key file, and selecting the option already revealed a "Private Key File" input with `accept=".p8"`.

Renamed the shared constant to `SNOWFLAKE_KEY_PAIR_LABEL` and updated the dropdown label to **"Key Pair (private key file)"**. BigQuery is unchanged — it still uses "Service Account (JSON key file)" inline in `BigQueryForm.tsx`.

### Test plan

- [x] Create project → Snowflake → Manually → open **Authentication Type** dropdown
- [x] Confirm option reads **Key Pair (private key file)** (not "Service Account (JSON key file)")
- [x] Select it and confirm **Private Key File** input still accepts `.p8`

## Screenshot
<img width="1333" height="773" alt="Screenshot 2026-07-19 at 1 21 58 AM" src="https://github.com/user-attachments/assets/d2d6a513-ddbd-4ac1-afb2-507e58d9ac6d" />
