### PR TITLE
feat: view scheduled deliveries as code

### DIFF
--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -775,6 +775,7 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
                         <SchedulersViewActionMenu
                             item={item}
                             projectUuid={itemProjectUuid}
+                            organizationUuid={project?.organizationUuid}
                             onReassignOwner={handleReassignOwner}
                         />
                     </Box>

--- a/packages/frontend/src/components/SchedulersView/SchedulersViewActionMenu.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewActionMenu.tsx
@@ -1,5 +1,9 @@
+import { subject } from '@casl/ability';
+import { SchedulerFormat } from '@lightdash/common';
 import { ActionIcon, Menu } from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
 import {
+    IconCode,
     IconDots,
     IconEdit,
     IconSend,
@@ -10,10 +14,12 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import React, { type FC } from 'react';
 import { Link } from 'react-router';
+import ScheduledDeliveryAsCodeModal from '../../features/contentAsCode/components/ScheduledDeliveryAsCodeModal';
 import { SchedulerDeleteModal } from '../../features/scheduler';
 import ConfirmSendNowModal from '../../features/scheduler/components/ConfirmSendNowModal';
 import { getSchedulerDeliveryType } from '../../features/scheduler/components/types';
 import { useSendNowSchedulerByUuid } from '../../features/scheduler/hooks/useScheduler';
+import useApp from '../../providers/App/useApp';
 import MantineIcon from '../common/MantineIcon';
 import {
     getItemLink,
@@ -27,6 +33,7 @@ interface SchedulersViewActionMenuProps {
     onClose?: () => void;
     item: SchedulerItem;
     projectUuid?: string | null;
+    organizationUuid?: string | null;
     onReassignOwner?: (
         schedulerUuid: string,
         ownerUuid: string | undefined,
@@ -37,12 +44,36 @@ interface SchedulersViewActionMenuProps {
 const SchedulersViewActionMenu: FC<SchedulersViewActionMenuProps> = ({
     item,
     projectUuid,
+    organizationUuid,
     onReassignOwner,
     hideReassign = false,
 }) => {
     const [isDeleting, setIsDeleting] = React.useState(false);
     const [isConfirmOpen, setIsConfirmOpen] = React.useState(false);
+    const [isAsCodeOpen, asCodeModalHandlers] = useDisclosure(false);
     const queryClient = useQueryClient();
+    const { user } = useApp();
+
+    const contentAsCodeSubject =
+        projectUuid && organizationUuid
+            ? subject('ContentAsCode', { projectUuid, organizationUuid })
+            : undefined;
+    const scheduledDeliveriesSubject =
+        projectUuid && organizationUuid
+            ? subject('ScheduledDeliveries', {
+                  projectUuid,
+                  organizationUuid,
+              })
+            : undefined;
+    const isScheduledDelivery =
+        !item.thresholds?.length &&
+        item.format !== SchedulerFormat.GSHEETS &&
+        Boolean(item.slug);
+    const userCanViewAsCode =
+        contentAsCodeSubject &&
+        scheduledDeliveriesSubject &&
+        user.data?.ability.can('view', contentAsCodeSubject) &&
+        user.data.ability.can('manage', scheduledDeliveriesSubject);
 
     const sendNowMutation = useSendNowSchedulerByUuid(item.schedulerUuid);
 
@@ -97,6 +128,16 @@ const SchedulersViewActionMenu: FC<SchedulersViewActionMenuProps> = ({
                     >
                         Send now
                     </Menu.Item>
+                    {isScheduledDelivery && userCanViewAsCode && (
+                        <Menu.Item
+                            component="button"
+                            role="menuitem"
+                            leftSection={<MantineIcon icon={IconCode} />}
+                            onClick={asCodeModalHandlers.open}
+                        >
+                            View as code
+                        </Menu.Item>
+                    )}
                     {!hideReassign && (
                         <Menu.Item
                             component="button"
@@ -143,6 +184,14 @@ const SchedulersViewActionMenu: FC<SchedulersViewActionMenuProps> = ({
                     setIsConfirmOpen(false);
                 }}
             />
+            {projectUuid && isAsCodeOpen && (
+                <ScheduledDeliveryAsCodeModal
+                    opened={isAsCodeOpen}
+                    onClose={asCodeModalHandlers.close}
+                    projectUuid={projectUuid}
+                    deliverySlug={item.slug}
+                />
+            )}
         </>
     );
 };

--- a/packages/frontend/src/features/contentAsCode/components/ScheduledDeliveryAsCodeModal.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/ScheduledDeliveryAsCodeModal.tsx
@@ -1,0 +1,35 @@
+import { type FC } from 'react';
+import { useScheduledDeliveryAsCode } from '../hooks/useScheduledDeliveryAsCode';
+import ContentAsCodeModal from './ContentAsCodeModal';
+
+type ScheduledDeliveryAsCodeModalProps = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    deliverySlug: string;
+};
+
+const ScheduledDeliveryAsCodeModal: FC<ScheduledDeliveryAsCodeModalProps> = ({
+    opened,
+    onClose,
+    projectUuid,
+    deliverySlug,
+}) => {
+    const scheduledDeliveryAsCode = useScheduledDeliveryAsCode({
+        projectUuid,
+        deliverySlug,
+        enabled: opened,
+    });
+
+    return (
+        <ContentAsCodeModal
+            opened={opened}
+            onClose={onClose}
+            resourceLabel="scheduled delivery"
+            contentAsCode={scheduledDeliveryAsCode}
+            warning={scheduledDeliveryAsCode.data?.skipped[0]?.reason}
+        />
+    );
+};
+
+export default ScheduledDeliveryAsCodeModal;

--- a/packages/frontend/src/features/contentAsCode/hooks/useScheduledDeliveryAsCode.ts
+++ b/packages/frontend/src/features/contentAsCode/hooks/useScheduledDeliveryAsCode.ts
@@ -1,0 +1,34 @@
+import { type ApiScheduledDeliveryAsCodeListResponse } from '@lightdash/common';
+import { lightdashApi } from '../../../api';
+import { useContentAsCode } from './useContentAsCode';
+
+const SCHEDULED_DELIVERY_FIELDS_TO_OMIT = ['downloadedAt'];
+
+const selectScheduledDelivery = (
+    results: ApiScheduledDeliveryAsCodeListResponse['results'],
+) => results.scheduledDeliveries[0];
+
+export const useScheduledDeliveryAsCode = ({
+    projectUuid,
+    deliverySlug,
+    enabled,
+}: {
+    projectUuid: string;
+    deliverySlug: string;
+    enabled: boolean;
+}) => {
+    return useContentAsCode<ApiScheduledDeliveryAsCodeListResponse['results']>({
+        queryKey: ['scheduled-delivery-as-code', projectUuid, deliverySlug],
+        queryFn: () =>
+            lightdashApi<ApiScheduledDeliveryAsCodeListResponse['results']>({
+                method: 'GET',
+                url: `/projects/${projectUuid}/code/scheduledDeliveries?${new URLSearchParams(
+                    [['slugs', deliverySlug]],
+                ).toString()}`,
+                body: undefined,
+            }),
+        selectDocument: selectScheduledDelivery,
+        enabled,
+        fieldsToOmit: SCHEDULED_DELIVERY_FIELDS_TO_OMIT,
+    });
+};

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerList.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerList.tsx
@@ -23,6 +23,7 @@ import {
     TextInput,
     Tooltip,
 } from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
 import {
     IconBell,
     IconBrandGoogle,
@@ -31,6 +32,7 @@ import {
     IconCalendarClock,
     IconCalendarTime,
     IconClock,
+    IconCode,
     IconHistory,
     IconMail,
     IconPencil,
@@ -65,6 +67,7 @@ import { useGetSlackChannelName } from '../../../../../hooks/slack/useGetSlackCh
 import { useActiveProjectUuid } from '../../../../../hooks/useActiveProject';
 import { useProject } from '../../../../../hooks/useProject';
 import useApp from '../../../../../providers/App/useApp';
+import ScheduledDeliveryAsCodeModal from '../../../../contentAsCode/components/ScheduledDeliveryAsCodeModal';
 import { useSendNowSchedulerByUuid } from '../../../hooks/useScheduler';
 import { useSchedulerAiAugmentation } from '../../../hooks/useSchedulerAiAugmentation';
 import { useSchedulersEnabledUpdateMutation } from '../../../hooks/useSchedulersUpdateMutation';
@@ -138,6 +141,7 @@ const SchedulerDetail: FC<{
 
     const [isConfirmSendNowOpen, setIsConfirmSendNowOpen] = useState(false);
     const [isConfirmPauseOpen, setIsConfirmPauseOpen] = useState(false);
+    const [isAsCodeOpen, asCodeModalHandlers] = useDisclosure(false);
 
     const canManage = useMemo(
         () =>
@@ -161,6 +165,36 @@ const SchedulerDetail: FC<{
                 }),
             ),
         [user.data, activeProjectUuid],
+    );
+    const canViewAsCode = useMemo(
+        () =>
+            !isThresholdAlert &&
+            Boolean(scheduler.slug) &&
+            Boolean(
+                activeProjectUuid &&
+                project &&
+                user.data?.ability.can(
+                    'view',
+                    subject('ContentAsCode', {
+                        organizationUuid: project.organizationUuid,
+                        projectUuid: activeProjectUuid,
+                    }),
+                ) &&
+                user.data.ability.can(
+                    'manage',
+                    subject('ScheduledDeliveries', {
+                        organizationUuid: project.organizationUuid,
+                        projectUuid: activeProjectUuid,
+                    }),
+                ),
+            ),
+        [
+            activeProjectUuid,
+            isThresholdAlert,
+            project,
+            scheduler.slug,
+            user.data,
+        ],
     );
 
     const frequency =
@@ -450,6 +484,15 @@ const SchedulerDetail: FC<{
                         <span />
                     )}
                     <Group gap="sm">
+                        {canViewAsCode && (
+                            <Button
+                                variant="default"
+                                leftSection={<MantineIcon icon={IconCode} />}
+                                onClick={asCodeModalHandlers.open}
+                            >
+                                View as code
+                            </Button>
+                        )}
                         {canManage && (
                             <Button
                                 variant="default"
@@ -468,6 +511,15 @@ const SchedulerDetail: FC<{
                         </Button>
                     </Group>
                 </div>
+            )}
+
+            {activeProjectUuid && isAsCodeOpen && (
+                <ScheduledDeliveryAsCodeModal
+                    opened={isAsCodeOpen}
+                    onClose={asCodeModalHandlers.close}
+                    projectUuid={activeProjectUuid}
+                    deliverySlug={scheduler.slug}
+                />
             )}
 
             <ConfirmSendNowModal


### PR DESCRIPTION
### ![CleanShot 2026-07-21 at 11.57.17.png](https://app.graphite.com/user-attachments/assets/1626a686-ef73-465d-ba90-77a40e9bf213.png)



### Description

Adds View as code to the selected delivery in the chart/dashboard Scheduled deliveries modal and to the project schedulers action menu. Both entry points reuse the generic content-as-code modal and lazy query hook, so the request runs only after the action is clicked.

The UI matches the backend content-as-code and scheduled-delivery permission checks and only exposes portable scheduled deliveries. Alerts and Google Sheets syncs remain separate because they have distinct resources and endpoints.

### Verification

- Verified the action and generated YAML in the local Scheduled deliveries modal
- Focused frontend formatting passed
- Focused frontend lint passed with zero warnings
- Content-as-code lazy-query unit test passed
- Commit is SSH-signed

Relates: PROD-8969