### PR TITLE
feat: add data apps to homepage Resources block with thumbnails

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -1256,11 +1256,9 @@ export class AppGenerateService extends BaseService {
         await this.assertDataAppsEnabled(user);
 
         const app = await this.appModel.getApp(appUuid, projectUuid);
-        await this.assertCanManageApp(
-            user,
-            app,
-            'Insufficient permissions to view app thumbnail',
-        );
+        // Viewing a thumbnail is a read: anyone who can view the app can see it
+        // (e.g. on a project homepage), not just those who can manage it.
+        await this.assertCanViewApp(user, app);
 
         const { client: s3Client, bucket } = this.getS3Client();
         const key = AppGenerateService.appThumbnailKey(appUuid);

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -34,7 +34,8 @@ export type HomepageResourceKind =
     | 'doc'
     | 'link'
     | 'claude'
-    | 'youtube';
+    | 'youtube'
+    | 'data-app';
 
 export type HomepageResourceItem = {
     title: string;
@@ -43,6 +44,10 @@ export type HomepageResourceItem = {
     // Optional for back-compat with already-stored items; new items always set them.
     description?: string;
     imageUrl?: string;
+    // Set only for `kind: 'data-app'` items. The referenced app's uuid is used
+    // to fetch its live thumbnail — data app thumbnails are short-lived signed
+    // URLs, so they're resolved at render time rather than baked into `imageUrl`.
+    appUuid?: string;
 };
 
 export type HomepageResourcesLayout = 'card' | 'list';

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/DataAppPickerModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/DataAppPickerModal.tsx
@@ -1,0 +1,207 @@
+import {
+    ContentType,
+    contentToResourceViewItem,
+    type HomepageResourceItem,
+    type SummaryContent,
+} from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Checkbox,
+    Group,
+    Loader,
+    Stack,
+    Text,
+    TextInput,
+} from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import { IconAppWindow, IconSearch } from '@tabler/icons-react';
+import { useMemo, useRef, useState, type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import MantineModal from '../../../../components/common/MantineModal';
+import { ResourceIcon } from '../../../../components/common/ResourceIcon';
+import { useInfiniteContent } from '../../../../hooks/useContent';
+import classes from './blockStyles.module.css';
+
+const PAGE_SIZE = 50;
+
+/** Build a resource item from a picked data app. Thumbnails aren't baked in —
+ * they're fetched live at render time from `appUuid` (see ResourcesBlock). */
+const dataAppToResourceItem = (
+    projectUuid: string,
+    content: SummaryContent,
+): HomepageResourceItem => ({
+    kind: 'data-app',
+    appUuid: content.uuid,
+    url: `/projects/${projectUuid}/n${content.uuid}`,
+    title: content.name,
+    ...(content.description ? { description: content.description } : {}),
+});
+
+const AppRow: FC<{
+    content: SummaryContent;
+    checked: boolean;
+    alreadyAdded: boolean;
+    onToggle: () => void;
+}> = ({ content, checked, alreadyAdded, onToggle }) => (
+    <Group
+        gap="sm"
+        wrap="nowrap"
+        className={classes.pickerRow}
+        onClick={alreadyAdded ? undefined : onToggle}
+        data-disabled={alreadyAdded || undefined}
+    >
+        <Checkbox size="xs" checked={checked || alreadyAdded} readOnly />
+        <ResourceIcon item={contentToResourceViewItem(content)} />
+        <Text size="sm" truncate flex={1}>
+            {content.name}
+        </Text>
+        {alreadyAdded && (
+            <Text size="xs" c="dimmed">
+                Added
+            </Text>
+        )}
+    </Group>
+);
+
+const DataAppPicker: FC<{
+    projectUuid: string;
+    existingAppUuids: string[];
+    onApply: (items: HomepageResourceItem[]) => void;
+    /** Hands the modal footer's Add button a callback that commits the current
+     * selection — the footer lives in MantineModal, outside this component. */
+    registerApply: (commit: () => void) => void;
+}> = ({ projectUuid, existingAppUuids, onApply, registerApply }) => {
+    const [search, setSearch] = useState('');
+    const [debouncedSearch] = useDebouncedValue(search, 300);
+    const [selected, setSelected] = useState<Map<string, SummaryContent>>(
+        new Map(),
+    );
+
+    // Re-point the parent's apply ref every render so it always commits the
+    // latest selection (idempotent, so safe during render — no effect needed).
+    registerApply(() =>
+        onApply(
+            [...selected.values()].map((content) =>
+                dataAppToResourceItem(projectUuid, content),
+            ),
+        ),
+    );
+
+    const {
+        data,
+        isInitialLoading,
+        hasNextPage,
+        fetchNextPage,
+        isFetchingNextPage,
+    } = useInfiniteContent(
+        {
+            projectUuids: [projectUuid],
+            contentTypes: [ContentType.DATA_APP],
+            pageSize: PAGE_SIZE,
+            search: debouncedSearch || undefined,
+        },
+        { keepPreviousData: true },
+    );
+
+    const apps = useMemo(
+        () => (data?.pages ?? []).flatMap((page) => page.data),
+        [data],
+    );
+    const existing = useMemo(
+        () => new Set(existingAppUuids),
+        [existingAppUuids],
+    );
+
+    const toggle = (content: SummaryContent) =>
+        setSelected((prev) => {
+            const next = new Map(prev);
+            if (next.has(content.uuid)) next.delete(content.uuid);
+            else next.set(content.uuid, content);
+            return next;
+        });
+
+    return (
+        <Stack gap="sm">
+            <TextInput
+                size="xs"
+                placeholder="Search data apps..."
+                leftSection={<MantineIcon icon={IconSearch} size={14} />}
+                value={search}
+                onChange={(e) => setSearch(e.currentTarget.value)}
+                autoFocus
+            />
+            <Box h="min(56vh, 560px)" className={classes.pickerScrollList}>
+                {isInitialLoading ? (
+                    <Group justify="center" p="md">
+                        <Loader size="sm" />
+                    </Group>
+                ) : apps.length === 0 ? (
+                    <Text size="sm" c="dimmed" p="sm">
+                        No data apps found.
+                    </Text>
+                ) : (
+                    <Stack gap={2}>
+                        {apps.map((content) => (
+                            <AppRow
+                                key={content.uuid}
+                                content={content}
+                                checked={selected.has(content.uuid)}
+                                alreadyAdded={existing.has(content.uuid)}
+                                onToggle={() => toggle(content)}
+                            />
+                        ))}
+                        {hasNextPage && (
+                            <Button
+                                variant="subtle"
+                                size="xs"
+                                w="fit-content"
+                                loading={isFetchingNextPage}
+                                onClick={() => void fetchNextPage()}
+                            >
+                                Load more
+                            </Button>
+                        )}
+                    </Stack>
+                )}
+            </Box>
+        </Stack>
+    );
+};
+
+export const DataAppPickerModal: FC<{
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    existingAppUuids: string[];
+    onAdd: (items: HomepageResourceItem[]) => void;
+}> = ({ opened, onClose, projectUuid, existingAppUuids, onAdd }) => {
+    // The Add/Cancel footer is MantineModal's own — it lives outside the
+    // remountable picker body, so the picker hands its commit fn up via ref.
+    const applyRef = useRef<() => void>(() => {});
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Add data apps"
+            icon={IconAppWindow}
+            size="lg"
+            confirmLabel="Add"
+            onConfirm={() => {
+                applyRef.current();
+                onClose();
+            }}
+        >
+            {opened && (
+                <DataAppPicker
+                    projectUuid={projectUuid}
+                    existingAppUuids={existingAppUuids}
+                    onApply={onAdd}
+                    registerApply={(fn) => {
+                        applyRef.current = fn;
+                    }}
+                />
+            )}
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -5,6 +5,7 @@ import {
 } from '@lightdash/common';
 import {
     ActionIcon,
+    Button,
     Group,
     SegmentedControl,
     Select,
@@ -13,6 +14,7 @@ import {
     TextInput,
 } from '@mantine-8/core';
 import {
+    IconAppWindow,
     IconBook,
     IconBrandYoutube,
     IconExternalLink,
@@ -34,8 +36,10 @@ import {
     type KeyboardEvent,
 } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
+import { useAppThumbnailUrl } from '../../../../features/apps/hooks/useAppThumbnail';
 import { BlockHeader, IconSquare, MiniPill } from './BlockShell';
 import classes from './blockStyles.module.css';
+import { DataAppPickerModal } from './DataAppPickerModal';
 import { PageGrid, PageGridItem } from './PageGrid';
 import {
     faviconUrl,
@@ -67,11 +71,18 @@ const KIND_META: Record<
         label: 'YouTube',
         thumbAccent: classes.resThumbYoutube,
     },
+    'data-app': {
+        icon: IconAppWindow,
+        label: 'Data app',
+        thumbAccent: classes.resThumbDataApp,
+    },
 };
 
-const KIND_OPTIONS = (Object.keys(KIND_META) as HomepageResourceKind[]).map(
-    (kind) => ({ value: kind, label: KIND_META[kind].label }),
-);
+// Data apps are added via the picker, not the kind dropdown, so they're
+// excluded from the manually-selectable kinds.
+const KIND_OPTIONS = (Object.keys(KIND_META) as HomepageResourceKind[])
+    .filter((kind) => kind !== 'data-app')
+    .map((kind) => ({ value: kind, label: KIND_META[kind].label }));
 
 const kindMeta = (kind: HomepageResourceKind) =>
     KIND_META[kind] ?? KIND_META.link;
@@ -83,7 +94,74 @@ const isDefaultFavicon = (img: HTMLImageElement) => img.naturalWidth < 32;
 
 // --- Thumbnails -------------------------------------------------------------
 
-const CardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
+// Data app thumbnails are short-lived signed URLs, so they're fetched live
+// from `appUuid` at render time. Missing thumbnail (or no view access) →
+// falls back to the data app glyph on a polished accent background.
+const DataAppCardThumb: FC<{
+    item: HomepageResourceItem;
+    projectUuid: string;
+}> = ({ item, projectUuid }) => {
+    const [failed, setFailed] = useState(false);
+    const { data } = useAppThumbnailUrl(
+        projectUuid,
+        item.appUuid,
+        !!item.appUuid,
+    );
+    const thumbnailUrl = data?.thumbnailUrl;
+    if (thumbnailUrl && !failed) {
+        return (
+            <div className={classes.resThumb}>
+                <img
+                    src={thumbnailUrl}
+                    alt={item.title}
+                    loading="lazy"
+                    onError={() => setFailed(true)}
+                />
+            </div>
+        );
+    }
+    return (
+        <div className={`${classes.resThumbTile} ${classes.resThumbDataApp}`}>
+            <div className={classes.resGlyphTile}>
+                <MantineIcon icon={IconAppWindow} size={22} />
+            </div>
+        </div>
+    );
+};
+
+const DataAppRowThumb: FC<{
+    item: HomepageResourceItem;
+    projectUuid: string;
+}> = ({ item, projectUuid }) => {
+    const [failed, setFailed] = useState(false);
+    const { data } = useAppThumbnailUrl(
+        projectUuid,
+        item.appUuid,
+        !!item.appUuid,
+    );
+    const thumbnailUrl = data?.thumbnailUrl;
+    if (thumbnailUrl && !failed) {
+        return (
+            <div className={classes.rowThumb}>
+                <img
+                    src={thumbnailUrl}
+                    alt=""
+                    loading="lazy"
+                    onError={() => setFailed(true)}
+                />
+            </div>
+        );
+    }
+    return (
+        <div
+            className={`${classes.rowThumb} ${classes.rowThumbFallback} ${classes.resThumbDataApp}`}
+        >
+            <MantineIcon icon={IconAppWindow} size={18} />
+        </div>
+    );
+};
+
+const UrlCardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
     const meta = kindMeta(item.kind);
     const [imgFailed, setImgFailed] = useState(false);
     const [faviconFailed, setFaviconFailed] = useState(false);
@@ -129,7 +207,17 @@ const CardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
     );
 };
 
-const RowThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
+const CardThumb: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
+    item,
+    projectUuid,
+}) =>
+    item.kind === 'data-app' ? (
+        <DataAppCardThumb item={item} projectUuid={projectUuid} />
+    ) : (
+        <UrlCardThumb item={item} />
+    );
+
+const UrlRowThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
     const [imgFailed, setImgFailed] = useState(false);
     const [faviconFailed, setFaviconFailed] = useState(false);
     const imageUrl = safeImageUrl(item.imageUrl);
@@ -166,50 +254,85 @@ const RowThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
     return <IconSquare icon={kindMeta(item.kind).icon} />;
 };
 
+const RowThumb: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
+    item,
+    projectUuid,
+}) =>
+    item.kind === 'data-app' ? (
+        <DataAppRowThumb item={item} projectUuid={projectUuid} />
+    ) : (
+        <UrlRowThumb item={item} />
+    );
+
 // --- Read-only presentation (published + preview) ---------------------------
 
-const ResourceCard: FC<{ item: HomepageResourceItem }> = ({ item }) => (
-    <a
-        href={item.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={`${classes.mediaCard} ${classes.cardUnit1} ${classes.clickable} ${classes.plainLink}`}
-    >
-        <MantineIcon
-            icon={IconExternalLink}
-            size={13}
-            className={classes.resExternal}
-        />
-        <CardThumb item={item} />
-        <div className={classes.mediaBody}>
-            <div className={classes.mediaTitle}>
-                {item.title || hostnameOf(item.url)}
-            </div>
-            <div className={classes.mediaDesc}>
-                {item.description || hostnameOf(item.url)}
-            </div>
-        </div>
-    </a>
-);
+// Data apps are internal links; everything else is an external resource. The
+// external-link chrome (new tab, hostname fallback) only applies to the latter.
+const isDataApp = (item: HomepageResourceItem) => item.kind === 'data-app';
 
-const ResourceRow: FC<{ item: HomepageResourceItem }> = ({ item }) => {
-    const meta = kindMeta(item.kind);
+const ResourceCard: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
+    item,
+    projectUuid,
+}) => {
+    const dataApp = isDataApp(item);
     return (
         <a
             href={item.url}
-            target="_blank"
-            rel="noopener noreferrer"
+            target={dataApp ? undefined : '_blank'}
+            rel={dataApp ? undefined : 'noopener noreferrer'}
+            className={`${classes.mediaCard} ${classes.cardUnit1} ${classes.clickable} ${classes.plainLink}`}
+        >
+            {!dataApp && (
+                <MantineIcon
+                    icon={IconExternalLink}
+                    size={13}
+                    className={classes.resExternal}
+                />
+            )}
+            <CardThumb item={item} projectUuid={projectUuid} />
+            <div className={classes.mediaBody}>
+                <div className={classes.mediaTitle}>
+                    {item.title || hostnameOf(item.url)}
+                </div>
+                <div className={classes.mediaDesc}>
+                    {item.description ||
+                        (dataApp
+                            ? kindMeta(item.kind).label
+                            : hostnameOf(item.url))}
+                </div>
+            </div>
+        </a>
+    );
+};
+
+const ResourceRow: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
+    item,
+    projectUuid,
+}) => {
+    const meta = kindMeta(item.kind);
+    const dataApp = isDataApp(item);
+    return (
+        <a
+            href={item.url}
+            target={dataApp ? undefined : '_blank'}
+            rel={dataApp ? undefined : 'noopener noreferrer'}
             className={`${classes.listRow} ${classes.clickable} ${classes.plainLink}`}
         >
-            <RowThumb item={item} />
+            <RowThumb item={item} projectUuid={projectUuid} />
             <div className={classes.flexFill}>
                 <div className={classes.rowName}>{item.title}</div>
                 <div className={classes.rowMeta}>
-                    {item.description || hostnameOf(item.url)}
+                    {item.description || (dataApp ? '' : hostnameOf(item.url))}
                 </div>
             </div>
             <MiniPill>{meta.label}</MiniPill>
-            <MantineIcon icon={IconExternalLink} size={14} color="ldGray.4" />
+            {!dataApp && (
+                <MantineIcon
+                    icon={IconExternalLink}
+                    size={14}
+                    color="ldGray.4"
+                />
+            )}
         </a>
     );
 };
@@ -217,6 +340,7 @@ const ResourceRow: FC<{ item: HomepageResourceItem }> = ({ item }) => {
 export const ResourcesBlockView: FC<BlockComponentProps> = ({
     block,
     itemSpan,
+    projectUuid,
 }) => {
     if (block.type !== 'resources' || block.config.items.length === 0) {
         return null;
@@ -229,14 +353,21 @@ export const ResourcesBlockView: FC<BlockComponentProps> = ({
                 <PageGrid itemSpan={itemSpan ?? null}>
                     {block.config.items.map((item, i) => (
                         <PageGridItem key={`${item.url}-${i}`}>
-                            <ResourceCard item={item} />
+                            <ResourceCard
+                                item={item}
+                                projectUuid={projectUuid}
+                            />
                         </PageGridItem>
                     ))}
                 </PageGrid>
             ) : (
                 <div className={classes.listCard}>
                     {block.config.items.map((item, i) => (
-                        <ResourceRow key={`${item.url}-${i}`} item={item} />
+                        <ResourceRow
+                            key={`${item.url}-${i}`}
+                            item={item}
+                            projectUuid={projectUuid}
+                        />
                     ))}
                 </div>
             )}
@@ -277,6 +408,7 @@ const SkeletonRow: FC = () => (
 
 type EditProps = {
     item: HomepageResourceItem;
+    projectUuid: string;
     onPatch: (patch: Partial<HomepageResourceItem>) => void;
     onRemove: () => void;
 };
@@ -297,13 +429,25 @@ const KindSelect: FC<{
     />
 );
 
-const BuildCard: FC<EditProps> = ({ item, onPatch, onRemove }) => (
+// Data app kind is fixed (set by the picker) — show a static pill instead of
+// the editable dropdown so it can't be switched to a URL-based kind.
+const KindControl: FC<{
+    item: HomepageResourceItem;
+    onChange: (kind: HomepageResourceKind) => void;
+}> = ({ item, onChange }) =>
+    item.kind === 'data-app' ? (
+        <MiniPill>{kindMeta(item.kind).label}</MiniPill>
+    ) : (
+        <KindSelect value={item.kind} onChange={onChange} />
+    );
+
+const BuildCard: FC<EditProps> = ({ item, projectUuid, onPatch, onRemove }) => (
     <div className={classes.mediaCard}>
-        <CardThumb item={item} />
+        <CardThumb item={item} projectUuid={projectUuid} />
         <div className={classes.mediaBody}>
             <Group gap={4} justify="space-between" wrap="nowrap">
-                <KindSelect
-                    value={item.kind}
+                <KindControl
+                    item={item}
                     onChange={(kind) => onPatch({ kind })}
                 />
                 <ActionIcon
@@ -340,9 +484,9 @@ const BuildCard: FC<EditProps> = ({ item, onPatch, onRemove }) => (
     </div>
 );
 
-const BuildRow: FC<EditProps> = ({ item, onPatch, onRemove }) => (
+const BuildRow: FC<EditProps> = ({ item, projectUuid, onPatch, onRemove }) => (
     <div className={classes.listRow}>
-        <RowThumb item={item} />
+        <RowThumb item={item} projectUuid={projectUuid} />
         <div className={classes.flexFill}>
             <TextInput
                 variant="unstyled"
@@ -361,7 +505,7 @@ const BuildRow: FC<EditProps> = ({ item, onPatch, onRemove }) => (
                 }
             />
         </div>
-        <KindSelect value={item.kind} onChange={(kind) => onPatch({ kind })} />
+        <KindControl item={item} onChange={(kind) => onPatch({ kind })} />
         <ActionIcon
             variant="subtle"
             color="ldGray.6"
@@ -390,6 +534,7 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
 }) => {
     const [pasteValue, setPasteValue] = useState('');
     const [batch, setBatch] = useState<BatchEntry[]>([]);
+    const [isAppPickerOpen, setIsAppPickerOpen] = useState(false);
     const keyCounter = useRef(0);
 
     // Flush the paste batch into config once every URL has resolved — a single
@@ -424,6 +569,19 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
 
     const removeItem = (index: number) =>
         patchConfig({ items: items.filter((_, i) => i !== index) });
+
+    const existingAppUuids = items.flatMap((it) =>
+        it.kind === 'data-app' && it.appUuid ? [it.appUuid] : [],
+    );
+
+    const addDataApps = (newItems: HomepageResourceItem[]) => {
+        const known = new Set(existingAppUuids);
+        const deduped = newItems.filter(
+            (it) => !it.appUuid || !known.has(it.appUuid),
+        );
+        if (deduped.length === 0) return;
+        patchConfig({ items: [...items, ...deduped] });
+    };
 
     const startResolving = (text: string) => {
         const urls = Array.from(
@@ -514,6 +672,7 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
                         <PageGridItem key={`${item.url}-${i}`}>
                             <BuildCard
                                 item={item}
+                                projectUuid={projectUuid}
                                 onPatch={(patch) => patchItem(i, patch)}
                                 onRemove={() => removeItem(i)}
                             />
@@ -521,7 +680,10 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
                     ))}
                     {resolvedBatch.map((e) => (
                         <PageGridItem key={e.key}>
-                            <ResourceCard item={e.item} />
+                            <ResourceCard
+                                item={e.item}
+                                projectUuid={projectUuid}
+                            />
                         </PageGridItem>
                     ))}
                     {Array.from({ length: pendingCount }).map((_, i) => (
@@ -536,12 +698,17 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
                         <BuildRow
                             key={`${item.url}-${i}`}
                             item={item}
+                            projectUuid={projectUuid}
                             onPatch={(patch) => patchItem(i, patch)}
                             onRemove={() => removeItem(i)}
                         />
                     ))}
                     {resolvedBatch.map((e) => (
-                        <ResourceRow key={e.key} item={e.item} />
+                        <ResourceRow
+                            key={e.key}
+                            item={e.item}
+                            projectUuid={projectUuid}
+                        />
                     ))}
                     {Array.from({ length: pendingCount }).map((_, i) => (
                         <SkeletonRow key={`sk-${i}`} />
@@ -568,9 +735,26 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
                     <MantineIcon icon={IconPlus} />
                 </ActionIcon>
             </Group>
-            <div className={classes.buildHint}>
-                Paste multiple links (one per line) to add them all at once.
-            </div>
+            <Group justify="space-between" wrap="nowrap" gap="xs">
+                <div className={classes.buildHint}>
+                    Paste multiple links (one per line) to add them all at once.
+                </div>
+                <Button
+                    variant="subtle"
+                    size="xs"
+                    leftSection={<MantineIcon icon={IconAppWindow} />}
+                    onClick={() => setIsAppPickerOpen(true)}
+                >
+                    Add data app
+                </Button>
+            </Group>
+            <DataAppPickerModal
+                opened={isAppPickerOpen}
+                onClose={() => setIsAppPickerOpen(false)}
+                projectUuid={projectUuid}
+                existingAppUuids={existingAppUuids}
+                onAdd={addDataApps}
+            />
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -535,6 +535,17 @@ a .hoverCard:hover,
     color: light-dark(#b0453a, #dd8a80);
 }
 
+/* Data apps use the brand orange, tinted into a quiet backdrop for the
+ * icon fallback when an app has no thumbnail. */
+.resThumbDataApp {
+    background: linear-gradient(
+        135deg,
+        light-dark(#fff3e8, #362a1c),
+        light-dark(#f8e3cd, #2c2114)
+    );
+    color: light-dark(#c2410c, #fdba74);
+}
+
 /* External-link affordance: quiet corner mark, revealed on hover. */
 .resExternal {
     position: absolute;

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/registry.tsx
@@ -103,7 +103,8 @@ export const blockLibrary: BlockDefinition[] = [
     {
         type: 'resources',
         label: 'Resources',
-        description: 'Rich cards — Claude artifacts, YouTube, docs, links.',
+        description:
+            'Rich cards — data apps, Claude artifacts, YouTube, docs, links.',
         icon: IconBook,
         create: () => ({
             id: uuidv4(),


### PR DESCRIPTION
### Description:

Adds data apps as an option in the homepage builder's **Resources** block.

- **Add data app**: a new button in the Resources block opens a searchable picker modal to browse and multi-select the project's data apps. Selected apps are added as resource items (deduped against ones already in the block).
- **Thumbnails**: data app cards/rows render the app's uploaded thumbnail when one exists. Thumbnails are short-lived signed URLs, so they're fetched live at render time from the app uuid rather than baked into the config. When an app has no thumbnail (or the viewer lacks access), it falls back to the standard data app icon on a polished orange backdrop.
- Data app items link internally (same tab) and skip the external-link chrome that URL resources use; their kind is fixed (shown as a static pill, not the editable kind dropdown).
- Relaxes `AppGenerateService.getThumbnailUrl` from a manage check to a view check, so regular homepage viewers can see thumbnails for apps they can view.

Generated API artifacts (`routes.ts`/`swagger.json`) are intentionally not committed — the pre-commit hook unstages them and the release workflow regenerates them; the source of truth is the `HomepageResourceKind` type in `@lightdash/common`.

<!-- Even better add a screenshot / gif / loom -->
