### PR TITLE
feat: view virtual views as code

### DIFF
--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.test.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.test.tsx
@@ -1,5 +1,6 @@
 import { ExploreType, type Explore } from '@lightdash/common';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -30,6 +31,13 @@ vi.mock('../../../features/virtualView', () => ({
     EditVirtualViewModal: () => null,
     DeleteVirtualViewModal: () => null,
 }));
+vi.mock(
+    '../../../features/contentAsCode/components/VirtualViewAsCodeModal',
+    () => ({
+        default: ({ opened }: { opened: boolean }) =>
+            opened ? <div role="dialog">Virtual view as code modal</div> : null,
+    }),
+);
 vi.mock('../../../providers/Tracking/useTracking', () => ({
     default: () => ({ track: vi.fn() }),
 }));
@@ -58,13 +66,14 @@ const exploreQuery = (overrides: Partial<ExploreQuery>): ExploreQuery =>
         ...overrides,
     }) as unknown as ExploreQuery;
 
-const renderPanel = () =>
+const renderPanel = (appMocks?: Parameters<typeof renderWithProviders>[1]) =>
     renderWithProviders(
         <MemoryRouter>
             <Provider store={createExplorerStore()}>
                 <ExplorePanel />
             </Provider>
         </MemoryRouter>,
+        appMocks,
     );
 
 describe('ExplorePanel loading state', () => {
@@ -105,5 +114,49 @@ describe('ExplorePanel loading state', () => {
         renderPanel();
 
         expect(screen.queryByTestId('explore-tree')).not.toBeNull();
+    });
+});
+
+describe('ExplorePanel virtual view actions', () => {
+    beforeEach(() => {
+        mockUseExplore.mockReset();
+    });
+
+    it('opens content as code from the virtual view menu', async () => {
+        const user = userEvent.setup();
+        mockUseExplore.mockReturnValue(
+            exploreQuery({
+                data: { ...mockExplore, type: ExploreType.VIRTUAL },
+            }),
+        );
+
+        renderPanel({
+            user: {
+                abilityRules: [
+                    {
+                        action: 'view',
+                        subject: 'ContentAsCode',
+                        conditions: {
+                            organizationUuid:
+                                '172a2270-000f-42be-9c68-c4752c23ae51',
+                            projectUuid: 'project-uuid',
+                        },
+                    },
+                ],
+            },
+        });
+
+        await user.click(
+            await screen.findByRole('button', {
+                name: 'Virtual view actions',
+            }),
+        );
+        await user.click(
+            await screen.findByRole('menuitem', { name: 'View as code' }),
+        );
+
+        expect(screen.getByRole('dialog')).toHaveTextContent(
+            'Virtual view as code modal',
+        );
     });
 });

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -14,6 +14,7 @@ import {
     ActionIcon,
     HoverCard,
 } from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
 import {
     IconAlertTriangle,
     IconCode,
@@ -30,6 +31,7 @@ import {
     useTransition,
     type FC,
 } from 'react';
+import VirtualViewAsCodeModal from '../../../features/contentAsCode/components/VirtualViewAsCodeModal';
 import {
     explorerActions,
     selectAdditionalMetrics,
@@ -70,6 +72,8 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
     const [isEditVirtualViewOpen, setIsEditVirtualViewOpen] = useState(false);
     const [isDeleteVirtualViewOpen, setIsDeleteVirtualViewOpen] =
         useState(false);
+    const [isVirtualViewAsCodeOpen, virtualViewAsCodeModalHandlers] =
+        useDisclosure();
     const [, startTransition] = useTransition();
 
     const projectUuid = useProjectUuid();
@@ -185,6 +189,26 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
 
     if (!explore) return null;
 
+    const virtualViewSubject = subject('VirtualView', {
+        organizationUuid: user.data?.organizationUuid,
+        projectUuid,
+    });
+    const canEditVirtualView = user.data?.ability.can(
+        'create',
+        virtualViewSubject,
+    );
+    const canDeleteVirtualView = user.data?.ability.can(
+        'delete',
+        virtualViewSubject,
+    );
+    const canViewContentAsCode = user.data?.ability.can(
+        'view',
+        subject('ContentAsCode', {
+            organizationUuid: user.data?.organizationUuid,
+            projectUuid,
+        }),
+    );
+
     // Only call `onBack` for 4XX errors, otherwise we lose URL state when there's a Network error or backend is down
     if (status === 'error' && error.error.statusCode < 500) {
         onBack?.();
@@ -241,17 +265,14 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                             </HoverCard>
                         )}
                     </Group>
-                    {explore.type === ExploreType.VIRTUAL && (
-                        <Can
-                            I="create"
-                            this={subject('VirtualView', {
-                                organizationUuid: user.data?.organizationUuid,
-                                projectUuid,
-                            })}
-                        >
+                    {explore.type === ExploreType.VIRTUAL &&
+                        (canEditVirtualView ||
+                            canDeleteVirtualView ||
+                            canViewContentAsCode) && (
                             <Menu withArrow offset={-2}>
                                 <Menu.Target>
                                     <ActionIcon
+                                        aria-label="Virtual view actions"
                                         color="gray"
                                         variant="transparent"
                                     >
@@ -259,40 +280,65 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                                     </ActionIcon>
                                 </Menu.Target>
                                 <Menu.Dropdown>
-                                    <Menu.Item
-                                        leftSection={
-                                            <MantineIcon icon={IconPencil} />
-                                        }
-                                        onClick={handleEditVirtualView}
-                                    >
-                                        <Text fz="xs" fw={500}>
-                                            Edit virtual view
-                                        </Text>
-                                    </Menu.Item>
-                                    <Can
-                                        I="delete"
-                                        this={subject('VirtualView', {
-                                            organizationUuid:
-                                                user.data?.organizationUuid,
-                                            projectUuid,
-                                        })}
-                                    >
+                                    {canEditVirtualView && (
                                         <Menu.Item
                                             leftSection={
-                                                <MantineIcon icon={IconTrash} />
+                                                <MantineIcon
+                                                    icon={IconPencil}
+                                                />
                                             }
-                                            color="red"
-                                            onClick={handleDeleteVirtualView}
+                                            onClick={handleEditVirtualView}
                                         >
                                             <Text fz="xs" fw={500}>
-                                                Delete
+                                                Edit virtual view
                                             </Text>
                                         </Menu.Item>
-                                    </Can>
+                                    )}
+                                    {canViewContentAsCode && (
+                                        <>
+                                            {canEditVirtualView && (
+                                                <Menu.Divider />
+                                            )}
+                                            <Menu.Label>
+                                                Content as code
+                                            </Menu.Label>
+                                            <Menu.Item
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconCode}
+                                                    />
+                                                }
+                                                onClick={
+                                                    virtualViewAsCodeModalHandlers.open
+                                                }
+                                            >
+                                                View as code
+                                            </Menu.Item>
+                                        </>
+                                    )}
+                                    {canDeleteVirtualView && (
+                                        <>
+                                            <Menu.Divider />
+                                            <Menu.Item
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconTrash}
+                                                    />
+                                                }
+                                                color="red"
+                                                onClick={
+                                                    handleDeleteVirtualView
+                                                }
+                                            >
+                                                <Text fz="xs" fw={500}>
+                                                    Delete
+                                                </Text>
+                                            </Menu.Item>
+                                        </>
+                                    )}
                                 </Menu.Dropdown>
                             </Menu>
-                        </Can>
-                    )}
+                        )}
                     {explore.type !== ExploreType.VIRTUAL &&
                         isGitProject &&
                         explore.ymlPath &&
@@ -353,6 +399,14 @@ const ExplorePanel: FC<ExplorePanelProps> = memo(({ onBack }) => {
                         onClose={() => setIsDeleteVirtualViewOpen(false)}
                         virtualViewName={activeTableName}
                         projectUuid={projectUuid}
+                    />
+                )}
+                {projectUuid && isVirtualViewAsCodeOpen && (
+                    <VirtualViewAsCodeModal
+                        opened={isVirtualViewAsCodeOpen}
+                        onClose={virtualViewAsCodeModalHandlers.close}
+                        projectUuid={projectUuid}
+                        virtualViewSlug={activeTableName}
                     />
                 )}
             </Stack>

--- a/packages/frontend/src/features/contentAsCode/components/VirtualViewAsCodeModal.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/VirtualViewAsCodeModal.tsx
@@ -1,0 +1,34 @@
+import { type FC } from 'react';
+import { useVirtualViewAsCode } from '../hooks/useVirtualViewAsCode';
+import ContentAsCodeModal from './ContentAsCodeModal';
+
+type VirtualViewAsCodeModalProps = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    virtualViewSlug: string;
+};
+
+const VirtualViewAsCodeModal: FC<VirtualViewAsCodeModalProps> = ({
+    opened,
+    onClose,
+    projectUuid,
+    virtualViewSlug,
+}) => {
+    const virtualViewAsCode = useVirtualViewAsCode({
+        projectUuid,
+        virtualViewSlug,
+        enabled: opened,
+    });
+
+    return (
+        <ContentAsCodeModal
+            opened={opened}
+            onClose={onClose}
+            resourceLabel="virtual view"
+            contentAsCode={virtualViewAsCode}
+        />
+    );
+};
+
+export default VirtualViewAsCodeModal;

--- a/packages/frontend/src/features/contentAsCode/hooks/useVirtualViewAsCode.ts
+++ b/packages/frontend/src/features/contentAsCode/hooks/useVirtualViewAsCode.ts
@@ -1,0 +1,31 @@
+import { type ApiVirtualViewAsCodeListResponse } from '@lightdash/common';
+import { lightdashApi } from '../../../api';
+import { useContentAsCode } from './useContentAsCode';
+
+const selectVirtualView = (
+    results: ApiVirtualViewAsCodeListResponse['results'],
+) => results.virtualViews[0];
+
+export const useVirtualViewAsCode = ({
+    projectUuid,
+    virtualViewSlug,
+    enabled,
+}: {
+    projectUuid: string;
+    virtualViewSlug: string;
+    enabled: boolean;
+}) => {
+    return useContentAsCode<ApiVirtualViewAsCodeListResponse['results']>({
+        queryKey: ['virtual-view-as-code', projectUuid, virtualViewSlug],
+        queryFn: () =>
+            lightdashApi<ApiVirtualViewAsCodeListResponse['results']>({
+                method: 'GET',
+                url: `/projects/${projectUuid}/code/virtualViews?${new URLSearchParams(
+                    [['slugs', virtualViewSlug]],
+                ).toString()}`,
+                body: undefined,
+            }),
+        selectDocument: selectVirtualView,
+        enabled,
+    });
+};


### PR DESCRIPTION
## Summary

- add a permission-gated **View as code** action to virtual-view actions
- reuse the shared content-as-code modal and lazy query hook
- fetch the existing virtual-view-as-code endpoint only after the modal opens
- keep Edit and Delete visibility tied to their existing virtual-view permissions

## Testing

- `pnpm -F frontend test src/components/Explorer/ExplorePanel/index.test.tsx src/features/contentAsCode/hooks/useContentAsCode.test.tsx`
- focused frontend formatting and lint checks
- local browser verification of the virtual-view action menu, generated YAML, and Copy YAML modal

Relates: PROD-8969