### PR TITLE
fix(ai): truncate overlong thread titles instead of 500

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/titleGenerator.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/titleGenerator.test.ts
@@ -1,0 +1,51 @@
+import { generateObject } from 'ai';
+import { generateThreadTitle, TITLE_MAX_LENGTH_CHARS } from './titleGenerator';
+
+vi.mock('ai', () => ({ generateObject: vi.fn() }));
+vi.mock('../../../../analytics/aiUsage', () => ({
+    emitAiUsage: vi.fn(),
+    languageModelUsageToTokens: vi.fn(() => ({})),
+}));
+vi.mock('../utils/aiCallTelemetry', () => ({
+    getGeneratorTelemetry: () => ({}),
+}));
+
+const generateObjectMock = vi.mocked(generateObject);
+
+const modelOptions = {
+    model: { modelId: 'test-model' },
+    callOptions: {},
+    providerOptions: {},
+} as Parameters<typeof generateThreadTitle>[0];
+
+describe('generateThreadTitle', () => {
+    beforeEach(() => {
+        generateObjectMock.mockReset();
+    });
+
+    it('stores short model titles verbatim', async () => {
+        const title = 'Order data analysis for last 30 days';
+        generateObjectMock.mockResolvedValueOnce({
+            object: { title },
+            usage: {},
+        } as never);
+
+        await expect(generateThreadTitle(modelOptions, [])).resolves.toBe(
+            title,
+        );
+    });
+
+    it('truncates model titles longer than 60 characters instead of throwing', async () => {
+        const longTitle =
+            'Monthly payment trends by partner for fiscal twenty twenty six extra';
+        generateObjectMock.mockResolvedValueOnce({
+            object: { title: longTitle },
+            usage: {},
+        } as never);
+
+        const title = await generateThreadTitle(modelOptions, []);
+
+        expect(title.length).toBeLessThanOrEqual(TITLE_MAX_LENGTH_CHARS);
+        expect(title.endsWith('...')).toBe(true);
+    });
+});

--- a/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
@@ -6,16 +6,14 @@ import {
 } from '../../../../analytics/aiUsage';
 import { GeneratorModelOptions } from '../models/types';
 import { getGeneratorTelemetry } from '../utils/aiCallTelemetry';
+import { truncateAtWordBoundary } from '../utils/truncation';
 
-const TITLE_MAX_LENGTH_CHARS = 60;
+export const TITLE_MAX_LENGTH_CHARS = 60;
+
 const TitleSchema = z.object({
     title: z
         .string()
         .min(1, 'Title must not be empty')
-        .max(
-            TITLE_MAX_LENGTH_CHARS,
-            `Title must be ${TITLE_MAX_LENGTH_CHARS} characters or less`,
-        )
         .describe('A concise, descriptive title for the conversation thread'),
 });
 
@@ -62,5 +60,5 @@ The title should be clear, specific, and helpful for someone browsing a list of 
 
     emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
-    return result.object.title;
+    return truncateAtWordBoundary(result.object.title, TITLE_MAX_LENGTH_CHARS);
 }

--- a/packages/backend/src/ee/services/ai/utils/truncation.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/truncation.test.ts
@@ -1,4 +1,4 @@
-import { truncate } from './truncation';
+import { truncate, truncateAtWordBoundary } from './truncation';
 
 describe('truncate', () => {
     it('keeps the requested number of characters before the suffix', () => {
@@ -13,5 +13,22 @@ describe('truncate', () => {
         expect(truncate('abc', 0)).toEqual('');
         expect(truncate('abc', -1)).toEqual('');
         expect(truncate('abc', Number.NaN)).toEqual('');
+    });
+});
+
+describe('truncateAtWordBoundary', () => {
+    it('returns short strings unchanged', () => {
+        const title = 'Revenue over last 12 months';
+        expect(truncateAtWordBoundary(title, 60)).toBe(title);
+    });
+
+    it('truncates at a word boundary with ellipsis', () => {
+        const title =
+            'Monthly payment trends by partner for fiscal twenty twenty six';
+        const truncated = truncateAtWordBoundary(title, 60);
+
+        expect(truncated.length).toBeLessThanOrEqual(60);
+        expect(truncated.endsWith('...')).toBe(true);
+        expect(truncated).not.toContain(' twenty six');
     });
 });

--- a/packages/backend/src/ee/services/ai/utils/truncation.ts
+++ b/packages/backend/src/ee/services/ai/utils/truncation.ts
@@ -22,5 +22,30 @@ export const truncate = (value: string, max: number) => {
     return `${valueChars.slice(0, maxChars).join('')}${TRUNCATED_SUFFIX}`;
 };
 
+const DEFAULT_WORD_BOUNDARY_ELLIPSIS = '...';
+
+export const truncateAtWordBoundary = (
+    value: string,
+    maxLength: number,
+    ellipsis = DEFAULT_WORD_BOUNDARY_ELLIPSIS,
+): string => {
+    const trimmed = value.trim();
+    const chars = Array.from(trimmed);
+    if (chars.length <= maxLength) return trimmed;
+
+    const ellipsisChars = Array.from(ellipsis);
+    const maxContentLength = maxLength - ellipsisChars.length;
+    if (maxContentLength <= 0) {
+        return ellipsisChars.slice(0, maxLength).join('');
+    }
+
+    const content = chars.slice(0, maxContentLength).join('');
+    const lastSpace = content.lastIndexOf(' ');
+    const truncatedContent =
+        lastSpace > 0 ? content.slice(0, lastSpace) : content;
+
+    return `${truncatedContent.trimEnd()}${ellipsis}`;
+};
+
 // TODO: move this out...
 export const DASHBOARD_CHARTS_PREVIEW_COUNT = 5;


### PR DESCRIPTION
Closes: #25726
Relates: PROD-8983

### Description

`POST .../threads/:threadUuid/generate-title` returned 500 when the title model produced a string longer than 60 characters. `TitleSchema` used `.max(60)`, so `generateObject` threw `AI_NoObjectGeneratedError` and the request failed with no recovery.

- Removed the strict 60-character Zod limit on the generated title object
- Truncate the model output to 60 characters at a word boundary with `...` before `updateThreadTitle`, using shared `truncateAtWordBoundary` in `truncation.ts`
- Titles ≤60 characters are stored unchanged

### Test plan

- [x] `pnpm -F backend test src/ee/services/ai/agents/titleGenerator.test.ts`
- [x] `pnpm -F backend test src/ee/services/ai/utils/truncation.test.ts`

### Screenshot
<img width="813" height="468" alt="Screenshot 2026-07-19 at 2 32 38 AM" src="https://github.com/user-attachments/assets/13884c70-a6c9-4bc5-b560-bd6bdd9d026d" />
