### PR TITLE
fix: rename Snowflake key-pair auth option from BigQuery service-account wording

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/util.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/util.ts
@@ -2,7 +2,7 @@ import { capitalize, type WarehouseTypes } from '@lightdash/common';
 
 export const getSsoLabel = (warehouse: WarehouseTypes, provider?: string) =>
     `User Account (Sign in with ${provider ?? capitalize(warehouse)})`;
-export const PRIVATE_KEY_LABEL = `Service Account (JSON key file)`;
+export const PRIVATE_KEY_LABEL = `Key Pair (private key file)`;
 export const PASSWORD_LABEL = `Password`;
 export const EXTERNAL_BROWSER_LABEL = `External Browser`;
 export const PERSONAL_ACCESS_TOKEN_LABEL = `Personal Access Token`;


### PR DESCRIPTION
## Summary

The Snowflake connection form's **Authentication Type** dropdown labelled its key-pair option **"Service Account (JSON key file)"** — BigQuery terminology. Selecting it reveals a **"Private Key File"** input that accepts a `.p8` key and links to Snowflake's key-pair auth docs, so the label contradicted the field it exposed. The wording appears to have been copied from the BigQuery form when the option was introduced in #15126.

Renamed `PRIVATE_KEY_LABEL` to **"Key Pair (private key file)"**, matching Snowflake's own key-pair authentication terminology and the revealed input.

`PRIVATE_KEY_LABEL` is consumed only by `SnowflakeForm.tsx` (verified repo-wide), so no other warehouse form changes. BigQuery keeps its own inline "Service Account (JSON key file)" literal, which is correct there. No e2e spec references the label for Snowflake (the only occurrence is a commented-out BigQuery block).

## Verification

- Reproduced in the create-project flow (Snowflake → manual): dropdown showed "Service Account (JSON key file)" above the `.p8` "Private Key File" input.
- After the change, the dropdown shows "Key Pair (private key file)" / "Password" (and the SSO/CLI options where enabled).
- `pnpm -F frontend typecheck:fast` and frontend linter on the touched path pass.

Closes: #25767

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVTP1jAaxyLfabWhc6aVPd

Linear: PROD-8997