### PR TITLE
feat: view dashboards as code

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -24,6 +24,7 @@ import {
     IconBolt,
     IconCircleCheck,
     IconCircleCheckFilled,
+    IconCode,
     IconCopy,
     IconDatabase,
     IconDatabaseExport,
@@ -60,6 +61,7 @@ import {
     useResolvedHomepage,
     useSetPersonalHomepage,
 } from '../../../ee/features/homepageBuilder/hooks/useProjectHomepage';
+import DashboardAsCodeModal from '../../../features/contentAsCode/components/DashboardAsCodeModal';
 import { PromotionConfirmDialog } from '../../../features/promotion/components/PromotionConfirmDialog';
 import {
     usePromoteDashboardDiffMutation,
@@ -190,6 +192,8 @@ const DashboardHeader = memo(
             useDisclosure(false);
         const [isPreAggAuditOpen, preAggAuditHandlers] = useDisclosure(false);
         const [isPreAggRefreshOpen, preAggRefreshHandlers] =
+            useDisclosure(false);
+        const [isDashboardAsCodeModalOpen, dashboardAsCodeModalHandlers] =
             useDisclosure(false);
 
         const uniquePreAggregateNames = useMemo(() => {
@@ -326,6 +330,16 @@ const DashboardHeader = memo(
             'manage',
             subject('ExportCsv', { organizationUuid, projectUuid }),
         );
+
+        const userCanViewContentAsCode =
+            project &&
+            user.data?.ability.can(
+                'view',
+                subject('ContentAsCode', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid: project.projectUuid,
+                }),
+            );
 
         const userCanPinDashboard = user.data?.ability.can(
             'manage',
@@ -738,7 +752,8 @@ const DashboardHeader = memo(
                                 shadow="md"
                                 disabled={
                                     !userCanManageDashboard &&
-                                    !userCanExportData
+                                    !userCanExportData &&
+                                    !userCanViewContentAsCode
                                 }
                             >
                                 <Menu.Target>
@@ -1019,6 +1034,27 @@ const DashboardHeader = memo(
                                         </Menu.Item>
                                     )}
 
+                                    {userCanViewContentAsCode && (
+                                        <>
+                                            <Menu.Divider />
+                                            <Menu.Label>
+                                                Content as code
+                                            </Menu.Label>
+                                            <Menu.Item
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconCode}
+                                                    />
+                                                }
+                                                onClick={
+                                                    dashboardAsCodeModalHandlers.open
+                                                }
+                                            >
+                                                View as code
+                                            </Menu.Item>
+                                        </>
+                                    )}
+
                                     {userCanManageDashboard && (
                                         <>
                                             <Menu.Divider />
@@ -1063,6 +1099,17 @@ const DashboardHeader = memo(
                                     toggleScheduledDeliveriesModal(false)
                                 }
                                 initialSchedulerUuid={initialSchedulerUuid}
+                            />
+                        )}
+                        {projectUuid && (
+                            <DashboardAsCodeModal
+                                opened={isDashboardAsCodeModalOpen}
+                                onClose={dashboardAsCodeModalHandlers.close}
+                                projectUuid={projectUuid}
+                                dashboardUuid={dashboard.uuid}
+                                hasUnsavedChanges={
+                                    hasDashboardChanged && isEditMode
+                                }
                             />
                         )}
                         {(promoteDashboardDiff ||

--- a/packages/frontend/src/features/contentAsCode/components/DashboardAsCodeModal.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/DashboardAsCodeModal.tsx
@@ -1,0 +1,41 @@
+import { type FC } from 'react';
+import { useDashboardAsCode } from '../hooks/useDashboardAsCode';
+import ContentAsCodeModal from './ContentAsCodeModal';
+
+type DashboardAsCodeModalProps = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    dashboardUuid: string;
+    hasUnsavedChanges: boolean;
+};
+
+const DashboardAsCodeModal: FC<DashboardAsCodeModalProps> = ({
+    opened,
+    onClose,
+    projectUuid,
+    dashboardUuid,
+    hasUnsavedChanges,
+}) => {
+    const dashboardAsCode = useDashboardAsCode({
+        projectUuid,
+        dashboardUuid,
+        enabled: opened,
+    });
+
+    return (
+        <ContentAsCodeModal
+            opened={opened}
+            onClose={onClose}
+            resourceLabel="dashboard"
+            contentAsCode={dashboardAsCode}
+            warning={
+                hasUnsavedChanges
+                    ? 'This YAML contains the last saved version. Save the dashboard to include your current changes.'
+                    : undefined
+            }
+        />
+    );
+};
+
+export default DashboardAsCodeModal;

--- a/packages/frontend/src/features/contentAsCode/hooks/useDashboardAsCode.ts
+++ b/packages/frontend/src/features/contentAsCode/hooks/useDashboardAsCode.ts
@@ -1,0 +1,33 @@
+import { type ApiDashboardAsCodeListResponse } from '@lightdash/common';
+import { lightdashApi } from '../../../api';
+import { useContentAsCode } from './useContentAsCode';
+
+const DASHBOARD_FIELDS_TO_OMIT = ['updatedAt', 'downloadedAt'];
+
+const selectDashboard = (results: ApiDashboardAsCodeListResponse['results']) =>
+    results.dashboards[0];
+
+export const useDashboardAsCode = ({
+    projectUuid,
+    dashboardUuid,
+    enabled,
+}: {
+    projectUuid: string;
+    dashboardUuid: string;
+    enabled: boolean;
+}) => {
+    return useContentAsCode<ApiDashboardAsCodeListResponse['results']>({
+        queryKey: ['dashboard-as-code', projectUuid, dashboardUuid],
+        queryFn: () =>
+            lightdashApi<ApiDashboardAsCodeListResponse['results']>({
+                method: 'GET',
+                url: `/projects/${projectUuid}/code/dashboards?${new URLSearchParams(
+                    [['ids', dashboardUuid]],
+                ).toString()}`,
+                body: undefined,
+            }),
+        selectDocument: selectDashboard,
+        enabled,
+        fieldsToOmit: DASHBOARD_FIELDS_TO_OMIT,
+    });
+};


### PR DESCRIPTION
![CleanShot 2026-07-21 at 11.56.39.png](https://app.graphite.com/user-attachments/assets/11946831-c0de-47da-ad07-b2f4474384ec.png)





### Description

Adds View as code to the dashboard action menu using the generic content-as-code modal and lazy query hook from the chart PR. The request runs only after the modal opens, uses the existing resource-scoped permission, omits non-portable timestamps, and warns when dashboard edits are unsaved.

### Verification

- Focused frontend formatting passed
- Focused frontend lint passed with zero warnings
- Content-as-code lazy-query unit test passed
- Commit is SSH-signed

Relates: PROD-8969