### PR TITLE
fix: homepage favourite data app link goes to view not builder

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/FavoritesBlock.tsx
@@ -12,6 +12,7 @@ import {
 import { useState, type FC, type MouseEvent } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
+import { getResourceUrl } from '../../../../components/common/ResourceView/resourceUtils';
 import { useFavoriteMutation } from '../../../../hooks/favorites/useFavoriteMutation';
 import { useFavorites } from '../../../../hooks/favorites/useFavorites';
 import layout from '../homepageLayout.module.css';
@@ -26,19 +27,6 @@ const FAVORITE_ICONS: Partial<Record<ResourceViewItemType, Icon>> = {
     [ResourceViewItemType.DASHBOARD]: IconLayoutDashboard,
     [ResourceViewItemType.SPACE]: IconFolder,
     [ResourceViewItemType.DATA_APP]: IconTerminal2,
-};
-
-const favoriteUrl = (projectUuid: string, item: ResourceViewItem): string => {
-    switch (item.type) {
-        case ResourceViewItemType.DASHBOARD:
-            return `/projects/${projectUuid}/dashboards/${item.data.uuid}/view`;
-        case ResourceViewItemType.SPACE:
-            return `/projects/${projectUuid}/spaces/${item.data.uuid}`;
-        case ResourceViewItemType.DATA_APP:
-            return `/projects/${projectUuid}/apps/${item.data.uuid}`;
-        default:
-            return `/projects/${projectUuid}/saved/${item.data.uuid}`;
-    }
 };
 
 const FavoritePills: FC<{
@@ -86,7 +74,7 @@ const FavoritePills: FC<{
             {visible.map((item) => (
                 <Link
                     key={item.data.uuid}
-                    to={favoriteUrl(projectUuid, item)}
+                    to={getResourceUrl(projectUuid, item)}
                     className={classes.favPill}
                 >
                     <MantineIcon


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-618/new-homepage-favourite-link-goes-to-builder-rather-than-view-page

### Description:
Favouriting a data app from the new homepage linked to /projects/:projectUuid/apps/:appUuid, which is the builder route (pages/AppGenerate). That page gates on `manage DataApp` and redirects to /home when the check fails, so interactive viewers clicking a favourited app bounced straight back to the homepage.

