### PR TITLE
docs: Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md
+
+General repo guidance for humans and AI lives in `CLAUDE.md` (architecture, package commands, testing memories, code style). Read it first. The section below only covers what is specific to the Cursor Cloud VM.
+
+## Cursor Cloud specific instructions
+
+This VM runs Lightdash **natively (no Docker)**. Docker is not installed, so the
+repo's `scripts/dev-fast-start.sh` and the `/docker-dev` flow do **not** apply here.
+Infra (PostgreSQL, MinIO) runs as native processes; the app runs via PM2 exactly as
+`ecosystem.config.js` defines. The update script only runs `pnpm install`; everything
+below (starting Postgres/MinIO/PM2) is a per-session action you must do yourself.
+
+### Node version (important gotcha)
+The repo pins Node `20.19` (`.nvmrc`). The VM's `/exec-daemon/node` is Node 22 and sits
+early in `PATH`, so it shadows nvm. This is worked around by symlinks in
+`/usr/local/cargo/bin` (first in `PATH`) pointing at nvm's `v20.19.6` binaries, so `node`
+resolves to 20.19.6 in every context (including non-interactive shells and PM2). If `node -v`
+ever reports v22, recreate the symlink: `ln -sf "$HOME/.nvm/versions/node/v20.19.6/bin/node" /usr/local/cargo/bin/node`.
+`node_modules` native addons are built for Node 20 — keep install and runtime on the same version.
+
+### Start everything (per session)
+Postgres and MinIO are not auto-started on VM boot, and PM2 is not resurrected. Run:
+
+```bash
+# 1. PostgreSQL (user: postgres / password: password, db: postgres, localhost:5432)
+sudo service postgresql start
+
+# 2. MinIO (S3) on :9000 (console :9001), buckets already created in ~/minio-data
+tmux -f /exec-daemon/tmux.portal.conf new-session -d -s minio \
+  'MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin ~/.local/bin/minio server ~/minio-data --address :9000 --console-address :9001'
+
+# 3. App stack (api, scheduler, frontend, common/warehouses/formula watchers, spotlight)
+pnpm pm2:start
+```
+
+Then wait for `http://localhost:8080/api/v1/health` to return 200 (the backend runs TS via
+`tsx`, ~15s cold start). Frontend (Vite): `http://localhost:3000`. Use `pnpm pm2:logs`,
+`pnpm exec pm2 status`, `pnpm exec pm2 restart lightdash-api` to manage processes.
+
+### Environment config
+`.env.development.local` (gitignored; present on the VM / snapshot) overrides the Docker
+hostnames in `.env.development` with native ones (`PGHOST=localhost`, `S3_ENDPOINT=http://localhost:9000`,
+`SITE_URL=http://localhost:3000`, seeded PAT `LDPAT`, `ALLOW_MULTIPLE_ORGS=true`). PM2 loads
+`.env.development` then `.env.development.local` (local wins).
+
+### Database, dbt demo, and reset
+- The DB is already migrated + seeded, and the Jaffle Shop demo warehouse tables are built in
+  the `jaffle` schema. Test login: `demo@lightdash.com` / `demo_password!` (admin of "Jaffle Shop").
+- Python/dbt venv lives at `./venv` (dbt-core 1.7 + dbt-postgres; `setuptools` is required
+  under Python 3.12 to provide the removed `distutils`). `venv/bin` is prepended to PATH by PM2.
+- To re-migrate/seed after a schema change (Postgres must be running):
+  ```bash
+  pnpx dotenv-cli -e .env.development.local -e .env.development -- pnpm -F backend migrate
+  pnpx dotenv-cli -e .env.development.local -e .env.development -- pnpm -F backend seed
+  ```
+- To rebuild the Jaffle warehouse data:
+  ```bash
+  PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=password PGDATABASE=postgres \
+    ./venv/bin/dbt seed --project-dir examples/full-jaffle-shop-demo/dbt --profiles-dir examples/full-jaffle-shop-demo/profiles
+  # then `dbt run` with the same env/flags
+  ```
+- EE migrations only run when `LIGHTDASH_LICENSE_KEY` is set; without it, `pgvector` is not
+  required (core migrations only need `ltree`, `uuid-ossp`, `citext`, all in `postgresql-contrib`).
+
+### Not running here
+Headless browser (screenshots/PDF exports & unfurls), NATS (async query worker), and
+Prometheus are not started. Chart/dashboard exploration, saving, and scheduling-via-DB work
+without them; features that render images or use the NATS worker will be unavailable.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: <!-- n/a -->

### Description:

Sets up the Lightdash development environment on the Cursor Cloud VM and documents how to run it. The only tracked change is `AGENTS.md` (force-added; it is gitignored upstream, so please decide whether to keep it) which records Cursor-Cloud-specific, non-obvious startup caveats for future agents.

This VM runs Lightdash **natively (no Docker)** since Docker isn't installed here and the `dev-fast-start.sh`/`/docker-dev` flow depends on it. Infra runs as native processes and the app runs via PM2 exactly as `ecosystem.config.js` defines.

What was set up (persisted on the VM, not in the repo):
- Node `20.19.6` via nvm, made the default in all shells via a `/usr/local/cargo/bin` symlink that overrides the VM's `/exec-daemon/node` (v22).
- PostgreSQL 16 (`postgresql` + `postgresql-contrib`) on `localhost:5432` (postgres/password); DB migrated (375 migrations) + seeded.
- Python venv at `./venv` with dbt-core/dbt-postgres 1.7 (plus `setuptools` for the Python 3.12 `distutils` shim); Jaffle Shop demo warehouse built in the `jaffle` schema.
- MinIO (S3) on `:9000` with `default`/`results`/`lightdash-apps` buckets.
- App stack via `pnpm pm2:start` (api, scheduler, frontend, common/warehouses/formula watchers, spotlight).
- `.env.development.local` (gitignored) pointing the backend at the native services.

Verified working:
- Lint: `pnpm -F warehouses lint` (clean).
- Tests: `pnpm formula:test:fast` (361/361 passing, DuckDB).
- Backend health `200`, frontend serving, demo login, and an end-to-end metric query against the jaffle warehouse.
- Hello-world UI flow: logged in as `demo@lightdash.com`, explored Orders, ran a query, and saved a chart "Hello World Orders by Status".

[lightdash_login_and_create_chart.mp4](https://cursor.com/agents/bc-11d38bbc-e00f-4490-be6d-9cda067c04a7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flightdash_login_and_create_chart.mp4)

[Saved chart](https://cursor.com/agents/bc-11d38bbc-e00f-4490-be6d-9cda067c04a7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_saved_chart.webp)

The update script for future VM boots is minimal: `pnpm install` (Node 20 resolves automatically via the persisted symlink). Service startup (Postgres, MinIO, PM2) is documented in `AGENTS.md`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11d38bbc-e00f-4490-be6d-9cda067c04a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11d38bbc-e00f-4490-be6d-9cda067c04a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

