### PR TITLE
chore(dev): make sdk-test app opt-in instead of autostarting

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -563,6 +563,20 @@ pm2 restart ${LD_INSTANCE_ID}-scheduler # Restart only the scheduler
 pm2 restart ${LD_INSTANCE_ID}-frontend  # Restart only the frontend
 \`\`\`
 
+### SDK test app is opt-in
+
+The `<instanceId>-sdk-test` process (a second full Vite dev server, ~1.5GB RSS) does NOT start by default. Enable it only when working on the embedded SDK:
+
+```bash
+scripts/dev-fast-start.sh --sdk-test        # one-off at instance start
+# or persist it for this instance:
+echo 'LD_ENABLE_SDK_TEST=true' >> .env.development.local && pnpm pm2:start
+# or ephemeral without touching the env file:
+LD_ENABLE_SDK_TEST=true pnpm pm2:start
+```
+
+When the flag is off the process is absent from `pm2 status` entirely (not "stopped" — the ecosystem config omits it).
+
 ### Picking up new env vars
 
 \`pm2 restart --update-env\` only inherits env from the **current shell**, not from \`.env.development.local\`. The dotenv loader inside Node only runs at *spawn* time, so PM2's cached env wins on restart. After editing the env file:

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -57,6 +57,8 @@ const schedulerPort = env.SCHEDULER_PORT || '8081';
 const debugPort = env.DEBUG_PORT || '9229';
 const fePort = env.FE_PORT || undefined; // Vite auto-detects if not set
 const sdkTestPort = env.SDK_TEST_PORT || '3030';
+const sdkTestEnabled =
+    (process.env.LD_ENABLE_SDK_TEST ?? env.LD_ENABLE_SDK_TEST) === 'true';
 const spotlightPort = env.SPOTLIGHT_PORT || '8969';
 
 // Log the root directory so it's obvious which worktree PM2 is running from
@@ -171,22 +173,27 @@ module.exports = {
             time: true,
         },
 
-        // SDK Test App
-        {
-            name: `${instanceId}-sdk-test`,
-            script: 'node_modules/.bin/vite',
-            args: `--port ${sdkTestPort}`,
-            interpreter: 'none',
-            cwd: path.join(__dirname, 'packages/sdk-test-app'),
-            env: {
-                NODE_ENV: 'development',
-            },
-            watch: false,
-            autorestart: false,
-            kill_timeout: 3000,
-            merge_logs: true,
-            time: true,
-        },
+        // SDK Test App (opt-in via LD_ENABLE_SDK_TEST=true — a full Vite dev
+        // server that costs ~1.5GB RSS, so it must not start by default)
+        ...(sdkTestEnabled
+            ? [
+                  {
+                      name: `${instanceId}-sdk-test`,
+                      script: 'node_modules/.bin/vite',
+                      args: `--port ${sdkTestPort}`,
+                      interpreter: 'none',
+                      cwd: path.join(__dirname, 'packages/sdk-test-app'),
+                      env: {
+                          NODE_ENV: 'development',
+                      },
+                      watch: false,
+                      autorestart: false,
+                      kill_timeout: 3000,
+                      merge_logs: true,
+                      time: true,
+                  },
+              ]
+            : []),
 
         // Spotlight.js Sidecar (Sentry Dev Debugging UI)
         {

--- a/scripts/dev-fast-start.sh
+++ b/scripts/dev-fast-start.sh
@@ -13,7 +13,7 @@
 #   - Exits 0 only after the backend /api/v1/health endpoint returns 200.
 #   - Idempotent: safe to re-run at any time.
 #
-# Usage: scripts/dev-fast-start.sh [--ee]
+# Usage: scripts/dev-fast-start.sh [--ee] [--sdk-test]
 #
 # When this script fails, /docker-dev reads the FAIL line, fixes the root cause
 # using the documented agentic steps, then patches this script so it won't recur.
@@ -22,9 +22,11 @@ set -uo pipefail
 
 SCHEMA_VERSION=1
 EE_MODE=false
+SDK_TEST_MODE=false
 for arg in "$@"; do
     case "$arg" in
         --ee|ee) EE_MODE=true ;;
+        --sdk-test|sdk-test) SDK_TEST_MODE=true ;;
         *) echo "FAIL: args -- unknown argument '$arg'" >&2; exit 2 ;;
     esac
 done
@@ -514,6 +516,9 @@ elif [ "${ENV_PORTS_CHANGED:-0}" = 1 ]; then
     echo "Env ports changed — recycling PM2 so the new env is picked up"
     # shellcheck disable=SC2046
     pm2 delete $(instance_pm2_names) >/dev/null 2>&1 || true
+fi
+if [ "$SDK_TEST_MODE" = true ]; then
+    export LD_ENABLE_SDK_TEST=true
 fi
 pnpm pm2:start >/dev/null 2>&1 || fail "pm2" "pnpm pm2:start failed (check 'pm2 logs ${LD_INSTANCE_ID}-api')"
 echo "OK: pm2 started"


### PR DESCRIPTION
## Summary

The `<instanceId>-sdk-test` PM2 process is a second full Vite dev server (~1.5GB RSS) that most dev sessions never use, yet it started with every `pnpm pm2:start`. On memory-constrained dev machines running multiple worktree instances this was pushing boxes into OOM kills.

It is now opt-in:

- `ecosystem.config.js` includes the sdk-test app only when `LD_ENABLE_SDK_TEST=true` (read from the shell env or `.env.development.local`)
- `scripts/dev-fast-start.sh` gains a `--sdk-test` flag that exports the var before starting PM2
- `.claude/commands/docker-dev.md` documents the opt-in paths

## Verification

- `bash -n scripts/dev-fast-start.sh` clean
- Evaluated `ecosystem.config.js` with and without the flag: 7 processes by default (no sdk-test), 8 with `LD_ENABLE_SDK_TEST=true` (sdk-test present, all others unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgRV4rVmrgxzuEizJ813gB