### PR TITLE
docs: remove stale Codespaces/devcontainer section from CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -174,36 +174,9 @@ Packages overview:
 -   `e2e` - End-to-end and integration tests
 -   `warehouses` - Classes for connecting to different databases
 
-#### using Github Codespaces / VS Code Remote Containers
-
-The fastest way to setup a development environment is to use Github Codespaces or VS Code Remote Containers.
-This provides:
-
--   All dependencies
--   A postgres database for development
--   A sample dbt project
--   A pre-configured code editor
-
-To get started:
-
--   in Github [create a codespace](https://docs.github.com/en/codespaces/developing-in-codespaces/creating-a-codespace)
--   in VS
-    Code [install the remote containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-
-Once connected run the following commands in the VS Code terminal:
-
-```shell
-# Setup the database
-pnpm -F backend migrate
-pnpm -F backend seed
-
-# Run Lightdash frontend and backend in dev mode
-pnpm dev
-```
-
 #### using Docker compose
 
-Alternatively you can create a developer environment using docker compose:
+You can create a developer environment using docker compose:
 
 ```shell
 # Clone the Lightdash repo


### PR DESCRIPTION
## Summary

CONTRIBUTING.md still recommended GitHub Codespaces / VS Code Remote Containers as the fastest way to set up a dev environment, but the `.devcontainer/devcontainer.json` it relied on was accidentally deleted in #5906 (Jun 2023) — a PR about the org projects API that had nothing to do with dev environments.

Restoring the old devcontainer as-is wouldn't work either: it referenced `lightdash.yml` / `LIGHTDASH_CONFIG_FILE` (removed completely in #10796), ran `git submodule update --init` (the repo has no submodules anymore), and used the deprecated top-level `extensions`/`settings` devcontainer schema.

This removes the stale section so the Docker compose instructions — the setup path we actually maintain — lead the dev-environment docs. Raised by a contributor on the community Slack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)