### PR TITLE
fix: filter for time interval should override filter for date

### DIFF
--- a/packages/common/src/utils/filters.mock.ts
+++ b/packages/common/src/utils/filters.mock.ts
@@ -444,6 +444,21 @@ export const mockExplore: Explore = {
             metrics: {},
             lineageGraph: {},
             dimensions: {
+                // Interval base dimensions have isIntervalBase set and no
+                // timeIntervalBaseDimensionName (see convertDimension in translator.ts)
+                order_date: {
+                    name: 'order_date',
+                    label: 'Order Date',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    compiledSql: 'order_date',
+                    tablesReferences: [],
+                    sql: 'order_date',
+                    hidden: false,
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.DATE,
+                    isIntervalBase: true,
+                },
                 order_date_year: {
                     name: 'order_date_year',
                     label: 'Order Date Year',

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -975,6 +975,115 @@ describe('trackWhichTimeBasedMetricFiltersToOverride', () => {
         );
     });
 
+    test('should track chart filter on interval base dimension when dashboard filter targets an interval dimension', () => {
+        const metricQueryDimensionFilters: AndFilterGroup = {
+            id: 'dim-filter-group',
+            and: [
+                {
+                    id: 'base-filter',
+                    target: { fieldId: 'order_date' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['2024-06-26'],
+                },
+            ],
+        };
+
+        const dashboardFilter: DashboardFilterRule = {
+            id: 'month-filter',
+            label: 'Month Filter',
+            target: {
+                fieldId: 'order_date_month',
+                tableName: 'orders',
+            },
+            operator: FilterOperator.EQUALS,
+            values: ['2025-01'],
+        };
+
+        const result = trackWhichTimeBasedMetricFiltersToOverride(
+            metricQueryDimensionFilters,
+            dashboardFilter,
+            mockExplore,
+        );
+
+        expect(result.overrideData?.fieldsToChange).toEqual(['order_date']);
+    });
+
+    test('should track chart filters on base and interval dimensions when dashboard filter targets an interval dimension', () => {
+        const metricQueryDimensionFilters: AndFilterGroup = {
+            id: 'dim-filter-group',
+            and: [
+                {
+                    id: 'base-filter',
+                    target: { fieldId: 'order_date' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['2024-03-01'],
+                },
+                {
+                    id: 'week-filter',
+                    target: { fieldId: 'order_date_week' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['2024-03-25'],
+                },
+            ],
+        };
+
+        const dashboardFilter: DashboardFilterRule = {
+            id: 'year-filter',
+            label: 'Year Filter',
+            target: {
+                fieldId: 'order_date_year',
+                tableName: 'orders',
+            },
+            operator: FilterOperator.EQUALS,
+            values: ['2024'],
+        };
+
+        const result = trackWhichTimeBasedMetricFiltersToOverride(
+            metricQueryDimensionFilters,
+            dashboardFilter,
+            mockExplore,
+        );
+
+        expect(result.overrideData?.fieldsToChange).toEqual(
+            expect.arrayContaining(['order_date', 'order_date_week']),
+        );
+    });
+
+    test('should track chart filter on interval dimension when dashboard filter targets the interval base dimension', () => {
+        const metricQueryDimensionFilters: AndFilterGroup = {
+            id: 'dim-filter-group',
+            and: [
+                {
+                    id: 'month-filter',
+                    target: { fieldId: 'order_date_month' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['2024-03'],
+                },
+            ],
+        };
+
+        const dashboardFilter: DashboardFilterRule = {
+            id: 'base-filter',
+            label: 'Order Date Filter',
+            target: {
+                fieldId: 'order_date',
+                tableName: 'orders',
+            },
+            operator: FilterOperator.EQUALS,
+            values: ['2024-03-01'],
+        };
+
+        const result = trackWhichTimeBasedMetricFiltersToOverride(
+            metricQueryDimensionFilters,
+            dashboardFilter,
+            mockExplore,
+        );
+
+        expect(result.overrideData?.fieldsToChange).toEqual([
+            'order_date_month',
+        ]);
+    });
+
     test('should not track fields when dashboard filter targets non-base dimension', () => {
         const metricQueryDimensionFilters: AndFilterGroup = {
             id: 'dim-filter-group',

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -1204,6 +1204,13 @@ const convertDashboardFilterRuleToFilterRule = (
 const getFieldIdWithoutTable = (fieldId: string, tableName: string) =>
     fieldId.replace(`${tableName}_`, '');
 
+const getBaseTimeDimensionName = (
+    timeDimension: Dimension,
+): string | undefined => {
+    if (timeDimension.isIntervalBase) return timeDimension.name;
+    return timeDimension.timeIntervalBaseDimensionName;
+};
+
 /**
  * Tracks time-based metric filters that need overriding via external map
  * @param metricQueryDimensionFilters - Existing dimension filters in the query
@@ -1232,7 +1239,11 @@ export const trackWhichTimeBasedMetricFiltersToOverride = (
             )
         ];
 
-    if (!baseDimension?.timeIntervalBaseDimensionName) {
+    const baseTimeDimensionName = baseDimension
+        ? getBaseTimeDimensionName(baseDimension)
+        : undefined;
+
+    if (!baseTimeDimensionName) {
         return { filter: dashboardFilterRule };
     }
 
@@ -1257,8 +1268,9 @@ export const trackWhichTimeBasedMetricFiltersToOverride = (
                             ?.dimensions[itemFieldId];
 
                     const isTimeOrDateDimension =
-                        itemDimension?.timeIntervalBaseDimensionName ===
-                        baseDimension.timeIntervalBaseDimensionName;
+                        itemDimension !== undefined &&
+                        getBaseTimeDimensionName(itemDimension) ===
+                            baseTimeDimensionName;
 
                     if (isTimeOrDateDimension) {
                         return [...acc, item.target.fieldId];
@@ -1277,8 +1289,7 @@ export const trackWhichTimeBasedMetricFiltersToOverride = (
         ? {
               filter: dashboardFilterRule,
               overrideData: {
-                  baseTimeDimensionName:
-                      baseDimension.timeIntervalBaseDimensionName,
+                  baseTimeDimensionName,
                   fieldsToChange,
               },
           }
@@ -1406,13 +1417,6 @@ export const isFilterRuleInQuery = (
     explore: Explore,
 ): undefined | boolean => {
     if (!dimensionsFilterGroup) return undefined;
-
-    const getBaseTimeDimensionName = (
-        timeDimension: Dimension,
-    ): string | undefined => {
-        if (timeDimension.isIntervalBase) return timeDimension.name;
-        return timeDimension.timeIntervalBaseDimensionName;
-    };
 
     const getDimensionFromExplore = (fieldId: string): Dimension | undefined =>
         Object.values(explore.tables)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15183 

### Description:

Makes it so that dashboard filters for a time interval will override a date fitler on the same field. 
