### PR TITLE
fix: rebase RAW filter LHS to match SELECT instant for correct timezone comparisons

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -29,6 +29,7 @@ import {
     Explore,
     ExploreCompiler,
     ExploreType,
+    FeatureFlags,
     FieldType,
     ForbiddenError,
     formatItemValue,
@@ -3550,6 +3551,22 @@ export class AsyncQueryService extends ProjectService {
             preloadedProjectTimezone,
         });
 
+        // Only meaningful with a non-UTC data timezone; skip the lookup otherwise.
+        const rebaseRawTimestampFilters =
+            columnTimezone && columnTimezone !== 'UTC'
+                ? (
+                      await this.featureFlagModel.get({
+                          featureFlagId:
+                              FeatureFlags.NaiveTimestampFilterRebase,
+                          user: {
+                              userUuid: account.user.id,
+                              organizationUuid:
+                                  account.organization.organizationUuid,
+                          },
+                      })
+                  ).enabled
+                : false;
+
         return new QueryComposer(
             { metricQuery, pivotConfiguration, totalConfiguration },
             {
@@ -3565,6 +3582,7 @@ export class AsyncQueryService extends ProjectService {
                 pivotDimensions: pivotDimensions ?? metricQuery.pivotDimensions,
                 useTimezoneAwareDateTrunc,
                 columnTimezone,
+                rebaseRawTimestampFilters,
                 applyDateZoomToFilters,
                 displayTimezone,
             },

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -6526,25 +6526,85 @@ describe('RAW time frame naive-column rebase', () => {
         expect(query).not.toContain('::timestamptz');
     });
 
-    test('RAW filter keeps the bare column (sargable) while the SELECT is rebased', () => {
+    // The filter LHS must be rebased like the SELECT — a bare predicate would
+    // compare the naive wall clock against the instant the SELECT displays.
+    // Flag-gated: the wrap defeats partition pruning.
+    const rawFilterQuery = (values: string[]): CompiledMetricQuery => ({
+        ...rawQuery,
+        filters: {
+            dimensions: {
+                id: 'root',
+                and: [
+                    {
+                        id: 'f1',
+                        target: { fieldId: 'events_occurred_at_raw' },
+                        operator: FilterOperator.GREATER_THAN,
+                        values,
+                    },
+                ],
+            },
+        },
+    });
+
+    test('RAW filter LHS is rebased to match the SELECT (Postgres)', () => {
         const { query } = buildQuery({
             explore: buildRawExplore(),
-            compiledMetricQuery: {
-                ...rawQuery,
-                filters: {
-                    dimensions: {
-                        id: 'root',
-                        and: [
-                            {
-                                id: 'f1',
-                                target: { fieldId: 'events_occurred_at_raw' },
-                                operator: FilterOperator.GREATER_THAN,
-                                values: ['2024-01-15 02:00:00'],
-                            },
-                        ],
-                    },
-                },
-            },
+            compiledMetricQuery: rawFilterQuery(['2024-01-15 02:00:00']),
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'Asia/Tokyo',
+            rebaseRawTimestampFilters: true,
+        });
+        expect(query).toContain(
+            `("events".occurred_at)::timestamptz AS "events_occurred_at_raw"`,
+        );
+        const whereClause = query.slice(query.indexOf('WHERE'));
+        // LHS is the rebased instant; the offset literal now compares correctly.
+        expect(whereClause).toContain(
+            `(("events".occurred_at)::timestamptz) >`,
+        );
+        expect(whereClause).toContain(`('2024-01-15 02:00:00+00:00')`);
+    });
+
+    test('RAW filter LHS is rebased and the literal pinned to UTC (BigQuery)', () => {
+        const { query } = buildQuery({
+            explore: buildRawExplore(SupportedDbtAdapter.BIGQUERY),
+            compiledMetricQuery: rawFilterQuery(['2024-01-15 02:00:00']),
+            warehouseSqlBuilder: bigqueryClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'Asia/Tokyo',
+            rebaseRawTimestampFilters: true,
+        });
+        const whereClause = query.slice(query.indexOf('WHERE'));
+        expect(whereClause).toContain(`(TIMESTAMP("events".occurred_at)) >`);
+        // Offset-less literal pinned to UTC so the job time_zone can't shift it.
+        expect(whereClause).toContain(
+            `TIMESTAMP('2024-01-15 02:00:00', 'UTC')`,
+        );
+    });
+
+    test('convert_timezone: false keeps the RAW filter bare (matches the bare SELECT)', () => {
+        const { query } = buildQuery({
+            explore: buildRawExplore(SupportedDbtAdapter.POSTGRES, true),
+            compiledMetricQuery: rawFilterQuery(['2024-01-15 02:00:00']),
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'Asia/Tokyo',
+            rebaseRawTimestampFilters: true,
+        });
+        expect(query).not.toContain('::timestamptz');
+    });
+
+    test('flag off keeps the RAW filter bare while the SELECT is rebased', () => {
+        const { query } = buildQuery({
+            explore: buildRawExplore(),
+            compiledMetricQuery: rawFilterQuery(['2024-01-15 02:00:00']),
             warehouseSqlBuilder: warehouseClientMock,
             intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
             timezone: 'Asia/Tokyo',
@@ -6554,8 +6614,21 @@ describe('RAW time frame naive-column rebase', () => {
         expect(query).toContain(
             `("events".occurred_at)::timestamptz AS "events_occurred_at_raw"`,
         );
-        // The WHERE clause must keep the bare column for partition pruning.
         const whereClause = query.slice(query.indexOf('WHERE'));
         expect(whereClause).not.toContain('::timestamptz');
+        expect(whereClause).toContain(`('2024-01-15 02:00:00+00:00')`);
+    });
+
+    test('UTC column timezone keeps the RAW filter bare (byte-identical)', () => {
+        const { query } = buildQuery({
+            explore: buildRawExplore(),
+            compiledMetricQuery: rawFilterQuery(['2024-01-15 02:00:00']),
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+        });
+        expect(query).not.toContain('::timestamptz');
+        expect(query).toContain(`("events".occurred_at) >`);
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -50,6 +50,7 @@ import {
     lightdashVariablePattern,
     MetricFilterRule,
     MetricType,
+    naiveTimestampRebaseAdapters,
     parseAllReferences,
     parseTableCalculationFunctions,
     PivotConfiguration,
@@ -150,6 +151,10 @@ export type BuildQueryProps = {
     /** Timezone the column data is in — source for the timezone-aware wrap.
      *  Derived from warehouse credentials via `getColumnTimezone`. */
     columnTimezone?: string;
+    /** Rebase RAW timestamp filter columns to instants so predicates match the
+     *  SELECT. Gated behind NaiveTimestampFilterRebase (the wrap defeats
+     *  partition pruning). */
+    rebaseRawTimestampFilters?: boolean;
 };
 
 /**
@@ -688,10 +693,20 @@ export class MetricQueryBuilder {
 
         // RAW passes the base column through untouched, so a naive column is
         // misparsed as UTC downstream — rebase it to a true instant via the
-        // session timezone (identity in value for aware columns). SELECT only:
-        // filters keep the bare column so raw predicates stay sargable.
+        // session timezone (identity in value for aware columns).
         if (isRaw) {
-            if (!respectConvertTimezone || this.columnTimezone === 'UTC') {
+            if (this.columnTimezone === 'UTC') {
+                return dimension.compiledSql;
+            }
+            // Filter LHS rebases too, so predicates match the displayed
+            // instants. Flag-gated (the wrap defeats partition pruning); bare
+            // when the opt-out or adapter makes the wrap a no-op.
+            if (
+                !respectConvertTimezone &&
+                (!this.args.rebaseRawTimestampFilters ||
+                    baseDimension.skipTimezoneConversion ||
+                    !naiveTimestampRebaseAdapters.has(adapterType))
+            ) {
                 return dimension.compiledSql;
             }
             return dateTruncTimezoneConversions[adapterType].castToInstant(
@@ -1753,6 +1768,13 @@ export class MetricQueryBuilder {
               }
             : field;
 
+        // A rebased RAW filter LHS is an instant — tag the literal to match.
+        // Decided here, where the wrap happened, so the two cannot diverge.
+        const rawFilterLhsIsInstant =
+            isDimension(field) &&
+            field.timeInterval === TimeFrames.RAW &&
+            filterField.compiledSql !== field.compiledSql;
+
         // For period-to-date filters on truncated dimensions, resolve the
         // base (raw) dimension SQL so EXTRACT operates on the actual date
         let baseDimensionSql: string | undefined;
@@ -1792,6 +1814,7 @@ export class MetricQueryBuilder {
                 baseDimensionSql,
                 this.args.useTimezoneAwareDateTrunc,
                 this.columnTimezone,
+                rawFilterLhsIsInstant,
             );
         });
 

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
@@ -70,6 +70,7 @@ export type QueryComposerContext = {
     continueOnError?: boolean;
     useTimezoneAwareDateTrunc?: boolean;
     columnTimezone?: string;
+    rebaseRawTimestampFilters?: boolean;
     applyDateZoomToFilters?: boolean;
     /**
      * Flag-gated timezone echoed to clients and persisted with the query.
@@ -270,6 +271,7 @@ export class QueryComposer {
             continueOnError,
             useTimezoneAwareDateTrunc,
             columnTimezone,
+            rebaseRawTimestampFilters,
             applyDateZoomToFilters,
         } = this.context;
 
@@ -327,6 +329,7 @@ export class QueryComposer {
                     : undefined,
             useTimezoneAwareDateTrunc,
             columnTimezone,
+            rebaseRawTimestampFilters,
         });
 
         return wrapSentryTransactionSync('QueryBuilder.buildQuery', {}, () =>

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -299,6 +299,7 @@ const renderDateOrTimestampFilterSql = ({
     baseDimensionSql,
     useTimezoneAwareDateTrunc,
     sourceTimezone,
+    instantLhs,
 }: {
     dimensionSql: string;
     filter: FilterRule<FilterOperator, unknown>;
@@ -310,6 +311,7 @@ const renderDateOrTimestampFilterSql = ({
     baseDimensionSql?: string;
     useTimezoneAwareDateTrunc?: boolean;
     sourceTimezone?: string;
+    instantLhs?: boolean;
 }): string => {
     // When startOfWeek is not explicitly configured, use the warehouse's default
     // to ensure JS-side week boundaries match the warehouse's DATE_TRUNC behavior.
@@ -348,6 +350,11 @@ const renderDateOrTimestampFilterSql = ({
                 }
             })();
             return toUTC(naive, timezone);
+        }
+        // The LHS is a rebased instant; BigQuery's offset-less literal would
+        // otherwise be parsed in the job-level time_zone — pin it to UTC.
+        if (instantLhs && adapterType === SupportedDbtAdapter.BIGQUERY) {
+            return `TIMESTAMP('${value}', 'UTC')`;
         }
         switch (adapterType) {
             case SupportedDbtAdapter.TRINO:
@@ -686,6 +693,7 @@ export const renderTimestampFilterSql = ({
     baseDimensionSql,
     useTimezoneAwareDateTrunc,
     sourceTimezone,
+    instantLhs,
 }: {
     dimensionSql: string;
     filter: FilterRule<FilterOperator, unknown>;
@@ -696,6 +704,7 @@ export const renderTimestampFilterSql = ({
     baseDimensionSql?: string;
     useTimezoneAwareDateTrunc?: boolean;
     sourceTimezone?: string;
+    instantLhs?: boolean;
 }): string =>
     renderDateOrTimestampFilterSql({
         dimensionSql,
@@ -708,6 +717,7 @@ export const renderTimestampFilterSql = ({
         baseDimensionSql,
         useTimezoneAwareDateTrunc,
         sourceTimezone,
+        instantLhs,
     });
 
 export const renderBooleanFilterSql = (
@@ -820,6 +830,7 @@ export const renderFilterRuleSql = (
     useTimezoneAwareDateTrunc?: boolean,
     baseTimeIntervalDimensionType?: DimensionType,
     sourceTimezone?: string,
+    instantLhs?: boolean,
 ): string => {
     if (filterRule.disabled) {
         return `1=1`; // When filter is disabled, we want to return all rows
@@ -890,6 +901,7 @@ export const renderFilterRuleSql = (
                         : formatTimestampAsUTC,
                 startOfWeek,
                 baseDimensionSql,
+                instantLhs,
             });
         }
         case DimensionType.BOOLEAN:
@@ -919,6 +931,7 @@ export const renderFilterRuleSqlFromField = (
     baseDimensionSql?: string,
     useTimezoneAwareDateTrunc?: boolean,
     sourceTimezone?: string,
+    instantLhs?: boolean,
 ): string => {
     const fieldType = isCompiledCustomSqlDimension(field)
         ? field.dimensionType
@@ -959,5 +972,6 @@ export const renderFilterRuleSqlFromField = (
         useTimezoneAwareDateTrunc,
         baseTimeIntervalDimensionType,
         sourceTimezone,
+        instantLhs,
     );
 };

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -14,6 +14,16 @@ export enum FeatureFlags {
     EnableTimezoneSupport = 'enable-timezone-support',
 
     /**
+     * Rebase RAW timestamp filter columns to instants when a data timezone is
+     * set, so sub-day filters return the rows the SELECT displays. Wrapping
+     * the filter column defeats partition pruning/index scans on BigQuery and
+     * Postgres-family warehouses, so this is off by default — enable per-org
+     * for data-timezone users who need filter correctness. Temporary: goes
+     * away once filters convert the literal into the column's domain instead.
+     */
+    NaiveTimestampFilterRebase = 'naive-timestamp-filter-rebase',
+
+    /**
      * Enable scheduler task that replaces custom metrics after project compile
      */
     ReplaceCustomMetricsOnCompile = 'replace-custom-metrics-on-compile',

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -107,6 +107,17 @@ const postgresLikeCastToInstant = (sql: string) => `(${sql})::timestamptz`;
 const clickhouseCastToInstant = (sql: string) => `toTimeZone(${sql}, 'UTC')`;
 const identityCastToInstant = (sql: string) => sql;
 
+// Adapters whose castToInstant genuinely rebases a naive column at the SQL
+// level. Identity adapters keep filter columns bare; ClickHouse has no naive
+// type (its castToInstant only relabels an instant) so its filters stay bare.
+export const naiveTimestampRebaseAdapters: ReadonlySet<SupportedDbtAdapter> =
+    new Set([
+        SupportedDbtAdapter.BIGQUERY,
+        SupportedDbtAdapter.POSTGRES,
+        SupportedDbtAdapter.REDSHIFT,
+        SupportedDbtAdapter.DUCKDB,
+    ]);
+
 export const dateTruncTimezoneConversions: Record<
     SupportedDbtAdapter,
     DateTruncTimezoneConversion


### PR DESCRIPTION
Closes: GLITCH-622

### Description:

Fixes a silent correctness bug where RAW timestamp filters compared a naive wall-clock value against the timezone-rebased instant shown in the SELECT, returning wrong rows whenever a **data timezone** is set. On BigQuery this also affects timezone-aware columns: the offset-less filter literal is parsed in the job-level `time_zone` (= data timezone), shifting the compared instant.

The fix rebases the filter LHS to match the SELECT expression and keeps the literal in the same domain:

- **Postgres/Redshift/DuckDB**: filter LHS cast to `timestamptz`; the existing offset literal (`'...+00:00'`) now compares correctly.
- **BigQuery**: filter LHS wrapped with `TIMESTAMP(...)`; the offset-less literal is pinned via `TIMESTAMP('...', 'UTC')`.
- **`convert_timezone: false`** dims stay bare (matches their bare SELECT).
- **Snowflake/Databricks/Spark/Trino/Athena/ClickHouse**: byte-identical output (`castToInstant` is identity / no naive type). A new `naiveTimestampRebaseAdapters` set gates this.
- The LHS wrap and the literal tagging are decided at a single point in `MetricQueryBuilder.getFilterRuleSQL`, so they cannot diverge.

### Rollout — gated behind a default-OFF feature flag

Wrapping the filter column defeats **partition pruning / index scans** on BigQuery and Postgres-family warehouses. To avoid imposing that scan cost on every project with a data timezone, the rebase is gated behind a new DB feature flag, `naive-timestamp-filter-rebase` (default OFF → compiled SQL is byte-identical to today):

1. Merge with the flag off — zero behavior change for anyone.
2. Enable per-org for data-timezone users who need filter correctness (starting with the org that reported the bug, when their timezone support is re-enabled).
3. The flag graduates and dies when GLITCH-616 lands: converting the *literal* into the column's domain (requires GLITCH-615's naive/aware detection) restores pruning, and the wrap remains only as the fallback for unknown-domain columns.

The flag is resolved once per query in `prepareMetricQueryAsyncQueryArgs` (skipped entirely when no non-UTC data timezone is set), covering all v2 async query paths. Embed and legacy sync paths default to off.
