### PR TITLE
fix: show data app Duplicate to users with create but not manage rights

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -1076,11 +1076,19 @@ The space columns assume the user is also at least an interactive viewer at the 
 | View someone else's personal app          | ✓             | —                  | —            | —                                 |
 | Create a new app                          | ✓             | ✓                  | ✗            | n/a                               |
 | Iterate / cancel / update / move / delete | ✓             | ✓ (in their space) | ✗            | ✓ (own personal app)              |
+| Duplicate                                 | ✓             | ✓                  | ✗            | ✓                                 |
 | Pin to homepage                           | ✓             | ✓ (in their space) | ✗            | — (personal apps can't be pinned) |
 | Restore / permanently delete              | ✓             | ✗                  | ✗            | ✗                                 |
 
 The "App creator" column applies while an app is still personal (`space_uuid IS NULL`). Once moved into a space, the
 app's permissions follow the space — the creator no longer has special rights unless they also have a space role.
+
+**Duplicate is deliberately looser than the other mutations.** It doesn't modify the source app — it forks the latest
+ready version into a **new personal app owned by the caller** — so `duplicateApp` requires only `view` on the source
+plus project-wide `create:DataApp`, not `manage`. A project editor who can see an app shared project-wide (or sitting
+in a space where they're only a viewer) can fork it into their own space to iterate on. Both frontend surfaces that
+offer the action gate it the same way — `useCanCreateDataApp` in `AppHeaderActions`, and `canDuplicateDataApp` in
+`ResourceActionMenu` (the browse list), where it is the one action a user without manage rights can still see.
 
 ### Implementation
 

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -268,9 +268,47 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
             return assertUnreachable(item, 'Resource type not supported');
     }
 
-    if (!userCanManage && !favoritesContext) {
+    // Duplicating a data app forks it into the user's own personal app, so the
+    // backend only asks for view access plus `create:DataApp` — not manage
+    // rights on the source app.
+    const canDuplicateDataApp =
+        item.type === ResourceViewItemType.DATA_APP &&
+        user.data?.ability?.can(
+            'create',
+            subject('DataApp', {
+                organizationUuid,
+                projectUuid,
+            }),
+        ) === true;
+
+    if (!userCanManage && !canDuplicateDataApp && !favoritesContext) {
         return null;
     }
+
+    // Apps duplicate synchronously via a direct mutation; charts and dashboards
+    // open a modal that lets the user pick a name/space first.
+    const duplicateDataAppMenuItem = (
+        <Menu.Item
+            component="button"
+            role="menuitem"
+            leftSection={<MantineIcon icon={IconCopy} size={18} />}
+            onClick={() => {
+                if (!projectUuid) return;
+                duplicateApp(
+                    { projectUuid, appUuid: item.data.uuid },
+                    {
+                        onSuccess: ({ appUuid: newAppUuid }) => {
+                            void navigate(
+                                `/projects/${projectUuid}/apps/${newAppUuid}`,
+                            );
+                        },
+                    },
+                );
+            }}
+        >
+            Duplicate
+        </Menu.Item>
+    );
 
     return (
         <>
@@ -346,7 +384,13 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                         </>
                     )}
 
-                    {userCanManage && favoritesContext && <Menu.Divider />}
+                    {(userCanManage || canDuplicateDataApp) &&
+                        favoritesContext && <Menu.Divider />}
+
+                    {/* A user who can't manage the app can still fork it. */}
+                    {!userCanManage &&
+                        canDuplicateDataApp &&
+                        duplicateDataAppMenuItem}
 
                     {userCanManage && (
                         <>
@@ -388,9 +432,11 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                     : 'Rename'}
                             </Menu.Item>
 
+                            {canDuplicateDataApp
+                                ? duplicateDataAppMenuItem
+                                : null}
                             {item.type === ResourceViewItemType.CHART ||
-                            item.type === ResourceViewItemType.DASHBOARD ||
-                            item.type === ResourceViewItemType.DATA_APP ? (
+                            item.type === ResourceViewItemType.DASHBOARD ? (
                                 <Menu.Item
                                     component="button"
                                     role="menuitem"
@@ -401,32 +447,6 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                         />
                                     }
                                     onClick={() => {
-                                        // Data apps are duplicated synchronously
-                                        // with a direct mutation; charts and
-                                        // dashboards open a modal that lets the
-                                        // user pick a name/space first.
-                                        if (
-                                            item.type ===
-                                            ResourceViewItemType.DATA_APP
-                                        ) {
-                                            if (!projectUuid) return;
-                                            duplicateApp(
-                                                {
-                                                    projectUuid,
-                                                    appUuid: item.data.uuid,
-                                                },
-                                                {
-                                                    onSuccess: ({
-                                                        appUuid: newAppUuid,
-                                                    }) => {
-                                                        void navigate(
-                                                            `/projects/${projectUuid}/apps/${newAppUuid}`,
-                                                        );
-                                                    },
-                                                },
-                                            );
-                                            return;
-                                        }
                                         onAction({
                                             type: ResourceViewItemAction.DUPLICATE,
                                             item,

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -24,6 +24,7 @@ import AppUpdateModal from '../../../components/common/modal/AppUpdateModal';
 import { useProject } from '../../../hooks/useProject';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { AppSchedulersModal } from '../../scheduler/components/SchedulerModals';
+import { useCanCreateDataApp } from '../hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../hooks/useCanEditDataApp';
 import { useDuplicateApp } from '../hooks/useDuplicateApp';
 import {
@@ -62,7 +63,8 @@ type Props = {
  * the same actions; the only per-surface difference is `navItem`.
  *
  * Edit-actions are gated by `useCanEditDataApp`, because the viewer can be
- * opened by users without manage rights.
+ * opened by users without manage rights. Duplicate is the exception — it forks
+ * the app into a personal copy, so it only needs `useCanCreateDataApp`.
  */
 const AppHeaderActions: FC<Props> = ({
     projectUuid,
@@ -85,6 +87,10 @@ const AppHeaderActions: FC<Props> = ({
         spaceUuid: appSpaceUuid,
         createdByUserUuid: appCreatedByUserUuid,
     });
+
+    // Duplicating forks the app into the user's own personal app, so it only
+    // needs `create:DataApp` — not manage rights on this app.
+    const canDuplicate = useCanCreateDataApp(projectUuid);
 
     const scheduledDeliveriesFlag = useServerFeatureFlag(
         FeatureFlags.DataAppsScheduledDeliveries,
@@ -182,26 +188,30 @@ const AppHeaderActions: FC<Props> = ({
                             Schedule delivery
                         </Menu.Item>
                     )}
+                    {(canEdit || canDuplicate) && <Menu.Divider />}
+                    {canEdit && (
+                        <Menu.Item
+                            leftSection={
+                                <MantineIcon icon={IconEdit} size={14} />
+                            }
+                            onClick={() => setIsUpdateModalOpen(true)}
+                        >
+                            Rename
+                        </Menu.Item>
+                    )}
+                    {canDuplicate && (
+                        <Menu.Item
+                            leftSection={
+                                <MantineIcon icon={IconCopy} size={14} />
+                            }
+                            disabled={isDuplicating}
+                            onClick={handleDuplicate}
+                        >
+                            Duplicate
+                        </Menu.Item>
+                    )}
                     {canEdit && (
                         <>
-                            <Menu.Divider />
-                            <Menu.Item
-                                leftSection={
-                                    <MantineIcon icon={IconEdit} size={14} />
-                                }
-                                onClick={() => setIsUpdateModalOpen(true)}
-                            >
-                                Rename
-                            </Menu.Item>
-                            <Menu.Item
-                                leftSection={
-                                    <MantineIcon icon={IconCopy} size={14} />
-                                }
-                                disabled={isDuplicating}
-                                onClick={handleDuplicate}
-                            >
-                                Duplicate
-                            </Menu.Item>
                             <Menu.Item
                                 leftSection={
                                     <MantineIcon

--- a/packages/frontend/src/features/apps/hooks/useCanCreateDataApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useCanCreateDataApp.ts
@@ -1,0 +1,28 @@
+import { subject } from '@casl/ability';
+import { useMemo } from 'react';
+import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
+import useApp from '../../../providers/App/useApp';
+
+/**
+ * Whether the current user can author new data apps in a project. Unlike
+ * `useCanEditDataApp` this is project-wide — `create:DataApp` carries no space
+ * or ownership context — so it also gates duplicating someone else's app,
+ * which forks it into the user's own personal app.
+ */
+export const useCanCreateDataApp = (
+    projectUuid: string | undefined,
+): boolean => {
+    const ability = useAbilityContext();
+    const { user } = useApp();
+
+    return useMemo(() => {
+        if (!projectUuid) return false;
+        return ability.can(
+            'create',
+            subject('DataApp', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+            }),
+        );
+    }, [ability, user.data?.organizationUuid, projectUuid]);
+};


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8859/data-app-duplicate-action-hidden-from-editors-who-dont-have-manage

### Description:
Duplicating a data app forks it into the caller's own personal app, so the backend only requires view on the source plus project-wide `create:DataApp`. Both frontend surfaces gated the action on `manage:DataApp` instead, hiding it from project editors who can view an app but don't own it or hold space editor/admin on its space.

Gate Duplicate on the new `useCanCreateDataApp` in the app header, and on an equivalent check in the browse list — where the whole action menu previously collapsed to nothing for those users.

The manage-path data-app Duplicate is now gated on create as well, so a custom role holding manage without create is no longer shown an action the backend rejects.
