### PR TITLE
fix: attach catalog types for empty-string db and Snowflake case

### DIFF
--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -397,7 +397,14 @@ export const compile = async (options: CompileHandlerOptions) => {
         }
 
         const validModelsWithTypes = applyMetricFlowMetrics(
-            attachTypesToModels(validModels, catalog, false),
+            attachTypesToModels(
+                validModels,
+                catalog,
+                false,
+                // Snowflake catalogs report uppercase identifiers; match the
+                // server-side adapter rule (dbtBaseProjectAdapter).
+                adapterType !== 'snowflake',
+            ),
             manifest,
         );
 

--- a/packages/common/src/compiler/translator.mock.ts
+++ b/packages/common/src/compiler/translator.mock.ts
@@ -1201,6 +1201,16 @@ export const warehouseSchema: WarehouseCatalog = {
     },
 };
 
+export const warehouseSchemaWithEmptyStringDatabase: WarehouseCatalog = {
+    '': {
+        [model.schema]: {
+            [model.name]: {
+                [column.name]: DimensionType.STRING,
+            },
+        },
+    },
+};
+
 export const warehouseSchemaWithMissingTable: WarehouseCatalog = {
     [model.database]: {
         [model.schema]: {},
@@ -1210,6 +1220,16 @@ export const warehouseSchemaWithMissingColumn: WarehouseCatalog = {
     [model.database]: {
         [model.schema]: {
             [model.name]: {},
+        },
+    },
+};
+
+export const warehouseSchemaWithAllUpperCaseKeys: WarehouseCatalog = {
+    [model.database.toUpperCase()]: {
+        [model.schema.toUpperCase()]: {
+            [model.name.toUpperCase()]: {
+                [column.name.toUpperCase()]: DimensionType.STRING,
+            },
         },
     },
 };

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -75,6 +75,8 @@ import {
     MODEL_WITH_WRONG_METRICS,
     SPOTLIGHT_CONFIG_WITH_CATEGORIES_AND_HIDE,
     warehouseSchema,
+    warehouseSchemaWithAllUpperCaseKeys,
+    warehouseSchemaWithEmptyStringDatabase,
     warehouseSchemaWithMissingColumn,
     warehouseSchemaWithMissingTable,
     warehouseSchemaWithUpperCaseColumn,
@@ -121,6 +123,33 @@ describe('attachTypesToModels', () => {
         ).toThrowError(
             'Column "myColumnName" from model "myTable" does not exist.\n "myTable.myColumnName" was not found in your target warehouse at myDatabase.mySchema.myTable. Try rerunning dbt to update your warehouse.',
         );
+    });
+    it('should match an empty-string database key (ClickHouse table_catalog)', async () => {
+        const emptyDbModel = { ...model, database: '' };
+        expect(() =>
+            attachTypesToModels(
+                [emptyDbModel],
+                warehouseSchemaWithEmptyStringDatabase,
+                true,
+            ),
+        ).not.toThrow();
+        expect(
+            attachTypesToModels(
+                [emptyDbModel],
+                warehouseSchemaWithEmptyStringDatabase,
+                false,
+            )[0].columns.myColumnName.data_type,
+        ).toEqual(DimensionType.STRING);
+    });
+    it('should match uppercase catalog keys at every level when case-insensitive (Snowflake)', async () => {
+        expect(
+            attachTypesToModels(
+                [model],
+                warehouseSchemaWithAllUpperCaseKeys,
+                true,
+                false,
+            )[0],
+        ).toEqual(expectedModelWithType);
     });
     it('should throw an error when column has wrong case', async () => {
         expect(() =>

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1378,23 +1378,27 @@ export const attachTypesToModels = (
                 ? db === database
                 : db.toLowerCase() === database.toLowerCase(),
         );
+        // Explicit undefined checks: a matched key can be the empty string
+        // (ClickHouse table_catalog), which is falsy but a real match.
         const schemaMatch =
-            databaseMatch &&
-            Object.keys(warehouseCatalog[databaseMatch]).find((s) =>
-                caseSensitiveMatching
-                    ? s === schema
-                    : s.toLowerCase() === schema.toLowerCase(),
-            );
+            databaseMatch !== undefined
+                ? Object.keys(warehouseCatalog[databaseMatch]).find((s) =>
+                      caseSensitiveMatching
+                          ? s === schema
+                          : s.toLowerCase() === schema.toLowerCase(),
+                  )
+                : undefined;
         const tableMatch =
-            databaseMatch &&
-            schemaMatch &&
-            Object.keys(warehouseCatalog[databaseMatch][schemaMatch]).find(
-                (t) =>
-                    caseSensitiveMatching
-                        ? t === name
-                        : t.toLowerCase() === name.toLowerCase(),
-            );
-        if (!tableMatch && throwOnMissingCatalogEntry) {
+            databaseMatch !== undefined && schemaMatch !== undefined
+                ? Object.keys(
+                      warehouseCatalog[databaseMatch][schemaMatch],
+                  ).find((t) =>
+                      caseSensitiveMatching
+                          ? t === name
+                          : t.toLowerCase() === name.toLowerCase(),
+                  )
+                : undefined;
+        if (tableMatch === undefined && throwOnMissingCatalogEntry) {
             throw new MissingCatalogEntryError(
                 `Model "${name}" was expected in your target warehouse at "${database}.${schema}.${name}". Does the table exist in your target data warehouse?`,
                 {},
@@ -1413,33 +1417,41 @@ export const attachTypesToModels = (
                 : db.toLowerCase() === database.toLowerCase(),
         );
         const schemaMatch =
-            databaseMatch &&
-            Object.keys(warehouseCatalog[databaseMatch]).find((s) =>
-                caseSensitiveMatching
-                    ? s === schema
-                    : s.toLowerCase() === schema.toLowerCase(),
-            );
+            databaseMatch !== undefined
+                ? Object.keys(warehouseCatalog[databaseMatch]).find((s) =>
+                      caseSensitiveMatching
+                          ? s === schema
+                          : s.toLowerCase() === schema.toLowerCase(),
+                  )
+                : undefined;
         const tableMatch =
-            databaseMatch &&
-            schemaMatch &&
-            Object.keys(warehouseCatalog[databaseMatch][schemaMatch]).find(
-                (t) =>
-                    caseSensitiveMatching
-                        ? t === tableName
-                        : t.toLowerCase() === tableName.toLowerCase(),
-            );
+            databaseMatch !== undefined && schemaMatch !== undefined
+                ? Object.keys(
+                      warehouseCatalog[databaseMatch][schemaMatch],
+                  ).find((t) =>
+                      caseSensitiveMatching
+                          ? t === tableName
+                          : t.toLowerCase() === tableName.toLowerCase(),
+                  )
+                : undefined;
         const columnMatch =
-            databaseMatch &&
-            schemaMatch &&
-            tableMatch &&
-            Object.keys(
-                warehouseCatalog[databaseMatch][schemaMatch][tableMatch],
-            ).find((c) =>
-                caseSensitiveMatching
-                    ? c === columnName
-                    : c.toLowerCase() === columnName.toLowerCase(),
-            );
-        if (databaseMatch && schemaMatch && tableMatch && columnMatch) {
+            databaseMatch !== undefined &&
+            schemaMatch !== undefined &&
+            tableMatch !== undefined
+                ? Object.keys(
+                      warehouseCatalog[databaseMatch][schemaMatch][tableMatch],
+                  ).find((c) =>
+                      caseSensitiveMatching
+                          ? c === columnName
+                          : c.toLowerCase() === columnName.toLowerCase(),
+                  )
+                : undefined;
+        if (
+            databaseMatch !== undefined &&
+            schemaMatch !== undefined &&
+            tableMatch !== undefined &&
+            columnMatch !== undefined
+        ) {
             return warehouseCatalog[databaseMatch][schemaMatch][tableMatch][
                 columnMatch
             ];


### PR DESCRIPTION
Two CLI catalog-attachment bugs that silently prevented warehouse types from ever reaching compiled explores:

- **Empty-string database keys were dropped as falsy.** ClickHouse reports `table_catalog = ''`, and the truthiness guards in `attachTypesToModels` treated the matched key as a miss — so ClickHouse deploys never attached catalog types. Guards are now explicit `!== undefined` checks.
- **Snowflake catalogs report uppercase identifiers**, but the CLI called `attachTypesToModels` with case-sensitive matching. The CLI now mirrors the server-side adapter rule (`adapterType !== 'snowflake'`), the same behavior `dbtBaseProjectAdapter` has always had.

**User-visible change:** columns *without* YAML-declared dimension types gain their real catalog types (previously they silently fell back to `string`). That is the fix working, but it can change dimension types (and therefore available time intervals) on affected projects. When this activates differs by warehouse:

- **Snowflake:** CLI-only change — inert until the project is redeployed with an upgraded CLI. The server path was already case-insensitive.
- **ClickHouse:** the empty-string fix lives in shared compiler code, so it also applies to **server-side compiles** — types flip on the next recompile after the backend release (refresh-dbt from the UI or API, project settings save, preview creation), no CLI upgrade needed. Previously every server-side ClickHouse compile threw an internally-caught `MissingCatalogEntryError`, paid a wasted full-catalog refetch, and still attached nothing; both are fixed.

When a dimension flips `string` → `timestamp`/`date`, saved filters using string operators fail loudly with a `CompileError` at query time (not silent wrong data), and newly auto-generated time-interval dimensions (`_day`, `_month`, …) can collide with same-named `additional_dimensions` or metrics. Projects using `lightdash generate` YAML are unaffected (it always writes explicit types). Escape hatches: pin the CLI, `--skip-warehouse-catalog`, or declare `meta.dimension.type` explicitly — YAML always wins.

Surfaced by the timestamp-domain detection work, which relies on catalog attachment actually running on these warehouses.

Relates: GLITCH-615
