### PR TITLE
feat: view charts as code from chart actions

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -26,6 +26,7 @@ import {
     IconCircleCheck,
     IconCircleCheckFilled,
     IconCirclesRelation,
+    IconCode,
     IconCopy,
     IconDatabaseExport,
     IconDots,
@@ -52,6 +53,7 @@ import {
 } from 'react';
 import { useBlocker, useLocation, useNavigate, useParams } from 'react-router';
 import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
+import ChartAsCodeModal from '../../../features/contentAsCode/components/ChartAsCodeModal';
 import {
     explorerActions,
     selectHasUnsavedChanges,
@@ -191,6 +193,7 @@ const SavedChartsHeader: FC = () => {
         useDisclosure();
     const [isTransferToSpaceModalOpen, transferToSpaceModalHandlers] =
         useDisclosure();
+    const [isChartAsCodeModalOpen, chartAsCodeModalHandlers] = useDisclosure();
 
     const { user, health } = useApp();
     const { mutateAsync: contentAction, isLoading: isContentActionLoading } =
@@ -320,6 +323,16 @@ const SavedChartsHeader: FC = () => {
         user.data?.ability?.can(
             'manage',
             subject('SavedChart', { ...savedChart }),
+        );
+
+    const userCanViewContentAsCode =
+        project &&
+        user.data?.ability.can(
+            'view',
+            subject('ContentAsCode', {
+                organizationUuid: project.organizationUuid,
+                projectUuid: project.projectUuid,
+            }),
         );
 
     const userCanPromoteChart =
@@ -563,7 +576,8 @@ const SavedChartsHeader: FC = () => {
                 </div>
                 {(userCanManageChart ||
                     userCanCreateDeliveriesAndAlerts ||
-                    userCanManageExplore) && (
+                    userCanManageExplore ||
+                    userCanViewContentAsCode) && (
                     <Group gap="xs">
                         {userCanManageExplore && !isEditMode && (
                             <ExploreFromHereButton />
@@ -832,6 +846,23 @@ const SavedChartsHeader: FC = () => {
                                         </Menu.Item>
                                     )}
 
+                                {userCanViewContentAsCode && savedChart && (
+                                    <>
+                                        <Menu.Divider />
+                                        <Menu.Label>Content as code</Menu.Label>
+                                        <Menu.Item
+                                            leftSection={
+                                                <MantineIcon icon={IconCode} />
+                                            }
+                                            onClick={
+                                                chartAsCodeModalHandlers.open
+                                            }
+                                        >
+                                            View as code
+                                        </Menu.Item>
+                                    </>
+                                )}
+
                                 <Menu.Divider />
                                 <Menu.Label>Integrations</Menu.Label>
                                 {userCanCreateDeliveriesAndAlerts && (
@@ -912,6 +943,7 @@ const SavedChartsHeader: FC = () => {
                             <Menu.Target>
                                 <ActionIcon
                                     variant="default"
+                                    aria-label="Chart actions"
                                     disabled={!unsavedChartVersion.tableName}
                                 >
                                     <MantineIcon icon={IconDots} />
@@ -1075,6 +1107,16 @@ const SavedChartsHeader: FC = () => {
                         hasUnsavedChanges={hasUnsavedChanges && isEditMode}
                     />
                 )}
+
+            {savedChart && projectUuid && (
+                <ChartAsCodeModal
+                    opened={isChartAsCodeModalOpen}
+                    onClose={chartAsCodeModalHandlers.close}
+                    projectUuid={projectUuid}
+                    chartUuid={savedChart.uuid}
+                    hasUnsavedChanges={hasUnsavedChanges && isEditMode}
+                />
+            )}
         </TrackSection>
     );
 };

--- a/packages/frontend/src/features/contentAsCode/components/ChartAsCodeModal.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/ChartAsCodeModal.tsx
@@ -1,0 +1,41 @@
+import { type FC } from 'react';
+import { useChartAsCode } from '../hooks/useChartAsCode';
+import ContentAsCodeModal from './ContentAsCodeModal';
+
+type ChartAsCodeModalProps = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    chartUuid: string;
+    hasUnsavedChanges: boolean;
+};
+
+const ChartAsCodeModal: FC<ChartAsCodeModalProps> = ({
+    opened,
+    onClose,
+    projectUuid,
+    chartUuid,
+    hasUnsavedChanges,
+}) => {
+    const chartAsCode = useChartAsCode({
+        projectUuid,
+        chartUuid,
+        enabled: opened,
+    });
+
+    return (
+        <ContentAsCodeModal
+            opened={opened}
+            onClose={onClose}
+            resourceLabel="chart"
+            contentAsCode={chartAsCode}
+            warning={
+                hasUnsavedChanges
+                    ? 'This YAML contains the last saved version. Save the chart to include your current changes.'
+                    : undefined
+            }
+        />
+    );
+};
+
+export default ChartAsCodeModal;

--- a/packages/frontend/src/features/contentAsCode/components/ContentAsCodeModal.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/ContentAsCodeModal.tsx
@@ -1,0 +1,86 @@
+import { type ApiError } from '@lightdash/common';
+import { Button, Code, Stack, Text } from '@mantine-8/core';
+import { useClipboard } from '@mantine-8/hooks';
+import { IconCheck, IconCode, IconCopy } from '@tabler/icons-react';
+import { type FC } from 'react';
+import Callout from '../../../components/common/Callout';
+import EmptyStateLoader from '../../../components/common/EmptyStateLoader';
+import ErrorState from '../../../components/common/ErrorState';
+import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
+
+type ContentAsCodeModalProps = {
+    opened: boolean;
+    onClose: () => void;
+    resourceLabel: string;
+    contentAsCode: {
+        contentYaml: string | undefined;
+        isLoading: boolean;
+        error: ApiError | null;
+    };
+    warning?: string;
+};
+
+const ContentAsCodeModal: FC<ContentAsCodeModalProps> = ({
+    opened,
+    onClose,
+    resourceLabel,
+    contentAsCode,
+    warning,
+}) => {
+    const clipboard = useClipboard({ timeout: 1_000 });
+    const { contentYaml, isLoading, error } = contentAsCode;
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title={`View ${resourceLabel} as code`}
+            icon={IconCode}
+            size="xl"
+            cancelLabel="Close"
+            actions={
+                <Button
+                    disabled={!contentYaml}
+                    leftSection={
+                        <MantineIcon
+                            icon={clipboard.copied ? IconCheck : IconCopy}
+                        />
+                    }
+                    onClick={() => contentYaml && clipboard.copy(contentYaml)}
+                >
+                    {clipboard.copied ? 'Copied' : 'Copy YAML'}
+                </Button>
+            }
+        >
+            {warning && <Callout variant="warning">{warning}</Callout>}
+
+            {isLoading && (
+                <EmptyStateLoader
+                    mih={320}
+                    title={`Generating ${resourceLabel} YAML`}
+                />
+            )}
+
+            {error && <ErrorState error={error.error} hasMarginTop={false} />}
+
+            {!isLoading && !error && !contentYaml && (
+                <Callout variant="warning" title="Content not found">
+                    Lightdash could not generate content as code for this{' '}
+                    {resourceLabel}.
+                </Callout>
+            )}
+
+            {contentYaml && (
+                <Stack gap="xs">
+                    <Text fz="sm" c="dimmed">
+                        This YAML is compatible with Lightdash content as code.
+                    </Text>
+                    <Code block>{contentYaml}</Code>
+                </Stack>
+            )}
+        </MantineModal>
+    );
+};
+
+export default ContentAsCodeModal;

--- a/packages/frontend/src/features/contentAsCode/hooks/useChartAsCode.ts
+++ b/packages/frontend/src/features/contentAsCode/hooks/useChartAsCode.ts
@@ -1,0 +1,33 @@
+import { type ApiChartAsCodeListResponse } from '@lightdash/common';
+import { lightdashApi } from '../../../api';
+import { useContentAsCode } from './useContentAsCode';
+
+const CHART_FIELDS_TO_OMIT = ['updatedAt', 'downloadedAt'];
+
+const selectChart = (results: ApiChartAsCodeListResponse['results']) =>
+    results.charts[0];
+
+export const useChartAsCode = ({
+    projectUuid,
+    chartUuid,
+    enabled,
+}: {
+    projectUuid: string;
+    chartUuid: string;
+    enabled: boolean;
+}) => {
+    return useContentAsCode<ApiChartAsCodeListResponse['results']>({
+        queryKey: ['chart-as-code', projectUuid, chartUuid],
+        queryFn: () =>
+            lightdashApi<ApiChartAsCodeListResponse['results']>({
+                method: 'GET',
+                url: `/projects/${projectUuid}/code/charts?${new URLSearchParams(
+                    [['ids', chartUuid]],
+                ).toString()}`,
+                body: undefined,
+            }),
+        selectDocument: selectChart,
+        enabled,
+        fieldsToOmit: CHART_FIELDS_TO_OMIT,
+    });
+};

--- a/packages/frontend/src/features/contentAsCode/hooks/useContentAsCode.test.tsx
+++ b/packages/frontend/src/features/contentAsCode/hooks/useContentAsCode.test.tsx
@@ -1,0 +1,58 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { type FC, type PropsWithChildren } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { useContentAsCode } from './useContentAsCode';
+
+const selectDocument = (results: { documents: object[] }) =>
+    results.documents[0];
+const fieldsToOmit = ['downloadedAt'];
+const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+});
+
+const QueryWrapper: FC<PropsWithChildren> = ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('useContentAsCode', () => {
+    it('fetches only when enabled and creates deterministic YAML', async () => {
+        const queryFn = vi.fn().mockResolvedValue({
+            documents: [
+                {
+                    version: 1,
+                    name: 'Revenue dashboard',
+                    downloadedAt: '2026-07-21T08:00:00.000Z',
+                    contentType: 'dashboard',
+                },
+            ],
+        });
+
+        const { result, rerender } = renderHook(
+            ({ enabled }) =>
+                useContentAsCode({
+                    queryKey: ['content-as-code-test'],
+                    queryFn,
+                    selectDocument,
+                    fieldsToOmit,
+                    enabled,
+                }),
+            {
+                initialProps: { enabled: false },
+                wrapper: QueryWrapper,
+            },
+        );
+
+        expect(queryFn).not.toHaveBeenCalled();
+        expect(result.current.contentYaml).toBeUndefined();
+
+        rerender({ enabled: true });
+
+        await waitFor(() => expect(queryFn).toHaveBeenCalledOnce());
+        await waitFor(() =>
+            expect(result.current.contentYaml).toBe(
+                'contentType: dashboard\nname: Revenue dashboard\nversion: 1\n',
+            ),
+        );
+    });
+});

--- a/packages/frontend/src/features/contentAsCode/hooks/useContentAsCode.ts
+++ b/packages/frontend/src/features/contentAsCode/hooks/useContentAsCode.ts
@@ -1,0 +1,43 @@
+import { type ApiError } from '@lightdash/common';
+import { useQuery, type QueryKey } from '@tanstack/react-query';
+import * as yaml from 'js-yaml';
+import omit from 'lodash/omit';
+import { useMemo } from 'react';
+
+const NO_FIELDS_TO_OMIT: string[] = [];
+
+type UseContentAsCodeArgs<Results> = {
+    queryKey: QueryKey;
+    queryFn: () => Promise<Results>;
+    selectDocument: (results: Results) => object | undefined;
+    enabled: boolean;
+    fieldsToOmit?: string[];
+};
+
+export const useContentAsCode = <Results>({
+    queryKey,
+    queryFn,
+    selectDocument,
+    enabled,
+    fieldsToOmit = NO_FIELDS_TO_OMIT,
+}: UseContentAsCodeArgs<Results>) => {
+    const query = useQuery<Results, ApiError>({
+        queryKey,
+        queryFn,
+        enabled,
+    });
+
+    const contentYaml = useMemo(() => {
+        if (!query.data) return undefined;
+
+        const document = selectDocument(query.data);
+        if (!document) return undefined;
+
+        return yaml.dump(omit(document, fieldsToOmit), {
+            quotingType: '"',
+            sortKeys: true,
+        });
+    }, [fieldsToOmit, query.data, selectDocument]);
+
+    return { ...query, contentYaml };
+};


### PR DESCRIPTION
## Summary

- add a permission-gated **View as code** action to saved chart actions
- add a reusable `ContentAsCodeModal` for loading, error, YAML display, and copy states
- add a reusable `useContentAsCode` hook for lazy querying and deterministic YAML serialization
- keep chart endpoint and result selection in small chart-specific hook/modal adapters

## Testing

- `pnpm -F frontend exec vitest run src/features/contentAsCode/hooks/useContentAsCode.test.tsx`
- focused `oxfmt` and `oxlint` checks for the content-as-code components and hooks
- local smoke test in both View Chart and Explore, including YAML loading and Copy YAML

Relates: PROD-8969