### PR TITLE
chore: pin chrome-devtools-mcp to 1.5.0

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "chrome-devtools": {
       "command": "pnpx",
-      "args": ["chrome-devtools-mcp@latest", "--isolated"]
+      "args": ["chrome-devtools-mcp@1.5.0", "--isolated"]
     },
     "lightdash-docs": {
       "type": "http",


### PR DESCRIPTION
## What

Pin `chrome-devtools-mcp` to `1.5.0` in `.mcp.json` (was `@latest`).

## Why

`.mcp.json` launches the Chrome DevTools MCP via `chrome-devtools-mcp@latest`, so `pnpx` silently re-resolves to the newest published release on every launch — an implicit, unpinned upgrade.

`chrome-devtools-mcp` **1.6.0** (published 2026-07-14) changed the browser launch default from **headless to headful**. In any environment without a display / X server — dev containers, remote dev boxes, CI, and the coding agents that use this MCP — `new_page` then fails with:

> Missing X server to start the headful browser

so the MCP "suddenly" stops working with no change on our side.

Pinning to **1.5.0** (the last release with the headless default) restores stable behaviour and removes the floating-`@latest` risk of future silent breakage. We can bump deliberately when we want a newer version.

## Scope

Tooling config only (`.mcp.json`) — no product or runtime code.

Linear: SPK-614

🤖 Generated with [Claude Code](https://claude.com/claude-code)
