### PR TITLE
feat(onboarding): polish warehouse-connect UI

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/InviteExpertFooter.module.css
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/InviteExpertFooter.module.css
@@ -1,0 +1,19 @@
+.callout {
+    padding: var(--mantine-spacing-md) var(--mantine-spacing-lg);
+    border-color: var(--mantine-color-ldGray-2);
+}
+
+.iconBox {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 40px;
+    height: 40px;
+    border-radius: var(--mantine-radius-md);
+    background-color: var(--mantine-color-ldGray-1);
+}
+
+.button {
+    flex-shrink: 0;
+}

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/InviteExpertFooter.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/InviteExpertFooter.tsx
@@ -1,6 +1,9 @@
-import { Anchor, Text } from '@mantine-8/core';
+import { Box, Button, Group, Paper, Stack, Text } from '@mantine-8/core';
 import { useDisclosure } from '@mantine/hooks';
+import { IconUsers } from '@tabler/icons-react';
 import { type FC } from 'react';
+import MantineIcon from '../../common/MantineIcon';
+import classes from './InviteExpertFooter.module.css';
 import SetupInviteModal from './SetupInviteModal';
 
 const InviteExpertFooter: FC = () => {
@@ -8,13 +11,40 @@ const InviteExpertFooter: FC = () => {
 
     return (
         <>
-            <Text c="dimmed" w={420} mx="auto" ta="center">
-                This step is best carried out by your organization’s analytics
-                experts. If this is not you,{' '}
-                <Anchor component="button" type="button" onClick={open}>
-                    invite them to help you set up.
-                </Anchor>
-            </Text>
+            <Paper
+                withBorder
+                shadow="subtle"
+                radius="md"
+                className={classes.callout}
+            >
+                <Group justify="space-between" wrap="nowrap" gap="md">
+                    <Group wrap="nowrap" gap="md">
+                        <Box className={classes.iconBox}>
+                            <MantineIcon
+                                icon={IconUsers}
+                                size="lg"
+                                color="ldGray.7"
+                            />
+                        </Box>
+                        <Stack gap={2}>
+                            <Text fw={600} size="sm">
+                                Not the right person?
+                            </Text>
+                            <Text size="sm" c="dimmed">
+                                Connecting the warehouse is usually a data-team
+                                job.
+                            </Text>
+                        </Stack>
+                    </Group>
+                    <Button
+                        variant="default"
+                        className={classes.button}
+                        onClick={open}
+                    >
+                        Invite an expert
+                    </Button>
+                </Group>
+            </Paper>
             <SetupInviteModal opened={opened} onClose={close} />
         </>
     );

--- a/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
@@ -53,7 +53,7 @@ export const ProjectForm: FC<Props> = ({
                 </SettingsGridCard>
             )}
 
-            <SettingsGridCard>
+            <SettingsGridCard p={warehouseOnly ? 'xl' : undefined}>
                 <div>
                     {warehouse && getWarehouseIcon(warehouse)}
                     <Flex align="center" gap={2}>

--- a/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
@@ -53,7 +53,7 @@ export const ProjectForm: FC<Props> = ({
                 </SettingsGridCard>
             )}
 
-            <SettingsGridCard p={warehouseOnly ? 'xl' : undefined}>
+            <SettingsGridCard p={warehouseOnly ? 'xl' : 'md'}>
                 <div>
                     {warehouse && getWarehouseIcon(warehouse)}
                     <Flex align="center" gap={2}>

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -14,6 +14,7 @@ import {
     Image,
     Loader,
     type ComboboxItem,
+    type OptionsFilter,
     Stack,
     Text,
     Select,
@@ -24,6 +25,7 @@ import { useDebouncedValue } from '@mantine/hooks';
 import { IconCheck, IconExclamationCircle } from '@tabler/icons-react';
 import {
     useEffect,
+    useMemo,
     useRef,
     useState,
     type ChangeEvent,
@@ -273,6 +275,7 @@ const BigQueryForm: FC<{
             BigqueryAuthenticationType.SSO;
     const {
         data: datasets,
+        isInitialLoading: isLoadingDatasets,
         refetch: refetchDatasets,
         error: datasetsError,
     } = useBigqueryDatasets(isAuthenticated && isSso, debouncedProject);
@@ -383,6 +386,36 @@ const BigQueryForm: FC<{
     const authenticationType: string =
         form.values.warehouse.authenticationType ?? defaultAuthenticationType;
     const locationField = form.getInputProps('warehouse.location');
+    const hasProjectValue =
+        typeof project.value === 'string' && project.value.length > 0;
+    const projectOptionsFilter = useMemo<OptionsFilter>(() => {
+        const friendlyNames = new Map(
+            gcpProjects?.map((p) => [
+                p.projectId,
+                (p.friendlyName ?? '').toLowerCase(),
+            ]) ?? [],
+        );
+        return ({ options, search }) => {
+            const items = options as ComboboxItem[];
+            const trimmed = search.trim().toLowerCase();
+            const isExistingValue = items.some((item) => item.value === search);
+            if (!trimmed || isExistingValue) {
+                return items;
+            }
+            return items.filter(
+                (item) =>
+                    item.value.toLowerCase().includes(trimmed) ||
+                    (friendlyNames.get(item.value) ?? '').includes(trimmed),
+            );
+        };
+    }, [gcpProjects]);
+    const isLocationLoading =
+        isSso &&
+        isAuthenticated &&
+        !locationField.value &&
+        (isLoadingProjectRecommendation ||
+            isLoadingDatasets ||
+            (hasProjectValue && !datasets && !datasetsError));
 
     const onChangeFactory =
         (onChange: (value: string | undefined) => void) =>
@@ -407,7 +440,7 @@ const BigQueryForm: FC<{
         <>
             <Stack mt={8}>
                 {
-                    <Group gap="sm">
+                    <Group gap="sm" align="flex-end">
                         <Select
                             allowDeselect={false}
                             name="warehouse.authenticationType"
@@ -441,7 +474,7 @@ const BigQueryForm: FC<{
                         />
                         {isAuthenticated && (
                             <Tooltip label="You are connected to BigQuery">
-                                <Group mt="40px">
+                                <Group mb={10}>
                                     <MantineIcon
                                         icon={IconCheck}
                                         color="green"
@@ -461,11 +494,12 @@ const BigQueryForm: FC<{
                 )}
                 {showWarehouseConfigFields && (
                     <>
-                        <Group gap="sm">
+                        <Group gap="sm" align="flex-end">
                             {isSso && isAuthenticated ? (
                                 <Autocomplete
                                     name="warehouse.project"
                                     label="Project"
+                                    filter={projectOptionsFilter}
                                     description={
                                         <p>
                                             <Anchor
@@ -593,7 +627,7 @@ const BigQueryForm: FC<{
                             )}
                             {hasDatasets && (
                                 <Tooltip label="You have access to this project">
-                                    <Group mt="50px">
+                                    <Group mb={10}>
                                         <MantineIcon
                                             icon={IconCheck}
                                             color="green"
@@ -623,7 +657,18 @@ const BigQueryForm: FC<{
                             }
                             {...locationField}
                             onChange={onChangeFactory(locationField.onChange)}
-                            disabled={disabled}
+                            placeholder={
+                                isLocationLoading
+                                    ? 'Detecting location...'
+                                    : undefined
+                            }
+                            disabled={disabled || isLocationLoading}
+                            rightSectionPointerEvents="none"
+                            rightSection={
+                                isLocationLoading ? (
+                                    <Loader size="xs" />
+                                ) : undefined
+                            }
                         />
 
                         {authenticationType ===

--- a/packages/frontend/src/pages/OnboardingDataSource.module.css
+++ b/packages/frontend/src/pages/OnboardingDataSource.module.css
@@ -8,7 +8,7 @@
 .column {
     flex: 1;
     width: 100%;
-    max-width: 1140px;
+    max-width: 880px;
     margin: 0 auto;
     padding: 56px var(--mantine-spacing-xxl) var(--mantine-spacing-xl);
     display: flex;
@@ -60,7 +60,7 @@
 .connectColumn {
     flex: 1;
     width: 100%;
-    max-width: 62rem;
+    max-width: 52rem;
     margin: 0 auto;
     padding: var(--mantine-spacing-xl) var(--mantine-spacing-sm);
 }


### PR DESCRIPTION
## Summary

Polish pass on the **new-onboarding** warehouse connection flow (behind the `new-onboarding` feature flag). Frontend-only — no API or schema changes.

### Data source picker
- Tighten the page width.
- Replace the inline "invite them to help you set up" text link with a neutral Lightdash-style callout card (subtle border + shadow, icon, and an outline **Invite an expert** button).

### BigQuery connection form
- **Fix validation tick alignment** — the green ticks now centre on the input row regardless of description height. Previously a fixed top-margin (`mt="40px"`) misaligned the tick whenever the Authentication Type description wrapped to two lines; switched to `align="flex-end"` so it anchors to the input.
- **Location field loading state** — added a spinner + `Detecting location…` placeholder that spans the whole project-recommendation → datasets resolution, removing an enabled→disabled flicker while the value auto-populates.
- **Project autocomplete** — show the full option list when a value is already selected (instead of collapsing to just the selection), and match on **friendly names** as well as project IDs.

### Connection page
- Tighten the page width and give the warehouse card more padding, scoped to the onboarding warehouse-only case (the shared `SettingsGridCard` used across 18 settings pages is untouched).

## Testing
- Verified each change live against a BigQuery SSO connection in local dev.
- `typecheck` + `lint` pass on all touched files.

Linear: SPK-612

🤖 Generated with [Claude Code](https://claude.com/claude-code)
