### PR TITLE
feat(authorization): add view:CompiledSql scope to view compiled SQL without authoring rights

### DIFF
--- a/packages/backend/src/database/migrations/20260720170411_grant_compiled_sql_view_to_custom_fields_roles.ts
+++ b/packages/backend/src/database/migrations/20260720170411_grant_compiled_sql_view_to_custom_fields_roles.ts
@@ -1,0 +1,55 @@
+import { Knex } from 'knex';
+
+const ScopedRolesTableName = 'scoped_roles';
+const CUSTOM_FIELDS_SCOPE = 'manage:CustomFields';
+const COMPILED_SQL_SCOPE = 'view:CompiledSql';
+
+/**
+ * `manage:CustomFields` used to gate both authoring custom SQL fields and
+ * viewing the compiled SQL of charts that contain them. Viewing has been split
+ * into the new `view:CompiledSql` scope. Copy the new scope into every custom
+ * role that currently has `manage:CustomFields` so nobody loses access.
+ *
+ * Wrapped in try/catch because this is a backfill: failing it would block all
+ * later migrations, and the worst case (some roles miss CompiledSql) is
+ * recoverable by re-running the SQL manually.
+ */
+export async function up(knex: Knex): Promise<void> {
+    try {
+        await knex.raw(
+            `
+            INSERT INTO ?? (role_uuid, scope_name, granted_by)
+            SELECT role_uuid, ?, granted_by
+            FROM ??
+            WHERE scope_name = ?
+            ON CONFLICT DO NOTHING
+            `,
+            [
+                ScopedRolesTableName,
+                COMPILED_SQL_SCOPE,
+                ScopedRolesTableName,
+                CUSTOM_FIELDS_SCOPE,
+            ],
+        );
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+            `[migration 20260720170411] Failed to backfill ${COMPILED_SQL_SCOPE} for roles with ${CUSTOM_FIELDS_SCOPE}. Affected custom roles will need to grant ${COMPILED_SQL_SCOPE} manually.`,
+            error,
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    try {
+        await knex(ScopedRolesTableName)
+            .where('scope_name', COMPILED_SQL_SCOPE)
+            .delete();
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+            `[migration 20260720170411] Failed to remove ${COMPILED_SQL_SCOPE} rows during rollback.`,
+            error,
+        );
+    }
+}

--- a/packages/common/src/authorization/organizationMemberAbility.test.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.test.ts
@@ -997,6 +997,10 @@ describe('Organization member permissions', () => {
                 expect(ability.can('manage', 'SqlRunner')).toEqual(false);
             });
 
+            it('cannot view compiled SQL', () => {
+                expect(ability.can('view', 'CompiledSql')).toEqual(false);
+            });
+
             it('can use the SemanticViewer', () => {
                 expect(ability.can('manage', 'SemanticViewer')).toEqual(true);
             });
@@ -1108,6 +1112,10 @@ describe('Organization member permissions', () => {
 
             it('can run SQL Queries', () => {
                 expect(ability.can('manage', 'SqlRunner')).toEqual(true);
+            });
+
+            it('can view compiled SQL', () => {
+                expect(ability.can('view', 'CompiledSql')).toEqual(true);
             });
 
             it('can use the SemanticViewer', () => {

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -300,6 +300,9 @@ export const applyOrganizationMemberStaticAbilities: Record<
         can('manage', 'CustomFields', {
             organizationUuid: member.organizationUuid,
         });
+        can('view', 'CompiledSql', {
+            organizationUuid: member.organizationUuid,
+        });
         can('manage', 'CustomSqlTableCalculations', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.test.ts
+++ b/packages/common/src/authorization/projectMemberAbility.test.ts
@@ -916,6 +916,15 @@ describe('Project member permissions', () => {
                 ).toEqual(false);
             });
 
+            it('cannot view compiled SQL', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('CompiledSql', { projectUuid }),
+                    ),
+                ).toEqual(false);
+            });
+
             it('can use the SemanticViewer', () => {
                 expect(
                     ability.can(
@@ -1113,6 +1122,15 @@ describe('Project member permissions', () => {
                     ability.can(
                         'manage',
                         subject('SqlRunner', { projectUuid }),
+                    ),
+                ).toEqual(true);
+            });
+
+            it('can view compiled SQL', () => {
+                expect(
+                    ability.can(
+                        'view',
+                        subject('CompiledSql', { projectUuid }),
                     ),
                 ).toEqual(true);
             });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -256,6 +256,9 @@ export const projectMemberAbilities: Record<
         can('manage', 'CustomFields', {
             projectUuid: member.projectUuid,
         });
+        can('view', 'CompiledSql', {
+            projectUuid: member.projectUuid,
+        });
         can('manage', 'CustomSqlTableCalculations', {
             projectUuid: member.projectUuid,
         });

--- a/packages/common/src/authorization/roleToScopeMapping.testUtils.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.testUtils.ts
@@ -207,6 +207,11 @@ export const createStandardTestCases = () => [
         resource: { projectUuid: 'test-project-uuid' },
     },
     {
+        action: 'view' as const,
+        subject: 'CompiledSql' as const,
+        resource: { projectUuid: 'test-project-uuid' },
+    },
+    {
         action: 'manage' as const,
         subject: 'CustomSqlTableCalculations' as const,
         resource: { projectUuid: 'test-project-uuid' },

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -112,6 +112,7 @@ const BASE_ROLE_SCOPES = {
         'delete:VirtualView',
         'manage:CustomSql',
         'manage:CustomFields',
+        'view:CompiledSql',
         'manage:CustomSqlTableCalculations',
         'manage:SqlRunner',
         'manage:Validation',

--- a/packages/common/src/authorization/scopeAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.test.ts
@@ -1807,6 +1807,37 @@ describe('scopeAbilityBuilder', () => {
                 ),
             ).toBe(true);
         });
+
+        it('should grant view:compiled_sql without custom field authoring', () => {
+            const builder = new AbilityBuilder<MemberAbility>(Ability);
+            buildAbilityFromScopes(
+                {
+                    ...baseContext,
+                    scopes: ['view:CompiledSql'],
+                },
+                builder,
+            );
+            const ability = builder.build();
+
+            expect(
+                ability.can(
+                    'view',
+                    subject('CompiledSql', {
+                        organizationUuid: 'org-123',
+                        projectUuid: 'project-123',
+                    }),
+                ),
+            ).toBe(true);
+            expect(
+                ability.can(
+                    'manage',
+                    subject('CustomFields', {
+                        organizationUuid: 'org-123',
+                        projectUuid: 'project-123',
+                    }),
+                ),
+            ).toBe(false);
+        });
     });
 
     describe('project delete permissions', () => {

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -1081,6 +1081,15 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
     {
+        name: 'view:CompiledSql',
+        description:
+            'View compiled SQL for charts, including charts with custom SQL fields',
+        isEnterprise: false,
+        group: ScopeGroup.DATA,
+        dependencies: [{ name: 'view:Project' }],
+        getConditions: addDefaultUuidCondition,
+    },
+    {
         name: 'manage:CustomFields',
         description: 'Create and edit custom dimensions',
         isEnterprise: false,

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -258,6 +258,9 @@ const applyServiceAccountStaticAbilities: Record<
         can('manage', 'CustomFields', {
             organizationUuid,
         });
+        can('view', 'CompiledSql', {
+            organizationUuid,
+        });
         can('manage', 'CustomSqlTableCalculations', {
             organizationUuid,
         });

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -27,6 +27,7 @@ export type CaslSubjectNames =
     | 'AiDeepResearch'
     | 'Analytics'
     | 'ChangeCsvResults'
+    | 'CompiledSql'
     | 'CompileProject'
     | 'ContentAsCode'
     | 'ContentVerification'

--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -34,7 +34,7 @@ import {
 } from '../../../features/explorer/store';
 import { useCompiledSql } from '../../../hooks/useCompiledSql';
 import { useProject } from '../../../hooks/useProject';
-import { useCannotAuthorCustomSql } from '../../../hooks/user/useCannotAuthorCustomSql';
+import { useCannotViewCompiledSql } from '../../../hooks/user/useCannotViewCompiledSql';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import { ExplorerSection } from '../../../providers/Explorer/types';
@@ -64,7 +64,7 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
 
     const unsavedChartVersionTableName = useExplorerSelector(selectTableName);
     const metricQuery = useExplorerSelector(selectMetricQuery);
-    const cannotAuthorCustomSql = useCannotAuthorCustomSql(projectUuid);
+    const cannotViewCompiledSql = useCannotViewCompiledSql(projectUuid);
 
     const toggleExpandedSection = useCallback(
         (section: ExplorerSection) => {
@@ -79,7 +79,7 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
         !!metricQuery.customDimensions?.some(isCustomSqlDimension) ||
         !!metricQuery.tableCalculations?.some(isSqlTableCalculation);
     const cannotViewSqlAuthoredFields =
-        hasSqlAuthoredFields && cannotAuthorCustomSql;
+        hasSqlAuthoredFields && cannotViewCompiledSql;
 
     const { data, isSuccess, isInitialLoading, error } = useCompiledSql({
         enabled: !!unsavedChartVersionTableName && !cannotViewSqlAuthoredFields,

--- a/packages/frontend/src/hooks/user/useCannotViewCompiledSql.ts
+++ b/packages/frontend/src/hooks/user/useCannotViewCompiledSql.ts
@@ -1,0 +1,14 @@
+import { subject } from '@casl/ability';
+import useApp from '../../providers/App/useApp';
+
+export const useCannotViewCompiledSql = (projectUuid: string | undefined) => {
+    const { user } = useApp();
+
+    return user.data?.ability.cannot(
+        'view',
+        subject('CompiledSql', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+        }),
+    );
+};


### PR DESCRIPTION
## Summary

Organizations want analysts and other non-developer users to see the compiled SQL behind any chart — including charts with custom SQL dimensions or raw-SQL table calculations — without granting them authoring rights over those fields. Today the only unblock is `manage:CustomFields`, which also grants full custom-SQL authoring.

This PR splits viewing out into a new narrow scope, `view:CompiledSql`:

* **New scope** `view:CompiledSql` (Data group, non-enterprise, depends on `view:Project`) with subject `CompiledSql`.
* **System roles**: granted at developer tier (and up), exactly mirroring today's `manage:CustomFields` gate — no default behavior change for system roles.
* **Frontend**: `SqlCard.tsx` now checks `view:CompiledSql` via a new `useCannotViewCompiledSql` hook. The three authoring call-sites (`CustomDimensionModal`, `ColumnHeaderContextMenu`, `TreeSingleNodeActions`) still check `manage:CustomFields`.
* **Migration**: backfills `view:CompiledSql` into every custom role that currently holds `manage:CustomFields` (scope-split rule, same pattern as `20260417111420_grant_custom_fields_to_custom_sql_roles.ts`), so existing custom roles keep SQL viewing after the frontend check switches.

Custom roles can now include `view:CompiledSql` alone to give viewer/analyst personas SQL transparency without SQL authoring.

## Out of scope

No server-side gate was added to `POST …/compileQuery` — it only checks `view:Project` today (the CustomFields restriction was never enforced backend-side), and adding one would be a new restriction beyond this request.

## Testing

* `packages/common` authorization suite (113 files / 2927 tests) passes, including the role↔scope parity and scope-vocabulary coverage tests.
* New tests: scope→ability translation (`view:CompiledSql` grants viewing but not `manage:CustomFields`), project + org ability tests (developer can view, editor cannot).
* Typecheck clean on common, backend, and frontend; lint + oxfmt clean on changed files.

Closes: lightdash/lightdash#25812  <br>Closes: lightdash/lightdash#25812

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

[https://claude.ai/code/session_01DkhXALcL3usV88Ymw7Ka3d](<https://claude.ai/code/session_01DkhXALcL3usV88Ymw7Ka3d>)