### PR TITLE
feat: seed data app in-app state from shareable URLs

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -214,6 +214,56 @@ boolean to `true` on the first refresh and forwards it through `AppIframePreview
 so the initial page load can still serve cached results fast; once you've asked for a refresh, every subsequent query
 runs against the warehouse fresh. (This mirrors the sticky behaviour of the dashboard tile below.)
 
+### Shareable URL state
+
+A data app's own interactive controls (period selectors, tabs, global filters) can round-trip their state through the
+**host page's URL**, so the address bar is always a shareable link to the current view: a colleague opening the link
+lands on the app with the same in-app state applied. Tracked in
+[PROD-8151](https://linear.app/lightdash/issue/PROD-8151).
+
+State is a single keyed map — each control owns a key with a JSON-serializable value, ≤ 4 KB serialized for the whole
+map — carried in one `?state=` query param on the host page. Two directions, no backend involvement:
+
+- **Seed (URL → app).** The validated `?state=` param is appended to the iframe hash
+  (`#transport=postMessage&projectUuid=…&state=<encoded>`). The SDK reads it synchronously at boot, so the app's
+  initial render and queries already use the seeded state — no flash of default state, no handshake race. The
+  appended value is re-latched **only when the iframe `src` changes for other reasons** (manual refresh, a new build
+  version, a token refetch), so reloads keep the current view without state changes reloading the app on every click.
+- **Write-back (app → URL).** The SDK's `useUrlState(key, default)` hook posts a `lightdash:sdk:url-state-change`
+  message to the parent immediately — the host must always hold the latest state so reloads can re-seed it.
+  `useAppSdkBridge` validates the payload (plain object, under the size cap; rejections log a console warning) and
+  the host updates in memory at once, debouncing only the `history.replaceState` URL write.
+
+State is **tagged with the app it came from**: when the builder switches preview apps, the previous app's state
+neither seeds the new app nor lingers in the page URL.
+
+The pre-installed template filter context (`lib/filters.tsx`, `useGlobalFilters`) stores its filters in
+`useUrlState('globalFilters')`, so **global filter selections are shareable with no effort from the generation agent**.
+Seeded values come from a user-editable URL and are treated as untrusted: the SDK drops non-object garbage at the map
+level, the filter provider sanitizes each filter's shape so malformed entries can't fail every query for an explore,
+and the skill instructs generated apps to validate individual values before use.
+
+Host opt-in is a single `urlStateSync` flag on `AppIframePreview`, which owns both halves internally via the
+`useAppUrlStateSync` hook — a host can't accidentally wire write-back without seeding or vice versa:
+
+| Host | URL state | Notes |
+| --- | --- | --- |
+| `AppPreviewTest` (`/view` routes) | ✓ | Primary share surface |
+| `AppGenerate` (builder) | ✓ | Authors can test shareable links |
+| `EmbedApp` (full-page embed) | ✓ | The embed page's own URL carries `?state=` |
+| Dashboard tiles, `MinimalApp`, viz renderer | ✗ | Tiles need per-tile key namespacing (multiple apps share one URL) — out of scope for now |
+
+Compatibility: old bundles never read the hash param or post the message — hosts' changes are inert for them. New
+bundles in non-opted hosts get in-memory state only (the change message is ignored). Existing apps pick up the
+auto-persisted global filters only after an iteration in a **fresh** sandbox with the current template *and* only if
+their restored source's `lib/filters.tsx` is updated — template files live in the app's own `src/` tree and are
+restored as-is from the source tarball.
+
+Key files: `packages/query-sdk/src/urlState.ts` (SDK side),
+`packages/frontend/src/features/apps/hooks/useAppUrlStateSync.ts` (host side),
+`sandboxes/data-apps/template/src/lib/filters.tsx` (global-filter persistence). Keep the "Shareable URL state" section
+of `sandboxes/data-apps/template/skill.md` in sync with this one.
+
 ### Manual app thumbnails
 
 The builder's Screenshot button uses the iframe-side screenshot handler (`screenshotHandler.js`) to rasterize the current

--- a/packages/frontend/src/ee/features/embed/EmbedApp/components/EmbedApp.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedApp/components/EmbedApp.tsx
@@ -55,6 +55,7 @@ const EmbedApp: FC<Props> = ({ appUuid, projectUuid }) => {
                     appUuid={appUuid}
                     identityKey={`${appUuid}:${tokenQuery.data!.version}`}
                     dashboardFilters={undefined}
+                    urlStateSync
                 />
             )}
         </Box>

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -7,6 +7,7 @@ import {
     useCallback,
     useEffect,
     useImperativeHandle,
+    useMemo,
     useRef,
 } from 'react';
 import {
@@ -15,6 +16,7 @@ import {
     type ExternalRequestEvent,
     type QueryEvent,
 } from './hooks/useAppSdkBridge';
+import { useAppUrlStateSync } from './hooks/useAppUrlStateSync';
 import { useIframeScreenshot } from './hooks/useIframeScreenshot';
 
 export type AppIframePreviewHandle = {
@@ -91,6 +93,10 @@ type Props = {
     // Render context for data app vizs: the field mapping + host rows, pushed
     // into the iframe over the SDK bridge. Undefined for ordinary data apps.
     dataAppVizContext?: DataAppVizContext;
+    // Round-trip the app's `useUrlState` controls through the page's `?state=`
+    // param. Leave unset where the page URL isn't the app's share surface
+    // (dashboard tiles, screenshots).
+    urlStateSync?: boolean;
 };
 
 /**
@@ -139,10 +145,22 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             onIframeLoad,
             capabilities,
             dataAppVizContext,
+            urlStateSync,
         },
         ref,
     ) => {
         const iframeRef = useRef<HTMLIFrameElement>(null);
+        const { applySeed, handleUrlStateChange } = useAppUrlStateSync({
+            appUuid,
+            enabled: urlStateSync === true,
+        });
+        // Memoized on `src`: the seed is re-latched exactly when the iframe
+        // would reload anyway (refresh counter, version bump, token refetch),
+        // never on state changes alone — that would reload per filter click.
+        const effectiveSrc = useMemo(
+            () => (urlStateSync ? applySeed(src) : src),
+            [urlStateSync, applySeed, src],
+        );
         // Memoized so the bridge's message listener doesn't re-attach on every
         // parent render — AppGenerate re-renders on every keystroke (editor's
         // `onUpdate` → `setIsPromptEmpty`) and we don't want to thrash listeners.
@@ -178,6 +196,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             onLineageSelected,
             onExternalRequestEvent,
             dataAppVizContext,
+            onUrlStateChange: urlStateSync ? handleUrlStateChange : undefined,
         });
         const { captureScreenshot } = useIframeScreenshot(iframeRef);
 
@@ -253,7 +272,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
         return (
             <iframe
                 ref={iframeRef}
-                src={src}
+                src={effectiveSrc}
                 style={{ width: '100%', height: '100%', border: 'none' }}
                 title="App preview"
                 sandbox="allow-scripts allow-modals allow-downloads allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -466,6 +466,73 @@ describe('lineage message routing', () => {
     });
 });
 
+describe('url-state-change routing', () => {
+    beforeEach(() => {
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    function renderUrlStateBridge(onUrlStateChange?: Mock) {
+        const iframeRef = {
+            current: { contentWindow: window } as unknown as HTMLIFrameElement,
+        } as RefObject<HTMLIFrameElement | null>;
+        renderHook(() =>
+            useAppSdkBridge({
+                iframeRef,
+                expectedPreviewOrigin: window.location.origin,
+                projectUuid: PROJECT_UUID,
+                appUuid: APP_UUID,
+                onUrlStateChange,
+            }),
+        );
+    }
+
+    it('forwards a valid state map to onUrlStateChange', () => {
+        const onUrlStateChange = vi.fn();
+        renderUrlStateBridge(onUrlStateChange);
+
+        dispatchFetchMessage({
+            type: 'lightdash:sdk:url-state-change',
+            state: { period: 'last_month', globalFilters: [] },
+        });
+
+        expect(onUrlStateChange).toHaveBeenCalledWith({
+            period: 'last_month',
+            globalFilters: [],
+        });
+    });
+
+    it('drops non-object state payloads', () => {
+        const onUrlStateChange = vi.fn();
+        renderUrlStateBridge(onUrlStateChange);
+
+        for (const state of [null, undefined, 'str', 42, ['a']]) {
+            dispatchFetchMessage({
+                type: 'lightdash:sdk:url-state-change',
+                state,
+            });
+        }
+
+        expect(onUrlStateChange).not.toHaveBeenCalled();
+    });
+
+    it('drops state maps over the serialized size cap', () => {
+        const onUrlStateChange = vi.fn();
+        renderUrlStateBridge(onUrlStateChange);
+
+        dispatchFetchMessage({
+            type: 'lightdash:sdk:url-state-change',
+            state: { big: 'x'.repeat(5000) },
+        });
+
+        expect(onUrlStateChange).not.toHaveBeenCalled();
+    });
+});
+
 describe('chart-query routing', () => {
     beforeEach(() => {
         vi.stubGlobal('fetch', vi.fn());

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -146,6 +146,10 @@ function isAllowedRoute(method: string, path: string): boolean {
     );
 }
 
+// Keep in sync with MAX_URL_STATE_CHARS in packages/query-sdk/src/urlState.ts.
+// Caps what an app can push into the host page's URL / browser history.
+const MAX_URL_STATE_CHARS = 4096;
+
 const isMetricQueryPost = (method: string, path: string): boolean =>
     method.toUpperCase() === 'POST' &&
     /^\/api\/v2\/projects\/[^/]+\/query\/metric-query$/.test(path);
@@ -237,6 +241,9 @@ export type UseAppSdkBridgeParams = {
     // When set, the host pushes this render context into the iframe over the
     // existing bridge — on load and on every change. Only set for data app vizs.
     dataAppVizContext?: DataAppVizContext;
+    // When set, `lightdash:sdk:url-state-change` messages from the iframe SDK
+    // are validated and forwarded. Left undefined, they're ignored.
+    onUrlStateChange?: (state: Record<string, unknown>) => void;
 };
 
 export function useAppSdkBridge({
@@ -255,6 +262,7 @@ export function useAppSdkBridge({
     onLineageSelected,
     onExternalRequestEvent,
     dataAppVizContext,
+    onUrlStateChange,
 }: UseAppSdkBridgeParams) {
     // Embed mode adapts the bridge's outgoing fetches in two ways:
     //   - Attaches the embed JWT header in lieu of session cookies
@@ -337,6 +345,36 @@ export function useAppSdkBridge({
 
             if (data?.type === 'lightdash:lineage:available') {
                 onLineageAvailable?.();
+                return;
+            }
+
+            if (data?.type === 'lightdash:sdk:url-state-change') {
+                if (!onUrlStateChange) return;
+                const state: unknown = data.state;
+                // Untrusted app payload: accept only a plain object under the
+                // size cap, and warn — a silent drop looks like a broken URL.
+                const reject = (reason: string) =>
+                    console.warn(
+                        `[lightdash] Ignoring app URL state update: ${reason}`,
+                    );
+                if (
+                    typeof state !== 'object' ||
+                    state === null ||
+                    Array.isArray(state)
+                ) {
+                    reject('not a plain object');
+                    return;
+                }
+                try {
+                    if (JSON.stringify(state).length > MAX_URL_STATE_CHARS) {
+                        reject(`over ${MAX_URL_STATE_CHARS} chars serialized`);
+                        return;
+                    }
+                } catch {
+                    reject('not JSON-serializable');
+                    return;
+                }
+                onUrlStateChange(state as Record<string, unknown>);
                 return;
             }
 
@@ -851,6 +889,7 @@ export function useAppSdkBridge({
             onLineageSelected,
             onExternalRequestEvent,
             pushDataAppVizContext,
+            onUrlStateChange,
             health.data,
             user.data,
         ],

--- a/packages/frontend/src/features/apps/hooks/useAppUrlStateSync.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppUrlStateSync.test.ts
@@ -1,0 +1,119 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAppUrlStateSync } from './useAppUrlStateSync';
+
+const BASE_URL =
+    'https://preview.example/api/apps/a/versions/1/t/tok/#transport=postMessage&projectUuid=p';
+const APP_A = 'app-aaaa';
+const APP_B = 'app-bbbb';
+
+const setPageUrl = (search: string) => {
+    window.history.replaceState(null, '', `/view${search}`);
+};
+
+const currentStateParam = () =>
+    new URLSearchParams(window.location.search).get('state');
+
+function render(appUuid: string = APP_A) {
+    return renderHook(
+        (props: { appUuid: string }) =>
+            useAppUrlStateSync({ appUuid: props.appUuid, enabled: true }),
+        { initialProps: { appUuid } },
+    );
+}
+
+describe('useAppUrlStateSync', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        setPageUrl('');
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('seeds applySeed from a valid ?state= param', () => {
+        const encoded = JSON.stringify({ period: 'ytd' });
+        setPageUrl(`?state=${encodeURIComponent(encoded)}`);
+        const { result } = render();
+        expect(result.current.applySeed(BASE_URL)).toBe(
+            `${BASE_URL}&state=${encodeURIComponent(encoded)}`,
+        );
+    });
+
+    it('ignores garbage, non-object, and oversized seeds', () => {
+        for (const raw of [
+            'not-json',
+            '[1,2]',
+            '42',
+            JSON.stringify({ big: 'x'.repeat(5000) }),
+        ]) {
+            setPageUrl(`?state=${encodeURIComponent(raw)}`);
+            const { result, unmount } = render();
+            expect(result.current.applySeed(BASE_URL)).toBe(BASE_URL);
+            unmount();
+        }
+    });
+
+    it('updates applySeed immediately on a state change, before the URL write fires', () => {
+        const { result } = render();
+        act(() => {
+            result.current.handleUrlStateChange({ period: 'last_7_days' });
+        });
+        // No timer advance: a reload right after the change must still seed it.
+        expect(result.current.applySeed(BASE_URL)).toBe(
+            `${BASE_URL}&state=${encodeURIComponent(
+                JSON.stringify({ period: 'last_7_days' }),
+            )}`,
+        );
+        expect(currentStateParam()).toBeNull();
+    });
+
+    it('debounces the URL write and keeps only the latest state', () => {
+        const { result } = render();
+        act(() => {
+            result.current.handleUrlStateChange({ period: 'ytd' });
+            result.current.handleUrlStateChange({ period: 'last_7_days' });
+        });
+        expect(currentStateParam()).toBeNull();
+        act(() => {
+            vi.advanceTimersByTime(300);
+        });
+        expect(currentStateParam()).toBe(
+            JSON.stringify({ period: 'last_7_days' }),
+        );
+    });
+
+    it('removes the ?state= param when the app reports an empty map', () => {
+        setPageUrl(`?state=${encodeURIComponent('{"period":"ytd"}')}`);
+        const { result } = render();
+        act(() => {
+            result.current.handleUrlStateChange({});
+            vi.advanceTimersByTime(300);
+        });
+        expect(currentStateParam()).toBeNull();
+        expect(result.current.applySeed(BASE_URL)).toBe(BASE_URL);
+    });
+
+    it('drops the previous app state and clears the URL on app switch', () => {
+        setPageUrl(`?state=${encodeURIComponent('{"period":"ytd"}')}`);
+        const { result, rerender } = render(APP_A);
+        expect(result.current.applySeed(BASE_URL)).not.toBe(BASE_URL);
+
+        rerender({ appUuid: APP_B });
+        expect(result.current.applySeed(BASE_URL)).toBe(BASE_URL);
+        expect(currentStateParam()).toBeNull();
+    });
+
+    it('cancels a pending URL write on unmount', () => {
+        const { result, unmount } = render();
+        act(() => {
+            result.current.handleUrlStateChange({ period: 'ytd' });
+        });
+        unmount();
+        act(() => {
+            vi.advanceTimersByTime(300);
+        });
+        expect(currentStateParam()).toBeNull();
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/useAppUrlStateSync.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppUrlStateSync.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+const URL_STATE_PARAM = 'state';
+
+// Keep in sync with MAX_URL_STATE_CHARS in packages/query-sdk/src/urlState.ts
+// and useAppSdkBridge. Applied on BOTH directions: the write-back cap bounds
+// what an app can push into browser history, and the seed cap keeps a crafted
+// ?state= from inflating the iframe URL past browser limits.
+const MAX_URL_STATE_CHARS = 4096;
+
+// Rate-limits history.replaceState (Safari throttles ~100 writes/30s). Only
+// the URL write is debounced — the in-memory latest state updates on every
+// change so iframe reloads always re-seed the current view.
+const URL_WRITE_DEBOUNCE_MS = 300;
+
+/** The page's ?state= param, or null when absent/oversized/not a JSON map. */
+const readValidatedSeed = (): string | null => {
+    const raw = new URLSearchParams(window.location.search).get(
+        URL_STATE_PARAM,
+    );
+    if (!raw || raw.length > MAX_URL_STATE_CHARS) return null;
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        return typeof parsed === 'object' &&
+            parsed !== null &&
+            !Array.isArray(parsed)
+            ? raw
+            : null;
+    } catch {
+        return null;
+    }
+};
+
+const writeUrlStateParam = (encoded: string | null) => {
+    const url = new URL(window.location.href);
+    if (encoded === null) {
+        url.searchParams.delete(URL_STATE_PARAM);
+    } else {
+        url.searchParams.set(URL_STATE_PARAM, encoded);
+    }
+    window.history.replaceState(window.history.state, '', url);
+};
+
+/**
+ * Host-side half of data-app shareable URL state, used by `AppIframePreview`
+ * when the host opts in via `urlStateSync`: `applySeed` appends the latest
+ * known state to the iframe URL, `handleUrlStateChange` mirrors the app's
+ * changes back into the page's `?state=`. State is tagged with the app it came
+ * from, so switching apps drops it. See docs/data-apps.md.
+ */
+export function useAppUrlStateSync({
+    appUuid,
+    enabled,
+}: {
+    appUuid: string;
+    enabled: boolean;
+}) {
+    // Latest known state, tagged with the app it belongs to. Initialized from
+    // the page URL for the app the page was opened on.
+    const stateRef = useRef<{ appUuid: string; encoded: string | null } | null>(
+        null,
+    );
+    if (enabled && stateRef.current === null) {
+        stateRef.current = { appUuid, encoded: readValidatedSeed() };
+    }
+
+    // Latest appUuid in a ref so the callbacks stay identity-stable.
+    const appUuidRef = useRef(appUuid);
+    appUuidRef.current = appUuid;
+
+    const writeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const cancelPendingWrite = useCallback(() => {
+        if (writeTimerRef.current !== null) {
+            clearTimeout(writeTimerRef.current);
+            writeTimerRef.current = null;
+        }
+    }, []);
+
+    // Cancel any pending URL write on unmount — firing after a route change
+    // would stamp ?state= onto an unrelated page's URL.
+    useEffect(() => cancelPendingWrite, [cancelPendingWrite]);
+
+    // App switch: the previous app's state no longer applies. Drop it and
+    // clear the page's ?state= so the URL doesn't claim a view of the old app.
+    useEffect(() => {
+        if (!enabled) return;
+        const current = stateRef.current;
+        if (current && current.appUuid !== appUuid) {
+            stateRef.current = { appUuid, encoded: null };
+            cancelPendingWrite();
+            writeUrlStateParam(null);
+        }
+    }, [enabled, appUuid, cancelPendingWrite]);
+
+    const handleUrlStateChange = useCallback(
+        (state: Record<string, unknown>) => {
+            // Already validated by the bridge (plain object, size-capped).
+            const encoded =
+                Object.keys(state).length > 0 ? JSON.stringify(state) : null;
+            stateRef.current = { appUuid: appUuidRef.current, encoded };
+            cancelPendingWrite();
+            writeTimerRef.current = setTimeout(() => {
+                writeTimerRef.current = null;
+                writeUrlStateParam(encoded);
+            }, URL_WRITE_DEBOUNCE_MS);
+        },
+        [cancelPendingWrite],
+    );
+
+    /** Append the latest state for this app to an iframe base URL (which must
+     *  already contain a hash fragment). Memoize on the base URL. */
+    const applySeed = useCallback((baseUrl: string): string => {
+        const current = stateRef.current;
+        const encoded =
+            current && current.appUuid === appUuidRef.current
+                ? current.encoded
+                : null;
+        return encoded
+            ? `${baseUrl}&state=${encodeURIComponent(encoded)}`
+            : baseUrl;
+    }, []);
+
+    return { applySeed, handleUrlStateChange };
+}

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -291,6 +291,7 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
                 onLineageCancelled={onLineageCancelled}
                 capabilities={{ gsheetExport: true }}
                 dataAppVizContext={dataAppVizContext}
+                urlStateSync
             />
         );
     },

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -237,6 +237,7 @@ export default function AppPreviewTest() {
                     invalidateCache={invalidateCache}
                     onQueryEvent={handleQueryEvent}
                     onExternalRequestEvent={handleExternalRequestEvent}
+                    urlStateSync
                     capabilities={{ gsheetExport: true }}
                     lineageEnabled={lineageEnabled}
                     onLineageAvailabilityChange={setLineageAvailable}

--- a/packages/query-sdk/src/index.ts
+++ b/packages/query-sdk/src/index.ts
@@ -93,3 +93,7 @@ export type {
     DataAppVizContextMessage,
     VizContextRequestMessage,
 } from './vizContext';
+
+// Shareable URL state (seeded from and written back to the host page URL)
+export { useUrlState } from './urlState';
+export type { SdkUrlStateChangeMessage, UrlStateMap } from './urlState';

--- a/packages/query-sdk/src/urlState.test.ts
+++ b/packages/query-sdk/src/urlState.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    createUrlStateStore,
+    MAX_URL_STATE_CHARS,
+    parseUrlStateSeed,
+    serializeUrlState,
+} from './urlState';
+
+describe('parseUrlStateSeed', () => {
+    const encoded = encodeURIComponent(
+        JSON.stringify({ period: 'last_month' }),
+    );
+
+    it('reads the seed from the iframe hash', () => {
+        expect(
+            parseUrlStateSeed({
+                hash: `#transport=postMessage&projectUuid=abc&state=${encoded}`,
+                search: '',
+            }),
+        ).toEqual({ period: 'last_month' });
+    });
+
+    it('falls back to the search param when the hash has no state (local dev)', () => {
+        expect(
+            parseUrlStateSeed({ hash: '', search: `?state=${encoded}` }),
+        ).toEqual({ period: 'last_month' });
+    });
+
+    it('prefers the hash over the search param', () => {
+        const other = encodeURIComponent(JSON.stringify({ period: 'ytd' }));
+        expect(
+            parseUrlStateSeed({
+                hash: `#state=${encoded}`,
+                search: `?state=${other}`,
+            }),
+        ).toEqual({ period: 'last_month' });
+    });
+
+    it('returns an empty map for an oversized raw value', () => {
+        const big = encodeURIComponent(
+            JSON.stringify({ big: 'x'.repeat(MAX_URL_STATE_CHARS) }),
+        );
+        expect(
+            parseUrlStateSeed({ hash: `#state=${big}`, search: '' }),
+        ).toEqual({});
+    });
+
+    it('returns an empty map for absent, malformed, or non-object state', () => {
+        expect(parseUrlStateSeed({ hash: '', search: '' })).toEqual({});
+        expect(
+            parseUrlStateSeed({ hash: '#state=not-json', search: '' }),
+        ).toEqual({});
+        expect(parseUrlStateSeed({ hash: '#state=42', search: '' })).toEqual(
+            {},
+        );
+        expect(
+            parseUrlStateSeed({ hash: '#state=%5B1%2C2%5D', search: '' }),
+        ).toEqual({});
+    });
+});
+
+describe('serializeUrlState', () => {
+    it('serializes a plain map', () => {
+        expect(serializeUrlState({ a: 1 })).toBe('{"a":1}');
+    });
+
+    it('returns null when over the size cap', () => {
+        const warn = vi
+            .spyOn(console, 'warn')
+            .mockImplementation(() => undefined);
+        expect(
+            serializeUrlState({ big: 'x'.repeat(MAX_URL_STATE_CHARS) }),
+        ).toBeNull();
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    it('returns null for non-JSON-serializable state', () => {
+        const warn = vi
+            .spyOn(console, 'warn')
+            .mockImplementation(() => undefined);
+        const circular: Record<string, unknown> = {};
+        circular.self = circular;
+        expect(serializeUrlState(circular)).toBeNull();
+        warn.mockRestore();
+    });
+});
+
+describe('createUrlStateStore', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('starts from the seed and updates immutably on setKey', () => {
+        const store = createUrlStateStore({
+            seed: { period: 'ytd' },
+            publish: () => undefined,
+        });
+        const before = store.getState();
+        store.setKey('tab', 'overview');
+        expect(store.getState()).toEqual({ period: 'ytd', tab: 'overview' });
+        expect(before).toEqual({ period: 'ytd' });
+    });
+
+    it('notifies subscribers on change and stops after unsubscribe', () => {
+        const store = createUrlStateStore({
+            seed: {},
+            publish: () => undefined,
+        });
+        const listener = vi.fn();
+        const unsubscribe = store.subscribe(listener);
+        store.setKey('a', 1);
+        expect(listener).toHaveBeenCalledTimes(1);
+        unsubscribe();
+        store.setKey('a', 2);
+        expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips notify and publish when the value is unchanged', () => {
+        const publish = vi.fn();
+        const store = createUrlStateStore({
+            seed: { a: 1 },
+            publish,
+            debounceMs: 10,
+        });
+        const listener = vi.fn();
+        store.subscribe(listener);
+        store.setKey('a', 1);
+        vi.advanceTimersByTime(50);
+        expect(listener).not.toHaveBeenCalled();
+        expect(publish).not.toHaveBeenCalled();
+    });
+
+    it('debounces publish to a single trailing call with the latest state', () => {
+        const publish = vi.fn();
+        const store = createUrlStateStore({
+            seed: {},
+            publish,
+            debounceMs: 10,
+        });
+        store.setKey('period', 'last_month');
+        store.setKey('period', 'ytd');
+        store.setKey('tab', 'detail');
+        expect(publish).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(10);
+        expect(publish).toHaveBeenCalledTimes(1);
+        expect(publish).toHaveBeenCalledWith({ period: 'ytd', tab: 'detail' });
+    });
+});

--- a/packages/query-sdk/src/urlState.ts
+++ b/packages/query-sdk/src/urlState.ts
@@ -1,0 +1,225 @@
+/**
+ * Shareable URL state — a keyed map of app view state that round-trips through
+ * the host page's `state` query param, so the address bar is always a link to
+ * the current view.
+ *
+ * Inside the Lightdash iframe the seed arrives synchronously in the hash
+ * (written there by the host from its own `?state=`) and changes are posted to
+ * the parent; top-level (local dev) the app reads and writes its own `?state=`.
+ * See the "Shareable URL state" section of docs/data-apps.md.
+ *
+ * Seeded values come from a user-editable URL — treat them as untrusted.
+ */
+
+import { useCallback, useRef, useSyncExternalStore } from 'react';
+
+export type UrlStateMap = Record<string, unknown>;
+
+/** Iframe → parent. The host writes `state` into its page URL. */
+export type SdkUrlStateChangeMessage = {
+    type: 'lightdash:sdk:url-state-change';
+    state: UrlStateMap;
+};
+
+export const URL_STATE_CHANGE_MESSAGE = 'lightdash:sdk:url-state-change';
+export const URL_STATE_PARAM = 'state';
+
+/** Keep in sync with the parent-side caps in useAppSdkBridge and
+ *  useAppUrlStateSync (packages/frontend). */
+export const MAX_URL_STATE_CHARS = 4096;
+
+// Coalesces same-tick setKey bursts into one publish, no more: the host
+// debounces its own URL writes and needs the latest state before any reload.
+const PUBLISH_COALESCE_MS = 0;
+
+const isPlainObject = (value: unknown): value is UrlStateMap =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * Parse the seed map. The iframe hash wins (that's where the host forwards its
+ * `?state=`); the search param is the top-level fallback.
+ */
+export function parseUrlStateSeed(location: {
+    hash: string;
+    search: string;
+}): UrlStateMap {
+    const raw =
+        new URLSearchParams(location.hash.replace(/^#/, '')).get(
+            URL_STATE_PARAM,
+        ) ?? new URLSearchParams(location.search).get(URL_STATE_PARAM);
+    if (!raw || raw.length > MAX_URL_STATE_CHARS) return {};
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        return isPlainObject(parsed) ? parsed : {};
+    } catch {
+        return {};
+    }
+}
+
+/**
+ * Serialize a state map, or null when it can't be published (non-JSON values,
+ * or over the size cap). Warns so the author sees why state stopped persisting.
+ */
+export function serializeUrlState(state: UrlStateMap): string | null {
+    let serialized: string;
+    try {
+        serialized = JSON.stringify(state);
+    } catch {
+        // eslint-disable-next-line no-console
+        console.warn(
+            '[lightdash] URL state must be JSON-serializable — not publishing',
+        );
+        return null;
+    }
+    if (serialized.length > MAX_URL_STATE_CHARS) {
+        // eslint-disable-next-line no-console
+        console.warn(
+            `[lightdash] URL state exceeds ${MAX_URL_STATE_CHARS} chars serialized — not publishing`,
+        );
+        return null;
+    }
+    return serialized;
+}
+
+// Latched once: app code may later mutate the hash (anchor links, hash
+// routing), and the delivery mode must not flip mid-session.
+let postMessageModeCache: boolean | null = null;
+const isPostMessageMode = (): boolean => {
+    if (postMessageModeCache === null) {
+        postMessageModeCache =
+            typeof window !== 'undefined' &&
+            new URLSearchParams(window.location.hash.replace(/^#/, '')).get(
+                'transport',
+            ) === 'postMessage';
+    }
+    return postMessageModeCache;
+};
+
+function publishUrlState(state: UrlStateMap): void {
+    if (typeof window === 'undefined') return;
+    const serialized = serializeUrlState(state);
+    if (serialized === null) return;
+
+    if (isPostMessageMode()) {
+        const message: SdkUrlStateChangeMessage = {
+            type: URL_STATE_CHANGE_MESSAGE,
+            // Round-tripped so the payload is structured-cloneable: values
+            // JSON.stringify drops would throw DataCloneError on postMessage.
+            state: JSON.parse(serialized) as UrlStateMap,
+        };
+        window.parent?.postMessage(message, '*');
+        return;
+    }
+
+    // Top-level (local dev): own the URL directly. Replace, not push — state
+    // churn must not spam browser history.
+    const url = new URL(window.location.href);
+    if (Object.keys(state).length === 0) {
+        url.searchParams.delete(URL_STATE_PARAM);
+    } else {
+        url.searchParams.set(URL_STATE_PARAM, serialized);
+    }
+    window.history.replaceState(window.history.state, '', url);
+}
+
+export type UrlStateStore = {
+    getState: () => UrlStateMap;
+    setKey: (key: string, value: unknown) => void;
+    subscribe: (listener: () => void) => () => void;
+};
+
+/**
+ * Minimal external store: synchronous reads for useSyncExternalStore, trailing-
+ * edge publish on writes. Exported for tests — app code uses `useUrlState`.
+ */
+export function createUrlStateStore(options: {
+    seed: UrlStateMap;
+    publish: (state: UrlStateMap) => void;
+    debounceMs?: number;
+}): UrlStateStore {
+    const { publish, debounceMs = PUBLISH_COALESCE_MS } = options;
+    let state = options.seed;
+    const listeners = new Set<() => void>();
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const schedulePublish = () => {
+        if (timer !== null) clearTimeout(timer);
+        timer = setTimeout(() => {
+            timer = null;
+            publish(state);
+        }, debounceMs);
+    };
+
+    return {
+        getState: () => state,
+        setKey: (key, value) => {
+            if (Object.is(state[key], value)) return;
+            state = { ...state, [key]: value };
+            listeners.forEach((listener) => listener());
+            schedulePublish();
+        },
+        subscribe: (listener) => {
+            listeners.add(listener);
+            return () => listeners.delete(listener);
+        },
+    };
+}
+
+// Lazily created so tests (and SSR) never touch window at import time.
+let sharedStore: UrlStateStore | null = null;
+function getSharedStore(): UrlStateStore {
+    if (sharedStore === null) {
+        // Prime the transport-mode latch now — first hook call happens during
+        // the first render, before any user interaction can mutate the hash.
+        isPostMessageMode();
+        sharedStore = createUrlStateStore({
+            seed:
+                typeof window === 'undefined'
+                    ? {}
+                    : parseUrlStateSeed(window.location),
+            publish: publishUrlState,
+        });
+    }
+    return sharedStore;
+}
+
+/**
+ * `useState`-shaped hook whose value round-trips through the page URL:
+ *
+ *   const [period, setPeriod] = useUrlState('period', 'last_month');
+ *
+ * Values must be JSON-serializable. All call sites share one map keyed by
+ * `key`, so no provider is needed.
+ */
+export function useUrlState<T>(
+    key: string,
+    defaultValue: T,
+): [T, (next: T | ((prev: T) => T)) => void] {
+    const store = getSharedStore();
+    const raw = useSyncExternalStore(
+        store.subscribe,
+        () => store.getState()[key],
+        () => undefined,
+    );
+
+    // Latest default in a ref so the setter identity is stable across renders.
+    const defaultRef = useRef(defaultValue);
+    defaultRef.current = defaultValue;
+
+    const set = useCallback(
+        (next: T | ((prev: T) => T)) => {
+            const prev = store.getState()[key];
+            const prevOrDefault = (
+                prev === undefined ? defaultRef.current : prev
+            ) as T;
+            const value =
+                typeof next === 'function'
+                    ? (next as (p: T) => T)(prevOrDefault)
+                    : next;
+            store.setKey(key, value);
+        },
+        [store, key],
+    );
+
+    return [(raw === undefined ? defaultValue : raw) as T, set];
+}

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -1032,6 +1032,33 @@ const client = useLightdashClient();
 const user = await client.auth.getUser();
 ```
 
+### Shareable URL state
+
+The host page keeps a `?state=` query param in sync with the app's view state, so the
+browser's address bar is always a shareable link — a colleague who opens the link lands
+on the same view. **Use `useUrlState` instead of `useState` for every user-facing view
+control**: period/date-range selectors, active tab, segment pickers, sort toggles.
+
+```tsx
+import { useUrlState } from '@lightdash/query-sdk';
+
+const [period, setPeriod] = useUrlState('period', 'last_month');
+```
+
+- Drop-in `useState` shape (functional updates work). Values must be JSON-serializable.
+- Each control owns a stable string key; all keys share one map, so keep the total
+  small (≤ 4 KB serialized — oversized state stays in memory but stops persisting).
+- **Global filters are persisted automatically** — `useGlobalFilters()` already stores
+  its filters in URL state. Never wire filter state through `useUrlState` yourself.
+- **Treat the seeded value as untrusted.** It comes from a user-editable URL: validate
+  it before use and fall back to the default when it's not what you expect
+  (e.g. `PERIODS.includes(period) ? period : 'last_month'`).
+- Do NOT build "copy link" / "share" buttons — the host page owns the URL; sharing is
+  just copying the address bar.
+- Ephemeral UI state (open dropdowns, hover, modal visibility, in-progress form input)
+  stays in plain `useState` — only state that defines *which view* the user is looking
+  at belongs in the URL.
+
 ### External APIs
 
 When an app needs data from an external HTTP API (Stripe, a CRM, a weather
@@ -1181,6 +1208,8 @@ Use `<Loader2 className="animate-spin" />` from `lucide-react`, not skeletons. G
 **Filters never cross-apply between explores.** Different explores have different field sets — a `status` dimension on `marketing_touchpoints` doesn't exist on `orders` or `regional_sales`. Sending `{ field: 'status' }` into a query against the wrong explore produces a `FieldReferenceError` (the SDK qualifies it to `<wrong_explore>_status`, which doesn't exist). The `explore` tag on every filter is what prevents this.
 
 > **Limitation by design:** A field that legitimately exists on multiple explores (e.g. `region` joined into both `orders` and `regional_sales`) won't cross-filter under this rule. That's the safe default. If the user explicitly asks for cross-explore linking on a shared dimension, you can call `addFilter` once per explore — but never broadcast a filter to all explores blindly.
+
+Global filters are automatically persisted to the host page URL (see [Shareable URL state](#shareable-url-state)) — filter selections survive reloads and shared links with no extra wiring.
 
 The filter context is pre-installed and wraps your app at the root. Import the hook from `@/lib/filters` — never reimplement it:
 

--- a/sandboxes/data-apps/template/src/lib/filters.tsx
+++ b/sandboxes/data-apps/template/src/lib/filters.tsx
@@ -3,12 +3,37 @@ import {
     useCallback,
     useContext,
     useMemo,
-    useState,
     type ReactNode,
 } from 'react';
-import type { Filter } from '@lightdash/query-sdk';
+import { useUrlState, type Filter } from '@lightdash/query-sdk';
 
 export type ScopedFilter = Filter & { explore: string };
+
+// Global filters live in URL state so the host page's address bar is always a
+// shareable link to the current filtered view. The seeded value comes from a
+// user-editable URL — sanitize before trusting its shape, or malformed
+// entries flow into every metric query for the explore and fail the run.
+const isScalar = (v: unknown): v is string | number | boolean =>
+    typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean';
+
+const sanitizeFilters = (value: unknown): ScopedFilter[] =>
+    Array.isArray(value)
+        ? value.filter((f): f is ScopedFilter => {
+              if (!f || typeof f !== 'object') return false;
+              const { explore, field, operator, value: filterValue } =
+                  f as ScopedFilter;
+              return (
+                  typeof explore === 'string' &&
+                  typeof field === 'string' &&
+                  typeof operator === 'string' &&
+                  operator.length > 0 &&
+                  (filterValue === undefined ||
+                      isScalar(filterValue) ||
+                      (Array.isArray(filterValue) &&
+                          filterValue.every(isScalar)))
+              );
+          })
+        : [];
 
 type FilterContextValue = {
     addFilter: (filter: ScopedFilter) => void;
@@ -26,22 +51,35 @@ const sameTarget = (a: ScopedFilter, b: ScopedFilter) =>
     JSON.stringify(a.value) === JSON.stringify(b.value);
 
 export function FilterProvider({ children }: { children: ReactNode }) {
-    const [filters, setFilters] = useState<ScopedFilter[]>([]);
+    const [rawFilters, setFilters] = useUrlState<ScopedFilter[]>(
+        'globalFilters',
+        [],
+    );
+    const filters = useMemo(() => sanitizeFilters(rawFilters), [rawFilters]);
 
-    const addFilter = useCallback((filter: ScopedFilter) => {
-        setFilters((prev) => {
-            const exists = prev.some((f) => sameTarget(f, filter));
-            return exists
-                ? prev.filter((f) => !sameTarget(f, filter))
-                : [...prev, filter];
-        });
-    }, []);
+    const addFilter = useCallback(
+        (filter: ScopedFilter) => {
+            setFilters((prev) => {
+                const current = sanitizeFilters(prev);
+                const exists = current.some((f) => sameTarget(f, filter));
+                return exists
+                    ? current.filter((f) => !sameTarget(f, filter))
+                    : [...current, filter];
+            });
+        },
+        [setFilters],
+    );
 
-    const removeFilter = useCallback((filter: ScopedFilter) => {
-        setFilters((prev) => prev.filter((f) => !sameTarget(f, filter)));
-    }, []);
+    const removeFilter = useCallback(
+        (filter: ScopedFilter) => {
+            setFilters((prev) =>
+                sanitizeFilters(prev).filter((f) => !sameTarget(f, filter)),
+            );
+        },
+        [setFilters],
+    );
 
-    const clearFilters = useCallback(() => setFilters([]), []);
+    const clearFilters = useCallback(() => setFilters([]), [setFilters]);
 
     const filtersFor = useCallback(
         (explore: string): Filter[] =>


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8151/data-apps-allow-seeding-a-data-apps-internal-filterstate-from-a

### Description:
Data apps' interactive controls (period selectors, tabs, global filters) now round-trip their state through the host page's ?state= param, so the address bar is always a shareable link to the current view.

- query-sdk: useUrlState(key, default) hook — seeds synchronously from the iframe hash, debounces changes into a lightdash:sdk:url-state-change postMessage (history.replaceState when running top-level). Module-level store, no provider needed.
- template: global filters persist via useUrlState automatically; skill section teaching useUrlState for view controls.
- frontend: bridge validates state (plain object, <=4KB) and the new useAppUrlStateSync hook latches the seed once, mirrors changes into the page URL, and snapshots current state across manual refreshes. Wired into the view page, builder, and full-page embed.

### Testing
E.g. switching tabs

Before:
`/view`

After:
`/view?state={%22tab%22%3A%22constructors%22}`


Note: it also works for auto reloading in the builder page. So it doesn't reset your filters/tabs anymore when it auto-reloads.