### PR TITLE
test: true TIMESTAMP_NTZ timezone_test seed column on Databricks

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/data/seeds.yml
+++ b/examples/full-jaffle-shop-demo/dbt/data/seeds.yml
@@ -3,6 +3,10 @@ version: 2
 seeds:
   - name: raw_timezone_test
     config:
+      # Delta gates TIMESTAMP_NTZ behind a table feature; non-Databricks
+      # adapters ignore tblproperties.
+      tblproperties:
+        delta.feature.timestampNtz: supported
       column_types:
         event_timestamp: >-
           {%- if target.type == 'snowflake' -%}
@@ -18,6 +22,8 @@ seeds:
           {%- endif -%}
         event_timestamp_ntz: >-
           {%- if target.type == 'snowflake' -%}
+            timestamp_ntz
+          {%- elif target.type in ['databricks', 'spark'] -%}
             timestamp_ntz
           {%- elif target.type == 'clickhouse' -%}
             DateTime64(3)

--- a/examples/full-jaffle-shop-demo/dbt/models/timezone_test.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/timezone_test.yml
@@ -24,6 +24,11 @@ models:
       continuous monthly axis that crosses both DST transitions (Mar 10 spring
       forward, Nov 3 fall back). Used to exercise the cartesian category date
       axis snap for non-UTC DST timezones.
+    config:
+      # Delta gates TIMESTAMP_NTZ behind a table feature; non-Databricks
+      # adapters ignore tblproperties.
+      tblproperties:
+        delta.feature.timestampNtz: supported
     meta:
       group_label: timezones
     columns:
@@ -77,8 +82,13 @@ models:
             ]
       - name: event_timestamp_ntz
         description: >
-          Snowflake only. Same events as event_timestamp cast to TIMESTAMP_NTZ
-          (timezone info stripped). Use with dataTimezone to test NTZ handling.
+          Naive (timezone-less) variant of event_timestamp — the column under
+          test for data-timezone handling. Stores the same wall clocks with the
+          zone stripped, typed per warehouse via seeds.yml: timestamp
+          (Postgres/Redshift/DuckDB/Trino/Athena), DATETIME (BigQuery),
+          TIMESTAMP_NTZ (Snowflake, Databricks, Spark). ClickHouse has no naive
+          type, so there it stays an instant (DateTime64(3)) and data-timezone
+          rebasing does not apply. Use with dataTimezone to test naive handling.
         meta:
           dimension:
             type: timestamp


### PR DESCRIPTION
## Why

Databricks' bare `timestamp` type is an instant (aware), so the `event_timestamp_ntz` seed column fell through to the aware type there and naive timestamp handling was untestable on Databricks. Every other warehouse already gets a real naive type from `seeds.yml` (Postgres/Trino `timestamp`, BigQuery `DATETIME`, Snowflake `TIMESTAMP_NTZ`). This is the test-bench prerequisite for the naive-timestamps correctness work: the detection matrix needs a Databricks column that is actually naive.

## What

- `seeds.yml`: `event_timestamp_ntz` becomes `timestamp_ntz` on `databricks`/`spark` targets
- Delta gates `TIMESTAMP_NTZ` behind a per-table feature, so the seed and the `timezone_test` model both set `tblproperties: delta.feature.timestampNtz: supported`. Other adapters ignore `tblproperties` and the type branch is target-scoped, so no other warehouse's DDL changes.
- Refreshed the stale "Snowflake only" description of the column

## Verification

Reseeded the staging Databricks project and checked live:

- both tables report `TIMESTAMP_NTZ` for `event_timestamp_ntz`
- wall clocks load unshifted (event 1 = `2024-01-15 02:00:00`, aware control unchanged)
- `to_utc_timestamp(event_timestamp_ntz, 'Asia/Tokyo')` returns `2024-01-14T17:00Z`, so the explicit rebase primitive is now testable on a real naive column

Needs Databricks Runtime 13.3+ / a Delta client with the `timestampNtz` feature. Only the two timezone test-bench tables are affected.

Closes: GLITCH-619
