### PR TITLE
fix: skip stored Databricks secret merge when serverHostName changes

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -4,7 +4,9 @@ import {
     CompiledDimension,
     CompiledMetric,
     CreateAthenaCredentials,
+    CreateDatabricksCredentials,
     CreatePostgresCredentials,
+    DatabricksAuthenticationType,
     DimensionType,
     ExploreType,
     FieldType,
@@ -265,6 +267,60 @@ describe('ProjectModel', () => {
             expect(result.authenticationType).toEqual(
                 AthenaAuthenticationType.IAM_ROLE,
             );
+        });
+
+        test('should NOT merge Databricks secrets when serverHostName changes', async () => {
+            const completeDatabricksCredentials: CreateDatabricksCredentials = {
+                type: WarehouseTypes.DATABRICKS,
+                database: 'default',
+                serverHostName: 'adb-123.azuredatabricks.net',
+                httpPath: '/sql/1.0/warehouses/abc',
+                authenticationType: DatabricksAuthenticationType.OAUTH_M2M,
+                oauthClientId: 'client-id',
+                oauthClientSecret: 'client-secret',
+            };
+            const incompleteDatabricksCredentials: CreateDatabricksCredentials =
+                {
+                    ...completeDatabricksCredentials,
+                    serverHostName: 'other-host.example.com',
+                    oauthClientId: undefined,
+                    oauthClientSecret: undefined,
+                };
+
+            const result = ProjectModel.mergeMissingWarehouseSecrets(
+                incompleteDatabricksCredentials,
+                completeDatabricksCredentials,
+            );
+
+            expect(result.oauthClientId).toBeUndefined();
+            expect(result.oauthClientSecret).toBeUndefined();
+        });
+
+        test('should merge Databricks secrets when serverHostName is unchanged', async () => {
+            const completeDatabricksCredentials: CreateDatabricksCredentials = {
+                type: WarehouseTypes.DATABRICKS,
+                database: 'default',
+                serverHostName: 'adb-123.azuredatabricks.net',
+                httpPath: '/sql/1.0/warehouses/abc',
+                authenticationType: DatabricksAuthenticationType.OAUTH_M2M,
+                oauthClientId: 'client-id',
+                oauthClientSecret: 'client-secret',
+            };
+            const incompleteDatabricksCredentials: CreateDatabricksCredentials =
+                {
+                    ...completeDatabricksCredentials,
+                    serverHostName: 'https://ADB-123.AZUREDATABRICKS.NET/',
+                    oauthClientId: undefined,
+                    oauthClientSecret: undefined,
+                };
+
+            const result = ProjectModel.mergeMissingWarehouseSecrets(
+                incompleteDatabricksCredentials,
+                completeDatabricksCredentials,
+            );
+
+            expect(result.oauthClientId).toEqual('client-id');
+            expect(result.oauthClientSecret).toEqual('client-secret');
         });
     });
 

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -64,6 +64,7 @@ import NodeCache from 'node-cache';
 import { DatabaseError } from 'pg';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashConfig } from '../../config/parseConfig';
+import { normalizeDatabricksHostLenient } from '../../controllers/authentication/strategies/databricksStrategy';
 import {
     DashboardsTableName,
     DashboardTabsTableName,
@@ -233,6 +234,16 @@ export class ProjectModel {
             (incompleteConfig.type === WarehouseTypes.ATHENA &&
                 incompleteConfig.authenticationType ===
                     AthenaAuthenticationType.IAM_ROLE)
+        ) {
+            return incompleteConfig;
+        }
+        // Databricks secrets are only valid for the host they were entered
+        // for, so a host change requires re-entering them instead of merging
+        if (
+            incompleteConfig.type === WarehouseTypes.DATABRICKS &&
+            completeConfig.type === WarehouseTypes.DATABRICKS &&
+            normalizeDatabricksHostLenient(incompleteConfig.serverHostName) !==
+                normalizeDatabricksHostLenient(completeConfig.serverHostName)
         ) {
             return incompleteConfig;
         }


### PR DESCRIPTION
Stored Databricks warehouse secrets are no longer merged into an updated project configuration when the serverHostName differs from the saved one, so a host change now requires re-entering the credentials.

Linear: SPK-572