### PR TITLE
feat: detect timestamp domain from warehouse catalogs

### DIFF
--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -1,6 +1,7 @@
 import {
     AnyType,
     attachTypesToModels,
+    catalogHasTimestampDomains,
     convertExplores,
     DbtManifestVersion,
     DbtModelNode,
@@ -8,6 +9,7 @@ import {
     DbtRawModelNode,
     DbtRpcGetManifestResults,
     DEFAULT_SPOTLIGHT_CONFIG,
+    ensureCatalogTimestampDomainsKey,
     Explore,
     ExploreError,
     friendlyName,
@@ -267,6 +269,19 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                     {},
                 );
             }
+            // A cache written before timestamp domains existed would otherwise
+            // be reused forever (only missing entries trigger a refetch),
+            // leaving every column unclassified — refetch it once.
+            if (
+                !catalogHasTimestampDomains(
+                    this.cachedWarehouse.warehouseCatalog,
+                )
+            ) {
+                throw new MissingCatalogEntryError(
+                    `Cached warehouse catalog predates timestamp domains`,
+                    {},
+                );
+            }
             Logger.info(`Attach types to ${validModels.length} models`);
             const lazyTypedModels = attachTypesToModels(
                 validModels,
@@ -307,6 +322,10 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
 
                 const warehouseCatalog =
                     await this.warehouseClient.getCatalog(modelCatalog);
+                // Clients only create the sidecar when they classify a column;
+                // stamp it (possibly empty) so the staleness check above can't
+                // refetch again on domain-less warehouses.
+                ensureCatalogTimestampDomainsKey(warehouseCatalog);
                 await this.cachedWarehouse?.onWarehouseCatalogChange(
                     warehouseCatalog,
                 );

--- a/packages/common/src/compiler/translator.mock.ts
+++ b/packages/common/src/compiler/translator.mock.ts
@@ -4,14 +4,10 @@ import { DimensionType, FieldType, MetricType } from '../types/field';
 import type { LightdashProjectConfig } from '../types/lightdashProjectConfig';
 import { OrderFieldsByStrategy } from '../types/table';
 import { TimeFrames } from '../types/timeFrames';
-
-type WarehouseCatalog = {
-    [database: string]: {
-        [schema: string]: {
-            [table: string]: { [column: string]: DimensionType };
-        };
-    };
-};
+import {
+    setCatalogTimestampDomain,
+    type WarehouseCatalog,
+} from '../types/warehouse';
 
 export const VALID_ID_COLUMN_NAMES = [
     { input: 'userid', output: 'user' },
@@ -1248,6 +1244,92 @@ export const expectedModelWithType: DbtModelNode = {
     ...model,
     columns: {
         myColumnName: { ...column, data_type: DimensionType.STRING },
+    },
+};
+
+export const warehouseSchemaWithTimestampDomain: WarehouseCatalog = (() => {
+    const catalog: WarehouseCatalog = {
+        [model.database]: {
+            [model.schema]: {
+                [model.name]: {
+                    [column.name]: DimensionType.TIMESTAMP,
+                },
+            },
+        },
+    };
+    setCatalogTimestampDomain(
+        catalog,
+        model.database,
+        model.schema,
+        model.name,
+        column.name,
+        'naive',
+    );
+    return catalog;
+})();
+
+export const expectedModelWithTimestampDomain: DbtModelNode = {
+    ...model,
+    columns: {
+        myColumnName: {
+            ...column,
+            data_type: DimensionType.TIMESTAMP,
+            timestamp_domain: 'naive',
+        },
+    },
+};
+
+export const MODEL_WITH_TIMESTAMP_DOMAIN: DbtModelNode & {
+    relation_name: string;
+} = {
+    ...model,
+    columns: {
+        user_created: {
+            name: 'user_created',
+            data_type: DimensionType.TIMESTAMP,
+            timestamp_domain: 'naive',
+            meta: {
+                dimension: {
+                    time_intervals: ['RAW', 'DAY', 'slt_week'],
+                },
+            },
+        },
+    },
+};
+
+export const MODEL_WITH_TIMESTAMP_DOMAIN_YAML_OVERRIDE: DbtModelNode & {
+    relation_name: string;
+} = {
+    ...model,
+    columns: {
+        user_created: {
+            name: 'user_created',
+            data_type: DimensionType.TIMESTAMP,
+            timestamp_domain: 'naive',
+            meta: {
+                dimension: {
+                    timestamp_domain: 'aware',
+                    time_intervals: ['RAW', 'DAY'],
+                },
+            },
+        },
+    },
+};
+
+export const MODEL_WITH_UNKNOWN_TIMESTAMP_DOMAIN: DbtModelNode & {
+    relation_name: string;
+} = {
+    ...model,
+    columns: {
+        user_created: {
+            name: 'user_created',
+            data_type: DimensionType.TIMESTAMP,
+            meta: {
+                dimension: {
+                    time_intervals: ['RAW', 'DAY'],
+                },
+            },
+        },
     },
 };
 

--- a/packages/common/src/compiler/translator.mock.ts
+++ b/packages/common/src/compiler/translator.mock.ts
@@ -1333,6 +1333,69 @@ export const MODEL_WITH_UNKNOWN_TIMESTAMP_DOMAIN: DbtModelNode & {
     },
 };
 
+export const MODEL_WITH_TIMESTAMP_DOMAIN_CUSTOM_SQL: DbtModelNode & {
+    relation_name: string;
+} = {
+    ...model,
+    columns: {
+        user_created: {
+            name: 'user_created',
+            data_type: DimensionType.TIMESTAMP,
+            timestamp_domain: 'naive',
+            meta: {
+                dimension: {
+                    sql: "${TABLE}.user_created AT TIME ZONE 'UTC'",
+                    time_intervals: ['RAW', 'DAY'],
+                },
+            },
+        },
+    },
+};
+
+export const MODEL_WITH_TIMESTAMP_DOMAIN_CUSTOM_SQL_ANNOTATED: DbtModelNode & {
+    relation_name: string;
+} = {
+    ...model,
+    columns: {
+        user_created: {
+            name: 'user_created',
+            data_type: DimensionType.TIMESTAMP,
+            timestamp_domain: 'naive',
+            meta: {
+                dimension: {
+                    sql: 'COALESCE(${TABLE}.user_created, ${TABLE}.fallback_at)',
+                    timestamp_domain: 'naive',
+                    time_intervals: ['RAW', 'DAY'],
+                },
+            },
+        },
+    },
+};
+
+export const MODEL_WITH_TIMESTAMP_DOMAIN_ADDITIONAL_DIMENSION: DbtModelNode & {
+    relation_name: string;
+} = {
+    ...model,
+    columns: {
+        user_created: {
+            name: 'user_created',
+            data_type: DimensionType.TIMESTAMP,
+            timestamp_domain: 'naive',
+            meta: {
+                dimension: {
+                    time_intervals: ['RAW'],
+                },
+                additional_dimensions: {
+                    user_created_shifted: {
+                        type: DimensionType.TIMESTAMP,
+                        sql: "${TABLE}.user_created + INTERVAL '1 day'",
+                    },
+                },
+            },
+        },
+    },
+};
+
 export const LIGHTDASH_TABLE_SQL_WHERE: Omit<Table, 'lineageGraph'> = {
     ...BASE_LIGHTDASH_TABLE,
     sqlWhere: '${payment_method} IS NOT NULL',

--- a/packages/common/src/compiler/translator.mock.ts
+++ b/packages/common/src/compiler/translator.mock.ts
@@ -1396,6 +1396,60 @@ export const MODEL_WITH_TIMESTAMP_DOMAIN_ADDITIONAL_DIMENSION: DbtModelNode & {
     },
 };
 
+export const MODEL_WITH_SQLLESS_ADDITIONAL_DIMENSION: DbtModelNode & {
+    relation_name: string;
+} = {
+    ...model,
+    columns: {
+        user_created: {
+            name: 'user_created',
+            data_type: DimensionType.TIMESTAMP,
+            timestamp_domain: 'naive',
+            meta: {
+                dimension: {
+                    time_intervals: ['RAW'],
+                },
+                additional_dimensions: {
+                    user_created_copy: {
+                        type: DimensionType.TIMESTAMP,
+                    },
+                },
+            },
+        },
+    },
+};
+
+export const MODEL_WITH_ANNOTATED_ADDITIONAL_DIMENSIONS: DbtModelNode & {
+    relation_name: string;
+} = {
+    ...model,
+    columns: {
+        user_created: {
+            name: 'user_created',
+            data_type: DimensionType.TIMESTAMP,
+            meta: {
+                dimension: {
+                    timestamp_domain: 'naive',
+                    time_intervals: ['RAW', 'DAY'],
+                },
+                additional_dimensions: {
+                    user_created_aware: {
+                        type: DimensionType.TIMESTAMP,
+                        sql: '${TABLE}.user_created_utc',
+                        timestamp_domain: 'aware',
+                        time_intervals: ['RAW', 'DAY'],
+                    },
+                    user_created_plain: {
+                        type: DimensionType.TIMESTAMP,
+                        sql: '${TABLE}.user_created_other',
+                        time_intervals: ['RAW', 'DAY'],
+                    },
+                },
+            },
+        },
+    },
+};
+
 export const LIGHTDASH_TABLE_SQL_WHERE: Omit<Table, 'lineageGraph'> = {
     ...BASE_LIGHTDASH_TABLE,
     sqlWhere: '${payment_method} IS NOT NULL',

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -73,6 +73,9 @@ import {
     MODEL_WITH_SQL_FILTER,
     MODEL_WITH_SQL_WHERE,
     MODEL_WITH_TIMESTAMP_DOMAIN,
+    MODEL_WITH_TIMESTAMP_DOMAIN_ADDITIONAL_DIMENSION,
+    MODEL_WITH_TIMESTAMP_DOMAIN_CUSTOM_SQL,
+    MODEL_WITH_TIMESTAMP_DOMAIN_CUSTOM_SQL_ANNOTATED,
     MODEL_WITH_TIMESTAMP_DOMAIN_YAML_OVERRIDE,
     MODEL_WITH_UNKNOWN_TIMESTAMP_DOMAIN,
     MODEL_WITH_WRONG_METRIC,
@@ -250,6 +253,47 @@ describe('timestamp domain', () => {
             'timestampDomain',
         );
         expect(result.dimensions.user_created_day).not.toHaveProperty(
+            'timestampDomain',
+        );
+    });
+
+    it('should not stamp the catalog domain on a custom SQL dimension', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            MODEL_WITH_TIMESTAMP_DOMAIN_CUSTOM_SQL,
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.dimensions.user_created).not.toHaveProperty(
+            'timestampDomain',
+        );
+        expect(result.dimensions.user_created_day).not.toHaveProperty(
+            'timestampDomain',
+        );
+    });
+
+    it('should honour the YAML timestamp_domain on a custom SQL dimension', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            MODEL_WITH_TIMESTAMP_DOMAIN_CUSTOM_SQL_ANNOTATED,
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.dimensions.user_created.timestampDomain).toEqual('naive');
+        expect(result.dimensions.user_created_day.timestampDomain).toEqual(
+            'naive',
+        );
+    });
+
+    it('should not stamp the catalog domain on additional dimensions', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            MODEL_WITH_TIMESTAMP_DOMAIN_ADDITIONAL_DIMENSION,
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.dimensions.user_created.timestampDomain).toEqual('naive');
+        expect(result.dimensions.user_created_shifted).not.toHaveProperty(
             'timestampDomain',
         );
     });

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -46,6 +46,7 @@ import {
     MODEL_WITH_AI_HINT,
     MODEL_WITH_AI_HINT_ARRAY,
     MODEL_WITH_AI_HINT_IN_CONFIG,
+    MODEL_WITH_ANNOTATED_ADDITIONAL_DIMENSIONS,
     MODEL_WITH_COMPOSITE_PRIMARY_KEY,
     MODEL_WITH_CUSTOM_GRANULARITY,
     MODEL_WITH_CUSTOM_GRANULARITY_AND_REQUIRED_ATTRIBUTES,
@@ -72,6 +73,7 @@ import {
     MODEL_WITH_SINGLE_PRIMARY_KEY,
     MODEL_WITH_SQL_FILTER,
     MODEL_WITH_SQL_WHERE,
+    MODEL_WITH_SQLLESS_ADDITIONAL_DIMENSION,
     MODEL_WITH_TIMESTAMP_DOMAIN,
     MODEL_WITH_TIMESTAMP_DOMAIN_ADDITIONAL_DIMENSION,
     MODEL_WITH_TIMESTAMP_DOMAIN_CUSTOM_SQL,
@@ -294,6 +296,48 @@ describe('timestamp domain', () => {
 
         expect(result.dimensions.user_created.timestampDomain).toEqual('naive');
         expect(result.dimensions.user_created_shifted).not.toHaveProperty(
+            'timestampDomain',
+        );
+    });
+
+    it('should not stamp the catalog domain on a sql-less additional dimension', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            MODEL_WITH_SQLLESS_ADDITIONAL_DIMENSION,
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.dimensions.user_created.timestampDomain).toEqual('naive');
+        expect(result.dimensions.user_created_copy).not.toHaveProperty(
+            'timestampDomain',
+        );
+    });
+
+    it('should carry an additional dimension timestamp_domain to its interval children and not leak the base annotation', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            MODEL_WITH_ANNOTATED_ADDITIONAL_DIMENSIONS,
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        // Base column YAML annotation applies to itself and its children
+        expect(result.dimensions.user_created.timestampDomain).toEqual('naive');
+        expect(result.dimensions.user_created_day.timestampDomain).toEqual(
+            'naive',
+        );
+        // Annotated additional dim: its own domain reaches its children
+        expect(result.dimensions.user_created_aware.timestampDomain).toEqual(
+            'aware',
+        );
+        expect(
+            result.dimensions.user_created_aware_day.timestampDomain,
+        ).toEqual('aware');
+        // Unannotated additional dim: neither the base annotation nor the
+        // catalog leaks onto it or its children
+        expect(result.dimensions.user_created_plain).not.toHaveProperty(
+            'timestampDomain',
+        );
+        expect(result.dimensions.user_created_plain_day).not.toHaveProperty(
             'timestampDomain',
         );
     });

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -15,6 +15,7 @@ import {
     convertTable,
 } from './translator';
 import {
+    expectedModelWithTimestampDomain,
     expectedModelWithType,
     LIGHTDASH_TABLE_SQL_WHERE,
     LIGHTDASH_TABLE_WITH_ADDITIONAL_DIMENSIONS,
@@ -71,6 +72,9 @@ import {
     MODEL_WITH_SINGLE_PRIMARY_KEY,
     MODEL_WITH_SQL_FILTER,
     MODEL_WITH_SQL_WHERE,
+    MODEL_WITH_TIMESTAMP_DOMAIN,
+    MODEL_WITH_TIMESTAMP_DOMAIN_YAML_OVERRIDE,
+    MODEL_WITH_UNKNOWN_TIMESTAMP_DOMAIN,
     MODEL_WITH_WRONG_METRIC,
     MODEL_WITH_WRONG_METRICS,
     SPOTLIGHT_CONFIG_WITH_CATEGORIES_AND_HIDE,
@@ -79,6 +83,7 @@ import {
     warehouseSchemaWithEmptyStringDatabase,
     warehouseSchemaWithMissingColumn,
     warehouseSchemaWithMissingTable,
+    warehouseSchemaWithTimestampDomain,
     warehouseSchemaWithUpperCaseColumn,
 } from './translator.mock';
 
@@ -171,6 +176,82 @@ describe('attachTypesToModels', () => {
                 false,
             )[0],
         ).toEqual(expectedModelWithType);
+    });
+});
+
+describe('timestamp domain', () => {
+    const customGranularities = {
+        slt_week: {
+            label: 'SLT Week',
+            sql: "DATE_TRUNC('week', ${COLUMN})",
+        },
+    };
+
+    it('should attach timestamp_domain as a sibling of data_type', () => {
+        expect(
+            attachTypesToModels(
+                [model],
+                warehouseSchemaWithTimestampDomain,
+                false,
+            )[0],
+        ).toEqual(expectedModelWithTimestampDomain);
+    });
+
+    it('should not attach timestamp_domain for legacy catalog entries', () => {
+        expect(
+            attachTypesToModels([model], warehouseSchema, false)[0].columns
+                .myColumnName,
+        ).not.toHaveProperty('timestamp_domain');
+    });
+
+    it('should stamp timestampDomain on the dimension and its interval children', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            MODEL_WITH_TIMESTAMP_DOMAIN,
+            DEFAULT_SPOTLIGHT_CONFIG,
+            undefined,
+            undefined,
+            customGranularities,
+        );
+
+        expect(result.dimensions.user_created.timestampDomain).toEqual('naive');
+        expect(result.dimensions.user_created_raw.timestampDomain).toEqual(
+            'naive',
+        );
+        expect(result.dimensions.user_created_day.timestampDomain).toEqual(
+            'naive',
+        );
+        expect(result.dimensions.user_created_slt_week.timestampDomain).toEqual(
+            'naive',
+        );
+    });
+
+    it('should prefer the YAML timestamp_domain over the catalog', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            MODEL_WITH_TIMESTAMP_DOMAIN_YAML_OVERRIDE,
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.dimensions.user_created.timestampDomain).toEqual('aware');
+        expect(result.dimensions.user_created_day.timestampDomain).toEqual(
+            'aware',
+        );
+    });
+
+    it('should leave timestampDomain absent when unknown', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            MODEL_WITH_UNKNOWN_TIMESTAMP_DOMAIN,
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.dimensions.user_created).not.toHaveProperty(
+            'timestampDomain',
+        );
+        expect(result.dimensions.user_created_day).not.toHaveProperty(
+            'timestampDomain',
+        );
     });
 });
 

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -33,9 +33,11 @@ import {
     DimensionType,
     FieldType,
     friendlyName,
+    isTimestampDomain,
     type Dimension,
     type Metric,
     type Source,
+    type TimestampDomain,
 } from '../types/field';
 import { parseModelRequiredFilters } from '../types/filterGrammar';
 import {
@@ -44,7 +46,11 @@ import {
 } from '../types/lightdashProjectConfig';
 import { OrderFieldsByStrategy, type FieldGroupType } from '../types/table';
 import { type TimeFrames } from '../types/timeFrames';
-import { type WarehouseSqlBuilder } from '../types/warehouse';
+import {
+    getCatalogTimestampDomain,
+    type WarehouseCatalog,
+    type WarehouseSqlBuilder,
+} from '../types/warehouse';
 import assertUnreachable from '../utils/assertUnreachable';
 import {
     getDefaultTimeFrames,
@@ -200,6 +206,15 @@ const convertDimension = (
     if (type === DimensionType.TIMESTAMP && !disableTimestampConversion) {
         sql = convertTimezone(sql, 'UTC', 'UTC', targetWarehouse);
     }
+    // YAML declaration wins over the warehouse catalog; computed on the base
+    // type so interval children inherit it like skipTimezoneConversion does.
+    const rawTimestampDomain =
+        meta.dimension?.timestamp_domain ?? column.timestamp_domain;
+    const timestampDomain: TimestampDomain | undefined =
+        type === DimensionType.TIMESTAMP &&
+        isTimestampDomain(rawTimestampDomain)
+            ? rawTimestampDomain
+            : undefined;
     const isIntervalBase =
         timeInterval === undefined && isInterval(type, meta.dimension);
 
@@ -291,6 +306,7 @@ const convertDimension = (
         ...(meta.dimension?.convert_timezone === false
             ? { skipTimezoneConversion: true }
             : {}),
+        ...(timestampDomain ? { timestampDomain } : {}),
         groups,
         isIntervalBase,
         ...(meta.dimension && meta.dimension.tags
@@ -779,6 +795,9 @@ export const convertTable = (
                                     dim.isAdditionalDimension,
                                 ...(dim.skipTimezoneConversion
                                     ? { skipTimezoneConversion: true }
+                                    : {}),
+                                ...(dim.timestampDomain
+                                    ? { timestampDomain: dim.timestampDomain }
                                     : {}),
                             } satisfies Dimension,
                         };
@@ -1361,13 +1380,7 @@ export const convertExplores = async (
 
 export const attachTypesToModels = (
     models: DbtModelNode[],
-    warehouseCatalog: {
-        [database: string]: {
-            [schema: string]: {
-                [table: string]: { [column: string]: DimensionType };
-            };
-        };
-    },
+    warehouseCatalog: WarehouseCatalog,
     throwOnMissingCatalogEntry: boolean = true,
     caseSensitiveMatching: boolean = true,
 ): DbtModelNode[] => {
@@ -1406,10 +1419,12 @@ export const attachTypesToModels = (
         }
     });
 
-    const getType = (
+    const getColumnType = (
         { database, schema, name, alias }: DbtModelNode,
         columnName: string,
-    ): DimensionType | undefined => {
+    ):
+        | { type: DimensionType; timestampDomain: TimestampDomain | undefined }
+        | undefined => {
         const tableName = alias || name;
         const databaseMatch = Object.keys(warehouseCatalog).find((db) =>
             caseSensitiveMatching
@@ -1452,9 +1467,18 @@ export const attachTypesToModels = (
             tableMatch !== undefined &&
             columnMatch !== undefined
         ) {
-            return warehouseCatalog[databaseMatch][schemaMatch][tableMatch][
-                columnMatch
-            ];
+            return {
+                type: warehouseCatalog[databaseMatch][schemaMatch][tableMatch][
+                    columnMatch
+                ],
+                timestampDomain: getCatalogTimestampDomain(
+                    warehouseCatalog,
+                    databaseMatch,
+                    schemaMatch,
+                    tableMatch,
+                    columnMatch,
+                ),
+            };
         }
         if (throwOnMissingCatalogEntry) {
             throw new MissingCatalogEntryError(
@@ -1469,10 +1493,21 @@ export const attachTypesToModels = (
     return models.map((model) => ({
         ...model,
         columns: Object.fromEntries(
-            Object.entries(model.columns).map(([column_name, column]) => [
-                column_name,
-                { ...column, data_type: getType(model, column_name) },
-            ]),
+            Object.entries(model.columns).map(([column_name, column]) => {
+                const columnType = getColumnType(model, column_name);
+                return [
+                    column_name,
+                    {
+                        ...column,
+                        data_type: columnType?.type,
+                        // Sibling of data_type: that field is overwritten
+                        // wholesale, so the domain must ride separately.
+                        ...(columnType?.timestampDomain
+                            ? { timestamp_domain: columnType.timestampDomain }
+                            : {}),
+                    },
+                ];
+            }),
         ),
     }));
 };

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -206,10 +206,13 @@ const convertDimension = (
     if (type === DimensionType.TIMESTAMP && !disableTimestampConversion) {
         sql = convertTimezone(sql, 'UTC', 'UTC', targetWarehouse);
     }
-    // YAML declaration wins over the warehouse catalog; computed on the base
+    // YAML declaration wins over the warehouse catalog. The catalog describes
+    // the physical column, so its domain is dropped when custom SQL replaces
+    // the column — the expression may change the domain. Computed on the base
     // type so interval children inherit it like skipTimezoneConversion does.
     const rawTimestampDomain =
-        meta.dimension?.timestamp_domain ?? column.timestamp_domain;
+        meta.dimension?.timestamp_domain ??
+        (meta.dimension?.sql ? undefined : column.timestamp_domain);
     const timestampDomain: TimestampDomain | undefined =
         type === DimensionType.TIMESTAMP &&
         isTimestampDomain(rawTimestampDomain)

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -208,11 +208,15 @@ const convertDimension = (
     }
     // YAML declaration wins over the warehouse catalog. The catalog describes
     // the physical column, so its domain is dropped when custom SQL replaces
-    // the column — the expression may change the domain. Computed on the base
-    // type so interval children inherit it like skipTimezoneConversion does.
+    // the column — the expression may change the domain — and for additional
+    // dimensions, whose carrier column is the parent's, not their own.
+    // Computed on the base type so interval children inherit it like
+    // skipTimezoneConversion does.
     const rawTimestampDomain =
         meta.dimension?.timestamp_domain ??
-        (meta.dimension?.sql ? undefined : column.timestamp_domain);
+        (meta.dimension?.sql || isAdditionalDimension
+            ? undefined
+            : column.timestamp_domain);
     const timestampDomain: TimestampDomain | undefined =
         type === DimensionType.TIMESTAMP &&
         isTimestampDomain(rawTimestampDomain)
@@ -695,6 +699,10 @@ export const convertTable = (
                         sql: dim.sql,
                         description: dim.description,
                         hidden: dim.hidden,
+                        // Additional-dim children must inherit the additional
+                        // dimension's own resolved domain, not the parent
+                        // column's annotation riding in the meta spread.
+                        timestamp_domain: dim.timestampDomain,
                     };
 
                     // Generate standard interval dimensions

--- a/packages/common/src/dbt/schemas/lightdashMetadata.json
+++ b/packages/common/src/dbt/schemas/lightdashMetadata.json
@@ -229,6 +229,11 @@
                     "type": "boolean",
                     "description": "When false, this dimension is rendered in its raw warehouse value and is not converted to the project timezone for display. Filter SQL still converts. Defaults to true."
                 },
+                "timestamp_domain": {
+                    "type": "string",
+                    "enum": ["aware", "naive"],
+                    "description": "Declares whether this timestamp column stores an instant ('aware') or a bare wall clock ('naive'); overrides the warehouse catalog."
+                },
                 "hidden": {
                     "type": "boolean"
                 },
@@ -289,6 +294,11 @@
                 "convert_timezone": {
                     "type": "boolean",
                     "description": "When false, this dimension is rendered in its raw warehouse value and is not converted to the project timezone for display. Filter SQL still converts. Defaults to true."
+                },
+                "timestamp_domain": {
+                    "type": "string",
+                    "enum": ["aware", "naive"],
+                    "description": "Declares whether this timestamp column stores an instant ('aware') or a bare wall clock ('naive'); overrides the warehouse catalog."
                 },
                 "hidden": {
                     "type": "boolean"

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -1454,6 +1454,11 @@
                             "type": "boolean",
                             "description": "When false, this dimension is rendered in its raw warehouse value and is not converted to the project timezone for display. Filter SQL still converts. Defaults to true."
                         },
+                        "timestamp_domain": {
+                            "type": "string",
+                            "enum": ["aware", "naive"],
+                            "description": "Declares whether this timestamp column stores an instant ('aware') or a bare wall clock ('naive'); overrides the warehouse catalog."
+                        },
                         "hidden": {
                             "type": "boolean"
                         },
@@ -1763,6 +1768,11 @@
                                 "convert_timezone": {
                                     "type": "boolean",
                                     "description": "When false, this dimension is rendered in its raw warehouse value and is not converted to the project timezone for display. Filter SQL still converts. Defaults to true."
+                                },
+                                "timestamp_domain": {
+                                    "type": "string",
+                                    "enum": ["aware", "naive"],
+                                    "description": "Declares whether this timestamp column stores an instant ('aware') or a bare wall clock ('naive'); overrides the warehouse catalog."
                                 },
                                 "hidden": {
                                     "type": "boolean"

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -27,6 +27,7 @@ import {
     type MetricType,
     type NumberSeparator,
     type Source,
+    type TimestampDomain,
 } from './field';
 import { parseFilters, type RequiredFilter } from './filterGrammar';
 import { type LightdashProjectConfig } from './lightdashProjectConfig';
@@ -77,6 +78,9 @@ export type DbtModelNode = DbtRawModelNode & {
 export type DbtModelColumn = ColumnInfo & {
     meta?: DbtColumnMetadata;
     data_type?: DimensionType;
+    /** Catalog-derived timestamp domain; sibling of data_type because
+     *  attachTypesToModels overwrites data_type wholesale. */
+    timestamp_domain?: TimestampDomain;
     config?: {
         meta?: DbtColumnMetadata;
     };
@@ -236,6 +240,9 @@ export type DbtColumnLightdashDimension = {
     time_intervals?: boolean | 'default' | 'OFF' | (TimeFrames | string)[];
     /** Set to false to opt this dim out of display-tz conversion. Defaults to true. */
     convert_timezone?: boolean;
+    /** Declares whether the column stores an instant ('aware') or a bare wall
+     *  clock ('naive'); overrides the warehouse catalog. */
+    timestamp_domain?: TimestampDomain;
     hidden?: boolean;
     // @deprecated Use format expression instead
     round?: number;

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -678,6 +678,15 @@ export enum DimensionType {
     BOOLEAN = 'boolean',
 }
 
+/**
+ * Whether a TIMESTAMP column stores an instant ('aware') or a bare wall clock
+ * ('naive'). Absent means unknown — never assume 'aware' for a missing value.
+ */
+export type TimestampDomain = 'aware' | 'naive';
+
+export const isTimestampDomain = (value: unknown): value is TimestampDomain =>
+    value === 'aware' || value === 'naive';
+
 export type FilterAutocompleteValue = {
     value: string;
     label?: string;
@@ -751,6 +760,7 @@ export interface Dimension extends Field {
     customTimeInterval?: string;
     isAdditionalDimension?: boolean;
     skipTimezoneConversion?: boolean;
+    timestampDomain?: TimestampDomain;
     colors?: Record<string, string>;
     isIntervalBase?: boolean;
     aiHint?: string | string[];

--- a/packages/common/src/types/warehouse.test.ts
+++ b/packages/common/src/types/warehouse.test.ts
@@ -1,7 +1,13 @@
+import { DimensionType } from './field';
 import {
+    catalogHasTimestampDomains,
+    ensureCatalogTimestampDomainsKey,
+    getCatalogTimestampDomain,
     getUserAttributeQueryTags,
     sanitizeQueryTagKey,
     sanitizeQueryTagValue,
+    setCatalogTimestampDomain,
+    type WarehouseCatalog,
 } from './warehouse';
 
 describe('getUserAttributeQueryTags', () => {
@@ -68,5 +74,54 @@ describe('getUserAttributeQueryTags', () => {
             'invalid_query_tag__',
         );
         expect(sanitizeQueryTagValue("O'Reilly Media")).toBe('o_reilly_media');
+    });
+});
+
+describe('catalog timestamp domain sidecar', () => {
+    const buildCatalog = (): WarehouseCatalog => ({
+        db: { schema: { table: { created_at: DimensionType.TIMESTAMP } } },
+    });
+
+    it('reports a catalog without the sidecar as pre-domain', () => {
+        expect(catalogHasTimestampDomains(buildCatalog())).toBe(false);
+    });
+
+    it('reports a catalog with a classified column as domain-aware', () => {
+        const catalog = buildCatalog();
+        setCatalogTimestampDomain(
+            catalog,
+            'db',
+            'schema',
+            'table',
+            'created_at',
+            'naive',
+        );
+        expect(catalogHasTimestampDomains(catalog)).toBe(true);
+    });
+
+    it('marks a domain-less catalog without clobbering classifications', () => {
+        const empty = buildCatalog();
+        ensureCatalogTimestampDomainsKey(empty);
+        expect(catalogHasTimestampDomains(empty)).toBe(true);
+
+        const classified = buildCatalog();
+        setCatalogTimestampDomain(
+            classified,
+            'db',
+            'schema',
+            'table',
+            'created_at',
+            'aware',
+        );
+        ensureCatalogTimestampDomainsKey(classified);
+        expect(
+            getCatalogTimestampDomain(
+                classified,
+                'db',
+                'schema',
+                'table',
+                'created_at',
+            ),
+        ).toEqual('aware');
     });
 });

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -139,6 +139,30 @@ export const setCatalogTimestampDomain = (
     domains[database][schema][table][column] = timestampDomain;
 };
 
+/**
+ * True when the catalog was produced by domain-aware code: the sidecar key is
+ * present, even if empty. A missing key means a pre-domain cache that should
+ * be refetched once so timestamp columns get classified.
+ */
+export const catalogHasTimestampDomains = (
+    catalog: WarehouseCatalog,
+): boolean => WAREHOUSE_TIMESTAMP_DOMAINS_KEY in catalog;
+
+/**
+ * Stamps the (possibly empty) sidecar onto a freshly fetched catalog so
+ * `catalogHasTimestampDomains` can tell it apart from a pre-domain cache —
+ * clients only create the key when they classify at least one column.
+ */
+export const ensureCatalogTimestampDomainsKey = (
+    catalog: WarehouseCatalog,
+): void => {
+    const catalogWithDomains = catalog as {
+        [WAREHOUSE_TIMESTAMP_DOMAINS_KEY]?: WarehouseCatalogTimestampDomains;
+    };
+    catalogWithDomains[WAREHOUSE_TIMESTAMP_DOMAINS_KEY] =
+        catalogWithDomains[WAREHOUSE_TIMESTAMP_DOMAINS_KEY] ?? {};
+};
+
 export type WarehouseTablesCatalog = {
     [database: string]: {
         [schema: string]: {

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -185,10 +185,7 @@ export type WarehouseTables = {
 }[];
 
 export type WarehouseResults = {
-    fields: Record<
-        string,
-        { type: DimensionType; timestampDomain?: TimestampDomain }
-    >;
+    fields: Record<string, { type: DimensionType }>;
     rows: Record<string, AnyType>[];
 };
 

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -98,6 +98,12 @@ export type WarehouseCatalogTimestampDomains = {
     };
 };
 
+/**
+ * WARNING: a catalog may carry the reserved `WAREHOUSE_TIMESTAMP_DOMAINS_KEY`
+ * sidecar alongside the database keys (its value is NOT a database entry).
+ * Never enumerate `Object.keys(catalog)` as database names without excluding
+ * it — look entries up by name, or use the sidecar accessors below.
+ */
 export type WarehouseCatalog = {
     [database: string]: {
         [schema: string]: {

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -2,7 +2,7 @@ import { type WeekDay } from '../utils/timeFrames';
 import { type QueryExecutionContext } from './analytics';
 import { type AnyType } from './any';
 import { type SupportedDbtAdapter } from './dbt';
-import { type DimensionType, type Metric } from './field';
+import { type DimensionType, type Metric, type TimestampDomain } from './field';
 import { type CreateWarehouseCredentials } from './projects';
 import type { WarehouseQueryMetadata } from './queryHistory';
 import { type UserAttributeValueMap } from './userAttributes';
@@ -80,12 +80,63 @@ export type WarehouseTableSchema = {
     [column: string]: DimensionType;
 };
 
+/**
+ * Sparse sidecar of timestamp domains, keyed like the catalog itself. It
+ * lives on the catalog under a reserved key next to the database keys, so it
+ * survives the `cached_warehouse` JSON round-trip unchanged and is inert to
+ * readers that only look up their own database names.
+ */
+export const WAREHOUSE_TIMESTAMP_DOMAINS_KEY = '__lightdashTimestampDomains';
+
+export type WarehouseCatalogTimestampDomains = {
+    [database: string]: {
+        [schema: string]: {
+            [table: string]: {
+                [column: string]: TimestampDomain;
+            };
+        };
+    };
+};
+
 export type WarehouseCatalog = {
     [database: string]: {
         [schema: string]: {
             [table: string]: WarehouseTableSchema;
         };
     };
+};
+
+export const getCatalogTimestampDomain = (
+    catalog: WarehouseCatalog,
+    database: string,
+    schema: string,
+    table: string,
+    column: string,
+): TimestampDomain | undefined =>
+    (
+        catalog as {
+            [WAREHOUSE_TIMESTAMP_DOMAINS_KEY]?: WarehouseCatalogTimestampDomains;
+        }
+    )[WAREHOUSE_TIMESTAMP_DOMAINS_KEY]?.[database]?.[schema]?.[table]?.[column];
+
+export const setCatalogTimestampDomain = (
+    catalog: WarehouseCatalog,
+    database: string,
+    schema: string,
+    table: string,
+    column: string,
+    timestampDomain: TimestampDomain | undefined,
+): void => {
+    if (timestampDomain === undefined) return;
+    const catalogWithDomains = catalog as {
+        [WAREHOUSE_TIMESTAMP_DOMAINS_KEY]?: WarehouseCatalogTimestampDomains;
+    };
+    const domains = catalogWithDomains[WAREHOUSE_TIMESTAMP_DOMAINS_KEY] ?? {};
+    catalogWithDomains[WAREHOUSE_TIMESTAMP_DOMAINS_KEY] = domains;
+    domains[database] = domains[database] ?? {};
+    domains[database][schema] = domains[database][schema] ?? {};
+    domains[database][schema][table] = domains[database][schema][table] ?? {};
+    domains[database][schema][table][column] = timestampDomain;
 };
 
 export type WarehouseTablesCatalog = {
@@ -104,7 +155,10 @@ export type WarehouseTables = {
 }[];
 
 export type WarehouseResults = {
-    fields: Record<string, { type: DimensionType }>;
+    fields: Record<
+        string,
+        { type: DimensionType; timestampDomain?: TimestampDomain }
+    >;
     rows: Record<string, AnyType>[];
 };
 
@@ -232,6 +286,7 @@ export interface WarehouseClient extends WarehouseSqlBuilder {
     parseWarehouseCatalog(
         rows: Record<string, AnyType>[],
         mapFieldType: (type: string) => DimensionType,
+        mapTimestampDomain?: (type: string) => TimestampDomain | undefined,
     ): WarehouseCatalog;
 
     parseError(error: Error): Error;

--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
@@ -16,12 +16,14 @@ import {
     getErrorMessage,
     Metric,
     MetricType,
+    setCatalogTimestampDomain,
     SupportedDbtAdapter,
     TimeIntervalUnit,
     WarehouseConnectionError,
     WarehouseQueryError,
     WarehouseResults,
     WarehouseTypes,
+    type TimestampDomain,
 } from '@lightdash/common';
 import { WarehouseCatalog } from '../types';
 import {
@@ -57,6 +59,20 @@ export enum AthenaTypes {
     IPADDRESS = 'ipaddress',
     UUID = 'uuid',
 }
+
+// Athena follows Trino semantics: bare timestamp is naive, with time zone is aware
+export const getAthenaTimestampDomain = (
+    type: AthenaTypes | string,
+): TimestampDomain | undefined => {
+    switch (type.toLowerCase().replace(/\(\d+(,\s*\d+)?\)/, '')) {
+        case AthenaTypes.TIMESTAMP:
+            return 'naive';
+        case AthenaTypes.TIMESTAMP_TZ:
+            return 'aware';
+        default:
+            return undefined;
+    }
+};
 
 export const convertDataTypeToDimensionType = (
     type: AthenaTypes | string,
@@ -458,18 +474,25 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
 
                 // Parse fields from metadata (only on first batch)
                 if (isFirstBatch && columnInfo) {
-                    fields = columnInfo.reduce<
-                        Record<string, { type: DimensionType }>
-                    >((acc, col) => {
-                        if (col.Name) {
-                            acc[normalizeColumnName(col.Name)] = {
-                                type: convertDataTypeToDimensionType(
-                                    col.Type || 'varchar',
-                                ),
-                            };
-                        }
-                        return acc;
-                    }, {});
+                    fields = columnInfo.reduce<WarehouseResults['fields']>(
+                        (acc, col) => {
+                            if (col.Name) {
+                                const rawType = col.Type || 'varchar';
+                                const timestampDomain =
+                                    getAthenaTimestampDomain(rawType);
+                                acc[normalizeColumnName(col.Name)] = {
+                                    type: convertDataTypeToDimensionType(
+                                        rawType,
+                                    ),
+                                    ...(timestampDomain
+                                        ? { timestampDomain }
+                                        : {}),
+                                };
+                            }
+                            return acc;
+                        },
+                        {},
+                    );
                 }
 
                 // Skip header row on first batch
@@ -550,16 +573,19 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
                 const { database, schema, table, columns } = result;
                 acc[database] = acc[database] || {};
                 acc[database][schema] = acc[database][schema] || {};
-                acc[database][schema][table] = columns.reduce<
-                    Record<string, DimensionType>
-                >(
-                    (colAcc, { name, type }) => ({
-                        ...colAcc,
-                        [normalizeColumnName(name)]:
-                            convertDataTypeToDimensionType(type),
-                    }),
-                    {},
-                );
+                acc[database][schema][table] = {};
+                columns.forEach(({ name, type }) => {
+                    acc[database][schema][table][normalizeColumnName(name)] =
+                        convertDataTypeToDimensionType(type);
+                    setCatalogTimestampDomain(
+                        acc,
+                        database,
+                        schema,
+                        table,
+                        normalizeColumnName(name),
+                        getAthenaTimestampDomain(type),
+                    );
+                });
             }
             return acc;
         }, {});
@@ -626,23 +652,22 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
 
             const columns = response.TableMetadata?.Columns || [];
             const result: WarehouseCatalog = {
-                [db]: {
-                    [sch]: {
-                        [tableName]: columns.reduce<
-                            Record<string, DimensionType>
-                        >(
-                            (acc, col) => ({
-                                ...acc,
-                                [normalizeColumnName(col.Name || '')]:
-                                    convertDataTypeToDimensionType(
-                                        col.Type || 'varchar',
-                                    ),
-                            }),
-                            {},
-                        ),
-                    },
-                },
+                [db]: { [sch]: { [tableName]: {} } },
             };
+            columns.forEach((col) => {
+                const columnName = normalizeColumnName(col.Name || '');
+                const rawType = col.Type || 'varchar';
+                result[db][sch][tableName][columnName] =
+                    convertDataTypeToDimensionType(rawType);
+                setCatalogTimestampDomain(
+                    result,
+                    db,
+                    sch,
+                    tableName,
+                    columnName,
+                    getAthenaTimestampDomain(rawType),
+                );
+            });
 
             return result;
         } catch (e: unknown) {

--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
@@ -477,16 +477,10 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
                     fields = columnInfo.reduce<WarehouseResults['fields']>(
                         (acc, col) => {
                             if (col.Name) {
-                                const rawType = col.Type || 'varchar';
-                                const timestampDomain =
-                                    getAthenaTimestampDomain(rawType);
                                 acc[normalizeColumnName(col.Name)] = {
                                     type: convertDataTypeToDimensionType(
-                                        rawType,
+                                        col.Type || 'varchar',
                                     ),
-                                    ...(timestampDomain
-                                        ? { timestampDomain }
-                                        : {}),
                                 };
                             }
                             return acc;

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -17,9 +17,9 @@ import {
 } from './BigqueryWarehouseClient.mock';
 import {
     config,
-    expectedFields,
+    expectedFieldsWithAwareTimestamp,
     expectedRow,
-    expectedWarehouseSchema,
+    expectedWarehouseSchemaWithAwareTimestamp,
 } from './WarehouseClient.mock';
 
 describe('BigqueryWarehouseClient', () => {
@@ -32,7 +32,7 @@ describe('BigqueryWarehouseClient', () => {
 
         const results = await warehouse.runQuery('fake sql');
 
-        expect(results.fields).toEqual(expectedFields);
+        expect(results.fields).toEqual(expectedFieldsWithAwareTimestamp);
         expect(results.rows[0]).toEqual(expectedRow);
         expect(warehouse.client.createQueryJob as Mock).toHaveBeenCalledTimes(
             1,
@@ -77,7 +77,7 @@ describe('BigqueryWarehouseClient', () => {
         Dataset.prototype.table = getTableMock;
         const warehouse = new BigqueryWarehouseClient(credentials);
         expect(await warehouse.getCatalog(config)).toEqual(
-            expectedWarehouseSchema,
+            expectedWarehouseSchemaWithAwareTimestamp,
         );
         expect(getTableMock).toHaveBeenCalledTimes(1);
         expect(getTableResponse.getMetadata).toHaveBeenCalledTimes(1);

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -17,7 +17,7 @@ import {
 } from './BigqueryWarehouseClient.mock';
 import {
     config,
-    expectedFieldsWithAwareTimestamp,
+    expectedFields,
     expectedRow,
     expectedWarehouseSchemaWithAwareTimestamp,
 } from './WarehouseClient.mock';
@@ -32,7 +32,7 @@ describe('BigqueryWarehouseClient', () => {
 
         const results = await warehouse.runQuery('fake sql');
 
-        expect(results.fields).toEqual(expectedFieldsWithAwareTimestamp);
+        expect(results.fields).toEqual(expectedFields);
         expect(results.rows[0]).toEqual(expectedRow);
         expect(warehouse.client.createQueryJob as Mock).toHaveBeenCalledTimes(
             1,

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -27,12 +27,14 @@ import {
     PartitionType,
     sanitizeQueryTagKey,
     sanitizeQueryTagValue,
+    setCatalogTimestampDomain,
     SupportedDbtAdapter,
     TimeIntervalUnit,
     WarehouseConnectionError,
     WarehouseQueryError,
     WarehouseResults,
     WarehouseTypes,
+    type TimestampDomain,
 } from '@lightdash/common';
 import Big from 'big.js';
 import { pipeline, Transform } from 'stream';
@@ -100,6 +102,19 @@ const parseCell = (cell: AnyType) => {
     }
 
     return `${cell}`;
+};
+
+export const getBigqueryTimestampDomain = (
+    type: string | undefined,
+): TimestampDomain | undefined => {
+    switch (type) {
+        case BigqueryFieldType.DATETIME:
+            return 'naive';
+        case BigqueryFieldType.TIMESTAMP:
+            return 'aware';
+        default:
+            return undefined;
+    }
 };
 
 const mapFieldType = (type: string | undefined): DimensionType => {
@@ -317,12 +332,16 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
 
     static getFieldsFromResponse(response: QueryRowsResponse[2] | undefined) {
         return (response?.schema?.fields || []).reduce<
-            Record<string, { type: DimensionType }>
+            WarehouseResults['fields']
         >((acc, field) => {
             if (field.name) {
+                const timestampDomain = getBigqueryTimestampDomain(field.type);
                 return {
                     ...acc,
-                    [field.name]: { type: mapFieldType(field.type) },
+                    [field.name]: {
+                        type: mapFieldType(field.type),
+                        ...(timestampDomain ? { timestampDomain } : {}),
+                    },
                 };
             }
             return acc;
@@ -499,14 +518,19 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                 const [database, schema, table, tableSchema] = result;
                 acc[database] = acc[database] || {};
                 acc[database][schema] = acc[database][schema] || {};
-                acc[database][schema][table] =
-                    tableSchema.fields.reduce<WarehouseTableSchema>(
-                        (sum, { name, type }) => ({
-                            ...sum,
-                            [name]: mapFieldType(type),
-                        }),
-                        {},
+                acc[database][schema][table] = {};
+                tableSchema.fields.forEach(({ name, type }) => {
+                    if (name === undefined) return;
+                    acc[database][schema][table][name] = mapFieldType(type);
+                    setCatalogTimestampDomain(
+                        acc,
+                        database,
+                        schema,
+                        table,
+                        name,
+                        getBigqueryTimestampDomain(type),
                     );
+                });
             }
 
             return acc;
@@ -597,6 +621,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                 data_type: column.type,
             })),
             mapFieldType,
+            getBigqueryTimestampDomain,
         );
     }
 

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -335,13 +335,9 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
             WarehouseResults['fields']
         >((acc, field) => {
             if (field.name) {
-                const timestampDomain = getBigqueryTimestampDomain(field.type);
                 return {
                     ...acc,
-                    [field.name]: {
-                        type: mapFieldType(field.type),
-                        ...(timestampDomain ? { timestampDomain } : {}),
-                    },
+                    [field.name]: { type: mapFieldType(field.type) },
                 };
             }
             return acc;

--- a/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts
@@ -325,12 +325,10 @@ export class ClickhouseWarehouseClient extends WarehouseBaseClient<CreateClickho
                     } else if (Object.keys(fields).length === 0) {
                         // handle second row with column types
                         columnNames.forEach((c, index) => {
-                            const rawType = String(row[index]);
-                            const timestampDomain =
-                                getClickhouseTimestampDomain(rawType);
                             fields[c] = {
-                                type: convertDataTypeToDimensionType(rawType),
-                                ...(timestampDomain ? { timestampDomain } : {}),
+                                type: convertDataTypeToDimensionType(
+                                    String(row[index]),
+                                ),
                             };
                         });
                         // eslint-disable-next-line no-await-in-loop

--- a/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts
@@ -11,12 +11,14 @@ import {
     getErrorMessage,
     Metric,
     MetricType,
+    setCatalogTimestampDomain,
     SupportedDbtAdapter,
     TimeIntervalUnit,
     WarehouseConnectionError,
     WarehouseQueryError,
     WarehouseResults,
     WarehouseTypes,
+    type TimestampDomain,
 } from '@lightdash/common';
 import { WarehouseCatalog } from '../types';
 import {
@@ -68,9 +70,7 @@ interface TableInfo {
     table: string;
 }
 
-export const convertDataTypeToDimensionType = (
-    type: ClickhouseTypes | string,
-): DimensionType => {
+const cleanClickhouseType = (type: ClickhouseTypes | string): string => {
     // Iteratively unwrap Nullable/LowCardinality wrappers in any nesting order
     // e.g. LowCardinality(Nullable(Int32)) -> Nullable(Int32) -> Int32
     let cleanType = type;
@@ -82,7 +82,27 @@ export const convertDataTypeToDimensionType = (
             .replace(/^LowCardinality\((.+)\)$/, '$1');
     }
     // Strip all parenthesized arguments (handles Decimal(18,2), DateTime64(3,'UTC'), FixedString(N), etc.)
-    cleanType = cleanType.replace(/\(.*\)$/, '');
+    return cleanType.replace(/\(.*\)$/, '');
+};
+
+// ClickHouse has no naive timestamp type: DateTime/DateTime64 store epoch
+// instants and their zone is display metadata, so they are always aware.
+export const getClickhouseTimestampDomain = (
+    type: ClickhouseTypes | string,
+): TimestampDomain | undefined => {
+    switch (cleanClickhouseType(type)) {
+        case ClickhouseTypes.DATETIME:
+        case ClickhouseTypes.DATETIME64:
+            return 'aware';
+        default:
+            return undefined;
+    }
+};
+
+export const convertDataTypeToDimensionType = (
+    type: ClickhouseTypes | string,
+): DimensionType => {
+    const cleanType = cleanClickhouseType(type);
 
     switch (cleanType) {
         case ClickhouseTypes.BOOL:
@@ -140,6 +160,14 @@ const catalogToSchema = (
             warehouseCatalog[database][tableSchema || 'default'][tableName][
                 columnName
             ] = convertDataTypeToDimensionType(dataType);
+            setCatalogTimestampDomain(
+                warehouseCatalog,
+                database,
+                tableSchema || 'default',
+                tableName,
+                columnName,
+                getClickhouseTimestampDomain(dataType),
+            );
         });
     });
     return warehouseCatalog;
@@ -297,10 +325,12 @@ export class ClickhouseWarehouseClient extends WarehouseBaseClient<CreateClickho
                     } else if (Object.keys(fields).length === 0) {
                         // handle second row with column types
                         columnNames.forEach((c, index) => {
+                            const rawType = String(row[index]);
+                            const timestampDomain =
+                                getClickhouseTimestampDomain(rawType);
                             fields[c] = {
-                                type: convertDataTypeToDimensionType(
-                                    String(row[index]),
-                                ),
+                                type: convertDataTypeToDimensionType(rawType),
+                                ...(timestampDomain ? { timestampDomain } : {}),
                             };
                         });
                         // eslint-disable-next-line no-await-in-loop
@@ -418,7 +448,11 @@ export class ClickhouseWarehouseClient extends WarehouseBaseClient<CreateClickho
                 databaseName,
             },
         );
-        return this.parseWarehouseCatalog(rows, convertDataTypeToDimensionType);
+        return this.parseWarehouseCatalog(
+            rows,
+            convertDataTypeToDimensionType,
+            getClickhouseTimestampDomain,
+        );
     }
 
     async getFields(
@@ -450,7 +484,11 @@ export class ClickhouseWarehouseClient extends WarehouseBaseClient<CreateClickho
                 tableName,
             },
         );
-        return this.parseWarehouseCatalog(rows, convertDataTypeToDimensionType);
+        return this.parseWarehouseCatalog(
+            rows,
+            convertDataTypeToDimensionType,
+            getClickhouseTimestampDomain,
+        );
     }
 
     async getAllTables() {

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -14,6 +14,7 @@ import {
     Metric,
     MetricType,
     ParseError,
+    setCatalogTimestampDomain,
     SupportedDbtAdapter,
     TimeIntervalUnit,
     UnexpectedServerError,
@@ -21,6 +22,7 @@ import {
     WarehouseQueryError,
     WarehouseResults,
     WarehouseTypes,
+    type TimestampDomain,
 } from '@lightdash/common';
 import fetch from 'node-fetch';
 import { WarehouseCatalog } from '../types';
@@ -140,6 +142,7 @@ enum DatabricksTypes {
     MAP = 'MAP',
     CHAR = 'CHAR',
     VARCHAR = 'VARCHAR',
+    TIMESTAMP_NTZ = 'TIMESTAMP_NTZ',
 }
 
 const normaliseDatabricksType = (type: string): DatabricksTypes => {
@@ -190,6 +193,22 @@ const mapFieldType = (type: string): DimensionType => {
             return DimensionType.TIMESTAMP;
         default:
             return DimensionType.STRING;
+    }
+};
+
+// Classifies on the full raw string BEFORE normaliseDatabricksType, whose
+// /^[A-Z]+/ regex truncates TIMESTAMP_NTZ to TIMESTAMP at the underscore.
+// Bare TIMESTAMP is an instant on Databricks; NTZ is the opt-in naive type.
+export const getDatabricksTimestampDomain = (
+    type: string,
+): TimestampDomain | undefined => {
+    switch (type.toUpperCase().replace(/\s*\(.*\)$/, '')) {
+        case DatabricksTypes.TIMESTAMP_NTZ:
+            return 'naive';
+        case DatabricksTypes.TIMESTAMP:
+            return 'aware';
+        default:
+            return undefined;
     }
 };
 
@@ -506,16 +525,23 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
         const catalog = this.catalog || 'DEFAULT';
         return results.reduce<WarehouseCatalog>(
             (acc, result, index) => {
-                const columns = Object.fromEntries<DimensionType>(
-                    result.map((col) => [
-                        col.COLUMN_NAME,
-                        mapFieldType(col.TYPE_NAME),
-                    ]),
-                );
                 const { schema, table } = requests[index];
 
                 acc[catalog][schema] = acc[catalog][schema] || {};
-                acc[catalog][schema][table] = columns;
+                acc[catalog][schema][table] = {};
+                result.forEach((col) => {
+                    acc[catalog][schema][table][col.COLUMN_NAME] = mapFieldType(
+                        col.TYPE_NAME,
+                    );
+                    setCatalogTimestampDomain(
+                        acc,
+                        catalog,
+                        schema,
+                        table,
+                        col.COLUMN_NAME,
+                        getDatabricksTimestampDomain(col.TYPE_NAME),
+                    );
+                });
 
                 return acc;
             },
@@ -556,7 +582,11 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
             undefined,
             schema ? [schema] : undefined,
         );
-        return this.parseWarehouseCatalog(rows, mapFieldType);
+        return this.parseWarehouseCatalog(
+            rows,
+            mapFieldType,
+            getDatabricksTimestampDomain,
+        );
     }
 
     async getFields(
@@ -584,7 +614,11 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
             values.push(database);
         }
         const { rows } = await this.runQuery(query, tags, undefined, values);
-        return this.parseWarehouseCatalog(rows, mapFieldType);
+        return this.parseWarehouseCatalog(
+            rows,
+            mapFieldType,
+            getDatabricksTimestampDomain,
+        );
     }
 }
 

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -229,7 +229,10 @@ describe('DuckdbWarehouseClient', () => {
         expect(result.fields).toEqual({
             customer_name: { type: DimensionType.STRING },
             order_count: { type: DimensionType.NUMBER },
-            last_order_at: { type: DimensionType.TIMESTAMP },
+            last_order_at: {
+                type: DimensionType.TIMESTAMP,
+                timestampDomain: 'naive',
+            },
         });
     });
 
@@ -982,6 +985,11 @@ describe('DuckdbWarehouseClient', () => {
                         order_id: DimensionType.NUMBER,
                         created_at: DimensionType.TIMESTAMP,
                     },
+                },
+            },
+            __lightdashTimestampDomains: {
+                analytics: {
+                    main: { orders: { created_at: 'naive' } },
                 },
             },
         });

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -229,10 +229,7 @@ describe('DuckdbWarehouseClient', () => {
         expect(result.fields).toEqual({
             customer_name: { type: DimensionType.STRING },
             order_count: { type: DimensionType.NUMBER },
-            last_order_at: {
-                type: DimensionType.TIMESTAMP,
-                timestampDomain: 'naive',
-            },
+            last_order_at: { type: DimensionType.TIMESTAMP },
         });
     });
 

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -142,24 +142,6 @@ export type DuckdbWarehouseClientOptions = {
     onQueryProfile?: (profile: DuckdbQueryProfileMetrics) => void;
 };
 
-// DuckDB follows Postgres semantics: bare TIMESTAMP (any precision) is naive,
-// TIMESTAMP WITH TIME ZONE is aware
-export const getTimestampDomainFromTypeId = (
-    typeId: number,
-): TimestampDomain | undefined => {
-    switch (typeId) {
-        case DuckDBTypeId.TIMESTAMP:
-        case DuckDBTypeId.TIMESTAMP_S:
-        case DuckDBTypeId.TIMESTAMP_MS:
-        case DuckDBTypeId.TIMESTAMP_NS:
-            return 'naive';
-        case DuckDBTypeId.TIMESTAMP_TZ:
-            return 'aware';
-        default:
-            return undefined;
-    }
-};
-
 export const mapFieldTypeFromTypeId = (typeId: number): DimensionType => {
     switch (typeId) {
         case DuckDBTypeId.DATE:
@@ -1451,11 +1433,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         const columnNames = result.columnNames();
         const fields: WarehouseResults['fields'] = {};
         for (let i = 0; i < result.columnCount; i += 1) {
-            const typeId = result.columnTypeId(i);
-            const timestampDomain = getTimestampDomainFromTypeId(typeId);
             fields[columnNames[i]] = {
-                type: mapFieldTypeFromTypeId(typeId),
-                ...(timestampDomain ? { timestampDomain } : {}),
+                type: mapFieldTypeFromTypeId(result.columnTypeId(i)),
             };
         }
         return fields;

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -14,10 +14,12 @@ import {
     MetricType,
     NotImplementedError,
     ParameterError,
+    setCatalogTimestampDomain,
     SupportedDbtAdapter,
     WarehouseCatalog,
     WarehouseResults,
     WarehouseTypes,
+    type TimestampDomain,
     type WarehouseQueryPhase,
 } from '@lightdash/common';
 import { createHash } from 'crypto';
@@ -140,6 +142,24 @@ export type DuckdbWarehouseClientOptions = {
     onQueryProfile?: (profile: DuckdbQueryProfileMetrics) => void;
 };
 
+// DuckDB follows Postgres semantics: bare TIMESTAMP (any precision) is naive,
+// TIMESTAMP WITH TIME ZONE is aware
+export const getTimestampDomainFromTypeId = (
+    typeId: number,
+): TimestampDomain | undefined => {
+    switch (typeId) {
+        case DuckDBTypeId.TIMESTAMP:
+        case DuckDBTypeId.TIMESTAMP_S:
+        case DuckDBTypeId.TIMESTAMP_MS:
+        case DuckDBTypeId.TIMESTAMP_NS:
+            return 'naive';
+        case DuckDBTypeId.TIMESTAMP_TZ:
+            return 'aware';
+        default:
+            return undefined;
+    }
+};
+
 export const mapFieldTypeFromTypeId = (typeId: number): DimensionType => {
     switch (typeId) {
         case DuckDBTypeId.DATE:
@@ -171,6 +191,17 @@ export const mapFieldTypeFromTypeId = (typeId: number): DimensionType => {
         default:
             return DimensionType.STRING;
     }
+};
+
+export const getDuckdbTimestampDomainFromString = (
+    typeName: string,
+): TimestampDomain | undefined => {
+    const upper = typeName.toUpperCase().replace(/\(\d+\)/, '');
+    if (upper === 'TIMESTAMP WITH TIME ZONE' || upper === 'TIMESTAMPTZ')
+        return 'aware';
+    // TIMESTAMP and its precision variants (TIMESTAMP_S/_MS/_NS)
+    if (upper.startsWith('TIMESTAMP')) return 'naive';
+    return undefined;
 };
 
 const mapFieldTypeFromString = (typeName: string): DimensionType => {
@@ -1420,8 +1451,11 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         const columnNames = result.columnNames();
         const fields: WarehouseResults['fields'] = {};
         for (let i = 0; i < result.columnCount; i += 1) {
+            const typeId = result.columnTypeId(i);
+            const timestampDomain = getTimestampDomainFromTypeId(typeId);
             fields[columnNames[i]] = {
-                type: mapFieldTypeFromTypeId(result.columnTypeId(i)),
+                type: mapFieldTypeFromTypeId(typeId),
+                ...(timestampDomain ? { timestampDomain } : {}),
             };
         }
         return fields;
@@ -1694,14 +1728,21 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
                     if (!catalog[ref.database][ref.schema]) {
                         catalog[ref.database][ref.schema] = {};
                     }
-                    catalog[ref.database][ref.schema][ref.table] = rows.reduce<
-                        Record<string, DimensionType>
-                    >((acc, row) => {
+                    catalog[ref.database][ref.schema][ref.table] = {};
+                    rows.forEach((row) => {
                         const colName = row.column_name as string;
                         const colType = row.data_type as string;
-                        acc[colName] = mapFieldTypeFromString(colType);
-                        return acc;
-                    }, {});
+                        catalog[ref.database][ref.schema][ref.table][colName] =
+                            mapFieldTypeFromString(colType);
+                        setCatalogTimestampDomain(
+                            catalog,
+                            ref.database,
+                            ref.schema,
+                            ref.table,
+                            colName,
+                            getDuckdbTimestampDomainFromString(colType),
+                        );
+                    });
                 }
             }
             /* eslint-enable no-await-in-loop */

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
@@ -13,9 +13,9 @@ import {
 } from './PostgresWarehouseClient.mock';
 import {
     config,
-    expectedFields,
+    expectedFieldsWithNaiveTimestamp,
     expectedRow,
-    expectedWarehouseSchema,
+    expectedWarehouseSchemaWithNaiveTimestamp,
 } from './WarehouseClient.mock';
 
 vi.mock('pg', async () => ({
@@ -61,7 +61,7 @@ describe('PostgresWarehouseClient', () => {
     it('expect query rows', async () => {
         const warehouse = new PostgresWarehouseClient(credentials);
         const results = await warehouse.runQuery('fake sql');
-        expect(results.fields).toEqual(expectedFields);
+        expect(results.fields).toEqual(expectedFieldsWithNaiveTimestamp);
         expect(results.rows[0]).toEqual(expectedRow);
     });
     it('expect schema with postgres types mapped to dimension types', async () => {
@@ -134,7 +134,7 @@ describe('PostgresWarehouseClient', () => {
                 };
             });
         expect(await warehouse.getCatalog(config)).toEqual(
-            expectedWarehouseSchema,
+            expectedWarehouseSchemaWithNaiveTimestamp,
         );
     });
     it('expect empty catalog when dbt project has no references', async () => {

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
@@ -13,7 +13,7 @@ import {
 } from './PostgresWarehouseClient.mock';
 import {
     config,
-    expectedFieldsWithNaiveTimestamp,
+    expectedFields,
     expectedRow,
     expectedWarehouseSchemaWithNaiveTimestamp,
 } from './WarehouseClient.mock';
@@ -61,7 +61,7 @@ describe('PostgresWarehouseClient', () => {
     it('expect query rows', async () => {
         const warehouse = new PostgresWarehouseClient(credentials);
         const results = await warehouse.runQuery('fake sql');
-        expect(results.fields).toEqual(expectedFieldsWithNaiveTimestamp);
+        expect(results.fields).toEqual(expectedFields);
         expect(results.rows[0]).toEqual(expectedRow);
     });
     it('expect schema with postgres types mapped to dimension types', async () => {

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -6,12 +6,14 @@ import {
     getErrorMessage,
     Metric,
     MetricType,
+    setCatalogTimestampDomain,
     SslConfiguration,
     SupportedDbtAdapter,
     WarehouseCatalog,
     WarehouseQueryError,
     WarehouseResults,
     WarehouseTypes,
+    type TimestampDomain,
     type WarehouseQueryPhase,
 } from '@lightdash/common';
 import { readFileSync } from 'fs';
@@ -71,6 +73,7 @@ export enum PostgresTypes {
     TIMESTAMP = 'timestamp',
     TIMESTAMP_TZ = 'timestamptz',
     TIMESTAMP_WITHOUT_TIME_ZONE = 'timestamp without time zone',
+    TIMESTAMP_WITH_TIME_ZONE = 'timestamp with time zone',
 }
 
 const mapFieldType = (type: string): DimensionType => {
@@ -104,12 +107,29 @@ const mapFieldType = (type: string): DimensionType => {
         case PostgresTypes.TIMESTAMP_TZ:
         case PostgresTypes.TIME_WITHOUT_TIME_ZONE:
         case PostgresTypes.TIMESTAMP_WITHOUT_TIME_ZONE:
+        case PostgresTypes.TIMESTAMP_WITH_TIME_ZONE:
             return DimensionType.TIMESTAMP;
         case PostgresTypes.BOOLEAN:
         case PostgresTypes.BOOL:
             return DimensionType.BOOLEAN;
         default:
             return DimensionType.STRING;
+    }
+};
+
+// Strips the precision that format_type emits, e.g. `timestamp(3) with time zone`
+export const getPostgresTimestampDomain = (
+    type: string,
+): TimestampDomain | undefined => {
+    switch (type.replace(/\(\d+\)/, '').replace(/\s{2,}/g, ' ')) {
+        case PostgresTypes.TIMESTAMP:
+        case PostgresTypes.TIMESTAMP_WITHOUT_TIME_ZONE:
+            return 'naive';
+        case PostgresTypes.TIMESTAMP_TZ:
+        case PostgresTypes.TIMESTAMP_WITH_TIME_ZONE:
+            return 'aware';
+        default:
+            return undefined;
     }
 };
 
@@ -153,6 +173,19 @@ const convertDataTypeIdToDimensionType = (
             return DimensionType.BOOLEAN;
         default:
             return DimensionType.STRING;
+    }
+};
+
+export const convertDataTypeIdToTimestampDomain = (
+    dataTypeId: number,
+): TimestampDomain | undefined => {
+    switch (dataTypeId) {
+        case builtins.TIMESTAMP:
+            return 'naive';
+        case builtins.TIMESTAMPTZ:
+            return 'aware';
+        default:
+            return undefined;
     }
 };
 
@@ -226,12 +259,19 @@ export class PostgresClient<
 
     static convertQueryResultFields(
         fields: QueryResult<AnyType>['fields'],
-    ): Record<string, { type: DimensionType }> {
+    ): WarehouseResults['fields'] {
         return Object.fromEntries(
-            fields.map(({ name, dataTypeID }) => [
-                name,
-                { type: convertDataTypeIdToDimensionType(dataTypeID) },
-            ]),
+            fields.map(({ name, dataTypeID }) => {
+                const timestampDomain =
+                    convertDataTypeIdToTimestampDomain(dataTypeID);
+                return [
+                    name,
+                    {
+                        type: convertDataTypeIdToDimensionType(dataTypeID),
+                        ...(timestampDomain ? { timestampDomain } : {}),
+                    },
+                ];
+            }),
         );
     }
 
@@ -592,6 +632,14 @@ export class PostgresClient<
                         acc[table_catalog][table_schema][table_name] || {};
                     acc[table_catalog][table_schema][table_name][column_name] =
                         mapFieldType(data_type);
+                    setCatalogTimestampDomain(
+                        acc,
+                        table_catalog,
+                        table_schema,
+                        table_name,
+                        column_name,
+                        getPostgresTimestampDomain(data_type),
+                    );
                 }
 
                 return acc;
@@ -652,7 +700,11 @@ export class PostgresClient<
         }
         const { rows } = await this.runQuery(query, tags, undefined, values);
 
-        return this.parseWarehouseCatalog(rows, mapFieldType);
+        return this.parseWarehouseCatalog(
+            rows,
+            mapFieldType,
+            getPostgresTimestampDomain,
+        );
     }
 
     parseError(error: pg.DatabaseError, query: string = '') {

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -176,19 +176,6 @@ const convertDataTypeIdToDimensionType = (
     }
 };
 
-export const convertDataTypeIdToTimestampDomain = (
-    dataTypeId: number,
-): TimestampDomain | undefined => {
-    switch (dataTypeId) {
-        case builtins.TIMESTAMP:
-            return 'naive';
-        case builtins.TIMESTAMPTZ:
-            return 'aware';
-        default:
-            return undefined;
-    }
-};
-
 export class PostgresSqlBuilder extends WarehouseBaseSqlBuilder {
     type = WarehouseTypes.POSTGRES;
 
@@ -261,17 +248,10 @@ export class PostgresClient<
         fields: QueryResult<AnyType>['fields'],
     ): WarehouseResults['fields'] {
         return Object.fromEntries(
-            fields.map(({ name, dataTypeID }) => {
-                const timestampDomain =
-                    convertDataTypeIdToTimestampDomain(dataTypeID);
-                return [
-                    name,
-                    {
-                        type: convertDataTypeIdToDimensionType(dataTypeID),
-                        ...(timestampDomain ? { timestampDomain } : {}),
-                    },
-                ];
-            }),
+            fields.map(({ name, dataTypeID }) => [
+                name,
+                { type: convertDataTypeIdToDimensionType(dataTypeID) },
+            ]),
         );
     }
 

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.mock.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.mock.ts
@@ -167,6 +167,12 @@ export const expectedWarehouseSchema = {
             },
         },
     },
+    // TIMESTAMP_NTZ in the catalog carries the naive domain
+    __lightdashTimestampDomains: {
+        myDatabase: {
+            mySchema: { myTable: { MYTIMESTAMPCOLUMN: 'naive' } },
+        },
+    },
 };
 
 export const expectedFields: Record<string, AnyType> = {

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -7,6 +7,7 @@ import {
     Metric,
     MetricType,
     ParseError,
+    setCatalogTimestampDomain,
     SnowflakeAuthenticationType,
     SupportedDbtAdapter,
     UnexpectedServerError,
@@ -14,6 +15,7 @@ import {
     WarehouseQueryError,
     WarehouseResults,
     WarehouseTypes,
+    type TimestampDomain,
     type WarehouseExecuteAsyncQuery,
     type WarehouseExecuteAsyncQueryArgs,
 } from '@lightdash/common';
@@ -92,6 +94,24 @@ const normaliseSnowflakeType = (type: string): string => {
         );
     }
     return match[0];
+};
+
+// Classifies on the full raw string: normaliseSnowflakeType truncates at the
+// underscore, collapsing TIMESTAMP_NTZ/TZ/LTZ into TIMESTAMP. Strips parameter
+// suffixes like TIMESTAMP_NTZ(9). Bare TIMESTAMP is left unknown — it aliases
+// per-account via TIMESTAMP_TYPE_MAPPING.
+export const getSnowflakeTimestampDomain = (
+    type: string,
+): TimestampDomain | undefined => {
+    switch (type.toUpperCase().replace(/\s*\(.*\)$/, '')) {
+        case SnowflakeTypes.TIMESTAMP_NTZ:
+            return 'naive';
+        case SnowflakeTypes.TIMESTAMP_TZ:
+        case SnowflakeTypes.TIMESTAMP_LTZ:
+            return 'aware';
+        default:
+            return undefined;
+    }
 };
 
 const EXTERNAL_BROWSER_AUTHENTICATOR = 'EXTERNALBROWSER';
@@ -1291,15 +1311,17 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         // There is a bug/mistype in snowflake-sdk since this method can return undefined
         const columns = stmt.getColumns() as Column[] | undefined;
         return columns
-            ? columns.reduce(
-                  (acc, column) => ({
+            ? columns.reduce((acc, column) => {
+                  const rawType = column.getType().toUpperCase();
+                  const timestampDomain = getSnowflakeTimestampDomain(rawType);
+                  return {
                       ...acc,
                       [column.getName()]: {
-                          type: mapFieldType(column.getType().toUpperCase()),
+                          type: mapFieldType(rawType),
+                          ...(timestampDomain ? { timestampDomain } : {}),
                       },
-                  }),
-                  {},
-              )
+                  };
+              }, {})
             : {};
     }
 
@@ -1701,9 +1723,18 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
                         acc[match.database][match.schema][match.table] =
                             acc[match.database][match.schema][match.table] ||
                             {};
+                        const rawType = JSON.parse(row.data_type).type;
                         acc[match.database][match.schema][match.table][
                             row.column_name
-                        ] = mapFieldType(JSON.parse(row.data_type).type);
+                        ] = mapFieldType(rawType);
+                        setCatalogTimestampDomain(
+                            acc,
+                            match.database,
+                            match.schema,
+                            match.table,
+                            row.column_name,
+                            getSnowflakeTimestampDomain(rawType),
+                        );
                     }
                 });
             }
@@ -1776,7 +1807,11 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             values,
         });
         const { rows } = await this.runQuery(query, tags, undefined, values);
-        return this.parseWarehouseCatalog(rows, mapFieldType);
+        return this.parseWarehouseCatalog(
+            rows,
+            mapFieldType,
+            getSnowflakeTimestampDomain,
+        );
     }
 
     /*

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -1311,17 +1311,15 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         // There is a bug/mistype in snowflake-sdk since this method can return undefined
         const columns = stmt.getColumns() as Column[] | undefined;
         return columns
-            ? columns.reduce((acc, column) => {
-                  const rawType = column.getType().toUpperCase();
-                  const timestampDomain = getSnowflakeTimestampDomain(rawType);
-                  return {
+            ? columns.reduce(
+                  (acc, column) => ({
                       ...acc,
                       [column.getName()]: {
-                          type: mapFieldType(rawType),
-                          ...(timestampDomain ? { timestampDomain } : {}),
+                          type: mapFieldType(column.getType().toUpperCase()),
                       },
-                  };
-              }, {})
+                  }),
+                  {},
+              )
             : {};
     }
 

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
@@ -23,10 +23,11 @@ vi.mock('trino-client', () => ({
 }));
 
 describe('TrinoWarehouseClient', () => {
-    const lowerCaseFields = Object.keys(warehouseClient.expectedFields).reduce<
-        Record<string, AnyType>
-    >((acc, key) => {
-        acc[key.toLowerCase()] = warehouseClient.expectedFields[key];
+    const lowerCaseFields = Object.keys(
+        warehouseClient.expectedFieldsWithNaiveTimestamp,
+    ).reduce<Record<string, AnyType>>((acc, key) => {
+        acc[key.toLowerCase()] =
+            warehouseClient.expectedFieldsWithNaiveTimestamp[key];
         return acc;
     }, {});
     const lowerCaseRow = Object.keys(warehouseClient.expectedRow).reduce<
@@ -76,7 +77,9 @@ describe('TrinoWarehouseClient', () => {
 
         await expect(
             warehouse.getCatalog(warehouseClient.config),
-        ).resolves.toEqual(warehouseClient.expectedWarehouseSchema);
+        ).resolves.toEqual(
+            warehouseClient.expectedWarehouseSchemaWithNaiveTimestamp,
+        );
     });
 
     describe('streamQuery client tag headers', () => {

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
@@ -23,11 +23,10 @@ vi.mock('trino-client', () => ({
 }));
 
 describe('TrinoWarehouseClient', () => {
-    const lowerCaseFields = Object.keys(
-        warehouseClient.expectedFieldsWithNaiveTimestamp,
-    ).reduce<Record<string, AnyType>>((acc, key) => {
-        acc[key.toLowerCase()] =
-            warehouseClient.expectedFieldsWithNaiveTimestamp[key];
+    const lowerCaseFields = Object.keys(warehouseClient.expectedFields).reduce<
+        Record<string, AnyType>
+    >((acc, key) => {
+        acc[key.toLowerCase()] = warehouseClient.expectedFields[key];
         return acc;
     }, {});
     const lowerCaseRow = Object.keys(warehouseClient.expectedRow).reduce<

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
@@ -5,12 +5,14 @@ import {
     Metric,
     MetricType,
     getErrorMessage as originalGetErrorMessage,
+    setCatalogTimestampDomain,
     SupportedDbtAdapter,
     TimeIntervalUnit,
     WarehouseConnectionError,
     WarehouseQueryError,
     WarehouseResults,
     WarehouseTypes,
+    type TimestampDomain,
 } from '@lightdash/common';
 import {
     BasicAuth,
@@ -92,10 +94,23 @@ const queryTableSchema = ({
                                                                       AND table_name = '${table}'
                                                                     ORDER BY 1, 2, 3, ordinal_position`;
 
+export const getTrinoTimestampDomain = (
+    type: TrinoTypes | string,
+): TimestampDomain | undefined => {
+    switch (type.replace(/\(\d+\)/, '')) {
+        case TrinoTypes.TIMESTAMP:
+            return 'naive';
+        case TrinoTypes.TIMESTAMP_TZ:
+            return 'aware';
+        default:
+            return undefined;
+    }
+};
+
 const convertDataTypeToDimensionType = (
     type: TrinoTypes | string,
 ): DimensionType => {
-    const typeWithoutTimePrecision = type.replace(/\(\d\)/, '');
+    const typeWithoutTimePrecision = type.replace(/\(\d+\)/, '');
     switch (typeWithoutTimePrecision) {
         case TrinoTypes.BOOLEAN:
             return DimensionType.BOOLEAN;
@@ -145,6 +160,14 @@ const catalogToSchema = (results: string[][][]): WarehouseCatalog => {
                 warehouseCatalog[table_catalog][table_schema][table_name][
                     column_name
                 ] = convertDataTypeToDimensionType(data_type);
+                setCatalogTimestampDomain(
+                    warehouseCatalog,
+                    table_catalog,
+                    table_schema,
+                    table_name,
+                    column_name,
+                    getTrinoTimestampDomain(data_type),
+                );
             },
         );
     });
@@ -334,17 +357,18 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
                 type: string;
                 typeSignature: { rawType: string };
             }[] = queryResult.value.columns ?? [];
-            const fields = schema.reduce(
-                (acc, column) => ({
+            const fields = schema.reduce((acc, column) => {
+                const rawType =
+                    column.typeSignature.rawType ?? TrinoTypes.VARCHAR;
+                const timestampDomain = getTrinoTimestampDomain(rawType);
+                return {
                     ...acc,
                     [normalizeColumnName(column.name)]: {
-                        type: convertDataTypeToDimensionType(
-                            column.typeSignature.rawType ?? TrinoTypes.VARCHAR,
-                        ),
+                        type: convertDataTypeToDimensionType(rawType),
+                        ...(timestampDomain ? { timestampDomain } : {}),
                     },
-                }),
-                {},
-            );
+                };
+            }, {});
 
             // stream initial data, if available
             if (queryResult.value.data) {
@@ -436,7 +460,11 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
             ORDER BY 1,2,3
         `;
         const { rows } = await this.runQuery(query, tags);
-        return this.parseWarehouseCatalog(rows, convertDataTypeToDimensionType);
+        return this.parseWarehouseCatalog(
+            rows,
+            convertDataTypeToDimensionType,
+            getTrinoTimestampDomain,
+        );
     }
 
     async getFields(
@@ -466,7 +494,11 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
         `;
         const { rows } = await this.runQuery(query, tags);
 
-        return this.parseWarehouseCatalog(rows, convertDataTypeToDimensionType);
+        return this.parseWarehouseCatalog(
+            rows,
+            convertDataTypeToDimensionType,
+            getTrinoTimestampDomain,
+        );
     }
 
     async getAllTables() {

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
@@ -357,18 +357,17 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
                 type: string;
                 typeSignature: { rawType: string };
             }[] = queryResult.value.columns ?? [];
-            const fields = schema.reduce((acc, column) => {
-                const rawType =
-                    column.typeSignature.rawType ?? TrinoTypes.VARCHAR;
-                const timestampDomain = getTrinoTimestampDomain(rawType);
-                return {
+            const fields = schema.reduce(
+                (acc, column) => ({
                     ...acc,
                     [normalizeColumnName(column.name)]: {
-                        type: convertDataTypeToDimensionType(rawType),
-                        ...(timestampDomain ? { timestampDomain } : {}),
+                        type: convertDataTypeToDimensionType(
+                            column.typeSignature.rawType ?? TrinoTypes.VARCHAR,
+                        ),
                     },
-                };
-            }, {});
+                }),
+                {},
+            );
 
             // stream initial data, if available
             if (queryResult.value.data) {

--- a/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
@@ -4,12 +4,14 @@ import {
     DimensionType,
     Metric,
     PartitionColumn,
+    setCatalogTimestampDomain,
     SupportedDbtAdapter,
     TimeIntervalUnit,
     WarehouseCatalog,
     WarehouseResults,
     WarehouseSqlBuilder,
     WeekDay,
+    type TimestampDomain,
     type WarehouseExecuteAsyncQuery,
     type WarehouseExecuteAsyncQueryArgs,
     type WarehousePhaseTimings,
@@ -198,6 +200,7 @@ export default abstract class WarehouseBaseClient<
     parseWarehouseCatalog(
         rows: Record<string, AnyType>[],
         mapFieldType: (type: string) => DimensionType,
+        mapTimestampDomain?: (type: string) => TimestampDomain | undefined,
     ): WarehouseCatalog {
         return rows.reduce(
             (
@@ -215,9 +218,18 @@ export default abstract class WarehouseBaseClient<
                     acc[table_catalog][table_schema] || {};
                 acc[table_catalog][table_schema][table_name] =
                     acc[table_catalog][table_schema][table_name] || {};
-                if (column_name && data_type)
+                if (column_name && data_type) {
                     acc[table_catalog][table_schema][table_name][column_name] =
                         mapFieldType(data_type);
+                    setCatalogTimestampDomain(
+                        acc,
+                        table_catalog,
+                        table_schema,
+                        table_name,
+                        column_name,
+                        mapTimestampDomain?.(data_type),
+                    );
+                }
                 return acc;
             },
             {},

--- a/packages/warehouses/src/warehouseClients/WarehouseClient.mock.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseClient.mock.ts
@@ -65,22 +65,6 @@ export const expectedFields: Record<string, AnyType> = {
     myObjectColumn: { type: DimensionType.STRING },
 };
 
-export const expectedFieldsWithNaiveTimestamp: Record<string, AnyType> = {
-    ...expectedFields,
-    myTimestampColumn: {
-        type: DimensionType.TIMESTAMP,
-        timestampDomain: 'naive',
-    },
-};
-
-export const expectedFieldsWithAwareTimestamp: Record<string, AnyType> = {
-    ...expectedFields,
-    myTimestampColumn: {
-        type: DimensionType.TIMESTAMP,
-        timestampDomain: 'aware',
-    },
-};
-
 export const expectedRow: Record<string, AnyType> = {
     myStringColumn: 'string value',
     myNumberColumn: 100,

--- a/packages/warehouses/src/warehouseClients/WarehouseClient.mock.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseClient.mock.ts
@@ -1,4 +1,9 @@
-import { AnyType, DimensionType } from '@lightdash/common';
+import {
+    AnyType,
+    DimensionType,
+    setCatalogTimestampDomain,
+    type TimestampDomain,
+} from '@lightdash/common';
 import { WarehouseCatalog } from '../types';
 
 export const config: {
@@ -29,6 +34,27 @@ export const expectedWarehouseSchema: WarehouseCatalog = {
     },
 };
 
+const schemaWithTimestampDomain = (
+    timestampDomain: TimestampDomain,
+): WarehouseCatalog => {
+    const catalog = structuredClone(expectedWarehouseSchema);
+    setCatalogTimestampDomain(
+        catalog,
+        'myDatabase',
+        'mySchema',
+        'myTable',
+        'myTimestampColumn',
+        timestampDomain,
+    );
+    return catalog;
+};
+
+export const expectedWarehouseSchemaWithNaiveTimestamp =
+    schemaWithTimestampDomain('naive');
+
+export const expectedWarehouseSchemaWithAwareTimestamp =
+    schemaWithTimestampDomain('aware');
+
 export const expectedFields: Record<string, AnyType> = {
     myStringColumn: { type: DimensionType.STRING },
     myNumberColumn: { type: DimensionType.NUMBER },
@@ -37,6 +63,22 @@ export const expectedFields: Record<string, AnyType> = {
     myBooleanColumn: { type: DimensionType.BOOLEAN },
     myArrayColumn: { type: DimensionType.STRING },
     myObjectColumn: { type: DimensionType.STRING },
+};
+
+export const expectedFieldsWithNaiveTimestamp: Record<string, AnyType> = {
+    ...expectedFields,
+    myTimestampColumn: {
+        type: DimensionType.TIMESTAMP,
+        timestampDomain: 'naive',
+    },
+};
+
+export const expectedFieldsWithAwareTimestamp: Record<string, AnyType> = {
+    ...expectedFields,
+    myTimestampColumn: {
+        type: DimensionType.TIMESTAMP,
+        timestampDomain: 'aware',
+    },
 };
 
 export const expectedRow: Record<string, AnyType> = {

--- a/packages/warehouses/src/warehouseClients/timestampDomain.test.ts
+++ b/packages/warehouses/src/warehouseClients/timestampDomain.test.ts
@@ -1,0 +1,157 @@
+import { DuckDBTypeId } from '@duckdb/node-api';
+import { getAthenaTimestampDomain } from './AthenaWarehouseClient';
+import { getBigqueryTimestampDomain } from './BigqueryWarehouseClient';
+import { getClickhouseTimestampDomain } from './ClickhouseWarehouseClient';
+import { getDatabricksTimestampDomain } from './DatabricksWarehouseClient';
+import {
+    getDuckdbTimestampDomainFromString,
+    getTimestampDomainFromTypeId,
+} from './DuckdbWarehouseClient';
+import {
+    convertDataTypeIdToTimestampDomain,
+    getPostgresTimestampDomain,
+} from './PostgresWarehouseClient';
+import { getSnowflakeTimestampDomain } from './SnowflakeWarehouseClient';
+import { getTrinoTimestampDomain } from './TrinoWarehouseClient';
+
+describe('postgres timestamp domain', () => {
+    it('classifies naive types', () => {
+        expect(getPostgresTimestampDomain('timestamp')).toEqual('naive');
+        expect(
+            getPostgresTimestampDomain('timestamp without time zone'),
+        ).toEqual('naive');
+    });
+    it('classifies aware types', () => {
+        expect(getPostgresTimestampDomain('timestamptz')).toEqual('aware');
+        expect(getPostgresTimestampDomain('timestamp with time zone')).toEqual(
+            'aware',
+        );
+    });
+    it('leaves non-timestamp types unclassified', () => {
+        expect(getPostgresTimestampDomain('integer')).toBeUndefined();
+        expect(getPostgresTimestampDomain('date')).toBeUndefined();
+        expect(getPostgresTimestampDomain('time')).toBeUndefined();
+    });
+    it('classifies result-field OIDs', () => {
+        expect(convertDataTypeIdToTimestampDomain(1114)).toEqual('naive');
+        expect(convertDataTypeIdToTimestampDomain(1184)).toEqual('aware');
+        expect(convertDataTypeIdToTimestampDomain(23)).toBeUndefined();
+    });
+});
+
+describe('bigquery timestamp domain', () => {
+    it('classifies DATETIME as naive and TIMESTAMP as aware', () => {
+        expect(getBigqueryTimestampDomain('DATETIME')).toEqual('naive');
+        expect(getBigqueryTimestampDomain('TIMESTAMP')).toEqual('aware');
+    });
+    it('leaves TIME and non-timestamp types unclassified', () => {
+        expect(getBigqueryTimestampDomain('TIME')).toBeUndefined();
+        expect(getBigqueryTimestampDomain('STRING')).toBeUndefined();
+    });
+});
+
+describe('snowflake timestamp domain', () => {
+    it('classifies NTZ as naive, including parameterised types', () => {
+        expect(getSnowflakeTimestampDomain('TIMESTAMP_NTZ')).toEqual('naive');
+        expect(getSnowflakeTimestampDomain('TIMESTAMP_NTZ(9)')).toEqual(
+            'naive',
+        );
+    });
+    it('classifies TZ and LTZ as aware', () => {
+        expect(getSnowflakeTimestampDomain('TIMESTAMP_TZ')).toEqual('aware');
+        expect(getSnowflakeTimestampDomain('TIMESTAMP_LTZ(9)')).toEqual(
+            'aware',
+        );
+    });
+    it('leaves bare TIMESTAMP unclassified (account-level alias)', () => {
+        expect(getSnowflakeTimestampDomain('TIMESTAMP')).toBeUndefined();
+    });
+});
+
+describe('databricks timestamp domain', () => {
+    it('classifies TIMESTAMP_NTZ as naive despite type normalization truncating it', () => {
+        expect(getDatabricksTimestampDomain('TIMESTAMP_NTZ')).toEqual('naive');
+    });
+    it('classifies bare TIMESTAMP as aware (stores an instant)', () => {
+        expect(getDatabricksTimestampDomain('TIMESTAMP')).toEqual('aware');
+    });
+    it('leaves non-timestamp types unclassified', () => {
+        expect(getDatabricksTimestampDomain('DECIMAL(10,2)')).toBeUndefined();
+    });
+});
+
+describe('trino timestamp domain', () => {
+    it('classifies bare timestamp as naive, stripping any precision', () => {
+        expect(getTrinoTimestampDomain('timestamp')).toEqual('naive');
+        expect(getTrinoTimestampDomain('timestamp(3)')).toEqual('naive');
+        expect(getTrinoTimestampDomain('timestamp(6)')).toEqual('naive');
+    });
+    it('classifies timestamp with time zone as aware', () => {
+        expect(getTrinoTimestampDomain('timestamp with time zone')).toEqual(
+            'aware',
+        );
+        expect(getTrinoTimestampDomain('timestamp(3) with time zone')).toEqual(
+            'aware',
+        );
+    });
+    it('leaves non-timestamp types unclassified', () => {
+        expect(getTrinoTimestampDomain('varchar')).toBeUndefined();
+    });
+});
+
+describe('clickhouse timestamp domain', () => {
+    it('classifies DateTime types as always aware', () => {
+        expect(getClickhouseTimestampDomain('DateTime')).toEqual('aware');
+        expect(getClickhouseTimestampDomain("DateTime64(3, 'UTC')")).toEqual(
+            'aware',
+        );
+        expect(getClickhouseTimestampDomain('Nullable(DateTime)')).toEqual(
+            'aware',
+        );
+    });
+    it('leaves non-timestamp types unclassified', () => {
+        expect(getClickhouseTimestampDomain('Date')).toBeUndefined();
+    });
+});
+
+describe('athena timestamp domain', () => {
+    it('classifies bare timestamp as naive and with time zone as aware', () => {
+        expect(getAthenaTimestampDomain('timestamp')).toEqual('naive');
+        expect(getAthenaTimestampDomain('timestamp(3)')).toEqual('naive');
+        expect(getAthenaTimestampDomain('timestamp with time zone')).toEqual(
+            'aware',
+        );
+    });
+    it('leaves non-timestamp types unclassified', () => {
+        expect(getAthenaTimestampDomain('varchar')).toBeUndefined();
+    });
+});
+
+describe('duckdb timestamp domain', () => {
+    it('classifies type ids', () => {
+        expect(getTimestampDomainFromTypeId(DuckDBTypeId.TIMESTAMP)).toEqual(
+            'naive',
+        );
+        expect(getTimestampDomainFromTypeId(DuckDBTypeId.TIMESTAMP_S)).toEqual(
+            'naive',
+        );
+        expect(getTimestampDomainFromTypeId(DuckDBTypeId.TIMESTAMP_TZ)).toEqual(
+            'aware',
+        );
+        expect(
+            getTimestampDomainFromTypeId(DuckDBTypeId.INTEGER),
+        ).toBeUndefined();
+    });
+    it('classifies type name strings', () => {
+        expect(getDuckdbTimestampDomainFromString('TIMESTAMP')).toEqual(
+            'naive',
+        );
+        expect(
+            getDuckdbTimestampDomainFromString('TIMESTAMP WITH TIME ZONE'),
+        ).toEqual('aware');
+        expect(getDuckdbTimestampDomainFromString('TIMESTAMPTZ')).toEqual(
+            'aware',
+        );
+        expect(getDuckdbTimestampDomainFromString('BOOLEAN')).toBeUndefined();
+    });
+});

--- a/packages/warehouses/src/warehouseClients/timestampDomain.test.ts
+++ b/packages/warehouses/src/warehouseClients/timestampDomain.test.ts
@@ -1,16 +1,9 @@
-import { DuckDBTypeId } from '@duckdb/node-api';
 import { getAthenaTimestampDomain } from './AthenaWarehouseClient';
 import { getBigqueryTimestampDomain } from './BigqueryWarehouseClient';
 import { getClickhouseTimestampDomain } from './ClickhouseWarehouseClient';
 import { getDatabricksTimestampDomain } from './DatabricksWarehouseClient';
-import {
-    getDuckdbTimestampDomainFromString,
-    getTimestampDomainFromTypeId,
-} from './DuckdbWarehouseClient';
-import {
-    convertDataTypeIdToTimestampDomain,
-    getPostgresTimestampDomain,
-} from './PostgresWarehouseClient';
+import { getDuckdbTimestampDomainFromString } from './DuckdbWarehouseClient';
+import { getPostgresTimestampDomain } from './PostgresWarehouseClient';
 import { getSnowflakeTimestampDomain } from './SnowflakeWarehouseClient';
 import { getTrinoTimestampDomain } from './TrinoWarehouseClient';
 
@@ -31,11 +24,6 @@ describe('postgres timestamp domain', () => {
         expect(getPostgresTimestampDomain('integer')).toBeUndefined();
         expect(getPostgresTimestampDomain('date')).toBeUndefined();
         expect(getPostgresTimestampDomain('time')).toBeUndefined();
-    });
-    it('classifies result-field OIDs', () => {
-        expect(convertDataTypeIdToTimestampDomain(1114)).toEqual('naive');
-        expect(convertDataTypeIdToTimestampDomain(1184)).toEqual('aware');
-        expect(convertDataTypeIdToTimestampDomain(23)).toBeUndefined();
     });
 });
 
@@ -128,20 +116,6 @@ describe('athena timestamp domain', () => {
 });
 
 describe('duckdb timestamp domain', () => {
-    it('classifies type ids', () => {
-        expect(getTimestampDomainFromTypeId(DuckDBTypeId.TIMESTAMP)).toEqual(
-            'naive',
-        );
-        expect(getTimestampDomainFromTypeId(DuckDBTypeId.TIMESTAMP_S)).toEqual(
-            'naive',
-        );
-        expect(getTimestampDomainFromTypeId(DuckDBTypeId.TIMESTAMP_TZ)).toEqual(
-            'aware',
-        );
-        expect(
-            getTimestampDomainFromTypeId(DuckDBTypeId.INTEGER),
-        ).toBeUndefined();
-    });
     it('classifies type name strings', () => {
         expect(getDuckdbTimestampDomainFromString('TIMESTAMP')).toEqual(
             'naive',


### PR DESCRIPTION
First slice of the naive-timestamp correctness work: warehouse catalogs now classify every TIMESTAMP column as **naive** (stores a bare wall clock) or **aware** (stores an instant), and that classification lands on compiled dimensions as `Dimension.timestampDomain`. Detection only — nothing consumes the domain yet.

**Two type-mapping fixes ride along and ARE user-visible** (same class as #25817, surfaced by the same detection work): the Postgres/Redshift catalog mapper now recognises `timestamp with time zone` (information_schema's verbose name — previously those columns fell through to `string` unless YAML-typed), and the Trino precision regex accepts multi-digit precisions like `timestamp(12)`. On the next catalog refresh, affected columns without YAML types flip string → timestamp and gain time intervals. Everything else is byte-identical.

### How
- Each warehouse client gets a `get<Client>TimestampDomain(typeString)` classifier (e.g. Postgres `timestamp without time zone` → naive, Snowflake `TIMESTAMP_NTZ` → naive, bare `TIMESTAMP` left unknown because it aliases per account; ClickHouse `DateTime` → always aware). Result-probe fields carry the domain too (PG OIDs, BigQuery schema, Snowflake column types, Trino/DuckDB raw types).
- **Catalog types are unchanged** — `WarehouseTableSchema` stays `{ [column]: DimensionType }`. Domains ride in a sparse sidecar under a reserved key (`__lightdashTimestampDomains`) on the catalog object itself, accessed only via two helpers. Because in-memory ≡ stored JSON ≡ wire, `ProjectModel`, the SQL-runner fields endpoint, the frontend, and the CLI handlers needed no changes at all.
- A YAML override (`timestamp_domain: naive | aware`) wins over the catalog; interval children inherit from their base dimension. Both dbt validation schemas updated.

### Rollback safety (why the sidecar, not object values)
If catalog values became objects, a rolled-back deploy would break: old `convertDimension` throws on a non-string `data_type`, `convertExplores` swallows it per model into `ExploreError`s, and the adapter's catalog-refetch never fires — every explore with a classified timestamp column would error persistently. The reserved sidecar key is inert to old readers (they only `.find()` their own database names) and any old-code catalog refresh simply overwrites it.

### Known scope cut
The dbt Cloud CLI proxy path (`getTableSchema` via the fields API) does not carry domains — those columns stay unclassified, which downstream slices treat as "keep today's behavior".

Closes: GLITCH-615


### Review follow-ups (added in-stack)
- **Bare-column guard**: the catalog domain is only stamped on dimensions whose SQL is the bare physical column. Custom `sql:` dimensions and `additional_dimensions` stay unknown unless annotated with `timestamp_domain` in YAML (the expression may change the domain — and a misclassified naive base would make the aggregate rebase upstack hard-error on Snowflake). Interval children still inherit from their guarded base.
- **Pre-domain cache invalidation**: a `cached_warehouse` catalog without the domain sidecar is treated as stale and refetched once, so backend-managed projects get classified on their next compile instead of waiting for schema drift. Fresh catalogs are stamped with an (possibly empty) sidecar so domain-less warehouses don't refetch repeatedly.
- Type-level warning against enumerating catalog keys as database names (the sidecar key would appear as a phantom database).



### Adversarial review follow-ups
- Additional dimensions are excluded from the catalog domain fallback entirely (their carrier column is the parent's — a sql-less additional dim inherited the parent's domain), and their interval children now inherit the additional dimension's own resolved domain instead of the parent's YAML annotation.
- `WarehouseResults.fields[].timestampDomain` (the per-query result-field classification) had no reader anywhere in the stack and was dropped; the catalog-side classifiers stay, and probe-derived domains for SQL charts can reintroduce the surface when something consumes it.
- Deploy note: every backend-managed project performs one catalog refetch on its first compile after this deploys (the pre-domain cache invalidation) — a one-off burst of information_schema queries, equivalent to a schema-drift refresh.

