### PR TITLE
feat: add managed onboarding lifecycle and sandbox executor

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -340,6 +340,10 @@ import {
     WarehouseCredentialTableName,
 } from '../database/entities/warehouseCredentials';
 import {
+    AgentOnboardingRunsTable,
+    AgentOnboardingRunsTableName,
+} from '../ee/database/entities/agentOnboarding';
+import {
     AiAgentToolCallErrorTable,
     AiAgentToolCallErrorTableName,
     AiAgentToolCallTable,
@@ -612,6 +616,7 @@ declare module 'knex/types/tables' {
         [AiSlackPromptTableName]: AiSlackPromptTable;
         [AiWebAppPromptTableName]: AiWebAppPromptTable;
         [AiWritebackThreadTableName]: AiWritebackThreadTable;
+        [AgentOnboardingRunsTableName]: AgentOnboardingRunsTable;
         [ProjectCiStatusTableName]: ProjectCiStatusTable;
         [AiAgentTableName]: AiAgentTable;
         [AiAgentDocumentTableName]: AiAgentDocumentTable;

--- a/packages/backend/src/ee/database/entities/agentOnboarding.ts
+++ b/packages/backend/src/ee/database/entities/agentOnboarding.ts
@@ -1,0 +1,65 @@
+import {
+    type AgentOnboardingHandoff,
+    type AgentOnboardingRunEvent,
+    type AgentOnboardingRunStatus,
+    type AgentOnboardingStage,
+    type AgentOnboardingUsage,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+
+export const AgentOnboardingRunsTableName = 'agent_onboarding_runs';
+
+export type DbAgentOnboardingFile = {
+    path: string;
+    s3Key: string;
+    sizeBytes: number;
+    updatedAt: string;
+};
+
+export type DbAgentOnboardingRun = {
+    agent_onboarding_run_uuid: string;
+    organization_uuid: string;
+    project_uuid: string;
+    created_by_user_uuid: string;
+    status: AgentOnboardingRunStatus;
+    stage: AgentOnboardingStage | null;
+    events: AgentOnboardingRunEvent[];
+    handoff: AgentOnboardingHandoff | null;
+    usage: AgentOnboardingUsage | null;
+    files: DbAgentOnboardingFile[];
+    pat_uuid: string | null;
+    sandbox_uuid: string | null;
+    error_message: string | null;
+    cancellation_requested_at: Date | null;
+    started_at: Date | null;
+    completed_at: Date | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+type DbAgentOnboardingRunUpdate = Partial<
+    Pick<
+        DbAgentOnboardingRun,
+        | 'status'
+        | 'stage'
+        | 'events'
+        | 'handoff'
+        | 'usage'
+        | 'pat_uuid'
+        | 'sandbox_uuid'
+        | 'error_message'
+        | 'cancellation_requested_at'
+        | 'started_at'
+        | 'completed_at'
+        | 'updated_at'
+    > & { files: string }
+>;
+
+export type AgentOnboardingRunsTable = Knex.CompositeTableType<
+    DbAgentOnboardingRun,
+    Pick<
+        DbAgentOnboardingRun,
+        'organization_uuid' | 'project_uuid' | 'created_by_user_uuid'
+    >,
+    DbAgentOnboardingRunUpdate
+>;

--- a/packages/backend/src/ee/database/migrations/20260721100000_add_agent_onboarding_runs.ts
+++ b/packages/backend/src/ee/database/migrations/20260721100000_add_agent_onboarding_runs.ts
@@ -1,0 +1,71 @@
+import {
+    AGENT_ONBOARDING_ACTIVE_STATUSES,
+    AGENT_ONBOARDING_RUN_STATUSES,
+    AGENT_ONBOARDING_STAGES,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+
+const AgentOnboardingRunsTableName = 'agent_onboarding_runs';
+const ActiveProjectIndexName = 'agent_onboarding_runs_active_project_idx';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(AgentOnboardingRunsTableName, (table) => {
+        table
+            .uuid('agent_onboarding_run_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('organization_uuid')
+            .notNullable()
+            .references('organization_uuid')
+            .inTable('organizations')
+            .onDelete('CASCADE');
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE');
+        table.uuid('created_by_user_uuid').notNullable();
+        table
+            .text('status')
+            .notNullable()
+            .defaultTo('queued')
+            .checkIn([...AGENT_ONBOARDING_RUN_STATUSES]);
+        table.text('stage').checkIn([...AGENT_ONBOARDING_STAGES]);
+        table.jsonb('events').notNullable().defaultTo('[]');
+        table.jsonb('handoff');
+        table.jsonb('usage');
+        table.jsonb('files').notNullable().defaultTo('[]');
+        table.uuid('pat_uuid');
+        table.uuid('sandbox_uuid');
+        table.text('error_message');
+        table.timestamp('cancellation_requested_at', { useTz: false });
+        table.timestamp('started_at', { useTz: false });
+        table.timestamp('completed_at', { useTz: false });
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.index(['project_uuid', 'created_at']);
+        table.index(['status', 'updated_at']);
+    });
+
+    const activeStatuses = AGENT_ONBOARDING_ACTIVE_STATUSES.map(
+        (status) => `'${status}'`,
+    ).join(', ');
+    await knex.raw(`
+        CREATE UNIQUE INDEX ${ActiveProjectIndexName}
+        ON ${AgentOnboardingRunsTableName} (project_uuid)
+        WHERE status IN (${activeStatuses})
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTable(AgentOnboardingRunsTableName);
+}

--- a/packages/backend/src/ee/database/migrations/20260721100000_add_agent_onboarding_runs.ts
+++ b/packages/backend/src/ee/database/migrations/20260721100000_add_agent_onboarding_runs.ts
@@ -56,14 +56,21 @@ export async function up(knex: Knex): Promise<void> {
         table.index(['status', 'updated_at']);
     });
 
-    const activeStatuses = AGENT_ONBOARDING_ACTIVE_STATUSES.map(
-        (status) => `'${status}'`,
+    const activeStatusPlaceholders = AGENT_ONBOARDING_ACTIVE_STATUSES.map(
+        () => '?',
     ).join(', ');
-    await knex.raw(`
-        CREATE UNIQUE INDEX ${ActiveProjectIndexName}
-        ON ${AgentOnboardingRunsTableName} (project_uuid)
-        WHERE status IN (${activeStatuses})
-    `);
+    await knex.raw(
+        `CREATE UNIQUE INDEX ??
+        ON ?? (??)
+        WHERE ?? IN (${activeStatusPlaceholders})`,
+        [
+            ActiveProjectIndexName,
+            AgentOnboardingRunsTableName,
+            'project_uuid',
+            'status',
+            ...AGENT_ONBOARDING_ACTIVE_STATUSES,
+        ],
+    );
 }
 
 export async function down(knex: Knex): Promise<void> {

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -28,6 +28,7 @@ import LicenseClient from './clients/License/LicenseClient';
 import { ManagedAgentClient } from './clients/ManagedAgentClient';
 import OpenAi from './clients/OpenAi';
 import { CommercialSlackClient } from './clients/Slack/SlackClient';
+import { AgentOnboardingRunModel } from './models/AgentOnboardingRunModel';
 import { AiAgentDocumentModel } from './models/AiAgentDocumentModel';
 import { AiAgentModel } from './models/AiAgentModel';
 import { AiAgentReviewClassifierModel } from './models/AiAgentReviewClassifierModel';
@@ -83,6 +84,7 @@ import { ExternalConnectionService } from './services/ExternalConnectionService/
 import { GoogleServiceAccountTokenProvider } from './services/ExternalConnectionService/GoogleServiceAccountTokenProvider';
 import { ManagedAgentService } from './services/ManagedAgentService/ManagedAgentService';
 import { McpService } from './services/McpService/McpService';
+import { OnboardingAgentService } from './services/OnboardingAgentService/OnboardingAgentService';
 import { OrganizationWarehouseCredentialsService } from './services/OrganizationWarehouseCredentialsService';
 import { PreviewDeploySetupService } from './services/PreviewDeploySetupService/PreviewDeploySetupService';
 import { ProjectContextService } from './services/ProjectContextService/ProjectContextService';
@@ -211,6 +213,19 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     userModel: models.getUserModel(),
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,
+                }),
+            onboardingAgentService: ({ context, models, repository }) =>
+                new OnboardingAgentService({
+                    lightdashConfig: context.lightdashConfig,
+                    agentOnboardingRunModel:
+                        models.getAgentOnboardingRunModel<AgentOnboardingRunModel>(),
+                    sandboxRegistryModel:
+                        models.getSandboxRegistryModel<SandboxRegistryModel>(),
+                    projectModel: models.getProjectModel(),
+                    personalAccessTokenService:
+                        repository.getPersonalAccessTokenService(),
+                    promptService: repository.getPromptService(),
+                    userService: repository.getUserService(),
                 }),
             previewDeploySetupService: ({ context, models }) =>
                 new PreviewDeploySetupService({
@@ -922,6 +937,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new AiWritebackRunModel({ database }),
             aiDeepResearchRunModel: ({ database }) =>
                 new AiDeepResearchRunModel({ database }),
+            agentOnboardingRunModel: ({ database }) =>
+                new AgentOnboardingRunModel({ database }),
             sandboxRegistryModel: ({ database }) =>
                 new SandboxRegistryModel({ database }),
             projectCiStatusModel: ({ database }) =>

--- a/packages/backend/src/ee/models/AgentOnboardingRunModel.ts
+++ b/packages/backend/src/ee/models/AgentOnboardingRunModel.ts
@@ -1,0 +1,300 @@
+import {
+    AGENT_ONBOARDING_ACTIVE_STATUSES,
+    AGENT_ONBOARDING_STAGES,
+    type AgentOnboardingHandoff,
+    type AgentOnboardingRunEvent,
+    type AgentOnboardingStage,
+    type AgentOnboardingUsage,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    AgentOnboardingRunsTable,
+    AgentOnboardingRunsTableName,
+    type DbAgentOnboardingFile,
+    type DbAgentOnboardingRun,
+} from '../database/entities/agentOnboarding';
+
+type Dependencies = {
+    database: Knex;
+};
+
+type CreateAgentOnboardingRun = {
+    organizationUuid: string;
+    projectUuid: string;
+    createdByUserUuid: string;
+};
+
+type UpdateAgentOnboardingRun = Partial<
+    Pick<
+        DbAgentOnboardingRun,
+        'pat_uuid' | 'sandbox_uuid' | 'usage' | 'handoff'
+    >
+>;
+
+const activeStatusesSql = AGENT_ONBOARDING_ACTIVE_STATUSES.map(
+    (status) => `'${status}'`,
+).join(', ');
+
+export class AgentOnboardingRunModel {
+    private readonly database: Knex;
+
+    constructor({ database }: Dependencies) {
+        this.database = database;
+    }
+
+    private getMonotonicStageValue(stage: AgentOnboardingStage) {
+        const stageIndex = AGENT_ONBOARDING_STAGES.indexOf(stage);
+        const earlierStages = AGENT_ONBOARDING_STAGES.slice(0, stageIndex);
+
+        if (earlierStages.length === 0) {
+            return this.database.raw('COALESCE(??, ?)', ['stage', stage]);
+        }
+
+        const placeholders = earlierStages.map(() => '?').join(', ');
+        return this.database.raw(
+            `CASE WHEN ?? IS NULL OR ?? IN (${placeholders}) THEN ? ELSE ?? END`,
+            ['stage', 'stage', ...earlierStages, stage, 'stage'],
+        );
+    }
+
+    async create(
+        data: CreateAgentOnboardingRun,
+    ): Promise<DbAgentOnboardingRun> {
+        const [run] = await this.database<AgentOnboardingRunsTable>(
+            AgentOnboardingRunsTableName,
+        )
+            .insert({
+                organization_uuid: data.organizationUuid,
+                project_uuid: data.projectUuid,
+                created_by_user_uuid: data.createdByUserUuid,
+            })
+            .onConflict(
+                this.database.raw(
+                    `(project_uuid) WHERE status IN (${activeStatusesSql})`,
+                ),
+            )
+            .merge({
+                updated_at: this.database.raw('??.??', [
+                    AgentOnboardingRunsTableName,
+                    'updated_at',
+                ]) as unknown as Date,
+            })
+            .returning('*');
+
+        return run;
+    }
+
+    async findByUuid(
+        agentOnboardingRunUuid: string,
+    ): Promise<DbAgentOnboardingRun | undefined> {
+        return this.database<AgentOnboardingRunsTable>(
+            AgentOnboardingRunsTableName,
+        )
+            .where('agent_onboarding_run_uuid', agentOnboardingRunUuid)
+            .first();
+    }
+
+    async findActiveRunForProject(
+        projectUuid: string,
+    ): Promise<DbAgentOnboardingRun | undefined> {
+        return this.database<AgentOnboardingRunsTable>(
+            AgentOnboardingRunsTableName,
+        )
+            .where('project_uuid', projectUuid)
+            .whereIn('status', [...AGENT_ONBOARDING_ACTIVE_STATUSES])
+            .first();
+    }
+
+    async claimQueuedRun(
+        agentOnboardingRunUuid: string,
+    ): Promise<DbAgentOnboardingRun | undefined> {
+        const [run] = await this.database<AgentOnboardingRunsTable>(
+            AgentOnboardingRunsTableName,
+        )
+            .where('agent_onboarding_run_uuid', agentOnboardingRunUuid)
+            .where('status', 'queued')
+            .whereNull('cancellation_requested_at')
+            .update({
+                status: 'running',
+                started_at: this.database.fn.now() as unknown as Date,
+                updated_at: this.database.fn.now() as unknown as Date,
+            })
+            .returning('*');
+
+        return run;
+    }
+
+    async update(
+        agentOnboardingRunUuid: string,
+        patch: UpdateAgentOnboardingRun,
+    ): Promise<boolean> {
+        const updated = await this.database<AgentOnboardingRunsTable>(
+            AgentOnboardingRunsTableName,
+        )
+            .where('agent_onboarding_run_uuid', agentOnboardingRunUuid)
+            .whereIn('status', [...AGENT_ONBOARDING_ACTIVE_STATUSES])
+            .update({
+                ...patch,
+                updated_at: this.database.fn.now() as unknown as Date,
+            });
+
+        return updated > 0;
+    }
+
+    async replaceFiles(
+        agentOnboardingRunUuid: string,
+        files: DbAgentOnboardingFile[],
+    ): Promise<boolean> {
+        const updated = await this.database<AgentOnboardingRunsTable>(
+            AgentOnboardingRunsTableName,
+        )
+            .where('agent_onboarding_run_uuid', agentOnboardingRunUuid)
+            .whereIn('status', [...AGENT_ONBOARDING_ACTIVE_STATUSES])
+            .update({
+                files: JSON.stringify(files),
+                updated_at: this.database.fn.now() as unknown as Date,
+            });
+
+        return updated > 0;
+    }
+
+    async appendEvent(
+        agentOnboardingRunUuid: string,
+        event: Omit<AgentOnboardingRunEvent, 'createdAt'>,
+    ): Promise<boolean> {
+        const fullEvent: AgentOnboardingRunEvent = {
+            ...event,
+            createdAt: new Date().toISOString(),
+        };
+        const updated = await this.database<AgentOnboardingRunsTable>(
+            AgentOnboardingRunsTableName,
+        )
+            .where('agent_onboarding_run_uuid', agentOnboardingRunUuid)
+            .whereIn('status', [...AGENT_ONBOARDING_ACTIVE_STATUSES])
+            .update({
+                events: this.database.raw('events || ?::jsonb', [
+                    JSON.stringify([fullEvent]),
+                ]) as unknown as AgentOnboardingRunEvent[],
+                ...(event.stage
+                    ? {
+                          stage: this.getMonotonicStageValue(
+                              event.stage,
+                          ) as unknown as AgentOnboardingStage,
+                      }
+                    : {}),
+                updated_at: this.database.fn.now() as unknown as Date,
+            });
+
+        return updated > 0;
+    }
+
+    async markCompleted(
+        agentOnboardingRunUuid: string,
+        result: {
+            handoff: AgentOnboardingHandoff | null;
+            usage: AgentOnboardingUsage | null;
+            stage: AgentOnboardingStage | null;
+        },
+    ): Promise<boolean> {
+        const updated = await this.database<AgentOnboardingRunsTable>(
+            AgentOnboardingRunsTableName,
+        )
+            .where('agent_onboarding_run_uuid', agentOnboardingRunUuid)
+            .where('status', 'running')
+            .whereNull('cancellation_requested_at')
+            .update({
+                status: 'completed',
+                handoff: result.handoff,
+                usage: result.usage,
+                ...(result.stage
+                    ? {
+                          stage: this.getMonotonicStageValue(
+                              result.stage,
+                          ) as unknown as AgentOnboardingStage,
+                      }
+                    : {}),
+                completed_at: this.database.fn.now() as unknown as Date,
+                updated_at: this.database.fn.now() as unknown as Date,
+            });
+
+        return updated > 0;
+    }
+
+    async markFailed(
+        agentOnboardingRunUuid: string,
+        errorMessage: string,
+    ): Promise<boolean> {
+        const updated = await this.database<AgentOnboardingRunsTable>(
+            AgentOnboardingRunsTableName,
+        )
+            .where('agent_onboarding_run_uuid', agentOnboardingRunUuid)
+            .whereIn('status', [...AGENT_ONBOARDING_ACTIVE_STATUSES])
+            .whereNull('cancellation_requested_at')
+            .update({
+                status: 'failed',
+                error_message: errorMessage,
+                completed_at: this.database.fn.now() as unknown as Date,
+                updated_at: this.database.fn.now() as unknown as Date,
+            });
+
+        return updated > 0;
+    }
+
+    async markCancelled(agentOnboardingRunUuid: string): Promise<boolean> {
+        const updated = await this.database<AgentOnboardingRunsTable>(
+            AgentOnboardingRunsTableName,
+        )
+            .where('agent_onboarding_run_uuid', agentOnboardingRunUuid)
+            .whereIn('status', [...AGENT_ONBOARDING_ACTIVE_STATUSES])
+            .update({
+                status: 'cancelled',
+                completed_at: this.database.fn.now() as unknown as Date,
+                updated_at: this.database.fn.now() as unknown as Date,
+            });
+
+        return updated > 0;
+    }
+
+    async requestCancellation(
+        agentOnboardingRunUuid: string,
+    ): Promise<DbAgentOnboardingRun | undefined> {
+        return this.database.transaction(async (transaction) => {
+            const now = transaction.fn.now() as unknown as Date;
+            const [queuedRun] = await transaction<AgentOnboardingRunsTable>(
+                AgentOnboardingRunsTableName,
+            )
+                .where('agent_onboarding_run_uuid', agentOnboardingRunUuid)
+                .where('status', 'queued')
+                .whereNull('cancellation_requested_at')
+                .update({
+                    status: 'cancelled',
+                    cancellation_requested_at: now,
+                    completed_at: now,
+                    updated_at: now,
+                })
+                .returning('*');
+
+            if (queuedRun) return queuedRun;
+
+            const [runningRun] = await transaction<AgentOnboardingRunsTable>(
+                AgentOnboardingRunsTableName,
+            )
+                .where('agent_onboarding_run_uuid', agentOnboardingRunUuid)
+                .where('status', 'running')
+                .whereNull('cancellation_requested_at')
+                .update({
+                    cancellation_requested_at: now,
+                    updated_at: now,
+                })
+                .returning('*');
+
+            if (runningRun) return runningRun;
+
+            return transaction<AgentOnboardingRunsTable>(
+                AgentOnboardingRunsTableName,
+            )
+                .where('agent_onboarding_run_uuid', agentOnboardingRunUuid)
+                .first();
+        });
+    }
+}

--- a/packages/backend/src/ee/models/AgentOnboardingRunModel.ts
+++ b/packages/backend/src/ee/models/AgentOnboardingRunModel.ts
@@ -79,6 +79,7 @@ export class AgentOnboardingRunModel {
                 ),
             )
             .merge({
+                // Force RETURNING on conflict without changing lifecycle time.
                 updated_at: this.database.raw('??.??', [
                     AgentOnboardingRunsTableName,
                     'updated_at',

--- a/packages/backend/src/ee/models/AgentOnboardingRunModel.ts
+++ b/packages/backend/src/ee/models/AgentOnboardingRunModel.ts
@@ -31,8 +31,8 @@ type UpdateAgentOnboardingRun = Partial<
     >
 >;
 
-const activeStatusesSql = AGENT_ONBOARDING_ACTIVE_STATUSES.map(
-    (status) => `'${status}'`,
+const activeStatusPlaceholders = AGENT_ONBOARDING_ACTIVE_STATUSES.map(
+    () => '?',
 ).join(', ');
 
 export class AgentOnboardingRunModel {
@@ -70,7 +70,12 @@ export class AgentOnboardingRunModel {
             })
             .onConflict(
                 this.database.raw(
-                    `(project_uuid) WHERE status IN (${activeStatusesSql})`,
+                    `(??) WHERE ?? IN (${activeStatusPlaceholders})`,
+                    [
+                        'project_uuid',
+                        'status',
+                        ...AGENT_ONBOARDING_ACTIVE_STATUSES,
+                    ],
                 ),
             )
             .merge({

--- a/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
@@ -1,4 +1,6 @@
+import { subject } from '@casl/ability';
 import {
+    ForbiddenError,
     getConnectionDefaults,
     getErrorMessage,
     MissingConfigError,
@@ -467,6 +469,25 @@ export class OnboardingAgentService extends BaseService {
                     run.organization_uuid,
                 ),
             );
+            const ability = this.createAuditedAbility(account);
+            if (
+                ability.cannot(
+                    'manage',
+                    subject('Project', {
+                        organizationUuid: run.organization_uuid,
+                        projectUuid: run.project_uuid,
+                    }),
+                ) ||
+                ability.cannot(
+                    'create',
+                    subject('PersonalAccessToken', {
+                        organizationUuid: run.organization_uuid,
+                        metadata: { userUuid: run.created_by_user_uuid },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
             pat =
                 await this.personalAccessTokenService.createPersonalAccessToken(
                     account,

--- a/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
@@ -1,0 +1,586 @@
+import {
+    getConnectionDefaults,
+    getErrorMessage,
+    MissingConfigError,
+    RequestMethod,
+    type AgentOnboardingHandoff,
+    type AgentOnboardingJobPayload,
+    type AgentOnboardingStage,
+    type AgentOnboardingUsage,
+} from '@lightdash/common';
+import { fromSession } from '../../../auth/account';
+import { type LightdashConfig } from '../../../config/parseConfig';
+import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { BaseService } from '../../../services/BaseService';
+import { type PersonalAccessTokenService } from '../../../services/PersonalAccessTokenService';
+import { type PromptService } from '../../../services/PromptService/PromptService';
+import { type UserService } from '../../../services/UserService';
+import { type DbAgentOnboardingRun } from '../../database/entities/agentOnboarding';
+import { type AgentOnboardingRunModel } from '../../models/AgentOnboardingRunModel';
+import { type SandboxRegistryModel } from '../../models/SandboxRegistryModel';
+import {
+    interpretAgentEvent,
+    resolveSandboxTemplateRef,
+    splitStreamBuffer,
+    summarizeToolInput,
+} from '../AiWritebackService/utils';
+import {
+    createSandboxManager,
+    S3SnapshotStore,
+    type PersistentWorkspace,
+    type SandboxHandle,
+    type SandboxManager,
+    type SandboxSpec,
+} from '../SandboxRuntime';
+import {
+    ALLOWED_TOOLS,
+    CANCELLATION_POLL_INTERVAL_MS,
+    CLAUDE_MODEL,
+    CLAUDE_SKILLS_DIR,
+    CLI_WRAPPER_PATH,
+    CLI_WRAPPER_SCRIPT,
+    PAT_EXPIRY_GRACE_MS,
+    PROMPT_PATH,
+    RUN_TIMEOUT_MS,
+    SANDBOX_TIMEOUT_MS,
+    WORKDIR,
+} from './constants';
+import { classifyOnboardingStage, sanitizeOnboardingMessage } from './utils';
+
+type Dependencies = {
+    lightdashConfig: LightdashConfig;
+    agentOnboardingRunModel: AgentOnboardingRunModel;
+    sandboxRegistryModel: SandboxRegistryModel;
+    projectModel: ProjectModel;
+    personalAccessTokenService: PersonalAccessTokenService;
+    promptService: PromptService;
+    userService: UserService;
+    sandboxManager?: SandboxManager;
+};
+
+const ONBOARDING_WORKSPACE: PersistentWorkspace = {
+    include: [WORKDIR],
+    exclude: [],
+};
+
+export class OnboardingAgentService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly agentOnboardingRunModel: AgentOnboardingRunModel;
+
+    private readonly sandboxRegistryModel: SandboxRegistryModel;
+
+    private readonly projectModel: ProjectModel;
+
+    private readonly personalAccessTokenService: PersonalAccessTokenService;
+
+    private readonly promptService: PromptService;
+
+    private readonly userService: UserService;
+
+    private sandboxManager: SandboxManager | undefined;
+
+    constructor(dependencies: Dependencies) {
+        super();
+        this.lightdashConfig = dependencies.lightdashConfig;
+        this.agentOnboardingRunModel = dependencies.agentOnboardingRunModel;
+        this.sandboxRegistryModel = dependencies.sandboxRegistryModel;
+        this.projectModel = dependencies.projectModel;
+        this.personalAccessTokenService =
+            dependencies.personalAccessTokenService;
+        this.promptService = dependencies.promptService;
+        this.userService = dependencies.userService;
+        this.sandboxManager = dependencies.sandboxManager;
+    }
+
+    private getSandboxManager(): SandboxManager {
+        if (!this.sandboxManager) {
+            const { sandboxProvider } = this.lightdashConfig.appRuntime;
+            this.sandboxManager = createSandboxManager({
+                provider: sandboxProvider,
+                e2bApiKey: this.lightdashConfig.appRuntime.e2bApiKey,
+                dockerImage:
+                    this.lightdashConfig.appRuntime
+                        .sandboxAgentOnboardingDockerImage,
+                lambdaMicroVm: null,
+                azureSandboxes: null,
+                snapshotStore:
+                    sandboxProvider === 'docker'
+                        ? new S3SnapshotStore({
+                              lightdashConfig: this.lightdashConfig,
+                          })
+                        : null,
+                registryModel: this.sandboxRegistryModel,
+                logger: this.logger,
+            });
+        }
+        return this.sandboxManager;
+    }
+
+    private getSandboxTemplateRef(): string {
+        const { appRuntime } = this.lightdashConfig;
+        switch (appRuntime.sandboxProvider) {
+            case 'docker':
+                return appRuntime.sandboxAgentOnboardingDockerImage;
+            case 'e2b':
+                return resolveSandboxTemplateRef({
+                    name: appRuntime.e2bAgentOnboardingTemplateName,
+                    tag: appRuntime.e2bAgentOnboardingTemplateTag,
+                });
+            default:
+                throw new MissingConfigError(
+                    `Agent onboarding does not support the ${appRuntime.sandboxProvider} sandbox provider`,
+                );
+        }
+    }
+
+    private getSandboxFacingSiteUrl(): string {
+        if (this.lightdashConfig.appRuntime.sandboxProvider !== 'docker') {
+            return this.lightdashConfig.siteUrl;
+        }
+        return this.lightdashConfig.siteUrl
+            .replace('://localhost', '://host.docker.internal')
+            .replace('://127.0.0.1', '://host.docker.internal');
+    }
+
+    private getAnthropicApiKey(): string {
+        const key = this.lightdashConfig.aiWriteback.anthropicApiKey;
+        if (!key) {
+            throw new MissingConfigError(
+                'Anthropic API key is not configured (AI_WRITEBACK_ANTHROPIC_API_KEY)',
+            );
+        }
+        return key;
+    }
+
+    private buildSandboxSpec(): SandboxSpec {
+        return {
+            templateRef: this.getSandboxTemplateRef(),
+            timeoutMs: SANDBOX_TIMEOUT_MS,
+            egress: {
+                allow: [
+                    new URL(this.getSandboxFacingSiteUrl()).hostname,
+                    'api.anthropic.com',
+                ],
+            },
+        };
+    }
+
+    private async buildPrompt(args: {
+        projectUuid: string;
+        warehouseType: string;
+        database: string | undefined;
+        schema: string | undefined;
+    }): Promise<string> {
+        const basePrompt =
+            await this.promptService.getPrompt('project-onboarding');
+        const siteUrl = this.lightdashConfig.siteUrl.replace(/\/+$/, '');
+        const preamble = [
+            '# Lightdash cloud onboarding run',
+            '',
+            'You are running inside a managed sandbox on Lightdash Cloud, completing project setup on behalf of a user.',
+            '',
+            '## Context',
+            `- Lightdash instance URL: ${siteUrl}`,
+            `- Warehouse type: ${args.warehouseType}`,
+            `- Prepared project UUID: ${args.projectUuid}`,
+            ...(args.database
+                ? [`- Configured database: ${args.database}`]
+                : []),
+            ...(args.schema ? [`- Configured schema: ${args.schema}`] : []),
+            '',
+            '## Managed environment',
+            '- The Lightdash CLI and skills are preinstalled. Skip local setup.',
+            `- Run every \`lightdash <args>\` command as \`${CLI_WRAPPER_PATH} <args>\`.`,
+            '- Authentication is already configured. Do not run `lightdash login` or inspect environment variables.',
+            `- Verify the selected project with \`${CLI_WRAPPER_PATH} config get-project\` and confirm it matches the prepared project UUID.`,
+            `- Create all working files under ${WORKDIR} and build a pure Lightdash semantic layer from the warehouse catalog.`,
+            '',
+            '---',
+            '',
+        ].join('\n');
+        return preamble + basePrompt;
+    }
+
+    private startCancellationPoll(
+        agentOnboardingRunUuid: string,
+        onCancel: () => void,
+    ): () => void {
+        const timer = setInterval(() => {
+            void this.agentOnboardingRunModel
+                .findByUuid(agentOnboardingRunUuid)
+                .then((run) => {
+                    if (run?.cancellation_requested_at) onCancel();
+                })
+                .catch((error) => {
+                    this.logger.warn(
+                        `OnboardingAgent: could not check cancellation: ${sanitizeOnboardingMessage(
+                            getErrorMessage(error),
+                        )}`,
+                    );
+                });
+        }, CANCELLATION_POLL_INTERVAL_MS);
+        timer.unref();
+        return () => clearInterval(timer);
+    }
+
+    private async runAgentInSandbox(args: {
+        run: DbAgentOnboardingRun;
+        sandbox: SandboxHandle;
+        patToken: string;
+        anthropicApiKey: string;
+    }): Promise<{
+        assistantText: string;
+        usage: AgentOnboardingUsage | null;
+    }> {
+        const { run, sandbox, patToken, anthropicApiKey } = args;
+        const { warehouseConnection } =
+            await this.projectModel.getWithSensitiveFields(run.project_uuid);
+        if (!warehouseConnection) {
+            throw new MissingConfigError(
+                'The prepared project does not have a warehouse connection',
+            );
+        }
+        const connectionDefaults = getConnectionDefaults(warehouseConnection);
+        const prompt = await this.buildPrompt({
+            projectUuid: run.project_uuid,
+            warehouseType: warehouseConnection.type,
+            database: connectionDefaults.database,
+            schema: connectionDefaults.schema,
+        });
+        const sensitiveValues = [patToken, anthropicApiKey];
+
+        await sandbox.commands.run(`mkdir -p ${WORKDIR}`);
+        await sandbox.files.write(PROMPT_PATH, prompt);
+        await sandbox.files.write(CLI_WRAPPER_PATH, CLI_WRAPPER_SCRIPT);
+        await sandbox.commands.run(`chmod +x ${CLI_WRAPPER_PATH}`);
+
+        let buffer = '';
+        let assistantText = '';
+        let usage: AgentOnboardingUsage | null = null;
+        let lastStep = '';
+        const pendingEvents: Promise<void>[] = [];
+
+        const recordStep = (
+            rawMessage: string,
+            stage: AgentOnboardingStage | null,
+        ) => {
+            const message = sanitizeOnboardingMessage(
+                rawMessage,
+                sensitiveValues,
+            );
+            if (message === lastStep) return;
+            lastStep = message;
+            pendingEvents.push(
+                this.agentOnboardingRunModel
+                    .appendEvent(run.agent_onboarding_run_uuid, {
+                        eventType: stage ? 'stage' : 'step',
+                        message,
+                        stage,
+                    })
+                    .then(() => undefined)
+                    .catch((error) => {
+                        this.logger.warn(
+                            `OnboardingAgent: could not append event: ${sanitizeOnboardingMessage(
+                                getErrorMessage(error),
+                                sensitiveValues,
+                            )}`,
+                        );
+                    }),
+            );
+        };
+
+        const handleEvent = (event: unknown): void => {
+            const interpreted = interpretAgentEvent(event);
+            if (interpreted.type === 'result') {
+                usage = {
+                    costUsd: interpreted.costUsd,
+                    inputTokens: interpreted.inputTokens,
+                    outputTokens: interpreted.outputTokens,
+                    numTurns: interpreted.numTurns,
+                };
+                return;
+            }
+            if (interpreted.type === 'ignored') return;
+            for (const toolCall of interpreted.toolCalls) {
+                const summary = summarizeToolInput(toolCall.input);
+                const stage = classifyOnboardingStage(
+                    toolCall.name,
+                    toolCall.input,
+                );
+                this.logger.info(
+                    `OnboardingAgent tool call: ${toolCall.name}${
+                        stage ? ` (${stage})` : ''
+                    }`,
+                );
+                const command =
+                    toolCall.name === 'Bash' &&
+                    toolCall.input &&
+                    typeof toolCall.input === 'object' &&
+                    'command' in toolCall.input &&
+                    typeof toolCall.input.command === 'string'
+                        ? toolCall.input.command
+                        : null;
+                recordStep(
+                    command?.slice(0, 200) ?? `${toolCall.name}: ${summary}`,
+                    stage,
+                );
+            }
+            if (interpreted.text !== null) {
+                assistantText = sanitizeOnboardingMessage(
+                    interpreted.text,
+                    sensitiveValues,
+                );
+            }
+        };
+
+        const flushBuffer = (): void => {
+            const { lines, remainder } = splitStreamBuffer(buffer);
+            buffer = remainder;
+            for (const line of lines) {
+                if (line.trim()) {
+                    try {
+                        handleEvent(JSON.parse(line));
+                    } catch {
+                        this.logger.debug(
+                            'OnboardingAgent: received an unparseable Claude event',
+                        );
+                    }
+                }
+            }
+        };
+
+        try {
+            await sandbox.commands.run(
+                `cat ${PROMPT_PATH} | claude -p ` +
+                    `--model ${CLAUDE_MODEL} ` +
+                    '--output-format stream-json --verbose ' +
+                    `--add-dir ${CLAUDE_SKILLS_DIR} ` +
+                    `--allowedTools "${ALLOWED_TOOLS}"`,
+                {
+                    cwd: WORKDIR,
+                    timeoutMs: RUN_TIMEOUT_MS,
+                    envs: {
+                        ANTHROPIC_API_KEY: anthropicApiKey,
+                        LIGHTDASH_URL: this.getSandboxFacingSiteUrl(),
+                        LIGHTDASH_API_KEY: patToken,
+                        LIGHTDASH_PROJECT: run.project_uuid,
+                    },
+                    onStdout: (chunk) => {
+                        buffer += chunk;
+                        flushBuffer();
+                    },
+                    onStderr: () => {
+                        this.logger.debug(
+                            'OnboardingAgent: Claude emitted diagnostic output',
+                        );
+                    },
+                },
+            );
+        } finally {
+            if (buffer.trim()) {
+                try {
+                    handleEvent(JSON.parse(buffer));
+                } catch {
+                    this.logger.debug(
+                        'OnboardingAgent: received an unparseable trailing Claude event',
+                    );
+                }
+            }
+            await Promise.all(pendingEvents);
+        }
+        return { assistantText, usage };
+    }
+
+    private buildHandoff(
+        rawAssistantText: string,
+        sensitiveValues: string[],
+    ): AgentOnboardingHandoff {
+        const siteUrl = this.lightdashConfig.siteUrl.replace(/\/+$/, '');
+        const assistantText = sanitizeOnboardingMessage(
+            rawAssistantText.replaceAll(
+                this.getSandboxFacingSiteUrl().replace(/\/+$/, ''),
+                siteUrl,
+            ),
+            sensitiveValues,
+        );
+        const urlPattern = new RegExp(
+            `${siteUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[^\\s)\`"']*dashboards[^\\s)\`"']*`,
+        );
+        return {
+            summary: assistantText.trim() || null,
+            dashboardUrl: assistantText.match(urlPattern)?.[0] ?? null,
+        };
+    }
+
+    async executeRun(payload: AgentOnboardingJobPayload): Promise<void> {
+        const run = await this.agentOnboardingRunModel.claimQueuedRun(
+            payload.agentOnboardingRunUuid,
+        );
+        if (!run) {
+            this.logger.info(
+                `OnboardingAgent: run ${payload.agentOnboardingRunUuid} was not claimable`,
+            );
+            return;
+        }
+
+        let account: ReturnType<typeof fromSession> | null = null;
+        let pat: Awaited<
+            ReturnType<PersonalAccessTokenService['createPersonalAccessToken']>
+        > | null = null;
+        let manager: SandboxManager | null = null;
+        let sandbox: { sandboxUuid: string; handle: SandboxHandle } | undefined;
+        let cancelled = false;
+        let stopCancellationPoll = () => {};
+        let destroyPromise: Promise<void> | null = null;
+
+        const sensitiveValues = (): string[] =>
+            [
+                pat?.token,
+                this.lightdashConfig.aiWriteback.anthropicApiKey,
+            ].filter((value): value is string => Boolean(value));
+
+        const destroySandbox = (): Promise<void> => {
+            if (!manager || !sandbox) return Promise.resolve();
+            if (!destroyPromise) {
+                destroyPromise = manager
+                    .destroy({
+                        sandboxUuid: sandbox.sandboxUuid,
+                        handle: sandbox.handle,
+                    })
+                    .catch((error) => {
+                        this.logger.warn(
+                            `OnboardingAgent: could not destroy sandbox: ${sanitizeOnboardingMessage(
+                                getErrorMessage(error),
+                                sensitiveValues(),
+                            )}`,
+                        );
+                    });
+            }
+            return destroyPromise;
+        };
+
+        try {
+            account = fromSession(
+                await this.userService.getSessionByUserUuidAndOrg(
+                    run.created_by_user_uuid,
+                    run.organization_uuid,
+                ),
+            );
+            pat =
+                await this.personalAccessTokenService.createPersonalAccessToken(
+                    account,
+                    {
+                        description: `Agent onboarding run ${run.agent_onboarding_run_uuid}`,
+                        expiresAt: new Date(
+                            Date.now() + RUN_TIMEOUT_MS + PAT_EXPIRY_GRACE_MS,
+                        ),
+                        autoGenerated: true,
+                    },
+                    RequestMethod.BACKEND,
+                );
+            await this.agentOnboardingRunModel.update(
+                run.agent_onboarding_run_uuid,
+                { pat_uuid: pat.uuid },
+            );
+
+            const sandboxSpec = this.buildSandboxSpec();
+            manager = this.getSandboxManager();
+            stopCancellationPoll = this.startCancellationPoll(
+                run.agent_onboarding_run_uuid,
+                () => {
+                    cancelled = true;
+                    void destroySandbox();
+                },
+            );
+
+            await this.agentOnboardingRunModel.appendEvent(
+                run.agent_onboarding_run_uuid,
+                {
+                    eventType: 'stage',
+                    message: 'Preparing the onboarding agent',
+                    stage: 'preparing_project',
+                },
+            );
+            sandbox = await manager.acquire({
+                spec: sandboxSpec,
+                organizationUuid: run.organization_uuid,
+                projectUuid: run.project_uuid,
+                workspace: ONBOARDING_WORKSPACE,
+            });
+            await this.agentOnboardingRunModel.update(
+                run.agent_onboarding_run_uuid,
+                { sandbox_uuid: sandbox.sandboxUuid },
+            );
+            if (cancelled) {
+                await destroySandbox();
+                throw new Error('Onboarding run cancelled');
+            }
+
+            const anthropicApiKey = this.getAnthropicApiKey();
+            const { assistantText, usage } = await this.runAgentInSandbox({
+                run,
+                sandbox: sandbox.handle,
+                patToken: pat.token,
+                anthropicApiKey,
+            });
+            const completed = await this.agentOnboardingRunModel.markCompleted(
+                run.agent_onboarding_run_uuid,
+                {
+                    handoff: this.buildHandoff(
+                        assistantText,
+                        sensitiveValues(),
+                    ),
+                    usage,
+                    stage: 'handoff',
+                },
+            );
+            if (!completed) {
+                const current = await this.agentOnboardingRunModel.findByUuid(
+                    run.agent_onboarding_run_uuid,
+                );
+                if (current?.cancellation_requested_at) {
+                    cancelled = true;
+                    await this.agentOnboardingRunModel.markCancelled(
+                        run.agent_onboarding_run_uuid,
+                    );
+                }
+            }
+        } catch (error) {
+            const current = await this.agentOnboardingRunModel
+                .findByUuid(run.agent_onboarding_run_uuid)
+                .catch(() => undefined);
+            if (cancelled || current?.cancellation_requested_at) {
+                cancelled = true;
+                await this.agentOnboardingRunModel.markCancelled(
+                    run.agent_onboarding_run_uuid,
+                );
+            } else {
+                const message = sanitizeOnboardingMessage(
+                    getErrorMessage(error),
+                    sensitiveValues(),
+                );
+                this.logger.error(`OnboardingAgent run failed: ${message}`);
+                await this.agentOnboardingRunModel.markFailed(
+                    run.agent_onboarding_run_uuid,
+                    message,
+                );
+            }
+        } finally {
+            stopCancellationPoll();
+            await destroySandbox();
+            if (account && pat) {
+                await this.personalAccessTokenService
+                    .deletePersonalAccessToken(account, pat.uuid)
+                    .catch((error) => {
+                        this.logger.warn(
+                            `OnboardingAgent: could not revoke PAT: ${sanitizeOnboardingMessage(
+                                getErrorMessage(error),
+                                sensitiveValues(),
+                            )}`,
+                        );
+                    });
+            }
+        }
+    }
+}

--- a/packages/backend/src/ee/services/OnboardingAgentService/constants.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/constants.ts
@@ -1,0 +1,32 @@
+export const WORKDIR = '/home/user/workspace';
+export const PROMPT_PATH = '/home/user/.ld-onboarding-prompt.txt';
+export const CLAUDE_SKILLS_DIR = '/home/user/.claude/skills';
+export const CLI_WRAPPER_PATH = '/tmp/ld';
+
+export const CLI_WRAPPER_SCRIPT = `#!/bin/bash
+while IFS='=' read -r name _; do
+    case "$name" in
+        LIGHTDASH_URL|LIGHTDASH_API_KEY|LIGHTDASH_PROJECT) ;;
+        ANTHROPIC_*|OPENAI_*|OPENROUTER_*|E2B_*|GITHUB_*|GH_*|GITLAB_*|AWS_*|AZURE_CLIENT_SECRET|GOOGLE_APPLICATION_CREDENTIALS|DBT_*|PGPASSWORD|POSTGRES_PASSWORD|MYSQL_PWD|SNOWFLAKE_*|BIGQUERY_*|DATABRICKS_*|REDSHIFT_*|CLICKHOUSE_*|MSSQL_*|TRINO_*|*_PASSWORD|*_TOKEN|*_SECRET|*_PRIVATE_KEY|*_API_KEY) unset "$name" ;;
+    esac
+done < <(env)
+exec lightdash "$@"
+`;
+
+export const CLAUDE_MODEL = 'claude-sonnet-4-6';
+export const RUN_TIMEOUT_MS = 45 * 60 * 1000;
+export const SANDBOX_TIMEOUT_MS = 60 * 60 * 1000;
+export const PAT_EXPIRY_GRACE_MS = 15 * 60 * 1000;
+export const CANCELLATION_POLL_INTERVAL_MS = 10 * 1000;
+
+export const ALLOWED_TOOLS = [
+    `Read(${WORKDIR}/**)`,
+    `Glob(${WORKDIR}/**)`,
+    `Grep(${WORKDIR}/**)`,
+    `Edit(${WORKDIR}/**)`,
+    `Write(${WORKDIR}/**)`,
+    `Read(${CLAUDE_SKILLS_DIR}/**)`,
+    'Skill',
+    'TodoWrite',
+    `Bash(${CLI_WRAPPER_PATH}:*)`,
+].join(',');

--- a/packages/backend/src/ee/services/OnboardingAgentService/utils.test.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/utils.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { ALLOWED_TOOLS, CLI_WRAPPER_SCRIPT } from './constants';
+import { classifyOnboardingStage, sanitizeOnboardingMessage } from './utils';
+
+describe('classifyOnboardingStage', () => {
+    it.each([
+        ['/tmp/ld config get-project', 'preparing_project'],
+        ['/tmp/ld warehouse-catalog tables', 'exploring_warehouse'],
+        ['lightdash sql "select 1" -o /tmp/profile.csv', 'exploring_warehouse'],
+        ['/tmp/ld deploy', 'deploying_semantic_layer'],
+        ['/tmp/ld run-chart chart.yml', 'building_dashboard'],
+        ['/tmp/ld validate', 'verifying'],
+    ] as const)('classifies %s', (command, stage) => {
+        expect(classifyOnboardingStage('Bash', { command })).toBe(stage);
+    });
+
+    it('classifies semantic layer and dashboard writes', () => {
+        expect(
+            classifyOnboardingStage('Write', {
+                file_path: '/home/user/workspace/models/orders.yml',
+            }),
+        ).toBe('deploying_semantic_layer');
+        expect(
+            classifyOnboardingStage('Edit', {
+                file_path:
+                    '/home/user/workspace/lightdash/dashboards/overview.yml',
+            }),
+        ).toBe('building_dashboard');
+    });
+
+    it('ignores help and unrelated tool calls', () => {
+        expect(
+            classifyOnboardingStage('Bash', {
+                command: '/tmp/ld deploy --help',
+            }),
+        ).toBeNull();
+        expect(classifyOnboardingStage('Read', {})).toBeNull();
+    });
+});
+
+describe('sanitizeOnboardingMessage', () => {
+    it('removes secrets, credential URLs, and sandbox paths', () => {
+        const message = sanitizeOnboardingMessage(
+            'ldpat_123 at /home/user/workspace/models/orders.yml via /tmp/ld and https://user:password@example.com; key anthropic-secret; prompt /home/user/.ld-onboarding-prompt.txt; log /var/tmp/agent.log',
+            ['anthropic-secret'],
+        );
+
+        expect(message).toBe(
+            '[REDACTED] at models/orders.yml via lightdash and https://[REDACTED]@example.com; key [REDACTED]; prompt the onboarding prompt; log [sandbox path]',
+        );
+    });
+});
+
+describe('onboarding command policy', () => {
+    it('allows only the secret-stripping wrapper as a Bash command', () => {
+        expect(ALLOWED_TOOLS).toContain('Bash(/tmp/ld:*)');
+        expect(ALLOWED_TOOLS).not.toContain('Bash(cat:*)');
+        expect(ALLOWED_TOOLS).not.toContain('Bash(ls:*)');
+        expect(ALLOWED_TOOLS).not.toContain('Bash(mkdir:*)');
+    });
+
+    it('strips provider and warehouse credentials but preserves scoped Lightdash auth', () => {
+        expect(CLI_WRAPPER_SCRIPT).toContain('ANTHROPIC_*');
+        expect(CLI_WRAPPER_SCRIPT).toContain('GITHUB_*');
+        expect(CLI_WRAPPER_SCRIPT).toContain('AWS_*');
+        expect(CLI_WRAPPER_SCRIPT).toContain('SNOWFLAKE_*');
+        expect(CLI_WRAPPER_SCRIPT).toContain('*_PASSWORD');
+        expect(CLI_WRAPPER_SCRIPT).toContain(
+            'LIGHTDASH_URL|LIGHTDASH_API_KEY|LIGHTDASH_PROJECT',
+        );
+    });
+});

--- a/packages/backend/src/ee/services/OnboardingAgentService/utils.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/utils.ts
@@ -1,0 +1,121 @@
+import { type AgentOnboardingStage } from '@lightdash/common';
+import {
+    CLAUDE_SKILLS_DIR,
+    CLI_WRAPPER_PATH,
+    PROMPT_PATH,
+    WORKDIR,
+} from './constants';
+
+const escapeRegExp = (value: string): string =>
+    value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const LIGHTDASH_COMMAND_PATTERN = new RegExp(
+    `(?:^|[\\s;&|()])(?:lightdash|${escapeRegExp(
+        CLI_WRAPPER_PATH,
+    )})\\s+([\\w-]+)`,
+);
+
+const normalizeToolPath = (path: string): string =>
+    path
+        .replaceAll('\\', '/')
+        .replace(WORKDIR, '')
+        .replace(/^\.?\/+/, '');
+
+const classifyCliStage = (command: string): AgentOnboardingStage | null => {
+    if (/\s--help(?:\s|$)/.test(command)) return null;
+
+    const subcommand = command.match(LIGHTDASH_COMMAND_PATTERN)?.[1];
+    switch (subcommand) {
+        case 'config':
+            return /\b(set-project|rename-project|get-project)\b/.test(command)
+                ? 'preparing_project'
+                : null;
+        case 'warehouse-catalog':
+        case 'sql':
+            return 'exploring_warehouse';
+        case 'deploy':
+            return 'deploying_semantic_layer';
+        case 'run-chart':
+        case 'upload':
+            return 'building_dashboard';
+        case 'validate':
+        case 'download':
+            return 'verifying';
+        default:
+            return null;
+    }
+};
+
+export const classifyOnboardingStage = (
+    toolName: string,
+    input: unknown,
+): AgentOnboardingStage | null => {
+    const fields =
+        input && typeof input === 'object'
+            ? (input as Record<string, unknown>)
+            : {};
+
+    if (toolName === 'Bash') {
+        return typeof fields.command === 'string'
+            ? classifyCliStage(fields.command)
+            : null;
+    }
+    if (toolName !== 'Write' && toolName !== 'Edit') return null;
+
+    const path =
+        typeof fields.file_path === 'string'
+            ? normalizeToolPath(fields.file_path)
+            : '';
+    const content = typeof fields.content === 'string' ? fields.content : '';
+
+    if (
+        /(^|\/)lightdash\/(charts|dashboards)\//.test(path) ||
+        /(^|\/)lightdash\/agent-starter-.*\.ya?ml$/.test(path) ||
+        /^contentType:\s*(chart|dashboard)\s*$/m.test(content)
+    ) {
+        return 'building_dashboard';
+    }
+
+    if (
+        /(^|\/)(models|macros|analyses|seeds|snapshots)\//.test(path) ||
+        /(^|\/)(dbt_project|lightdash\.config|packages|dependencies)\.ya?ml$/.test(
+            path,
+        )
+    ) {
+        return 'deploying_semantic_layer';
+    }
+
+    return null;
+};
+
+export const sanitizeOnboardingMessage = (
+    message: string,
+    sensitiveValues: string[] = [],
+): string => {
+    const redacted = sensitiveValues
+        .filter(Boolean)
+        .reduce(
+            (result, value) => result.replaceAll(value, '[REDACTED]'),
+            message,
+        );
+
+    return redacted
+        .replace(/(https?:\/\/)[^/\s:@]+:[^/\s@]+@/gi, '$1[REDACTED]@')
+        .replace(/\bldpat_[A-Za-z0-9_-]+\b/g, '[REDACTED]')
+        .replace(/\bgh[pousr]_[A-Za-z0-9]{20,}\b/g, '[REDACTED]')
+        .replace(/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, '[REDACTED]')
+        .replace(
+            /\bgl(?:pat|oas|ptt|rt|cbt|soat)-[A-Za-z0-9_-]{20,}\b/g,
+            '[REDACTED]',
+        )
+        .replaceAll(`${CLI_WRAPPER_PATH} `, 'lightdash ')
+        .replaceAll(CLI_WRAPPER_PATH, 'lightdash')
+        .replaceAll(`${WORKDIR}/`, '')
+        .replaceAll(WORKDIR, '.')
+        .replaceAll(PROMPT_PATH, 'the onboarding prompt')
+        .replaceAll(CLAUDE_SKILLS_DIR, 'the onboarding skills directory')
+        .replace(
+            /(^|[\s("'`])\/(?:home\/user|tmp|var\/tmp|root)(?:\/[^\s)"'`]*)?/g,
+            '$1[sandbox path]',
+        );
+};

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -154,6 +154,7 @@ export type ModelManifest = {
     aiWritebackThreadModel: unknown;
     aiWritebackRunModel: unknown;
     aiDeepResearchRunModel: unknown;
+    agentOnboardingRunModel: unknown;
     sandboxRegistryModel: unknown;
     projectCiStatusModel: unknown;
     aiAgentReviewClassifierModel: unknown;
@@ -833,6 +834,10 @@ export class ModelRepository
 
     public getAiDeepResearchRunModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiDeepResearchRunModel');
+    }
+
+    public getAgentOnboardingRunModel<ModelImplT>(): ModelImplT {
+        return this.getModel('agentOnboardingRunModel');
     }
 
     public getSandboxRegistryModel<ModelImplT>(): ModelImplT {

--- a/packages/backend/src/services/PromptService/prompts/projectOnboarding.md
+++ b/packages/backend/src/services/PromptService/prompts/projectOnboarding.md
@@ -31,13 +31,11 @@ Do not rename the prepared project. Keep its existing name for compatibility wit
 ## 2. Discover, author, and deploy the semantic layer
 
 1. Inspect repository documentation, project metadata, and the working tree. Detect whether there is a usable dbt project or an existing pure Lightdash project.
-2. Run one broad catalog query: `lightdash warehouse-catalog --json`. Store large output only in a gitignored temporary location. Prioritize tables in the configured database and schema from the original prompt (matching names case-insensitively) unless repository evidence points elsewhere. If the catalog spans many databases or schemas and neither the configured connection nor repository evidence identifies where to look, ask the user which database and schema to use and wait before continuing.
+2. Start discovery in the configured database and schema from the original prompt, matching names case-insensitively: `lightdash warehouse-catalog --database <database> --schema <schema> --json`. Run the broader `lightdash warehouse-catalog --json` only when that configured scope has no coherent analytics use case or when no database and schema were provided. Store large output only in a gitignored temporary location. If a broad catalog spans many databases or schemas and repository evidence does not identify where to look, ask the user which database and schema to use and wait before continuing.
 3. Choose the smallest coherent analytics use case supported by repository and warehouse evidence. Do not infer business meaning from names alone.
-4. Narrow the catalog only for shortlisted relations. Use the complete command shape:
-    - `lightdash warehouse-catalog --database <database> --schema <schema> --json`
-    - `lightdash warehouse-catalog --database <database> --schema <schema> --table <table> --include-fields --json`
-5. Use `lightdash sql` for aggregate-only profiling. Combine grain, date range, measure, category, and join checks into as few queries as practical. Never output raw identifiers or row samples.
-6. Follow the installed skill and read only the semantic-layer references required for the detected project type.
+4. Fetch fields for each shortlisted relation exactly once with `lightdash warehouse-catalog --database <database> --schema <schema> --table <table> --include-fields --json`. Do not repeat field discovery through `information_schema`, another catalog call, or a raw SQL query.
+5. Use `lightdash sql "<aggregate query>" -o <temporary-output-file>` for aggregate-only profiling; the output file is required. Combine compatible grain, date range, measure, category, and join profiles into as few queries as practical. Read each output file once, extract the evidence needed for authoring, then delete it. Never output raw identifiers or row samples.
+6. Follow the installed skill and read each semantic-layer reference required for the detected project type at most once. Start from its basic example. Read a full schema or run `--help` only after a concrete command or lint failure cannot be resolved from the already-read reference.
 7. Extend a usable dbt project when present. Otherwise, build a minimal pure Lightdash semantic layer from the catalog evidence. A pure project must include the prepared warehouse type before its first deploy:
 
     ```yaml
@@ -54,7 +52,7 @@ Do not rename the prepared project. Keep its existing name for compatibility wit
 
 Create one dashboard for the selected use case with dashboard slug `agent-starter-dashboard` and space slug `lightdash-starter`. Accept the display name generated from that slug; do not rename the space through another interface.
 
-Before authoring, read the installed big-number, cartesian, table, and dashboard references; also read the pie reference only when using a pie or donut chart. Start from their basic examples rather than searching the full schemas ad hoc.
+Before authoring, decide the complete dashboard structure and files. Read the installed big-number, cartesian, table, and dashboard references exactly once; also read the pie reference exactly once only when using a pie or donut chart. Start from their basic examples. Read a full schema or run `--help` only after a concrete lint, upload, or chart-execution failure cannot be resolved from the already-read reference.
 
 Every chart must include these common fields before the first lint:
 
@@ -65,7 +63,7 @@ Every chart must include these common fields before the first lint:
 - top-level `tableName`
 - `version: 1`
 
-Use deterministic `agent-starter-*` chart slugs so reruns update the same content. Author and lint one representative of each chart type before reusing its structure for additional KPI variants.
+Use deterministic `agent-starter-*` chart slugs so reruns update the same content. Author all chart and dashboard files as one batch after deciding the structure. Run one lint across the completed batch, fix only the files and fields it reports, and repeat only failed checks.
 
 ### Dashboard specification
 
@@ -79,16 +77,15 @@ Use deterministic `agent-starter-*` chart slugs so reruns update the same conten
 - Place primary charts below the KPI row at balanced widths such as 24+12 or 18+18; use width 36 for the detail table.
 - Never expose direct identifiers such as names, emails, addresses, account numbers, or IDs. Keep all starter content aggregated regardless of domain.
 
-Run a final `lightdash lint`, execute every chart with `lightdash run-chart -p <chart-yaml-path>`, and upload with `lightdash upload --project <Prepared project UUID> --validate`. Resolve every compile, field, filter, formatting, and query failure, then repeat only the failed check.
+After the batch is authored, run `lightdash lint` once, execute every chart with `lightdash run-chart -p <chart-yaml-path>`, and upload with `lightdash upload --project <Prepared project UUID> --validate`. Resolve every compile, field, filter, formatting, and query failure by changing only the reported files, then repeat only the failed check.
 
 **Gate:** Lint passes, every chart executes successfully, and validated upload succeeds.
 
 ## 4. Validate and hand off
 
-1. Run `lightdash config get-project` and confirm the prepared UUID and existing project name.
-2. Run `lightdash validate --project <Prepared project UUID>` and resolve every reported semantic-layer error.
-3. Do not perform a round-trip download or call internal APIs for additional verification.
-4. Create `LIGHTDASH_HANDOFF.md` in the repository root as the durable, secret-free audit report for this setup. If that file already exists, preserve it and create `LIGHTDASH_ONBOARDING_HANDOFF_<YYYY-MM-DD>.md` using the current date. If that path also exists, append `-2` before `.md`, incrementing the suffix until the path is unused. Never overwrite an existing handoff file.
+1. Run `lightdash validate --project <Prepared project UUID>` and resolve every reported semantic-layer error. Repeat validation only when it failed.
+2. Do not perform a round-trip download, repeat successful chart executions or uploads, or call internal APIs for additional verification.
+3. Create `LIGHTDASH_HANDOFF.md` in the repository root as the durable, secret-free audit report for this setup. If that file already exists, preserve it and create `LIGHTDASH_ONBOARDING_HANDOFF_<YYYY-MM-DD>.md` using the current date. If that path also exists, append `-2` before `.md`, incrementing the suffix until the path is unused. Never overwrite an existing handoff file.
 
 The report must describe what was discovered, why the use case was selected, what was built, and how it was verified. Make it easy to audit with concise prose and Markdown tables. Include:
 

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -153,6 +153,7 @@ interface ServiceManifest {
     /** An implementation signature for these services are not available at this stage */
     aiWritebackService: unknown;
     aiDeepResearchService: unknown;
+    onboardingAgentService: unknown;
     aiAgentReviewNotificationService: unknown;
     writebackPreviewService: unknown;
     previewDeploySetupService: unknown;
@@ -1387,6 +1388,12 @@ export class ServiceRepository
         AiDeepResearchServiceImplT,
     >(): AiDeepResearchServiceImplT {
         return this.getService('aiDeepResearchService');
+    }
+
+    public getOnboardingAgentService<
+        OnboardingAgentServiceImplT,
+    >(): OnboardingAgentServiceImplT {
+        return this.getService('onboardingAgentService');
     }
 
     public getPreviewDeploySetupService<

--- a/packages/common/src/ee/agentOnboarding/types.ts
+++ b/packages/common/src/ee/agentOnboarding/types.ts
@@ -1,0 +1,99 @@
+import { type ApiSuccess } from '../../types/api/success';
+
+export const AGENT_ONBOARDING_RUN_STATUSES = [
+    'queued',
+    'running',
+    'completed',
+    'failed',
+    'cancelled',
+] as const;
+
+export type AgentOnboardingRunStatus =
+    (typeof AGENT_ONBOARDING_RUN_STATUSES)[number];
+
+export const AGENT_ONBOARDING_ACTIVE_STATUSES = [
+    'queued',
+    'running',
+] as const satisfies readonly AgentOnboardingRunStatus[];
+
+export const AGENT_ONBOARDING_TERMINAL_STATUSES = [
+    'completed',
+    'failed',
+    'cancelled',
+] as const satisfies readonly AgentOnboardingRunStatus[];
+
+export type AgentOnboardingTerminalStatus =
+    (typeof AGENT_ONBOARDING_TERMINAL_STATUSES)[number];
+
+export const isAgentOnboardingRunTerminal = (
+    status: AgentOnboardingRunStatus,
+): status is AgentOnboardingTerminalStatus =>
+    AGENT_ONBOARDING_TERMINAL_STATUSES.includes(
+        status as AgentOnboardingTerminalStatus,
+    );
+
+export const AGENT_ONBOARDING_STAGES = [
+    'preparing_project',
+    'exploring_warehouse',
+    'deploying_semantic_layer',
+    'building_dashboard',
+    'verifying',
+    'handoff',
+] as const;
+
+export type AgentOnboardingStage = (typeof AGENT_ONBOARDING_STAGES)[number];
+
+export type AgentOnboardingRunEvent = {
+    eventType: 'stage' | 'step' | 'log';
+    message: string;
+    stage: AgentOnboardingStage | null;
+    createdAt: string;
+};
+
+export type AgentOnboardingHandoff = {
+    summary: string | null;
+    dashboardUrl: string | null;
+};
+
+export type AgentOnboardingUsage = {
+    costUsd: number | null;
+    inputTokens: number | null;
+    outputTokens: number | null;
+    numTurns: number | null;
+};
+
+export type AgentOnboardingFile = {
+    path: string;
+    sizeBytes: number;
+    updatedAt: string;
+};
+
+export type AgentOnboardingFileContent = AgentOnboardingFile & {
+    content: string;
+    encoding: 'utf8' | 'base64';
+};
+
+export type AgentOnboardingRun = {
+    agentOnboardingRunUuid: string;
+    projectUuid: string;
+    status: AgentOnboardingRunStatus;
+    stage: AgentOnboardingStage | null;
+    events: AgentOnboardingRunEvent[];
+    handoff: AgentOnboardingHandoff | null;
+    usage: AgentOnboardingUsage | null;
+    files: AgentOnboardingFile[];
+    errorMessage: string | null;
+    createdAt: string;
+    updatedAt: string;
+    startedAt: string | null;
+    completedAt: string | null;
+};
+
+export type ApiAgentOnboardingRunResponse = ApiSuccess<AgentOnboardingRun>;
+
+export type ApiAgentOnboardingFileResponse =
+    ApiSuccess<AgentOnboardingFileContent>;
+
+export type AgentOnboardingJobPayload = {
+    agentOnboardingRunUuid: string;
+};

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -1,4 +1,5 @@
 export * from './AiAgent';
+export * from './agentOnboarding/types';
 export * from './aiDeepResearch/markdown';
 export * from './aiDeepResearch/types';
 export * from './aiWriteback/types';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -4,6 +4,8 @@ import { type ExploreWarningReport } from '../compiler/compilationReport';
 import type {
     ApiAgentAsCodeListResponse,
     ApiAgentAsCodeUpsertResponse,
+    ApiAgentOnboardingFileResponse,
+    ApiAgentOnboardingRunResponse,
     ApiAgentSuggestionsResponse,
     ApiAiAgentAdminConversationsResponse,
     ApiAiAgentAdminPromptActivityResponse,
@@ -1301,6 +1303,8 @@ type ApiResults =
     | ApiHomepageLinkMetadataResponse['results']
     | ApiProjectColorPaletteResponse['results']
     | ApiOrganizationBrandResponse['results']
+    | ApiAgentOnboardingFileResponse['results']
+    | ApiAgentOnboardingRunResponse['results']
     | ApiManagedAgentRunResponse['results']
     | ApiManagedAgentRunsListResponse['results']
     | ApiManagedAgentActionResponse['results']


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-9043
Closes: PROD-9046
Closes: PROD-9047

### Description:
Adds shared contracts, database persistence, and repository wiring for durable onboarding runs.
Executes the canonical onboarding workflow in a constrained managed sandbox with sanitized progress, cancellation, usage and handoff persistence, and guaranteed PAT and sandbox cleanup.
Optimizes the canonical prompt to avoid redundant discovery, reference reading, authoring, and validation work while preserving the starter dashboard requirements.
Validation includes the focused utility suite, backend fast typecheck, staged lint and formatting hooks, secret scanning, and unused-export checks.