### PR TITLE
feat: domain-aware timestamp filter literals

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -6723,6 +6723,7 @@ describe('RAW time frame naive-column rebase', () => {
 const buildNaiveExplore = (
     adapter: SupportedDbtAdapter = SupportedDbtAdapter.POSTGRES,
     timestampDomain?: TimestampDomain,
+    skipTimezoneConversion: boolean = false,
 ): Explore => ({
     targetDatabase: adapter,
     name: 'events',
@@ -6751,6 +6752,9 @@ const buildNaiveExplore = (
                     tablesReferences: ['events'],
                     hidden: false,
                     ...(timestampDomain ? { timestampDomain } : {}),
+                    ...(skipTimezoneConversion
+                        ? { skipTimezoneConversion: true }
+                        : {}),
                 },
                 occurred_at_raw: {
                     type: DimensionType.TIMESTAMP,
@@ -7164,6 +7168,32 @@ describe('Naive timestamp domain — explicit, session-independent conversion', 
                 `("events".occurred_at) = ('2024-01-15 02:00:00'::timestamp)`,
             );
         });
+
+        test.each(['events_occurred_at', 'events_occurred_at_raw'])(
+            'convert_timezone: false keeps the known-naive %s filter literal in the raw value space',
+            (fieldId) => {
+                const { query } = buildQuery({
+                    explore: buildNaiveExplore(
+                        SupportedDbtAdapter.POSTGRES,
+                        'naive',
+                        true,
+                    ),
+                    compiledMetricQuery: filteredQuery(fieldId),
+                    warehouseSqlBuilder: warehouseClientMock,
+                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                    timezone: 'UTC',
+                    useTimezoneAwareDateTrunc: true,
+                    columnTimezone: 'Asia/Tokyo',
+                });
+                const whereClause = query.slice(query.indexOf('WHERE'));
+                expect(whereClause).toContain(
+                    `("events".occurred_at) = ('2024-01-14 17:00:00+00:00')`,
+                );
+                expect(whereClause).not.toContain(
+                    `'2024-01-15 02:00:00'::timestamp`,
+                );
+            },
+        );
 
         test('hour filter at display == data timezone wraps LHS and literal symmetrically (Trino, known-naive)', () => {
             const { query } = buildQuery({

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -6767,6 +6767,21 @@ const buildNaiveExplore = (
                     timeIntervalBaseDimensionName: 'occurred_at',
                     timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
                 },
+                occurred_at_hour: {
+                    type: DimensionType.TIMESTAMP,
+                    name: 'occurred_at_hour',
+                    label: 'occurred_at_hour',
+                    table: 'events',
+                    tableLabel: 'events',
+                    fieldType: FieldType.DIMENSION,
+                    sql: `DATE_TRUNC('HOUR', \${TABLE}.occurred_at)`,
+                    compiledSql: `DATE_TRUNC('HOUR', "events".occurred_at)`,
+                    tablesReferences: ['events'],
+                    hidden: false,
+                    timeInterval: TimeFrames.HOUR,
+                    timeIntervalBaseDimensionName: 'occurred_at',
+                    timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+                },
                 occurred_at_day: {
                     type: DimensionType.DATE,
                     name: 'occurred_at_day',
@@ -7112,6 +7127,74 @@ describe('Naive timestamp domain — explicit, session-independent conversion', 
             useTimezoneAwareDateTrunc: true,
         });
         expect(query).toContain(`MAX("events".occurred_at) AS "events_max_ts"`);
+    });
+
+    describe('filter literals follow the resolved domain', () => {
+        const filteredQuery = (fieldId: string): CompiledMetricQuery => ({
+            ...naiveQuery([fieldId]),
+            filters: {
+                dimensions: {
+                    id: 'root',
+                    and: [
+                        {
+                            id: 'f1',
+                            target: { fieldId },
+                            operator: FilterOperator.EQUALS,
+                            values: ['2024-01-14T17:00:00Z'],
+                        },
+                    ],
+                },
+            },
+        });
+
+        test('RAW filter on a known-naive column compares data-timezone wall clocks (Postgres)', () => {
+            const { query } = buildQuery({
+                explore: buildNaiveExplore(
+                    SupportedDbtAdapter.POSTGRES,
+                    'naive',
+                ),
+                compiledMetricQuery: filteredQuery('events_occurred_at_raw'),
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: 'Asia/Tokyo',
+                useTimezoneAwareDateTrunc: true,
+                columnTimezone: 'Asia/Tokyo',
+            });
+            expect(query).toContain(
+                `("events".occurred_at) = ('2024-01-15 02:00:00'::timestamp)`,
+            );
+        });
+
+        test('hour filter at display == data timezone wraps LHS and literal symmetrically (Trino, known-naive)', () => {
+            const { query } = buildQuery({
+                explore: buildNaiveExplore(SupportedDbtAdapter.TRINO, 'naive'),
+                compiledMetricQuery: filteredQuery('events_occurred_at_hour'),
+                warehouseSqlBuilder: trinoClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: 'Asia/Tokyo',
+                useTimezoneAwareDateTrunc: true,
+                columnTimezone: 'Asia/Tokyo',
+            });
+            const rebasedColumn = `CAST(with_timezone(CAST(with_timezone("events".occurred_at, 'Asia/Tokyo') AT TIME ZONE 'UTC' AS timestamp), 'UTC') AT TIME ZONE 'Asia/Tokyo' AS timestamp)`;
+            const wrappedLhs = `CAST(with_timezone(DATE_TRUNC('HOUR', CAST(${rebasedColumn} AS TIMESTAMP)), 'Asia/Tokyo') AT TIME ZONE 'UTC' AS timestamp)`;
+            const wrappedLiteral = `CAST(with_timezone(CAST('2024-01-15 02:00:00' AS timestamp), 'Asia/Tokyo') AT TIME ZONE 'UTC' AS timestamp)`;
+            expect(query).toContain(`(${wrappedLhs}) = ${wrappedLiteral}`);
+        });
+
+        test('hour filter without a domain stays byte-identical (Trino equal-zones skip)', () => {
+            const { query } = buildQuery({
+                explore: buildNaiveExplore(SupportedDbtAdapter.TRINO),
+                compiledMetricQuery: filteredQuery('events_occurred_at_hour'),
+                warehouseSqlBuilder: trinoClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: 'Asia/Tokyo',
+                useTimezoneAwareDateTrunc: true,
+                columnTimezone: 'Asia/Tokyo',
+            });
+            expect(query).toContain(
+                `(DATE_TRUNC('HOUR', CAST("events".occurred_at AS TIMESTAMP))) = CAST('2024-01-14 17:00:00+00:00' AS timestamp)`,
+            );
+        });
     });
 });
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -904,13 +904,16 @@ export class MetricQueryBuilder {
      * Effective timestamp domain for a filter target, resolved with the same
      * guards as the LHS in `getTimezoneAwareDimensionSql` so literal and
      * column decisions stay symmetric: the dim's own value, falling back to
-     * its interval base dimension.
+     * its interval base dimension. Bare targets with timezone conversion
+     * disabled keep the legacy RHS so the literal stays in the raw value
+     * space alongside the column.
      */
     private resolveFilterTimestampDomain(
         dimension: CompiledDimension,
     ): TimestampDomain | undefined {
         if (!dimension.timeInterval) {
-            return dimension.type === DimensionType.TIMESTAMP
+            return dimension.type === DimensionType.TIMESTAMP &&
+                !dimension.skipTimezoneConversion
                 ? dimension.timestampDomain
                 : undefined;
         }
@@ -924,6 +927,12 @@ export class MetricQueryBuilder {
         if (
             !baseDimension?.compiledSql ||
             baseDimension.type !== DimensionType.TIMESTAMP
+        ) {
+            return undefined;
+        }
+        if (
+            dimension.timeInterval === TimeFrames.RAW &&
+            baseDimension.skipTimezoneConversion
         ) {
             return undefined;
         }

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -72,6 +72,7 @@ import {
     type FieldsContext,
     type ParameterDefinitions,
     type ParametersValuesMap,
+    type TimestampDomain,
     type WarehouseSqlBuilder,
     type WeekDay,
 } from '@lightdash/common';
@@ -897,6 +898,36 @@ export class MetricQueryBuilder {
             this.columnTimezone,
             timestampDomain,
         );
+    }
+
+    /**
+     * Effective timestamp domain for a filter target, resolved with the same
+     * guards as the LHS in `getTimezoneAwareDimensionSql` so literal and
+     * column decisions stay symmetric: the dim's own value, falling back to
+     * its interval base dimension.
+     */
+    private resolveFilterTimestampDomain(
+        dimension: CompiledDimension,
+    ): TimestampDomain | undefined {
+        if (!dimension.timeInterval) {
+            return dimension.type === DimensionType.TIMESTAMP
+                ? dimension.timestampDomain
+                : undefined;
+        }
+        const baseDimensionId = dimension.timeIntervalBaseDimensionName
+            ? `${dimension.table}_${dimension.timeIntervalBaseDimensionName}`
+            : undefined;
+        const baseDimension = baseDimensionId
+            ? (this.originalExploreDimensions[baseDimensionId] ??
+              this.exploreDimensions[baseDimensionId])
+            : undefined;
+        if (
+            !baseDimension?.compiledSql ||
+            baseDimension.type !== DimensionType.TIMESTAMP
+        ) {
+            return undefined;
+        }
+        return dimension.timestampDomain ?? baseDimension.timestampDomain;
     }
 
     /**
@@ -2067,6 +2098,10 @@ export class MetricQueryBuilder {
             field.timeInterval === TimeFrames.RAW &&
             filterField.compiledSql !== field.compiledSql;
 
+        const timestampDomain = isDimension(field)
+            ? this.resolveFilterTimestampDomain(field)
+            : undefined;
+
         // For period-to-date filters on truncated dimensions, resolve the
         // base (raw) dimension SQL so EXTRACT operates on the actual date
         let baseDimensionSql: string | undefined;
@@ -2107,6 +2142,7 @@ export class MetricQueryBuilder {
                 this.args.useTimezoneAwareDateTrunc,
                 this.columnTimezone,
                 rawFilterLhsIsInstant,
+                timestampDomain,
             );
         });
 

--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -1,8 +1,9 @@
 import momentTz from 'moment-timezone';
 import moment from 'moment/moment';
 import { SupportedDbtAdapter } from '../types/dbt';
-import { DimensionType } from '../types/field';
+import { DimensionType, type TimestampDomain } from '../types/field';
 import { FilterOperator, UnitOfTime, type FilterRule } from '../types/filter';
+import { TimeFrames } from '../types/timeFrames';
 import { WeekDay } from '../utils/timeFrames';
 import {
     createBoundaryDateFormatter,
@@ -3157,6 +3158,345 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
             );
             expect(sql).not.toContain('toDateTime(');
             expect(sql).toContain("'2024-01-15'");
+        });
+    });
+});
+
+describe('domain-directed timestamp filter literals', () => {
+    // 2024-01-14T17:00:00Z == 2024-01-15 02:00:00 in Asia/Tokyo
+    const equalsInstantFilter: FilterRule<FilterOperator, unknown> = {
+        id: 'id',
+        target: { fieldId: 'fieldId' },
+        operator: FilterOperator.EQUALS,
+        values: ['2024-01-14T17:00:00Z'],
+    };
+    const inBetweenInstantFilter: FilterRule<FilterOperator, unknown> = {
+        id: 'id',
+        target: { fieldId: 'fieldId' },
+        operator: FilterOperator.IN_BETWEEN,
+        values: ['2024-01-14T16:30:00Z', '2024-01-14T17:30:00Z'],
+    };
+
+    const renderTimestamp = (
+        adapter: SupportedDbtAdapter,
+        filter: FilterRule<FilterOperator, unknown>,
+        {
+            timezone = 'UTC',
+            sourceTimezone,
+            timestampDomain,
+            timeInterval = TimeFrames.RAW,
+            useTimezoneAwareDateTrunc = true,
+        }: {
+            timezone?: string;
+            sourceTimezone?: string;
+            timestampDomain?: TimestampDomain;
+            timeInterval?: TimeFrames;
+            useTimezoneAwareDateTrunc?: boolean;
+        },
+    ) =>
+        renderFilterRuleSql(
+            filter,
+            DimensionType.TIMESTAMP,
+            DimensionSqlMock,
+            "'",
+            (s: string) => s,
+            null,
+            adapter,
+            timezone,
+            true,
+            undefined,
+            useTimezoneAwareDateTrunc,
+            DimensionType.TIMESTAMP,
+            sourceTimezone,
+            undefined,
+            timestampDomain,
+            timeInterval,
+        );
+
+    describe('bare naive LHS (RAW frame) renders typed data-timezone wall clocks', () => {
+        test.each([
+            [
+                SupportedDbtAdapter.POSTGRES,
+                `(${DimensionSqlMock}) = ('2024-01-15 02:00:00'::timestamp)`,
+            ],
+            [
+                SupportedDbtAdapter.BIGQUERY,
+                `(${DimensionSqlMock}) = DATETIME '2024-01-15 02:00:00'`,
+            ],
+            [
+                SupportedDbtAdapter.TRINO,
+                `(${DimensionSqlMock}) = TIMESTAMP '2024-01-15 02:00:00'`,
+            ],
+            [
+                SupportedDbtAdapter.DATABRICKS,
+                `(${DimensionSqlMock}) = TIMESTAMP_NTZ '2024-01-15 02:00:00'`,
+            ],
+        ])('equals on %s', (adapter, expected) => {
+            expect(
+                renderTimestamp(adapter, equalsInstantFilter, {
+                    sourceTimezone: 'Asia/Tokyo',
+                    timestampDomain: 'naive',
+                }),
+            ).toStrictEqual(expected);
+        });
+
+        test.each([
+            [
+                SupportedDbtAdapter.POSTGRES,
+                `((${DimensionSqlMock}) >= ('2024-01-15 01:30:00'::timestamp) AND (${DimensionSqlMock}) <= ('2024-01-15 02:30:00'::timestamp))`,
+            ],
+            [
+                SupportedDbtAdapter.BIGQUERY,
+                `((${DimensionSqlMock}) >= DATETIME '2024-01-15 01:30:00' AND (${DimensionSqlMock}) <= DATETIME '2024-01-15 02:30:00')`,
+            ],
+            [
+                SupportedDbtAdapter.TRINO,
+                `((${DimensionSqlMock}) >= TIMESTAMP '2024-01-15 01:30:00' AND (${DimensionSqlMock}) <= TIMESTAMP '2024-01-15 02:30:00')`,
+            ],
+            [
+                SupportedDbtAdapter.DATABRICKS,
+                `((${DimensionSqlMock}) >= TIMESTAMP_NTZ '2024-01-15 01:30:00' AND (${DimensionSqlMock}) <= TIMESTAMP_NTZ '2024-01-15 02:30:00')`,
+            ],
+        ])('inBetween on %s', (adapter, expected) => {
+            expect(
+                renderTimestamp(adapter, inBetweenInstantFilter, {
+                    sourceTimezone: 'Asia/Tokyo',
+                    timestampDomain: 'naive',
+                }),
+            ).toStrictEqual(expected);
+        });
+    });
+
+    describe('bare aware LHS renders typed instant literals', () => {
+        test('ClickHouse pins the literal to UTC with toDateTime64', () => {
+            expect(
+                renderTimestamp(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    equalsInstantFilter,
+                    {
+                        sourceTimezone: 'Asia/Tokyo',
+                        timestampDomain: 'aware',
+                    },
+                ),
+            ).toStrictEqual(
+                `(${DimensionSqlMock}) = toDateTime64('2024-01-14 17:00:00', 3, 'UTC')`,
+            );
+        });
+
+        test('ClickHouse treats known-naive as aware (no naive representation)', () => {
+            expect(
+                renderTimestamp(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    equalsInstantFilter,
+                    {
+                        sourceTimezone: 'Asia/Tokyo',
+                        timestampDomain: 'naive',
+                    },
+                ),
+            ).toStrictEqual(
+                `(${DimensionSqlMock}) = toDateTime64('2024-01-14 17:00:00', 3, 'UTC')`,
+            );
+        });
+
+        test('BigQuery emits an offset-bearing TIMESTAMP literal', () => {
+            expect(
+                renderTimestamp(
+                    SupportedDbtAdapter.BIGQUERY,
+                    equalsInstantFilter,
+                    {
+                        sourceTimezone: 'Asia/Tokyo',
+                        timestampDomain: 'aware',
+                    },
+                ),
+            ).toStrictEqual(
+                `(${DimensionSqlMock}) = TIMESTAMP '2024-01-14 17:00:00+00'`,
+            );
+        });
+
+        test('Trino emits a zoned TIMESTAMP literal', () => {
+            expect(
+                renderTimestamp(
+                    SupportedDbtAdapter.TRINO,
+                    equalsInstantFilter,
+                    {
+                        sourceTimezone: 'Asia/Tokyo',
+                        timestampDomain: 'aware',
+                    },
+                ),
+            ).toStrictEqual(
+                `(${DimensionSqlMock}) = TIMESTAMP '2024-01-14 17:00:00 UTC'`,
+            );
+        });
+
+        test('Postgres keeps the offset-string form byte-identical', () => {
+            expect(
+                renderTimestamp(
+                    SupportedDbtAdapter.POSTGRES,
+                    equalsInstantFilter,
+                    {
+                        sourceTimezone: 'Asia/Tokyo',
+                        timestampDomain: 'aware',
+                    },
+                ),
+            ).toStrictEqual(
+                `(${DimensionSqlMock}) = ('2024-01-14 17:00:00+00:00')`,
+            );
+        });
+    });
+
+    describe('wrapped LHS (sub-day trunc) wraps the literal with the same round trip', () => {
+        test('Trino known-naive at display == data timezone wraps both sides', () => {
+            expect(
+                renderTimestamp(
+                    SupportedDbtAdapter.TRINO,
+                    equalsInstantFilter,
+                    {
+                        timezone: 'Asia/Tokyo',
+                        sourceTimezone: 'Asia/Tokyo',
+                        timestampDomain: 'naive',
+                        timeInterval: TimeFrames.HOUR,
+                    },
+                ),
+            ).toStrictEqual(
+                `(${DimensionSqlMock}) = CAST(with_timezone(CAST('2024-01-15 02:00:00' AS timestamp), 'Asia/Tokyo') AT TIME ZONE 'UTC' AS timestamp)`,
+            );
+        });
+
+        test('BigQuery emits a single explicit TIMESTAMP(s, tz) wrap', () => {
+            expect(
+                renderTimestamp(
+                    SupportedDbtAdapter.BIGQUERY,
+                    equalsInstantFilter,
+                    {
+                        timezone: 'Asia/Tokyo',
+                        sourceTimezone: 'Asia/Tokyo',
+                        timestampDomain: 'naive',
+                        timeInterval: TimeFrames.HOUR,
+                    },
+                ),
+            ).toStrictEqual(
+                `(${DimensionSqlMock}) = TIMESTAMP('2024-01-15 02:00:00', 'Asia/Tokyo')`,
+            );
+        });
+
+        test('Postgres known-aware wraps the literal through the project timezone', () => {
+            expect(
+                renderTimestamp(
+                    SupportedDbtAdapter.POSTGRES,
+                    equalsInstantFilter,
+                    {
+                        timezone: 'Asia/Tokyo',
+                        sourceTimezone: 'Asia/Tokyo',
+                        timestampDomain: 'aware',
+                        timeInterval: TimeFrames.HOUR,
+                    },
+                ),
+            ).toStrictEqual(
+                `(${DimensionSqlMock}) = ('2024-01-15 02:00:00'::timestamp) AT TIME ZONE 'Asia/Tokyo'`,
+            );
+        });
+    });
+
+    describe('unknown domain stays byte-identical (the flag-gated LHS rebase owns this case)', () => {
+        test.each([
+            [
+                SupportedDbtAdapter.POSTGRES,
+                `(${DimensionSqlMock}) = ('2024-01-14 17:00:00+00:00')`,
+            ],
+            [
+                SupportedDbtAdapter.REDSHIFT,
+                `(${DimensionSqlMock}) = ('2024-01-14 17:00:00+00:00')`,
+            ],
+            [
+                SupportedDbtAdapter.DUCKDB,
+                `(${DimensionSqlMock}) = ('2024-01-14 17:00:00+00:00')`,
+            ],
+            [
+                SupportedDbtAdapter.BIGQUERY,
+                `(${DimensionSqlMock}) = ('2024-01-14 17:00:00')`,
+            ],
+            [
+                SupportedDbtAdapter.CLICKHOUSE,
+                `(${DimensionSqlMock}) = ('2024-01-14 17:00:00')`,
+            ],
+            [
+                SupportedDbtAdapter.TRINO,
+                `(${DimensionSqlMock}) = CAST('2024-01-14 17:00:00+00:00' AS timestamp)`,
+            ],
+            [
+                SupportedDbtAdapter.DATABRICKS,
+                `(${DimensionSqlMock}) = ('2024-01-14 17:00:00+00:00')`,
+            ],
+        ])('RAW equals on %s', (adapter, expected) => {
+            expect(
+                renderTimestamp(adapter, equalsInstantFilter, {
+                    sourceTimezone: 'Asia/Tokyo',
+                }),
+            ).toStrictEqual(expected);
+        });
+
+        test('sub-day trunc literal stays bare without a domain (Trino)', () => {
+            expect(
+                renderTimestamp(
+                    SupportedDbtAdapter.TRINO,
+                    equalsInstantFilter,
+                    {
+                        timezone: 'Asia/Tokyo',
+                        sourceTimezone: 'Asia/Tokyo',
+                        timeInterval: TimeFrames.HOUR,
+                    },
+                ),
+            ).toStrictEqual(
+                `(${DimensionSqlMock}) = CAST('2024-01-14 17:00:00+00:00' AS timestamp)`,
+            );
+        });
+    });
+
+    describe('legacy invariants with a known domain', () => {
+        test('flag off keeps the legacy literal', () => {
+            expect(
+                renderTimestamp(
+                    SupportedDbtAdapter.POSTGRES,
+                    equalsInstantFilter,
+                    {
+                        sourceTimezone: 'Asia/Tokyo',
+                        timestampDomain: 'naive',
+                        useTimezoneAwareDateTrunc: false,
+                    },
+                ),
+            ).toStrictEqual(
+                `(${DimensionSqlMock}) = ('2024-01-14 17:00:00+00:00')`,
+            );
+        });
+
+        test('UTC data timezone keeps the legacy literal', () => {
+            expect(
+                renderTimestamp(
+                    SupportedDbtAdapter.POSTGRES,
+                    equalsInstantFilter,
+                    {
+                        sourceTimezone: 'UTC',
+                        timestampDomain: 'naive',
+                    },
+                ),
+            ).toStrictEqual(
+                `(${DimensionSqlMock}) = ('2024-01-14 17:00:00+00:00')`,
+            );
+        });
+
+        test('Snowflake keeps the legacy literal even with a known domain', () => {
+            expect(
+                renderTimestamp(
+                    SupportedDbtAdapter.SNOWFLAKE,
+                    equalsInstantFilter,
+                    {
+                        sourceTimezone: 'Asia/Tokyo',
+                        timestampDomain: 'naive',
+                    },
+                ),
+            ).toStrictEqual(
+                `(${DimensionSqlMock}) = ('2024-01-14 17:00:00+00:00')`,
+            );
         });
     });
 });

--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -3395,6 +3395,23 @@ describe('domain-directed timestamp filter literals', () => {
                 `(${DimensionSqlMock}) = ('2024-01-15 02:00:00'::timestamp) AT TIME ZONE 'Asia/Tokyo'`,
             );
         });
+
+        test('Databricks freezes the wrapped literal as TIMESTAMP_NTZ to match the frozen LHS', () => {
+            expect(
+                renderTimestamp(
+                    SupportedDbtAdapter.DATABRICKS,
+                    equalsInstantFilter,
+                    {
+                        timezone: 'Asia/Tokyo',
+                        sourceTimezone: 'Asia/Tokyo',
+                        timestampDomain: 'naive',
+                        timeInterval: TimeFrames.HOUR,
+                    },
+                ),
+            ).toStrictEqual(
+                `(${DimensionSqlMock}) = CAST(to_utc_timestamp('2024-01-15 02:00:00', 'Asia/Tokyo') AS TIMESTAMP_NTZ)`,
+            );
+        });
     });
 
     describe('unknown domain stays byte-identical (the flag-gated LHS rebase owns this case)', () => {

--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -3396,6 +3396,25 @@ describe('domain-directed timestamp filter literals', () => {
             );
         });
 
+        test('Trino known-aware sub-day at display == data keeps the legacy literal (unwrapped LHS)', () => {
+            // Equal-zones no-op: the LHS is the legacy naive trunc, so a
+            // typed instant literal would lean on session coercion.
+            expect(
+                renderTimestamp(
+                    SupportedDbtAdapter.TRINO,
+                    equalsInstantFilter,
+                    {
+                        timezone: 'Asia/Tokyo',
+                        sourceTimezone: 'Asia/Tokyo',
+                        timestampDomain: 'aware',
+                        timeInterval: TimeFrames.HOUR,
+                    },
+                ),
+            ).toStrictEqual(
+                `(${DimensionSqlMock}) = CAST('2024-01-14 17:00:00+00:00' AS timestamp)`,
+            );
+        });
+
         test('Databricks freezes the wrapped literal as TIMESTAMP_NTZ to match the frozen LHS', () => {
             expect(
                 renderTimestamp(

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -11,6 +11,7 @@ import {
     type CompiledCustomSqlDimension,
     type CompiledField,
     type TableCalculation,
+    type TimestampDomain,
 } from '../types/field';
 import {
     FilterOperator,
@@ -21,6 +22,7 @@ import {
     type FilterRule,
 } from '../types/filter';
 import { type WarehouseTypes } from '../types/projects';
+import { type TimeFrames } from '../types/timeFrames';
 import assertUnreachable from '../utils/assertUnreachable';
 import { convertToBooleanValue } from '../utils/booleanConverter';
 import { formatDate } from '../utils/formatting';
@@ -29,6 +31,7 @@ import { getMomentDateWithCustomStartOfWeek } from '../utils/time';
 import {
     dateTruncTimezoneConversions,
     isTimezoneRoundTripNoOp,
+    SUB_DAY_TIME_FRAMES,
     WeekDay,
 } from '../utils/timeFrames';
 
@@ -81,6 +84,15 @@ const formatTimestampAsUTC = (date: Date): string =>
 // timezone offsets. Both already interpret bare strings correctly as UTC.
 const formatTimestampAsUTCNoOffset = (date: Date): string =>
     moment(date).utc().format('YYYY-MM-DD HH:mm:ss');
+
+// Wall clock of the UTC instant in `zone` — domain-directed literals render
+// the boundary in the same zone the LHS compares in.
+const formatTimestampAsWallClock =
+    (zone: string) =>
+    (date: Date): string =>
+        moment(date).tz(zone).format('YYYY-MM-DD HH:mm:ss');
+
+type TimestampLiteralMode = 'legacy' | 'wrapped' | 'naiveWall' | 'awareInstant';
 
 /**
  * Cast a date/timestamp string to warehouse-specific SQL literal.
@@ -293,13 +305,15 @@ const renderDateOrTimestampFilterSql = ({
     filter,
     adapterType,
     timezone,
-    literalFormatter,
-    boundaryFormatter,
+    literalFormatter: baseLiteralFormatter,
+    boundaryFormatter: baseBoundaryFormatter,
     startOfWeek,
     baseDimensionSql,
     useTimezoneAwareDateTrunc,
     sourceTimezone,
     instantLhs,
+    timestampDomain,
+    timeInterval,
 }: {
     dimensionSql: string;
     filter: FilterRule<FilterOperator, unknown>;
@@ -312,57 +326,162 @@ const renderDateOrTimestampFilterSql = ({
     useTimezoneAwareDateTrunc?: boolean;
     sourceTimezone?: string;
     instantLhs?: boolean;
+    timestampDomain?: TimestampDomain;
+    timeInterval?: TimeFrames;
 }): string => {
     // When startOfWeek is not explicitly configured, use the warehouse's default
     // to ensure JS-side week boundaries match the warehouse's DATE_TRUNC behavior.
     const effectiveStartOfWeek =
         startOfWeek ?? getDefaultStartOfWeek(adapterType);
 
-    // Mirror the dim-side `resolveTimezoneWrap` short-circuit: when target tz
-    // equals source tz, dropping the literal's TIMESTAMP cast keeps both sides
-    // symmetric (a custom dim SQL emitting DATETIME can otherwise mismatch a
-    // TIMESTAMP boundary on BigQuery).
-    const wrapTimezoneLiteral =
+    // Domain-directed literal rendering: when the column's naive/aware domain
+    // is known, render the literal in the same domain the LHS compares in.
+    // Unknown domain, flag off, UTC data timezone, and Snowflake (compile-time
+    // wrap) keep today's literals byte-identical.
+    const domainZone = sourceTimezone ?? 'UTC';
+    // Adapters with no naive representation (ClickHouse) treat known-naive
+    // like aware, mirroring the LHS fallback to `castToInstant`.
+    const effectiveDomain =
+        timestampDomain === 'naive' &&
+        dateTruncTimezoneConversions[adapterType].castNaiveToInstant === null
+            ? 'aware'
+            : timestampDomain;
+    const domainDirected =
         !!useTimezoneAwareDateTrunc &&
-        !isTimezoneRoundTripNoOp(adapterType, timezone, sourceTimezone);
+        effectiveDomain !== undefined &&
+        domainZone !== 'UTC' &&
+        adapterType !== SupportedDbtAdapter.SNOWFLAKE;
+    // A truncated sub-day LHS round-trips through the project tz into a UTC
+    // instant; sharing `isTimezoneRoundTripNoOp` with the SELECT side keeps
+    // both sides of the comparison symmetric by construction.
+    const lhsWrapped =
+        domainDirected &&
+        timeInterval !== undefined &&
+        SUB_DAY_TIME_FRAMES.has(timeInterval) &&
+        !isTimezoneRoundTripNoOp(
+            adapterType,
+            timezone,
+            sourceTimezone,
+            timestampDomain,
+        );
+    let literalMode: TimestampLiteralMode = 'legacy';
+    if (domainDirected) {
+        if (lhsWrapped) {
+            literalMode = 'wrapped';
+        } else {
+            literalMode =
+                effectiveDomain === 'naive' ? 'naiveWall' : 'awareInstant';
+        }
+    }
 
-    const castValue = (value: string): string => {
-        if (wrapTimezoneLiteral) {
-            // Column is a timestamptz (round-trip through project TZ). Tag
-            // the literal in project TZ so coercion aligns with the column.
-            const { toUTC } = dateTruncTimezoneConversions[adapterType];
-            const naive = (() => {
+    const domainFormatter = ((): ((date: Date) => string) | null => {
+        switch (literalMode) {
+            case 'wrapped':
+                return formatTimestampAsWallClock(timezone);
+            case 'naiveWall':
+                return formatTimestampAsWallClock(domainZone);
+            case 'awareInstant':
                 switch (adapterType) {
+                    case SupportedDbtAdapter.BIGQUERY:
+                    case SupportedDbtAdapter.CLICKHOUSE:
                     case SupportedDbtAdapter.TRINO:
                     case SupportedDbtAdapter.ATHENA:
-                        return `CAST('${value}' AS timestamp)`;
-                    case SupportedDbtAdapter.SNOWFLAKE:
-                        return `'${value}'::timestamp_ntz`;
-                    case SupportedDbtAdapter.DATABRICKS:
-                        return `'${value}'`;
-                    case SupportedDbtAdapter.BIGQUERY:
-                        // No `::` cast; TIMESTAMP(s, tz) yields the UTC instant.
-                        return `TIMESTAMP('${value}', '${timezone}')`;
-                    case SupportedDbtAdapter.CLICKHOUSE:
-                        return `toDateTime('${value}', '${timezone}')`;
+                        return formatTimestampAsWallClock('UTC');
                     default:
-                        return `'${value}'::timestamp`;
+                        // Offset-bearing legacy literal is already an instant.
+                        return null;
                 }
-            })();
-            return toUTC(naive, timezone);
-        }
-        // The LHS is a rebased instant; BigQuery's offset-less literal would
-        // otherwise be parsed in the job-level time_zone — pin it to UTC.
-        if (instantLhs && adapterType === SupportedDbtAdapter.BIGQUERY) {
-            return `TIMESTAMP('${value}', 'UTC')`;
-        }
-        switch (adapterType) {
-            case SupportedDbtAdapter.TRINO:
-            case SupportedDbtAdapter.ATHENA: {
-                return `CAST('${value}' AS timestamp)`;
-            }
+            case 'legacy':
+                return null;
             default:
-                return `('${value}')`;
+                return assertUnreachable(
+                    literalMode,
+                    `Unknown literal mode ${literalMode}`,
+                );
+        }
+    })();
+    const literalFormatter = domainFormatter ?? baseLiteralFormatter;
+    const boundaryFormatter = domainFormatter ?? baseBoundaryFormatter;
+
+    const castValue = (value: string): string => {
+        switch (literalMode) {
+            case 'wrapped': {
+                // Column is a UTC instant (round-trip through project TZ).
+                // Convert the project-TZ wall-clock literal the same way so
+                // coercion aligns with the column.
+                if (adapterType === SupportedDbtAdapter.BIGQUERY) {
+                    // TIMESTAMP(s, tz) already yields the UTC instant,
+                    // independent of the job timezone — no outer toUTC.
+                    return `TIMESTAMP('${value}', '${timezone}')`;
+                }
+                const { toUTC } = dateTruncTimezoneConversions[adapterType];
+                const naive = (() => {
+                    switch (adapterType) {
+                        case SupportedDbtAdapter.TRINO:
+                        case SupportedDbtAdapter.ATHENA:
+                            return `CAST('${value}' AS timestamp)`;
+                        case SupportedDbtAdapter.DATABRICKS:
+                        case SupportedDbtAdapter.SPARK:
+                            return `'${value}'`;
+                        case SupportedDbtAdapter.CLICKHOUSE:
+                            return `toDateTime('${value}', '${timezone}')`;
+                        default:
+                            return `'${value}'::timestamp`;
+                    }
+                })();
+                return toUTC(naive, timezone);
+            }
+            case 'naiveWall':
+                // Bare naive column: compare wall clocks in the data timezone.
+                switch (adapterType) {
+                    case SupportedDbtAdapter.BIGQUERY:
+                        return `DATETIME '${value}'`;
+                    case SupportedDbtAdapter.DATABRICKS:
+                    case SupportedDbtAdapter.SPARK:
+                        return `TIMESTAMP_NTZ '${value}'`;
+                    case SupportedDbtAdapter.TRINO:
+                    case SupportedDbtAdapter.ATHENA:
+                        return `TIMESTAMP '${value}'`;
+                    default:
+                        return `('${value}'::timestamp)`;
+                }
+            case 'awareInstant':
+                // Bare aware column: typed instant literal, immune to the
+                // session/job timezone.
+                switch (adapterType) {
+                    case SupportedDbtAdapter.CLICKHOUSE:
+                        return `toDateTime64('${value}', 3, 'UTC')`;
+                    case SupportedDbtAdapter.BIGQUERY:
+                        return `TIMESTAMP '${value}+00'`;
+                    case SupportedDbtAdapter.TRINO:
+                    case SupportedDbtAdapter.ATHENA:
+                        return `TIMESTAMP '${value} UTC'`;
+                    default:
+                        return `('${value}')`;
+                }
+            case 'legacy':
+                // The LHS is a flag-rebased instant; BigQuery's offset-less
+                // literal would otherwise be parsed in the job-level
+                // time_zone — pin it to UTC.
+                if (
+                    instantLhs &&
+                    adapterType === SupportedDbtAdapter.BIGQUERY
+                ) {
+                    return `TIMESTAMP('${value}', 'UTC')`;
+                }
+                switch (adapterType) {
+                    case SupportedDbtAdapter.TRINO:
+                    case SupportedDbtAdapter.ATHENA: {
+                        return `CAST('${value}' AS timestamp)`;
+                    }
+                    default:
+                        return `('${value}')`;
+                }
+            default:
+                return assertUnreachable(
+                    literalMode,
+                    `Unknown literal mode ${literalMode}`,
+                );
         }
     };
 
@@ -694,6 +813,8 @@ export const renderTimestampFilterSql = ({
     useTimezoneAwareDateTrunc,
     sourceTimezone,
     instantLhs,
+    timestampDomain,
+    timeInterval,
 }: {
     dimensionSql: string;
     filter: FilterRule<FilterOperator, unknown>;
@@ -705,6 +826,8 @@ export const renderTimestampFilterSql = ({
     useTimezoneAwareDateTrunc?: boolean;
     sourceTimezone?: string;
     instantLhs?: boolean;
+    timestampDomain?: TimestampDomain;
+    timeInterval?: TimeFrames;
 }): string =>
     renderDateOrTimestampFilterSql({
         dimensionSql,
@@ -718,6 +841,8 @@ export const renderTimestampFilterSql = ({
         useTimezoneAwareDateTrunc,
         sourceTimezone,
         instantLhs,
+        timestampDomain,
+        timeInterval,
     });
 
 export const renderBooleanFilterSql = (
@@ -838,6 +963,8 @@ export const renderFilterRuleSql = (
     baseTimeIntervalDimensionType?: DimensionType,
     sourceTimezone?: string,
     instantLhs?: boolean,
+    timestampDomain?: TimestampDomain,
+    timeInterval?: TimeFrames,
 ): string => {
     if (filterRule.disabled) {
         return `1=1`; // When filter is disabled, we want to return all rows
@@ -908,7 +1035,11 @@ export const renderFilterRuleSql = (
                         : formatTimestampAsUTC,
                 startOfWeek,
                 baseDimensionSql,
+                useTimezoneAwareDateTrunc,
+                sourceTimezone,
                 instantLhs,
+                timestampDomain,
+                timeInterval,
             });
         }
         case DimensionType.BOOLEAN:
@@ -939,6 +1070,7 @@ export const renderFilterRuleSqlFromField = (
     useTimezoneAwareDateTrunc?: boolean,
     sourceTimezone?: string,
     instantLhs?: boolean,
+    timestampDomain?: TimestampDomain,
 ): string => {
     const fieldType = isCompiledCustomSqlDimension(field)
         ? field.dimensionType
@@ -965,6 +1097,11 @@ export const renderFilterRuleSqlFromField = (
             ? field.timeIntervalBaseDimensionType
             : undefined;
 
+    const timeInterval =
+        !isCompiledCustomSqlDimension(field) && !isMetric(field)
+            ? field.timeInterval
+            : undefined;
+
     return renderFilterRuleSql(
         filterRule,
         fieldType,
@@ -980,5 +1117,7 @@ export const renderFilterRuleSqlFromField = (
         baseTimeIntervalDimensionType,
         sourceTimezone,
         instantLhs,
+        timestampDomain,
+        timeInterval,
     );
 };

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -414,7 +414,8 @@ const renderDateOrTimestampFilterSql = ({
                     // independent of the job timezone — no outer toUTC.
                     return `TIMESTAMP('${value}', '${timezone}')`;
                 }
-                const { toUTC } = dateTruncTimezoneConversions[adapterType];
+                const { toUTC, freezeInstantOutput } =
+                    dateTruncTimezoneConversions[adapterType];
                 const naive = (() => {
                     switch (adapterType) {
                         case SupportedDbtAdapter.TRINO:
@@ -429,7 +430,13 @@ const renderDateOrTimestampFilterSql = ({
                             return `'${value}'::timestamp`;
                     }
                 })();
-                return toUTC(naive, timezone);
+                const wrapped = toUTC(naive, timezone);
+                // The truncated LHS is frozen as TIMESTAMP_NTZ on
+                // Databricks/Spark — freeze the literal identically so the
+                // comparison never relies on session coercion.
+                return freezeInstantOutput
+                    ? freezeInstantOutput(wrapped)
+                    : wrapped;
             }
             case 'naiveWall':
                 // Bare naive column: compare wall clocks in the data timezone.

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -354,10 +354,11 @@ const renderDateOrTimestampFilterSql = ({
     // A truncated sub-day LHS round-trips through the project tz into a UTC
     // instant; sharing `isTimezoneRoundTripNoOp` with the SELECT side keeps
     // both sides of the comparison symmetric by construction.
+    const subDayLhs =
+        timeInterval !== undefined && SUB_DAY_TIME_FRAMES.has(timeInterval);
     const lhsWrapped =
         domainDirected &&
-        timeInterval !== undefined &&
-        SUB_DAY_TIME_FRAMES.has(timeInterval) &&
+        subDayLhs &&
         !isTimezoneRoundTripNoOp(
             adapterType,
             timezone,
@@ -368,6 +369,13 @@ const renderDateOrTimestampFilterSql = ({
     if (domainDirected) {
         if (lhsWrapped) {
             literalMode = 'wrapped';
+        } else if (subDayLhs) {
+            // Equal-zones no-op: the LHS is the legacy unwrapped trunc (a
+            // naive value), so a typed instant literal would lean on session
+            // coercion — keep the legacy literal, which matches it exactly.
+            // Known-naive columns never reach this state: their round trip
+            // is never a no-op.
+            literalMode = 'legacy';
         } else {
             literalMode =
                 effectiveDomain === 'naive' ? 'naiveWall' : 'awareInstant';

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -189,8 +189,9 @@ describe('timestamp domain', () => {
         slt_week: {
             label: 'SLT Week',
             sql: "DATE_TRUNC('week', ${COLUMN})",
+            type: DimensionType.TIMESTAMP,
         },
-    };
+    } as const;
 
     it('should attach timestamp_domain as a sibling of data_type', () => {
         expect(
@@ -209,7 +210,7 @@ describe('timestamp domain', () => {
         ).not.toHaveProperty('timestamp_domain');
     });
 
-    it('should stamp timestampDomain on the dimension and its interval children', () => {
+    it('should stamp timestampDomain on standard intervals but not custom granularities', () => {
         const result = convertTable(
             SupportedDbtAdapter.POSTGRES,
             MODEL_WITH_TIMESTAMP_DOMAIN,
@@ -226,8 +227,8 @@ describe('timestamp domain', () => {
         expect(result.dimensions.user_created_day.timestampDomain).toEqual(
             'naive',
         );
-        expect(result.dimensions.user_created_slt_week.timestampDomain).toEqual(
-            'naive',
+        expect(result.dimensions.user_created_slt_week).not.toHaveProperty(
+            'timestampDomain',
         );
     });
 

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -807,9 +807,8 @@ export const convertTable = (
                                 ...(dim.skipTimezoneConversion
                                     ? { skipTimezoneConversion: true }
                                     : {}),
-                                ...(dim.timestampDomain
-                                    ? { timestampDomain: dim.timestampDomain }
-                                    : {}),
+                                // Custom granularity SQL may change the base
+                                // column's domain, so keep its output unknown.
                             } satisfies Dimension,
                         };
                     }, {});


### PR DESCRIPTION
Final slice of the naive-timestamp correctness stack: timestamp filter literals are rendered in the same domain the column compares in, so WHERE boundaries land on the right instants without wrapping the column (predicates stay sargable).

### Literal modes
- **Known-naive, bare LHS** → typed wall-clock literal in the data timezone (`DATETIME '...'`, `TIMESTAMP_NTZ '...'`, `('...'::timestamp)`).
- **Known-aware, bare LHS** → typed instant literal, immune to session/job timezone.
- **Sub-day truncated LHS** → the literal takes the same project-timezone round-trip as the column (`isTimezoneRoundTripNoOp` is shared with the SELECT side, so both sides stay symmetric by construction). This also replaces the previously unreachable BigQuery composition with the valid `TIMESTAMP('literal', tz)` form.
- **Unknown domain** → byte-identical to main. The flag-gated RAW filter LHS rebase from #25807 (`naive-timestamp-filter-rebase`) remains the interim fallback for unclassified columns, exactly as its rollout plan describes; its `instantLhs` literal pinning composes untouched with these modes and this PR keeps known-domain filter columns bare so that flag's wrap never applies to a classified column. The flag can retire per-org once that org's explores are classified.

### Deliberate literal-text changes (everything else is byte-identical)
1. Known-domain typed literals (above).
2. BigQuery wrapped-LHS `TIMESTAMP('literal', tz)` for sub-day truncated filters.
3. Sub-day filters whose LHS round-trip is a no-op (display == data timezone on the equal-zones adapters) keep the **legacy** literal — the LHS there is the legacy unwrapped trunc, so the literal byte-matches it exactly as on main. Known-naive columns never reach this state.
4. Databricks/Spark wrapped literals are frozen as `TIMESTAMP_NTZ`, matching the frozen LHS from #25819 — the comparison is a direct NTZ face match instead of relying on both sides passing through the same session coercion (which breaks for wall clocks inside the data timezone's DST gap).

Byte-identical: flag off, UTC data timezone, DATE dimensions (bare date literals), EXTRACT-based filters, Snowflake, and all unknown-domain columns. Since the session pin was removed in #25819, classification is per-column on every adapter: classified filter targets take the typed-literal modes while unclassified ones in the same query keep their legacy literals.

Closes: GLITCH-616
Relates: #25792



### Live verification (post pin-removal base)
- Matrix 3 filter cases green on BigQuery/Snowflake/Databricks/Trino; ClickHouse raw-frame gap case returns 1 with the typed `toDateTime64` literal.
- RAW literal modes exercised directly on Databricks and Trino (the matrix only covers truncated filters): `naiveWall` (bare NTZ LHS vs data-timezone wall-clock literal) and `awareInstant` (bare aware LHS vs typed instant literal) both return exactly the on-screen row for an `inBetween` window around it.
- Sub-day truncated `inBetween` (two wrapped boundaries against the NTZ-frozen LHS on Databricks) returns the computed 5/5.



### Known remaining gap (explicitly out of scope)
Statically compiled **metric filters** (YAML metric `filters:` and custom-metric filters) bake their literals at explore compile time, where no data timezone or domain is available — so a filtered metric over a naive timestamp still compares in the legacy domain even on classified explores. Only relative-date predicates are re-rendered at query time today. The clean fix is generalizing that query-time rewrite (the `compiledRelativeDateFilters` pattern) to all timestamp predicates — follow-up in GLITCH-627, since it changes the compiled-explore shape. Dimension filters (this PR) are unaffected.


