### PR TITLE
feat(dev): add newux docker-dev profile + warn on partial --ee

### DIFF
--- a/scripts/dev-fast-start.sh
+++ b/scripts/dev-fast-start.sh
@@ -242,6 +242,24 @@ if [ "$EE_MODE" = true ] && ! grep -q "^LIGHTDASH_LICENSE_KEY=eyJ" .env.developm
     fail "ee-license" "EE requested but no LIGHTDASH_LICENSE_KEY in .env.development.local; run Step EE-1 (1Password) first"
 fi
 
+# The bare `--ee` fast path only applies the license + EE schema. The full AI/agent
+# experience — Copilot, default-agent (Aurora) auto-provisioning, and BigQuery Google-SSO —
+# comes from the `/docker-dev start ee` PROFILE, which additionally pulls ANTHROPIC_API_KEY
+# and the AUTH_GOOGLE_OAUTH2_* creds and sets AI_COPILOT_ENABLED. Without those a `--ee` run
+# still reports READY, so it silently ships half of EE. Warn (non-fatal) when that config is
+# absent so the gap is visible immediately instead of at feature-hit time. See scripts/dev-profiles.json.
+if [ "$EE_MODE" = true ]; then
+    _ee_missing=""
+    grep -q "^AI_COPILOT_ENABLED=true" .env.development.local 2>/dev/null || _ee_missing="${_ee_missing} AI_COPILOT_ENABLED"
+    grep -q "^ANTHROPIC_API_KEY=." .env.development.local 2>/dev/null || _ee_missing="${_ee_missing} ANTHROPIC_API_KEY"
+    grep -q "^AUTH_GOOGLE_OAUTH2_CLIENT_ID=." .env.development.local 2>/dev/null || _ee_missing="${_ee_missing} AUTH_GOOGLE_OAUTH2_CLIENT_ID"
+    if [ -n "$_ee_missing" ]; then
+        echo "WARN: EE license present but the AI profile config is incomplete (missing:${_ee_missing})."
+        echo "WARN: this bare --ee run brings up license + EE schema only; Copilot, agents (Aurora), and BigQuery Google-SSO stay OFF."
+        echo "WARN: for the full experience run '/docker-dev start ee' (or 'start newux' for the new onboarding UX) — it pulls the secrets and sets the flags. See scripts/dev-profiles.json."
+    fi
+fi
+
 # ---------------------------------------------------------------------------
 # The backend reads and writes S3 objects at localhost:9000 (S3_ENDPOINT). The
 # only thing that should be answering there is the MinIO container that

--- a/scripts/dev-profiles.json
+++ b/scripts/dev-profiles.json
@@ -1,5 +1,5 @@
 {
-    "$comment": "Instance capabilities for /docker-dev. The AI tier is just Core vs EE: all AI features (agents, writeback, reviews classifier) are bundled into the `ee` profile. GitHub and Slack are integrations (extra credentials / a tunnel), kept as their own toggles. EE requires `github` because AI writeback opens PRs through it, so an EE instance is turnkey for writeback. The start-time multi-select composes these; each pulls in its `requires` transitively, then the union of secrets/flags/env/orgSettings is applied, `reconcile` steps run, and `verify` checks confirm it. `secrets` are keys in scripts/dev-secrets.manifest.json. Addressable by name: `/docker-dev start ee` or `/docker-dev start ee,slack`; no profile = a plain Core instance.",
+    "$comment": "Instance capabilities for /docker-dev. The AI tier is just Core vs EE: all AI features (agents, writeback, reviews classifier) are bundled into the `ee` profile. GitHub and Slack are integrations (extra credentials / a tunnel), kept as their own toggles. EE requires `github` because AI writeback opens PRs through it, so an EE instance is turnkey for writeback. The start-time multi-select composes these; each pulls in its `requires` transitively, then the union of secrets/flags/env/orgSettings is applied, `reconcile` steps run, and `verify` checks confirm it. `secrets` are keys in scripts/dev-secrets.manifest.json. The `newux` profile composes `ee` and turns on the new onboarding + agentic-homepage UX (`new-onboarding`) on top of it. Addressable by name: `/docker-dev start ee`, `/docker-dev start ee,slack`, or `/docker-dev start newux`; no profile = a plain Core instance.",
     "profiles": {
         "github": {
             "label": "GitHub integration (dbt-over-GitHub)",
@@ -58,6 +58,17 @@
                 "SLACK_APP"
             ],
             "notes": "SLACK_APP is not yet in the secrets manifest \u2014 confirm the 1Password item name before enabling."
+        },
+        "newux": {
+            "label": "New onboarding UX (in-progress), on top of EE",
+            "description": "The new self-serve onboarding: email-only signup, full-page organization setup, and the dbt-less warehouse-connect flow with Snowflake/BigQuery SSO smart defaults, plus the agentic project homepage (Ask Aurora). Composes `ee` and adds the `new-onboarding` flag. Use to reproduce the real new-signup to agentic-homepage experience end to end.",
+            "requires": [
+                "ee"
+            ],
+            "flags": [
+                "new-onboarding"
+            ],
+            "notes": "Only `new-onboarding` is added here: `homepage-builder` is inherited from `ee`, and the `ai-copilot` flag does not need listing because `ee` sets AI_COPILOT_ENABLED=true, which resolves that flag on when AI_COPILOT_REQUIRES_FEATURE_FLAG is unset (see CommercialFeatureFlagModel.getAiCopilotFlag). The register page evaluates `new-onboarding` anonymously, so enabling it instance-wide via LIGHTDASH_ENABLE_FEATURE_FLAGS (what the profile does) is required for signup to switch."
         }
     },
     "snapshots": {


### PR DESCRIPTION
## What

Two dev-environment fixes so a local EE instance can reproduce the full new-onboarding + AI experience turnkey, and so a partially-configured EE is visible instead of silent.

1. **`newux` docker-dev profile** (`scripts/dev-profiles.json`) — composes the `ee` profile and adds the `new-onboarding` flag. `/docker-dev start newux` resolves to the full plan: license + Copilot + Anthropic key + Google-SSO creds + `homepage-builder` + `new-onboarding`. `ai-copilot` isn't listed because `AI_COPILOT_ENABLED=true` (set by `ee`) already resolves that flag on when `AI_COPILOT_REQUIRES_FEATURE_FLAG` is unset (see `CommercialFeatureFlagModel.getAiCopilotFlag`); `homepage-builder` is inherited from `ee`.

2. **Partial-`--ee` warning** (`scripts/dev-fast-start.sh`) — the bare `dev-fast-start.sh --ee` applies only the license + EE schema; Copilot, default-agent (Aurora) auto-provisioning, and BigQuery Google-SSO come from the `ee` *profile* (Step P). A bare run still prints `READY:`, so it silently ships half of EE. Now emits a non-fatal `WARN:` when the AI profile config (`AI_COPILOT_ENABLED` / `ANTHROPIC_API_KEY` / `AUTH_GOOGLE_OAUTH2_CLIENT_ID`) is absent, pointing to `/docker-dev start ee` (or `newux`).

## Why

Walking the new onboarding flow end to end on a fresh EE instance took ~6 restarts and 3 manual secret/flag steps, because the bare `--ee` path skips the profile and no profile turned on `new-onboarding`. This makes the right path turnkey and the wrong path self-announcing.

## Scope / testing

Dev-tooling only (`scripts/`), no product code. Verified:
- `python3 -m json.tool scripts/dev-profiles.json` — valid
- `scripts/dev-profiles.sh resolve newux` — yields `ee` + `github` + `new-onboarding` with the expected secrets/flags/env
- `bash -n scripts/dev-fast-start.sh` — clean

## Follow-up (not here)

Profile drift is the recurring risk: every new flag-gated experience needs the profile updated or it becomes unreachable via `/docker-dev start`. Worth a lightweight convention/check.

Linear: SPK-611

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCSduwJpXz6DAyHvE3yEga
