### PR TITLE
chore: run parallel-safe api tests with file parallelism

### DIFF
--- a/packages/api-tests/helpers/projects.ts
+++ b/packages/api-tests/helpers/projects.ts
@@ -1,5 +1,6 @@
 import { WarehouseTypes } from '@lightdash/common';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { expect } from 'vitest';
 import { ApiClient, Body } from './api-client';
@@ -203,6 +204,56 @@ async function waitForV1JobCompletion(
 }
 
 /**
+ * All test-created projects point at the same server-side dbt directory, so
+ * concurrent refreshes race on `dbt deps` and fail. This lock serializes
+ * refreshes across vitest forks and concurrent tests; mkdir is atomic on the
+ * shared runner filesystem. Stale locks (crashed fork) are stolen after 8 min.
+ */
+const REFRESH_LOCK_DIR = path.join(
+    os.tmpdir(),
+    'lightdash-api-tests-refresh.lock',
+);
+const REFRESH_LOCK_STALE_MS = 8 * 60 * 1000;
+
+async function acquireRefreshLock(): Promise<void> {
+    for (;;) {
+        try {
+            fs.mkdirSync(REFRESH_LOCK_DIR);
+            return;
+        } catch {
+            try {
+                const age = Date.now() - fs.statSync(REFRESH_LOCK_DIR).mtimeMs;
+                if (age > REFRESH_LOCK_STALE_MS) {
+                    fs.rmdirSync(REFRESH_LOCK_DIR);
+                }
+            } catch {
+                // released or stolen between checks; retry below
+            }
+            await new Promise<void>((r) => {
+                setTimeout(r, 500);
+            });
+        }
+    }
+}
+
+function releaseRefreshLock(): void {
+    try {
+        fs.rmdirSync(REFRESH_LOCK_DIR);
+    } catch {
+        // already stolen as stale
+    }
+}
+
+export async function withRefreshLock<T>(fn: () => Promise<T>): Promise<T> {
+    await acquireRefreshLock();
+    try {
+        return await fn();
+    } finally {
+        releaseRefreshLock();
+    }
+}
+
+/**
  * Create a project, run a full refresh, and return its UUID once compiled.
  * Throws if the refresh job fails so callers fail loudly instead of querying
  * an empty project.
@@ -218,13 +269,18 @@ export async function createAndRefreshProject(
         warehouseConnection,
     );
 
-    const refreshResp = await client.post<Body<{ jobUuid: string }>>(
-        `/api/v1/projects/${projectUuid}/refresh`,
-    );
-    expect(refreshResp.status).toBe(200);
+    const { outcome, jobUuid } = await withRefreshLock(async () => {
+        const refreshResp = await client.post<Body<{ jobUuid: string }>>(
+            `/api/v1/projects/${projectUuid}/refresh`,
+        );
+        expect(refreshResp.status).toBe(200);
 
-    const { jobUuid } = refreshResp.body.results;
-    const outcome = await waitForV1JobCompletion(client, jobUuid);
+        const id = refreshResp.body.results.jobUuid;
+        return {
+            outcome: await waitForV1JobCompletion(client, id),
+            jobUuid: id,
+        };
+    });
     if (outcome === 'ERROR') {
         const jobResp = await client.get<
             Body<{ steps: { stepError?: string }[] }>

--- a/packages/api-tests/package.json
+++ b/packages/api-tests/package.json
@@ -12,7 +12,8 @@
         "fix-format": "oxfmt .",
         "typecheck": "tsc6 --project tsconfig.json --noEmit",
         "typecheck:fast": "tsc --project tsconfig.json --noEmit",
-        "test:api": "vitest run --config vitest.config.ts",
+        "test:api": "API_TEST_GROUP=serial vitest run --config vitest.config.ts && API_TEST_GROUP=parallel vitest run --config vitest.config.ts",
+        "test:api:single": "vitest run --config vitest.config.ts",
         "test:api:watch": "vitest watch --config vitest.config.ts"
     },
     "dependencies": {

--- a/packages/api-tests/tests/pivotQuery.test.ts
+++ b/packages/api-tests/tests/pivotQuery.test.ts
@@ -297,7 +297,9 @@ const pivotWarehouseEntries = getAvailableWarehouseConfigs({
     includePostgres: false,
 });
 
-describe('Pivot query API', () => {
+// Each warehouse block owns its project and only runs read-only queries, so
+// tests can run concurrently — this overlaps the slow per-warehouse refreshes.
+describe.concurrent('Pivot query API', () => {
     // Postgres: reuse the already-seeded project (no create/refresh needed).
     describe('postgres (seed project)', () => {
         let admin: ApiClient;

--- a/packages/api-tests/tests/savedChartGet.test.ts
+++ b/packages/api-tests/tests/savedChartGet.test.ts
@@ -11,6 +11,7 @@ import { randomUUID } from 'crypto';
 import { Body } from '../helpers/api-client';
 import { login } from '../helpers/auth';
 import { chartMock } from '../helpers/mocks';
+import { withRefreshLock } from '../helpers/projects';
 import { uniqueName } from '../helpers/test-isolation';
 
 const apiUrl = '/api/v1';
@@ -94,15 +95,14 @@ async function createAndRefreshProject(
     // Track before refreshing so a failed compile cannot leak the project
     createdProjectUuids.push(secondProjectUuid);
 
-    const refreshResp = await client.post<Body<{ jobUuid: string }>>(
-        `/api/v1/projects/${secondProjectUuid}/refresh`,
-    );
-    expect(refreshResp.status).toBe(200);
+    const compiled = await withRefreshLock(async () => {
+        const refreshResp = await client.post<Body<{ jobUuid: string }>>(
+            `/api/v1/projects/${secondProjectUuid}/refresh`,
+        );
+        expect(refreshResp.status).toBe(200);
 
-    const compiled = await waitForV1JobCompletion(
-        client,
-        refreshResp.body.results.jobUuid,
-    );
+        return waitForV1JobCompletion(client, refreshResp.body.results.jobUuid);
+    });
     expect(compiled).toBe(true);
 
     return secondProjectUuid;

--- a/packages/api-tests/tests/v2/dashboards.test.ts
+++ b/packages/api-tests/tests/v2/dashboards.test.ts
@@ -12,6 +12,10 @@ import { TestResourceTracker, uniqueName } from '../../helpers/test-isolation';
 const v1 = '/api/v1';
 const v2 = '/api/v2';
 
+// Without an explicit spaceUuid the backend picks a default space, which can
+// belong to a concurrently-running test file that deletes it mid-test.
+let testSpaceUuid: string;
+
 async function createDashboardV1(
     client: ApiClient,
     projectUuid: string,
@@ -19,7 +23,7 @@ async function createDashboardV1(
 ): Promise<Dashboard> {
     const resp = await client.post<{ results: Dashboard }>(
         `${v1}/projects/${projectUuid}/dashboards`,
-        body,
+        { spaceUuid: testSpaceUuid, ...body },
     );
     expect(resp.status).toBe(201);
     return resp.body.results;
@@ -32,6 +36,13 @@ describe('V2 Project Dashboard endpoints', () => {
 
     beforeAll(async () => {
         admin = await login();
+        const spaceResp = await admin.post<{ results: { uuid: string } }>(
+            `${v1}/projects/${projectUuid}/spaces/`,
+            { name: uniqueName('V2 dashboards space') },
+        );
+        expect(spaceResp.status).toBe(200);
+        testSpaceUuid = spaceResp.body.results.uuid;
+        tracker.trackSpace(testSpaceUuid);
     });
 
     afterAll(async () => {

--- a/packages/api-tests/tests/v2/savedCharts.test.ts
+++ b/packages/api-tests/tests/v2/savedCharts.test.ts
@@ -11,6 +11,10 @@ import { TestResourceTracker, uniqueName } from '../../helpers/test-isolation';
 const v1 = '/api/v1';
 const v2 = '/api/v2';
 
+// Without an explicit spaceUuid the backend picks a default space, which can
+// belong to a concurrently-running test file that deletes it mid-test.
+let testSpaceUuid: string;
+
 async function createChartV1(
     client: ApiClient,
     projectUuid: string,
@@ -19,7 +23,7 @@ async function createChartV1(
     const body: CreateChartInSpace = {
         ...chartMock,
         name,
-        spaceUuid: undefined,
+        spaceUuid: testSpaceUuid,
         dashboardUuid: null,
     };
     const resp = await client.post<{ results: SavedChart }>(
@@ -37,6 +41,13 @@ describe('V2 Project Saved Chart endpoints', () => {
 
     beforeAll(async () => {
         admin = await login();
+        const spaceResp = await admin.post<{ results: { uuid: string } }>(
+            `${v1}/projects/${projectUuid}/spaces/`,
+            { name: uniqueName('V2 saved charts space') },
+        );
+        expect(spaceResp.status).toBe(200);
+        testSpaceUuid = spaceResp.body.results.uuid;
+        tracker.trackSpace(testSpaceUuid);
     });
 
     afterAll(async () => {

--- a/packages/api-tests/vitest.config.ts
+++ b/packages/api-tests/vitest.config.ts
@@ -1,14 +1,56 @@
-import { defineConfig } from 'vitest/config';
+import { defaultExclude, defineConfig } from 'vitest/config';
+
+/**
+ * Files that are safe to run with file parallelism: they only create/delete
+ * their own resources or read seed data. Files that mutate state shared across
+ * files (org member roles, seed-project settings like dataTimezone, embed
+ * config, pinning, or assertions on global listings) must NOT be added here —
+ * they run serially. New test files default to the serial group.
+ *
+ * Project refreshes run `dbt deps` in a shared server-side directory, so all
+ * refresh calls must go through `withRefreshLock` (helpers/projects.ts).
+ * Files that trigger fire-and-forget compiles the lock can't cover (preview
+ * creation, promotion) must stay in the serial group.
+ *
+ * Project-wide listing endpoints (/charts, /chart-summaries, catalog) 404 when
+ * another test deletes a space mid-request, so files asserting on them are
+ * serial too.
+ *
+ * CI runs the two groups as separate sequential vitest invocations (see
+ * `test:api`), so serial-group mutations can never race parallel-group reads.
+ */
+const PARALLEL_SAFE = [
+    'tests/async-query.test.ts',
+    'tests/cors.test.ts',
+    'tests/fieldSearch.test.ts',
+    'tests/headlessBrowser.test.ts',
+    'tests/mcpServer.test.ts',
+    'tests/nestedSpaces.test.ts',
+    'tests/pivotQuery.test.ts',
+    'tests/savedChartGet.test.ts',
+    'tests/sqlRunner.test.ts',
+    'tests/v2/dashboards.test.ts',
+    'tests/v2/metricsWithTimeDimensions.test.ts',
+    'tests/v2/savedCharts.test.ts',
+];
+
+// serial | parallel | undefined (= all files, serial — local default)
+const group = process.env.API_TEST_GROUP;
 
 export default defineConfig({
     test: {
-        include: ['tests/**/*.test.ts'],
+        include: group === 'parallel' ? PARALLEL_SAFE : ['tests/**/*.test.ts'],
+        exclude:
+            group === 'serial'
+                ? [...defaultExclude, ...PARALLEL_SAFE]
+                : defaultExclude,
         environment: 'node',
         testTimeout: 120_000,
         hookTimeout: 30_000,
         globals: true,
         setupFiles: ['vitest.setup.ts'],
         pool: 'forks',
-        fileParallelism: false,
+        fileParallelism: group === 'parallel',
+        maxConcurrency: 10,
     },
 });

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
@@ -8,8 +8,9 @@ import {
     ActionIcon,
     Badge,
     ColorSwatch,
+    Menu,
 } from '@mantine-8/core';
-import { Menu, Tooltip } from '@mantine/core';
+import { Tooltip } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
     IconDotsVertical,
@@ -186,20 +187,26 @@ export const PaletteItem: FC<PaletteItemProps> = ({
 
                             <Menu.Dropdown>
                                 <Menu.Item
-                                    icon={<MantineIcon icon={IconCopy} />}
+                                    leftSection={
+                                        <MantineIcon icon={IconCopy} />
+                                    }
                                     onClick={handleCopyUuid}
                                 >
                                     Copy UUID
                                 </Menu.Item>
                                 <Menu.Item
                                     disabled={readOnly}
-                                    icon={<MantineIcon icon={IconEdit} />}
+                                    leftSection={
+                                        <MantineIcon icon={IconEdit} />
+                                    }
                                     onClick={() => setIsEditModalOpen(true)}
                                 >
                                     Edit palette
                                 </Menu.Item>
                                 <Menu.Item
-                                    icon={<MantineIcon icon={IconTrash} />}
+                                    leftSection={
+                                        <MantineIcon icon={IconTrash} />
+                                    }
                                     onClick={() => setIsDeleteModalOpen(true)}
                                     disabled={isActive || readOnly}
                                     color="red"

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -1,7 +1,15 @@
 import { subject } from '@casl/ability';
 import { DbtProjectType } from '@lightdash/common';
-import { Group, Paper, Stack, Text, Button, ActionIcon } from '@mantine-8/core';
-import { Menu, Tooltip } from '@mantine/core';
+import {
+    Group,
+    Paper,
+    Stack,
+    Text,
+    Button,
+    ActionIcon,
+    Menu,
+} from '@mantine-8/core';
+import { Tooltip } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
     IconBrandGithub,

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -7,8 +7,9 @@ import {
     Button,
     ActionIcon,
     HoverCard,
+    Menu,
 } from '@mantine-8/core';
-import { Menu, Tooltip } from '@mantine/core';
+import { Tooltip } from '@mantine/core';
 import {
     IconArrowBack,
     IconDots,
@@ -265,7 +266,9 @@ export const HeaderEdit: FC = () => {
                                 <Menu.Label>Manage</Menu.Label>
                                 <Menu.Item
                                     disabled={!config || !sql}
-                                    icon={<MantineIcon icon={IconTrash} />}
+                                    leftSection={
+                                        <MantineIcon icon={IconTrash} />
+                                    }
                                     color="red"
                                     onClick={() =>
                                         dispatch(

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -7,8 +7,9 @@ import {
     Title,
     Button,
     ActionIcon,
+    Menu,
 } from '@mantine-8/core';
-import { Menu, Tooltip } from '@mantine/core';
+import { Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconCirclesRelation,
@@ -222,7 +223,7 @@ export const HeaderView: FC = () => {
                                 <Menu.Dropdown>
                                     <Menu.Label>Manage</Menu.Label>
                                     <Menu.Item
-                                        icon={
+                                        leftSection={
                                             <MantineIcon
                                                 icon={IconLayoutGridAdd}
                                             />
@@ -247,7 +248,7 @@ export const HeaderView: FC = () => {
                                                 })}
                                             >
                                                 <Menu.Item
-                                                    icon={
+                                                    leftSection={
                                                         <MantineIcon
                                                             icon={
                                                                 IconCirclesRelation
@@ -273,7 +274,7 @@ export const HeaderView: FC = () => {
                                         >
                                             <div>
                                                 <Menu.Item
-                                                    icon={
+                                                    leftSection={
                                                         <MantineIcon
                                                             icon={
                                                                 IconDatabaseExport
@@ -296,7 +297,7 @@ export const HeaderView: FC = () => {
                                         </Tooltip>
                                     )}
                                     <Menu.Item
-                                        icon={
+                                        leftSection={
                                             <MantineIcon
                                                 icon={IconTrash}
                                                 color="red"


### PR DESCRIPTION
## Summary

Experiment to speed up the `E2E: API (Vitest)` job (~14 min, fully serial since #21127 reverted parallelism after a flake). This re-enables file parallelism for a curated allowlist of test files while keeping everything that touches shared state serial.

- `test:api` now runs two sequential vitest invocations: the **serial group** (`fileParallelism: false`, default for new files) and a **parallel group** of files that only create/delete their own resources or read seed data.
- The two invocations never overlap, so serial-group mutations (seed-project `dataTimezone`, org roles, embed config) can never race parallel-group reads.
- `pnpm -F api-tests test:api:single` keeps the old single-invocation behavior for local use.

## Root causes of the March flakiness, found while stress-testing locally

Re-enabling parallelism naively reproduced real races (likely the same class that got it turned off in #21127):

1. **`dbt deps` race**: all test-created projects point at the same server-side dbt directory, so concurrent refreshes fail with `Failed to run "dbt1.7 deps"`. Fixed with a cross-process file lock (`withRefreshLock`) that serializes refreshes; files that trigger fire-and-forget compiles the lock can't cover (preview creation, promotion) stay serial.
2. **Default-space races**: charts/dashboards created without an explicit `spaceUuid` land in "the first accessible space", which a concurrent test file can delete mid-request. `v2/dashboards` and `v2/savedCharts` now create their own space; files that intentionally *test* default-space selection (`savedChart`, `dashboard`) stay serial.
3. **Listing 404s**: project-wide listing endpoints (`/charts`, `/chart-summaries`, catalog) 404 with `Space with uuid … not found` when a space is deleted mid-request, so files asserting on them stay serial. (Arguably a backend TOCTOU bug worth a separate look.)

`pivotQuery` additionally uses `describe.concurrent` so its independent per-warehouse blocks overlap instead of running back to back.

## Validation

- Parallel group stress-tested locally: 12/12 consecutive green runs after the fixes above (each earlier flake reproduced, was diagnosed, and its file either fixed or moved to serial).
- Serial group unchanged in content; local failures there are pre-existing env gaps (no SMTP relay, `LIGHTDASH_ENABLE_TIMEZONE_SUPPORT` unset) that don't apply to CI.

The point of this PR is to observe the CI timing and stability of the split — comparing against the ~14 min baseline.
