### PR TITLE
fix: invalid <p> nesting in Snowflake form input descriptions

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -513,6 +513,7 @@ const SnowflakeForm: FC<{
                                             value={temporaryFile}
                                             onChange={(file) => {
                                                 if (!file) {
+                                                    setTemporaryFile(undefined);
                                                     form.setFieldValue(
                                                         'warehouse.privateKey',
                                                         null,
@@ -543,6 +544,13 @@ const SnowflakeForm: FC<{
                                                             null,
                                                         );
                                                     }
+                                                };
+                                                fileReader.onerror = () => {
+                                                    setTemporaryFile(undefined);
+                                                    form.setFieldValue(
+                                                        'warehouse.privateKey',
+                                                        null,
+                                                    );
                                                 };
                                                 fileReader.readAsText(file);
                                             }}

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -494,7 +494,7 @@ const SnowflakeForm: FC<{
                                                     : 'Choose file...'
                                             }
                                             description={
-                                                <p>
+                                                <>
                                                     This is the .p8 private key
                                                     file. You can see{' '}
                                                     <Anchor
@@ -506,7 +506,7 @@ const SnowflakeForm: FC<{
                                                         how to create a key here
                                                     </Anchor>
                                                     .
-                                                </p>
+                                                </>
                                             }
                                             required={requireSecrets}
                                             accept=".p8"
@@ -659,7 +659,7 @@ const SnowflakeForm: FC<{
                                             name="warehouse.clientSessionKeepAlive"
                                             label="Keep client session alive"
                                             description={
-                                                <p>
+                                                <>
                                                     This is intended to keep
                                                     Snowflake sessions alive
                                                     beyond the typical 4 hour
@@ -674,7 +674,7 @@ const SnowflakeForm: FC<{
                                                         dbt documentation
                                                     </Anchor>
                                                     .
-                                                </p>
+                                                </>
                                             }
                                             onLabel="Yes"
                                             offLabel="No"
@@ -694,7 +694,7 @@ const SnowflakeForm: FC<{
                                             )}
                                             label="Query tag"
                                             description={
-                                                <p>
+                                                <>
                                                     This is Snowflake query tags
                                                     parameter. You can see more
                                                     details in{' '}
@@ -707,7 +707,7 @@ const SnowflakeForm: FC<{
                                                         dbt documentation
                                                     </Anchor>
                                                     .
-                                                </p>
+                                                </>
                                             }
                                             disabled={disabled}
                                         />
@@ -716,7 +716,7 @@ const SnowflakeForm: FC<{
                                             name="warehouse.accessUrl"
                                             label="Snowflake URL override"
                                             description={
-                                                <p>
+                                                <>
                                                     Usually Lightdash would
                                                     connect to a default url:
                                                     account.snowflakecomputing.com.
@@ -724,7 +724,7 @@ const SnowflakeForm: FC<{
                                                     this (e.g. for the dbt
                                                     server) you can specify a
                                                     full custom URL here.
-                                                </p>
+                                                </>
                                             }
                                             disabled={disabled}
                                             {...form.getInputProps(


### PR DESCRIPTION
## Summary

Selecting the key-pair authentication type on the Snowflake connection form logged a React DOM-nesting error in the console:

```
In HTML, <p> cannot be a descendant of <p>.
This will cause a hydration error.
```

Mantine v8's `InputDescription` renders the description content inside a `<p>` (`Box component="p"`, class `mantine-8-FileInput-description`), so passing a JSX `<p>` element as the `description` prop produces invalid nested `<p>` markup. React flags it as a guaranteed hydration mismatch (console-noise today, a real hydration error under SSR/streaming).

This PR replaces the `<p>` wrappers with fragments for the four affected inputs in `SnowflakeForm.tsx`:

- Private Key File `FileInput` (the one reported in the issue)
- "Keep client session alive" `BooleanSwitch` (renders via v8 `Input.Description`)
- "Query tag" `TextInput`
- "Snowflake URL override" `TextInput`

The "Timeout in seconds" `NumberInput` in the same file also passes a `<p>` description but is left unchanged: it is still the Mantine **v6** `NumberInput`, whose `InputDescription` renders a `<div>`, so no invalid nesting occurs there.

A second commit fixes an adjacent state-sync issue in the same `FileInput` flagged during review: the clear path nulled the form value but never cleared `temporaryFile` (the controlled display value), so the input could keep showing a previously selected file, and a failed `FileReader` read left stale state with no handler. Both paths now reset `temporaryFile` so the displayed value tracks the form value.

## Verification

Repro path: create project → Snowflake → key-pair auth type selected → open console (advanced configuration expanded to cover the sibling inputs).

**Before** — console error with component stack ending at the private-key `FileInput`:

```
In HTML, <p> cannot be a descendant of <p>.
This will cause a hydration error.
  ...
  <@mantine/core/FileInput name="warehouse...." accept=".p8" ...>
    <@mantine/core/InputBase component="button" ...>
      <@mantine/core/InputWrapper label="Private Ke..." description={<p>} ...>
        <@mantine/core/InputDescription __staticSelector="FileInput" ...>
          <@mantine/core/Box component="p" ...>
>           <p className="m_fe47ce59 mantine-8-InputWrapper-description mantine-8-FileInput-description" ...>
>             <p>
```

`document.querySelectorAll('p p')` confirmed the same nesting for the three sibling inputs above.

**After** — no DOM-nesting error from `SnowflakeForm.tsx`; `document.querySelectorAll('p p')` returns zero matches in the warehouse-connection section, and the descriptions render unchanged (text, links, standard description spacing). Cosmetic side effect: the nested `<p>` carried a browser-default 10px bottom margin, so the affected descriptions now sit with the same spacing as every other description on the form.

Note: the dbt-connection section of the same page (`GithubForm` and friends — Branch, Project directory path, Target name, dbt selectors) and several other warehouse forms (Postgres, Redshift, Databricks, ClickHouse, Athena) have the same class of `<p>` descriptions; those are separate files and out of scope here.

Selecting a `.p8` file still works (file name displayed, form value populated, console clean).

`pnpm -F frontend typecheck:fast` and the frontend linter pass on the touched file.

Linear: PROD-8996
Closes: #25766

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rHg4LS4xvR5ZAdbwBK4pZ
