### PR TITLE
fix(dashboards): register SQL chart tile parameters on the dashboard

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     ChartKind,
+    getParameterReferences,
     isVizCartesianChartConfig,
     isVizPieChartConfig,
     isVizTableConfig,
@@ -105,6 +106,9 @@ const SqlChartTile: FC<Props> = ({
         (c) => c.updateSqlChartTilesMetadata,
     );
     const parameters = useDashboardContext((c) => c.parameterValues);
+    const addParameterReferences = useDashboardContext(
+        (c) => c.addParameterReferences,
+    );
     const markTileScreenshotReady = useDashboardTileStatusContext(
         (c) => c.markTileScreenshotReady,
     );
@@ -163,6 +167,18 @@ const SqlChartTile: FC<Props> = ({
             animation: false,
         };
     }, [chartResultsData?.chartSpec]);
+
+    // Report the parameters this chart's SQL needs so the dashboard renders
+    // controls for them. Derived from the SQL rather than the query response,
+    // so the controls appear before the first (otherwise failing) run.
+    const parameterReferences = useMemo(
+        () => getParameterReferences(chartData?.sql),
+        [chartData?.sql],
+    );
+
+    useEffect(() => {
+        addParameterReferences(tile.uuid, parameterReferences);
+    }, [addParameterReferences, tile.uuid, parameterReferences]);
 
     // Update SQL chart columns in the dashboard context
     useEffect(() => {


### PR DESCRIPTION
Closes #25847

## Problem

A SQL runner chart whose SQL references a project parameter works when opened directly, but breaks when added to a dashboard: no parameter control appears, and the tile fails with `Missing values for SQL parameter(s): …`.

The dashboard's parameter set is built entirely by a *push* from tiles — `addParameterReferences` had exactly one call site (`useDashboardChartReadyQuery`), used only by explore-based chart tiles. `DashboardSqlChartTile` never called it, so:

`dashboardParameterReferences` stays empty → `referencedParameters` is empty → no controls render → `parameterValues` is `{}` → `combineParameters` finds no value → `ParameterError` thrown in `AsyncQueryService.prepareSqlChartAsyncQueryArgs`.

The rest of the plumbing already worked: values *are* passed from dashboard context into the SQL tile query and merged with chart-saved and project defaults server-side. Only the registration of references was missing.

## Fix

Derive the references from the chart's SQL and register them, mirroring what the standalone viewer already does (`ViewSqlChart.tsx`).

Chose SQL-derivation over consuming the `parameterReferences` the backend already returns on the dashboard-sql-chart response (currently discarded in `executeQuery.ts`, which keeps only `queryUuid`). Deriving client-side means the controls appear on first render rather than only after a query that is guaranteed to fail — no chicken-and-egg.

## Regression analysis

- **Explore chart tiles** — untouched; they keep using the `useDashboardChartReadyQuery` path.
- **Dashboards with no parameterised SQL tiles** — `getParameterReferences` returns `[]`, so an empty array is registered under the tile uuid. `dashboardParameterReferences` is a flattened set, so an empty entry changes nothing; the `!dashboardParameterReferences.size` early-return in `missingRequiredParameters` still holds.
- **Tile removal** — the provider already prunes references for tiles no longer on the dashboard, so no stale entries.
- **Embed dashboards** — `DashboardSqlChartTile` is shared, and the embed parameter bar filters by the same reference set, so embedded dashboards get the same fix.
- **Parameters not defined at project level** — still resolve to no definition, so no control renders. Unchanged, and out of scope here; definitions come from `/projects/:uuid/parameters?names=` and explore tables only.

## Testing

Verified locally against a dashboard containing a single SQL runner chart tile whose SQL uses a `type: date` project parameter:

- Before: no parameter control, tile shows `Missing values for SQL parameter(s): date_custom_parameter`.
- After: the control renders with the project default (`2025-08-06`) and the tile loads.
- Changing the value to `2026-02-10` re-runs the tile and the results update accordingly.

## Tabs

Raised in review: tiles on inactive tabs don't mount, so do they register their parameters?

They don't — but that's pre-existing, symmetric with explore tiles, and deliberate:

- Tab scoping is enforced at the display layer, not by mounting. `features/dashboardTabs/index.tsx:624-660` builds `activeTabParameters` from tiles passing `isActiveTile` and passes *that* to `DashboardFiltersBar` (`:1122`). Added in #19431 (PROD-2454, "Parameter widgets remain visible when switching dashboard tabs"). So a SQL tile on tab 2 structurally cannot surface a control on tab 1.
- References are never pruned on tab switch — the pruning effect keys off all dashboard tiles and ignores `activeTab` (`DashboardProvider.tsx:575-591`), so the set accumulates across visited tabs. The display filter above is what keeps it correct.
- #16734 was fixed by #16795, which scoped `areAllChartsLoaded` to the active tab. That was about the parameter bar hanging on a spinner waiting for other tabs' charts, not about registration. (That function filters by `isDashboardChartTileType` = saved_chart only, so SQL tiles never gated the spinner either way.)

Explore tiles register when their query returns; SQL tiles now register from the chart SQL, i.e. slightly earlier within a mount. No new tab-related behaviour.

Embed dashboards read the unfiltered reference set, so parameters accumulate there as you visit tabs — pre-existing and true of explore tiles today. Filed separately as #25856.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EBC4MuemYzm3CzC5Kxc95