### PR TITLE
fix: allow service accounts to apply space-as-code

### DIFF
--- a/packages/backend/src/models/SpaceModel.test.ts
+++ b/packages/backend/src/models/SpaceModel.test.ts
@@ -672,6 +672,7 @@ describe('SpaceModel space access as code', () => {
                     roleUuid: 'group-role-uuid',
                 },
             ],
+            isActive: false,
             isInternal: true,
         });
         const beforeMutation = vi.fn(async () => {
@@ -766,6 +767,7 @@ describe('SpaceModel space access as code', () => {
             )
             .responseOnce({ parentSpaceUuid: null });
         mockAuthorizationSources({
+            isActive: false,
             isInternal: true,
             serviceAccountExists: false,
         });

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -301,7 +301,9 @@ export class SpaceModel {
         if (actor === undefined) {
             throw new ForbiddenError('The authenticated user no longer exists');
         }
-        if (!actor.isActive) {
+        // Service-account users are always inactive by design; their
+        // liveness is rechecked against the service_accounts row below.
+        if (serviceAccountUuid === null && !actor.isActive) {
             throw new ForbiddenError(
                 'The authenticated user is no longer active',
             );

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -1290,7 +1290,12 @@ export class CoderService extends BaseService {
                         project.organizationUuid,
                         { trx },
                     );
-                if (!reloadedUser.isActive) {
+                // Service-account users are always inactive by design;
+                // applySpaceAsCode rechecks the service_accounts row instead.
+                if (
+                    account.authentication.type !== 'service-account' &&
+                    !reloadedUser.isActive
+                ) {
                     throw new ForbiddenError(
                         'The authenticated user is no longer active',
                     );


### PR DESCRIPTION
## Description

Applying space-as-code (`.space.yml`) with a service account token always failed with `ForbiddenError: The authenticated user is no longer active`, breaking CI pipelines that authenticate with a service account.

Service accounts are backed by an internal `users` row that is intentionally created with `is_active: false`. The mid-transaction actor recheck introduced in #25627 asserted `isActive` unconditionally — in both `SpaceModel.lockActorAuthorizationSources` and `CoderService.upsertSpace`'s `beforeMutation` hook — so it rejected every service-account actor before ever reaching the service-account identity checks below it.

## Fix

- Only enforce the `isActive` assertion for human actors (`serviceAccountUuid === null` / non-service-account auth). The equivalent liveness recheck for service accounts (the `service_accounts` row still exists, matches the user and org, locked `forShare` in the same transaction) already existed and is unchanged, so the TOCTOU protection is preserved.
- Updated the existing service-account tests to mock the actor as inactive, matching how service-account user rows actually exist in the database — the lock-order test now guards against this regression.

Closes: PROD-9009
Closes: #25783

🤖 Generated with [Claude Code](https://claude.com/claude-code)