### PR TITLE
fix(backend): rebase MIN/MAX over naive TIMESTAMP columns to true instant for non-UTC column timezones (GLITCH-623)

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -5497,8 +5497,9 @@ describe('Timezone-aware DATE_TRUNC day-or-coarser → DATE cast (GLITCH-452)', 
         expect(query).not.toContain('AT TIME ZONE');
     });
 
-    // A MAX over a raw TIMESTAMP base is an instant, not a calendar date — it
-    // stays an un-cast MAX, shifted only at display time.
+    // A MAX over a raw TIMESTAMP base is an instant, not a calendar date — with
+    // the default UTC column timezone it stays an un-cast MAX, shifted only at
+    // display time. Non-UTC column timezones rebase it (tests below).
     const maxTsQuery: CompiledMetricQuery = {
         ...dayQuery,
         dimensions: [],
@@ -5541,6 +5542,91 @@ describe('Timezone-aware DATE_TRUNC day-or-coarser → DATE cast (GLITCH-452)', 
         });
         expect(query).toContain(`MAX("events".occurred_at) AS "events_max_ts"`);
         expect(query).not.toMatch(/MAX\(CAST/);
+    });
+
+    // With a non-UTC column timezone the bare aggregate emits a naive wall
+    // clock that the wire stamps as UTC — the aggregate output is rebased.
+    test('MAX over a TIMESTAMP base + non-UTC column timezone rebases the aggregate (Postgres)', () => {
+        const { query } = buildQuery({
+            explore: buildDayExplore(),
+            compiledMetricQuery: maxTsQuery,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'Asia/Tokyo',
+        });
+        expect(query).toContain(
+            `(MAX("events".occurred_at))::timestamptz AS "events_max_ts"`,
+        );
+    });
+
+    test('MAX over a TIMESTAMP base + non-UTC column timezone rebases the aggregate (BigQuery)', () => {
+        const { query } = buildQuery({
+            explore: buildDayExplore(
+                DimensionType.TIMESTAMP,
+                SupportedDbtAdapter.BIGQUERY,
+            ),
+            compiledMetricQuery: maxTsQuery,
+            warehouseSqlBuilder: bigqueryClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'Asia/Tokyo',
+        });
+        expect(query).toContain(
+            'TIMESTAMP(MAX("events".occurred_at)) AS `events_max_ts`',
+        );
+    });
+
+    test('a YAML MIN/MAX metric (dimensionReference) gets the same rebase', () => {
+        const explore = buildDayExplore();
+        explore.tables.events.metrics.max_ts_yaml = {
+            type: MetricType.MAX,
+            fieldType: FieldType.METRIC,
+            table: 'events',
+            tableLabel: 'events',
+            name: 'max_ts_yaml',
+            label: 'max_ts_yaml',
+            sql: '${TABLE}.occurred_at',
+            compiledSql: 'MAX("events".occurred_at)',
+            tablesReferences: ['events'],
+            hidden: false,
+            baseDimensionType: DimensionType.TIMESTAMP,
+            dimensionReference: 'events_occurred_at',
+        };
+        const { query } = buildQuery({
+            explore,
+            compiledMetricQuery: {
+                ...dayQuery,
+                dimensions: [],
+                metrics: ['events_max_ts_yaml'],
+            },
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'Asia/Tokyo',
+        });
+        expect(query).toContain(
+            `(MAX("events".occurred_at))::timestamptz AS "events_max_ts_yaml"`,
+        );
+    });
+
+    test('convert_timezone: false on the base dim leaves the TIMESTAMP MAX un-cast', () => {
+        const explore = buildDayExplore();
+        explore.tables.events.dimensions.occurred_at.skipTimezoneConversion = true;
+        const { query } = buildQuery({
+            explore,
+            compiledMetricQuery: maxTsQuery,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'Asia/Tokyo',
+        });
+        expect(query).toContain(`MAX("events".occurred_at) AS "events_max_ts"`);
+        expect(query).not.toContain('::timestamptz');
     });
 
     // A coarser grain (month) is just as truncatable as day — it takes the same

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -806,6 +806,20 @@ export class MetricQueryBuilder {
         if (metric.type !== MetricType.MIN && metric.type !== MetricType.MAX) {
             return baseSql;
         }
+        // A MIN/MAX over a naive TIMESTAMP column aggregates the bare wall
+        // clock, which the wire stamps as UTC — rebase the aggregate output to
+        // a true instant (identity in value for aware columns).
+        if (metric.baseDimensionType === DimensionType.TIMESTAMP) {
+            if (this.columnTimezone === 'UTC') return baseSql;
+            const baseDimension = this.resolveMinMaxBaseDimension(
+                metricId,
+                metric,
+            );
+            if (baseDimension?.skipTimezoneConversion) return baseSql;
+            return dateTruncTimezoneConversions[adapterType].castToInstant(
+                baseSql,
+            );
+        }
         // Only a calendar-DATE aggregation over a truncatable interval can drift:
         // a plain DATE column carries no interval, and a TIMESTAMP base is not
         // recast to a calendar date.
@@ -843,6 +857,31 @@ export class MetricQueryBuilder {
         return baseSql
             .split(baseDimension.compiledSql)
             .join(tzAwareDimensionSql);
+    }
+
+    /**
+     * Base dimension of a MIN/MAX metric: custom metrics carry
+     * baseDimensionName; YAML column metrics carry dimensionReference.
+     */
+    private resolveMinMaxBaseDimension(
+        metricId: string,
+        metric: CompiledMetric,
+    ): CompiledDimension | undefined {
+        const additionalMetric =
+            this.args.compiledMetricQuery.additionalMetrics?.find(
+                (am) => getItemId(am) === metricId,
+            );
+        const baseDimensionId = additionalMetric?.baseDimensionName
+            ? getItemId({
+                  table: metric.table,
+                  name: additionalMetric.baseDimensionName,
+              })
+            : metric.dimensionReference;
+        if (!baseDimensionId) return undefined;
+        return (
+            this.originalExploreDimensions[baseDimensionId] ??
+            this.exploreDimensions[baseDimensionId]
+        );
     }
 
     private buildDimensionsWhereClause(


### PR DESCRIPTION
Closes: GLITCH-623

### Description:

When a `MIN`/`MAX` metric is built over a naive `TIMESTAMP` column with a non-UTC column timezone, the aggregate operates on bare wall-clock values that the wire stamps as UTC, causing incorrect results. This fix rebases the aggregate output to a true instant using the session timezone via a `castToInstant` call. The rebase is safe because `MIN`/`MAX` is order-preserving under the monotonic timezone conversion.

The rebase is skipped when:
- The column timezone is UTC (no correction needed)
- The base dimension has `convert_timezone: false` / `skipTimezoneConversion` set

A new `resolveMinMaxBaseDimension` helper resolves the base dimension for both custom metrics (via `baseDimensionName`) and YAML column metrics (via `dimensionReference`) so that the `skipTimezoneConversion` flag can be checked in both cases.

New tests cover:
- Postgres and BigQuery `MAX` over a `TIMESTAMP` with a non-UTC column timezone producing the correct `::timestamptz` cast
- YAML-defined `MIN`/`MAX` metrics receiving the same rebase
- `convert_timezone: false` on the base dimension leaving the aggregate un-cast