### PR TITLE
feat: end-to-end analytics for the new onboarding flow

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -62,6 +62,15 @@ type Identify = {
     };
 };
 export type BaseTrack = Omit<AnalyticsTrack, 'context'>;
+export type OnboardingFlow = 'new' | 'legacy';
+export type OneTimePasscodePurpose =
+    | 'signup_verification'
+    | 'login'
+    | 'email_change';
+export type OneTimePasscodeFailureReason =
+    | 'invalid'
+    | 'expired'
+    | 'max_attempts';
 type Group = {
     userId: string;
     groupId: string;
@@ -114,14 +123,19 @@ export type CreateUserEvent = BaseTrack & {
     event: 'user.created';
     userId?: string;
     properties: {
-        context: string; // context on where/why this user was created
         createdUserId: string;
         organizationId: string | undefined; // undefined because they can join an org later
         userConnectionType:
             | 'password'
             | 'email_only'
             | OpenIdIdentityIssuerType;
-    };
+    } & (
+        | {
+              context: 'registration' | 'accept_invite';
+              onboardingFlow: OnboardingFlow;
+          }
+        | { context: 'scim' }
+    );
 };
 
 export type DeleteUserEvent = BaseTrack & {
@@ -158,6 +172,28 @@ type VerifiedUserEvent = BaseTrack & {
         isTrackingAnonymized: boolean;
         email?: string;
         location: 'onboarding' | 'settings';
+        method: 'otp' | 'link' | 'sso';
+        onboardingFlow: OnboardingFlow;
+    };
+};
+
+type OneTimePasscodeSentEvent = BaseTrack & {
+    event: 'one_time_passcode.sent';
+    userId: string;
+    properties: {
+        purpose: OneTimePasscodePurpose;
+        isResend: boolean;
+        onboardingFlow: OnboardingFlow;
+    };
+};
+
+type OneTimePasscodeFailedEvent = BaseTrack & {
+    event: 'one_time_passcode.failed';
+    userId: string;
+    properties: {
+        purpose: OneTimePasscodePurpose;
+        reason: OneTimePasscodeFailureReason;
+        onboardingFlow: OnboardingFlow;
     };
 };
 
@@ -193,6 +229,19 @@ type WarehouseConnectEvent = BaseTrack & {
         userId?: string;
         warehouseType?: WarehouseTypes.SNOWFLAKE;
         authenticationMethod?: 'private_key' | 'password';
+    };
+};
+
+type WarehouseConnectionTestedEvent = BaseTrack & {
+    event: 'warehouse_connection.tested';
+    userId: string;
+    properties: {
+        warehouseType: WarehouseTypes;
+        result: 'success' | 'failure';
+        errorType?: string;
+        context: 'project_create' | 'project_update';
+        method: RequestMethod;
+        onboardingFlow: OnboardingFlow;
     };
 };
 
@@ -463,6 +512,7 @@ type CreateOrganizationEvent = BaseTrack & {
         type: string;
         organizationId: string;
         organizationName: string;
+        onboardingFlow: OnboardingFlow;
     };
 };
 
@@ -733,6 +783,17 @@ export type ProjectEvent = BaseTrack & {
         copiedFromProjectUuid?: string;
         authenticationType?: string;
         requireUserCredentials?: boolean;
+        onboardingFlow: OnboardingFlow;
+    };
+};
+
+type OnboardingHomepageProvisionedEvent = BaseTrack & {
+    event: 'onboarding_homepage.provisioned';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        homepageUuid: string;
     };
 };
 
@@ -2022,6 +2083,16 @@ export type AiAgentCreatedEvent = BaseTrack & {
     };
 };
 
+type AiAgentProvisioningFailedEvent = BaseTrack & {
+    event: 'ai_agent.provisioning_failed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        error: string;
+    };
+};
+
 export type AiAgentGithubMcpConnectedEvent = BaseTrack & {
     event: 'ai_agent.github_mcp_connected';
     userId: string;
@@ -2517,6 +2588,8 @@ type TypedEvent =
     | UpdateUserEvent
     | DeleteUserEvent
     | VerifiedUserEvent
+    | OneTimePasscodeSentEvent
+    | OneTimePasscodeFailedEvent
     | UserJoinOrganizationEvent
     | QueryExecutionEvent
     | QueryReadyEvent
@@ -2546,6 +2619,7 @@ type TypedEvent =
     | ProjectErrorEvent
     | ApiErrorEvent
     | ProjectEvent
+    | OnboardingHomepageProvisionedEvent
     | ProjectDeletedEvent
     | ProjectCompiledEvent
     | UpdatedDashboardEvent
@@ -2560,6 +2634,7 @@ type TypedEvent =
     | UserWarehouseCredentialsEvent
     | UserWarehouseCredentialsDeleteEvent
     | WarehouseConnectEvent
+    | WarehouseConnectionTestedEvent
     | LoginEvent
     | IdentityLinkedEvent
     | DbtCloudIntegration
@@ -2624,6 +2699,7 @@ type TypedEvent =
     | SubtotalQueryEvent
     | DeprecatedRouteCalled
     | AiAgentCreatedEvent
+    | AiAgentProvisioningFailedEvent
     | AiAgentGithubMcpConnectedEvent
     | AiAgentDeletedEvent
     | AiAgentUpdatedEvent

--- a/packages/backend/src/controllers/userController.ts
+++ b/packages/backend/src/controllers/userController.ts
@@ -161,9 +161,13 @@ export class UserController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiEmailStatusResponse> {
         assertRegisteredAccount(req.account);
+        const user = toSessionUser(req.account);
         const status = await this.services
             .getUserService()
-            .sendOneTimePasscodeToPrimaryEmail(toSessionUser(req.account));
+            .sendOneTimePasscodeToPrimaryEmail(
+                user,
+                user.isSetupComplete ? 'email_change' : 'signup_verification',
+            );
         this.setStatus(200);
         return {
             status: 'ok',

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -707,6 +707,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                             projectModel: models.getProjectModel(),
                             projectHomepageModel:
                                 models.getProjectHomepageModel<ProjectHomepageModel>(),
+                            analytics: context.lightdashAnalytics,
                         }),
                 }),
             instanceConfigurationService: ({

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
@@ -93,6 +93,8 @@ const buildArguments = () => {
         vi.fn<
             ProvisionOnboardingHomepageArguments['projectHomepageModel']['publish']
         >();
+    const track =
+        vi.fn<ProvisionOnboardingHomepageArguments['analytics']['track']>();
 
     const featureFlagService = { get: getFeatureFlag };
     const projectModel = { getAllByOrganizationUuid };
@@ -101,6 +103,7 @@ const buildArguments = () => {
         create: createHomepage,
         publish: publishHomepage,
     };
+    const analytics = { track };
 
     vi.mocked(getFeatureFlag).mockImplementation(async ({ featureFlagId }) => ({
         id: featureFlagId,
@@ -121,12 +124,14 @@ const buildArguments = () => {
             featureFlagService,
             projectModel,
             projectHomepageModel,
+            analytics,
         } satisfies ProvisionOnboardingHomepageArguments,
         getFeatureFlag: vi.mocked(getFeatureFlag),
         getAllByOrganizationUuid: vi.mocked(getAllByOrganizationUuid),
         listHomepages: vi.mocked(listHomepages),
         createHomepage: vi.mocked(createHomepage),
         publishHomepage: vi.mocked(publishHomepage),
+        track: vi.mocked(track),
     };
 };
 
@@ -213,5 +218,14 @@ describe('provisionOnboardingHomepage', () => {
             { type: 'everyone' },
             true,
         );
+        expect(mocks.track).toHaveBeenCalledWith({
+            event: 'onboarding_homepage.provisioned',
+            userId: USER_UUID,
+            properties: {
+                organizationId: ORGANIZATION_UUID,
+                projectId: PROJECT_UUID,
+                homepageUuid: HOMEPAGE_UUID,
+            },
+        });
     });
 });

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
@@ -5,6 +5,7 @@ import {
     ProjectType,
     type SessionUser,
 } from '@lightdash/common';
+import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { type FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { type ProjectHomepageModel } from '../../models/ProjectHomepageModel';
@@ -19,6 +20,7 @@ export type ProvisionOnboardingHomepageArguments = {
         ProjectHomepageModel,
         'list' | 'create' | 'publish'
     >;
+    analytics: Pick<LightdashAnalytics, 'track'>;
 };
 
 export const provisionOnboardingHomepage = async ({
@@ -28,6 +30,7 @@ export const provisionOnboardingHomepage = async ({
     featureFlagService,
     projectModel,
     projectHomepageModel,
+    analytics,
 }: ProvisionOnboardingHomepageArguments): Promise<void> => {
     if (projectType !== ProjectType.DEFAULT || !user.organizationUuid) {
         return;
@@ -73,4 +76,13 @@ export const provisionOnboardingHomepage = async ({
         { type: 'everyone' },
         true,
     );
+    analytics.track({
+        event: 'onboarding_homepage.provisioned',
+        userId: user.userUuid,
+        properties: {
+            organizationId: user.organizationUuid,
+            projectId: projectUuid,
+            homepageUuid: homepage.homepageUuid,
+        },
+    });
 };

--- a/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.test.ts
@@ -25,7 +25,20 @@ const projectModel = {
 };
 const organizationModel = {
     get: vi.fn(async () => organization),
+    create: vi.fn<OrganizationModel['create']>(async () => organization),
+    hasOrgs: vi.fn<OrganizationModel['hasOrgs']>(async () => false),
 };
+const userModel = {
+    hasUsers: vi.fn<UserModel['hasUsers']>(async () => false),
+    joinOrg: vi.fn<UserModel['joinOrg']>(async () => user),
+};
+const featureFlagModel = {
+    get: vi.fn<FeatureFlagModel['get']>(async ({ featureFlagId }) => ({
+        id: featureFlagId,
+        enabled: true,
+    })),
+};
+vi.spyOn(analyticsMock, 'track');
 const organizationMemberProfileModel = {
     getOrganizationMembersAndGroups: vi.fn(),
 };
@@ -39,11 +52,11 @@ describe('organization service', () => {
         onboardingModel: {} as OnboardingModel,
         organizationMemberProfileModel:
             organizationMemberProfileModel as unknown as OrganizationMemberProfileModel,
-        userModel: {} as UserModel,
+        userModel: userModel as unknown as UserModel,
         organizationAllowedEmailDomainsModel:
             {} as OrganizationAllowedEmailDomainsModel,
         groupsModel: {} as GroupsModel,
-        featureFlagModel: {} as FeatureFlagModel,
+        featureFlagModel: featureFlagModel as unknown as FeatureFlagModel,
     });
 
     afterEach(() => {
@@ -54,6 +67,24 @@ describe('organization service', () => {
         process.env = {
             LIGHTDASH_INSTALL_TYPE: LightdashInstallType.UNKNOWN,
         };
+    });
+
+    it('tracks the onboarding flow when creating an organization', async () => {
+        await organizationService.createAndJoinOrg(
+            { ...user, organizationUuid: undefined },
+            { name: 'Organization' },
+        );
+
+        expect(analyticsMock.track).toHaveBeenCalledWith({
+            event: 'organization.created',
+            userId: user.userUuid,
+            properties: {
+                type: 'self-hosted',
+                organizationId: organization.organizationUuid,
+                organizationName: organization.name,
+                onboardingFlow: 'new',
+            },
+        });
     });
 
     it('Should return needsProject false if there are projects in DB', async () => {

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -860,6 +860,11 @@ export class OrganizationService extends BaseService {
             throw new ForbiddenError('User already has an organization');
         }
         const org = await this.organizationModel.create(data);
+        const { enabled: newOnboardingEnabled } =
+            await this.featureFlagModel.get({
+                user,
+                featureFlagId: FeatureFlags.NewOnboarding,
+            });
         this.analytics.track({
             event: 'organization.created',
             userId: user.userUuid,
@@ -870,6 +875,7 @@ export class OrganizationService extends BaseService {
                         : 'self-hosted',
                 organizationId: org.organizationUuid,
                 organizationName: org.name,
+                onboardingFlow: newOnboardingEnabled ? 'new' : 'legacy',
             },
         });
         await this.userModel.joinOrg(

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -365,6 +365,23 @@ describe('ProjectService', () => {
         vi.clearAllMocks();
     });
 
+    test('includes onboarding flow in project analytics properties', () => {
+        expect(
+            ProjectService.getAnalyticProperties(
+                {
+                    name: projectWithSensitiveFields.name,
+                    type: projectWithSensitiveFields.type,
+                    dbtConnection: projectWithSensitiveFields.dbtConnection,
+                    warehouseConnection: warehouseClientMock.credentials,
+                },
+                projectUuid,
+                user,
+                RequestMethod.WEB_APP,
+                'new',
+            ),
+        ).toMatchObject({ onboardingFlow: 'new' });
+    });
+
     describe('refreshTablesAndProjectConfig for a CLI/NONE preview', () => {
         const upstreamProjectUuid = 'upstream-project-uuid';
         const previewProjectUuid = 'preview-project-uuid';

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -216,6 +216,7 @@ import {
     LightdashAnalytics,
     MetricQueryExecutionProperties,
     ProjectEvent,
+    type OnboardingFlow,
 } from '../../analytics/LightdashAnalytics';
 import { S3CacheClient } from '../../clients/Aws/S3CacheClient';
 import EmailClient from '../../clients/EmailClient/EmailClient';
@@ -568,6 +569,16 @@ export class ProjectService extends BaseService {
         this.onProjectCreated = onProjectCreated;
     }
 
+    private async getOnboardingFlow(
+        user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
+    ): Promise<OnboardingFlow> {
+        const { enabled } = await this.featureFlagModel.get({
+            user,
+            featureFlagId: FeatureFlags.NewOnboarding,
+        });
+        return enabled ? 'new' : 'legacy';
+    }
+
     private async provisionDefaultAiAgent(
         user: SessionUser,
         projectUuid: string,
@@ -577,12 +588,12 @@ export class ProjectService extends BaseService {
             return;
         }
 
-        try {
-            const { organizationUuid } = user;
-            if (!organizationUuid) {
-                return;
-            }
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            return;
+        }
 
+        try {
             const projects =
                 await this.projectModel.getAllByOrganizationUuid(
                     organizationUuid,
@@ -602,8 +613,19 @@ export class ProjectService extends BaseService {
                 projectUuid,
             );
         } catch (error) {
+            const errorMessage =
+                error instanceof Error ? error.message : String(error);
+            this.analytics.track({
+                event: 'ai_agent.provisioning_failed',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: organizationUuid,
+                    projectId: projectUuid,
+                    error: errorMessage,
+                },
+            });
             this.logger.warn(
-                `Failed to provision default AI agent for project ${projectUuid}: ${error instanceof Error ? error.message : String(error)}`,
+                `Failed to provision default AI agent for project ${projectUuid}: ${errorMessage}`,
             );
         }
     }
@@ -2384,6 +2406,7 @@ export class ProjectService extends BaseService {
                 ),
             );
 
+        const onboardingFlow = await this.getOnboardingFlow(user);
         // Do not give this user admin permissions on this new project,
         // as it could be an interactive viewer creating a preview
         // and we don't want to allow users to acces sql runner or leak admin data
@@ -2395,6 +2418,7 @@ export class ProjectService extends BaseService {
                 projectUuid,
                 user,
                 method,
+                onboardingFlow,
             ),
         });
 
@@ -2631,6 +2655,7 @@ export class ProjectService extends BaseService {
         projectUuid: string,
         user: SessionUser,
         method: RequestMethod,
+        onboardingFlow: OnboardingFlow,
     ): ProjectEvent['properties'] {
         const warehouseType = createProject.warehouseConnection?.type;
         const authenticationType =
@@ -2650,6 +2675,7 @@ export class ProjectService extends BaseService {
             authenticationType,
             requireUserCredentials:
                 createProject.warehouseConnection?.requireUserCredentials,
+            onboardingFlow,
         };
     }
 
@@ -2675,7 +2701,13 @@ export class ProjectService extends BaseService {
             const { adapter, sshTunnel } = await this.jobModel.tryJobStep(
                 jobUuid,
                 JobStepType.TESTING_ADAPTOR,
-                async () => this.testProjectAdapter(createProject, user),
+                async () =>
+                    this.testProjectAdapter(
+                        createProject,
+                        user,
+                        'project_create',
+                        method,
+                    ),
             );
 
             const { explores, lightdashProjectConfig, projectContext } =
@@ -2814,6 +2846,7 @@ export class ProjectService extends BaseService {
                     projectUuid,
                 },
             });
+            const onboardingFlow = await this.getOnboardingFlow(user);
             this.analytics.track({
                 event: 'project.created',
                 userId: user.userUuid,
@@ -2822,6 +2855,7 @@ export class ProjectService extends BaseService {
                     projectUuid,
                     user,
                     method,
+                    onboardingFlow,
                 ),
             });
 
@@ -3316,6 +3350,8 @@ export class ProjectService extends BaseService {
                     this.testProjectAdapter(
                         updatedProject as UpdateProject,
                         user,
+                        'project_update',
+                        method,
                     ),
             );
             timings.testAdapter.end = performance.now();
@@ -3453,6 +3489,7 @@ export class ProjectService extends BaseService {
                 ...updatedProject,
                 warehouseConnection: updatedProject.warehouseConnection,
             };
+            const onboardingFlow = await this.getOnboardingFlow(user);
             this.analytics.track({
                 event: 'project.updated',
                 userId: user.userUuid,
@@ -3461,6 +3498,7 @@ export class ProjectService extends BaseService {
                     projectUuid,
                     user,
                     method,
+                    onboardingFlow,
                 ),
             });
             const totalTime = performance.now() - totalStartTime;
@@ -3535,7 +3573,9 @@ export class ProjectService extends BaseService {
 
     private async testProjectAdapter(
         data: UpdateProject,
-        _user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
+        user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
+        context: 'project_create' | 'project_update',
+        method: RequestMethod,
     ): Promise<{
         adapter: ProjectAdapter;
         sshTunnel: SshTunnel<CreateWarehouseCredentials>;
@@ -3543,40 +3583,70 @@ export class ProjectService extends BaseService {
         cachedWarehouse: CachedWarehouse;
         dbtVersionOption: DbtVersionOption;
     }> {
+        const onboardingFlow = await this.getOnboardingFlow(user);
         const sshTunnel = new SshTunnel(data.warehouseConnection);
-        await sshTunnel.connect();
-        const dbtConnection = await this.resolveDbtConnectionInstallationId(
-            data.dbtConnection,
-            _user.organizationUuid,
-        );
-        const warehouseCredentials = sshTunnel.overrideCredentials;
-        const cachedWarehouse: CachedWarehouse = {
-            warehouseCatalog: undefined,
-            onWarehouseCatalogChange: () => {},
-        };
-        const dbtVersionOption = data.dbtVersion || DefaultSupportedDbtVersion;
-        const adapter = await projectAdapterFromConfig(
-            dbtConnection,
-            warehouseCredentials,
-            cachedWarehouse,
-            dbtVersionOption,
-            this.analytics,
-        );
+        let adapter: ProjectAdapter | undefined;
         try {
+            await sshTunnel.connect();
+            const dbtConnection = await this.resolveDbtConnectionInstallationId(
+                data.dbtConnection,
+                user.organizationUuid,
+            );
+            const warehouseCredentials = sshTunnel.overrideCredentials;
+            const cachedWarehouse: CachedWarehouse = {
+                warehouseCatalog: undefined,
+                onWarehouseCatalogChange: () => {},
+            };
+            const dbtVersionOption =
+                data.dbtVersion || DefaultSupportedDbtVersion;
+            adapter = await projectAdapterFromConfig(
+                dbtConnection,
+                warehouseCredentials,
+                cachedWarehouse,
+                dbtVersionOption,
+                this.analytics,
+            );
             await adapter.test();
-        } catch (e) {
-            Logger.error(`Error testing project adapter: ${e}`);
-            await adapter.destroy();
+            this.analytics.track({
+                event: 'warehouse_connection.tested',
+                userId: user.userUuid,
+                properties: {
+                    warehouseType: data.warehouseConnection.type,
+                    result: 'success',
+                    context,
+                    method,
+                    onboardingFlow,
+                },
+            });
+            return {
+                adapter,
+                sshTunnel,
+                warehouseCredentials,
+                cachedWarehouse,
+                dbtVersionOption,
+            };
+        } catch (error) {
+            const errorType =
+                error instanceof Error && error.constructor.name
+                    ? error.constructor.name
+                    : 'UnknownError';
+            this.analytics.track({
+                event: 'warehouse_connection.tested',
+                userId: user.userUuid,
+                properties: {
+                    warehouseType: data.warehouseConnection.type,
+                    result: 'failure',
+                    errorType,
+                    context,
+                    method,
+                    onboardingFlow,
+                },
+            });
+            Logger.error(`Error testing project adapter: ${error}`);
+            await adapter?.destroy();
             await sshTunnel.disconnect();
-            throw e;
+            throw error;
         }
-        return {
-            adapter,
-            sshTunnel,
-            warehouseCredentials,
-            cachedWarehouse,
-            dbtVersionOption,
-        };
     }
 
     async previewDataTimezone(

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -373,7 +373,21 @@ describe('UserService', () => {
                 'email-only@example.com',
                 'email',
             );
-            expect(sendOneTimePasscodeSpy).toHaveBeenCalledWith(sessionUser);
+            expect(sendOneTimePasscodeSpy).toHaveBeenCalledWith(
+                sessionUser,
+                'signup_verification',
+            );
+            expect(analyticsMock.track).toHaveBeenCalledWith({
+                event: 'user.created',
+                userId: sessionUser.userUuid,
+                properties: {
+                    context: 'registration',
+                    createdUserId: sessionUser.userUuid,
+                    organizationId: sessionUser.organizationUuid,
+                    userConnectionType: 'email_only',
+                    onboardingFlow: 'new',
+                },
+            });
         });
 
         test('rejects an email-only user when the feature is disabled', async () => {
@@ -414,14 +428,20 @@ describe('UserService', () => {
                 password: 'password1!',
             });
 
-            expect(featureFlagModel.get).not.toHaveBeenCalled();
+            expect(featureFlagModel.get).toHaveBeenCalledWith({
+                user: undefined,
+                featureFlagId: FeatureFlags.NewOnboarding,
+            });
             expect(userModel.createUser).toHaveBeenCalledWith({
                 firstName: 'Full',
                 lastName: 'User',
                 email: 'full@example.com',
                 password: 'password1!',
             });
-            expect(sendOneTimePasscodeSpy).toHaveBeenCalledWith(sessionUser);
+            expect(sendOneTimePasscodeSpy).toHaveBeenCalledWith(
+                sessionUser,
+                'signup_verification',
+            );
         });
     });
 
@@ -478,6 +498,7 @@ describe('UserService', () => {
                     createdUserId: memberUser.userUuid,
                     organizationId: memberUser.organizationUuid,
                     userConnectionType: 'email_only',
+                    onboardingFlow: 'legacy',
                 },
             });
         });
@@ -643,6 +664,7 @@ describe('UserService', () => {
         );
         expect(service.sendOneTimePasscodeToPrimaryEmail).toHaveBeenCalledWith(
             sessionUser,
+            'signup_verification',
         );
         expect(analyticsMock.track).toHaveBeenCalledWith({
             event: 'user.created',
@@ -652,6 +674,7 @@ describe('UserService', () => {
                 createdUserId: sessionUser.userUuid,
                 organizationId: sessionUser.organizationUuid,
                 userConnectionType: 'password',
+                onboardingFlow: 'legacy',
             },
         });
     });
@@ -746,6 +769,39 @@ describe('UserService', () => {
                     recipient: 'email',
                     passcode,
                 });
+                expect(analyticsMock.track).toHaveBeenCalledWith({
+                    event: 'one_time_passcode.sent',
+                    userId: sessionUser.userUuid,
+                    properties: {
+                        purpose: 'login',
+                        isResend: false,
+                        onboardingFlow: 'new',
+                    },
+                });
+            });
+
+            test('marks an unexpired OTP replacement as a resend', async () => {
+                const service = createUserService(lightdashConfigMock, {
+                    featureFlagModel: createFeatureFlagModel(true),
+                });
+                userModel.findUserByEmail.mockResolvedValueOnce(sessionUser);
+                userModel.hasPassword.mockResolvedValueOnce(false);
+                userModel.hasOpenIdIdentity.mockResolvedValueOnce(false);
+                emailModel.getPrimaryEmailStatus.mockResolvedValueOnce(
+                    activeOtp(),
+                );
+
+                await service.requestEmailOtpLogin('email');
+
+                expect(analyticsMock.track).toHaveBeenCalledWith({
+                    event: 'one_time_passcode.sent',
+                    userId: sessionUser.userUuid,
+                    properties: {
+                        purpose: 'login',
+                        isResend: true,
+                        onboardingFlow: 'new',
+                    },
+                });
             });
         });
 
@@ -788,6 +844,19 @@ describe('UserService', () => {
                 );
                 expect(analyticsMock.track).toHaveBeenCalledWith({
                     userId: sessionUser.userUuid,
+                    event: 'user.verified',
+                    properties: {
+                        email: emailStatus.email,
+                        location: sessionUser.isSetupComplete
+                            ? 'settings'
+                            : 'onboarding',
+                        isTrackingAnonymized: sessionUser.isTrackingAnonymized,
+                        method: 'otp',
+                        onboardingFlow: 'new',
+                    },
+                });
+                expect(analyticsMock.track).toHaveBeenCalledWith({
+                    userId: sessionUser.userUuid,
                     event: 'user.logged_in',
                     properties: { loginProvider: 'email_otp' },
                 });
@@ -812,6 +881,15 @@ describe('UserService', () => {
                 expect(
                     emailModel.incrementPrimaryEmailOtpAttempts,
                 ).toHaveBeenCalledWith(sessionUser.userUuid);
+                expect(analyticsMock.track).toHaveBeenCalledWith({
+                    event: 'one_time_passcode.failed',
+                    userId: sessionUser.userUuid,
+                    properties: {
+                        purpose: 'login',
+                        reason: 'invalid',
+                        onboardingFlow: 'new',
+                    },
+                });
             });
 
             test('rejects a sixth attempt without comparing the code', async () => {
@@ -833,6 +911,15 @@ describe('UserService', () => {
                 expect(
                     emailModel.incrementPrimaryEmailOtpAttempts,
                 ).not.toHaveBeenCalled();
+                expect(analyticsMock.track).toHaveBeenCalledWith({
+                    event: 'one_time_passcode.failed',
+                    userId: sessionUser.userUuid,
+                    properties: {
+                        purpose: 'login',
+                        reason: 'max_attempts',
+                        onboardingFlow: 'new',
+                    },
+                });
             });
 
             test('rejects an expired OTP', async () => {
@@ -851,6 +938,15 @@ describe('UserService', () => {
                 expect(
                     emailModel.getPrimaryEmailStatusByUserAndOtp,
                 ).not.toHaveBeenCalled();
+                expect(analyticsMock.track).toHaveBeenCalledWith({
+                    event: 'one_time_passcode.failed',
+                    userId: sessionUser.userUuid,
+                    properties: {
+                        purpose: 'login',
+                        reason: 'expired',
+                        onboardingFlow: 'new',
+                    },
+                });
             });
 
             test('rejects a passworded account with the generic error', async () => {
@@ -899,6 +995,65 @@ describe('UserService', () => {
                 await expect(
                     service.loginWithEmailOtp('EMAIL', '123456'),
                 ).resolves.toBe(sessionUser);
+            });
+        });
+
+        describe('getPrimaryEmailStatus', () => {
+            test.each([
+                {
+                    status: activeOtp(5),
+                    reason: 'max_attempts' as const,
+                },
+                {
+                    status: activeOtp(0, new Date(Date.now() - 16 * 60 * 1000)),
+                    reason: 'expired' as const,
+                },
+            ])(
+                'tracks $reason verification failures',
+                async ({ status, reason }) => {
+                    const service = createUserService(lightdashConfigMock, {
+                        featureFlagModel: createFeatureFlagModel(true),
+                    });
+                    emailModel.getPrimaryEmailStatusByUserAndOtp.mockResolvedValueOnce(
+                        status,
+                    );
+
+                    await service.getPrimaryEmailStatus(
+                        { ...sessionUser, isSetupComplete: false },
+                        '123456',
+                    );
+
+                    expect(analyticsMock.track).toHaveBeenCalledWith({
+                        event: 'one_time_passcode.failed',
+                        userId: sessionUser.userUuid,
+                        properties: {
+                            purpose: 'signup_verification',
+                            reason,
+                            onboardingFlow: 'new',
+                        },
+                    });
+                },
+            );
+
+            test('tracks an invalid verification passcode', async () => {
+                const service = createUserService(lightdashConfigMock, {
+                    featureFlagModel: createFeatureFlagModel(true),
+                });
+                emailModel.getPrimaryEmailStatusByUserAndOtp.mockRejectedValueOnce(
+                    new NotFoundError('No matching OTP'),
+                );
+
+                await service.getPrimaryEmailStatus(sessionUser, 'wrong');
+
+                expect(analyticsMock.track).toHaveBeenCalledWith({
+                    event: 'one_time_passcode.failed',
+                    userId: sessionUser.userUuid,
+                    properties: {
+                        purpose: 'email_change',
+                        reason: 'invalid',
+                        onboardingFlow: 'new',
+                    },
+                });
             });
         });
     });

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -75,7 +75,12 @@ import { randomInt } from 'crypto';
 import { uniq } from 'lodash';
 import { nanoid } from 'nanoid';
 import refresh from 'passport-oauth2-refresh';
-import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
+import {
+    LightdashAnalytics,
+    type OnboardingFlow,
+    type OneTimePasscodeFailureReason,
+    type OneTimePasscodePurpose,
+} from '../analytics/LightdashAnalytics';
 import * as AccountFactory from '../auth/account';
 import EmailClient from '../clients/EmailClient/EmailClient';
 import { LightdashConfig } from '../config/parseConfig';
@@ -356,15 +361,27 @@ export class UserService extends BaseService {
         }
     }
 
+    private async getOnboardingFlow(
+        user?: Pick<LightdashUser, 'userUuid' | 'organizationUuid'>,
+    ): Promise<OnboardingFlow> {
+        const { enabled } = await this.featureFlagModel.get({
+            user,
+            featureFlagId: FeatureFlags.NewOnboarding,
+        });
+        return enabled ? 'new' : 'legacy';
+    }
+
     private async tryVerifyUserEmail(
         user: LightdashUser,
         email: string,
+        method: 'otp' | 'link' | 'sso',
     ): Promise<void> {
         const updatedEmails = await this.emailModel.verifyUserEmailIfExists(
             user.userUuid,
             email,
         );
         if (updatedEmails.length > 0) {
+            const onboardingFlow = await this.getOnboardingFlow(user);
             this.analytics.track({
                 userId: user.userUuid,
                 event: 'user.verified',
@@ -372,6 +389,8 @@ export class UserService extends BaseService {
                     email,
                     location: user.isSetupComplete ? 'settings' : 'onboarding',
                     isTrackingAnonymized: user.isTrackingAnonymized,
+                    method,
+                    onboardingFlow,
                 },
             });
         }
@@ -392,7 +411,7 @@ export class UserService extends BaseService {
         const user = await this.activateUserFromInviteLink(inviteLink);
         // The invite link was delivered to this address, so opening it proves
         // mailbox ownership — same trust as OpenID email verification.
-        await this.tryVerifyUserEmail(user, inviteLink.email);
+        await this.tryVerifyUserEmail(user, inviteLink.email, 'link');
         return this.userModel.findSessionUserByUUID(user.userUuid);
     }
 
@@ -500,6 +519,7 @@ export class UserService extends BaseService {
         } else {
             userConnectionType = 'password';
         }
+        const onboardingFlow = await this.getOnboardingFlow(user);
         this.analytics.track({
             event: 'user.created',
             userId: user.userUuid,
@@ -508,10 +528,14 @@ export class UserService extends BaseService {
                 createdUserId: user.userUuid,
                 organizationId: user.organizationUuid,
                 userConnectionType,
+                onboardingFlow,
             },
         });
         if (activateUser && !isOpenIdUser(activateUser)) {
-            await this.sendOneTimePasscodeToPrimaryEmail(user);
+            await this.sendOneTimePasscodeToPrimaryEmail(
+                user,
+                'signup_verification',
+            );
         }
         return user;
     }
@@ -1009,7 +1033,11 @@ export class UserService extends BaseService {
                 ...openIdUser.openId,
                 refreshToken,
             });
-            await this.tryVerifyUserEmail(loginUser, openIdUser.openId.email);
+            await this.tryVerifyUserEmail(
+                loginUser,
+                openIdUser.openId.email,
+                'sso',
+            );
             this.identifyUser(loginUser);
             this.analytics.track({
                 userId: loginUser.userUuid,
@@ -1198,7 +1226,11 @@ export class UserService extends BaseService {
             openIdUser,
             inviteCode,
         );
-        await this.tryVerifyUserEmail(createdUser, openIdUser.openId.email);
+        await this.tryVerifyUserEmail(
+            createdUser,
+            openIdUser.openId.email,
+            'sso',
+        );
         const allowedOrgs =
             await this.organizationModel.getAllowedOrgsForDomain(
                 getEmailDomain(openIdUser.openId.email),
@@ -1260,7 +1292,10 @@ export class UserService extends BaseService {
             );
             return this.userModel.findSessionUserByUUID(user.userUuid);
         }
-        const user = await this.registerUser(openIdUser);
+        const user = await this.registerUser(
+            openIdUser,
+            await this.getOnboardingFlow(),
+        );
         return this.userModel.findSessionUserByUUID(user.userUuid);
     }
 
@@ -1278,7 +1313,11 @@ export class UserService extends BaseService {
             refreshToken,
             teamId: openIdUser.openId.teamId,
         });
-        await this.tryVerifyUserEmail(sessionUser, openIdUser.openId.email);
+        await this.tryVerifyUserEmail(
+            sessionUser,
+            openIdUser.openId.email,
+            'sso',
+        );
         this.analytics.track({
             userId: sessionUser.userUuid,
             event: 'user.identity_linked',
@@ -1608,7 +1647,10 @@ export class UserService extends BaseService {
         });
 
         if (emailChanged) {
-            await this.sendOneTimePasscodeToPrimaryEmail(updatedUser);
+            await this.sendOneTimePasscodeToPrimaryEmail(
+                updatedUser,
+                'email_change',
+            );
         }
 
         return updatedUser;
@@ -1662,30 +1704,34 @@ export class UserService extends BaseService {
                 password: user.password,
             });
         } else if ('password' in user) {
+            const onboardingFlow = await this.getOnboardingFlow();
             await this.checkNewUserRegistrationAllowed(undefined, user.email);
 
-            lightdashUser = await this.registerUser({
-                firstName: user.firstName,
-                lastName: user.lastName,
-                email: user.email,
-                password: user.password,
-            });
+            lightdashUser = await this.registerUser(
+                {
+                    firstName: user.firstName,
+                    lastName: user.lastName,
+                    email: user.email,
+                    password: user.password,
+                },
+                onboardingFlow,
+            );
         } else {
-            const emailOnlySignupFlag = await this.featureFlagModel.get({
-                user: undefined,
-                featureFlagId: FeatureFlags.NewOnboarding,
-            });
-            if (!emailOnlySignupFlag.enabled) {
+            const onboardingFlow = await this.getOnboardingFlow();
+            if (onboardingFlow !== 'new') {
                 throw new ForbiddenError('Email-only signup is not enabled');
             }
 
             await this.checkNewUserRegistrationAllowed(undefined, user.email);
 
-            lightdashUser = await this.registerUser({
-                firstName: '',
-                lastName: '',
-                email: user.email,
-            });
+            lightdashUser = await this.registerUser(
+                {
+                    firstName: '',
+                    lastName: '',
+                    email: user.email,
+                },
+                onboardingFlow,
+            );
         }
 
         return this.userModel.findSessionUserByUUID(lightdashUser.userUuid);
@@ -1693,6 +1739,7 @@ export class UserService extends BaseService {
 
     private async registerUser(
         createUser: CreateUserArgs | CreatePasswordlessUserArgs | OpenIdUser,
+        onboardingFlow: OnboardingFlow,
     ) {
         if (isOpenIdUser(createUser)) {
             if (
@@ -1737,10 +1784,11 @@ export class UserService extends BaseService {
             event: 'user.created',
             userId: user.userUuid,
             properties: {
-                context: 'accept_invite',
+                context: 'registration',
                 createdUserId: user.userUuid,
                 organizationId: user.organizationUuid,
                 userConnectionType,
+                onboardingFlow,
             },
         });
         if (isOpenIdUser(createUser)) {
@@ -1752,7 +1800,10 @@ export class UserService extends BaseService {
                 },
             });
         } else {
-            await this.sendOneTimePasscodeToPrimaryEmail(user);
+            await this.sendOneTimePasscodeToPrimaryEmail(
+                user,
+                'signup_verification',
+            );
         }
         return user;
     }
@@ -1943,8 +1994,16 @@ export class UserService extends BaseService {
     }
 
     async sendOneTimePasscodeToPrimaryEmail(
-        user: Pick<SessionUser, 'userUuid'>,
+        user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
+        purpose: OneTimePasscodePurpose,
     ): Promise<EmailStatusExpiring> {
+        const currentEmailStatus = await this.emailModel.getPrimaryEmailStatus(
+            user.userUuid,
+        );
+        const isResend = Boolean(
+            currentEmailStatus.otp &&
+            !this.isOtpExpired(currentEmailStatus.otp.createdAt),
+        );
         const passcode =
             this.lightdashConfig.mode === LightdashMode.PR ||
             this.lightdashConfig.mode === LightdashMode.DEV
@@ -1958,6 +2017,16 @@ export class UserService extends BaseService {
             recipient: emailStatus.email,
             passcode,
         });
+        const onboardingFlow = await this.getOnboardingFlow(user);
+        this.analytics.track({
+            event: 'one_time_passcode.sent',
+            userId: user.userUuid,
+            properties: {
+                purpose,
+                isResend,
+                onboardingFlow,
+            },
+        });
         return {
             ...emailStatus,
             otp: emailStatus.otp && {
@@ -1969,6 +2038,23 @@ export class UserService extends BaseService {
                 ),
             },
         };
+    }
+
+    private async trackOneTimePasscodeFailed(
+        user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
+        purpose: OneTimePasscodePurpose,
+        reason: OneTimePasscodeFailureReason,
+    ): Promise<void> {
+        const onboardingFlow = await this.getOnboardingFlow(user);
+        this.analytics.track({
+            event: 'one_time_passcode.failed',
+            userId: user.userUuid,
+            properties: {
+                purpose,
+                reason,
+                onboardingFlow,
+            },
+        });
     }
 
     private async isStrictlyPasswordlessUser(
@@ -1997,7 +2083,7 @@ export class UserService extends BaseService {
         ) {
             return;
         }
-        await this.sendOneTimePasscodeToPrimaryEmail(user);
+        await this.sendOneTimePasscodeToPrimaryEmail(user, 'login');
     }
 
     async loginWithEmailOtp(
@@ -2035,16 +2121,26 @@ export class UserService extends BaseService {
             );
         } catch (error) {
             if (error instanceof NotFoundError) {
+                await this.trackOneTimePasscodeFailed(user, 'login', 'invalid');
                 throw invalidCode();
             }
             throw error;
         }
 
-        if (
-            !emailStatus.otp ||
-            this.isOtpMaxAttempts(emailStatus.otp.numberOfAttempts) ||
-            this.isOtpExpired(emailStatus.otp.createdAt)
-        ) {
+        if (!emailStatus.otp) {
+            await this.trackOneTimePasscodeFailed(user, 'login', 'invalid');
+            throw invalidCode();
+        }
+        if (this.isOtpMaxAttempts(emailStatus.otp.numberOfAttempts)) {
+            await this.trackOneTimePasscodeFailed(
+                user,
+                'login',
+                'max_attempts',
+            );
+            throw invalidCode();
+        }
+        if (this.isOtpExpired(emailStatus.otp.createdAt)) {
+            await this.trackOneTimePasscodeFailed(user, 'login', 'expired');
             throw invalidCode();
         }
 
@@ -2058,6 +2154,7 @@ export class UserService extends BaseService {
                 await this.emailModel.incrementPrimaryEmailOtpAttempts(
                     user.userUuid,
                 );
+                await this.trackOneTimePasscodeFailed(user, 'login', 'invalid');
                 throw invalidCode();
             }
             throw error;
@@ -2074,7 +2171,7 @@ export class UserService extends BaseService {
             }
             throw error;
         }
-        await this.tryVerifyUserEmail(sessionUser, emailStatus.email);
+        await this.tryVerifyUserEmail(sessionUser, emailStatus.email, 'otp');
         await this.emailModel.deleteEmailOtp(
             sessionUser.userUuid,
             emailStatus.email,
@@ -2113,6 +2210,9 @@ export class UserService extends BaseService {
     ): Promise<EmailStatusExpiring> {
         // Attempt to verify the passcode if it's provided
         if (passcode) {
+            const purpose = user.isSetupComplete
+                ? 'email_change'
+                : 'signup_verification';
             try {
                 const emailStatus =
                     await this.emailModel.getPrimaryEmailStatusByUserAndOtp({
@@ -2124,10 +2224,29 @@ export class UserService extends BaseService {
                     !this.isOtpMaxAttempts(emailStatus.otp.numberOfAttempts) &&
                     !this.isOtpExpired(emailStatus.otp.createdAt)
                 ) {
-                    await this.tryVerifyUserEmail(user, emailStatus.email);
+                    await this.tryVerifyUserEmail(
+                        user,
+                        emailStatus.email,
+                        'otp',
+                    );
                     await this.emailModel.deleteEmailOtp(
                         user.userUuid,
                         emailStatus.email,
+                    );
+                } else {
+                    let reason: OneTimePasscodeFailureReason = 'invalid';
+                    if (
+                        emailStatus.otp &&
+                        this.isOtpMaxAttempts(emailStatus.otp.numberOfAttempts)
+                    ) {
+                        reason = 'max_attempts';
+                    } else if (emailStatus.otp) {
+                        reason = 'expired';
+                    }
+                    await this.trackOneTimePasscodeFailed(
+                        user,
+                        purpose,
+                        reason,
                     );
                 }
             } catch (e) {
@@ -2135,6 +2254,11 @@ export class UserService extends BaseService {
                 if (e instanceof NotFoundError) {
                     await this.emailModel.incrementPrimaryEmailOtpAttempts(
                         user.userUuid,
+                    );
+                    await this.trackOneTimePasscodeFailed(
+                        user,
+                        purpose,
+                        'invalid',
                     );
                 } else {
                     throw e;

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -784,7 +784,9 @@ const PRIVATE_ROUTES: RouteObject[] = [
                         Component: () => (
                             <>
                                 <NavBar />
-                                <NoProjectHomepage />
+                                <TrackPage name={PageName.NO_PROJECT_HOMEPAGE}>
+                                    <NoProjectHomepage />
+                                </TrackPage>
                             </>
                         ),
                     };

--- a/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/CreateProjectconnection.tsx
@@ -80,6 +80,14 @@ const CreateProjectConnection: FC<CreateProjectConnectionProps> = ({
         } = formValues;
         track({
             name: EventName.CREATE_PROJECT_BUTTON_CLICKED,
+            properties: {
+                warehouse: selectedWarehouse ?? warehouseConnection.type,
+                authenticationType:
+                    'authenticationType' in warehouseConnection
+                        ? warehouseConnection.authenticationType
+                        : undefined,
+                warehouseOnly,
+            },
         });
         if (selectedWarehouse) {
             const data = await mutateAsync({

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectUsingAgent.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectUsingAgent.tsx
@@ -12,6 +12,8 @@ import { Button, Code, CopyButton, Stack, Text, Title } from '@mantine-8/core';
 import { IconCheck, IconChevronLeft, IconCopy } from '@tabler/icons-react';
 import { useMemo, useRef, useState, type FC } from 'react';
 import { useCreateProjectWithoutCompileMutation } from '../../../hooks/useProject';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 import MantineIcon from '../../common/MantineIcon';
 import {
     SettingsCard,
@@ -106,6 +108,7 @@ const ConnectUsingAgent: FC<ConnectUsingAgentProps> = ({
     const isCreatingProjectRef = useRef(false);
     const createProjectMutation = useCreateProjectWithoutCompileMutation();
     const onProjectError = useOnProjectError();
+    const { track } = useTracking();
 
     const form = useForm({
         initialValues: {
@@ -211,7 +214,12 @@ const ConnectUsingAgent: FC<ConnectUsingAgentProps> = ({
                         <CopyButton value={agentSetupPrompt ?? ''}>
                             {({ copied, copy }) => (
                                 <Button
-                                    onClick={copy}
+                                    onClick={() => {
+                                        copy();
+                                        track({
+                                            name: EventName.AGENT_SETUP_PROMPT_COPIED,
+                                        });
+                                    }}
                                     leftSection={
                                         <MantineIcon
                                             icon={copied ? IconCheck : IconCopy}

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SetupInviteModal.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SetupInviteModal.tsx
@@ -21,6 +21,8 @@ import { z } from 'zod';
 import { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
 import { useUserUpdateMutation } from '../../../hooks/user/useUserUpdateMutation';
 import useApp from '../../../providers/App/useApp';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
 
@@ -65,6 +67,7 @@ const SetupInviteModal: FC<{
     } = useCreateInviteLinkMutation();
     const { mutateAsync: updateUserAsync, isLoading: isUpdatingUser } =
         useUserUpdateMutation();
+    const { track } = useTracking();
 
     const handleClose = () => {
         form.reset();
@@ -84,6 +87,7 @@ const SetupInviteModal: FC<{
             role: OrganizationMemberRole.ADMIN,
             purpose: InviteLinkPurpose.Setup,
         });
+        track({ name: EventName.SETUP_INVITE_SENT });
     };
 
     const isSubmitting = isLoading || isUpdatingUser;

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -40,6 +40,8 @@ import {
     useIsBigQueryAuthenticated,
 } from '../../../hooks/useBigquerySSO';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 import MantineIcon from '../../common/MantineIcon';
 import DocumentationHelpButton from '../../DocumentationHelpButton';
 import FormCollapseButton from '../FormCollapseButton';
@@ -355,13 +357,29 @@ const BigQueryForm: FC<{
         savedProject,
     ]);
 
+    const { track } = useTracking();
     const { mutate: openLoginPopup } = useGoogleLoginPopup(
         'bigquery',
         async () => {
             await refetchAuth();
             await refetchDatasets();
+            track({
+                name: EventName.BIGQUERY_SSO_SIGNIN_COMPLETED,
+                properties: { success: true },
+            });
         },
     );
+    const handleBigQuerySsoSignIn = () => {
+        track({ name: EventName.BIGQUERY_SSO_SIGNIN_CLICKED });
+        openLoginPopup(undefined, {
+            onError: () => {
+                track({
+                    name: EventName.BIGQUERY_SSO_SIGNIN_COMPLETED,
+                    properties: { success: false },
+                });
+            },
+        });
+    };
     const authenticationType: string =
         form.values.warehouse.authenticationType ?? defaultAuthenticationType;
     const locationField = form.getInputProps('warehouse.location');
@@ -438,7 +456,7 @@ const BigQueryForm: FC<{
                     <BigQuerySSOInput
                         isAuthenticated={isAuthenticated}
                         disabled={disabled}
-                        openLoginPopup={openLoginPopup}
+                        openLoginPopup={handleBigQuerySsoSignIn}
                     />
                 )}
                 {showWarehouseConfigFields && (

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoPanel.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoPanel.tsx
@@ -27,6 +27,8 @@ import {
     useWarehouseConnectCodeClaim,
 } from '../../../hooks/useWarehouseConnectCode';
 import useApp from '../../../providers/App/useApp';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 import MantineIcon from '../../common/MantineIcon';
 import { useFormContext } from '../formContext';
 import {
@@ -72,7 +74,10 @@ const readValidStoredCode = (): {
     return { code: stored.code, secondsRemaining };
 };
 
-const CopyableCommand: FC<{ command: string }> = ({ command }) => (
+const CopyableCommand: FC<{ command: string; onCopy?: () => void }> = ({
+    command,
+    onCopy,
+}) => (
     <Group gap="xs" align="flex-start" wrap="nowrap">
         <Code block flex={1} miw={0}>
             {command}
@@ -83,7 +88,10 @@ const CopyableCommand: FC<{ command: string }> = ({ command }) => (
                     <ActionIcon
                         variant="subtle"
                         color={copied ? 'green' : 'gray'}
-                        onClick={copy}
+                        onClick={() => {
+                            copy();
+                            onCopy?.();
+                        }}
                         aria-label="Copy command"
                     >
                         <MantineIcon icon={copied ? IconCheck : IconCopy} />
@@ -137,6 +145,7 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
     onDeposited,
 }) => {
     const { health } = useApp();
+    const { track } = useTracking();
     const form = useFormContext();
     const siteUrl = health.data?.siteUrl ?? '';
     const mint = useMintWarehouseConnectCode();
@@ -430,7 +439,14 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
                                 ? 'Connect with SSO (dev CLI — run from the repo root)'
                                 : '2. Connect with SSO'}
                         </Text>
-                        <CopyableCommand command={connectCommand} />
+                        <CopyableCommand
+                            command={connectCommand}
+                            onCopy={() =>
+                                track({
+                                    name: EventName.SNOWFLAKE_CLI_SSO_COMMAND_COPIED,
+                                })
+                            }
+                        />
                     </Stack>
 
                     <Group gap="xs">

--- a/packages/frontend/src/components/RegisterForms/VerifyEmailForm.tsx
+++ b/packages/frontend/src/components/RegisterForms/VerifyEmailForm.tsx
@@ -8,6 +8,8 @@ import {
     useVerifyEmail,
 } from '../../hooks/useEmailVerification';
 import useApp from '../../providers/App/useApp';
+import useTracking from '../../providers/Tracking/useTracking';
+import { EventName } from '../../types/Events';
 import Callout from '../common/Callout';
 import EmptyStateLoader from '../common/EmptyStateLoader';
 
@@ -17,6 +19,7 @@ const VerifyEmailForm: FC<{
     statusLoading?: boolean;
 }> = ({ isLoading, emailStatusData, statusLoading }) => {
     const { health } = useApp();
+    const { track } = useTracking();
     const { mutate: verifyCode, isLoading: verificationLoading } =
         useVerifyEmail();
     const data = emailStatusData;
@@ -157,6 +160,10 @@ const VerifyEmailForm: FC<{
                 fz="sm"
                 component="button"
                 onClick={() => {
+                    track({
+                        name: EventName.OTP_RESEND_CLICKED,
+                        properties: { purpose: 'signup_verification' },
+                    });
                     form.reset();
                     sendVerificationEmail();
                 }}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -413,6 +413,7 @@ export const AgentChatInput = ({
                             chip.kind === 'prompt' ? chip.tool : undefined,
                         chipIndex: index,
                         mode: emptyStateMode ? 'empty-state' : 'post-response',
+                        placement: 'agent_chat',
                     },
                 });
             };
@@ -475,6 +476,7 @@ export const AgentChatInput = ({
                     projectId: projectUuid,
                     agentId: agentUuid,
                     chipCount,
+                    placement: 'agent_chat',
                 },
             });
         },

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
@@ -116,7 +116,8 @@ const DayOneAskInputInner: FC<Props> = ({
     hideSuggestions,
 }) => {
     const navigate = useNavigate();
-    const { track } = useTracking();
+    const { track, data: trackingData } = useTracking();
+    const isTrackingReady = !!trackingData.rudder;
     const { user } = useApp();
     const { setPendingPrompt } = usePendingPrompt();
     const { data: agents, isInitialLoading: isLoadingAgents } =
@@ -248,6 +249,7 @@ const DayOneAskInputInner: FC<Props> = ({
     const impressionFiredRef = useRef(false);
     useEffect(() => {
         if (impressionFiredRef.current) return;
+        if (!isTrackingReady) return;
         if (hideSuggestions) return;
         if (!projectUuid || !referenceAgent?.uuid) return;
         if (chips.length === 0) return;
@@ -262,6 +264,7 @@ const DayOneAskInputInner: FC<Props> = ({
             },
         });
     }, [
+        isTrackingReady,
         chips.length,
         projectUuid,
         referenceAgent?.uuid,

--- a/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/DayOneAskInput.tsx
@@ -8,10 +8,13 @@ import {
 import { Anchor, Skeleton, Text } from '@mantine-8/core';
 import { IconArrowUpRight } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useState, type FC } from 'react';
+import { useEffect, useRef, useState, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useProject } from '../../../hooks/useProject';
+import useApp from '../../../providers/App/useApp';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 import {
     AI_ROUTING_AUTO_VALUE,
     AI_ROUTING_SEARCH_PARAM,
@@ -74,17 +77,17 @@ const useAiRouterEnabledFromCache = (): boolean | undefined => {
 const SuggestionPills: FC<{
     chips: AgentSuggestion[];
     loading: boolean;
-    onPick: (chip: AgentSuggestion) => void;
+    onPick: (chip: AgentSuggestion, index: number) => void;
 }> = ({ chips, loading, onPick }) => {
     if (!loading && chips.length === 0) return null;
     return (
         <div className={classes.pillRow}>
-            {chips.map((chip) => (
+            {chips.map((chip, index) => (
                 <button
                     key={chip.label}
                     type="button"
                     className={classes.pill}
-                    onClick={() => onPick(chip)}
+                    onClick={() => onPick(chip, index)}
                 >
                     <MantineIcon
                         icon={IconArrowUpRight}
@@ -113,6 +116,8 @@ const DayOneAskInputInner: FC<Props> = ({
     hideSuggestions,
 }) => {
     const navigate = useNavigate();
+    const { track } = useTracking();
+    const { user } = useApp();
     const { setPendingPrompt } = usePendingPrompt();
     const { data: agents, isInitialLoading: isLoadingAgents } =
         useProjectAiAgents({
@@ -204,16 +209,65 @@ const DayOneAskInputInner: FC<Props> = ({
     }) => {
         const prompt = message.trim();
         if (!prompt) return;
+        track({
+            name: EventName.HOMEPAGE_ASK_SUBMITTED,
+            properties: {
+                mode: activeSelection === 'auto' ? 'auto' : 'agent',
+                hasProject: !!projectUuid,
+            },
+        });
         submitPrompt(prompt, toolHints, context, optimisticContext);
     };
 
-    const handleChipPick = (chip: AgentSuggestion) => {
+    const handleChipPick = (chip: AgentSuggestion, index: number) => {
+        const organizationId = user.data?.organizationUuid;
+        if (organizationId && projectUuid && referenceAgent?.uuid) {
+            track({
+                name: EventName.AI_AGENT_SUGGESTION_CLICK,
+                properties: {
+                    organizationId,
+                    projectId: projectUuid,
+                    agentId: referenceAgent.uuid,
+                    chipLabel: chip.label,
+                    chipKind: chip.kind,
+                    chipTool: chip.kind === 'prompt' ? chip.tool : undefined,
+                    chipIndex: index,
+                    mode: 'empty-state',
+                    placement: 'homepage_hero',
+                },
+            });
+        }
         if (chip.kind === 'navigate') {
             void navigate(chip.url);
             return;
         }
         submitPrompt(chip.label, [chip.tool]);
     };
+
+    const chips = suggestionsQuery.data?.chips ?? [];
+    const impressionFiredRef = useRef(false);
+    useEffect(() => {
+        if (impressionFiredRef.current) return;
+        if (hideSuggestions) return;
+        if (!projectUuid || !referenceAgent?.uuid) return;
+        if (chips.length === 0) return;
+        impressionFiredRef.current = true;
+        track({
+            name: EventName.AI_AGENT_SUGGESTION_IMPRESSION,
+            properties: {
+                projectId: projectUuid,
+                agentId: referenceAgent.uuid,
+                chipCount: chips.length,
+                placement: 'homepage_hero',
+            },
+        });
+    }, [
+        chips.length,
+        projectUuid,
+        referenceAgent?.uuid,
+        hideSuggestions,
+        track,
+    ]);
 
     if (isLoadingAgents || isLoadingPreferences) {
         return <Skeleton h={64} radius="lg" />;
@@ -267,7 +321,7 @@ const DayOneAskInputInner: FC<Props> = ({
             )}
             {!hideSuggestions && (canCreateThread || preview) && (
                 <SuggestionPills
-                    chips={suggestionsQuery.data?.chips ?? []}
+                    chips={chips}
                     loading={suggestionsQuery.isLoading}
                     onPick={handleChipPick}
                 />

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
@@ -203,7 +203,8 @@ export const RecommendedActionsChecklist: FC<{
     projectUuid: string | null;
     actions: RecommendedActionsState;
 }> = ({ projectUuid, actions }) => {
-    const { track } = useTracking();
+    const { track, data: trackingData } = useTracking();
+    const isTrackingReady = !!trackingData.rudder;
     const { statuses, skippedActions, setSkippedActions, visibleActions } =
         actions;
     const [carouselIndex, setCarouselIndex] = useState(0);
@@ -314,7 +315,7 @@ export const RecommendedActionsChecklist: FC<{
     }, [activeIndex, isStackHovered, rotatableCount]);
 
     useEffect(() => {
-        if (!frontActionKey) return;
+        if (!isTrackingReady || !frontActionKey) return;
         if (lastImpressionKeyRef.current === frontActionKey) return;
         lastImpressionKeyRef.current = frontActionKey;
         track({
@@ -326,7 +327,7 @@ export const RecommendedActionsChecklist: FC<{
             },
         });
         impressionTriggerRef.current = 'initial';
-    }, [frontActionKey, activeIndex, track]);
+    }, [isTrackingReady, frontActionKey, activeIndex, track]);
 
     if (visibleActions.length === 0) return null;
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
@@ -13,7 +13,7 @@ import {
     IconX,
     type Icon,
 } from '@tabler/icons-react';
-import { useCallback, useEffect, useState, type FC } from 'react';
+import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import useTracking from '../../../../providers/Tracking/useTracking';
@@ -262,8 +262,12 @@ export const RecommendedActionsChecklist: FC<{
                 );
                 return next;
             });
+            track({
+                name: EventName.HOMEPAGE_RECOMMENDED_ACTION_RESTORED,
+                properties: { actionKey },
+            });
         },
-        [projectUuid, statuses, setSkippedActions],
+        [projectUuid, statuses, setSkippedActions, track],
     );
 
     const isSkipped = (key: HomepageRecommendedActionKey) =>
@@ -294,13 +298,35 @@ export const RecommendedActionsChecklist: FC<{
 
     const rotatableCount = incompleteActions.length;
 
+    const impressionTriggerRef = useRef<'initial' | 'auto_rotate' | 'manual'>(
+        'initial',
+    );
+    const lastImpressionKeyRef = useRef<string | null>(null);
+    const frontActionKey = orderedAll[activeIndex];
+
     useEffect(() => {
         if (isStackHovered || rotatableCount <= 1) return;
         const timeout = setTimeout(() => {
+            impressionTriggerRef.current = 'auto_rotate';
             setCarouselIndex((activeIndex + 1) % rotatableCount);
         }, AUTO_ROTATE_INTERVAL_MS);
         return () => clearTimeout(timeout);
     }, [activeIndex, isStackHovered, rotatableCount]);
+
+    useEffect(() => {
+        if (!frontActionKey) return;
+        if (lastImpressionKeyRef.current === frontActionKey) return;
+        lastImpressionKeyRef.current = frontActionKey;
+        track({
+            name: EventName.HOMEPAGE_RECOMMENDED_ACTION_IMPRESSION,
+            properties: {
+                actionKey: frontActionKey,
+                position: activeIndex,
+                trigger: impressionTriggerRef.current,
+            },
+        });
+        impressionTriggerRef.current = 'initial';
+    }, [frontActionKey, activeIndex, track]);
 
     if (visibleActions.length === 0) return null;
 
@@ -316,12 +342,13 @@ export const RecommendedActionsChecklist: FC<{
                                 color="gray"
                                 size="sm"
                                 aria-label="Previous step"
-                                onClick={() =>
+                                onClick={() => {
+                                    impressionTriggerRef.current = 'manual';
                                     setCarouselIndex(
                                         (activeIndex - 1 + orderedAll.length) %
                                             orderedAll.length,
-                                    )
-                                }
+                                    );
+                                }}
                             >
                                 <MantineIcon icon={IconChevronUp} size={14} />
                             </ActionIcon>
@@ -330,11 +357,12 @@ export const RecommendedActionsChecklist: FC<{
                                 color="gray"
                                 size="sm"
                                 aria-label="Next step"
-                                onClick={() =>
+                                onClick={() => {
+                                    impressionTriggerRef.current = 'manual';
                                     setCarouselIndex(
                                         (activeIndex + 1) % orderedAll.length,
-                                    )
-                                }
+                                    );
+                                }}
                             >
                                 <MantineIcon icon={IconChevronDown} size={14} />
                             </ActionIcon>

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -25,7 +25,14 @@ import {
 import { useForm, zodResolver } from '@mantine/form';
 import { useTimeout } from '@mantine/hooks';
 import { IconX } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
 import { Navigate, useLocation } from 'react-router';
 import { z } from 'zod';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -36,6 +43,7 @@ import useToaster from '../../../hooks/toaster/useToaster';
 import { useFlashMessages } from '../../../hooks/useFlashMessages';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 import {
     useFetchLoginOptions,
     useLoginWithEmailMutation,
@@ -49,7 +57,7 @@ import LoginWithEmailOtp from './LoginWithEmailOtp';
 
 const Login: FC<{}> = () => {
     const { health } = useApp();
-    const { identify } = useTracking();
+    const { identify, track } = useTracking();
     const location = useLocation();
 
     const { showToastError, showToastApiError } = useToaster();
@@ -125,6 +133,44 @@ const Login: FC<{}> = () => {
             }
         }
     }, [loginOptionsSuccess, loginOptions, redirectUrl]);
+
+    const trackedMethodForEmail = useRef<string | undefined>(undefined);
+    useEffect(() => {
+        if (
+            !preCheckEmail ||
+            !loginOptions ||
+            !loginOptionsSuccess ||
+            loginOptionsFetching
+        ) {
+            return;
+        }
+        if (trackedMethodForEmail.current === preCheckEmail) {
+            return;
+        }
+        trackedMethodForEmail.current = preCheckEmail;
+        const method =
+            loginOptions.forceRedirect && loginOptions.redirectUri
+                ? 'sso_redirect'
+                : loginOptions.showOptions.includes(LocalIssuerTypes.EMAIL)
+                  ? 'password'
+                  : loginOptions.showOptions.includes(
+                          LocalIssuerTypes.EMAIL_OTP,
+                      )
+                    ? 'email_otp'
+                    : undefined;
+        if (method) {
+            track({
+                name: EventName.LOGIN_FLOW_METHOD_SELECTED,
+                properties: { method },
+            });
+        }
+    }, [
+        preCheckEmail,
+        loginOptions,
+        loginOptionsSuccess,
+        loginOptionsFetching,
+        track,
+    ]);
 
     const ssoOptions = loginOptions
         ? (loginOptions.showOptions.filter(

--- a/packages/frontend/src/features/users/components/LoginWithEmailOtp.tsx
+++ b/packages/frontend/src/features/users/components/LoginWithEmailOtp.tsx
@@ -3,6 +3,8 @@ import { Anchor, Button, PinInput, Stack, Text } from '@mantine-8/core';
 import { isNotEmpty, useForm } from '@mantine/form';
 import { useCallback, useEffect, useRef, type FC } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
 import {
     useEmailOtpRequestMutation,
     useEmailOtpVerifyMutation,
@@ -14,6 +16,7 @@ const LoginWithEmailOtp: FC<{
     onSuccess: (user: LightdashUser) => void;
 }> = ({ email, disabled, onSuccess }) => {
     const { showToastApiError, showToastSuccess } = useToaster();
+    const { track } = useTracking();
 
     const form = useForm<{ passcode: string }>({
         initialValues: { passcode: '' },
@@ -123,6 +126,10 @@ const LoginWithEmailOtp: FC<{
                 type="button"
                 disabled={isRequesting}
                 onClick={() => {
+                    track({
+                        name: EventName.OTP_RESEND_CLICKED,
+                        properties: { purpose: 'login' },
+                    });
                     form.reset();
                     requestCodeForEmail(() => {
                         showToastSuccess({

--- a/packages/frontend/src/pages/OnboardingDataSource.tsx
+++ b/packages/frontend/src/pages/OnboardingDataSource.tsx
@@ -29,6 +29,8 @@ import {
 import { ProjectFormProvider } from '../components/ProjectConnection/ProjectFormProvider';
 import { useOrganization } from '../hooks/organization/useOrganization';
 import { useOnboardingPageGuard } from '../hooks/useOnboardingPageGuard';
+import useTracking from '../providers/Tracking/useTracking';
+import { EventName } from '../types/Events';
 import classes from './OnboardingDataSource.module.css';
 
 const WAREHOUSE_ORDER = [
@@ -102,6 +104,18 @@ const SectionHeader: FC<{ title: string; hint?: string }> = ({
 
 const DataSourcePicker: FC = () => {
     const navigate = useNavigate();
+    const { track } = useTracking();
+
+    const handleSelect = (
+        key: SelectedWarehouse,
+        tier: 'popular' | 'all' | 'other',
+    ) => {
+        track({
+            name: EventName.ONBOARDING_WAREHOUSE_SELECTED,
+            properties: { warehouse: String(key), tier },
+        });
+        void navigate(getWarehouseRoute(key));
+    };
 
     return (
         <Box className={classes.column}>
@@ -124,7 +138,7 @@ const DataSourcePicker: FC = () => {
                             radius="md"
                             className={`${classes.heroCard} ${classes.warehouseCardEnabled}`}
                             onClick={() =>
-                                void navigate(getWarehouseRoute(warehouse.key))
+                                handleSelect(warehouse.key, 'popular')
                             }
                         >
                             <Box>{getWarehouseIcon(warehouse.key, 48)}</Box>
@@ -151,7 +165,12 @@ const DataSourcePicker: FC = () => {
                             radius="md"
                             className={`${classes.warehouseCard} ${classes.warehouseCardEnabled}`}
                             onClick={() =>
-                                void navigate(getWarehouseRoute(warehouse.key))
+                                handleSelect(
+                                    warehouse.key,
+                                    warehouse.key === OtherWarehouse.Other
+                                        ? 'other'
+                                        : 'all',
+                                )
                             }
                         >
                             <Box>{getWarehouseIcon(warehouse.key, 40)}</Box>

--- a/packages/frontend/src/pages/OnboardingProjectReady.tsx
+++ b/packages/frontend/src/pages/OnboardingProjectReady.tsx
@@ -18,6 +18,8 @@ import MantineIcon from '../components/common/MantineIcon';
 import { useTables } from '../features/sqlRunner/hooks/useTables';
 import { useOnboardingPageGuard } from '../hooks/useOnboardingPageGuard';
 import { useProject } from '../hooks/useProject';
+import useTracking from '../providers/Tracking/useTracking';
+import { EventName } from '../types/Events';
 import classes from './OnboardingProjectReady.module.css';
 
 const TOTAL_STEPS = 3;
@@ -27,6 +29,7 @@ const OnboardingProjectReadyContent: FC<{ projectUuid: string }> = ({
     projectUuid,
 }) => {
     const navigate = useNavigate();
+    const { track } = useTracking();
     const { data: project } = useProject(projectUuid);
     const {
         data: tables,
@@ -194,9 +197,13 @@ const OnboardingProjectReadyContent: FC<{ projectUuid: string }> = ({
                         size="lg"
                         radius="md"
                         className={classes.startButton}
-                        onClick={() =>
-                            void navigate(`/projects/${projectUuid}/home`)
-                        }
+                        onClick={() => {
+                            track({
+                                name: EventName.ONBOARDING_PROJECT_READY_START_EXPLORING_CLICKED,
+                                properties: { projectId: projectUuid },
+                            });
+                            void navigate(`/projects/${projectUuid}/home`);
+                        }}
                     >
                         Go to your homepage
                     </Button>

--- a/packages/frontend/src/pages/OrganizationSetup.tsx
+++ b/packages/frontend/src/pages/OrganizationSetup.tsx
@@ -36,6 +36,8 @@ import { type UserWithAbility } from '../hooks/user/useUser';
 import { useUserCompleteMutation } from '../hooks/user/useUserCompleteMutation';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import useApp from '../providers/App/useApp';
+import useTracking from '../providers/Tracking/useTracking';
+import { EventName } from '../types/Events';
 import classes from './OrganizationSetup.module.css';
 import { OrganizationSetupPreview } from './OrganizationSetupPreview';
 
@@ -146,9 +148,12 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
         ),
     });
 
+    const { track } = useTracking();
+    const brandDetectionEnabled =
+        health.hasBrandfetch && canEnterOrganizationName && isCompanyDomain;
     const brandDetection = useDetectOrganizationBrand(
         emailDomain,
-        health.hasBrandfetch && canEnterOrganizationName && isCompanyDomain,
+        brandDetectionEnabled,
     );
     const saveBrand = useSaveOrganizationBrand({ showSuccessToast: false });
 
@@ -169,6 +174,30 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
                 : {}),
         }));
     }, [brandDetection.data, isDirty, setValues]);
+
+    const hasTrackedBrandDetection = useRef(false);
+    useEffect(() => {
+        if (!brandDetectionEnabled || hasTrackedBrandDetection.current) return;
+        if (!brandDetection.isFetched || brandDetection.isFetching) return;
+        hasTrackedBrandDetection.current = true;
+        const brand = brandDetection.data;
+        track({
+            name: EventName.ORGANIZATION_BRAND_DETECTED,
+            properties: {
+                found: !!brand,
+                autoApplied: !!(
+                    brand &&
+                    (brand.name || brandColorsSorted(brand.colors).length > 0)
+                ),
+            },
+        });
+    }, [
+        brandDetectionEnabled,
+        brandDetection.isFetched,
+        brandDetection.isFetching,
+        brandDetection.data,
+        track,
+    ]);
 
     const detectedBrand = brandDetection.data ?? null;
     const detectedColors = detectedBrand
@@ -200,10 +229,19 @@ const OrganizationSetupContent: FC<OrganizationSetupContentProps> = ({
     const handleSubmit = form.onSubmit((values) => {
         if (isWorkspaceStep) {
             if (values.organizationName.trim()) {
+                track({
+                    name: EventName.ORGANIZATION_SETUP_STEP_COMPLETED,
+                    properties: { step: 'workspace' },
+                });
                 setStep(2);
             }
             return;
         }
+
+        track({
+            name: EventName.ORGANIZATION_SETUP_STEP_COMPLETED,
+            properties: { step: 'about_you' },
+        });
 
         if (user.organizationName) {
             completeMutation.mutate({

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -30,6 +30,7 @@ import { useFlashMessages } from '../hooks/useFlashMessages';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import useApp from '../providers/App/useApp';
 import useTracking from '../providers/Tracking/useTracking';
+import { EventName } from '../types/Events';
 
 const registerQuery = async (data: CreateUserArgs | CreateEmailOnlyUserArgs) =>
     lightdashApi<LightdashUser>({
@@ -58,7 +59,7 @@ const Register: FC = () => {
         FeatureFlags.NewOnboarding,
         { retry: 3 },
     );
-    const { identify } = useTracking();
+    const { identify, track } = useTracking();
     const redirectUrl = location.state?.from
         ? `${location.state.from.pathname}${location.state.from.search}`
         : '/';
@@ -110,6 +111,10 @@ const Register: FC = () => {
             <CreateEmailOnlyUserForm
                 isLoading={isLoading || isSuccess}
                 onSubmit={(data: CreateEmailOnlyUserArgs) => {
+                    track({
+                        name: EventName.SIGNUP_FORM_SUBMITTED,
+                        properties: { variant: 'email_only' },
+                    });
                     mutate(data);
                 }}
             />
@@ -117,6 +122,10 @@ const Register: FC = () => {
             <CreateUserForm
                 isLoading={isLoading || isSuccess}
                 onSubmit={(data: CreateUserArgs) => {
+                    track({
+                        name: EventName.SIGNUP_FORM_SUBMITTED,
+                        properties: { variant: 'password' },
+                    });
                     mutate(data);
                 }}
             />

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -4,6 +4,7 @@ import {
     type SearchItemType,
     type TableCalculationType,
     type TimeFrames,
+    type WarehouseTypes,
 } from '@lightdash/common';
 import type * as rudderSDK from 'rudder-sdk-js';
 import {
@@ -24,7 +25,6 @@ type GenericEvent = {
         | EventName.CONFIRM_DELETE_TABLE_CALCULATION_BUTTON_CLICKED
         | EventName.DELETE_TABLE_CALCULATION_BUTTON_CLICKED
         | EventName.EDIT_TABLE_CALCULATION_BUTTON_CLICKED
-        | EventName.CREATE_PROJECT_BUTTON_CLICKED
         | EventName.REFRESH_DBT_CONNECTION_BUTTON_CLICKED
         | EventName.UPDATE_PROJECT_TABLES_CONFIGURATION_BUTTON_CLICKED
         | EventName.UPDATE_PROJECT_BUTTON_CLICKED
@@ -74,7 +74,11 @@ type GenericEvent = {
         | EventName.METRICS_CATALOG_SEARCH_APPLIED
         | EventName.METRICS_CATALOG_TREES_EDGE_CREATED
         | EventName.METRICS_CATALOG_TREES_EDGE_REMOVED
-        | EventName.METRICS_CATALOG_TREES_CANVAS_MODE_CLICKED;
+        | EventName.METRICS_CATALOG_TREES_CANVAS_MODE_CLICKED
+        | EventName.BIGQUERY_SSO_SIGNIN_CLICKED
+        | EventName.SNOWFLAKE_CLI_SSO_COMMAND_COPIED
+        | EventName.SETUP_INVITE_SENT
+        | EventName.AGENT_SETUP_PROMPT_COPIED;
     properties?: {};
 };
 
@@ -500,6 +504,7 @@ type AiAgentSuggestionImpressionEvent = {
         projectId: string;
         agentId: string;
         chipCount: number;
+        placement: 'agent_chat' | 'homepage_hero';
     };
 };
 
@@ -516,6 +521,7 @@ type AiAgentSuggestionClickEvent = {
         chipTool?: string;
         chipIndex: number;
         mode: 'empty-state' | 'post-response';
+        placement: 'agent_chat' | 'homepage_hero';
     };
 };
 
@@ -584,8 +590,111 @@ type DashboardFilterRequirementsSavedEvent = {
     };
 };
 
+type CreateProjectButtonClickedEvent = {
+    name: EventName.CREATE_PROJECT_BUTTON_CLICKED;
+    properties: {
+        warehouse: WarehouseTypes;
+        authenticationType?: string;
+        warehouseOnly?: boolean;
+    };
+};
+
+type SignupFormSubmittedEvent = {
+    name: EventName.SIGNUP_FORM_SUBMITTED;
+    properties: {
+        variant: 'email_only' | 'password';
+    };
+};
+
+type OtpResendClickedEvent = {
+    name: EventName.OTP_RESEND_CLICKED;
+    properties: {
+        purpose: 'signup_verification' | 'login';
+    };
+};
+
+type LoginFlowMethodSelectedEvent = {
+    name: EventName.LOGIN_FLOW_METHOD_SELECTED;
+    properties: {
+        method: 'password' | 'email_otp' | 'sso_redirect';
+    };
+};
+
+type OrganizationSetupStepCompletedEvent = {
+    name: EventName.ORGANIZATION_SETUP_STEP_COMPLETED;
+    properties: {
+        step: 'workspace' | 'about_you';
+    };
+};
+
+type OrganizationBrandDetectedEvent = {
+    name: EventName.ORGANIZATION_BRAND_DETECTED;
+    properties: {
+        found: boolean;
+        autoApplied: boolean;
+    };
+};
+
+type OnboardingWarehouseSelectedEvent = {
+    name: EventName.ONBOARDING_WAREHOUSE_SELECTED;
+    properties: {
+        warehouse: string;
+        tier: 'popular' | 'all' | 'other';
+    };
+};
+
+type BigquerySsoSigninCompletedEvent = {
+    name: EventName.BIGQUERY_SSO_SIGNIN_COMPLETED;
+    properties: {
+        success: boolean;
+    };
+};
+
+type OnboardingProjectReadyStartExploringClickedEvent = {
+    name: EventName.ONBOARDING_PROJECT_READY_START_EXPLORING_CLICKED;
+    properties: {
+        projectId: string;
+    };
+};
+
+type HomepageAskSubmittedEvent = {
+    name: EventName.HOMEPAGE_ASK_SUBMITTED;
+    properties: {
+        mode: string;
+        hasProject: boolean;
+    };
+};
+
+type HomepageRecommendedActionImpressionEvent = {
+    name: EventName.HOMEPAGE_RECOMMENDED_ACTION_IMPRESSION;
+    properties: {
+        actionKey: HomepageRecommendedActionKey;
+        position: number;
+        trigger: 'initial' | 'auto_rotate' | 'manual';
+    };
+};
+
+type HomepageRecommendedActionRestoredEvent = {
+    name: EventName.HOMEPAGE_RECOMMENDED_ACTION_RESTORED;
+    properties: {
+        actionKey: HomepageRecommendedActionKey;
+    };
+};
+
 export type EventData =
     | GenericEvent
+    | CreateProjectButtonClickedEvent
+    | SignupFormSubmittedEvent
+    | OtpResendClickedEvent
+    | LoginFlowMethodSelectedEvent
+    | OrganizationSetupStepCompletedEvent
+    | OrganizationBrandDetectedEvent
+    | OnboardingWarehouseSelectedEvent
+    | BigquerySsoSigninCompletedEvent
+    | OnboardingProjectReadyStartExploringClickedEvent
+    | HomepageAskSubmittedEvent
+    | HomepageRecommendedActionImpressionEvent
+    | HomepageRecommendedActionRestoredEvent
     | HomepageQuickActionClickedEvent
     | HomepageRecommendedActionClickedEvent
     | HomepageRecommendedActionSkippedEvent

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -52,6 +52,7 @@ export enum PageName {
     ORGANIZATION_SETUP = 'organization_setup',
     ONBOARDING_DATA_SOURCE = 'onboarding_data_source',
     ONBOARDING_PROJECT_READY = 'onboarding_project_ready',
+    NO_PROJECT_HOMEPAGE = 'no_project_homepage',
     EMBED_DASHBOARD = 'embed_dashboard',
     EMBED_SAVED_CHART = 'embed_saved_chart',
     EMBED_EXPLORE = 'embed_explore',
@@ -186,4 +187,20 @@ export enum EventName {
 
     // Dashboard UI Version Toggle
     DASHBOARD_UI_VERSION_TOGGLED = 'dashboard_ui_version.toggled',
+
+    SIGNUP_FORM_SUBMITTED = 'signup_form.submitted',
+    OTP_RESEND_CLICKED = 'otp.resend_clicked',
+    LOGIN_FLOW_METHOD_SELECTED = 'login_flow.method_selected',
+    ORGANIZATION_SETUP_STEP_COMPLETED = 'organization_setup_step.completed',
+    ORGANIZATION_BRAND_DETECTED = 'organization_brand.detected',
+    ONBOARDING_WAREHOUSE_SELECTED = 'onboarding_warehouse.selected',
+    BIGQUERY_SSO_SIGNIN_CLICKED = 'bigquery_sso.signin_clicked',
+    BIGQUERY_SSO_SIGNIN_COMPLETED = 'bigquery_sso.signin_completed',
+    SNOWFLAKE_CLI_SSO_COMMAND_COPIED = 'snowflake_cli_sso.command_copied',
+    SETUP_INVITE_SENT = 'setup_invite.sent',
+    ONBOARDING_PROJECT_READY_START_EXPLORING_CLICKED = 'onboarding_project_ready.start_exploring_clicked',
+    HOMEPAGE_ASK_SUBMITTED = 'homepage_ask.submitted',
+    HOMEPAGE_RECOMMENDED_ACTION_IMPRESSION = 'homepage_recommended_action.impression',
+    HOMEPAGE_RECOMMENDED_ACTION_RESTORED = 'homepage_recommended_action.restored',
+    AGENT_SETUP_PROMPT_COPIED = 'agent_setup_prompt.copied',
 }


### PR DESCRIPTION
## Summary

Full funnel instrumentation for the new onboarding experience (`new-onboarding` + `coding-agent-onboarding` flags), designed for direct old-vs-new comparison: existing event names and step semantics are reused and extended with properties, backend events form the adblock-proof funnel spine, and frontend events add step/interaction granularity.

**Cross-flow contract:** `onboardingFlow: 'new' | 'legacy'` is computed from the evaluated `new-onboarding` flag at fire time and stamped on every spine event. The classic-flow instrumentation branch (SPK-569) reuses `onboarding_warehouse.selected` (with `tier: 'all' | 'other'`) and `onboarding_project_ready.start_exploring_clicked` with identical shapes — these names/shapes and the `OnboardingFlow` type are a shared contract.

## Event dictionary

### Backend — modified events

| Event | Change |
|---|---|
| `user.created` | `context` now correctly `'registration'` for self-serve signup (was mislabeled `'accept_invite'` for both paths); + `onboardingFlow` |
| `user.verified` | + `method: 'otp' \| 'link' \| 'sso'`, + `onboardingFlow` |
| `organization.created` | + `onboardingFlow` |
| `project.created` / `project.updated` | + `onboardingFlow` |

### Backend — new events

| Event | Properties | Fires |
|---|---|---|
| `one_time_passcode.sent` | `purpose: 'signup_verification' \| 'login' \| 'email_change'`, `isResend`, `onboardingFlow` | every OTP email send (signup, login, email change; purpose derived from `isSetupComplete` on the generic resend endpoint) |
| `one_time_passcode.failed` | `purpose`, `reason: 'invalid' \| 'expired' \| 'max_attempts'`, `onboardingFlow` | each failed OTP verification attempt (email-verify + login paths) |
| `warehouse_connection.tested` | `warehouseType`, `result: 'success' \| 'failure'`, `errorType?` (exception class name only — never messages or credentials), `context: 'project_create' \| 'project_update'`, `method`, `onboardingFlow` | adapter test during project create/update |
| `onboarding_homepage.provisioned` | `organizationId`, `projectId`, `homepageUuid` | after the "Getting started" homepage is published for a first project |
| `ai_agent.provisioning_failed` | `organizationId`, `projectId`, `error` | default-agent auto-provisioning failure (success already tracked via `ai_agent.created` `autoProvisioned: true`) |

OTP successes intentionally reuse existing semantics: email-verify success = `user.verified` (`method: 'otp'`), login success = `user.logged_in` (`loginProvider: 'email_otp'`).

### Frontend — modified events

| Event | Change |
|---|---|
| `create_project_button.click` | typed properties `{warehouse, authenticationType?, warehouseOnly?}` (was property-less) |
| `ai_agent.suggestion_impression` / `.suggestion_click` | + `placement: 'agent_chat' \| 'homepage_hero'`; the homepage hero pills previously bypassed tracking entirely and are now wired |
| Page events | new `no_project_homepage` page name + `TrackPage` for the day-0 homepage (was the only new-flow screen without a page event) |

### Frontend — new events

`signup_form.submitted` `{variant}` · `otp.resend_clicked` `{purpose}` · `login_flow.method_selected` `{method}` · `organization_setup_step.completed` `{step}` · `organization_brand.detected` `{found, autoApplied}` · `onboarding_warehouse.selected` `{warehouse, tier: 'popular' | 'all' | 'other'}` · `bigquery_sso.signin_clicked` · `bigquery_sso.signin_completed` `{success}` · `snowflake_cli_sso.command_copied` · `setup_invite.sent` · `onboarding_project_ready.start_exploring_clicked` `{projectId}` · `homepage_ask.submitted` `{mode, hasProject}` · `homepage_recommended_action.impression` `{actionKey, position, trigger}` (denominator for the existing clicked/skipped) · `homepage_recommended_action.restored` `{actionKey}` · `agent_setup_prompt.copied`

All new frontend events have typed payload entries in `providers/Tracking/types.ts`; no existing event string was renamed.

## Bug fix included

Mount-time impression events were silently dropped when they fired before the async Rudder SDK finished loading, and the once-only refs blocked the retry. Both impression sites now gate on SDK readiness (verified live — the checklist impression never reached the data plane before the fix).

## Verification

- `pnpm -F backend typecheck`, `pnpm -F frontend typecheck`, touched-path lint, focused vitest suites (UserService 101, ProjectService 71, OrganizationService, homepage provisioning), `pnpm generate-api` (no generated diffs).
- Live e2e with the Rudder data plane pointed at a local capture sink: fresh passwordless signup → wrong OTP → resend → verify → org setup (both steps) → warehouse picker → failed then successful Postgres connect → project ready → provisioned-homepage event → setup invite → logout → OTP login. Every event above that is exercisable in a local EE dev env was observed with the expected properties, both `lightdash_webapp.*` and `lightdash_server.*`.
- Not live-verifiable locally (verified by typecheck + review only): BigQuery SSO events (needs Google), Snowflake CLI-SSO copy, `agent_setup_prompt.copied`, `organization_brand.detected` (needs Brandfetch), homepage hero ask/chips (needs AI copilot), `ai_agent.provisioning_failed`.

Closes: SPK-568

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aF2TUiavMv2AJBQdVchUy