### PR TITLE
fix: validate default time dimensions

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.grepPrecision.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.grepPrecision.test.ts
@@ -171,8 +171,6 @@ describe('getDefaultTimeDimensionFieldIds', () => {
         });
     });
 
-    // Malformed dbt YAML (wrong keys inside default_time_dimension) compiles
-    // to {}; must not crash the whole grep_fields index build
     it('returns null when the model default time dimension has no field', () => {
         const explore = makeExplore({
             name: 'orders',

--- a/packages/cli/src/dbt/validation.test.ts
+++ b/packages/cli/src/dbt/validation.test.ts
@@ -1,0 +1,56 @@
+import {
+    DbtManifestVersion,
+    InlineErrorType,
+    type DbtRawModelNode,
+} from '@lightdash/common';
+import { validateDbtModel } from './validation';
+
+const makeModel = (name: string): DbtRawModelNode =>
+    ({
+        name,
+        resource_type: 'model',
+        database: 'database',
+        columns: { id: { name: 'id', meta: {} } },
+        meta: {},
+    }) as unknown as DbtRawModelNode;
+
+describe('validateDbtModel', () => {
+    test('keeps valid v12 models when column config metadata is invalid', async () => {
+        const validModel = makeModel('valid_orders');
+        const invalidModel = {
+            ...makeModel('invalid_orders'),
+            columns: {
+                amount: {
+                    name: 'amount',
+                    config: {
+                        meta: {
+                            metrics: {
+                                total_amount: {
+                                    type: 'sum',
+                                    default_time_dimension: {
+                                        field: { created_at: null },
+                                        interval: 'DAY',
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        } as unknown as DbtRawModelNode;
+
+        const result = await validateDbtModel(
+            'postgres',
+            DbtManifestVersion.V12,
+            [validModel, invalidModel],
+        );
+
+        expect(result.valid.map(({ name }) => name)).toEqual(['valid_orders']);
+        expect(result.invalid).toMatchObject([
+            {
+                name: 'invalid_orders',
+                errors: [{ type: InlineErrorType.METADATA_PARSE_ERROR }],
+            },
+        ]);
+    });
+});

--- a/packages/common/src/dbt/schemas/lightdashMetadata.json
+++ b/packages/common/src/dbt/schemas/lightdashMetadata.json
@@ -61,6 +61,20 @@
                 }
             }
         },
+        "DefaultTimeDimension": {
+            "type": "object",
+            "properties": {
+                "field": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "interval": {
+                    "type": "string",
+                    "enum": ["DAY", "WEEK", "MONTH", "YEAR"]
+                }
+            },
+            "required": ["field", "interval"]
+        },
         "Compact": {
             "type": "string",
             "enum": [
@@ -404,6 +418,9 @@
                 },
                 "tags": {
                     "$ref": "#/definitions/Tags"
+                },
+                "default_time_dimension": {
+                    "$ref": "#/definitions/DefaultTimeDimension"
                 }
             }
         },
@@ -427,6 +444,21 @@
                         "$ref": "#/definitions/LightdashMetric"
                     },
                     "default": {}
+                }
+            }
+        },
+        "LightdashColumnConfig": {
+            "type": "object",
+            "properties": {
+                "meta": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/LightdashColumnMetadata"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             }
         },
@@ -520,11 +552,21 @@
                     },
                     "maxItems": 5
                 },
+                "metrics": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/LightdashMetric"
+                    },
+                    "default": {}
+                },
                 "required_attributes": {
                     "$ref": "#/definitions/RequiredAttributes"
                 },
                 "any_attributes": {
                     "$ref": "#/definitions/AnyAttributes"
+                },
+                "default_time_dimension": {
+                    "$ref": "#/definitions/DefaultTimeDimension"
                 }
             },
             "default": {}

--- a/packages/common/src/dbt/schemas/lightdashV12.json
+++ b/packages/common/src/dbt/schemas/lightdashV12.json
@@ -33,6 +33,9 @@
                                     "type": "null"
                                 }
                             ]
+                        },
+                        "config": {
+                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashColumnConfig"
                         }
                     }
                 }

--- a/packages/common/src/dbt/schemas/lightdashV20.json
+++ b/packages/common/src/dbt/schemas/lightdashV20.json
@@ -33,6 +33,9 @@
                                     "type": "null"
                                 }
                             ]
+                        },
+                        "config": {
+                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashColumnConfig"
                         }
                     }
                 }

--- a/packages/common/src/dbt/validation.test.ts
+++ b/packages/common/src/dbt/validation.test.ts
@@ -1,0 +1,137 @@
+import { model } from '../compiler/translator.mock';
+import { DbtManifestVersion, type DbtRawModelNode } from '../types/dbt';
+import { ManifestValidator } from './validation';
+
+const metadataSchemaId =
+    'https://schemas.lightdash.com/lightdash/metadata.json';
+const defaultTimeDimensionValidator = ManifestValidator.getValidator(
+    `${metadataSchemaId}#/definitions/DefaultTimeDimension`,
+);
+
+const withMeta = (meta: Record<string, unknown>): DbtRawModelNode =>
+    ({ ...model, meta }) as unknown as DbtRawModelNode;
+
+const usesColumnConfigMeta = (manifestVersion: DbtManifestVersion) =>
+    manifestVersion === DbtManifestVersion.V12 ||
+    manifestVersion === DbtManifestVersion.V20;
+
+const withColumnMetricDefault = (
+    manifestVersion: DbtManifestVersion,
+    field: unknown,
+): DbtRawModelNode => {
+    const meta = {
+        metrics: {
+            total_amount: {
+                type: 'sum',
+                default_time_dimension: { field, interval: 'DAY' },
+            },
+        },
+    };
+
+    return {
+        ...model,
+        ...(manifestVersion === DbtManifestVersion.V7
+            ? { root_path: 'root' }
+            : {}),
+        columns: {
+            amount: {
+                name: 'amount',
+                ...(usesColumnConfigMeta(manifestVersion)
+                    ? { config: { meta } }
+                    : { meta }),
+            },
+        },
+    } as unknown as DbtRawModelNode;
+};
+
+describe('DefaultTimeDimension metadata schema', () => {
+    test.each([
+        {
+            name: 'non-string field',
+            value: { field: { created_at: null }, interval: 'DAY' },
+            error: 'must be string',
+        },
+        {
+            name: 'missing interval',
+            value: { field: 'created_at' },
+            error: "must have required property 'interval'",
+        },
+        {
+            name: 'unsupported interval',
+            value: { field: 'created_at', interval: 'HOUR' },
+            error: 'must be equal to one of the allowed values',
+        },
+    ])('rejects a $name', ({ value, error: expectedError }) => {
+        const [isValid, error] = ManifestValidator.isValid(
+            defaultTimeDimensionValidator,
+            value,
+        );
+
+        expect(isValid).toBe(false);
+        expect(error).toContain(expectedError);
+    });
+
+    test('accepts the documented shape', () => {
+        expect(
+            ManifestValidator.isValid(defaultTimeDimensionValidator, {
+                field: 'created_at',
+                interval: 'MONTH',
+            }),
+        ).toEqual([true, undefined]);
+    });
+});
+
+describe('ManifestValidator default_time_dimension composition', () => {
+    test.each(Object.values(DbtManifestVersion))(
+        'validates the column metadata path for %s',
+        (manifestVersion) => {
+            const validator = new ManifestValidator(manifestVersion);
+            const [isValid, error] = validator.isModelValid(
+                withColumnMetricDefault(manifestVersion, {
+                    created_at: null,
+                }),
+            );
+
+            expect(isValid).toBe(false);
+            expect(error).toContain('must be string');
+            expect(
+                validator.isModelValid(
+                    withColumnMetricDefault(manifestVersion, 'created_at'),
+                ),
+            ).toEqual([true, undefined]);
+        },
+    );
+
+    test.each([
+        {
+            name: 'model default',
+            meta: {
+                default_time_dimension: {
+                    field: { created_at: null },
+                    interval: 'DAY',
+                },
+            },
+        },
+        {
+            name: 'model-level metric default',
+            meta: {
+                metrics: {
+                    total_amount: {
+                        type: 'sum',
+                        default_time_dimension: {
+                            field: { created_at: null },
+                            interval: 'DAY',
+                        },
+                    },
+                },
+            },
+        },
+    ])('validates the $name path', ({ meta }) => {
+        const [isValid, error] = new ManifestValidator(
+            DbtManifestVersion.V12,
+        ).isModelValid(withMeta(meta));
+
+        expect(isValid).toBe(false);
+        expect(error).toContain('must be string');
+    });
+});

--- a/packages/common/src/types/timeFrames.ts
+++ b/packages/common/src/types/timeFrames.ts
@@ -69,6 +69,21 @@ export const timeFrameToDateGranularityMap: Partial<
     [TimeFrames.YEAR]: DateGranularity.YEAR,
 };
 
+export const DEFAULT_TIME_DIMENSION_INTERVALS = [
+    TimeFrames.DAY,
+    TimeFrames.WEEK,
+    TimeFrames.MONTH,
+    TimeFrames.YEAR,
+] as const;
+
+export type DefaultTimeDimensionInterval =
+    (typeof DEFAULT_TIME_DIMENSION_INTERVALS)[number];
+
+export const isDefaultTimeDimensionInterval = (
+    value: unknown,
+): value is DefaultTimeDimensionInterval =>
+    DEFAULT_TIME_DIMENSION_INTERVALS.some((interval) => interval === value);
+
 export type DefaultTimeDimension = {
     field: string;
     interval: TimeFrames;

--- a/packages/common/src/utils/metricsExplorer.test.ts
+++ b/packages/common/src/utils/metricsExplorer.test.ts
@@ -197,9 +197,6 @@ describe('getDefaultTimeDimension', () => {
         hidden: false,
     };
 
-    // Malformed dbt YAML (wrong keys inside default_time_dimension) compiles
-    // to an empty object; treat it as absent instead of returning
-    // { field: undefined } that crashes downstream getItemId calls.
     test('ignores a metric-level default time dimension without a field', () => {
         expect(
             getDefaultTimeDimension({
@@ -216,6 +213,41 @@ describe('getDefaultTimeDimension', () => {
         } as CompiledTable;
 
         expect(getDefaultTimeDimension(metric, table)).toBeUndefined();
+    });
+
+    test('falls back to the model default when the metric field is malformed', () => {
+        const table = {
+            name: 'orders',
+            defaultTimeDimension: {
+                field: 'created_at',
+                interval: TimeFrames.WEEK,
+            },
+        } as CompiledTable;
+
+        expect(
+            getDefaultTimeDimension(
+                {
+                    ...metric,
+                    defaultTimeDimension: {
+                        field: { created_at: null },
+                        interval: TimeFrames.DAY,
+                    } as unknown as DefaultTimeDimension,
+                },
+                table,
+            ),
+        ).toEqual({ field: 'created_at', interval: TimeFrames.WEEK });
+    });
+
+    test('ignores an unsupported default interval', () => {
+        expect(
+            getDefaultTimeDimension({
+                ...metric,
+                defaultTimeDimension: {
+                    field: 'created_at',
+                    interval: TimeFrames.HOUR,
+                } as unknown as DefaultTimeDimension,
+            }),
+        ).toBeUndefined();
     });
 
     test('returns the metric-level default time dimension when valid', () => {

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -37,7 +37,11 @@ import {
 } from '../types/metricsExplorer';
 import { type WarehouseTypes } from '../types/projects';
 import type { ResultRow } from '../types/results';
-import { TimeFrames, type DefaultTimeDimension } from '../types/timeFrames';
+import {
+    isDefaultTimeDimensionInterval,
+    TimeFrames,
+    type DefaultTimeDimension,
+} from '../types/timeFrames';
 import assertUnreachable from './assertUnreachable';
 import { createFilterRuleFromModelRequiredFilterRule } from './filters';
 import { getItemId } from './item';
@@ -502,6 +506,14 @@ export const DEFAULT_METRICS_EXPLORER_TIME_INTERVAL = TimeFrames.MONTH;
 
 export type TimeDimensionConfig = DefaultTimeDimension & { table: string };
 
+const hasValidDefaultTimeDimension = (
+    defaultTimeDimension: DefaultTimeDimension | undefined,
+): defaultTimeDimension is DefaultTimeDimension =>
+    typeof defaultTimeDimension?.field === 'string' &&
+    defaultTimeDimension.field.length > 0 &&
+    (defaultTimeDimension.interval === undefined ||
+        isDefaultTimeDimensionInterval(defaultTimeDimension.interval));
+
 export const getFirstAvailableTimeDimension = (
     metric: MetricWithAssociatedTimeDimension,
 ): TimeDimensionConfig | undefined => {
@@ -522,10 +534,8 @@ export const getDefaultTimeDimension = (
     metric: CompiledMetric,
     table?: CompiledTable,
 ): DefaultTimeDimension | undefined => {
-    // Malformed yml (e.g. wrong keys inside default_time_dimension) compiles
-    // to a field-less object — treat it as absent
     // Priority 1: Use metric-level default time dimension if defined in yml
-    if (metric.defaultTimeDimension?.field) {
+    if (hasValidDefaultTimeDimension(metric.defaultTimeDimension)) {
         return {
             field: metric.defaultTimeDimension.field,
             interval:
@@ -535,7 +545,7 @@ export const getDefaultTimeDimension = (
     }
 
     // Priority 2: Use model-level default time dimension if defined in yml
-    if (table?.defaultTimeDimension?.field) {
+    if (hasValidDefaultTimeDimension(table?.defaultTimeDimension)) {
         return {
             field: table.defaultTimeDimension.field,
             interval:


### PR DESCRIPTION
## Summary

- reject malformed default time dimensions during dbt manifest validation
- validate dbt 1.10+ and Fusion column `config.meta` metadata
- safely ignore malformed defaults already stored in compiled explores
- preserve partial compilation so valid explores can still deploy

## Validation

- common, backend, and CLI focused tests
- common, backend, and CLI fast typechecks
- development CLI deploy with malformed and restored metadata
- web `Refresh dbt` with malformed and restored metadata

Closes: PROD-9014
Closes: #25793
