### PR TITLE
fix(filters): boolean filter with no value compiles to a no-op

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -2060,6 +2060,33 @@ describe('Boolean Filter SQL', () => {
                 '(("table"."is_active")) = true',
             );
         });
+
+        it('should be a no-op when no value is selected', () => {
+            const filterEmptyArray = {
+                ...baseFilter,
+                operator: FilterOperator.EQUALS,
+                values: [],
+            };
+            const filterUndefined = {
+                ...baseFilter,
+                operator: FilterOperator.EQUALS,
+            };
+            const filterEmptyString = {
+                ...baseFilter,
+                operator: FilterOperator.EQUALS,
+                values: [''],
+            };
+
+            expect(renderBooleanFilterSql(dimensionSql, filterEmptyArray)).toBe(
+                'true',
+            );
+            expect(renderBooleanFilterSql(dimensionSql, filterUndefined)).toBe(
+                'true',
+            );
+            expect(renderBooleanFilterSql(dimensionSql, filterEmptyString)).toBe(
+                'true',
+            );
+        });
     });
 
     describe('notEquals operator', () => {
@@ -2084,6 +2111,15 @@ describe('Boolean Filter SQL', () => {
             expect(renderBooleanFilterSql(dimensionSql, filter)).toBe(
                 '((("table"."is_active")) != false OR (("table"."is_active")) IS NULL)',
             );
+        });
+
+        it('should be a no-op when no value is selected', () => {
+            const filter = {
+                ...baseFilter,
+                operator: FilterOperator.NOT_EQUALS,
+                values: [],
+            };
+            expect(renderBooleanFilterSql(dimensionSql, filter)).toBe('true');
         });
     });
 

--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -2083,9 +2083,9 @@ describe('Boolean Filter SQL', () => {
             expect(renderBooleanFilterSql(dimensionSql, filterUndefined)).toBe(
                 'true',
             );
-            expect(renderBooleanFilterSql(dimensionSql, filterEmptyString)).toBe(
-                'true',
-            );
+            expect(
+                renderBooleanFilterSql(dimensionSql, filterEmptyString),
+            ).toBe('true');
         });
     });
 

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -724,15 +724,22 @@ export const renderBooleanFilterSql = (
     dimensionSql: string,
     filter: FilterRule<FilterOperator, unknown>,
 ): string => {
+    const firstValue: unknown = filter.values?.[0];
+    // No value selected: compile to a no-op instead of silently filtering `= false`
+    const hasValue =
+        firstValue !== undefined && firstValue !== null && firstValue !== '';
+
     switch (filter.operator) {
         case 'equals':
-            return `(${dimensionSql}) = ${convertToBooleanValue(
-                filter.values?.[0],
-            )}`;
+            return hasValue
+                ? `(${dimensionSql}) = ${convertToBooleanValue(firstValue)}`
+                : 'true';
         case 'notEquals':
-            return `((${dimensionSql}) != ${convertToBooleanValue(
-                filter.values?.[0],
-            )} OR (${dimensionSql}) IS NULL)`;
+            return hasValue
+                ? `((${dimensionSql}) != ${convertToBooleanValue(
+                      firstValue,
+                  )} OR (${dimensionSql}) IS NULL)`
+                : 'true';
         case 'isNull':
             return `(${dimensionSql}) IS NULL`;
         case 'notNull':

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -349,8 +349,9 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
                 break;
             }
             case FilterType.BOOLEAN: {
-                filterRuleDefaults.values =
-                    values !== undefined ? values : [false];
+                // No default value: an unset boolean filter is a no-op until the
+                // user picks true/false (see renderBooleanFilterSql)
+                filterRuleDefaults.values = values !== undefined ? values : [];
                 break;
             }
             default:

--- a/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
+++ b/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
@@ -127,7 +127,7 @@ export const getPlaceholderByFilterTypeAndOperator = ({
             switch (operator) {
                 case FilterOperator.EQUALS:
                 case FilterOperator.NOT_EQUALS:
-                    return 'False';
+                    return 'Select value';
                 case FilterOperator.NULL:
                 case FilterOperator.NOT_NULL:
                     return '';

--- a/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
+++ b/packages/frontend/src/components/common/Filters/utils/getPlaceholderByFilterTypeAndOperator.ts
@@ -127,7 +127,7 @@ export const getPlaceholderByFilterTypeAndOperator = ({
             switch (operator) {
                 case FilterOperator.EQUALS:
                 case FilterOperator.NOT_EQUALS:
-                    return 'Select value';
+                    return 'Select a value';
                 case FilterOperator.NULL:
                 case FilterOperator.NOT_NULL:
                     return '';


### PR DESCRIPTION
## Problem

Adding a filter on a boolean dimension silently applied `= false` even when no value was selected. The value input showed a greyed-out "False" placeholder (so it looked unset), but the generated SQL actually excluded rows. This is inconsistent with other field types — a string/number filter with no value selected compiles to a no-op (`true`).

## Cause

Two halves of the same bug, previously consistent with each other in a bad way:

- `renderBooleanFilterSql` didn't guard against empty values like the string/number renderers do. Boolean filters are created with `values: []`, so `convertToBooleanValue(undefined)` returned `false` and the filter compiled to `(dimension) = false`.
- The FE honestly described that behaviour: a `'False'` placeholder, and a `[false]` default seed in `getFilterRuleWithDefaultValue`.

## Fix

Pick the no-op design (match every other field type — "adding a filter instantly changes results" is worse UX) and make both halves coherent:

- `renderBooleanFilterSql` returns `true` (no-op) for `equals`/`notEquals` when no value is selected. Genuine `false` / `'false'` selections still compile to `= false`. The compiler needs defined semantics for empty values regardless of the UI, since saved charts, dashboards, chart-as-code and the raw API can all send `values: []`.
- Neutral `'Select a value'` placeholder instead of `'False'`, which was actively misleading.
- Boolean filters are created with empty values (dropped the `[false]` default) so nothing applies until the user picks true/false. `BooleanFilterInputs` already auto-opens the dropdown to prompt the choice.

Added test coverage for the empty-value no-op case.
