### PR TITLE
feat: add bulk delete for theme files

### DIFF
--- a/packages/backend/src/controllers/organizationDesignController.ts
+++ b/packages/backend/src/controllers/organizationDesignController.ts
@@ -264,6 +264,31 @@ export class OrganizationDesignController extends BaseController {
     }
 
     /**
+     * Delete every file in an organization design, keeping the design itself.
+     * Idempotent — succeeds when the design already has no files.
+     * @summary Delete all files from organization design
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Delete('/{designUuid}/files')
+    @OperationId('DeleteAllOrganizationDesignFiles')
+    async deleteAllFiles(
+        @Request() req: express.Request,
+        @Path() designUuid: string,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.services
+            .getOrganizationDesignService()
+            .clearFiles(req.account, designUuid);
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+
+    /**
      * Delete a single file from an organization design.
      * @summary Delete file from organization design
      */

--- a/packages/backend/src/models/OrganizationDesignModel.test.ts
+++ b/packages/backend/src/models/OrganizationDesignModel.test.ts
@@ -209,4 +209,42 @@ describe('OrganizationDesignModel', () => {
             expect(tracker.history.update).toHaveLength(0);
         });
     });
+
+    describe('removeAllFiles', () => {
+        it('returns every deleted row so the caller can delete their S3 objects', async () => {
+            // The service builds S3 keys from these rows — dropping any here
+            // silently orphans its bytes in the bucket.
+            const rows = [
+                makeDbFile(),
+                makeDbFile({
+                    file_uuid: '00000000-0000-0000-0000-000000000101',
+                    kind: 'image',
+                    filename: 'logo.png',
+                }),
+            ];
+            tracker.on
+                .delete(OrganizationDesignFilesTableName)
+                .responseOnce(rows);
+            tracker.on.update(OrganizationDesignsTableName).responseOnce(1);
+
+            const removed = await model.removeAllFiles(DESIGN_UUID);
+
+            expect(removed.map((f) => f.filename)).toEqual([
+                'theme.css',
+                'logo.png',
+            ]);
+            expect(tracker.history.update).toHaveLength(1);
+        });
+
+        it('skips the parent bump when the design already has no files', async () => {
+            tracker.on
+                .delete(OrganizationDesignFilesTableName)
+                .responseOnce([]);
+
+            await expect(model.removeAllFiles(DESIGN_UUID)).resolves.toEqual(
+                [],
+            );
+            expect(tracker.history.update).toHaveLength(0);
+        });
+    });
 });

--- a/packages/backend/src/models/OrganizationDesignModel.ts
+++ b/packages/backend/src/models/OrganizationDesignModel.ts
@@ -273,4 +273,26 @@ export class OrganizationDesignModel {
             return mapDbFile(row);
         });
     }
+
+    /**
+     * Remove every file row for a design. Returns the deleted rows so the
+     * caller can delete exactly those S3 objects — sweeping the design's
+     * whole S3 prefix instead would race with a concurrent upload.
+     */
+    async removeAllFiles(
+        designUuid: string,
+    ): Promise<ApiOrganizationDesignFile[]> {
+        return this.database.transaction(async (trx) => {
+            const rows = await trx(OrganizationDesignFilesTableName)
+                .where('design_uuid', designUuid)
+                .delete()
+                .returning('*');
+            if (rows.length > 0) {
+                await trx(OrganizationDesignsTableName)
+                    .where('design_uuid', designUuid)
+                    .update({ updated_at: trx.fn.now() as unknown as Date });
+            }
+            return rows.map(mapDbFile);
+        });
+    }
 }

--- a/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.ts
+++ b/packages/backend/src/services/OrganizationDesignService/OrganizationDesignService.ts
@@ -263,6 +263,10 @@ export const designS3Key = (
 const designS3Prefix = (organizationUuid: string, designUuid: string): string =>
     `designs/${organizationUuid}/${designUuid}/`;
 
+// S3 DeleteObjects accepts at most 1000 keys per call. Themes are capped by
+// total bytes, not file count, so a theme can legitimately exceed this.
+const S3_DELETE_BATCH_SIZE = 1000;
+
 export class OrganizationDesignService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
 
@@ -608,6 +612,61 @@ export class OrganizationDesignService extends BaseService {
                 },
             }),
         );
+    }
+
+    /**
+     * Delete every file in a design, keeping the design itself (name,
+     * description, extra instructions, default flag and any `apps.design_uuid`
+     * links all survive). Deleting and recreating the theme is not an
+     * equivalent workaround — that unlinks every app already using it.
+     */
+    async clearFiles(account: Account, designUuid: string): Promise<void> {
+        const { organizationUuid } = this.assertCanManage(account);
+        // Key off the stored uuid, not the raw path arg — Postgres matches uuids
+        // case-insensitively, so an uppercase arg would build keys that hit
+        // nothing and silently orphan every object.
+        const design = await this.loadOwned(organizationUuid, designUuid);
+
+        // Fail loudly if storage isn't configured — a swallowed MissingConfigError
+        // here would report a successful clear that never deleted any bytes.
+        const { client, bucket } = this.getS3Client();
+
+        // Drop the metadata first — once gone, no API path can reference these
+        // S3 objects, so an orphaned-S3 failure is safe and reconcilable later.
+        const removed = await this.organizationDesignModel.removeAllFiles(
+            design.designUuid,
+        );
+        if (removed.length === 0) return;
+
+        const keys = removed.map((file) => ({
+            Key: designS3Key(
+                organizationUuid,
+                design.designUuid,
+                file.fileUuid,
+                file.filename,
+            ),
+        }));
+
+        try {
+            /* eslint-disable no-await-in-loop */
+            for (let i = 0; i < keys.length; i += S3_DELETE_BATCH_SIZE) {
+                await client.send(
+                    new DeleteObjectsCommand({
+                        Bucket: bucket,
+                        Delete: {
+                            Objects: keys.slice(i, i + S3_DELETE_BATCH_SIZE),
+                            Quiet: true,
+                        },
+                    }),
+                );
+            }
+            /* eslint-enable no-await-in-loop */
+        } catch (err) {
+            this.logger.error(
+                `Failed to delete S3 objects while clearing files for design ${designUuid} (org ${organizationUuid}); objects are orphaned and require manual reconciliation`,
+                { organizationUuid, designUuid, error: err },
+            );
+        }
     }
 
     async getFileStream(

--- a/packages/frontend/src/features/organizationDesigns/components/DesignDetailPanel.tsx
+++ b/packages/frontend/src/features/organizationDesigns/components/DesignDetailPanel.tsx
@@ -9,6 +9,7 @@ import {
     ActionIcon,
     Badge,
     Box,
+    Button,
     Center,
     Divider,
     Group,
@@ -26,8 +27,10 @@ import { IconCheck, IconDownload, IconTrash } from '@tabler/icons-react';
 import { useEffect, useRef, useState, type FC } from 'react';
 import Callout from '../../../components/common/Callout';
 import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
 import {
     useClearDefaultOrganizationDesign,
+    useDeleteAllDesignFiles,
     useDeleteDesignFile,
     useOrganizationDesign,
     useSetDefaultOrganizationDesign,
@@ -117,6 +120,7 @@ const DesignForm: FC<{ design: ApiOrganizationDesign }> = ({ design }) => {
     const setDefault = useSetDefaultOrganizationDesign();
     const clearDefault = useClearDefaultOrganizationDesign();
     const deleteFile = useDeleteDesignFile();
+    const deleteAllFiles = useDeleteAllDesignFiles();
 
     const form = useForm({
         initialValues: {
@@ -128,6 +132,7 @@ const DesignForm: FC<{ design: ApiOrganizationDesign }> = ({ design }) => {
     const [pendingDeleteUuid, setPendingDeleteUuid] = useState<string | null>(
         null,
     );
+    const [clearFilesOpen, setClearFilesOpen] = useState(false);
 
     // Theme size guardrail: files are streamed into the sandbox on each build,
     // so an oversized theme times out when applied. Surface the budget as it fills.
@@ -311,14 +316,32 @@ const DesignForm: FC<{ design: ApiOrganizationDesign }> = ({ design }) => {
                 <Box>
                     <Group justify="space-between" align="baseline">
                         <Title order={6}>Files</Title>
-                        <Text
-                            size="xs"
-                            c={limitViolation ? 'red.6' : 'ldGray.6'}
-                        >
-                            {design.files.length} files ·{' '}
-                            {formatBytes(totalBytes)} /{' '}
-                            {formatBytes(MAX_THEME_TOTAL_BYTES)}
-                        </Text>
+                        <Group gap="xs" align="baseline">
+                            <Text
+                                size="xs"
+                                c={limitViolation ? 'red.6' : 'ldGray.6'}
+                            >
+                                {design.files.length} files ·{' '}
+                                {formatBytes(totalBytes)} /{' '}
+                                {formatBytes(MAX_THEME_TOTAL_BYTES)}
+                            </Text>
+                            {design.files.length > 0 && (
+                                <Button
+                                    variant="subtle"
+                                    color="red"
+                                    size="compact-xs"
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconTrash}
+                                            size={12}
+                                        />
+                                    }
+                                    onClick={() => setClearFilesOpen(true)}
+                                >
+                                    Delete all
+                                </Button>
+                            )}
+                        </Group>
                     </Group>
                     <Text size="sm" c="ldGray.6" mt={4}>
                         Drag &amp; drop CSS, font, image, or markdown
@@ -382,6 +405,26 @@ const DesignForm: FC<{ design: ApiOrganizationDesign }> = ({ design }) => {
                     </Stack>
                 )}
             </Stack>
+
+            <MantineModal
+                opened={clearFilesOpen}
+                onClose={() => setClearFilesOpen(false)}
+                variant="delete"
+                title="Delete all files"
+                description={`Are you sure you want to delete all ${design.files.length} files from "${design.name}"?`}
+                size="md"
+                confirmLoading={deleteAllFiles.isLoading}
+                onConfirm={() =>
+                    deleteAllFiles.mutate(design.designUuid, {
+                        onSuccess: () => setClearFilesOpen(false),
+                    })
+                }
+            >
+                <span>
+                    The theme itself is kept, along with its description, extra
+                    instructions, and anything already using it.
+                </span>
+            </MantineModal>
         </Group>
     );
 };

--- a/packages/frontend/src/features/organizationDesigns/hooks/useOrganizationDesigns.ts
+++ b/packages/frontend/src/features/organizationDesigns/hooks/useOrganizationDesigns.ts
@@ -109,6 +109,13 @@ const deleteDesignFileApi = async (args: {
         body: undefined,
     });
 
+const deleteAllDesignFilesApi = async (designUuid: string) =>
+    lightdashApi<null>({
+        url: `/org/designs/${designUuid}/files`,
+        method: 'DELETE',
+        body: undefined,
+    });
+
 export const useOrganizationDesigns = ({
     enabled = true,
 }: { enabled?: boolean } = {}) =>
@@ -299,4 +306,29 @@ export const useDeleteDesignFile = () => {
             });
         },
     });
+};
+
+export const useDeleteAllDesignFiles = () => {
+    const { showToastSuccess, showToastApiError } = useToaster();
+    const queryClient = useQueryClient();
+    return useMutation<null, ApiError, string>(
+        (designUuid) => deleteAllDesignFilesApi(designUuid),
+        {
+            mutationKey: ['delete_all_org_design_files'],
+            onSuccess: async (_result, designUuid) => {
+                await queryClient.invalidateQueries([ORG_DESIGNS_QUERY_KEY]);
+                await queryClient.invalidateQueries([
+                    ORG_DESIGN_QUERY_KEY,
+                    designUuid,
+                ]);
+                showToastSuccess({ title: 'All files deleted' });
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to delete files',
+                    apiError: error,
+                });
+            },
+        },
+    );
 };


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7939/make-it-possible-to-clear-theme-files

### Description:
Themes could only have their files removed one at a time. Deleting and recreating the theme was not an equivalent workaround: it drops the name, description, extra instructions and default flag, and `apps.design_uuid` is ON DELETE SET NULL, so it silently unlinks every data app using it.

Adds DELETE /api/v1/org/designs/{designUuid}/files, which clears every file while keeping the theme itself, plus a "Delete all" action in the theme editor's file list.

S3 keys are built from the rows removeAllFiles returns rather than sweeping the design's S3 prefix, which would race a concurrent upload, and are keyed off the stored uuid so a differently-cased path arg (uuid comparison in Postgres is case-insensitive) can't produce keys that match nothing. DeleteObjects is chunked at 1000 keys since themes are capped by total bytes, not file count.