### PR TITLE
feat: view AI agents as code

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentAsCodeModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentAsCodeModal.tsx
@@ -1,0 +1,34 @@
+import { type FC } from 'react';
+import ContentAsCodeModal from '../../../../features/contentAsCode/components/ContentAsCodeModal';
+import { useAiAgentAsCode } from '../hooks/useAiAgentAsCode';
+
+type AiAgentAsCodeModalProps = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    agentUuid: string;
+};
+
+const AiAgentAsCodeModal: FC<AiAgentAsCodeModalProps> = ({
+    opened,
+    onClose,
+    projectUuid,
+    agentUuid,
+}) => {
+    const aiAgentAsCode = useAiAgentAsCode({
+        projectUuid,
+        agentUuid,
+        enabled: opened,
+    });
+
+    return (
+        <ContentAsCodeModal
+            opened={opened}
+            onClose={onClose}
+            resourceLabel="AI agent"
+            contentAsCode={aiAgentAsCode}
+        />
+    );
+};
+
+export default AiAgentAsCodeModal;

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader.tsx
@@ -1,5 +1,7 @@
-import { ActionIcon, Box, Button, Group, Tooltip } from '@mantine-8/core';
+import { ActionIcon, Box, Button, Group, Menu, Tooltip } from '@mantine-8/core';
 import {
+    IconCode,
+    IconDots,
     IconSettings,
     IconShare2,
     IconWindowMinimize,
@@ -13,6 +15,7 @@ type Props = {
     leftSection?: ReactNode;
     onMinimize?: () => void;
     onShare?: () => void;
+    onViewAsCode?: () => void;
     isSharing?: boolean;
     settingsHref?: string;
 };
@@ -21,6 +24,7 @@ export const AgentPageHeader: FC<Props> = ({
     leftSection,
     onMinimize,
     onShare,
+    onViewAsCode,
     isSharing,
     settingsHref,
 }) => (
@@ -35,13 +39,6 @@ export const AgentPageHeader: FC<Props> = ({
                         onClick={onShare}
                         loading={isSharing}
                         aria-label="Share thread"
-                        styles={(theme) => ({
-                            root: {
-                                borderColor: theme.colors.ldGray[2],
-                                boxShadow: `var(--mantine-shadow-subtle)`,
-                                color: theme.colors.ldGray[9],
-                            },
-                        })}
                     >
                         <MantineIcon icon={IconShare2} size={14} stroke={1.8} />
                     </ActionIcon>
@@ -57,17 +54,9 @@ export const AgentPageHeader: FC<Props> = ({
                             icon={IconWindowMinimize}
                             size={14}
                             stroke={1.8}
-                            style={{ transform: 'scaleX(-1)' }}
+                            className={styles.flippedIcon}
                         />
                     }
-                    styles={(theme) => ({
-                        root: {
-                            borderColor: theme.colors.ldGray[2],
-                            boxShadow: `var(--mantine-shadow-subtle)`,
-                            color: theme.colors.ldGray[9],
-                            fontSize: theme.fontSizes.xs,
-                        },
-                    })}
                 >
                     Minimize
                 </Button>
@@ -85,17 +74,33 @@ export const AgentPageHeader: FC<Props> = ({
                             stroke={1.8}
                         />
                     }
-                    styles={(theme) => ({
-                        root: {
-                            borderColor: theme.colors.ldGray[2],
-                            boxShadow: `var(--mantine-shadow-subtle)`,
-                            color: theme.colors.ldGray[9],
-                            fontSize: theme.fontSizes.xs,
-                        },
-                    })}
                 >
                     Settings
                 </Button>
+            )}
+            {onViewAsCode && (
+                <Menu position="bottom-end" withArrow withinPortal shadow="md">
+                    <Menu.Target>
+                        <ActionIcon
+                            variant="default"
+                            size="md"
+                            radius="md"
+                            className={`${styles.action} ${styles.actionIcon}`}
+                            aria-label="More actions"
+                        >
+                            <MantineIcon icon={IconDots} />
+                        </ActionIcon>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                        <Menu.Label>Content as code</Menu.Label>
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconCode} />}
+                            onClick={onViewAsCode}
+                        >
+                            View as code
+                        </Menu.Item>
+                    </Menu.Dropdown>
+                </Menu>
             )}
         </Group>
     </Group>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/agentPageHeader.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/agentPageHeader.module.css
@@ -4,4 +4,16 @@
 
 .action {
     height: rem(32px);
+    border-color: var(--mantine-color-ldGray-2);
+    box-shadow: var(--mantine-shadow-subtle);
+    color: var(--mantine-color-ldGray-9);
+    font-size: var(--mantine-font-size-xs);
+}
+
+.actionIcon {
+    width: rem(32px);
+}
+
+.flippedIcon {
+    transform: scaleX(-1);
 }

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAsCode.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAsCode.ts
@@ -1,0 +1,32 @@
+import { type ApiAgentAsCodeListResponse } from '@lightdash/common';
+import { lightdashApi } from '../../../../api';
+import { useContentAsCode } from '../../../../features/contentAsCode/hooks/useContentAsCode';
+
+const AI_AGENT_FIELDS_TO_OMIT = ['updatedAt', 'downloadedAt'];
+
+const selectAiAgent = (results: ApiAgentAsCodeListResponse['results']) =>
+    results.agents[0];
+
+export const useAiAgentAsCode = ({
+    projectUuid,
+    agentUuid,
+    enabled,
+}: {
+    projectUuid: string;
+    agentUuid: string;
+    enabled: boolean;
+}) =>
+    useContentAsCode<ApiAgentAsCodeListResponse['results']>({
+        queryKey: ['ai-agent-as-code', projectUuid, agentUuid],
+        queryFn: () =>
+            lightdashApi<ApiAgentAsCodeListResponse['results']>({
+                method: 'GET',
+                url: `/projects/${projectUuid}/code/aiAgents?${new URLSearchParams(
+                    [['ids', agentUuid]],
+                ).toString()}`,
+                body: undefined,
+            }),
+        selectDocument: selectAiAgent,
+        enabled,
+        fieldsToOmit: AI_AGENT_FIELDS_TO_OMIT,
+    });

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -1,5 +1,7 @@
+import { subject } from '@casl/ability';
 import { type AiAgent } from '@lightdash/common';
 import { Box, Group, Loader, Stack, Text, TextInput } from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
 import { IconShare2 } from '@tabler/icons-react';
 import { useCallback, useState } from 'react';
 import {
@@ -15,6 +17,7 @@ import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { AgentSelector } from '../../features/aiCopilot/components/AgentSelector';
+import AiAgentAsCodeModal from '../../features/aiCopilot/components/AiAgentAsCodeModal';
 import { AgentPageHeader } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader';
 import { AgentSidebar } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentSidebar';
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
@@ -76,6 +79,17 @@ const AgentPage = () => {
         useCreateAgentThreadShareMutation();
     const [isShareModalOpen, setIsShareModalOpen] = useState(false);
     const [shareUrl, setShareUrl] = useState<string | null>(null);
+    const [isAgentAsCodeModalOpen, agentAsCodeModalHandlers] = useDisclosure();
+
+    const canViewContentAsCode =
+        agent &&
+        user.data?.ability.can(
+            'view',
+            subject('ContentAsCode', {
+                organizationUuid: agent.organizationUuid,
+                projectUuid: agent.projectUuid,
+            }),
+        );
 
     const handleMinimize = useCallback(
         (targetUrl?: string, options?: NavigateFromAgentChatOptions) => {
@@ -235,6 +249,11 @@ const AgentPage = () => {
                         }
                         isSharing={isCreatingShare}
                         onMinimize={() => handleMinimize()}
+                        onViewAsCode={
+                            canViewContentAsCode
+                                ? agentAsCodeModalHandlers.open
+                                : undefined
+                        }
                         settingsHref={
                             canManageAgents
                                 ? `/projects/${projectUuid}/ai-agents/${agent.uuid}/edit`
@@ -244,6 +263,12 @@ const AgentPage = () => {
                 ) : undefined
             }
         >
+            <AiAgentAsCodeModal
+                opened={isAgentAsCodeModalOpen}
+                onClose={agentAsCodeModalHandlers.close}
+                projectUuid={agent.projectUuid}
+                agentUuid={agent.uuid}
+            />
             <MantineModal
                 opened={isShareModalOpen}
                 onClose={closeShareModal}


### PR DESCRIPTION
### ![CleanShot 2026-07-21 at 12.04.37.png](https://app.graphite.com/user-attachments/assets/80c24d0a-5b26-4aa2-9e1d-9bfac5a3b10d.png)



### Description

Adds View as code to the AI agent header using the generic content-as-code modal and lazy query hook. The request runs only after the modal opens, uses the agent resource identifiers for the existing content-as-code permission, and omits non-portable timestamps.

### Verification

- Focused frontend formatting passed
- Focused frontend lint passed with zero warnings
- Content-as-code lazy-query unit test passed
- Commit is SSH-signed

Relates: PROD-8969