### PR TITLE
chore(devx): persist local MinIO bucket contents

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -97,6 +97,8 @@ MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin
 MINIO_DEFAULT_BUCKETS=default,results,lightdash-apps
 MINIO_BROWSER=on
+# Auto-delete bucket objects after N days. 0 keeps them forever.
+MINIO_EXPIRATION_DAYS=0
 
 # S3 Configuration
 S3_ENDPOINT=http://minio:9000

--- a/docker/docker-compose.dev.mini.yml
+++ b/docker/docker-compose.dev.mini.yml
@@ -13,8 +13,9 @@ services:
             - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
             - MINIO_DEFAULT_BUCKETS=${MINIO_DEFAULT_BUCKETS}
             - MINIO_BROWSER=${MINIO_BROWSER:-off}
+            - MINIO_EXPIRATION_DAYS=${MINIO_EXPIRATION_DAYS:-1}
         volumes:
-            - minio_data:/minio/data
+            - minio_data:/data
             - ./init-minio.sh:/init-minio.sh
         entrypoint: '/init-minio.sh'
 

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -1,5 +1,6 @@
 volumes:
     postgres_data:
+    minio_data:
 
 services:
     minio:
@@ -9,6 +10,7 @@ services:
             - '9000:9000'
             - '9001:9001' # for minio console
         volumes:
+            - minio_data:/data
             - ./init-minio.sh:/init-minio.sh
         entrypoint: '/init-minio.sh'
         environment:
@@ -16,6 +18,7 @@ services:
             - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
             - MINIO_DEFAULT_BUCKETS=${MINIO_DEFAULT_BUCKETS}
             - MINIO_BROWSER=${MINIO_BROWSER:-off}
+            - MINIO_EXPIRATION_DAYS=${MINIO_EXPIRATION_DAYS:-1}
 
     db-dev:
         image: pgvector/pgvector:pg18

--- a/docker/init-minio.sh
+++ b/docker/init-minio.sh
@@ -18,13 +18,16 @@ for bucket in $MINIO_DEFAULT_BUCKETS; do
     if ! mc mb -p local/"$bucket" 2>/dev/null; then
       echo "Bucket '$bucket' already exists or could not be created"
     fi
-    
+
     # Configure lifecycle policy to auto-delete files after MINIO_EXPIRATION_DAYS days (default: 1 day)
     EXPIRATION_DAYS="${MINIO_EXPIRATION_DAYS:-1}"
+    mc ilm rule rm --all --force local/"$bucket" 2>/dev/null || true
     if [ "$EXPIRATION_DAYS" -gt 0 ] 2>/dev/null; then
       echo "Setting lifecycle policy for bucket '$bucket': expire after $EXPIRATION_DAYS day(s)"
       mc ilm rule add --expire-days "$EXPIRATION_DAYS" local/"$bucket" 2>/dev/null || \
-        echo "Could not set lifecycle policy for bucket '$bucket' (may already exist)"
+        echo "Could not set lifecycle policy for bucket '$bucket'"
+    else
+      echo "Lifecycle expiration disabled for bucket '$bucket'"
     fi
   fi
 done


### PR DESCRIPTION
### Description:
Local MinIO objects disappeared overnight. The cause was the lifecycle policy in init-minio.sh, which defaults to expiring objects after 1 day and was never overridden in the dev env.
This is especially annoying when working with data apps, since you might want to persist them for much longer than a day when working on a large project, as re-creating them takes time.
