### PR TITLE
test: guard content-as-code model coverage

### DIFF
--- a/docs/content-as-code.md
+++ b/docs/content-as-code.md
@@ -84,7 +84,7 @@ the resource returned by the backend.
 
 1. The CLI discovers and parses the relevant YAML files.
 2. The CLI sends each portable document to the resource's backend `POST
-   .../code/{resource}` endpoint.
+.../code/{resource}` endpoint.
 3. The backend authenticates and authorizes the request.
 4. The backend validates the portable document and its domain invariants.
 5. The backend resolves the existing resource using the documented portable
@@ -455,7 +455,11 @@ Use this sequence when adding a new resource:
    normal YAML document.
 6. Keep organization resources under `lightdash/<resource>/` and project
    resources within the existing project content layout.
-7. Add parser, filename, adapter, backend-domain, and round-trip tests, including
+7. Add a schema coverage contract under
+   `packages/backend/src/contentAsCode/fieldCoverage/`. Name the test after the
+   resource key so the registry test can verify that every registered resource
+   is covered.
+8. Add parser, filename, adapter, backend-domain, and round-trip tests, including
    partial failures and dependency skipping where applicable.
 
 ## Evolving an existing resource
@@ -471,6 +475,57 @@ the new meaning is incompatible with existing files, increment the resource
 version and add an explicit normalizer or migration path. Never spread an
 entire persistence model into a portable document: UUIDs, ownership, secrets,
 and instance-specific state must remain excluded.
+
+### Schema coverage guardrail
+
+Every registered single-document resource has a field coverage contract in
+`packages/backend/src/contentAsCode/fieldCoverage/`. These unit tests compare
+the top-level fields in the generated OpenAPI schema for the domain model with
+the fields in its portable content-as-code document. A model field cannot be
+silently added without making one of these decisions:
+
+- Add the field to the portable document and its adapters.
+- Add the field to `skippedModelFields` when excluding it is intentional.
+- Add a document-only field to `documentOnlyFields` when it has no direct model
+  equivalent, such as `version` or `contentType`.
+
+The lists are exact contracts rather than permanent allowlists. A test also
+fails when an entry becomes stale because the model and document now share the
+field. `registry.test.ts` ensures that adding a resource to
+`CONTENT_AS_CODE_VERSIONS` also requires adding a matching coverage test.
+
+When a model changes, regenerate the OpenAPI schema before running a focused
+contract test. CI does this through `build:fast`, but focused local test runs do
+not:
+
+```bash
+pnpm generate-api:backend:fast
+pnpm -F backend exec vitest run \
+  src/contentAsCode/fieldCoverage/chart.test.ts \
+  --config vitest.config.ts
+```
+
+An unclassified chart field fails with an actionable error:
+
+```text
+[content-as-code:chart] SavedChartDAO has new fields not covered by ChartAsCode:
+  - newField
+
+Add them to ChartAsCode and its adapters, or intentionally add them to
+skippedModelFields in chart.test.ts.
+```
+
+Run every coverage contract with:
+
+```bash
+pnpm -F backend exec vitest run \
+  src/contentAsCode/fieldCoverage \
+  --config vitest.config.ts
+```
+
+This is a schema coverage contract, not a replacement for behavior tests. It
+catches unclassified top-level fields; resource adapters and round-trip tests
+must still prove that portable fields download, compare, and upload correctly.
 
 Charts, dashboards, and spaces do not yet have universal database-enforced
 project-scoped slug uniqueness. Application-level locking protects current

--- a/packages/backend/src/contentAsCode/fieldCoverage/ai_agent.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/ai_agent.test.ts
@@ -1,0 +1,26 @@
+import { describeContentAsCodeSchemaContract } from './schemaContractTestUtils';
+
+describeContentAsCodeSchemaContract({
+    resource: 'ai_agent',
+    modelSchema: 'AiAgent',
+    documentSchema: 'AgentAsCode',
+    skippedModelFields: [
+        'adminOnly',
+        'createdAt',
+        'groupAccess',
+        'imageUrlSource',
+        'integrations',
+        'organizationUuid',
+        'projectUuid',
+        'spaceAccess',
+        'userAccess',
+        'uuid',
+    ],
+    documentOnlyFields: [
+        'agentVersion',
+        'contentType',
+        'downloadedAt',
+        'evaluations',
+        'slug',
+    ],
+});

--- a/packages/backend/src/contentAsCode/fieldCoverage/alert.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/alert.test.ts
@@ -1,0 +1,31 @@
+import { describeContentAsCodeSchemaContract } from './schemaContractTestUtils';
+
+describeContentAsCodeSchemaContract({
+    resource: 'alert',
+    modelSchema: 'SchedulerAndTargets',
+    documentSchema: 'AlertAsCode',
+    skippedModelFields: [
+        'appName',
+        'appUuid',
+        'createdAt',
+        'createdBy',
+        'createdByName',
+        'customViewportWidth',
+        'dashboardName',
+        'dashboardUuid',
+        'format',
+        'latestRun',
+        'options',
+        'projectName',
+        'projectSchedulerTimezone',
+        'projectUuid',
+        'savedChartName',
+        'savedChartUuid',
+        'savedSqlName',
+        'savedSqlUuid',
+        'schedulerUuid',
+        'selectedTabs',
+        'updatedAt',
+    ],
+    documentOnlyFields: ['contentType', 'downloadedAt', 'resource', 'version'],
+});

--- a/packages/backend/src/contentAsCode/fieldCoverage/chart.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/chart.test.ts
@@ -1,0 +1,32 @@
+import { describeContentAsCodeSchemaContract } from './schemaContractTestUtils';
+
+describeContentAsCodeSchemaContract({
+    resource: 'chart',
+    modelSchema: 'SavedChartDAO',
+    documentSchema: 'ChartAsCode',
+    skippedModelFields: [
+        'colorPalette',
+        'colorPaletteUuid',
+        'dashboardName',
+        'dashboardUuid',
+        'deletedAt',
+        'deletedBy',
+        'organizationUuid',
+        'pinnedListOrder',
+        'pinnedListUuid',
+        'projectUuid',
+        'resolvedColorPalette',
+        'spaceName',
+        'spaceUuid',
+        'updatedByUser',
+        'uuid',
+    ],
+    documentOnlyFields: [
+        'contentType',
+        'dashboardSlug',
+        'downloadedAt',
+        'spaceSlug',
+        'verified',
+        'version',
+    ],
+});

--- a/packages/backend/src/contentAsCode/fieldCoverage/custom_role.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/custom_role.test.ts
@@ -1,0 +1,16 @@
+import { describeContentAsCodeSchemaContract } from './schemaContractTestUtils';
+
+describeContentAsCodeSchemaContract({
+    resource: 'custom_role',
+    modelSchema: 'RoleWithScopes',
+    documentSchema: 'CustomRoleAsCode',
+    skippedModelFields: [
+        'createdAt',
+        'createdBy',
+        'organizationUuid',
+        'ownerType',
+        'roleUuid',
+        'updatedAt',
+    ],
+    documentOnlyFields: ['version'],
+});

--- a/packages/backend/src/contentAsCode/fieldCoverage/dashboard.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/dashboard.test.ts
@@ -1,0 +1,31 @@
+import { describeContentAsCodeSchemaContract } from './schemaContractTestUtils';
+
+describeContentAsCodeSchemaContract({
+    resource: 'dashboard',
+    modelSchema: 'DashboardDAO',
+    documentSchema: 'DashboardAsCode',
+    skippedModelFields: [
+        'colorPaletteUuid',
+        'dashboardVersionId',
+        'deletedAt',
+        'deletedBy',
+        'firstViewedAt',
+        'organizationUuid',
+        'pinnedListOrder',
+        'pinnedListUuid',
+        'projectUuid',
+        'spaceName',
+        'spaceUuid',
+        'updatedByUser',
+        'uuid',
+        'versionUuid',
+        'views',
+    ],
+    documentOnlyFields: [
+        'contentType',
+        'downloadedAt',
+        'spaceSlug',
+        'verified',
+        'version',
+    ],
+});

--- a/packages/backend/src/contentAsCode/fieldCoverage/google_sheets_sync.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/google_sheets_sync.test.ts
@@ -1,0 +1,38 @@
+import { describeContentAsCodeSchemaContract } from './schemaContractTestUtils';
+
+describeContentAsCodeSchemaContract({
+    resource: 'google_sheets_sync',
+    modelSchema: 'SchedulerAndTargets',
+    documentSchema: 'GoogleSheetsSyncAsCode',
+    skippedModelFields: [
+        'appName',
+        'appUuid',
+        'createdAt',
+        'createdBy',
+        'createdByName',
+        'dashboardName',
+        'dashboardUuid',
+        'format',
+        'latestRun',
+        'notificationFrequency',
+        'options',
+        'projectName',
+        'projectSchedulerTimezone',
+        'projectUuid',
+        'savedChartName',
+        'savedChartUuid',
+        'savedSqlName',
+        'savedSqlUuid',
+        'schedulerUuid',
+        'targets',
+        'thresholds',
+        'updatedAt',
+    ],
+    documentOnlyFields: [
+        'contentType',
+        'destination',
+        'downloadedAt',
+        'resource',
+        'version',
+    ],
+});

--- a/packages/backend/src/contentAsCode/fieldCoverage/group.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/group.test.ts
@@ -1,0 +1,16 @@
+import { describeContentAsCodeSchemaContract } from './schemaContractTestUtils';
+
+describeContentAsCodeSchemaContract({
+    resource: 'group',
+    modelSchema: 'Group',
+    documentSchema: 'GroupAsCode',
+    skippedModelFields: [
+        'createdAt',
+        'createdByUserUuid',
+        'organizationUuid',
+        'updatedAt',
+        'updatedByUserUuid',
+        'uuid',
+    ],
+    documentOnlyFields: ['members', 'version'],
+});

--- a/packages/backend/src/contentAsCode/fieldCoverage/registry.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/registry.test.ts
@@ -1,0 +1,19 @@
+import { CONTENT_AS_CODE_VERSIONS } from '@lightdash/common';
+import { readdirSync } from 'fs';
+
+describe('content-as-code schema contract registry', () => {
+    it('has one field-coverage test per registered resource', () => {
+        const resourceTests = readdirSync(__dirname)
+            .filter(
+                (fileName) =>
+                    fileName.endsWith('.test.ts') &&
+                    fileName !== 'registry.test.ts',
+            )
+            .map((fileName) => fileName.replace('.test.ts', ''))
+            .sort();
+
+        expect(resourceTests).toEqual(
+            Object.keys(CONTENT_AS_CODE_VERSIONS).sort(),
+        );
+    });
+});

--- a/packages/backend/src/contentAsCode/fieldCoverage/scheduled_delivery.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/scheduled_delivery.test.ts
@@ -1,0 +1,29 @@
+import { describeContentAsCodeSchemaContract } from './schemaContractTestUtils';
+
+describeContentAsCodeSchemaContract({
+    resource: 'scheduled_delivery',
+    modelSchema: 'SchedulerAndTargets',
+    documentSchema: 'ScheduledDeliveryAsCode',
+    skippedModelFields: [
+        'appName',
+        'appUuid',
+        'createdAt',
+        'createdBy',
+        'createdByName',
+        'dashboardName',
+        'dashboardUuid',
+        'latestRun',
+        'notificationFrequency',
+        'projectName',
+        'projectSchedulerTimezone',
+        'projectUuid',
+        'savedChartName',
+        'savedChartUuid',
+        'savedSqlName',
+        'savedSqlUuid',
+        'schedulerUuid',
+        'thresholds',
+        'updatedAt',
+    ],
+    documentOnlyFields: ['contentType', 'downloadedAt', 'resource', 'version'],
+});

--- a/packages/backend/src/contentAsCode/fieldCoverage/schemaContractTestUtils.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/schemaContractTestUtils.ts
@@ -1,0 +1,135 @@
+import { type ContentAsCodeResourceKind } from '@lightdash/common';
+import { describe, it } from 'vitest';
+import swagger from '../../generated/swagger.json';
+
+type OpenApiSchema = {
+    $ref?: string;
+    properties?: Record<string, unknown>;
+    allOf?: OpenApiSchema[];
+    anyOf?: OpenApiSchema[];
+    oneOf?: OpenApiSchema[];
+};
+
+export interface ContentAsCodeSchemaContract {
+    resource: ContentAsCodeResourceKind;
+    modelSchema: string;
+    documentSchema: string;
+    skippedModelFields: readonly string[];
+    documentOnlyFields: readonly string[];
+}
+
+const schemas = swagger.components.schemas as Record<string, OpenApiSchema>;
+const schemaReferencePrefix = '#/components/schemas/';
+
+const getSchemaFields = (schemaName: string): string[] => {
+    const visited = new Set<string>();
+
+    const visit = (schema: OpenApiSchema): Set<string> => {
+        if (schema.$ref) {
+            const referencedName = schema.$ref.replace(
+                schemaReferencePrefix,
+                '',
+            );
+            if (visited.has(referencedName)) return new Set();
+            visited.add(referencedName);
+            const referencedSchema = schemas[referencedName];
+            if (!referencedSchema) {
+                throw new Error(`OpenAPI schema "${referencedName}" not found`);
+            }
+            return visit(referencedSchema);
+        }
+
+        const fields = new Set(Object.keys(schema.properties ?? {}));
+        [
+            ...(schema.allOf ?? []),
+            ...(schema.anyOf ?? []),
+            ...(schema.oneOf ?? []),
+        ]
+            .map(visit)
+            .forEach((nestedFields) =>
+                nestedFields.forEach((field) => fields.add(field)),
+            );
+        return fields;
+    };
+
+    const schema = schemas[schemaName];
+    if (!schema) throw new Error(`OpenAPI schema "${schemaName}" not found`);
+    return [...visit(schema)].sort();
+};
+
+const difference = (left: readonly string[], right: readonly string[]) =>
+    left.filter((field) => !right.includes(field));
+
+const formatFields = (fields: readonly string[]) =>
+    fields.map((field) => `  - ${field}`).join('\n');
+
+export const assertContentAsCodeSchemaContract = ({
+    resource,
+    modelSchema,
+    documentSchema,
+    skippedModelFields,
+    documentOnlyFields,
+}: ContentAsCodeSchemaContract): void => {
+    const modelFields = getSchemaFields(modelSchema);
+    const documentFields = getSchemaFields(documentSchema);
+    const currentSkippedFields = difference(modelFields, documentFields);
+    const currentDocumentOnlyFields = difference(documentFields, modelFields);
+
+    const uncoveredFields = difference(
+        currentSkippedFields,
+        skippedModelFields,
+    );
+    if (uncoveredFields.length > 0) {
+        throw new Error(
+            `[content-as-code:${resource}] ${modelSchema} has new fields not covered by ${documentSchema}:\n${formatFields(
+                uncoveredFields,
+            )}\n\nAdd them to ${documentSchema} and its adapters, or intentionally add them to skippedModelFields in ${resource}.test.ts.`,
+        );
+    }
+
+    const staleSkippedFields = difference(
+        skippedModelFields,
+        currentSkippedFields,
+    );
+    if (staleSkippedFields.length > 0) {
+        throw new Error(
+            `[content-as-code:${resource}] Remove fields that are no longer skipped from ${resource}.test.ts:\n${formatFields(
+                staleSkippedFields,
+            )}`,
+        );
+    }
+
+    const uncoveredDocumentFields = difference(
+        currentDocumentOnlyFields,
+        documentOnlyFields,
+    );
+    if (uncoveredDocumentFields.length > 0) {
+        throw new Error(
+            `[content-as-code:${resource}] ${documentSchema} has new fields without a matching ${modelSchema} field:\n${formatFields(
+                uncoveredDocumentFields,
+            )}\n\nAdd the matching model field, or intentionally add them to documentOnlyFields in ${resource}.test.ts.`,
+        );
+    }
+
+    const staleDocumentOnlyFields = difference(
+        documentOnlyFields,
+        currentDocumentOnlyFields,
+    );
+    if (staleDocumentOnlyFields.length > 0) {
+        throw new Error(
+            `[content-as-code:${resource}] Remove fields that are no longer document-only from ${resource}.test.ts:\n${formatFields(
+                staleDocumentOnlyFields,
+            )}`,
+        );
+    }
+};
+
+export const describeContentAsCodeSchemaContract = (
+    contract: ContentAsCodeSchemaContract,
+): void => {
+    describe(`${contract.resource} content-as-code schema contract`, () => {
+        it('classifies every model and document field', () => {
+            assertContentAsCodeSchemaContract(contract);
+        });
+    });
+};

--- a/packages/backend/src/contentAsCode/fieldCoverage/space.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/space.test.ts
@@ -1,0 +1,27 @@
+import { describeContentAsCodeSchemaContract } from './schemaContractTestUtils';
+
+describeContentAsCodeSchemaContract({
+    resource: 'space',
+    modelSchema: 'Space',
+    documentSchema: 'SpaceAsCode',
+    skippedModelFields: [
+        'breadcrumbs',
+        'childSpaces',
+        'colorPaletteUuid',
+        'dashboards',
+        'groupsAccess',
+        'inheritParentPermissions',
+        'inheritsFromOrgOrProject',
+        'name',
+        'organizationUuid',
+        'parentSpaceUuid',
+        'path',
+        'pinnedListOrder',
+        'pinnedListUuid',
+        'projectMemberAccessRole',
+        'projectUuid',
+        'queries',
+        'uuid',
+    ],
+    documentOnlyFields: ['contentType', 'spaceName', 'version'],
+});

--- a/packages/backend/src/contentAsCode/fieldCoverage/sql_chart.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/sql_chart.test.ts
@@ -1,0 +1,29 @@
+import { describeContentAsCodeSchemaContract } from './schemaContractTestUtils';
+
+describeContentAsCodeSchemaContract({
+    resource: 'sql_chart',
+    modelSchema: 'SqlChart',
+    documentSchema: 'SqlChartAsCode',
+    skippedModelFields: [
+        'createdAt',
+        'createdBy',
+        'dashboard',
+        'firstViewedAt',
+        'lastUpdatedAt',
+        'lastUpdatedBy',
+        'lastViewedAt',
+        'organization',
+        'project',
+        'resolvedColorPalette',
+        'savedSqlUuid',
+        'space',
+        'views',
+    ],
+    documentOnlyFields: [
+        'contentType',
+        'downloadedAt',
+        'spaceSlug',
+        'updatedAt',
+        'version',
+    ],
+});

--- a/packages/backend/src/contentAsCode/fieldCoverage/user.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/user.test.ts
@@ -1,0 +1,22 @@
+import { describeContentAsCodeSchemaContract } from './schemaContractTestUtils';
+
+describeContentAsCodeSchemaContract({
+    resource: 'user',
+    modelSchema: 'OrganizationMemberProfile',
+    documentSchema: 'UserAsCode',
+    skippedModelFields: [
+        'avatarGradient',
+        'avatarUrl',
+        'firstName',
+        'isActive',
+        'isInviteExpired',
+        'isPending',
+        'lastName',
+        'organizationUuid',
+        'roleUuid',
+        'userCreatedAt',
+        'userUpdatedAt',
+        'userUuid',
+    ],
+    documentOnlyFields: ['disabled', 'version'],
+});

--- a/packages/backend/src/contentAsCode/fieldCoverage/virtual_view.test.ts
+++ b/packages/backend/src/contentAsCode/fieldCoverage/virtual_view.test.ts
@@ -1,0 +1,32 @@
+import { describeContentAsCodeSchemaContract } from './schemaContractTestUtils';
+
+describeContentAsCodeSchemaContract({
+    resource: 'virtual_view',
+    modelSchema: 'Explore',
+    documentSchema: 'VirtualViewAsCode',
+    skippedModelFields: [
+        'aiHint',
+        'baseTable',
+        'caseSensitive',
+        'databricksCompute',
+        'granularityLabels',
+        'groupLabel',
+        'groups',
+        'joinedTables',
+        'label',
+        'preAggregateSource',
+        'preAggregates',
+        'savedParameterValues',
+        'spotlight',
+        'sqlPath',
+        'tables',
+        'tags',
+        'targetDatabase',
+        'type',
+        'unfilteredTables',
+        'warehouse',
+        'warnings',
+        'ymlPath',
+    ],
+    documentOnlyFields: ['columns', 'contentType', 'slug', 'sql', 'version'],
+});


### PR DESCRIPTION
![CleanShot 2026-07-21 at 09.47.12.png](https://app.graphite.com/user-attachments/assets/b44029bd-8aee-4340-95fd-204793a90d5c.png)



## Summary

- add runtime schema contract tests for every registered content-as-code resource
- snapshot fields that are intentionally model-only or document-only in separate resource test files
- fail with actionable guidance when a domain model gains a field without a content-as-code decision
- require every newly registered content-as-code resource to add its own contract test

## Why

Domain models and their portable content-as-code documents evolve independently. A new model field could previously ship without being represented in content-as-code or explicitly excluded. These tests compare the generated OpenAPI model and document schemas so omissions require an intentional test update.

This PR only adds unit-test coverage and does not change runtime business logic.

## Validation

- `pnpm -F backend exec vitest run --config vitest.config.ts src/contentAsCode/fieldCoverage`
- `pnpm -F backend typecheck`
- backend lint and formatting hooks

Closes: PROD-8969