### PR TITLE
fix(api-tests): widen project-refresh poll window and report job outcome

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -437,7 +437,7 @@ jobs:
 
   api-tests:
     if: needs.files-changed.outputs.backend == 'true'
-    timeout-minutes: 20
+    timeout-minutes: 25
     runs-on: depot-ubuntu-24.04-4
     needs: [preview, files-changed]
     name: "E2E: API (Vitest)"

--- a/packages/api-tests/helpers/projects.ts
+++ b/packages/api-tests/helpers/projects.ts
@@ -188,18 +188,18 @@ export async function createProject(
 async function waitForV1JobCompletion(
     client: ApiClient,
     jobUuid: string,
-    maxRetries = 120,
-): Promise<boolean> {
+    maxRetries = 300,
+): Promise<'DONE' | 'ERROR' | 'TIMEOUT'> {
     for (let i = 0; i < maxRetries; i++) {
         const resp = await client.get<
             Body<{ jobStatus: 'STARTED' | 'RUNNING' | 'DONE' | 'ERROR' }>
         >(`/api/v1/jobs/${jobUuid}`);
         const { jobStatus } = resp.body.results;
-        if (jobStatus === 'ERROR') return false;
-        if (jobStatus === 'DONE') return true;
+        if (jobStatus === 'ERROR') return 'ERROR';
+        if (jobStatus === 'DONE') return 'DONE';
         await new Promise((r) => setTimeout(r, 1000));
     }
-    return false;
+    return 'TIMEOUT';
 }
 
 /**
@@ -223,12 +223,24 @@ export async function createAndRefreshProject(
     );
     expect(refreshResp.status).toBe(200);
 
-    const success = await waitForV1JobCompletion(
-        client,
-        refreshResp.body.results.jobUuid,
-    );
-    if (!success) {
-        throw new Error(`Project refresh failed for "${projectName}"`);
+    const { jobUuid } = refreshResp.body.results;
+    const outcome = await waitForV1JobCompletion(client, jobUuid);
+    if (outcome === 'ERROR') {
+        const jobResp = await client.get<
+            Body<{ steps: { stepError?: string }[] }>
+        >(`/api/v1/jobs/${jobUuid}`);
+        const stepErrors = jobResp.body.results.steps
+            .map((step) => step.stepError)
+            .filter(Boolean)
+            .join('; ');
+        throw new Error(
+            `Project refresh errored for "${projectName}" (job ${jobUuid}): ${stepErrors}`,
+        );
+    }
+    if (outcome === 'TIMEOUT') {
+        throw new Error(
+            `Project refresh timed out for "${projectName}" (job ${jobUuid} still running after poll window)`,
+        );
     }
     return projectUuid;
 }

--- a/packages/api-tests/tests/async-query.test.ts
+++ b/packages/api-tests/tests/async-query.test.ts
@@ -338,7 +338,7 @@ describe('Async Query API', () => {
                 bigqueryWarehouseConfig(),
             );
             await runAsyncQueryTest(admin, projectUuid);
-        }, 120_000);
+        }, 420_000);
     });
 
     describe('JWT Auth', () => {

--- a/packages/api-tests/tests/dataTimezone.test.ts
+++ b/packages/api-tests/tests/dataTimezone.test.ts
@@ -427,7 +427,7 @@ describe.skipIf(!hasBigqueryCredentials())(
                 projectName,
                 bigqueryWarehouseConfig(),
             );
-        }, 180_000);
+        }, 420_000);
 
         afterAll(async () => {
             if (bqAdmin) {

--- a/packages/api-tests/tests/pivotQuery.test.ts
+++ b/packages/api-tests/tests/pivotQuery.test.ts
@@ -327,7 +327,7 @@ describe('Pivot query API', () => {
                     projectName,
                     config,
                 );
-            }, 180_000);
+            }, 420_000);
 
             afterAll(async () => {
                 if (projectUuid) {

--- a/packages/api-tests/tests/queryTimezone.test.ts
+++ b/packages/api-tests/tests/queryTimezone.test.ts
@@ -469,7 +469,7 @@ describe.skipIf(!hasBigqueryCredentials())(
                 projectName,
                 bigqueryWarehouseConfig(),
             );
-        }, 180_000);
+        }, 420_000);
 
         afterAll(async () => {
             if (bqAdmin) {


### PR DESCRIPTION
## Problem

The `E2E: API (Vitest)` job has been failing deterministically on backend PRs with `Project refresh failed for "bigQuery data timezone test"` (`dataTimezone.test.ts`). Investigation showed this is not a product bug:

- An identical `createAndRefreshProject(bigqueryWarehouseConfig())` in `queryTimezone.test.ts` passes in the same runs — credentials, preview connectivity, and the keyfile fix (#25768, verified directly against a live preview) are all fine.
- `waitForV1JobCompletion` polls the refresh job for only ~120s and returns the same `false` for "job errored" and "job still running". The first (cold) BigQuery refresh of a run exceeds 120s (BigQuery compile/metadata fetch is slow when cold — observed 39s warm vs 171s+ cold for the same suite across attempts); later refreshes pass warm. The generic error message sent debugging down the wrong path (three stacked PRs were blocked on it: #25762, #25763, #25764).

## Fix

- Widen the refresh poll window to 300s.
- Throw distinct errors: job **error** (now includes the actual step errors fetched from `/api/v1/jobs/{jobUuid}`) vs **timeout** — so future failures report the real cause.
- Raise BigQuery suite hook timeouts (180s → 420s; async-query 120s → 420s) and the api-tests job timeout (20 → 25 min) to fit the wider window.

Test-infra only; no product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxoGjP2tibLJPEGNJDNLYS
