### PR TITLE
fix: dashboard filters dropped on SQL chart tiles by TSOA validation

### DIFF
--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -250,7 +250,7 @@
                             "type": "boolean"
                         },
                         "tileTargets": {
-                            "$ref": "#/$defs/Record_string.DashboardTileTarget_"
+                            "$ref": "#/$defs/DashboardTileTargets"
                         }
                     },
                     "type": "object"
@@ -586,6 +586,25 @@
             "required": ["w", "h", "y", "x", "type"],
             "type": "object"
         },
+        "DashboardTileTarget": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/DashboardFieldTarget"
+                },
+                {
+                    "enum": [false],
+                    "type": "boolean"
+                }
+            ]
+        },
+        "DashboardTileTargets": {
+            "additionalProperties": {
+                "$ref": "#/$defs/DashboardTileTarget"
+            },
+            "description": "Deliberately an index-signature literal, not `Record<string, ...>`. When\nTSOA first resolves `Record<string, DashboardTileTarget>` inside a mapped\ntype (e.g. `Omit<DashboardFilterRule, 'id'>` in content-as-code types), it\ncaches an EMPTY model under the shared `Record_string.DashboardTileTarget_`\nname, and request validation then strips every tileTargets entry from\nbodies — silently breaking dashboard filters on SQL chart tiles. The\nindex-signature form resolves correctly in every context.",
+            "properties": {},
+            "type": "object"
+        },
         "DashboardTileTypes": {
             "enum": [
                 "saved_chart",
@@ -855,7 +874,7 @@
                     "description": "Target field for the filter"
                 },
                 "tileTargets": {
-                    "$ref": "#/$defs/Record_string.DashboardTileTarget_"
+                    "$ref": "#/$defs/DashboardTileTargets"
                 },
                 "values": {
                     "description": "Values to filter by",
@@ -886,11 +905,6 @@
             "additionalProperties": {
                 "$ref": "#/$defs/DashboardParameterValue"
             },
-            "description": "Construct a type with a set of properties K of type T",
-            "properties": {},
-            "type": "object"
-        },
-        "Record_string.DashboardTileTarget_": {
             "description": "Construct a type with a set of properties K of type T",
             "properties": {},
             "type": "object"

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -181,13 +181,26 @@ export const isDashboardFieldTarget = (
 
 export type DashboardTileTarget = DashboardFieldTarget | false;
 
+/**
+ * Deliberately an index-signature literal, not `Record<string, ...>`. When
+ * TSOA first resolves `Record<string, DashboardTileTarget>` inside a mapped
+ * type (e.g. `Omit<DashboardFilterRule, 'id'>` in content-as-code types), it
+ * caches an EMPTY model under the shared `Record_string.DashboardTileTarget_`
+ * name, and request validation then strips every tileTargets entry from
+ * bodies — silently breaking dashboard filters on SQL chart tiles. The
+ * index-signature form resolves correctly in every context.
+ */
+export type DashboardTileTargets = {
+    [tileUuid: string]: DashboardTileTarget;
+};
+
 export type DashboardFilterRule<
     O = FilterOperator,
     T extends DashboardFieldTarget = DashboardFieldTarget,
     V = AnyType,
     S = AnyType,
 > = FilterRule<O, T, V, S> & {
-    tileTargets?: Record<string, DashboardTileTarget>;
+    tileTargets?: DashboardTileTargets;
     label: undefined | string;
     singleValue?: boolean;
     /**
@@ -270,13 +283,13 @@ export type DashboardFilters = {
 
 export type DashboardFiltersFromSearchParam = {
     dimensions: (Omit<DashboardFilterRule, 'tileTargets'> & {
-        tileTargets?: (string | Record<string, DashboardTileTarget>)[];
+        tileTargets?: (string | DashboardTileTargets)[];
     })[];
     metrics: (Omit<DashboardFilterRule, 'tileTargets'> & {
-        tileTargets?: (string | Record<string, DashboardTileTarget>)[];
+        tileTargets?: (string | DashboardTileTargets)[];
     })[];
     tableCalculations: (Omit<DashboardFilterRule, 'tileTargets'> & {
-        tileTargets?: (string | Record<string, DashboardTileTarget>)[];
+        tileTargets?: (string | DashboardTileTargets)[];
     })[];
 };
 


### PR DESCRIPTION
## Summary

Since 0.3406.1 (Jul 17), dashboard filters mapped to SQL chart tiles have had no effect: results come back unfiltered even when the "Chart tiles" mapping is correctly configured. Regular chart tiles are also affected more subtly — per-tile filter overrides and exclusions are ignored and fall back to defaults.

## Root cause

TSOA request validation on the v2 query endpoints strips every `tileTargets` entry from `dashboardFilters` before they reach the backend. TSOA caches generated validation models first-write-wins: when it first resolves `Record<string, DashboardTileTarget>` inside a mapped type (`Omit<DashboardFilterRule, 'id'>` in the content-as-code types), it emits an EMPTY model under the shared `Record_string.DashboardTileTarget_` name — no `additionalProperties` — so validation rebuilds every tile-target record as `{}`. #25677 didn't touch filter logic but reordered TSOA's type resolution so the broken context wins; the regression shipped with the regenerated `routes.ts` in 0.3406.1.

With `tileTargets` emptied, the SQL-chart path (`getDashboardFilterRulesForTileAndReferences`, which requires an explicit tile override) drops the filter entirely and `SqlQueryBuilder` never adds the WHERE clause.

Saved dashboards are unaffected — dashboard saves go through the legacy Express router, not TSOA — which is why the filter configuration looks intact in the UI.

## Fix

Declare the record as a named index-signature alias (`DashboardTileTargets`) instead of an inline `Record<string, ...>`. TSOA resolves the alias through its own declaration in every context, so both the mapped-type and direct usages generate the correct model. (A plain `type X = Record<string, ...>` alias does NOT work — the checker normalizes it away.)

## Testing

- Reproduced on local main: dashboard filter mapped to a SQL chart column returned unfiltered rows, response echoed `appliedDashboardFilters: {dimensions: []}` despite a well-formed request.
- After fix: same request echoes the applied filter and returns only matching rows.
- `Record_string.DashboardTileTarget_` no longer exists in generated spec; `DashboardTileTargets` carries `additionalProperties` correctly.
- Typechecks pass on common/backend/frontend. The alias is structurally identical to the previous `Record`, so no downstream type changes.

Follow-up (separate PR): `Record_string.string_` is poisoned the same way (via the checker-inferred language-map types), and a generation-time check to fail CI when any record schema is generated empty.

Closes: PROD-9036
Closes: #25838

🤖 Generated with [Claude Code](https://claude.com/claude-code)
