### PR TITLE
fix: deliver Slack alerts without requiring a public image URL

### DIFF
--- a/packages/backend/src/clients/Slack/SlackClient.test.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.test.ts
@@ -1,0 +1,124 @@
+import { type WebClient } from '@slack/web-api';
+import { SlackClient } from './SlackClient';
+
+const invalidBlocksError = (messages: string[]) => ({
+    data: {
+        error: 'invalid_blocks',
+        response_metadata: { messages },
+    },
+});
+
+const blocks = [
+    { type: 'header', text: { type: 'plain_text', text: 'Chart' } },
+    { type: 'section', text: { type: 'mrkdwn', text: 'Description' } },
+    {
+        type: 'image',
+        image_url: 'https://internal.example.com/img.png',
+        alt_text: 'Chart',
+    },
+];
+
+describe('SlackClient.postMessage invalid_blocks retry', () => {
+    const postMessageMock = vi.fn();
+    let client: SlackClient;
+
+    beforeEach(() => {
+        postMessageMock.mockReset();
+        client = new SlackClient({
+            slackAuthenticationModel: {
+                getInstallationFromOrganizationUuid: vi
+                    .fn()
+                    .mockResolvedValue({ appProfilePhotoUrl: undefined }),
+            },
+            slackChannelCacheModel: {},
+            lightdashConfig: { slack: {} },
+            analytics: {},
+            schedulerClient: {},
+        } as unknown as ConstructorParameters<typeof SlackClient>[0]);
+        vi.spyOn(client, 'getWebClient').mockResolvedValue({
+            chat: { postMessage: postMessageMock },
+        } as unknown as WebClient);
+        vi.spyOn(client, 'resolveChannelToId').mockResolvedValue('C123');
+    });
+
+    it('retries once with a notice when Slack only rejected image blocks', async () => {
+        postMessageMock
+            .mockRejectedValueOnce(
+                invalidBlocksError([
+                    '[ERROR] downloading image failed [json-pointer:/blocks/2/image_url]',
+                ]),
+            )
+            .mockResolvedValueOnce({ ok: true, ts: '1.2' });
+
+        const result = await client.postMessage({
+            organizationUuid: 'org-uuid',
+            channel: 'C123',
+            text: 'Alert',
+            blocks,
+        });
+
+        expect(result).toEqual({ ok: true, ts: '1.2' });
+        expect(postMessageMock).toHaveBeenCalledTimes(2);
+        const retryBlocks = postMessageMock.mock.calls[1][0].blocks;
+        expect(retryBlocks).toHaveLength(blocks.length);
+        expect(retryBlocks[0]).toEqual(blocks[0]);
+        expect(retryBlocks[1]).toEqual(blocks[1]);
+        expect(retryBlocks[2].type).toBe('section');
+        expect(retryBlocks[2].text.text).toMatch(/preview unavailable/i);
+    });
+
+    it('does not retry when Slack rejected a non-image block', async () => {
+        const error = invalidBlocksError([
+            '[ERROR] failed to match all allowed schemas [json-pointer:/blocks/1]',
+        ]);
+        postMessageMock.mockRejectedValueOnce(error);
+
+        await expect(
+            client.postMessage({
+                organizationUuid: 'org-uuid',
+                channel: 'C123',
+                text: 'Alert',
+                blocks,
+            }),
+        ).rejects.toBe(error);
+        expect(postMessageMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retry when both image and non-image blocks were rejected', async () => {
+        const error = invalidBlocksError([
+            '[ERROR] downloading image failed [json-pointer:/blocks/2/image_url]',
+            '[ERROR] failed to match all allowed schemas [json-pointer:/blocks/1]',
+        ]);
+        postMessageMock.mockRejectedValueOnce(error);
+
+        await expect(
+            client.postMessage({
+                organizationUuid: 'org-uuid',
+                channel: 'C123',
+                text: 'Alert',
+                blocks,
+            }),
+        ).rejects.toBe(error);
+        expect(postMessageMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('rethrows when the retry also fails', async () => {
+        const firstError = invalidBlocksError([
+            '[ERROR] downloading image failed [json-pointer:/blocks/2/image_url]',
+        ]);
+        const retryError = new Error('channel_not_found');
+        postMessageMock
+            .mockRejectedValueOnce(firstError)
+            .mockRejectedValueOnce(retryError);
+
+        await expect(
+            client.postMessage({
+                organizationUuid: 'org-uuid',
+                channel: 'C123',
+                text: 'Alert',
+                blocks,
+            }),
+        ).rejects.toBe(retryError);
+        expect(postMessageMock).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -1536,6 +1536,11 @@ export class SlackClient {
             if (buffer === undefined) {
                 if (!imageUrl) return undefined;
                 const response = await fetch(imageUrl);
+                if (!response.ok) {
+                    throw new SlackFileUploadError(
+                        `Failed to fetch image for Slack upload (status ${response.status})`,
+                    );
+                }
                 buffer = Buffer.from(await response.arrayBuffer());
             }
             const { id } = await this.uploadFile({

--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -3,6 +3,7 @@ import {
     friendlyName,
     getErrorMessage,
     getSlackErrorCode,
+    getSlackInvalidBlockIndices,
     isSlackRateLimitedError,
     isUnrecoverableSlackError,
     MissingConfigError,
@@ -43,6 +44,10 @@ import Logger from '../../logging/logger';
 import { SlackAuthenticationModel } from '../../models/SlackAuthenticationModel';
 import { SlackChannelCacheModel } from '../../models/SlackChannelCacheModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
+import {
+    replaceImageBlocksWithNotice,
+    type SlackChartImage,
+} from './SlackMessageBlocks';
 
 export type SlackStreamChunk =
     | {
@@ -984,7 +989,7 @@ export class SlackClient {
                 channel: resolvedChannel,
                 ...slackMessageArgs,
             })
-            .catch((e) => {
+            .catch(async (e) => {
                 if (getSlackErrorCode(e) === 'invalid_blocks') {
                     Logger.error(
                         `Slack invalid_blocks error for channel ${channel}`,
@@ -992,6 +997,44 @@ export class SlackClient {
                             blocks: JSON.stringify(slackMessageArgs.blocks),
                         },
                     );
+                    // Slack points at the rejected blocks in the error
+                    // metadata. When every rejected block is an image (e.g.
+                    // Slack can't fetch the image URL), retry once with
+                    // those blocks swapped for a notice so the message still
+                    // delivers. Any other rejected block means the message
+                    // itself is malformed — retrying wouldn't help.
+                    const { blocks } = slackMessageArgs;
+                    const rejectedIndices = getSlackInvalidBlockIndices(e);
+                    const onlyImagesRejected =
+                        blocks !== undefined &&
+                        rejectedIndices.length > 0 &&
+                        rejectedIndices.every(
+                            (index) => blocks[index]?.type === 'image',
+                        );
+                    if (onlyImagesRejected) {
+                        Logger.info(
+                            `Retrying Slack message without rejected image blocks for channel ${channel}`,
+                        );
+                        return webClient.chat
+                            .postMessage({
+                                ...(appProfilePhotoUrl
+                                    ? { icon_url: appProfilePhotoUrl }
+                                    : {}),
+                                channel: resolvedChannel,
+                                ...slackMessageArgs,
+                                blocks: replaceImageBlocksWithNotice(
+                                    blocks,
+                                    rejectedIndices,
+                                ),
+                            })
+                            .catch((retryError) => {
+                                slackErrorHandler(
+                                    retryError,
+                                    'Unable to post message on Slack without image blocks',
+                                );
+                                throw retryError;
+                            });
+                    }
                 }
                 slackErrorHandler(e, 'Unable to post message on Slack');
                 throw e;
@@ -1349,14 +1392,13 @@ export class SlackClient {
     /*
     This method will try to upload an image to slack, so it can be used in blocks,
     instead of sharing the file directly on a channel or a thread
-    It returns a promise that resolves to the file url, but it takes a while for the file to be uploaded
     Note: method sharedPublicURL will not work here because it requires a user token, and we only use bot tokens
     */
     async uploadFile(args: {
         organizationUuid: string;
         file: Buffer;
         title: string;
-    }) {
+    }): Promise<{ id: string; url: string }> {
         const webClient = await this.getWebClient(args.organizationUuid);
         const filename = friendlyName(args.title);
         const result = (await webClient.files.uploadV2({
@@ -1404,9 +1446,9 @@ export class SlackClient {
             return checkFile(0);
         }
 
-        const fileUrl = await waitForFileReady(uploadedFile?.id);
+        const fileUrl = await waitForFileReady(uploadedFile.id);
 
-        return fileUrl;
+        return { id: uploadedFile.id, url: fileUrl };
     }
 
     async getUserInfo(
@@ -1474,33 +1516,41 @@ export class SlackClient {
     }
 
     /**
-     * Helper method to try to upload an image to slack, so it can be used in blocks without expiration
-     * If it fails, we will keep using the same URL (s3)
+     * Helper method to try to upload an image to slack, so blocks can reference
+     * it by file id — no public URL and no expiration. If the upload fails we
+     * fall back to the external URL, which requires the instance to be
+     * reachable by Slack's servers.
      */
-    async tryUploadingImageToSlack(
-        organizationUuid: string,
-        imageUrl: string | undefined,
-        name: string,
-    ) {
+    async tryUploadingImageToSlack(args: {
+        organizationUuid: string;
+        imageUrl: string | undefined;
+        imageBuffer: Buffer | undefined;
+        title: string;
+    }): Promise<SlackChartImage | undefined> {
+        const { organizationUuid, imageUrl, imageBuffer, title } = args;
+        const fallback: SlackChartImage | undefined = imageUrl
+            ? { source: 'url', url: imageUrl }
+            : undefined;
         try {
-            if (!imageUrl) {
-                return { url: imageUrl, expiring: true };
+            let buffer = imageBuffer;
+            if (buffer === undefined) {
+                if (!imageUrl) return undefined;
+                const response = await fetch(imageUrl);
+                buffer = Buffer.from(await response.arrayBuffer());
             }
-            const response = await fetch(imageUrl);
-            const buffer = Buffer.from(await response.arrayBuffer());
-            const slackFileUrl = await this.uploadFile({
+            const { id } = await this.uploadFile({
                 organizationUuid,
                 file: buffer,
-                title: name,
+                title,
             });
-            return { url: slackFileUrl, expiring: false };
+            return { source: 'slackFile', fileId: id };
         } catch (e) {
             if (e instanceof SlackFileUploadError) {
                 Logger.warn(e.message);
             } else {
                 slackErrorHandler(e, 'Failed to upload image to slack');
             }
-            return { url: imageUrl, expiring: true };
+            return fallback;
         }
     }
 

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.test.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.test.ts
@@ -4,6 +4,7 @@ import {
     getChartAndDashboardBlocks,
     getChartCsvResultsBlocks,
     getDashboardCsvResultsBlocks,
+    replaceImageBlocksWithNotice,
 } from './SlackMessageBlocks';
 
 const SLACK_MAX_BLOCKS = 50;
@@ -243,7 +244,7 @@ describe('SlackMessageBlocks', () => {
                 name: 'Chart',
                 description: 'Chart desc',
                 ctaUrl: 'https://app.lightdash.com/chart/abc',
-                imageUrl: 'not-a-url',
+                image: { source: 'url', url: 'not-a-url' },
             });
 
             const sectionTexts = findBlocks(blocks, 'section')
@@ -311,7 +312,7 @@ describe('SlackMessageBlocks', () => {
                 name: 'Chart',
                 description: 'Chart desc',
                 ctaUrl: 'https://app.lightdash.com/chart/abc',
-                imageUrl: longImage,
+                image: { source: 'url', url: longImage },
             });
 
             expect(findBlocks(blocks, 'image')).toHaveLength(0);
@@ -323,10 +324,54 @@ describe('SlackMessageBlocks', () => {
                 name: 'Chart',
                 description: 'Chart desc',
                 ctaUrl: 'https://app.lightdash.com/chart/abc',
-                imageUrl: 'https://s3.example.com/img.png',
+                image: { source: 'url', url: 'https://s3.example.com/img.png' },
             });
 
             expect(findBlocks(blocks, 'image')).toHaveLength(1);
+        });
+
+        it('references Slack-hosted files by id instead of image_url', () => {
+            const blocks = getChartAndDashboardBlocks({
+                title: 'Chart',
+                name: 'Chart',
+                description: 'Chart desc',
+                ctaUrl: 'https://app.lightdash.com/chart/abc',
+                image: { source: 'slackFile', fileId: 'F12345' },
+            });
+
+            const images = findBlocks(blocks, 'image');
+            expect(images).toHaveLength(1);
+            expect(images[0]).toEqual(
+                expect.objectContaining({ slack_file: { id: 'F12345' } }),
+            );
+            expect(images[0]).not.toHaveProperty('image_url');
+        });
+    });
+
+    describe('replaceImageBlocksWithNotice', () => {
+        it('swaps only the blocks at the given indices and keeps everything else', () => {
+            const blocks = getChartAndDashboardBlocks({
+                title: 'Chart',
+                name: 'Chart',
+                description: 'Chart desc',
+                ctaUrl: 'https://app.lightdash.com/chart/abc',
+                image: { source: 'url', url: 'https://s3.example.com/img.png' },
+                footerMarkdown: 'sent by scheduler',
+            });
+            const imageIndex = blocks.findIndex((b) => b.type === 'image');
+
+            const replaced = replaceImageBlocksWithNotice(blocks, [
+                imageIndex,
+            ]) as KnownBlock[];
+
+            expect(replaced).toHaveLength(blocks.length);
+            expect(findBlocks(replaced, 'image')).toHaveLength(0);
+            expect(findBlocks(replaced, 'header')).toHaveLength(1);
+            expect(findBlocks(replaced, 'context')).toHaveLength(1);
+            const sectionTexts = findBlocks(replaced, 'section')
+                .map((s) => s.text?.text ?? '')
+                .join('\n');
+            expect(sectionTexts).toMatch(/preview unavailable/i);
         });
     });
 
@@ -375,7 +420,7 @@ describe('SlackMessageBlocks', () => {
                 name: 'My chart',
                 description: 'A description',
                 message: 'Custom message',
-                imageUrl: 'https://s3.example.com/img.png',
+                image: { source: 'url', url: 'https://s3.example.com/img.png' },
                 ctaUrl: 'https://app.lightdash.com/chart/abc',
                 footerMarkdown: 'sent by scheduler',
             });

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
@@ -129,6 +129,8 @@ const DOWNLOAD_UNAVAILABLE_MESSAGE =
     'Download link unavailable for this delivery (the URL was too long or invalid). Open in Lightdash to download.';
 const PREVIEW_UNAVAILABLE_MESSAGE =
     'Chart preview unavailable (the image URL was too long or invalid). Open in Lightdash to view.';
+const PREVIEW_REJECTED_MESSAGE =
+    'Chart preview unavailable. Open in Lightdash to view.';
 
 const buildChartImageBlock = (
     image: SlackChartImage | undefined,
@@ -167,9 +169,7 @@ export const replaceImageBlocksWithNotice = <T extends { type?: string }>(
     const rejected = new Set(indices);
     return blocks.map((block, index) =>
         rejected.has(index)
-            ? unavailableSection(
-                  'Chart preview unavailable. Open in Lightdash to view.',
-              )
+            ? unavailableSection(PREVIEW_REJECTED_MESSAGE)
             : block,
     );
 };

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
@@ -70,13 +70,20 @@ export const safeUrl = (
     return url;
 };
 
+// A chart image for a message block: either a file hosted on the workspace's
+// Slack (referenced by id, no public URL needed) or an externally hosted URL
+// that Slack's servers must be able to fetch.
+export type SlackChartImage =
+    | { source: 'slackFile'; fileId: string }
+    | { source: 'url'; url: string };
+
 type GetChartAndDashboardBlocksArgs = {
     title: string;
     name?: string;
     description?: string;
     message?: string;
     ctaUrl: string;
-    imageUrl?: string;
+    image?: SlackChartImage;
     footerMarkdown?: string;
     includeLinks?: boolean;
 };
@@ -123,12 +130,56 @@ const DOWNLOAD_UNAVAILABLE_MESSAGE =
 const PREVIEW_UNAVAILABLE_MESSAGE =
     'Chart preview unavailable (the image URL was too long or invalid). Open in Lightdash to view.';
 
+const buildChartImageBlock = (
+    image: SlackChartImage | undefined,
+    altText: string,
+): KnownBlock | undefined => {
+    if (image === undefined) return undefined;
+    const truncatedAltText = truncateText(
+        sanitizeText(altText),
+        SLACK_LIMITS.ALT_TEXT,
+    );
+    if (image.source === 'slackFile') {
+        return {
+            type: 'image',
+            slack_file: { id: image.fileId },
+            alt_text: truncatedAltText,
+        };
+    }
+    if (!image.url.trim()) return undefined;
+    const safeImageUrl = safeUrl(image.url);
+    if (safeImageUrl) {
+        return {
+            type: 'image',
+            image_url: safeImageUrl,
+            alt_text: truncatedAltText,
+        };
+    }
+    return unavailableSection(PREVIEW_UNAVAILABLE_MESSAGE);
+};
+
+// Fallback for messages Slack rejected with invalid_blocks: swap the blocks
+// Slack pointed at for a notice so the delivery still reaches the channel.
+export const replaceImageBlocksWithNotice = <T extends { type?: string }>(
+    blocks: T[],
+    indices: number[],
+): (T | KnownBlock)[] => {
+    const rejected = new Set(indices);
+    return blocks.map((block, index) =>
+        rejected.has(index)
+            ? unavailableSection(
+                  'Chart preview unavailable. Open in Lightdash to view.',
+              )
+            : block,
+    );
+};
+
 export const getChartAndDashboardBlocks = ({
     title,
     name,
     description,
     message,
-    imageUrl,
+    image,
     ctaUrl,
     footerMarkdown,
     includeLinks,
@@ -147,24 +198,6 @@ export const getChartAndDashboardBlocks = ({
           }
         : undefined;
     const headerText = sanitizeHeaderText(title);
-    const hasImageUrl = Boolean(imageUrl?.trim());
-    const safeImageUrl = safeUrl(imageUrl);
-    const buildImageBlock = (): KnownBlock | undefined => {
-        if (safeImageUrl) {
-            return {
-                type: 'image',
-                image_url: safeImageUrl,
-                alt_text: truncateText(
-                    sanitizeText(title),
-                    SLACK_LIMITS.ALT_TEXT,
-                ),
-            };
-        }
-        if (hasImageUrl) {
-            return unavailableSection(PREVIEW_UNAVAILABLE_MESSAGE);
-        }
-        return undefined;
-    };
     return getBlocks([
         headerText
             ? {
@@ -195,7 +228,7 @@ export const getChartAndDashboardBlocks = ({
             ]),
             accessory: lightdashLink,
         },
-        buildImageBlock(),
+        buildChartImageBlock(image, title),
         footerMarkdown?.trim()
             ? {
                   type: 'context',
@@ -332,7 +365,7 @@ type GetChartThresholdBlocksArgs = {
     message?: string;
     description: string | undefined;
     ctaUrl: string;
-    imageUrl?: string;
+    image?: SlackChartImage;
     footerMarkdown?: string;
     thresholds: ThresholdOptions[];
     includeLinks?: boolean;
@@ -342,7 +375,7 @@ export const getChartThresholdAlertBlocks = ({
     title,
     message,
     description,
-    imageUrl,
+    image,
     ctaUrl,
     thresholds,
     footerMarkdown,
@@ -364,24 +397,6 @@ export const getChartThresholdAlertBlocks = ({
           }
         : undefined;
     const headerText = sanitizeHeaderText(title);
-    const hasImageUrl = Boolean(imageUrl?.trim());
-    const safeImageUrl = safeUrl(imageUrl);
-    const buildImageBlock = (): KnownBlock | undefined => {
-        if (safeImageUrl) {
-            return {
-                type: 'image',
-                image_url: safeImageUrl,
-                alt_text: truncateText(
-                    sanitizeText(title),
-                    SLACK_LIMITS.ALT_TEXT,
-                ),
-            };
-        }
-        if (hasImageUrl) {
-            return unavailableSection(PREVIEW_UNAVAILABLE_MESSAGE);
-        }
-        return undefined;
-    };
     const thresholdBlocks: KnownBlock[] = thresholds.map((threshold) => ({
         type: 'section',
         text: {
@@ -433,7 +448,7 @@ export const getChartThresholdAlertBlocks = ({
             accessory: lightdashLink,
         },
         ...thresholdBlocks,
-        buildImageBlock(),
+        buildChartImageBlock(image, title),
         footerMarkdown?.trim()
             ? {
                   type: 'context',
@@ -789,7 +804,9 @@ export const getUnfurlBlocks = (
                 : getChartAndDashboardBlocks({
                       title: unfurl.title,
                       description: unfurl.description,
-                      imageUrl: unfurl.imageUrl,
+                      image: unfurl.imageUrl
+                          ? { source: 'url', url: unfurl.imageUrl }
+                          : undefined,
                       ctaUrl: originalUrl,
                   }),
     },

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1360,6 +1360,34 @@ export default class SchedulerTask {
         };
     }
 
+    // Reads the delivery screenshot straight from storage so consumers don't
+    // need an HTTP round-trip through the instance's public URL (which may not
+    // be reachable from inside the network). Returns undefined on any failure
+    // so callers can fall back to the image URL.
+    private async getImageBufferFromStorage(
+        imageS3Key: string | undefined,
+    ): Promise<Buffer | undefined> {
+        if (!imageS3Key || !this.fileStorageClient.isEnabled()) {
+            return undefined;
+        }
+        try {
+            const stream =
+                await this.fileStorageClient.getFileStream(imageS3Key);
+            const chunks: Buffer[] = [];
+            for await (const chunk of stream) {
+                chunks.push(
+                    Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk),
+                );
+            }
+            return Buffer.concat(chunks);
+        } catch (e) {
+            Logger.warn(
+                `Failed to read image from storage (key: ${imageS3Key}), falling back to external image URL: ${e}`,
+            );
+            return undefined;
+        }
+    }
+
     protected async sendSlackNotification(
         jobId: string,
         notification: SlackNotificationPayload,
@@ -1446,6 +1474,7 @@ export default class SchedulerTask {
                 pageType,
                 organizationUuid,
                 imageUrl,
+                imageS3Key,
                 csvUrl,
                 csvUrls,
                 pdfFile,
@@ -1487,12 +1516,16 @@ export default class SchedulerTask {
             if (thresholds !== undefined && thresholds.length > 0) {
                 // We assume the threshold is possitive , so we don't need to get results here
                 if (savedChartUuid) {
-                    const slackImageUrl =
-                        await this.slackClient.tryUploadingImageToSlack(
+                    const slackImage =
+                        await this.slackClient.tryUploadingImageToSlack({
                             organizationUuid,
                             imageUrl,
-                            name,
-                        );
+                            imageBuffer:
+                                await this.getImageBufferFromStorage(
+                                    imageS3Key,
+                                ),
+                            title: name,
+                        });
                     const thresholdFooter = includeLinks
                         ? `<${url}?${setUuidParam(
                               'threshold_uuid',
@@ -1500,14 +1533,15 @@ export default class SchedulerTask {
                           )}|data alert>`
                         : 'data alert';
 
-                    const expiration = slackImageUrl.expiring
-                        ? `Delivered files expire after ${slackExpirationDays} days.`
-                        : '';
+                    const expiration =
+                        slackImage?.source === 'url'
+                            ? `Delivered files expire after ${slackExpirationDays} days.`
+                            : '';
 
                     const blocks = getChartThresholdAlertBlocks({
                         ...getBlocksArgs,
                         footerMarkdown: `This is a ${thresholdFooter} sent by Lightdash. ${expiration}`,
-                        imageUrl: slackImageUrl.url,
+                        image: slackImage,
                         thresholds,
                         includeLinks,
                     });
@@ -1521,20 +1555,23 @@ export default class SchedulerTask {
                     throw new Error('Not implemented');
                 }
             } else if (format === SchedulerFormat.IMAGE) {
-                const slackImageUrl =
-                    await this.slackClient.tryUploadingImageToSlack(
+                const slackImage =
+                    await this.slackClient.tryUploadingImageToSlack({
                         organizationUuid,
                         imageUrl,
-                        name,
-                    );
+                        imageBuffer:
+                            await this.getImageBufferFromStorage(imageS3Key),
+                        title: name,
+                    });
 
-                const expiration = slackImageUrl.expiring
-                    ? `Delivered files expire after ${slackExpirationDays} days.`
-                    : '';
+                const expiration =
+                    slackImage?.source === 'url'
+                        ? `Delivered files expire after ${slackExpirationDays} days.`
+                        : '';
                 const blocks = getChartAndDashboardBlocks({
                     ...getBlocksArgs,
                     footerMarkdown: `${getBlocksArgs.footerMarkdown} ${expiration}`,
-                    imageUrl: slackImageUrl.url,
+                    image: slackImage,
                 });
 
                 const message = await this.slackClient.postMessage({
@@ -2978,28 +3015,10 @@ export default class SchedulerTask {
                 failures,
             } = notificationPageData;
 
-            let imageBuffer: Buffer | undefined;
-            if (
-                this.lightdashConfig.smtp?.inlineImageCid === true &&
-                imageS3Key &&
-                this.fileStorageClient.isEnabled()
-            ) {
-                try {
-                    const stream =
-                        await this.fileStorageClient.getFileStream(imageS3Key);
-                    const chunks: Buffer[] = [];
-                    for await (const chunk of stream) {
-                        chunks.push(
-                            Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk),
-                        );
-                    }
-                    imageBuffer = Buffer.concat(chunks);
-                } catch (e) {
-                    Logger.warn(
-                        `Failed to stream CID inline image from S3 (key: ${imageS3Key}), falling back to external image URL: ${e}`,
-                    );
-                }
-            }
+            const imageBuffer =
+                this.lightdashConfig.smtp?.inlineImageCid === true
+                    ? await this.getImageBufferFromStorage(imageS3Key)
+                    : undefined;
 
             const schedulerUrl = `${url}?${setUuidParam(
                 'scheduler_uuid',

--- a/packages/common/src/utils/slack.test.ts
+++ b/packages/common/src/utils/slack.test.ts
@@ -45,6 +45,21 @@ describe('getSlackInvalidBlockIndices', () => {
             getSlackInvalidBlockIndices({ data: { error: 'invalid_blocks' } }),
         ).toEqual([]);
     });
+
+    it('ignores [WARN] messages — warnings are non-fatal and did not cause the rejection', () => {
+        const error = {
+            data: {
+                error: 'invalid_blocks',
+                response_metadata: {
+                    messages: [
+                        '[WARN] text object is deprecated [json-pointer:/blocks/0/text]',
+                        '[ERROR] downloading image failed [json-pointer:/blocks/3/image_url]',
+                    ],
+                },
+            },
+        };
+        expect(getSlackInvalidBlockIndices(error)).toEqual([3]);
+    });
 });
 
 describe('isUnrecoverableSlackError', () => {

--- a/packages/common/src/utils/slack.test.ts
+++ b/packages/common/src/utils/slack.test.ts
@@ -1,5 +1,6 @@
 import {
     getSlackErrorCode,
+    getSlackInvalidBlockIndices,
     isSlackMessageTooLongError,
     isSlackRateLimitedError,
     isUnrecoverableSlackError,
@@ -20,6 +21,29 @@ describe('getSlackErrorCode', () => {
         expect(getSlackErrorCode(null)).toBeUndefined();
         expect(getSlackErrorCode('string')).toBeUndefined();
         expect(getSlackErrorCode({ data: {} })).toBeUndefined();
+    });
+});
+
+describe('getSlackInvalidBlockIndices', () => {
+    it('identifies the blocks Slack rejected so only those get dropped from a delivery', () => {
+        const error = {
+            data: {
+                error: 'invalid_blocks',
+                response_metadata: {
+                    messages: [
+                        '[ERROR] downloading image failed [json-pointer:/blocks/3/image_url]',
+                        '[ERROR] failed to match all allowed schemas [json-pointer:/blocks/5]',
+                    ],
+                },
+            },
+        };
+        expect(getSlackInvalidBlockIndices(error)).toEqual([3, 5]);
+    });
+
+    it('never attributes blame to blocks Slack did not point at', () => {
+        expect(
+            getSlackInvalidBlockIndices({ data: { error: 'invalid_blocks' } }),
+        ).toEqual([]);
     });
 });
 

--- a/packages/common/src/utils/slack.ts
+++ b/packages/common/src/utils/slack.ts
@@ -45,6 +45,8 @@ export const getSlackErrorCode = (error: unknown): string | undefined => {
  * error. Slack reports block-level failures in response_metadata.messages as
  * strings containing json-pointers, e.g.
  * "[ERROR] downloading image failed [json-pointer:/blocks/3/image_url]".
+ * [WARN] entries are ignored — Slack mixes non-fatal warnings into the same
+ * list and those blocks were not the cause of the rejection.
  * Returns an empty array when the error carries no block pointers.
  */
 export const getSlackInvalidBlockIndices = (error: unknown): number[] => {
@@ -61,7 +63,8 @@ export const getSlackInvalidBlockIndices = (error: unknown): number[] => {
     }
     const indices = responseMetadata.messages.reduce<Set<number>>(
         (acc, message) => {
-            if (typeof message !== 'string') return acc;
+            if (typeof message !== 'string' || !message.includes('[ERROR]'))
+                return acc;
             const match = message.match(/json-pointer:\/blocks\/(\d+)/);
             if (match) acc.add(Number(match[1]));
             return acc;

--- a/packages/common/src/utils/slack.ts
+++ b/packages/common/src/utils/slack.ts
@@ -41,6 +41,37 @@ export const getSlackErrorCode = (error: unknown): string | undefined => {
 };
 
 /**
+ * Extracts the indices of the blocks Slack rejected from an invalid_blocks
+ * error. Slack reports block-level failures in response_metadata.messages as
+ * strings containing json-pointers, e.g.
+ * "[ERROR] downloading image failed [json-pointer:/blocks/3/image_url]".
+ * Returns an empty array when the error carries no block pointers.
+ */
+export const getSlackInvalidBlockIndices = (error: unknown): number[] => {
+    if (getSlackErrorCode(error) !== 'invalid_blocks') return [];
+    const { data } = error as { data: Record<string, unknown> };
+    const responseMetadata = data.response_metadata;
+    if (
+        !responseMetadata ||
+        typeof responseMetadata !== 'object' ||
+        !('messages' in responseMetadata) ||
+        !Array.isArray(responseMetadata.messages)
+    ) {
+        return [];
+    }
+    const indices = responseMetadata.messages.reduce<Set<number>>(
+        (acc, message) => {
+            if (typeof message !== 'string') return acc;
+            const match = message.match(/json-pointer:\/blocks\/(\d+)/);
+            if (match) acc.add(Number(match[1]));
+            return acc;
+        },
+        new Set(),
+    );
+    return [...indices].sort((a, b) => a - b);
+};
+
+/**
  * Checks if a Slack error is unrecoverable (installation is broken).
  */
 export const isUnrecoverableSlackError = (error: unknown): boolean => {


### PR DESCRIPTION
### Description:

Slack alert and scheduled-delivery images previously required two network paths that break on private deployments: the backend fetched the screenshot from its own `SITE_URL` before uploading to Slack, and when the upload failed the message embedded a `SITE_URL`-based `image_url` that Slack's servers had to fetch. On instances that aren't publicly reachable this caused an `invalid_blocks` rejection — the entire alert failed to deliver, not just the image.

Three changes:

**1. Read the screenshot straight from object storage.** The scheduler passes the S3 buffer (`imageS3Key`) directly to the Slack upload, skipping the HTTP round-trip through `SITE_URL`. The existing email CID path used the same logic, now shared via `getImageBufferFromStorage`. Fallback to fetching `imageUrl` remains for deployments without object storage (now with a `response.ok` check so an error body is never uploaded as the "image").

**2. Reference Slack-hosted files by id.** `tryUploadingImageToSlack` returns a `SlackChartImage` discriminated union (`slackFile` | `url`), and image blocks use `slack_file: { id }` instead of the file's URL — no public URL involved at any point. Slack registers the file share on hydration (`BK_IMAGE`), so rendering works on private instances. The external-URL form remains as last-resort fallback, and the "files expire after N days" footer now only appears on that path.

**3. Degrade gracefully on `invalid_blocks`.** `getSlackInvalidBlockIndices` parses the block json-pointers from Slack's error metadata (`[ERROR]` entries only — Slack mixes non-fatal `[WARN]` lines into the same list). When every rejected block is an image, `postMessage` retries once with those blocks swapped for a `:warning: Chart preview unavailable` notice, so the alert text still reaches the channel instead of failing entirely.

Verified end-to-end on a deployment whose backend cannot reach `SITE_URL`: images deliver via the Slack-hosted file path, and forcing the upload to fail delivers the alert with the notice instead of dropping it.

Relates: #25800