### PR TITLE
feat(frontend): playground onboarding integration (invite-an-expert → sample data)

### DIFF
--- a/packages/frontend/src/components/NavBar/PlaygroundBanner.module.css
+++ b/packages/frontend/src/components/NavBar/PlaygroundBanner.module.css
@@ -1,0 +1,12 @@
+.banner {
+    z-index: var(--mantine-z-index-app);
+}
+
+.connectLink {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+    white-space: nowrap;
+    font-family: inherit;
+}

--- a/packages/frontend/src/components/NavBar/PlaygroundBanner.tsx
+++ b/packages/frontend/src/components/NavBar/PlaygroundBanner.tsx
@@ -1,0 +1,41 @@
+import { Anchor, Center, Group, Text } from '@mantine-8/core';
+import { IconArrowRight, IconFlask } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../common/MantineIcon';
+import { BANNER_HEIGHT } from '../common/Page/constants';
+import classes from './PlaygroundBanner.module.css';
+
+export const PlaygroundBanner: FC = () => (
+    <Center
+        id="playground-banner"
+        pos="fixed"
+        top={0}
+        w="100%"
+        h={BANNER_HEIGHT}
+        bg="violet.6"
+        className={classes.banner}
+        px="md"
+    >
+        <Group gap="xs" wrap="nowrap" miw={0}>
+            <MantineIcon icon={IconFlask} color="white" size="sm" />
+            <Text c="white" fw={500} fz="xs" truncate>
+                You're exploring sample data — this isn't your company's data.
+            </Text>
+            <Anchor
+                component={Link}
+                to="/onboarding/data-source"
+                c="white"
+                fz="xs"
+                fw={600}
+                underline="always"
+                className={classes.connectLink}
+            >
+                <Text span fz="xs" fw={600}>
+                    Connect your warehouse
+                </Text>
+                <MantineIcon icon={IconArrowRight} size="sm" />
+            </Anchor>
+        </Group>
+    </Center>
+);

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -10,11 +10,13 @@ import { useProject } from '../../hooks/useProject';
 import { useImpersonation } from '../../hooks/user/useImpersonation';
 import useFullscreen from '../../providers/Fullscreen/useFullscreen';
 import Mantine8Provider from '../../providers/Mantine8Provider';
+import { isPlaygroundProvisioningSource } from '../../utils/playgroundProject';
 import { BANNER_HEIGHT, NAVBAR_HEIGHT } from '../common/Page/constants';
 import { DashboardExplorerBanner } from './DashboardExplorerBanner';
 import { ImpersonationBanner } from './ImpersonationBanner';
 import classes from './index.module.css';
 import { MainNavBarContent } from './MainNavBarContent';
+import { PlaygroundBanner } from './PlaygroundBanner';
 import { PreviewBanner } from './PreviewBanner';
 import { TrialWarningBanner } from './TrialWarningBanner';
 
@@ -70,6 +72,9 @@ const NavBar = memo(({ isFixed = true }: NavBarProps) => {
     const { data: project } = useProject(activeProjectUuid);
 
     const isCurrentProjectPreview = project?.type === ProjectType.PREVIEW;
+    const isCurrentProjectPlayground = isPlaygroundProvisioningSource(
+        project?.provisioningSource,
+    );
     const upstreamProjectUuid = isCurrentProjectPreview
         ? project?.upstreamProjectUuid
         : undefined;
@@ -82,13 +87,17 @@ const NavBar = memo(({ isFixed = true }: NavBarProps) => {
     const showTrialWarning =
         !isImpersonating &&
         !isCurrentProjectPreview &&
+        !isCurrentProjectPlayground &&
         (organizationAccess?.status ===
             OrganizationAccessStatus.TRIAL_WARNING ||
             organizationAccess?.status ===
                 OrganizationAccessStatus.TRIAL_EXPIRED);
 
     const hasBanner =
-        isImpersonating || isCurrentProjectPreview || showTrialWarning;
+        isImpersonating ||
+        isCurrentProjectPreview ||
+        isCurrentProjectPlayground ||
+        showTrialWarning;
 
     // Calculate placeholder height: navbar + banner.
     const headerContainerHeight =
@@ -119,6 +128,8 @@ const NavBar = memo(({ isFixed = true }: NavBarProps) => {
                                 : null
                         }
                     />
+                ) : isCurrentProjectPlayground ? (
+                    <PlaygroundBanner />
                 ) : (
                     organizationAccess && (
                         <TrialWarningBanner access={organizationAccess} />

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SetupInviteModal.test.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SetupInviteModal.test.tsx
@@ -1,0 +1,177 @@
+import { type ApiError } from '@lightdash/common';
+import { MantineProvider } from '@mantine-8/core';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type * as ReactRouter from 'react-router';
+import { MemoryRouter } from 'react-router';
+import { useOrganization } from '../../../hooks/organization/useOrganization';
+import { useEnsurePlaygroundProject } from '../../../hooks/useEnsurePlaygroundProject';
+import { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
+import { useUserUpdateMutation } from '../../../hooks/user/useUserUpdateMutation';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../../providers/App/useApp';
+import useTracking from '../../../providers/Tracking/useTracking';
+import SetupInviteModal from './SetupInviteModal';
+
+vi.mock('../../../hooks/organization/useOrganization');
+vi.mock('../../../hooks/useEnsurePlaygroundProject');
+vi.mock('../../../hooks/useInviteLink');
+vi.mock('../../../hooks/useServerOrClientFeatureFlag');
+vi.mock('../../../hooks/user/useUserUpdateMutation');
+vi.mock('../../../providers/App/useApp');
+vi.mock('../../../providers/Tracking/useTracking');
+vi.mock('@sentry/react', () => ({ captureException: vi.fn() }));
+
+const navigate = vi.fn();
+vi.mock('react-router', async (importOriginal) => ({
+    ...(await importOriginal<typeof ReactRouter>()),
+    useNavigate: () => navigate,
+}));
+
+const inviteLink = {
+    email: 'expert@company.com',
+    inviteUrl: 'https://lightdash.test/invite/abc',
+};
+
+const apiError = (name: string, message: string): ApiError => ({
+    status: 'error',
+    error: { name, statusCode: 404, message, data: {} },
+});
+
+let createInvite: ReturnType<typeof vi.fn>;
+let ensurePlayground: ReturnType<typeof vi.fn>;
+
+const mockInviteCreated = (created: boolean) => {
+    vi.mocked(useCreateInviteLinkMutation).mockReturnValue({
+        data: created ? inviteLink : undefined,
+        mutateAsync: createInvite,
+        reset: vi.fn(),
+        isLoading: false,
+    } as unknown as ReturnType<typeof useCreateInviteLinkMutation>);
+};
+
+const renderModal = () =>
+    render(
+        <MantineProvider>
+            <MemoryRouter>
+                <SetupInviteModal opened onClose={vi.fn()} />
+            </MemoryRouter>
+        </MantineProvider>,
+    );
+
+const submitInvite = async () => {
+    await userEvent.type(
+        screen.getByRole('textbox', { name: /their email address/i }),
+        inviteLink.email,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /send invite/i }));
+};
+
+describe('SetupInviteModal', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        createInvite = vi.fn().mockResolvedValue(inviteLink);
+        ensurePlayground = vi
+            .fn()
+            .mockResolvedValue({ projectUuid: 'playground-uuid' });
+
+        vi.mocked(useApp).mockReturnValue({
+            health: { data: { hasEmailClient: true } },
+            user: { data: { firstName: 'Ada', lastName: 'Lovelace' } },
+        } as unknown as ReturnType<typeof useApp>);
+        vi.mocked(useTracking).mockReturnValue({
+            track: vi.fn(),
+        } as unknown as ReturnType<typeof useTracking>);
+        vi.mocked(useServerFeatureFlag).mockReturnValue({
+            data: { enabled: true },
+        } as unknown as ReturnType<typeof useServerFeatureFlag>);
+        vi.mocked(useOrganization).mockReturnValue({
+            data: { needsProject: true },
+        } as ReturnType<typeof useOrganization>);
+        vi.mocked(useUserUpdateMutation).mockReturnValue({
+            mutateAsync: vi.fn(),
+            isLoading: false,
+        } as unknown as ReturnType<typeof useUserUpdateMutation>);
+        vi.mocked(useEnsurePlaygroundProject).mockReturnValue({
+            mutateAsync: ensurePlayground,
+            isLoading: false,
+        } as unknown as ReturnType<typeof useEnsurePlaygroundProject>);
+        mockInviteCreated(false);
+    });
+
+    it('navigates into the playground when provisioning succeeds', async () => {
+        renderModal();
+        await submitInvite();
+
+        await waitFor(() => {
+            expect(navigate).toHaveBeenCalledWith(
+                '/projects/playground-uuid/home',
+            );
+        });
+    });
+
+    it('explains an unavailable instance and keeps the invite as a fallback', async () => {
+        ensurePlayground.mockRejectedValue(
+            apiError('NotFoundError', 'Playground projects are not available'),
+        );
+        const { rerender } = renderModal();
+        await submitInvite();
+        mockInviteCreated(true);
+        rerender(
+            <MantineProvider>
+                <MemoryRouter>
+                    <SetupInviteModal opened onClose={vi.fn()} />
+                </MemoryRouter>
+            </MantineProvider>,
+        );
+
+        expect(
+            await screen.findByText(/couldn't set up a sample project/i),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(/aren't available on this instance/i),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Invite ready')).toBeInTheDocument();
+        expect(navigate).not.toHaveBeenCalled();
+        expect(
+            screen.queryByRole('button', { name: /try again/i }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('offers a retry for unrecognised failures', async () => {
+        ensurePlayground.mockRejectedValue(
+            apiError('UnexpectedServerError', 'boom'),
+        );
+        const { rerender } = renderModal();
+        await submitInvite();
+        mockInviteCreated(true);
+        rerender(
+            <MantineProvider>
+                <MemoryRouter>
+                    <SetupInviteModal opened onClose={vi.fn()} />
+                </MemoryRouter>
+            </MantineProvider>,
+        );
+
+        expect(
+            await screen.findByText(/something went wrong while preparing/i),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /try again/i }),
+        ).toBeInTheDocument();
+    });
+
+    it('skips provisioning when the organization already has a project', async () => {
+        vi.mocked(useOrganization).mockReturnValue({
+            data: { needsProject: false },
+        } as ReturnType<typeof useOrganization>);
+        renderModal();
+        await submitInvite();
+
+        await waitFor(() => {
+            expect(createInvite).toHaveBeenCalled();
+        });
+        expect(ensurePlayground).not.toHaveBeenCalled();
+        expect(navigate).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SetupInviteModal.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SetupInviteModal.tsx
@@ -1,4 +1,5 @@
 import {
+    FeatureFlags,
     getEmailSchema,
     InviteLinkPurpose,
     OrganizationMemberRole,
@@ -9,22 +10,35 @@ import {
     Button,
     CopyButton,
     Group,
+    Loader,
     Stack,
     Text,
     TextInput,
     Tooltip,
 } from '@mantine-8/core';
 import { useForm, zodResolver } from '@mantine/form';
+import { captureException } from '@sentry/react';
 import { IconCheck, IconCopy, IconUserPlus } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { useState, type FC } from 'react';
+import { useNavigate } from 'react-router';
 import { z } from 'zod';
+import { useOrganization } from '../../../hooks/organization/useOrganization';
+import { useEnsurePlaygroundProject } from '../../../hooks/useEnsurePlaygroundProject';
 import { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
 import { useUserUpdateMutation } from '../../../hooks/user/useUserUpdateMutation';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
+import Callout from '../../common/Callout';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
+import {
+    getPlaygroundSetupFailure,
+    isRetryablePlaygroundSetupFailure,
+    PLAYGROUND_SETUP_FAILURE_MESSAGES,
+    type PlaygroundSetupFailure,
+} from './playgroundSetupFailure';
 
 type SetupInviteFormValues = {
     firstName: string;
@@ -68,11 +82,42 @@ const SetupInviteModal: FC<{
     const { mutateAsync: updateUserAsync, isLoading: isUpdatingUser } =
         useUserUpdateMutation();
     const { track } = useTracking();
+    const navigate = useNavigate();
+
+    const newOnboardingFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
+    const { data: organization } = useOrganization();
+    const [playgroundFailure, setPlaygroundFailure] =
+        useState<PlaygroundSetupFailure | null>(null);
+    const {
+        mutateAsync: ensurePlaygroundAsync,
+        isLoading: isPreparingPlayground,
+    } = useEnsurePlaygroundProject();
+
+    // The flag says the flow exists, not that a playground can be provisioned:
+    // an org that already has a project would be sent into that project instead
+    const canOfferPlayground =
+        newOnboardingFlag.data?.enabled === true &&
+        organization?.needsProject === true &&
+        playgroundFailure === null;
 
     const handleClose = () => {
         form.reset();
         reset();
+        setPlaygroundFailure(null);
         onClose();
+    };
+
+    const preparePlayground = async () => {
+        try {
+            const { projectUuid } = await ensurePlaygroundAsync();
+            track({ name: EventName.PLAYGROUND_PROJECT_ENTERED });
+            void navigate(`/projects/${projectUuid}/home`);
+        } catch (error) {
+            setPlaygroundFailure(getPlaygroundSetupFailure(error));
+            captureException(error, {
+                tags: { feature: 'playground-onboarding' },
+            });
+        }
     };
 
     const handleSubmit = async (values: SetupInviteFormValues) => {
@@ -88,6 +133,10 @@ const SetupInviteModal: FC<{
             purpose: InviteLinkPurpose.Setup,
         });
         track({ name: EventName.SETUP_INVITE_SENT });
+
+        if (canOfferPlayground) {
+            await preparePlayground();
+        }
     };
 
     const isSubmitting = isLoading || isUpdatingUser;
@@ -99,10 +148,26 @@ const SetupInviteModal: FC<{
             title="Invite someone to set this up"
             icon={IconUserPlus}
             size="lg"
-            cancelLabel={inviteLink ? false : 'Cancel'}
+            cancelLabel={inviteLink || isPreparingPlayground ? false : 'Cancel'}
             actions={
-                inviteLink ? (
-                    <Button onClick={handleClose}>Done</Button>
+                isPreparingPlayground ? null : inviteLink ? (
+                    <Group gap="xs">
+                        {playgroundFailure &&
+                            isRetryablePlaygroundSetupFailure(
+                                playgroundFailure,
+                            ) && (
+                                <Button
+                                    variant="default"
+                                    onClick={() => {
+                                        setPlaygroundFailure(null);
+                                        void preparePlayground();
+                                    }}
+                                >
+                                    Try again
+                                </Button>
+                            )}
+                        <Button onClick={handleClose}>Done</Button>
+                    </Group>
                 ) : (
                     <Button
                         loading={isSubmitting}
@@ -114,54 +179,92 @@ const SetupInviteModal: FC<{
                 )
             }
         >
-            {inviteLink ? (
-                <Alert icon={<IconCheck />} color="green" title="Invite ready">
-                    <Stack gap="sm">
-                        <Text size="sm">
-                            {health.data?.hasEmailClient ? (
-                                <>
-                                    Invite sent to <b>{inviteLink.email}</b> —
-                                    we'll take them straight to warehouse setup.
-                                </>
-                            ) : (
-                                <>
-                                    Share this link with{' '}
-                                    <b>{inviteLink.email}</b> to take them
-                                    straight to warehouse setup.
-                                </>
-                            )}
+            {isPreparingPlayground ? (
+                <Group gap="md" wrap="nowrap">
+                    <Loader size="sm" />
+                    <Stack gap={2}>
+                        <Text size="sm" fw={500}>
+                            Preparing a sample project…
                         </Text>
-                        <TextInput
-                            readOnly
-                            className="sentry-block ph-no-capture"
-                            value={inviteLink.inviteUrl}
-                            rightSection={
-                                <CopyButton value={inviteLink.inviteUrl}>
-                                    {({ copied, copy }) => (
-                                        <Tooltip
-                                            label={copied ? 'Copied' : 'Copy'}
-                                            withArrow
-                                            position="right"
-                                        >
-                                            <ActionIcon
-                                                color={copied ? 'teal' : 'gray'}
-                                                onClick={copy}
-                                            >
-                                                <MantineIcon
-                                                    icon={
-                                                        copied
-                                                            ? IconCheck
-                                                            : IconCopy
-                                                    }
-                                                />
-                                            </ActionIcon>
-                                        </Tooltip>
-                                    )}
-                                </CopyButton>
-                            }
-                        />
+                        <Text size="sm" c="dimmed">
+                            Explore sample data while your expert connects your
+                            warehouse.
+                        </Text>
                     </Stack>
-                </Alert>
+                </Group>
+            ) : inviteLink ? (
+                <Stack gap="sm">
+                    {playgroundFailure && (
+                        <Callout
+                            variant="warning"
+                            title="We couldn't set up a sample project"
+                        >
+                            <Text size="sm">
+                                {
+                                    PLAYGROUND_SETUP_FAILURE_MESSAGES[
+                                        playgroundFailure
+                                    ]
+                                }
+                            </Text>
+                        </Callout>
+                    )}
+                    <Alert
+                        icon={<IconCheck />}
+                        color="green"
+                        title="Invite ready"
+                    >
+                        <Stack gap="sm">
+                            <Text size="sm">
+                                {health.data?.hasEmailClient ? (
+                                    <>
+                                        Invite sent to <b>{inviteLink.email}</b>{' '}
+                                        — we'll take them straight to warehouse
+                                        setup.
+                                    </>
+                                ) : (
+                                    <>
+                                        Share this link with{' '}
+                                        <b>{inviteLink.email}</b> to take them
+                                        straight to warehouse setup.
+                                    </>
+                                )}
+                            </Text>
+                            <TextInput
+                                readOnly
+                                className="sentry-block ph-no-capture"
+                                value={inviteLink.inviteUrl}
+                                rightSection={
+                                    <CopyButton value={inviteLink.inviteUrl}>
+                                        {({ copied, copy }) => (
+                                            <Tooltip
+                                                label={
+                                                    copied ? 'Copied' : 'Copy'
+                                                }
+                                                withArrow
+                                                position="right"
+                                            >
+                                                <ActionIcon
+                                                    color={
+                                                        copied ? 'teal' : 'gray'
+                                                    }
+                                                    onClick={copy}
+                                                >
+                                                    <MantineIcon
+                                                        icon={
+                                                            copied
+                                                                ? IconCheck
+                                                                : IconCopy
+                                                        }
+                                                    />
+                                                </ActionIcon>
+                                            </Tooltip>
+                                        )}
+                                    </CopyButton>
+                                }
+                            />
+                        </Stack>
+                    </Alert>
+                </Stack>
             ) : (
                 <form
                     id="setup_invite"

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/playgroundSetupFailure.test.ts
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/playgroundSetupFailure.test.ts
@@ -1,0 +1,51 @@
+import { type ApiError } from '@lightdash/common';
+import { getPlaygroundSetupFailure } from './playgroundSetupFailure';
+
+const apiError = (name: string, message: string): ApiError => ({
+    status: 'error',
+    error: { name, statusCode: 404, message, data: {} },
+});
+
+describe('getPlaygroundSetupFailure', () => {
+    it('detects an instance without playground support', () => {
+        expect(
+            getPlaygroundSetupFailure(
+                apiError(
+                    'NotFoundError',
+                    'Playground projects are not available',
+                ),
+            ),
+        ).toBe('unavailable');
+    });
+
+    it('detects a playground that was deleted', () => {
+        expect(
+            getPlaygroundSetupFailure(
+                apiError(
+                    'NotFoundError',
+                    'Playground project was previously removed',
+                ),
+            ),
+        ).toBe('previously-removed');
+    });
+
+    it('detects a permission failure', () => {
+        expect(
+            getPlaygroundSetupFailure(
+                apiError(
+                    'ForbiddenError',
+                    'User is not part of an organization',
+                ),
+            ),
+        ).toBe('forbidden');
+    });
+
+    it('falls back to unknown for unrecognised errors', () => {
+        expect(
+            getPlaygroundSetupFailure(
+                apiError('UnexpectedServerError', 'boom'),
+            ),
+        ).toBe('unknown');
+        expect(getPlaygroundSetupFailure(new Error('network'))).toBe('unknown');
+    });
+});

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/playgroundSetupFailure.ts
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/playgroundSetupFailure.ts
@@ -1,0 +1,38 @@
+import { isApiError } from '@lightdash/common';
+
+export type PlaygroundSetupFailure =
+    | 'unavailable'
+    | 'previously-removed'
+    | 'forbidden'
+    | 'unknown';
+
+export const getPlaygroundSetupFailure = (
+    error: unknown,
+): PlaygroundSetupFailure => {
+    if (!isApiError(error)) return 'unknown';
+    const { name, message } = error.error;
+    if (name === 'ForbiddenError') return 'forbidden';
+    if (name === 'NotFoundError') {
+        if (message.includes('previously removed')) return 'previously-removed';
+        if (message.includes('not available')) return 'unavailable';
+    }
+    return 'unknown';
+};
+
+export const PLAYGROUND_SETUP_FAILURE_MESSAGES: Record<
+    PlaygroundSetupFailure,
+    string
+> = {
+    unavailable:
+        "Sample projects aren't available on this instance. Your invite is still ready below.",
+    'previously-removed':
+        "Your organization's sample project was removed and can't be set up again. Your invite is still ready below.",
+    forbidden:
+        "You don't have permission to create a sample project. Your invite is still ready below.",
+    unknown:
+        'Something went wrong while preparing your sample project. Your invite is still ready below.',
+};
+
+export const isRetryablePlaygroundSetupFailure = (
+    failure: PlaygroundSetupFailure,
+): boolean => failure === 'unknown';

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
@@ -1,0 +1,156 @@
+import { ProjectType, type OrganizationProject } from '@lightdash/common';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useGithubConfig } from '../../../../components/common/GithubIntegration/hooks/useGithubIntegration';
+import { useGitlabRepositories } from '../../../../components/common/GitlabIntegration/hooks/useGitlabIntegration';
+import { useOrganization } from '../../../../hooks/organization/useOrganization';
+import { useGetSlack } from '../../../../hooks/slack/useSlack';
+import { useProject } from '../../../../hooks/useProject';
+import { useProjects } from '../../../../hooks/useProjects';
+import useApp from '../../../../providers/App/useApp';
+import { useRecommendedActions } from './useRecommendedActions';
+
+vi.mock(
+    '../../../../components/common/GithubIntegration/hooks/useGithubIntegration',
+);
+vi.mock(
+    '../../../../components/common/GitlabIntegration/hooks/useGitlabIntegration',
+);
+vi.mock('../../../../hooks/organization/useOrganization');
+vi.mock('../../../../hooks/slack/useSlack');
+vi.mock('../../../../hooks/useProject');
+vi.mock('../../../../hooks/useProjects');
+vi.mock('../../../../providers/App/useApp');
+
+const organizationProject = (
+    overrides: Partial<OrganizationProject>,
+): OrganizationProject => ({
+    projectUuid: 'project-uuid',
+    name: 'Project',
+    type: ProjectType.DEFAULT,
+    createdByUserUuid: null,
+    createdByUserName: null,
+    createdAt: new Date(0),
+    upstreamProjectUuid: null,
+    expiresAt: null,
+    ...overrides,
+});
+
+describe('useRecommendedActions', () => {
+    beforeEach(() => {
+        vi.mocked(useApp).mockReturnValue({
+            health: { data: {} },
+            user: {
+                data: {
+                    ability: { can: () => true },
+                },
+            },
+        } as unknown as ReturnType<typeof useApp>);
+        vi.mocked(useOrganization).mockReturnValue({
+            data: { needsProject: true },
+        } as ReturnType<typeof useOrganization>);
+        vi.mocked(useProject).mockReturnValue({
+            data: undefined,
+        } as ReturnType<typeof useProject>);
+        vi.mocked(useProjects).mockReturnValue({
+            data: [],
+        } as unknown as ReturnType<typeof useProjects>);
+        vi.mocked(useGithubConfig).mockReturnValue({
+            data: undefined,
+        } as ReturnType<typeof useGithubConfig>);
+        vi.mocked(useGitlabRepositories).mockReturnValue({
+            isSuccess: false,
+        } as ReturnType<typeof useGitlabRepositories>);
+        vi.mocked(useGetSlack).mockReturnValue({
+            data: undefined,
+            isSuccess: false,
+        } as ReturnType<typeof useGetSlack>);
+        localStorage.clear();
+    });
+
+    it('reloads skipped actions when the project changes', async () => {
+        localStorage.setItem(
+            'lightdash:recommended-actions:skipped:no-project',
+            JSON.stringify(['connect-slack']),
+        );
+        localStorage.setItem(
+            'lightdash:recommended-actions:skipped:project-uuid',
+            JSON.stringify(['add-semantic-layer']),
+        );
+
+        const { result, rerender } = renderHook(
+            ({ projectUuid }: { projectUuid: string | null }) =>
+                useRecommendedActions(projectUuid),
+            { initialProps: { projectUuid: null as string | null } },
+        );
+
+        expect(result.current.skippedActions).toEqual(['connect-slack']);
+
+        rerender({ projectUuid: 'project-uuid' });
+
+        await waitFor(() => {
+            expect(result.current.skippedActions).toEqual([
+                'add-semantic-layer',
+            ]);
+        });
+    });
+
+    describe('on a playground project', () => {
+        beforeEach(() => {
+            vi.mocked(useOrganization).mockReturnValue({
+                data: { needsProject: false },
+            } as ReturnType<typeof useOrganization>);
+            vi.mocked(useProject).mockReturnValue({
+                data: { provisioningSource: 'playground' },
+            } as unknown as ReturnType<typeof useProject>);
+            vi.mocked(useProjects).mockReturnValue({
+                data: [
+                    organizationProject({
+                        projectUuid: 'playground-uuid',
+                        provisioningSource: 'playground',
+                    }),
+                ],
+            } as unknown as ReturnType<typeof useProjects>);
+        });
+
+        it('keeps connect-warehouse as the only visible action', () => {
+            const { result } = renderHook(() =>
+                useRecommendedActions('playground-uuid'),
+            );
+
+            expect(result.current.visibleActions).toEqual([
+                'connect-warehouse',
+            ]);
+        });
+
+        it('does not count the playground as a connected warehouse', () => {
+            const { result } = renderHook(() =>
+                useRecommendedActions('playground-uuid'),
+            );
+
+            expect(
+                result.current.statuses['connect-warehouse'].isComplete,
+            ).toBe(false);
+            expect(result.current.hasPendingActions).toBe(true);
+        });
+
+        it('completes connect-warehouse once a real project exists', () => {
+            vi.mocked(useProjects).mockReturnValue({
+                data: [
+                    organizationProject({
+                        projectUuid: 'playground-uuid',
+                        provisioningSource: 'playground',
+                    }),
+                    organizationProject({ projectUuid: 'real-uuid' }),
+                ],
+            } as unknown as ReturnType<typeof useProjects>);
+
+            const { result } = renderHook(() =>
+                useRecommendedActions('playground-uuid'),
+            );
+
+            expect(
+                result.current.statuses['connect-warehouse'].isComplete,
+            ).toBe(true);
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
@@ -2,9 +2,10 @@ import { subject } from '@casl/ability';
 import {
     DbtProjectType,
     DbtProjectTypeLabels,
+    ProjectType,
     type HomepageRecommendedActionKey,
 } from '@lightdash/common';
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { useGithubConfig } from '../../../../components/common/GithubIntegration/hooks/useGithubIntegration';
 import { useGitlabRepositories } from '../../../../components/common/GitlabIntegration/hooks/useGitlabIntegration';
 import {
@@ -14,7 +15,9 @@ import {
 import { useOrganization } from '../../../../hooks/organization/useOrganization';
 import { useGetSlack } from '../../../../hooks/slack/useSlack';
 import { useProject } from '../../../../hooks/useProject';
+import { useProjects } from '../../../../hooks/useProjects';
 import useApp from '../../../../providers/App/useApp';
+import { isPlaygroundProvisioningSource } from '../../../../utils/playgroundProject';
 import {
     RECOMMENDED_ACTION_KEYS,
     readSkippedActions,
@@ -35,6 +38,7 @@ const useActionStatuses = (
     const { health } = useApp();
     const { data: organization } = useOrganization();
     const { data: project } = useProject(projectUuid ?? undefined);
+    const { data: projects } = useProjects();
     const { data: githubConfig } = useGithubConfig();
     const { data: slack, isSuccess: isSlackSuccess } = useGetSlack();
 
@@ -51,12 +55,26 @@ const useActionStatuses = (
     const isSlackConnected =
         isSlackSuccess && !!slack && slack.hasRequiredScopes !== false;
 
-    const warehouseType = project?.warehouseConnection?.type;
+    // A playground is a project, so `needsProject` alone would report the
+    // warehouse step as done on sample data
+    const hasRealWarehouseProject =
+        organization?.needsProject === false &&
+        (projects?.some(
+            ({ type, provisioningSource }) =>
+                type === ProjectType.DEFAULT &&
+                !isPlaygroundProvisioningSource(provisioningSource),
+        ) ??
+            false);
+    const warehouseType =
+        hasRealWarehouseProject &&
+        !isPlaygroundProvisioningSource(project?.provisioningSource)
+            ? project?.warehouseConnection?.type
+            : undefined;
 
     return {
         'connect-warehouse': {
             isVisible: true,
-            isComplete: organization?.needsProject === false,
+            isComplete: hasRealWarehouseProject,
             annotation: warehouseType ? getWarehouseLabel(warehouseType) : null,
             doneIcon: warehouseType
                 ? getWarehouseIcon(warehouseType, 'sm')
@@ -92,6 +110,10 @@ const useActionStatuses = (
 export const useRecommendedActions = (projectUuid: string | null) => {
     const { user } = useApp();
     const statuses = useActionStatuses(projectUuid);
+    const { data: project } = useProject(projectUuid ?? undefined);
+    const isPlaygroundProject = isPlaygroundProvisioningSource(
+        project?.provisioningSource,
+    );
     const [skippedActions, setSkippedActions] = useState<
         HomepageRecommendedActionKey[]
     >(() => readSkippedActions(projectUuid));
@@ -105,9 +127,15 @@ export const useRecommendedActions = (projectUuid: string | null) => {
             }),
         ) ?? false;
 
-    const visibleActions = RECOMMENDED_ACTION_KEYS.filter(
-        (key) => statuses[key].isVisible,
-    );
+    useEffect(() => {
+        setSkippedActions(readSkippedActions(projectUuid));
+    }, [projectUuid]);
+
+    // On sample data the only step worth offering is the way out — the rest
+    // point at the playground's own settings
+    const visibleActions = isPlaygroundProject
+        ? (['connect-warehouse'] as HomepageRecommendedActionKey[])
+        : RECOMMENDED_ACTION_KEYS.filter((key) => statuses[key].isVisible);
     const hasPendingActions =
         canManageProject &&
         visibleActions.some(

--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -145,9 +145,15 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
         },
     );
 
-    // Find fallback project: first try ProjectType.DEFAULT, then first available
+    // Find fallback project: first try a non-playground ProjectType.DEFAULT,
+    // then any DEFAULT, then first available
     const fallbackProject = shouldFetchFallbackProjects
-        ? projects?.find(({ type }) => type === ProjectType.DEFAULT) ||
+        ? projects?.find(
+              ({ type, provisioningSource }) =>
+                  type === ProjectType.DEFAULT &&
+                  provisioningSource !== 'playground',
+          ) ||
+          projects?.find(({ type }) => type === ProjectType.DEFAULT) ||
           projects?.[0]
         : undefined;
 

--- a/packages/frontend/src/hooks/useEnsurePlaygroundProject.ts
+++ b/packages/frontend/src/hooks/useEnsurePlaygroundProject.ts
@@ -1,0 +1,27 @@
+import {
+    type ApiError,
+    type EnsurePlaygroundProjectResults,
+} from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../api';
+
+const ensurePlaygroundProjectQuery = async () =>
+    lightdashApi<EnsurePlaygroundProjectResults>({
+        url: `/org/playground-projects/ensure`,
+        method: 'POST',
+        body: undefined,
+    });
+
+export const useEnsurePlaygroundProject = () => {
+    const queryClient = useQueryClient();
+    return useMutation<EnsurePlaygroundProjectResults, ApiError>(
+        ensurePlaygroundProjectQuery,
+        {
+            mutationKey: ['ensure_playground_project'],
+            onSuccess: async () => {
+                await queryClient.invalidateQueries(['organization']);
+                await queryClient.invalidateQueries(['projects']);
+            },
+        },
+    );
+};

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -78,6 +78,7 @@ type GenericEvent = {
         | EventName.BIGQUERY_SSO_SIGNIN_CLICKED
         | EventName.SNOWFLAKE_CLI_SSO_COMMAND_COPIED
         | EventName.SETUP_INVITE_SENT
+        | EventName.PLAYGROUND_PROJECT_ENTERED
         | EventName.AGENT_SETUP_PROMPT_COPIED;
     properties?: {};
 };

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -199,6 +199,7 @@ export enum EventName {
     BIGQUERY_SSO_SIGNIN_COMPLETED = 'bigquery_sso.signin_completed',
     SNOWFLAKE_CLI_SSO_COMMAND_COPIED = 'snowflake_cli_sso.command_copied',
     SETUP_INVITE_SENT = 'setup_invite.sent',
+    PLAYGROUND_PROJECT_ENTERED = 'playground_project.entered',
     ONBOARDING_PROJECT_READY_START_EXPLORING_CLICKED = 'onboarding_project_ready.start_exploring_clicked',
     HOMEPAGE_ASK_SUBMITTED = 'homepage_ask.submitted',
     HOMEPAGE_RECOMMENDED_ACTION_IMPRESSION = 'homepage_recommended_action.impression',

--- a/packages/frontend/src/utils/playgroundProject.ts
+++ b/packages/frontend/src/utils/playgroundProject.ts
@@ -1,0 +1,5 @@
+const PLAYGROUND_PROVISIONING_SOURCE = 'playground';
+
+export const isPlaygroundProvisioningSource = (
+    provisioningSource: string | null | undefined,
+): boolean => provisioningSource === PLAYGROUND_PROVISIONING_SOURCE;


### PR DESCRIPTION
Stack 6/9. This PR now carries only the frontend integration — the backend, warehouse and bundle content moved into the five PRs below it in the stack. The tree at this PR's head is byte-identical to the previously reviewed head `aa965254f` (verified: empty diff); nothing was rewritten, only resliced.

- Sample-data navbar banner on playground projects, linking to warehouse setup.
- Setup-invite modal provisions the playground and surfaces failures per cause (unavailable instance / previously removed / no permission / unknown + retry), invite kept as the explicit fallback; the playground is only offered when the org has no project.
- Recommended-actions checklist keeps a connect-warehouse action on playground projects; a playground does not count as a connected warehouse.
- Active-project fallback prefers non-playground projects; `useEnsurePlaygroundProject`; tracking event types.

Linear: PROD-9029

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWZc9bPFq2dnCVdXAxyZiu
