### PR TITLE
feat: add AI agent evals as code

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -76,6 +76,7 @@ import {
     UpdateSlackResponseTs,
     UpdateWebAppResponse,
     type AgentAsCode,
+    type AgentAsCodeEvaluation,
     type AiAgent,
     type AiAgentIntegration,
     type AiChartRuntimeOverrides,
@@ -5133,6 +5134,81 @@ export class AiAgentModel {
             .limit(40);
 
         return rows;
+    }
+
+    async findAgentEvalsForCode(agentUuids: string[]): Promise<
+        Array<
+            AgentAsCodeEvaluation & {
+                agentUuid: string;
+                evalUuid: string;
+            }
+        >
+    > {
+        if (agentUuids.length === 0) return [];
+
+        const rows = await this.database
+            .from(AiEvalTableName)
+            .leftJoin(
+                AiEvalPromptTableName,
+                `${AiEvalTableName}.ai_eval_uuid`,
+                `${AiEvalPromptTableName}.ai_eval_uuid`,
+            )
+            .leftJoin(
+                AiPromptTableName,
+                `${AiEvalPromptTableName}.ai_prompt_uuid`,
+                `${AiPromptTableName}.ai_prompt_uuid`,
+            )
+            .whereIn(`${AiEvalTableName}.agent_uuid`, agentUuids)
+            .select<
+                Array<{
+                    agent_uuid: string;
+                    ai_eval_uuid: string;
+                    ai_eval_prompt_uuid: string | null;
+                    title: string;
+                    prompt: string | null;
+                    expected_response: string | null;
+                }>
+            >(
+                `${AiEvalTableName}.agent_uuid`,
+                `${AiEvalTableName}.ai_eval_uuid`,
+                `${AiEvalPromptTableName}.ai_eval_prompt_uuid`,
+                `${AiEvalTableName}.title`,
+                this.database.raw(
+                    `COALESCE(${AiEvalPromptTableName}.prompt, ${AiPromptTableName}.prompt) as prompt`,
+                ),
+                `${AiEvalPromptTableName}.expected_response`,
+            )
+            .orderBy(`${AiEvalTableName}.agent_uuid`, 'asc')
+            .orderBy(`${AiEvalTableName}.title`, 'asc')
+            .orderBy(`${AiEvalTableName}.created_at`, 'asc')
+            .orderBy(`${AiEvalPromptTableName}.created_at`, 'asc');
+
+        const evaluationsByUuid = new Map<
+            string,
+            AgentAsCodeEvaluation & {
+                agentUuid: string;
+                evalUuid: string;
+            }
+        >();
+
+        rows.forEach((row) => {
+            const evaluation = evaluationsByUuid.get(row.ai_eval_uuid) ?? {
+                agentUuid: row.agent_uuid,
+                evalUuid: row.ai_eval_uuid,
+                title: row.title,
+                prompts: [],
+            };
+
+            if (row.ai_eval_prompt_uuid && row.prompt) {
+                evaluation.prompts.push({
+                    prompt: row.prompt,
+                    expectedResponse: row.expected_response,
+                });
+            }
+            evaluationsByUuid.set(row.ai_eval_uuid, evaluation);
+        });
+
+        return [...evaluationsByUuid.values()];
     }
 
     async updateSlackResponseTs(data: UpdateSlackResponseTs) {

--- a/packages/backend/src/ee/services/AiAgentCoderService/AiAgentCoderService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentCoderService/AiAgentCoderService.test.ts
@@ -84,11 +84,32 @@ const agentAsCode: AgentAsCode = {
     modelConfig: null,
 };
 
-const buildService = ({ existing = [agentRow] } = {}) => {
+const existingEvaluation = {
+    agentUuid: 'agent-uuid',
+    evalUuid: 'eval-uuid',
+    title: 'Core regression suite',
+    prompts: [
+        {
+            prompt: 'What was revenue last month?',
+            expectedResponse: 'Uses the certified revenue metric.',
+        },
+    ],
+};
+
+const buildService = ({
+    existing = [agentRow],
+    evaluations = [],
+}: {
+    existing?: (typeof agentRow)[];
+    evaluations?: (typeof existingEvaluation)[];
+} = {}) => {
     const aiAgentModel = {
         findAgentsForCode: vi.fn(async () => existing),
+        findAgentEvalsForCode: vi.fn(async () => evaluations),
         updateAgent: vi.fn(async () => undefined),
-        createAgent: vi.fn(async () => undefined),
+        createAgent: vi.fn(async () => ({ uuid: 'created-agent-uuid' })),
+        createEval: vi.fn(async () => undefined),
+        updateEval: vi.fn(async () => undefined),
     };
     const service = new AiAgentCoderService({
         aiAgentModel: aiAgentModel as never,
@@ -115,6 +136,7 @@ describe('AiAgentCoderService', () => {
         expect(result.agents).toEqual([
             {
                 ...agentAsCode,
+                evaluations: [],
                 updatedAt: agentRow.updatedAt,
             },
         ]);
@@ -125,6 +147,26 @@ describe('AiAgentCoderService', () => {
             slugs: ['revenue-agent'],
             agentUuids: undefined,
         });
+    });
+
+    it('exports evaluation definitions without runtime history', async () => {
+        const { service, aiAgentModel } = buildService({
+            evaluations: [existingEvaluation],
+        });
+
+        const result = await service.downloadAgents(user, projectUuid, [
+            'revenue-agent',
+        ]);
+
+        expect(result.agents[0].evaluations).toEqual([
+            {
+                title: existingEvaluation.title,
+                prompts: existingEvaluation.prompts,
+            },
+        ]);
+        expect(aiAgentModel.findAgentEvalsForCode).toHaveBeenCalledWith([
+            'agent-uuid',
+        ]);
     });
 
     it('looks up UUID-shaped identifiers as both slugs and UUIDs', async () => {
@@ -155,6 +197,134 @@ describe('AiAgentCoderService', () => {
             deleted: [],
         });
         expect(aiAgentModel.updateAgent).not.toHaveBeenCalled();
+    });
+
+    it('upserts declared evaluations by title without deleting undeclared suites', async () => {
+        const unrelatedEvaluation = {
+            ...existingEvaluation,
+            evalUuid: 'unrelated-eval-uuid',
+            title: 'UI-managed suite',
+        };
+        const { service, aiAgentModel } = buildService({
+            evaluations: [existingEvaluation, unrelatedEvaluation],
+        });
+        const updatedPrompts = [
+            {
+                prompt: 'What was revenue this quarter?',
+                expectedResponse: 'Uses the certified revenue metric.',
+            },
+        ];
+        const newPrompts = [
+            {
+                prompt: 'Which region grew fastest?',
+                expectedResponse: null,
+            },
+        ];
+
+        const result = await service.upsertAgents(user, projectUuid, [
+            {
+                ...agentAsCode,
+                evaluations: [
+                    {
+                        title: existingEvaluation.title,
+                        prompts: updatedPrompts,
+                    },
+                    {
+                        title: 'Regional regression suite',
+                        prompts: newPrompts,
+                    },
+                ],
+            },
+        ]);
+
+        expect(result.updated).toEqual(['revenue-agent']);
+        expect(aiAgentModel.updateAgent).not.toHaveBeenCalled();
+        expect(aiAgentModel.updateEval).toHaveBeenCalledWith('eval-uuid', {
+            title: existingEvaluation.title,
+            prompts: updatedPrompts,
+        });
+        expect(aiAgentModel.createEval).toHaveBeenCalledWith(
+            'agent-uuid',
+            {
+                title: 'Regional regression suite',
+                prompts: newPrompts,
+            },
+            'user-uuid',
+        );
+        expect(aiAgentModel.updateEval).not.toHaveBeenCalledWith(
+            'unrelated-eval-uuid',
+            expect.anything(),
+        );
+    });
+
+    it('preserves evaluations when the optional field is omitted', async () => {
+        const { service, aiAgentModel } = buildService({
+            evaluations: [existingEvaluation],
+        });
+
+        const result = await service.upsertAgents(user, projectUuid, [
+            agentAsCode,
+        ]);
+
+        expect(result.unchanged).toEqual(['revenue-agent']);
+        expect(aiAgentModel.createEval).not.toHaveBeenCalled();
+        expect(aiAgentModel.updateEval).not.toHaveBeenCalled();
+    });
+
+    it('does not update an unchanged declared evaluation', async () => {
+        const prompts = [
+            ...existingEvaluation.prompts,
+            {
+                prompt: 'Which region grew fastest?',
+                expectedResponse: 'Compares regional growth rates.',
+            },
+        ];
+        const { service, aiAgentModel } = buildService({
+            evaluations: [{ ...existingEvaluation, prompts }],
+        });
+
+        const result = await service.upsertAgents(user, projectUuid, [
+            {
+                ...agentAsCode,
+                evaluations: [
+                    {
+                        title: existingEvaluation.title,
+                        prompts: [...prompts].reverse(),
+                    },
+                ],
+            },
+        ]);
+
+        expect(result.unchanged).toEqual(['revenue-agent']);
+        expect(aiAgentModel.createEval).not.toHaveBeenCalled();
+        expect(aiAgentModel.updateEval).not.toHaveBeenCalled();
+    });
+
+    it('rejects duplicate evaluation titles before changing an agent', async () => {
+        const { service, aiAgentModel } = buildService();
+
+        await expect(
+            service.upsertAgents(user, projectUuid, [
+                {
+                    ...agentAsCode,
+                    evaluations: [
+                        {
+                            title: 'Duplicate suite',
+                            prompts: [],
+                        },
+                        {
+                            title: 'Duplicate suite',
+                            prompts: [],
+                        },
+                    ],
+                },
+            ]),
+        ).rejects.toThrow(
+            "Duplicate evaluation titles for AI agent 'revenue-agent': Duplicate suite",
+        );
+        expect(aiAgentModel.updateAgent).not.toHaveBeenCalled();
+        expect(aiAgentModel.createEval).not.toHaveBeenCalled();
+        expect(aiAgentModel.updateEval).not.toHaveBeenCalled();
     });
 
     it('updates the managed project configuration without touching access or integrations', async () => {
@@ -226,7 +396,16 @@ describe('AiAgentCoderService', () => {
         const { service, aiAgentModel } = buildService({ existing: [] });
 
         const result = await service.upsertAgents(user, projectUuid, [
-            { ...agentAsCode, agentVersion: 1 },
+            {
+                ...agentAsCode,
+                agentVersion: 1,
+                evaluations: [
+                    {
+                        title: 'Core regression suite',
+                        prompts: existingEvaluation.prompts,
+                    },
+                ],
+            },
         ]);
 
         expect(result.created).toEqual(['revenue-agent']);
@@ -242,6 +421,14 @@ describe('AiAgentCoderService', () => {
                 mcpServerUuids: [],
                 version: 1,
             }),
+        );
+        expect(aiAgentModel.createEval).toHaveBeenCalledWith(
+            'created-agent-uuid',
+            {
+                title: 'Core regression suite',
+                prompts: existingEvaluation.prompts,
+            },
+            'user-uuid',
         );
     });
 

--- a/packages/backend/src/ee/services/AiAgentCoderService/AiAgentCoderService.ts
+++ b/packages/backend/src/ee/services/AiAgentCoderService/AiAgentCoderService.ts
@@ -5,6 +5,7 @@ import {
     ForbiddenError,
     ParameterError,
     type AgentAsCode,
+    type AgentAsCodeEvaluation,
     type AgentAsCodeUpsertChanges,
     type SessionUser,
 } from '@lightdash/common';
@@ -23,7 +24,38 @@ type AgentForCode = Awaited<
     ReturnType<AiAgentModel['findAgentsForCode']>
 >[number];
 
-const toAgentAsCode = (agent: AgentForCode): AgentAsCode => ({
+type EvaluationForCode = Awaited<
+    ReturnType<AiAgentModel['findAgentEvalsForCode']>
+>[number];
+
+const normalizeEvaluation = (
+    evaluation: AgentAsCodeEvaluation,
+): AgentAsCodeEvaluation => ({
+    title: evaluation.title,
+    prompts: [...evaluation.prompts].sort(
+        (left, right) =>
+            left.prompt.localeCompare(right.prompt) ||
+            (left.expectedResponse ?? '').localeCompare(
+                right.expectedResponse ?? '',
+            ),
+    ),
+});
+
+const groupEvaluationsByAgentUuid = (
+    evaluations: EvaluationForCode[],
+): Map<string, EvaluationForCode[]> =>
+    evaluations.reduce<Map<string, EvaluationForCode[]>>((grouped, item) => {
+        grouped.set(item.agentUuid, [
+            ...(grouped.get(item.agentUuid) ?? []),
+            item,
+        ]);
+        return grouped;
+    }, new Map());
+
+const toAgentAsCode = (
+    agent: AgentForCode,
+    evaluations: EvaluationForCode[],
+): AgentAsCode => ({
     contentType: ContentAsCodeType.AI_AGENT,
     version: AGENT_AS_CODE_VERSION,
     agentVersion: agent.agentVersion,
@@ -38,6 +70,9 @@ const toAgentAsCode = (agent: AgentForCode): AgentAsCode => ({
     enableContentTools: agent.enableContentTools,
     enableUserContext: agent.enableUserContext,
     modelConfig: agent.modelConfig,
+    evaluations: [...evaluations]
+        .sort((left, right) => left.title.localeCompare(right.title))
+        .map(normalizeEvaluation),
     updatedAt: agent.updatedAt,
 });
 
@@ -170,9 +205,18 @@ export class AiAgentCoderService extends BaseService {
             offset,
             pageSize: this.lightdashConfig.contentAsCode.maxDownloads,
         });
+        const evaluations = await this.aiAgentModel.findAgentEvalsForCode(
+            page.page.map(({ uuid }) => uuid),
+        );
+        const evaluationsByAgentUuid = groupEvaluationsByAgentUuid(evaluations);
 
         return {
-            agents: page.page.map(toAgentAsCode),
+            agents: page.page.map((agent) =>
+                toAgentAsCode(
+                    agent,
+                    evaluationsByAgentUuid.get(agent.uuid) ?? [],
+                ),
+            ),
             missingIds,
             total: page.total,
             offset: page.offset,
@@ -222,6 +266,32 @@ export class AiAgentCoderService extends BaseService {
                     `AI agent '${agent.slug}' must enable data access before enabling content tools`,
                 );
             }
+            const duplicateEvaluationTitles = (agent.evaluations ?? [])
+                .map(({ title }) => title)
+                .filter(
+                    (title, index, titles) => titles.indexOf(title) !== index,
+                );
+            if (duplicateEvaluationTitles.length > 0) {
+                throw new ParameterError(
+                    `Duplicate evaluation titles for AI agent '${agent.slug}': ${[
+                        ...new Set(duplicateEvaluationTitles),
+                    ].join(', ')}`,
+                );
+            }
+            agent.evaluations?.forEach((evaluation) => {
+                if (evaluation.title.trim().length === 0) {
+                    throw new ParameterError(
+                        `AI agent '${agent.slug}' has an evaluation with an empty title`,
+                    );
+                }
+                evaluation.prompts.forEach(({ prompt }) => {
+                    if (prompt.trim().length === 0) {
+                        throw new ParameterError(
+                            `Evaluation '${evaluation.title}' for AI agent '${agent.slug}' has an empty prompt`,
+                        );
+                    }
+                });
+            });
         });
 
         const existingAgents = await this.aiAgentModel.findAgentsForCode({
@@ -232,6 +302,45 @@ export class AiAgentCoderService extends BaseService {
         const existingBySlug = new Map(
             existingAgents.map((agent) => [agent.slug, agent]),
         );
+        const existingEvaluations =
+            await this.aiAgentModel.findAgentEvalsForCode(
+                existingAgents
+                    .filter((existing) =>
+                        agents.some(
+                            (agent) =>
+                                agent.slug === existing.slug &&
+                                agent.evaluations !== undefined,
+                        ),
+                    )
+                    .map(({ uuid }) => uuid),
+            );
+        const existingEvaluationsByAgentUuid =
+            groupEvaluationsByAgentUuid(existingEvaluations);
+
+        agents.forEach((agent) => {
+            const existing = existingBySlug.get(agent.slug);
+            if (!existing || agent.evaluations === undefined) return;
+
+            const declaredTitles = new Set(
+                agent.evaluations.map(({ title }) => title),
+            );
+            const ambiguousTitles = [
+                ...(existingEvaluationsByAgentUuid.get(existing.uuid) ?? [])
+                    .filter(({ title }) => declaredTitles.has(title))
+                    .reduce<Map<string, number>>(
+                        (counts, { title }) =>
+                            counts.set(title, (counts.get(title) ?? 0) + 1),
+                        new Map(),
+                    ),
+            ]
+                .filter(([, count]) => count > 1)
+                .map(([title]) => title);
+            if (ambiguousTitles.length > 0) {
+                throw new ParameterError(
+                    `AI agent '${agent.slug}' has multiple existing evaluations titled: ${ambiguousTitles.join(', ')}`,
+                );
+            }
+        });
         const changes: AgentAsCodeUpsertChanges = {
             created: [],
             updated: [],
@@ -241,18 +350,19 @@ export class AiAgentCoderService extends BaseService {
 
         for (const agent of agents) {
             const existing = existingBySlug.get(agent.slug);
+            let agentUuid: string;
+            let agentChanged = false;
             if (existing) {
+                agentUuid = existing.uuid;
                 const imageUrlChanged = existing.imageUrl !== agent.imageUrl;
                 const isUnchanged =
                     !force &&
                     isEqual(
-                        getComparableAgent(toAgentAsCode(existing)),
+                        getComparableAgent(toAgentAsCode(existing, [])),
                         getComparableAgent(agent),
                     );
 
-                if (isUnchanged) {
-                    changes.unchanged.push(agent.slug);
-                } else {
+                if (!isUnchanged) {
                     // eslint-disable-next-line no-await-in-loop
                     await this.aiAgentModel.updateAgent({
                         agentUuid: existing.uuid,
@@ -275,11 +385,11 @@ export class AiAgentCoderService extends BaseService {
                         enableUserContext: agent.enableUserContext,
                         modelConfig: agent.modelConfig,
                     });
-                    changes.updated.push(agent.slug);
+                    agentChanged = true;
                 }
             } else {
                 // eslint-disable-next-line no-await-in-loop
-                await this.aiAgentModel.createAgent({
+                const createdAgent = await this.aiAgentModel.createAgent({
                     slug: agent.slug,
                     organizationUuid,
                     projectUuid,
@@ -301,7 +411,53 @@ export class AiAgentCoderService extends BaseService {
                     adminOnly: false,
                     version: agent.agentVersion,
                 });
+                agentUuid = createdAgent.uuid;
+                agentChanged = true;
+            }
+
+            if (agent.evaluations !== undefined) {
+                const evaluationsByTitle = new Map(
+                    (existingEvaluationsByAgentUuid.get(agentUuid) ?? []).map(
+                        (evaluation) => [evaluation.title, evaluation],
+                    ),
+                );
+
+                for (const declaredEvaluation of agent.evaluations) {
+                    const evaluation = normalizeEvaluation(declaredEvaluation);
+                    const existingEvaluation = evaluationsByTitle.get(
+                        evaluation.title,
+                    );
+                    if (!existingEvaluation) {
+                        // eslint-disable-next-line no-await-in-loop
+                        await this.aiAgentModel.createEval(
+                            agentUuid,
+                            evaluation,
+                            user.userUuid,
+                        );
+                        agentChanged = true;
+                    } else if (
+                        force ||
+                        !isEqual(
+                            normalizeEvaluation(existingEvaluation),
+                            evaluation,
+                        )
+                    ) {
+                        // eslint-disable-next-line no-await-in-loop
+                        await this.aiAgentModel.updateEval(
+                            existingEvaluation.evalUuid,
+                            evaluation,
+                        );
+                        agentChanged = true;
+                    }
+                }
+            }
+
+            if (!existing) {
                 changes.created.push(agent.slug);
+            } else if (agentChanged) {
+                changes.updated.push(agent.slug);
+            } else {
+                changes.unchanged.push(agent.slug);
             }
         }
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -34,7 +34,9 @@ lightdash upload
 
 Use `--agents <slugs...>` on either command to select specific agents. The
 files manage the agent name, description, image URL, instructions, semantic
-tags, data/content/user-context flags, self-improvement flag, and model config.
+tags, data/content/user-context flags, self-improvement flag, model config,
+and evaluation suites. Evaluation suites are upserted by title; suites omitted
+from YAML remain unchanged, and evaluation run history is never downloaded.
 The YAML `version` identifies the as-code schema, while `agentVersion` preserves
 the AI agent runtime version.
 Access lists, Slack integrations, MCP servers, documents, conversations, and

--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -388,6 +388,37 @@ describe('readAiAgentFiles', () => {
             'Invalid contentType in AI agent file',
         );
     });
+
+    it('reads evaluation suites nested in an AI agent file', async () => {
+        await fs.writeFile(
+            path.join(tmpDir, 'ai-agents', 'revenue-agent.yml'),
+            [
+                'contentType: ai_agent',
+                'version: 1',
+                'slug: revenue-agent',
+                'evaluations:',
+                '  - title: Core regression suite',
+                '    prompts:',
+                '      - prompt: What was revenue last month?',
+                '        expectedResponse: Uses the certified revenue metric.',
+                '',
+            ].join('\n'),
+        );
+
+        const agents = await readAiAgentFiles(tmpDir);
+
+        expect(agents[0].evaluations).toEqual([
+            {
+                title: 'Core regression suite',
+                prompts: [
+                    {
+                        prompt: 'What was revenue last month?',
+                        expectedResponse: 'Uses the certified revenue metric.',
+                    },
+                ],
+            },
+        ]);
+    });
 });
 
 describe('shouldDownloadAiAgents', () => {

--- a/packages/common/src/ee/AiAgent/coder.ts
+++ b/packages/common/src/ee/AiAgent/coder.ts
@@ -1,6 +1,16 @@
 import type { ContentAsCodeType } from '../../types/coder';
 import type { AiAgentModelConfig } from './requestTypes';
 
+export type AgentAsCodeEvaluationPrompt = {
+    prompt: string;
+    expectedResponse: string | null;
+};
+
+export type AgentAsCodeEvaluation = {
+    title: string;
+    prompts: AgentAsCodeEvaluationPrompt[];
+};
+
 export type AgentAsCode = {
     contentType: ContentAsCodeType.AI_AGENT;
     version: number;
@@ -16,6 +26,7 @@ export type AgentAsCode = {
     enableContentTools: boolean;
     enableUserContext: boolean;
     modelConfig: AiAgentModelConfig | null;
+    evaluations?: AgentAsCodeEvaluation[];
     updatedAt?: Date;
     downloadedAt?: Date;
 };


### PR DESCRIPTION

<img width="881" height="469" alt="CleanShot 2026-07-20 at 13 22 47" src="https://github.com/user-attachments/assets/51c7a1d7-546e-4001-93da-27f535ca3a35" />

<img width="473" height="309" alt="CleanShot 2026-07-20 at 13 27 34" src="https://github.com/user-attachments/assets/79e2b1f4-73af-4636-998a-af6bc5042379" />

## Summary

- add evaluation suites to AI agent as-code YAML
- download suite definitions without evaluation run history
- upsert declared suites by title while preserving undeclared suites
- validate duplicate titles and keep generated YAML deterministic

## Tests

- `pnpm -F backend exec vitest run --config vitest.config.ts src/ee/services/AiAgentCoderService/AiAgentCoderService.test.ts --reporter=dot`
- `pnpm -F cli exec vitest run --config vitest.config.ts src/handlers/download.test.ts --reporter=dot`
- `pnpm -F common typecheck`
- `pnpm -F backend typecheck`
- `pnpm -F cli typecheck`
- local CLI download/upload round trip with an agent evaluation suite

Closes: PROD-9006
Closes: #25781