### PR TITLE
feat(data-apps): bump claude code to `2.1.215`

### DIFF
--- a/sandboxes/data-apps/e2b.Dockerfile
+++ b/sandboxes/data-apps/e2b.Dockerfile
@@ -2,7 +2,7 @@ FROM node:22
 
 # Global tooling
 RUN npm install -g pnpm@10.33.0
-RUN npm install -g @anthropic-ai/claude-code
+RUN npm install -g @anthropic-ai/claude-code@2.1.215
 
 WORKDIR /app
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-621/update-claude-code-version

### Description:
We've been running on a Claude Code version from April, since the docker image layer cached that version. This also meant that we were stuck with Sonnet 4.6 and Opus 4.7.

<img width="3438" height="1482" alt="image" src="https://github.com/user-attachments/assets/808e22f0-74fd-46a3-9466-cb60c0f3370a" />
