### PR TITLE
feat(homepage): one 12-column page grid every block subscribes to

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.module.css
@@ -177,8 +177,10 @@
     overflow-y: auto;
 }
 
+/* Same content width as the published page (tierFull 1160) so the canvas
+ * shows real proportions instead of a compressed approximation. */
 .canvasInner {
-    max-width: 960px;
+    max-width: 1224px;
     margin: 0 auto;
     padding: 32px 32px 120px;
 }

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -332,6 +332,7 @@ type BlockCardProps = {
     onRemove: () => void;
     onChange: (updated: HomepageBlock) => void;
     justPlaced: boolean;
+    itemSpan: number | null;
 };
 
 const BlockCard: FC<BlockCardProps> = ({
@@ -346,6 +347,7 @@ const BlockCard: FC<BlockCardProps> = ({
     onRemove,
     onChange,
     justPlaced,
+    itemSpan,
 }) => {
     const {
         attributes,
@@ -435,6 +437,7 @@ const BlockCard: FC<BlockCardProps> = ({
                 block={block}
                 projectUuid={projectUuid}
                 onChange={onChange}
+                itemSpan={itemSpan}
             />
         </div>
     );
@@ -1036,6 +1039,15 @@ export const HomepageEditor: FC<Props> = ({
                                                                         }
                                                                     >
                                                                         <BlockCard
+                                                                            itemSpan={
+                                                                                resolvedRows[
+                                                                                    rowIndex
+                                                                                ]
+                                                                                    .columns[
+                                                                                    blockIndex
+                                                                                ]
+                                                                                    .itemSpan
+                                                                            }
                                                                             block={
                                                                                 block
                                                                             }

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -991,6 +991,10 @@ export const HomepageEditor: FC<Props> = ({
                                                         resolvedRows[rowIndex]
                                                             .fit
                                                     }
+                                                    data-align={
+                                                        resolvedRows[rowIndex]
+                                                            .align
+                                                    }
                                                 >
                                                     {row.blocks.map(
                                                         (block, blockIndex) => {

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -61,7 +61,7 @@ import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import { useAiAgentButtonVisibility } from '../aiCopilot/hooks/useAiAgentsButtonVisibility';
-import { traitFor } from './blockLayout';
+import { TIER_CLASS, traitFor } from './blockLayout';
 import { IconSquare } from './blocks/BlockShell';
 import {
     blockLibrary,
@@ -85,6 +85,7 @@ import {
     type DropTarget,
 } from './configOps';
 import classes from './HomepageEditor.module.css';
+import layout from './homepageLayout.module.css';
 import {
     useDeleteHomepage,
     useDiscardHomepageDraft,
@@ -97,6 +98,7 @@ import {
     type HomepageViewType,
 } from './PreviewPane';
 import { PublishModal } from './PublishModal';
+import { resolveHomepageLayout } from './resolveHomepageLayout';
 
 type DragSource =
     | { kind: 'new'; definition: BlockDefinition }
@@ -497,6 +499,13 @@ export const HomepageEditor: FC<Props> = ({
     const lastSavedRef = useRef<HomepageConfig>(draft);
     // Compare-and-set token so a stale editor can never clobber newer state
     const baseUpdatedAtRef = useRef<Date>(homepage.updatedAt);
+
+    // WYSIWYG: the canvas adopts the published layout's geometry. Build
+    // surface keeps rows/blocks 1:1 with the draft, so indexes line up.
+    const resolvedRows = useMemo(
+        () => resolveHomepageLayout(draft, { surface: 'build' }).rows,
+        [draft],
+    );
 
     const [activeDrag, setActiveDrag] = useState<DragSource | null>(null);
     // Where the drop will land, shown as an insertion indicator. The real
@@ -966,8 +975,18 @@ export const HomepageEditor: FC<Props> = ({
                                                     gap="md"
                                                     align="stretch"
                                                     wrap="nowrap"
-                                                    className={
+                                                    className={`${
                                                         classes.rowColumns
+                                                    } ${layout.row} ${
+                                                        TIER_CLASS[
+                                                            resolvedRows[
+                                                                rowIndex
+                                                            ].widthTier
+                                                        ]
+                                                    }`}
+                                                    data-fit={
+                                                        resolvedRows[rowIndex]
+                                                            .fit
                                                     }
                                                 >
                                                     {row.blocks.map(
@@ -992,86 +1011,111 @@ export const HomepageEditor: FC<Props> = ({
                                                                             )}
                                                                         />
                                                                     )}
-                                                                    <BlockCard
-                                                                        block={
-                                                                            block
+                                                                    <div
+                                                                        className={
+                                                                            layout.col
                                                                         }
-                                                                        definition={
-                                                                            definition
+                                                                        data-weight={
+                                                                            resolvedRows[
+                                                                                rowIndex
+                                                                            ]
+                                                                                .columns[
+                                                                                blockIndex
+                                                                            ]
+                                                                                .weight
                                                                         }
-                                                                        justPlaced={
-                                                                            block.id ===
-                                                                            justPlacedId
+                                                                        data-hug-units={
+                                                                            resolvedRows[
+                                                                                rowIndex
+                                                                            ]
+                                                                                .columns[
+                                                                                blockIndex
+                                                                            ]
+                                                                                .hugUnits ??
+                                                                            undefined
                                                                         }
-                                                                        projectUuid={
-                                                                            projectUuid
-                                                                        }
-                                                                        canUp={canMoveUp(
-                                                                            draft,
-                                                                            block.id,
-                                                                        )}
-                                                                        canDown={canMoveDown(
-                                                                            draft,
-                                                                            block.id,
-                                                                        )}
-                                                                        onUp={() =>
-                                                                            setDraft(
-                                                                                (
-                                                                                    prev,
-                                                                                ) =>
-                                                                                    moveBlockUp(
+                                                                    >
+                                                                        <BlockCard
+                                                                            block={
+                                                                                block
+                                                                            }
+                                                                            definition={
+                                                                                definition
+                                                                            }
+                                                                            justPlaced={
+                                                                                block.id ===
+                                                                                justPlacedId
+                                                                            }
+                                                                            projectUuid={
+                                                                                projectUuid
+                                                                            }
+                                                                            canUp={canMoveUp(
+                                                                                draft,
+                                                                                block.id,
+                                                                            )}
+                                                                            canDown={canMoveDown(
+                                                                                draft,
+                                                                                block.id,
+                                                                            )}
+                                                                            onUp={() =>
+                                                                                setDraft(
+                                                                                    (
                                                                                         prev,
-                                                                                        block.id,
-                                                                                    ),
-                                                                            )
-                                                                        }
-                                                                        onDown={() =>
-                                                                            setDraft(
-                                                                                (
-                                                                                    prev,
-                                                                                ) =>
-                                                                                    moveBlockDown(
+                                                                                    ) =>
+                                                                                        moveBlockUp(
+                                                                                            prev,
+                                                                                            block.id,
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                            onDown={() =>
+                                                                                setDraft(
+                                                                                    (
                                                                                         prev,
-                                                                                        block.id,
-                                                                                    ),
-                                                                            )
-                                                                        }
-                                                                        onDuplicate={() =>
-                                                                            setDraft(
-                                                                                (
-                                                                                    prev,
-                                                                                ) =>
-                                                                                    duplicateBlock(
+                                                                                    ) =>
+                                                                                        moveBlockDown(
+                                                                                            prev,
+                                                                                            block.id,
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                            onDuplicate={() =>
+                                                                                setDraft(
+                                                                                    (
                                                                                         prev,
-                                                                                        block.id,
-                                                                                    ),
-                                                                            )
-                                                                        }
-                                                                        onRemove={() =>
-                                                                            setDraft(
-                                                                                (
-                                                                                    prev,
-                                                                                ) =>
-                                                                                    removeBlock(
+                                                                                    ) =>
+                                                                                        duplicateBlock(
+                                                                                            prev,
+                                                                                            block.id,
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                            onRemove={() =>
+                                                                                setDraft(
+                                                                                    (
                                                                                         prev,
-                                                                                        block.id,
-                                                                                    ),
-                                                                            )
-                                                                        }
-                                                                        onChange={(
-                                                                            updated,
-                                                                        ) =>
-                                                                            setDraft(
-                                                                                (
-                                                                                    prev,
-                                                                                ) =>
-                                                                                    replaceBlock(
+                                                                                    ) =>
+                                                                                        removeBlock(
+                                                                                            prev,
+                                                                                            block.id,
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                            onChange={(
+                                                                                updated,
+                                                                            ) =>
+                                                                                setDraft(
+                                                                                    (
                                                                                         prev,
-                                                                                        updated,
-                                                                                    ),
-                                                                            )
-                                                                        }
-                                                                    />
+                                                                                    ) =>
+                                                                                        replaceBlock(
+                                                                                            prev,
+                                                                                            updated,
+                                                                                        ),
+                                                                                )
+                                                                            }
+                                                                        />
+                                                                    </div>
                                                                 </Fragment>
                                                             );
                                                         },

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -22,7 +22,7 @@ const BlockRenderer: FC<{
     projectUuid: string;
     personalPlaceholders: boolean;
     presentation?: BlockPresentation;
-    itemSpan?: number | null;
+    itemSpan: number | null;
 }> = ({ block, projectUuid, personalPlaceholders, presentation, itemSpan }) => {
     const definition = getBlockDefinition(block.type);
     if (!definition) return null;
@@ -125,6 +125,7 @@ export const PublishedHomepage: FC<Props> = ({
                             projectUuid={projectUuid}
                             personalPlaceholders={personalPlaceholders}
                             presentation="hero"
+                            itemSpan={hero.row.columns[0].itemSpan}
                         />
                     </div>
                 </div>

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -22,7 +22,8 @@ const BlockRenderer: FC<{
     projectUuid: string;
     personalPlaceholders: boolean;
     presentation?: BlockPresentation;
-}> = ({ block, projectUuid, personalPlaceholders, presentation }) => {
+    itemSpan?: number | null;
+}> = ({ block, projectUuid, personalPlaceholders, presentation, itemSpan }) => {
     const definition = getBlockDefinition(block.type);
     if (!definition) return null;
     if (personalPlaceholders && PERSONAL_BLOCK_TYPES.includes(block.type)) {
@@ -46,6 +47,7 @@ const BlockRenderer: FC<{
             block={block}
             projectUuid={projectUuid}
             presentation={presentation}
+            itemSpan={itemSpan}
         />
     );
 };
@@ -72,6 +74,7 @@ const RowRenderer: FC<{
                     block={column.block}
                     projectUuid={projectUuid}
                     personalPlaceholders={personalPlaceholders}
+                    itemSpan={column.itemSpan}
                 />
             </Box>
         ))}

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -5,7 +5,7 @@ import {
 } from '@lightdash/common';
 import { Box, Paper, Text } from '@mantine-8/core';
 import { type FC, type ReactNode } from 'react';
-import { type BlockWidthTier } from './blockLayout';
+import { TIER_CLASS } from './blockLayout';
 import { getBlockDefinition } from './blocks/registry';
 import { type BlockPresentation } from './blocks/types';
 import layout from './homepageLayout.module.css';
@@ -15,13 +15,6 @@ import {
 } from './resolveHomepageLayout';
 
 const PERSONAL_BLOCK_TYPES: HomepageBlock['type'][] = ['favorites', 'recent'];
-
-const TIER_CLASS: Record<BlockWidthTier, string> = {
-    reading: layout.tierReading,
-    composer: layout.tierComposer,
-    content: layout.tierContent,
-    full: layout.tierFull,
-};
 
 // Unknown block types render nothing so newer configs degrade gracefully
 const BlockRenderer: FC<{

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishedHomepage.tsx
@@ -61,6 +61,7 @@ const RowRenderer: FC<{
         className={`${layout.row} ${TIER_CLASS[row.widthTier]}`}
         data-gap={row.gap}
         data-role={row.role}
+        data-align={row.align}
         data-fit={row.fit}
     >
         {row.columns.map((column) => (

--- a/packages/frontend/src/ee/features/homepageBuilder/blockLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blockLayout.ts
@@ -9,6 +9,19 @@ export type BlockWidthTier = 'reading' | 'composer' | 'content' | 'full';
 // tucks under what precedes it; a `section` block starts a new section.
 export type BlockRhythm = 'section' | 'grouped';
 
+// The page is one 12-column grid (the track count lives in
+// homepageLayout.module.css). A card-grid block declares how many of those
+// columns a single item spans, so every block's card edges land on shared
+// tracks instead of each block inventing its own width.
+export type BlockItemSpan = {
+    // Item span when the block owns a full-width row.
+    full: number;
+    // Item span at the narrower `content` tier.
+    content: number;
+    // Item span when the block shares a row with another block.
+    narrow: number;
+};
+
 export type BlockLayoutTrait = {
     widthTier: BlockWidthTier;
     // Relative flex weight when this block shares a row with others.
@@ -16,6 +29,8 @@ export type BlockLayoutTrait = {
     rhythm: BlockRhythm;
     // Full-row blocks can never share a row (enforced by configOps guards).
     fullRowOnly: boolean;
+    // null for blocks that render as a list or prose rather than a card grid.
+    itemSpan: BlockItemSpan | null;
 };
 
 // Declarative per-type layout. A resolver composes these for whatever
@@ -27,54 +42,63 @@ const blockLayoutTraits: Record<HomepageBlock['type'], BlockLayoutTrait> = {
         columnWeight: 2,
         rhythm: 'section',
         fullRowOnly: true,
+        itemSpan: null,
     },
     'quick-actions': {
         widthTier: 'content',
         columnWeight: 1,
         rhythm: 'grouped',
         fullRowOnly: false,
+        itemSpan: null,
     },
     metrics: {
         widthTier: 'full',
         columnWeight: 2,
         rhythm: 'section',
         fullRowOnly: false,
+        itemSpan: { full: 3, content: 4, narrow: 6 },
     },
     collection: {
         widthTier: 'full',
         columnWeight: 2,
         rhythm: 'section',
         fullRowOnly: false,
+        itemSpan: { full: 4, content: 4, narrow: 6 },
     },
     resources: {
         widthTier: 'content',
         columnWeight: 1,
         rhythm: 'grouped',
         fullRowOnly: false,
+        itemSpan: { full: 4, content: 4, narrow: 6 },
     },
     announcements: {
         widthTier: 'reading',
         columnWeight: 1,
         rhythm: 'section',
         fullRowOnly: false,
+        itemSpan: null,
     },
     favorites: {
         widthTier: 'content',
         columnWeight: 1,
         rhythm: 'grouped',
         fullRowOnly: false,
+        itemSpan: null,
     },
     recent: {
         widthTier: 'content',
         columnWeight: 1,
         rhythm: 'grouped',
         fullRowOnly: false,
+        itemSpan: null,
     },
     markdown: {
         widthTier: 'reading',
         columnWeight: 1,
         rhythm: 'grouped',
         fullRowOnly: false,
+        itemSpan: null,
     },
 };
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blockLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blockLayout.ts
@@ -1,4 +1,5 @@
 import { type HomepageBlock } from '@lightdash/common';
+import layout from './homepageLayout.module.css';
 
 // How wide a single-block row of this type should render. Formalises the
 // magic widths that used to live as ad-hoc maps in PublishedHomepage.
@@ -79,3 +80,11 @@ const blockLayoutTraits: Record<HomepageBlock['type'], BlockLayoutTrait> = {
 
 export const traitFor = (type: HomepageBlock['type']): BlockLayoutTrait =>
     blockLayoutTraits[type];
+
+// Width tier → shared layout class, used by both render surfaces.
+export const TIER_CLASS: Record<BlockWidthTier, string> = {
+    reading: layout.tierReading,
+    composer: layout.tierComposer,
+    content: layout.tierContent,
+    full: layout.tierFull,
+};

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
@@ -29,6 +29,7 @@ describe('AskAiHeroBlockView', () => {
     it('greets in the hero slot', () => {
         wrap(
             <AskAiHeroBlockView
+                itemSpan={null}
                 block={block}
                 projectUuid="p1"
                 presentation="hero"
@@ -41,7 +42,13 @@ describe('AskAiHeroBlockView', () => {
     });
 
     it('renders inline mid-page without the greeting, even when toggled on', () => {
-        wrap(<AskAiHeroBlockView block={block} projectUuid="p1" />);
+        wrap(
+            <AskAiHeroBlockView
+                itemSpan={null}
+                block={block}
+                projectUuid="p1"
+            />,
+        );
         expect(screen.queryByText(/What do you want to know/)).toBeNull();
         expect(screen.getByTestId('ask-input')).toBeInTheDocument();
     });

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/BlockShell.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/BlockShell.tsx
@@ -24,7 +24,7 @@ export const BlockHeader: FC<PropsWithChildren<BlockHeaderProps>> = ({
     iconColor,
     title,
     pill,
-    mb = 12,
+    mb = 10,
     centered = false,
     children,
 }) => (

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -44,10 +44,12 @@ import { useInfiniteContent } from '../../../../hooks/useContent';
 import { useProject } from '../../../../hooks/useProject';
 import { useSpaceSummaries } from '../../../../hooks/useSpaces';
 import { reorderCollectionItems } from '../configOps';
+import layoutClasses from '../homepageLayout.module.css';
 import { useCollectionContent } from '../hooks/useCollectionContent';
 import { BlockHeader } from './BlockShell';
 import classes from './blockStyles.module.css';
 import { ContentCard } from './ContentCard';
+import { PageGrid, PageGridItem } from './PageGrid';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const toFavoriteType = (content: SummaryContent) =>
@@ -315,6 +317,7 @@ const CollectionPickerModal: FC<{
 };
 
 export const CollectionBlockView: FC<BlockComponentProps> = ({
+    itemSpan,
     block,
     projectUuid,
 }) => {
@@ -334,31 +337,21 @@ export const CollectionBlockView: FC<BlockComponentProps> = ({
     const favoriteUuids = new Set(
         (favorites ?? []).map((item) => item.data.uuid),
     );
-    // A partial row centres its cards, so centre the header with them — the
-    // whole block reads as one unit instead of a left-anchored orphan title.
-    const cardCount = (contents ?? uuids).length;
     return (
         <Stack gap={0}>
-            <BlockHeader
-                icon={IconLayoutGrid}
-                title={block.config.title}
-                centered={cardCount > 0 && cardCount < 3}
-            />
+            <BlockHeader icon={IconLayoutGrid} title={block.config.title} />
             {isInitialLoading ? (
-                <div className={classes.hugGrid}>
+                <PageGrid itemSpan={itemSpan ?? null}>
                     {uuids.slice(0, 3).map((uuid) => (
-                        <div key={uuid} className={classes.hugGridItem}>
+                        <PageGridItem key={uuid}>
                             <Skeleton h={108} radius="md" />
-                        </div>
+                        </PageGridItem>
                     ))}
-                </div>
+                </PageGrid>
             ) : (
-                <div
-                    className={classes.hugGrid}
-                    data-per-row={Math.min(cardCount, 3)}
-                >
+                <PageGrid itemSpan={itemSpan ?? null}>
                     {(contents ?? []).map((content) => (
-                        <div key={content.uuid} className={classes.hugGridItem}>
+                        <PageGridItem key={content.uuid}>
                             <ContentCard
                                 content={content}
                                 projectUuid={projectUuid}
@@ -373,9 +366,9 @@ export const CollectionBlockView: FC<BlockComponentProps> = ({
                                         }),
                                 }}
                             />
-                        </div>
+                        </PageGridItem>
                     ))}
-                </div>
+                </PageGrid>
             )}
         </Stack>
     );
@@ -399,7 +392,7 @@ const SortableTile: FC<{
     return (
         <div
             ref={setNodeRef}
-            className={`${classes.sortableTile} ${classes.hugGridItem}`}
+            className={`${classes.sortableTile} ${layoutClasses.pageGridItem}`}
             data-dragging={isDragging}
             style={{
                 transform: CSS.Translate.toString(transform),
@@ -419,6 +412,7 @@ const SortableTile: FC<{
 };
 
 export const CollectionBlockBuild: FC<BuildComponentProps> = ({
+    itemSpan,
     block,
     projectUuid,
     onChange,
@@ -495,7 +489,7 @@ export const CollectionBlockBuild: FC<BuildComponentProps> = ({
                     items={(contents ?? []).map((content) => content.uuid)}
                     strategy={rectSortingStrategy}
                 >
-                    <div className={classes.hugGrid}>
+                    <PageGrid itemSpan={itemSpan ?? null}>
                         {(contents ?? []).map((content) => (
                             <SortableTile
                                 key={content.uuid}
@@ -515,7 +509,7 @@ export const CollectionBlockBuild: FC<BuildComponentProps> = ({
                                 }
                             />
                         ))}
-                        <div className={classes.hugGridItem}>
+                        <PageGridItem>
                             <button
                                 type="button"
                                 className={classes.addContentTile}
@@ -524,8 +518,8 @@ export const CollectionBlockBuild: FC<BuildComponentProps> = ({
                                 <MantineIcon icon={IconPlus} size={14} />
                                 Add content
                             </button>
-                        </div>
-                    </div>
+                        </PageGridItem>
+                    </PageGrid>
                 </SortableContext>
             </DndContext>
             {block.config.items.length === 0 && importablePins.length > 0 && (

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -341,7 +341,7 @@ export const CollectionBlockView: FC<BlockComponentProps> = ({
         <Stack gap={0}>
             <BlockHeader icon={IconLayoutGrid} title={block.config.title} />
             {isInitialLoading ? (
-                <PageGrid itemSpan={itemSpan ?? null}>
+                <PageGrid itemSpan={itemSpan ?? null} elastic>
                     {uuids.slice(0, 3).map((uuid) => (
                         <PageGridItem key={uuid}>
                             <Skeleton h={108} radius="md" />
@@ -349,7 +349,7 @@ export const CollectionBlockView: FC<BlockComponentProps> = ({
                     ))}
                 </PageGrid>
             ) : (
-                <PageGrid itemSpan={itemSpan ?? null}>
+                <PageGrid itemSpan={itemSpan ?? null} elastic>
                     {(contents ?? []).map((content) => (
                         <PageGridItem key={content.uuid}>
                             <ContentCard
@@ -489,7 +489,7 @@ export const CollectionBlockBuild: FC<BuildComponentProps> = ({
                     items={(contents ?? []).map((content) => content.uuid)}
                     strategy={rectSortingStrategy}
                 >
-                    <PageGrid itemSpan={itemSpan ?? null}>
+                    <PageGrid itemSpan={itemSpan ?? null} elastic>
                         {(contents ?? []).map((content) => (
                             <SortableTile
                                 key={content.uuid}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
@@ -48,7 +48,7 @@ const VerifiedBadge: FC<{ content: SummaryContent }> = ({ content }) =>
 
 const TileUpdated: FC<{ date: Date | string }> = ({ date }) => {
     const timeAgo = useTimeAgo(date, 60000);
-    return <span>updated {timeAgo}</span>;
+    return <>updated {timeAgo}</>;
 };
 
 const TileExtra: FC<{ content: SummaryContent }> = ({ content }) => {
@@ -56,13 +56,13 @@ const TileExtra: FC<{ content: SummaryContent }> = ({ content }) => {
         'space' in content && content.space ? content.space.name : null;
     if (!spaceName && !content.lastUpdatedAt) return null;
     return (
-        <div className={classes.tileExtra}>
+        <Box className={classes.tileExtra}>
             {spaceName ? `in ${spaceName}` : null}
             {spaceName && content.lastUpdatedAt ? ' · ' : null}
             {content.lastUpdatedAt ? (
                 <TileUpdated date={content.lastUpdatedAt} />
             ) : null}
-        </div>
+        </Box>
     );
 };
 
@@ -132,7 +132,7 @@ const MaybeLink: FC<
             {children}
         </Link>
     ) : (
-        <div className={className}>{children}</div>
+        <Box className={className}>{children}</Box>
     );
 
 export const ContentCard: FC<Props> = ({
@@ -154,7 +154,7 @@ export const ContentCard: FC<Props> = ({
                 className={`${cardClass} ${classes.cardUnitHalf} ${classes.contentTile}`}
             >
                 <ResourceIcon item={contentToResourceViewItem(content)} />
-                <div className={classes.tileBody}>
+                <Box className={classes.tileBody}>
                     <Group gap={5} wrap="nowrap">
                         <Text size="sm" fw={600} truncate>
                             {content.name}
@@ -163,14 +163,14 @@ export const ContentCard: FC<Props> = ({
                     </Group>
                     <KindAndViews content={content} />
                     <TileExtra content={content} />
-                </div>
-                <div className={classes.tileActions}>
+                </Box>
+                <Box className={classes.tileActions}>
                     <CardActions
                         content={content}
                         onRemove={onRemove}
                         star={star}
                     />
-                </div>
+                </Box>
             </MaybeLink>
         );
     }

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
@@ -126,7 +126,7 @@ export const ContentCard: FC<Props> = ({
 
     if (variant === 'tile') {
         return (
-            <MaybeLink to={to} className={cardClass}>
+            <MaybeLink to={to} className={`${cardClass} ${classes.cardUnit1}`}>
                 <Box p={14} h="100%">
                     <Group
                         justify="space-between"

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
@@ -15,6 +15,7 @@ import { type FC, type PropsWithChildren } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { ResourceIcon } from '../../../../components/common/ResourceIcon';
+import { useTimeAgo } from '../../../../hooks/useTimeAgo';
 import classes from './blockStyles.module.css';
 
 const contentUrl = (projectUuid: string, content: SummaryContent): string => {
@@ -44,6 +45,26 @@ const VerifiedBadge: FC<{ content: SummaryContent }> = ({ content }) =>
             </Box>
         </Tooltip>
     ) : null;
+
+const TileUpdated: FC<{ date: Date | string }> = ({ date }) => {
+    const timeAgo = useTimeAgo(date);
+    return <span>updated {timeAgo}</span>;
+};
+
+const TileExtra: FC<{ content: SummaryContent }> = ({ content }) => {
+    const spaceName =
+        'space' in content && content.space ? content.space.name : null;
+    if (!spaceName && !content.lastUpdatedAt) return null;
+    return (
+        <div className={classes.tileExtra}>
+            {spaceName ? `in ${spaceName}` : null}
+            {spaceName && content.lastUpdatedAt ? ' · ' : null}
+            {content.lastUpdatedAt ? (
+                <TileUpdated date={content.lastUpdatedAt} />
+            ) : null}
+        </div>
+    );
+};
 
 const KindAndViews: FC<{ content: SummaryContent }> = ({ content }) => (
     <Group gap={5} wrap="nowrap" className={classes.rowMeta}>
@@ -130,25 +151,26 @@ export const ContentCard: FC<Props> = ({
         return (
             <MaybeLink
                 to={to}
-                className={`${cardClass} ${classes.cardUnitHalf}`}
+                className={`${cardClass} ${classes.cardUnitHalf} ${classes.contentTile}`}
             >
-                <Group gap={10} wrap="nowrap" align="center" p={12} h="100%">
-                    <ResourceIcon item={contentToResourceViewItem(content)} />
-                    <Box flex={1} miw={0}>
-                        <Group gap={5} wrap="nowrap">
-                            <Text size="sm" fw={600} truncate>
-                                {content.name}
-                            </Text>
-                            <VerifiedBadge content={content} />
-                        </Group>
-                        <KindAndViews content={content} />
-                    </Box>
+                <ResourceIcon item={contentToResourceViewItem(content)} />
+                <div className={classes.tileBody}>
+                    <Group gap={5} wrap="nowrap">
+                        <Text size="sm" fw={600} truncate>
+                            {content.name}
+                        </Text>
+                        <VerifiedBadge content={content} />
+                    </Group>
+                    <KindAndViews content={content} />
+                    <TileExtra content={content} />
+                </div>
+                <div className={classes.tileActions}>
                     <CardActions
                         content={content}
                         onRemove={onRemove}
                         star={star}
                     />
-                </Group>
+                </div>
             </MaybeLink>
         );
     }

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
@@ -47,7 +47,7 @@ const VerifiedBadge: FC<{ content: SummaryContent }> = ({ content }) =>
     ) : null;
 
 const TileUpdated: FC<{ date: Date | string }> = ({ date }) => {
-    const timeAgo = useTimeAgo(date);
+    const timeAgo = useTimeAgo(date, 60000);
     return <span>updated {timeAgo}</span>;
 };
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
@@ -127,7 +127,7 @@ export const ContentCard: FC<Props> = ({
     if (variant === 'tile') {
         return (
             <MaybeLink to={to} className={`${cardClass} ${classes.cardUnit1}`}>
-                <Box p={14} h="100%">
+                <Box p={12} h="100%">
                     <Group
                         justify="space-between"
                         align="flex-start"

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ContentCard.tsx
@@ -125,32 +125,30 @@ export const ContentCard: FC<Props> = ({
     const cardClass = `${classes.hoverCard}${to ? ` ${classes.clickable}` : ''}`;
 
     if (variant === 'tile') {
+        // Horizontal at half a card unit: two content tiles stack to exactly
+        // one unit card, so mixed rows keep sharing horizontal edges.
         return (
-            <MaybeLink to={to} className={`${cardClass} ${classes.cardUnit1}`}>
-                <Box p={12} h="100%">
-                    <Group
-                        justify="space-between"
-                        align="flex-start"
-                        mb={10}
-                        wrap="nowrap"
-                    >
-                        <ResourceIcon
-                            item={contentToResourceViewItem(content)}
-                        />
-                        <CardActions
-                            content={content}
-                            onRemove={onRemove}
-                            star={star}
-                        />
-                    </Group>
-                    <Group gap={5} wrap="nowrap" mb={2}>
-                        <Text size="sm" fw={600} truncate>
-                            {content.name}
-                        </Text>
-                        <VerifiedBadge content={content} />
-                    </Group>
-                    <KindAndViews content={content} />
-                </Box>
+            <MaybeLink
+                to={to}
+                className={`${cardClass} ${classes.cardUnitHalf}`}
+            >
+                <Group gap={10} wrap="nowrap" align="center" p={12} h="100%">
+                    <ResourceIcon item={contentToResourceViewItem(content)} />
+                    <Box flex={1} miw={0}>
+                        <Group gap={5} wrap="nowrap">
+                            <Text size="sm" fw={600} truncate>
+                                {content.name}
+                            </Text>
+                            <VerifiedBadge content={content} />
+                        </Group>
+                        <KindAndViews content={content} />
+                    </Box>
+                    <CardActions
+                        content={content}
+                        onRemove={onRemove}
+                        star={star}
+                    />
+                </Group>
             </MaybeLink>
         );
     }

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricSparkline.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricSparkline.tsx
@@ -60,7 +60,7 @@ const MetricSparkline: FC<Props> = ({ points, change }) => {
             option={option}
             notMerge
             opts={{ renderer: 'svg' }}
-            style={{ height: 40, width: '100%' }}
+            style={{ height: 30, width: '100%' }}
         />
     );
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
@@ -113,7 +113,7 @@ const MetricKpiCard: FC<{
             c="inherit"
         >
             <Box
-                className={`${classes.hoverCard} ${classes.clickable} ${classes.kpiCard}`}
+                className={`${classes.hoverCard} ${classes.clickable} ${classes.kpiCard} ${classes.cardUnit1}`}
                 p={14}
             >
                 <div className={classes.kpiLabel}>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
@@ -145,7 +145,11 @@ const MetricKpiCard: FC<{
                                     />
                                 </Box>
                             ) : null)}
-                        <Group gap={6} className={classes.kpiFoot}>
+                        <Group
+                            gap={6}
+                            wrap="nowrap"
+                            className={classes.kpiFoot}
+                        >
                             {change !== undefined && (
                                 <span
                                     className={`${classes.kpiDelta} ${
@@ -161,7 +165,7 @@ const MetricKpiCard: FC<{
                                     })}
                                 </span>
                             )}
-                            <Text size="xs" c="dimmed">
+                            <Text size="xs" c="dimmed" truncate miw={0}>
                                 vs previous period
                             </Text>
                         </Group>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
@@ -16,7 +16,6 @@ import {
     Card,
     Group,
     Loader,
-    SimpleGrid,
     Skeleton,
     Stack,
     Text,
@@ -40,6 +39,7 @@ import { calculateComparisonValue } from '../../../../hooks/useBigNumberConfig';
 import { BlockHeader } from './BlockShell';
 import classes from './blockStyles.module.css';
 import MetricSparkline from './MetricSparkline';
+import { PageGrid, PageGridItem } from './PageGrid';
 import { type BlockComponentProps, type BuildComponentProps } from './types';
 
 const KPI_TIME_FRAME = TimeFrames.MONTH;
@@ -263,31 +263,26 @@ const MetricsPickerModal: FC<{
 export const MetricsBlockView: FC<BlockComponentProps> = ({
     block,
     projectUuid,
+    itemSpan,
 }) => {
     if (block.type !== 'metrics' || block.config.items.length === 0) {
         return null;
     }
-    const itemCount = block.config.items.length;
     return (
         <Stack gap={0}>
             <BlockHeader icon={IconChartDots} title={block.config.title} />
-            {/* Tracks match the item count so sparse rows leave no phantom columns */}
-            <SimpleGrid
-                cols={{
-                    base: 1,
-                    sm: Math.min(itemCount, 2),
-                    md: Math.min(itemCount, 4),
-                }}
-                spacing={12}
-            >
+            <PageGrid itemSpan={itemSpan ?? null}>
                 {block.config.items.map((metricRef) => (
-                    <MetricKpiCard
+                    <PageGridItem
                         key={`${metricRef.tableName}-${metricRef.metricName}`}
-                        metricRef={metricRef}
-                        projectUuid={projectUuid}
-                    />
+                    >
+                        <MetricKpiCard
+                            metricRef={metricRef}
+                            projectUuid={projectUuid}
+                        />
+                    </PageGridItem>
                 ))}
-            </SimpleGrid>
+            </PageGrid>
         </Stack>
     );
 };
@@ -296,6 +291,7 @@ export const MetricsBlockBuild: FC<BuildComponentProps> = ({
     block,
     projectUuid,
     onChange,
+    itemSpan,
 }) => {
     const [isPickerOpen, setIsPickerOpen] = useState(false);
     if (block.type !== 'metrics') return null;
@@ -319,7 +315,7 @@ export const MetricsBlockBuild: FC<BuildComponentProps> = ({
                     })
                 }
             />
-            <SimpleGrid cols={{ base: 1, sm: 2, md: 4 }} spacing="sm">
+            <PageGrid itemSpan={itemSpan ?? null}>
                 {block.config.items.map((metricRef) => (
                     <Card
                         key={`${metricRef.tableName}-${metricRef.metricName}`}
@@ -361,7 +357,7 @@ export const MetricsBlockBuild: FC<BuildComponentProps> = ({
                         </Group>
                     </Card>
                 ))}
-            </SimpleGrid>
+            </PageGrid>
             <Button
                 variant="default"
                 size="xs"

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
@@ -113,9 +113,8 @@ const MetricKpiCard: FC<{
             c="inherit"
         >
             <Box
-                className={`${classes.hoverCard} ${classes.clickable}`}
+                className={`${classes.hoverCard} ${classes.clickable} ${classes.kpiCard}`}
                 p={14}
-                h="100%"
             >
                 <div className={classes.kpiLabel}>
                     {totalQuery.data?.metric.label ?? metricRef.label}
@@ -146,7 +145,7 @@ const MetricKpiCard: FC<{
                                     />
                                 </Box>
                             ) : null)}
-                        <Group gap={6}>
+                        <Group gap={6} className={classes.kpiFoot}>
                             {change !== undefined && (
                                 <span
                                     className={`${classes.kpiDelta} ${

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
@@ -114,7 +114,7 @@ const MetricKpiCard: FC<{
         >
             <Box
                 className={`${classes.hoverCard} ${classes.clickable} ${classes.kpiCard} ${classes.cardUnit1}`}
-                p={14}
+                p={12}
             >
                 <div className={classes.kpiLabel}>
                     {totalQuery.data?.metric.label ?? metricRef.label}
@@ -135,10 +135,10 @@ const MetricKpiCard: FC<{
                         </div>
                         {timeDimension &&
                             (seriesQuery.isInitialLoading ? (
-                                <Skeleton h={40} my={4} radius="sm" />
+                                <Skeleton h={30} my={3} radius="sm" />
                             ) : seriesQuery.data &&
                               seriesQuery.data.points.length > 0 ? (
-                                <Box my={4}>
+                                <Box my={3}>
                                     <MetricSparkline
                                         points={seriesQuery.data.points}
                                         change={change}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
@@ -274,7 +274,7 @@ export const MetricsBlockView: FC<BlockComponentProps> = ({
     return (
         <Stack gap={0}>
             <BlockHeader icon={IconChartDots} title={block.config.title} />
-            <PageGrid itemSpan={itemSpan ?? null}>
+            <PageGrid itemSpan={itemSpan ?? null} elastic floor="unit">
                 {block.config.items.map((metricRef) => (
                     <PageGridItem
                         key={`${metricRef.tableName}-${metricRef.metricName}`}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
@@ -317,45 +317,49 @@ export const MetricsBlockBuild: FC<BuildComponentProps> = ({
             />
             <PageGrid itemSpan={itemSpan ?? null}>
                 {block.config.items.map((metricRef) => (
-                    <Card
+                    <PageGridItem
                         key={`${metricRef.tableName}-${metricRef.metricName}`}
-                        withBorder
-                        p="sm"
                     >
-                        <Group gap="xs" wrap="nowrap" justify="space-between">
-                            <Box miw={0}>
-                                <Text size="sm" fw={500} truncate>
-                                    {metricRef.label}
-                                </Text>
-                                <Text size="xs" c="dimmed" truncate>
-                                    {metricRef.tableName}
-                                </Text>
-                            </Box>
-                            <ActionIcon
-                                variant="subtle"
-                                color="ldGray.6"
-                                size="sm"
-                                aria-label={`Remove metric ${metricRef.label}`}
-                                onClick={() =>
-                                    onChange({
-                                        ...block,
-                                        config: {
-                                            ...block.config,
-                                            items: block.config.items.filter(
-                                                (item) =>
-                                                    item.metricName !==
-                                                        metricRef.metricName ||
-                                                    item.tableName !==
-                                                        metricRef.tableName,
-                                            ),
-                                        },
-                                    })
-                                }
+                        <Card withBorder p="sm" h="100%">
+                            <Group
+                                gap="xs"
+                                wrap="nowrap"
+                                justify="space-between"
                             >
-                                <MantineIcon icon={IconX} />
-                            </ActionIcon>
-                        </Group>
-                    </Card>
+                                <Box miw={0}>
+                                    <Text size="sm" fw={500} truncate>
+                                        {metricRef.label}
+                                    </Text>
+                                    <Text size="xs" c="dimmed" truncate>
+                                        {metricRef.tableName}
+                                    </Text>
+                                </Box>
+                                <ActionIcon
+                                    variant="subtle"
+                                    color="ldGray.6"
+                                    size="sm"
+                                    aria-label={`Remove metric ${metricRef.label}`}
+                                    onClick={() =>
+                                        onChange({
+                                            ...block,
+                                            config: {
+                                                ...block.config,
+                                                items: block.config.items.filter(
+                                                    (item) =>
+                                                        item.metricName !==
+                                                            metricRef.metricName ||
+                                                        item.tableName !==
+                                                            metricRef.tableName,
+                                                ),
+                                            },
+                                        })
+                                    }
+                                >
+                                    <MantineIcon icon={IconX} />
+                                </ActionIcon>
+                            </Group>
+                        </Card>
+                    </PageGridItem>
                 ))}
             </PageGrid>
             <Button

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/PageGrid.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/PageGrid.test.tsx
@@ -1,0 +1,144 @@
+import {
+    type HomepageMetricsBlock,
+    type HomepageResourcesBlock,
+} from '@lightdash/common';
+import { MantineProvider } from '@mantine-8/core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import { MetricsBlockBuild } from './MetricsBlock';
+import { ResourcesBlockBuild, ResourcesBlockView } from './ResourcesBlock';
+
+const block: HomepageResourcesBlock = {
+    id: 'r1',
+    type: 'resources',
+    config: {
+        title: 'Resources',
+        layout: 'card',
+        items: [
+            { title: 'One', url: 'https://a.example', kind: 'link' },
+            { title: 'Two', url: 'https://b.example', kind: 'doc' },
+            { title: 'Three', url: 'https://c.example', kind: 'link' },
+        ],
+    },
+};
+
+const metricsBlock: HomepageMetricsBlock = {
+    id: 'm1',
+    type: 'metrics',
+    config: {
+        title: 'KPIs',
+        items: [
+            { tableName: 'orders', metricName: 'a', label: 'A' },
+            { tableName: 'orders', metricName: 'b', label: 'B' },
+        ],
+    },
+};
+
+const gridOf = (container: HTMLElement) =>
+    container.querySelector('[data-span]');
+
+// The metrics picker subscribes to the metrics catalog, so the tree needs a
+// query client even though these assertions never touch fetched data.
+const renderIn = (ui: React.ReactElement) =>
+    render(
+        <QueryClientProvider client={new QueryClient()}>
+            <MantineProvider>{ui}</MantineProvider>
+        </QueryClientProvider>,
+    );
+
+describe('PageGrid', () => {
+    it('stamps the resolved span on the grid', () => {
+        const { container } = renderIn(
+            <ResourcesBlockView block={block} projectUuid="p1" itemSpan={4} />,
+        );
+        expect(gridOf(container)?.getAttribute('data-span')).toBe('4');
+    });
+
+    // The bug this guards: the builder canvas rendered Build components without
+    // threading itemSpan, so every card fell back to full width in edit mode
+    // while the published page showed them 3-up. Same block, same span, both
+    // surfaces must produce the same grid.
+    it('renders the same grid on the view and build surfaces', () => {
+        const view = renderIn(
+            <ResourcesBlockView block={block} projectUuid="p1" itemSpan={4} />,
+        );
+        const build = renderIn(
+            <ResourcesBlockBuild
+                block={block}
+                projectUuid="p1"
+                itemSpan={4}
+                onChange={vi.fn()}
+            />,
+        );
+        expect(gridOf(build.container)?.getAttribute('data-span')).toBe(
+            gridOf(view.container)?.getAttribute('data-span'),
+        );
+    });
+
+    it('falls back to a single full-width column when there is no span', () => {
+        const { container } = renderIn(
+            <ResourcesBlockView
+                block={block}
+                projectUuid="p1"
+                itemSpan={null}
+            />,
+        );
+        expect(gridOf(container)?.getAttribute('data-span')).toBe('12');
+    });
+
+    // A grid child that isn't a PageGridItem silently occupies a single track
+    // instead of spanning — which is how the build surface ended up rendering
+    // 79px-wide metric tiles while the view surface was correct. Only the item
+    // wrapper carries the span rule, so every direct child must be one.
+    // (jsdom doesn't apply CSS-module stylesheets, so the class is the
+    // assertable proxy for the span; counting children would not catch this.)
+    it.each([
+        [
+            'view',
+            () => (
+                <ResourcesBlockView
+                    block={block}
+                    projectUuid="p1"
+                    itemSpan={4}
+                />
+            ),
+        ],
+        [
+            'resources build',
+            () => (
+                <ResourcesBlockBuild
+                    block={block}
+                    projectUuid="p1"
+                    itemSpan={4}
+                    onChange={vi.fn()}
+                />
+            ),
+        ],
+        [
+            'metrics build',
+            () => (
+                <MetricsBlockBuild
+                    block={metricsBlock}
+                    projectUuid="p1"
+                    itemSpan={4}
+                    onChange={vi.fn()}
+                />
+            ),
+        ],
+    ])('wraps every grid child on the %s surface', (_surface, ui) => {
+        const { container } = renderIn(ui());
+        const grid = gridOf(container);
+        expect(grid).not.toBeNull();
+        expect(grid!.children.length).toBeGreaterThan(0);
+        [...grid!.children].forEach((child) => {
+            expect(child.className).toContain('pageGridItem');
+        });
+    });
+
+    it('gives every item its own grid cell', () => {
+        const { container } = renderIn(
+            <ResourcesBlockView block={block} projectUuid="p1" itemSpan={4} />,
+        );
+        expect(gridOf(container)?.children).toHaveLength(3);
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/PageGrid.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/PageGrid.tsx
@@ -1,0 +1,24 @@
+import { type FC, type ReactNode } from 'react';
+import layout from '../homepageLayout.module.css';
+
+type PageGridProps = {
+    // Page columns one item spans, from the resolver. null falls back to a
+    // single full-width column.
+    itemSpan: number | null;
+    children: ReactNode;
+};
+
+/**
+ * The homepage's shared 12-column card grid. Every card-grid block renders
+ * through this so card edges land on the same tracks regardless of block type,
+ * and a remainder row starts on the same track as a full one.
+ */
+export const PageGrid: FC<PageGridProps> = ({ itemSpan, children }) => (
+    <div className={layout.pageGrid} data-span={itemSpan ?? 12}>
+        {children}
+    </div>
+);
+
+export const PageGridItem: FC<{ children: ReactNode }> = ({ children }) => (
+    <div className={layout.pageGridItem}>{children}</div>
+);

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/PageGrid.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/PageGrid.tsx
@@ -5,6 +5,15 @@ type PageGridProps = {
     // Page columns one item spans, from the resolver. null falls back to a
     // single full-width column.
     itemSpan: number | null;
+    // Elastic grids stretch to fill their column, distributing height across
+    // their rows — a short block beside a taller sibling closes the gap
+    // bento-style instead of leaving dead space. Only for blocks whose cards
+    // tolerate growing; rigid cards (resources) define height.
+    elastic?: boolean;
+    // Row floor for elastic grids: 'half' for half-unit tiles, 'unit' for
+    // full-unit cards. Containment stops content sizing the rows, so the
+    // floor is what holds an unstretched grid at its natural height.
+    floor?: 'half' | 'unit';
     children: ReactNode;
 };
 
@@ -13,8 +22,18 @@ type PageGridProps = {
  * through this so card edges land on the same tracks regardless of block type,
  * and a remainder row starts on the same track as a full one.
  */
-export const PageGrid: FC<PageGridProps> = ({ itemSpan, children }) => (
-    <div className={layout.pageGrid} data-span={itemSpan ?? 12}>
+export const PageGrid: FC<PageGridProps> = ({
+    itemSpan,
+    elastic = false,
+    floor = 'half',
+    children,
+}) => (
+    <div
+        className={layout.pageGrid}
+        data-span={itemSpan ?? 12}
+        data-elastic={elastic || undefined}
+        data-floor={elastic ? floor : undefined}
+    >
         {children}
     </div>
 );

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/PageGrid.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/PageGrid.tsx
@@ -1,3 +1,4 @@
+import { Box } from '@mantine-8/core';
 import { type FC, type ReactNode } from 'react';
 import layout from '../homepageLayout.module.css';
 
@@ -28,16 +29,16 @@ export const PageGrid: FC<PageGridProps> = ({
     floor = 'half',
     children,
 }) => (
-    <div
+    <Box
         className={layout.pageGrid}
         data-span={itemSpan ?? 12}
         data-elastic={elastic || undefined}
         data-floor={elastic ? floor : undefined}
     >
         {children}
-    </div>
+    </Box>
 );
 
 export const PageGridItem: FC<{ children: ReactNode }> = ({ children }) => (
-    <div className={layout.pageGridItem}>{children}</div>
+    <Box className={layout.pageGridItem}>{children}</Box>
 );

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.test.tsx
@@ -34,6 +34,7 @@ describe('ResourcesBlockView', () => {
     it('renders a card with title, description and a link to the resource', () => {
         wrap(
             <ResourcesBlockView
+                itemSpan={null}
                 projectUuid="p1"
                 block={block({ layout: 'card', items: [claudeItem] })}
             />,
@@ -49,6 +50,7 @@ describe('ResourcesBlockView', () => {
     it('renders a compact row in list layout', () => {
         wrap(
             <ResourcesBlockView
+                itemSpan={null}
                 projectUuid="p1"
                 block={block({ layout: 'list', items: [claudeItem] })}
             />,
@@ -63,6 +65,7 @@ describe('ResourcesBlockView', () => {
     it('renders nothing when there are no items', () => {
         wrap(
             <ResourcesBlockView
+                itemSpan={null}
                 projectUuid="p1"
                 block={block({ items: [] })}
             />,
@@ -85,6 +88,7 @@ describe('ResourcesBlockBuild smart paste', () => {
         const onChange = vi.fn();
         wrap(
             <ResourcesBlockBuild
+                itemSpan={null}
                 projectUuid="p1"
                 onChange={onChange}
                 block={block({ layout: 'card', items: [] })}
@@ -123,6 +127,7 @@ describe('ResourcesBlockBuild smart paste', () => {
         const onChange = vi.fn();
         wrap(
             <ResourcesBlockBuild
+                itemSpan={null}
                 projectUuid="p1"
                 onChange={onChange}
                 block={block({ layout: 'card', items: [] })}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -169,7 +169,7 @@ const ResourceCard: FC<{ item: HomepageResourceItem }> = ({ item }) => {
             href={item.url}
             target="_blank"
             rel="noopener noreferrer"
-            className={`${classes.mediaCard} ${classes.clickable} ${classes.plainLink}`}
+            className={`${classes.mediaCard} ${classes.cardUnit1} ${classes.clickable} ${classes.plainLink}`}
         >
             <CardThumb item={item} />
             <div className={classes.mediaBody}>

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -36,6 +36,7 @@ import {
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { BlockHeader, IconSquare, MiniPill } from './BlockShell';
 import classes from './blockStyles.module.css';
+import { PageGrid, PageGridItem } from './PageGrid';
 import {
     faviconUrl,
     hostnameOf,
@@ -214,7 +215,10 @@ const ResourceRow: FC<{ item: HomepageResourceItem }> = ({ item }) => {
     );
 };
 
-export const ResourcesBlockView: FC<BlockComponentProps> = ({ block }) => {
+export const ResourcesBlockView: FC<BlockComponentProps> = ({
+    block,
+    itemSpan,
+}) => {
     if (block.type !== 'resources' || block.config.items.length === 0) {
         return null;
     }
@@ -223,11 +227,13 @@ export const ResourcesBlockView: FC<BlockComponentProps> = ({ block }) => {
         <Stack gap={0}>
             <BlockHeader icon={IconBook} title={block.config.title} />
             {layout === 'card' ? (
-                <div className={classes.mediaGrid}>
+                <PageGrid itemSpan={itemSpan ?? null}>
                     {block.config.items.map((item, i) => (
-                        <ResourceCard key={`${item.url}-${i}`} item={item} />
+                        <PageGridItem key={`${item.url}-${i}`}>
+                            <ResourceCard item={item} />
+                        </PageGridItem>
                     ))}
-                </div>
+                </PageGrid>
             ) : (
                 <div className={classes.listCard}>
                     {block.config.items.map((item, i) => (
@@ -381,6 +387,7 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
     block,
     projectUuid,
     onChange,
+    itemSpan,
 }) => {
     const [pasteValue, setPasteValue] = useState('');
     const [batch, setBatch] = useState<BatchEntry[]>([]);
@@ -503,22 +510,27 @@ export const ResourcesBlockBuild: FC<BuildComponentProps> = ({
             </Group>
 
             {layout === 'card' ? (
-                <div className={classes.mediaGrid}>
+                <PageGrid itemSpan={itemSpan ?? null}>
                     {items.map((item, i) => (
-                        <BuildCard
-                            key={`${item.url}-${i}`}
-                            item={item}
-                            onPatch={(patch) => patchItem(i, patch)}
-                            onRemove={() => removeItem(i)}
-                        />
+                        <PageGridItem key={`${item.url}-${i}`}>
+                            <BuildCard
+                                item={item}
+                                onPatch={(patch) => patchItem(i, patch)}
+                                onRemove={() => removeItem(i)}
+                            />
+                        </PageGridItem>
                     ))}
                     {resolvedBatch.map((e) => (
-                        <ResourceCard key={e.key} item={e.item} />
+                        <PageGridItem key={e.key}>
+                            <ResourceCard item={e.item} />
+                        </PageGridItem>
                     ))}
                     {Array.from({ length: pendingCount }).map((_, i) => (
-                        <SkeletonCard key={`sk-${i}`} />
+                        <PageGridItem key={`sk-${i}`}>
+                            <SkeletonCard />
+                        </PageGridItem>
                     ))}
-                </div>
+                </PageGrid>
             ) : (
                 <div className={classes.listCard}>
                     {items.map((item, i) => (

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -76,6 +76,11 @@ const KIND_OPTIONS = (Object.keys(KIND_META) as HomepageResourceKind[]).map(
 const kindMeta = (kind: HomepageResourceKind) =>
     KIND_META[kind] ?? KIND_META.link;
 
+// Google's favicon service never 404s: sites with no favicon get its default
+// globe, served at 16px however large we ask. Detect it by size and fall back
+// to our own kind glyph instead of showing the blurry globe.
+const isDefaultFavicon = (img: HTMLImageElement) => img.naturalWidth < 32;
+
 // --- Thumbnails -------------------------------------------------------------
 
 const CardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
@@ -110,6 +115,10 @@ const CardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
                     alt={item.title}
                     loading="lazy"
                     onError={() => setFaviconFailed(true)}
+                    onLoad={(e) => {
+                        if (isDefaultFavicon(e.currentTarget))
+                            setFaviconFailed(true);
+                    }}
                 />
             ) : (
                 <div className={classes.resGlyphTile}>
@@ -146,6 +155,10 @@ const RowThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
                     alt=""
                     loading="lazy"
                     onError={() => setFaviconFailed(true)}
+                    onLoad={(e) => {
+                        if (isDefaultFavicon(e.currentTarget))
+                            setFaviconFailed(true);
+                    }}
                 />
             </div>
         );

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -50,9 +50,13 @@ const KIND_META: Record<
     HomepageResourceKind,
     { icon: Icon; label: string; thumbAccent: string }
 > = {
-    video: { icon: IconVideo, label: 'Video', thumbAccent: '' },
-    doc: { icon: IconBook, label: 'Doc', thumbAccent: '' },
-    link: { icon: IconLink, label: 'Link', thumbAccent: '' },
+    video: {
+        icon: IconVideo,
+        label: 'Video',
+        thumbAccent: classes.resThumbVideo,
+    },
+    doc: { icon: IconBook, label: 'Doc', thumbAccent: classes.resThumbDoc },
+    link: { icon: IconLink, label: 'Link', thumbAccent: classes.resThumbLink },
     claude: {
         icon: IconSparkles,
         label: 'Claude',
@@ -96,31 +100,20 @@ const CardThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
         );
     }
 
-    // No sharp photo → blurred colour backdrop (claude's card, else the site's
-    // own favicon) with the crisp favicon floating on top.
-    const backdrop = item.kind === 'claude' ? imageUrl : favicon;
+    // No sharp photo → a quiet kind-tinted wash with the bare favicon on it.
     return (
         <div className={`${classes.resThumbTile} ${meta.thumbAccent}`}>
-            {backdrop ? (
-                <img
-                    className={classes.resThumbBackdrop}
-                    src={backdrop}
-                    alt=""
-                    loading="lazy"
-                    aria-hidden
-                />
-            ) : null}
             {favicon && !faviconFailed ? (
                 <img
-                    className={classes.resFaviconFloat}
+                    className={classes.resFavTile}
                     src={favicon}
                     alt={item.title}
                     loading="lazy"
                     onError={() => setFaviconFailed(true)}
                 />
             ) : (
-                <div className={classes.resGlyphFloat}>
-                    <MantineIcon icon={meta.icon} size={26} />
+                <div className={classes.resGlyphTile}>
+                    <MantineIcon icon={meta.icon} size={22} />
                 </div>
             )}
         </div>
@@ -162,36 +155,29 @@ const RowThumb: FC<{ item: HomepageResourceItem }> = ({ item }) => {
 
 // --- Read-only presentation (published + preview) ---------------------------
 
-const ResourceCard: FC<{ item: HomepageResourceItem }> = ({ item }) => {
-    const meta = kindMeta(item.kind);
-    return (
-        <a
-            href={item.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={`${classes.mediaCard} ${classes.cardUnit1} ${classes.clickable} ${classes.plainLink}`}
-        >
-            <CardThumb item={item} />
-            <div className={classes.mediaBody}>
-                <div className={classes.mediaKind}>
-                    <MantineIcon icon={meta.icon} size={12} />
-                    <span>{meta.label}</span>
-                    <MantineIcon
-                        icon={IconExternalLink}
-                        size={12}
-                        className={classes.mediaExternal}
-                    />
-                </div>
-                <div className={classes.mediaTitle}>
-                    {item.title || hostnameOf(item.url)}
-                </div>
-                {item.description ? (
-                    <div className={classes.mediaDesc}>{item.description}</div>
-                ) : null}
+const ResourceCard: FC<{ item: HomepageResourceItem }> = ({ item }) => (
+    <a
+        href={item.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${classes.mediaCard} ${classes.cardUnit1} ${classes.clickable} ${classes.plainLink}`}
+    >
+        <MantineIcon
+            icon={IconExternalLink}
+            size={13}
+            className={classes.resExternal}
+        />
+        <CardThumb item={item} />
+        <div className={classes.mediaBody}>
+            <div className={classes.mediaTitle}>
+                {item.title || hostnameOf(item.url)}
             </div>
-        </a>
-    );
-};
+            <div className={classes.mediaDesc}>
+                {item.description || hostnameOf(item.url)}
+            </div>
+        </div>
+    </a>
+);
 
 const ResourceRow: FC<{ item: HomepageResourceItem }> = ({ item }) => {
     const meta = kindMeta(item.kind);

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -232,6 +232,20 @@ a .hoverCard:hover,
     margin-bottom: 8px;
 }
 
+/* KPI cards stack top-down with their comparison line pinned to the bottom.
+ * A metric without a time dimension has no sparkline, so without this its
+ * content stops mid-card and the tile reads as empty next to a fuller
+ * neighbour — the grid already stretches every card to the row's height. */
+.kpiCard {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.kpiFoot {
+    margin-top: auto;
+}
+
 .kpiLabel {
     font-size: 12px;
     color: var(--mantine-color-ldGray-6);

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -379,6 +379,8 @@ a .hoverCard:hover,
 .mediaCard {
     --card-unit: 140px;
 
+    position: relative;
+
     /* Fixed to the unit rather than floored by it: the band below absorbs
      * whatever the body doesn't use, so a one-line and a two-line description
      * still produce the same card height. */
@@ -415,7 +417,6 @@ a .hoverCard:hover,
     min-height: 56px;
     overflow: hidden;
     background: var(--mantine-color-ldGray-1);
-    border-bottom: 1px solid var(--mantine-color-ldGray-2);
 }
 
 .resThumb img {
@@ -437,7 +438,8 @@ a .hoverCard:hover,
     color: var(--mantine-color-ldGray-6);
 }
 
-/* App-store style tile: blurred colour backdrop + crisp floating favicon */
+/* Quiet duotone tile: a muted per-kind wash with a small bare favicon —
+ * no blurred backdrop, no floating chip. */
 .resThumbTile {
     position: relative;
     width: 100%;
@@ -446,54 +448,87 @@ a .hoverCard:hover,
     overflow: hidden;
     display: grid;
     place-items: center;
-    background: var(--mantine-color-ldGray-1);
-    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+    background: linear-gradient(
+        135deg,
+        light-dark(#eef0f4, #23262e),
+        light-dark(#e3e6ee, #1c1f26)
+    );
+    color: var(--mantine-color-ldGray-6);
 }
 
-.resThumbBackdrop {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    filter: blur(18px) saturate(1.25);
-    transform: scale(1.35);
-    animation: resFadeIn 0.2s ease-out;
-}
-
-.resFaviconFloat,
-.resGlyphFloat {
-    position: relative;
-    z-index: 1;
-    width: 38px;
-    height: 38px;
-    border-radius: 10px;
+.resFavTile {
+    width: 22px;
+    height: 22px;
+    border-radius: 5px;
     object-fit: contain;
-    background: light-dark(#fff, var(--mantine-color-dark-5));
-    box-shadow:
-        0 3px 14px rgba(0, 0, 0, 0.22),
-        0 0 0 1px rgba(0, 0, 0, 0.04);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.18);
     animation: resFadeIn 0.2s ease-out;
 }
 
-.resFaviconFloat {
-    padding: 8px;
-}
-
-.resGlyphFloat {
+.resGlyphTile {
     display: grid;
     place-items: center;
-    color: var(--mantine-color-ldGray-7);
+    opacity: 0.75;
+}
+
+.resThumbDoc {
+    background: linear-gradient(
+        135deg,
+        light-dark(#e8f0ea, #222e27),
+        light-dark(#dbe8df, #1a251f)
+    );
+    color: light-dark(#4c7a5c, #8fbf9f);
+}
+
+.resThumbLink {
+    background: linear-gradient(
+        135deg,
+        light-dark(#eaedf8, #252a3b),
+        light-dark(#dfe3f2, #1e2231)
+    );
+    color: light-dark(#5a68a8, #9ba8dd);
+}
+
+.resThumbVideo {
+    background: linear-gradient(
+        135deg,
+        light-dark(#efeaf8, #2b2539),
+        light-dark(#e5def2, #231e2f)
+    );
+    color: light-dark(#7a5aa8, #b19bdd);
 }
 
 .resThumbClaude {
-    background: light-dark(#f8ede8, #3a2a22);
+    background: linear-gradient(
+        135deg,
+        light-dark(#f7ede5, #362a21),
+        light-dark(#f1e2d3, #2c221b)
+    );
     color: light-dark(#c15f3c, #e0916f);
 }
 
 .resThumbYoutube {
-    background: light-dark(#fdecec, #3a2323);
-    color: light-dark(#c0392b, #e07a6f);
+    background: linear-gradient(
+        135deg,
+        light-dark(#f8eae8, #362525),
+        light-dark(#f2dedb, #2c1f1f)
+    );
+    color: light-dark(#b0453a, #dd8a80);
+}
+
+/* External-link affordance: quiet corner mark, revealed on hover. */
+.resExternal {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 1;
+    color: light-dark(rgba(0, 0, 0, 0.35), rgba(255, 255, 255, 0.45));
+    opacity: 0;
+    transition: opacity 0.15s ease;
+}
+
+.mediaCard:hover .resExternal {
+    opacity: 1;
 }
 
 .resFavicon {
@@ -509,22 +544,6 @@ a .hoverCard:hover,
     flex-direction: column;
     gap: 3px;
     padding: 9px 11px 11px;
-}
-
-.mediaKind {
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    font-size: 10.5px;
-    font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--mantine-color-ldGray-5);
-}
-
-.mediaExternal {
-    margin-left: auto;
-    color: var(--mantine-color-ldGray-4);
 }
 
 .mediaTitle {
@@ -547,9 +566,10 @@ a .hoverCard:hover,
     line-height: 1.4;
     color: var(--mantine-color-ldGray-6);
     display: -webkit-box;
-    /* One line, like the title: with band + body sharing a fixed card, a
-     * wrapping description would push past the unit and clip. */
-    -webkit-line-clamp: 1;
+    /* Two lines, but a *fixed* two-line box either way — the band absorbs
+     * the card's slack, so a variable body would make it wobble. */
+    -webkit-line-clamp: 2;
+    height: 2.8em;
     -webkit-box-orient: vertical;
     overflow: hidden;
 }

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -236,14 +236,6 @@ a .hoverCard:hover,
     color: var(--mantine-color-ldGray-7);
 }
 
-.starAccent {
-    color: light-dark(#de7f0b, #e08a20);
-}
-
-.violetAccent {
-    color: #7262ff;
-}
-
 .rowName {
     font-size: 13.5px;
     font-weight: 500;
@@ -379,28 +371,6 @@ a .hoverCard:hover,
     background: light-dark(#fff, var(--mantine-color-dark-6));
 }
 
-.rankBadge {
-    width: 18px;
-    height: 18px;
-    border-radius: 5px;
-    background: var(--mantine-color-foreground-0, var(--mantine-color-dark-9));
-    color: #fff;
-    font-size: 11px;
-    font-weight: 600;
-    display: grid;
-    place-items: center;
-    flex-shrink: 0;
-}
-
-.presetChip {
-    font-size: 11px;
-    font-weight: 500;
-    color: var(--mantine-color-ldGray-6);
-    background: var(--mantine-color-ldGray-1);
-    border-radius: 5px;
-    padding: 2px 7px;
-}
-
 .quickActionChip {
     display: inline-flex;
     align-items: center;
@@ -481,12 +451,6 @@ a .hoverCard:hover,
 
 .mediaCard.clickable:hover .resThumb img {
     transform: scale(1.03);
-}
-
-.resThumbFallback {
-    display: grid;
-    place-items: center;
-    color: var(--mantine-color-ldGray-6);
 }
 
 /* Quiet duotone tile: a muted per-kind wash with a small bare favicon —
@@ -580,14 +544,6 @@ a .hoverCard:hover,
 
 .mediaCard:hover .resExternal {
     opacity: 1;
-}
-
-.resFavicon {
-    width: 30px;
-    height: 30px;
-    border-radius: 7px;
-    object-fit: contain;
-    animation: resFadeIn 0.2s ease-out;
 }
 
 .mediaBody {
@@ -720,9 +676,6 @@ a .hoverCard:hover,
         transform: none;
     }
     .resThumb img,
-    .resFavicon {
-        animation: none;
-    }
     .skeletonBlock,
     .skeletonLine {
         animation: none;

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -410,7 +410,9 @@ a .hoverCard:hover,
     position: relative;
     width: 100%;
     flex: 1;
-    min-height: 0;
+    /* Floor, not zero: the band absorbs slack but must always frame the
+     * floating icon with margin rather than being flush with it. */
+    min-height: 56px;
     overflow: hidden;
     background: var(--mantine-color-ldGray-1);
     border-bottom: 1px solid var(--mantine-color-ldGray-2);
@@ -440,7 +442,7 @@ a .hoverCard:hover,
     position: relative;
     width: 100%;
     flex: 1;
-    min-height: 0;
+    min-height: 56px;
     overflow: hidden;
     display: grid;
     place-items: center;
@@ -463,9 +465,9 @@ a .hoverCard:hover,
 .resGlyphFloat {
     position: relative;
     z-index: 1;
-    width: 46px;
-    height: 46px;
-    border-radius: 12px;
+    width: 38px;
+    height: 38px;
+    border-radius: 10px;
     object-fit: contain;
     background: light-dark(#fff, var(--mantine-color-dark-5));
     box-shadow:
@@ -529,6 +531,11 @@ a .hoverCard:hover,
     font-size: 13.5px;
     font-weight: 600;
     line-height: 1.3;
+    /* One line always: a wrapped title eats the image band above it, since
+     * the band absorbs whatever the body leaves. */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
@@ -540,7 +547,9 @@ a .hoverCard:hover,
     line-height: 1.4;
     color: var(--mantine-color-ldGray-6);
     display: -webkit-box;
-    -webkit-line-clamp: 2;
+    /* One line, like the title: with band + body sharing a fixed card, a
+     * wrapping description would push past the unit and clip. */
+    -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
     overflow: hidden;
 }

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -349,54 +349,7 @@ a .hoverCard:hover,
     border-color: var(--mantine-color-ldGray-3);
 }
 
-/* Collection card grid: three-up like SimpleGrid, but a partial row centres
- * instead of leaving dead columns on the right. */
-.hugGrid {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 12px;
-}
-
-/* Single-cell grid so the child (an inline <a> card) is blockified and
- * stretched exactly like a SimpleGrid cell would. */
-.hugGridItem {
-    flex: 0 1 calc((100% - 24px) / 3);
-    min-width: 0;
-    display: grid;
-}
-
-/* Sparse collections split the width across the cards they actually have
- * instead of reserving three phantom tracks. */
-.hugGrid[data-per-row='1'] > .hugGridItem {
-    flex-basis: 100%;
-}
-
-.hugGrid[data-per-row='2'] > .hugGridItem {
-    flex-basis: calc((100% - 12px) / 2);
-}
-
-/* The blockifying grid gives its single child (the card) a fresh min-width:
- * auto default of its own, sized to the untruncated title's natural width —
- * so a long title (e.g. via Text truncate's white-space: nowrap) overflows
- * the narrow cell instead of shrinking into it. */
-.hugGridItem > * {
-    min-width: 0;
-}
-
-@media (max-width: 47.99em) {
-    .hugGridItem {
-        flex-basis: 100%;
-    }
-}
-
 /* --- Resource cards ---------------------------------------------------- */
-
-.mediaGrid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
-    gap: 10px;
-}
 
 .mediaCard {
     display: flex;

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -38,12 +38,8 @@
     min-height: var(--card-unit);
 }
 
-.cardUnit2 {
-    height: calc(var(--card-unit) * 2 + var(--page-grid-gap, 12px));
-}
-
 .hoverCard {
-    --card-unit: 156px;
+    --card-unit: 140px;
 
     border: 1px solid var(--mantine-color-ldGray-2);
     border-radius: 10px;
@@ -265,7 +261,7 @@ a .hoverCard:hover,
     font-size: 12px;
     color: var(--mantine-color-ldGray-6);
     font-weight: 500;
-    margin-bottom: 5px;
+    margin-bottom: 4px;
 }
 
 .kpiValue {
@@ -381,7 +377,7 @@ a .hoverCard:hover,
 /* --- Resource cards ---------------------------------------------------- */
 
 .mediaCard {
-    --card-unit: 156px;
+    --card-unit: 140px;
 
     /* Fixed to the unit rather than floored by it: the band below absorbs
      * whatever the body doesn't use, so a one-line and a two-line description

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -38,6 +38,11 @@
     min-height: var(--card-unit);
 }
 
+/* Half a unit: two of these plus the 10px grid gap equal one unit card. */
+.cardUnitHalf {
+    height: calc((var(--card-unit) - 10px) / 2);
+}
+
 .hoverCard {
     --card-unit: 140px;
 
@@ -307,7 +312,7 @@ a .hoverCard:hover,
 .addContentTile {
     border: 1px dashed var(--mantine-color-ldGray-3);
     border-radius: 10px;
-    min-height: 108px;
+    min-height: calc((var(--card-unit, 140px) - 10px) / 2);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -459,7 +464,7 @@ a .hoverCard:hover,
 .resFavTile {
     width: 22px;
     height: 22px;
-    border-radius: 5px;
+    border-radius: 6px;
     object-fit: contain;
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.18);
     animation: resFadeIn 0.2s ease-out;
@@ -582,10 +587,12 @@ a .hoverCard:hover,
 .rowThumb {
     width: 34px;
     height: 34px;
-    border-radius: 7px;
+    border-radius: 10px;
     overflow: hidden;
     flex-shrink: 0;
-    border: 1px solid var(--mantine-color-ldGray-2);
+    /* Inset ring instead of a hard border — softer against the favicon. */
+    box-shadow: inset 0 0 0 1px
+        light-dark(rgba(0, 0, 0, 0.06), rgba(255, 255, 255, 0.08));
     background: var(--mantine-color-ldGray-1);
 }
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -29,7 +29,22 @@
     cursor: pointer;
 }
 
+/* Card height scale. Every card is one unit or two, so cards of different
+ * types tessellate: two collection cards stack to exactly one resource card.
+ * The unit is the metric card's natural height — it has the most content
+ * (label, value, sparkline, comparison), so it sets the floor. Shorter cards
+ * grow into it rather than the metric card shrinking and crushing its chart. */
+.cardUnit1 {
+    min-height: var(--card-unit);
+}
+
+.cardUnit2 {
+    height: calc(var(--card-unit) * 2 + var(--page-grid-gap, 12px));
+}
+
 .hoverCard {
+    --card-unit: 156px;
+
     border: 1px solid var(--mantine-color-ldGray-2);
     border-radius: 10px;
     background: light-dark(#fff, var(--mantine-color-dark-6));
@@ -366,6 +381,13 @@ a .hoverCard:hover,
 /* --- Resource cards ---------------------------------------------------- */
 
 .mediaCard {
+    --card-unit: 156px;
+
+    /* Fixed to the unit rather than floored by it: the band below absorbs
+     * whatever the body doesn't use, so a one-line and a two-line description
+     * still produce the same card height. */
+    height: var(--card-unit);
+
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -385,10 +407,14 @@ a .hoverCard:hover,
     color: inherit;
 }
 
+/* The band takes the card's spare height instead of an aspect ratio, so the
+ * image stays a calm strip at any column width and the card stays one unit.
+ * object-fit keeps it framed as the box changes shape. */
 .resThumb {
     position: relative;
     width: 100%;
-    aspect-ratio: 16 / 9;
+    flex: 1;
+    min-height: 0;
     overflow: hidden;
     background: var(--mantine-color-ldGray-1);
     border-bottom: 1px solid var(--mantine-color-ldGray-2);
@@ -417,7 +443,8 @@ a .hoverCard:hover,
 .resThumbTile {
     position: relative;
     width: 100%;
-    aspect-ratio: 16 / 9;
+    flex: 1;
+    min-height: 0;
     overflow: hidden;
     display: grid;
     place-items: center;

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -38,9 +38,52 @@
     min-height: var(--card-unit);
 }
 
-/* Half a unit: two of these plus the 10px grid gap equal one unit card. */
+/* Content tile: a compact horizontal row at the half-unit floor. When its
+ * elastic grid hands it more height (container query on the cell), it turns
+ * into a vertical card and reveals the extra meta line — richer, not airier. */
+.contentTile {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px;
+}
+
+.tileBody {
+    flex: 1;
+    min-width: 0;
+}
+
+.tileExtra {
+    display: none;
+    font-size: 11.5px;
+    color: var(--mantine-color-ldGray-6);
+    margin-top: 8px;
+}
+
+@container (min-height: 112px) {
+    .contentTile {
+        flex-direction: column;
+        align-items: stretch;
+        justify-content: space-between;
+    }
+
+    .contentTile .tileActions {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+    }
+
+    .tileExtra {
+        display: block;
+    }
+}
+
+/* Half a unit: two of these plus the 10px grid gap equal one unit card.
+ * A floor, not a fixed height — elastic grids stretch tiles to close the
+ * gap to a taller sibling column. */
 .cardUnitHalf {
-    height: calc((var(--card-unit) - 10px) / 2);
+    min-height: calc((var(--card-unit) - 10px) / 2);
 }
 
 .hoverCard {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/blockStyles.module.css
@@ -276,7 +276,10 @@ a .hoverCard:hover,
     margin-bottom: 2px;
 }
 
+/* The delta keeps its size; only the caption beside it gives way. */
 .kpiDelta {
+    flex-shrink: 0;
+
     font-size: 12px;
     font-weight: 500;
 }

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/types.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/types.ts
@@ -9,9 +9,11 @@ export type BlockComponentProps = {
     projectUuid: string;
     presentation?: BlockPresentation;
     // Page-grid columns one of this block's cards spans, from the resolver.
-    // null for blocks that don't render a card grid; omitted by call sites
-    // that render a block outside a resolved row (e.g. the hero slot).
-    itemSpan?: number | null;
+    // null for blocks that don't render a card grid, or that render outside a
+    // resolved row (the hero slot). Required, not optional: a call site that
+    // silently omits it renders every card full width, and that failed once
+    // already — the compiler now catches it instead of a reviewer.
+    itemSpan: number | null;
 };
 
 export type BuildComponentProps = BlockComponentProps & {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/types.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/types.ts
@@ -8,6 +8,10 @@ export type BlockComponentProps = {
     block: HomepageBlock;
     projectUuid: string;
     presentation?: BlockPresentation;
+    // Page-grid columns one of this block's cards spans, from the resolver.
+    // null for blocks that don't render a card grid; omitted by call sites
+    // that render a block outside a resolved row (e.g. the hero slot).
+    itemSpan?: number | null;
 };
 
 export type BuildComponentProps = BlockComponentProps & {

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -156,9 +156,10 @@
 }
 
 /* Below the two-column breakpoint the 12-track grid stops earning its keep —
- * every card goes full width rather than becoming an unreadable sliver. */
+ * every card goes full width rather than becoming an unreadable sliver.
+ * Matches the [data-span] selectors' specificity so it actually wins. */
 @media (max-width: 47.99em) {
-    .pageGridItem {
+    .pageGrid[data-span] > .pageGridItem {
         grid-column: 1 / -1;
     }
 }

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -159,6 +159,15 @@
     min-width: 0;
 }
 
+/* EXPERIMENT: an item alone on its final row stretches across it instead of
+ * holding its track — the lone card reads as a footer row, not a leftover.
+ * (last child that lands first on a row: perRow = 12 / span) */
+.pageGrid[data-span='3'] > .pageGridItem:nth-child(4n + 1):last-child,
+.pageGrid[data-span='4'] > .pageGridItem:nth-child(3n + 1):last-child,
+.pageGrid[data-span='6'] > .pageGridItem:nth-child(2n + 1):last-child {
+    grid-column: 1 / -1;
+}
+
 /* Below the two-column breakpoint the 12-track grid stops earning its keep —
  * every card goes full width rather than becoming an unreadable sliver.
  * Matches the [data-span] selectors' specificity so it actually wins. */

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -205,7 +205,10 @@
  * container-relative and have no natural width); list/text blocks hug their
  * own content. Dense clusters exceed the row and shrink back to fill it. */
 .row[data-fit='hug'] {
-    --hug-unit: 236px;
+    /* One hug unit is one canonical card: the width a metrics tile takes at
+     * full page width ((1160 - 3 gaps) / 4). Sizing units to the real card
+     * width means a column asking for one card actually gets a readable one. */
+    --hug-unit: 281px;
     --hug-gap: 12px;
 
     justify-content: center;
@@ -217,8 +220,12 @@
     min-width: 0;
 }
 
+/* Card-grid columns may grow past their basis but never shrink below one
+ * card. Without the floor, a column asking for a single card gets squeezed by
+ * a busier neighbour until its card truncates to nothing. */
 .row[data-fit='hug'] .col[data-hug-units] {
     max-width: none;
+    min-width: var(--hug-unit);
 }
 
 .row[data-fit='hug'] .col[data-hug-units='1'] {

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -8,7 +8,7 @@
 
     display: flex;
     flex-direction: column;
-    padding: 32px 24px 64px;
+    padding: 24px 24px 48px;
 }
 
 .heroSection {
@@ -93,7 +93,7 @@
  * permutation renders balanced. */
 .row {
     display: flex;
-    gap: 14px;
+    gap: 12px;
     align-items: stretch;
     width: 100%;
     margin-inline: auto;
@@ -104,11 +104,11 @@
 }
 
 .row[data-gap='grouped'] {
-    margin-top: 18px;
+    margin-top: 14px;
 }
 
 .row[data-gap='section'] {
-    margin-top: 40px;
+    margin-top: 30px;
 }
 
 /* A lone leading text block opens the page: give it breathing room on top of
@@ -122,7 +122,7 @@
  * so their edges land on shared tracks instead of drifting apart. Items are
  * left-aligned, so a remainder row starts on the same track as a full one. */
 .pageGrid {
-    --page-grid-gap: 12px;
+    --page-grid-gap: 10px;
 
     display: grid;
     grid-template-columns: repeat(12, minmax(0, 1fr));
@@ -213,8 +213,8 @@
     /* One hug unit is one canonical card: the width a metrics tile takes at
      * full page width ((1160 - 3 gaps) / 4). Sizing units to the real card
      * width means a column asking for one card actually gets a readable one. */
-    --hug-unit: 281px;
-    --hug-gap: 12px;
+    --hug-unit: 282px;
+    --hug-gap: 10px;
 
     justify-content: center;
 }

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -207,6 +207,28 @@
 
 .col > * {
     width: 100%;
+    /* The block fills its column; non-elastic grids leave the slack at the
+     * bottom exactly as before, elastic ones distribute it across rows. */
+    flex: 1 0 auto;
+    display: flex;
+    flex-direction: column;
+}
+
+.pageGrid[data-elastic] {
+    flex: 1;
+    /* With size containment below, a row's height can't come from its
+     * content — the floor is what stops an unstretched grid collapsing. */
+    grid-auto-rows: minmax(var(--elastic-floor, 65px), 1fr);
+}
+
+.pageGrid[data-floor='unit'] {
+    --elastic-floor: 140px;
+}
+
+/* Elastic cells are size containers, so a tile can adapt its layout to the
+ * height it actually received (see contentTile's container query). */
+.pageGrid[data-elastic] > .pageGridItem {
+    container-type: size;
 }
 
 .col[data-weight='2'] {

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -113,6 +113,56 @@
     padding-top: 24px;
 }
 
+/* The page grid: one 12-column track system every card-grid block subscribes
+ * to via a resolver-assigned span. Blocks no longer pick their own card width,
+ * so their edges land on shared tracks instead of drifting apart. Items are
+ * left-aligned, so a remainder row starts on the same track as a full one. */
+.pageGrid {
+    --page-grid-gap: 12px;
+
+    display: grid;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    gap: var(--page-grid-gap);
+    width: 100%;
+}
+
+.pageGridItem {
+    min-width: 0;
+    /* Blockifies inline <a> cards so they keep their box, and stretches them
+     * to the cell exactly as a grid cell child would. */
+    display: grid;
+}
+
+/* Span is enumerated rather than passed as an inline custom property, matching
+ * the data-hug-units pattern below and keeping styling out of the TSX. */
+.pageGrid[data-span='3'] > .pageGridItem {
+    grid-column: span 3;
+}
+
+.pageGrid[data-span='4'] > .pageGridItem {
+    grid-column: span 4;
+}
+
+.pageGrid[data-span='6'] > .pageGridItem {
+    grid-column: span 6;
+}
+
+.pageGrid[data-span='12'] > .pageGridItem {
+    grid-column: span 12;
+}
+
+.pageGridItem > * {
+    min-width: 0;
+}
+
+/* Below the two-column breakpoint the 12-track grid stops earning its keep —
+ * every card goes full width rather than becoming an unreadable sliver. */
+@media (max-width: 47.99em) {
+    .pageGridItem {
+        grid-column: 1 / -1;
+    }
+}
+
 .tierReading {
     max-width: 680px;
 }
@@ -132,12 +182,13 @@
 .col {
     flex: 1 1 0;
     min-width: 0;
-    /* In multi-column rows the shorter column centres vertically instead of
-     * hugging the top edge next to a taller neighbour. Single-block rows are
-     * unaffected (column height equals content height). */
+    /* Columns start at the top so neighbouring blocks' headers sit on one
+     * line. Centring the shorter column reads as a misalignment once blocks
+     * carry headers — a ragged bottom edge is much cheaper than headers at
+     * two different heights. */
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
 }
 
 .col > * {

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -42,7 +42,7 @@
     align-items: center;
     gap: 12px;
     width: 100%;
-    max-width: 1160px;
+    max-width: 1000px;
     min-height: var(--homepage-favbar-height);
     margin: 0 auto;
     overflow-x: auto;
@@ -84,7 +84,7 @@
 
 .secondary {
     width: 100%;
-    max-width: 1160px;
+    max-width: 1000px;
     margin: 0 auto;
 }
 
@@ -178,7 +178,7 @@
 }
 
 .tierReading {
-    max-width: 680px;
+    max-width: 640px;
 }
 
 .tierComposer {
@@ -186,11 +186,11 @@
 }
 
 .tierContent {
-    max-width: 960px;
+    max-width: 860px;
 }
 
 .tierFull {
-    max-width: 1160px;
+    max-width: 1000px;
 }
 
 .col {
@@ -220,9 +220,9 @@
  * own content. Dense clusters exceed the row and shrink back to fill it. */
 .row[data-fit='hug'] {
     /* One hug unit is one canonical card: the width a metrics tile takes at
-     * full page width ((1160 - 3 gaps) / 4). Sizing units to the real card
+     * full page width ((1000 - 3 gaps) / 4). Sizing units to the real card
      * width means a column asking for one card actually gets a readable one. */
-    --hug-unit: 282px;
+    --hug-unit: 242px;
     --hug-gap: 10px;
 
     justify-content: center;

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -99,6 +99,10 @@
     margin-inline: auto;
 }
 
+.row[data-align='start'] {
+    margin-inline: 0 auto;
+}
+
 .row[data-gap='grouped'] {
     margin-top: 18px;
 }

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -213,47 +213,12 @@
     flex: 2 1 0;
 }
 
-/* Hug rows: the cluster sizes to its content and centres as one unit — no
- * grow, so sparse combos stop smearing full-bleed. Card-grid blocks carry a
- * resolver-assigned intrinsic basis in card units (their internals are
- * container-relative and have no natural width); list/text blocks hug their
- * own content. Dense clusters exceed the row and shrink back to fill it. */
-.row[data-fit='hug'] {
-    /* One hug unit is one canonical card: the width a metrics tile takes at
-     * full page width ((1000 - 3 gaps) / 4). Sizing units to the real card
-     * width means a column asking for one card actually gets a readable one. */
-    --hug-unit: 242px;
-    --hug-gap: 10px;
-
-    justify-content: center;
-}
-
+/* Multi-column rows split into equal halves, so the column boundary sits at
+ * the same x in every row — collection | metrics and collection | resources
+ * share their split. Column widths come from the page, not from item counts:
+ * shared-row cards are span-6, landing 2-up at the same width the full rows
+ * use. (data-hug-units is still stamped for the editor; sizing ignores it.) */
 .row[data-fit='hug'] .col {
-    flex: 0 1 auto;
-    max-width: max-content;
+    flex: 1 1 0;
     min-width: 0;
-}
-
-/* Card-grid columns may grow past their basis but never shrink below one
- * card. Without the floor, a column asking for a single card gets squeezed by
- * a busier neighbour until its card truncates to nothing. */
-.row[data-fit='hug'] .col[data-hug-units] {
-    max-width: none;
-    min-width: var(--hug-unit);
-}
-
-.row[data-fit='hug'] .col[data-hug-units='1'] {
-    flex-basis: var(--hug-unit);
-}
-
-.row[data-fit='hug'] .col[data-hug-units='2'] {
-    flex-basis: calc(var(--hug-unit) * 2 + var(--hug-gap));
-}
-
-.row[data-fit='hug'] .col[data-hug-units='3'] {
-    flex-basis: calc(var(--hug-unit) * 3 + var(--hug-gap) * 2);
-}
-
-.row[data-fit='hug'] .col[data-hug-units='4'] {
-    flex-basis: calc(var(--hug-unit) * 4 + var(--hug-gap) * 3);
 }

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
@@ -309,6 +309,61 @@ describe('resolveHomepageLayout', () => {
         });
     });
 
+    describe('build surface', () => {
+        it('keeps config-empty blocks and rows 1:1 with the config', () => {
+            const config = makeConfig([
+                [emptyBlock('ann', 'announcements')],
+                [emptyBlock('r', 'resources'), block('f', 'favorites')],
+                [block('c', 'collection')],
+            ]);
+            const { rows } = resolveHomepageLayout(config, {
+                surface: 'build',
+            });
+            expect(rows.map((r) => r.id)).toEqual([
+                'row-0',
+                'row-1',
+                'row-2',
+            ]);
+            expect(rows[1].columns.map((c) => c.block.id)).toEqual([
+                'r',
+                'f',
+            ]);
+        });
+
+        it('never hoists a hero — the ask-ai row stays in flow at composer width', () => {
+            const config = makeConfig([
+                [block('a', 'ask-ai-hero')],
+                [block('c', 'collection')],
+            ]);
+            const { hero, rows } = resolveHomepageLayout(config, {
+                surface: 'build',
+            });
+            expect(hero).toBeNull();
+            expect(rows.map((r) => r.id)).toEqual(['row-0', 'row-1']);
+            expect(rows[0].widthTier).toBe('composer');
+        });
+
+        it('applies the same fit and width math as view for visible content', () => {
+            const config = makeConfig([
+                [block('m', 'metrics'), block('f', 'favorites')],
+                [block('c', 'collection')],
+            ]);
+            const view = resolveHomepageLayout(config);
+            const build = resolveHomepageLayout(config, {
+                surface: 'build',
+            });
+            expect(build.rows.map((r) => r.fit)).toEqual(
+                view.rows.map((r) => r.fit),
+            );
+            expect(build.rows.map((r) => r.widthTier)).toEqual(
+                view.rows.map((r) => r.widthTier),
+            );
+            expect(
+                build.rows[0].columns.map((c) => c.hugUnits),
+            ).toEqual(view.rows[0].columns.map((c) => c.hugUnits));
+        });
+    });
+
     describe('hug fit', () => {
         it('multi-column rows hug', () => {
             const config = makeConfig([

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
@@ -319,15 +319,8 @@ describe('resolveHomepageLayout', () => {
             const { rows } = resolveHomepageLayout(config, {
                 surface: 'build',
             });
-            expect(rows.map((r) => r.id)).toEqual([
-                'row-0',
-                'row-1',
-                'row-2',
-            ]);
-            expect(rows[1].columns.map((c) => c.block.id)).toEqual([
-                'r',
-                'f',
-            ]);
+            expect(rows.map((r) => r.id)).toEqual(['row-0', 'row-1', 'row-2']);
+            expect(rows[1].columns.map((c) => c.block.id)).toEqual(['r', 'f']);
         });
 
         it('never hoists a hero — the ask-ai row stays in flow at composer width', () => {
@@ -358,9 +351,9 @@ describe('resolveHomepageLayout', () => {
             expect(build.rows.map((r) => r.widthTier)).toEqual(
                 view.rows.map((r) => r.widthTier),
             );
-            expect(
-                build.rows[0].columns.map((c) => c.hugUnits),
-            ).toEqual(view.rows[0].columns.map((c) => c.hugUnits));
+            expect(build.rows[0].columns.map((c) => c.hugUnits)).toEqual(
+                view.rows[0].columns.map((c) => c.hugUnits),
+            );
         });
     });
 
@@ -451,5 +444,64 @@ describe('resolveHomepageLayout', () => {
                 'body',
             ]);
         });
+    });
+});
+
+describe('page grid — item spans', () => {
+    it("gives a full-width row the block type's full span", () => {
+        const { rows } = resolveHomepageLayout(
+            makeConfig([[collectionWithItems('c', 6)]]),
+        );
+        expect(rows[0].widthTier).toBe('full');
+        expect(rows[0].columns[0].itemSpan).toBe(4);
+    });
+
+    it('uses the content span when the row stays at content width', () => {
+        // resources alone, no full row on the page, so no width smoothing
+        const { rows } = resolveHomepageLayout(
+            makeConfig([[block('r', 'resources')]]),
+        );
+        expect(rows[0].widthTier).toBe('content');
+        expect(rows[0].columns[0].itemSpan).toBe(4);
+    });
+
+    it("follows the smoothed tier, not the block's declared tier", () => {
+        // metrics forces the page wide, so the resources row is promoted
+        // content -> full and must take its *full* span with it
+        const { rows } = resolveHomepageLayout(
+            makeConfig([[block('m', 'metrics')], [block('r', 'resources')]]),
+        );
+        expect(rows[1].widthTier).toBe('full');
+        expect(rows[1].columns[0].itemSpan).toBe(4);
+    });
+
+    it('narrows the span when a block shares a row', () => {
+        const { rows } = resolveHomepageLayout(
+            makeConfig([[block('m', 'metrics'), block('r', 'resources')]]),
+        );
+        const [metrics, resources] = rows[0].columns;
+        expect(metrics.itemSpan).toBe(6);
+        // content cards land at the same ~281px width as metrics tiles
+        expect(resources.itemSpan).toBe(6);
+    });
+
+    it('gives list and prose blocks no span', () => {
+        const { rows } = resolveHomepageLayout(
+            makeConfig([[block('f', 'favorites')], [block('t', 'markdown')]]),
+        );
+        expect(rows[0].columns[0].itemSpan).toBeNull();
+        expect(rows[1].columns[0].itemSpan).toBeNull();
+    });
+
+    it('keeps metrics denser than content cards at the same width', () => {
+        const { rows } = resolveHomepageLayout(
+            makeConfig([
+                [block('m', 'metrics')],
+                [collectionWithItems('c', 6)],
+            ]),
+        );
+        // 3 columns per tile => 4-up; 4 columns per card => 3-up
+        expect(rows[0].columns[0].itemSpan).toBe(3);
+        expect(rows[1].columns[0].itemSpan).toBe(4);
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
@@ -618,3 +618,76 @@ describe('page grid — sparse blocks stretch', () => {
         expect(rows[0].columns[0].itemSpan).toBe(4);
     });
 });
+
+describe('build surface — uniform editing width', () => {
+    it('renders every build row at full width so block cards align', () => {
+        const config = makeConfig([
+            [block('t', 'markdown')],
+            [metricsWithCount('m', 4)],
+            [resourcesWithItems('r', 3)],
+        ]);
+        const { rows } = resolveHomepageLayout(config, { surface: 'build' });
+        expect(rows.map((r) => r.widthTier)).toEqual(['full', 'full', 'full']);
+    });
+
+    it('leaves the composer at its own width — that is its design', () => {
+        const { rows } = resolveHomepageLayout(
+            makeConfig([[block('a', 'ask-ai-hero')], [block('t', 'markdown')]]),
+            { surface: 'build' },
+        );
+        expect(rows[0].widthTier).toBe('composer');
+        expect(rows[1].widthTier).toBe('full');
+    });
+
+    it('keeps the published widths on the view surface', () => {
+        const config = makeConfig([
+            [block('t', 'markdown')],
+            [metricsWithCount('m', 4)],
+        ]);
+        const { rows } = resolveHomepageLayout(config);
+        expect(rows[0].widthTier).toBe('reading');
+    });
+
+    it('does not change any card span — only chrome width', () => {
+        const config = makeConfig([
+            [resourcesWithItems('r', 3)],
+            [collectionWithItems('c', 6)],
+            [metricsWithCount('m', 4)],
+        ]);
+        const spans = (surface: 'view' | 'build') =>
+            resolveHomepageLayout(config, { surface }).rows.map(
+                (r) => r.columns[0].itemSpan,
+            );
+        expect(spans('build')).toEqual(spans('view'));
+    });
+});
+
+describe('row alignment — narrow rows meet the page edge', () => {
+    it('left-aligns a text row when a wider row shares the page', () => {
+        const { rows } = resolveHomepageLayout(
+            makeConfig([[block('t', 'markdown')], [metricsWithCount('m', 4)]]),
+        );
+        expect(rows[0].widthTier).toBe('reading');
+        expect(rows[0].align).toBe('start');
+        expect(rows[1].align).toBe('center');
+    });
+
+    it('leaves a uniform-width page centred — nothing to align to', () => {
+        const { rows } = resolveHomepageLayout(
+            makeConfig([[block('t', 'markdown')], [block('u', 'markdown')]]),
+        );
+        expect(rows.map((r) => r.align)).toEqual(['center', 'center']);
+    });
+
+    it('aligns by resolved tier, so a smoothed row counts as wide', () => {
+        // resources is promoted content -> full by smoothing, so it is not
+        // "narrower than the widest" and must stay centred
+        const { rows } = resolveHomepageLayout(
+            makeConfig([
+                [metricsWithCount('m', 4)],
+                [resourcesWithItems('r', 3)],
+            ]),
+        );
+        expect(rows.map((r) => r.align)).toEqual(['center', 'center']);
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
@@ -707,3 +707,37 @@ describe('row fit — hug is only for card grids', () => {
         expect(rows[0].fit).toBe('hug');
     });
 });
+
+describe('page grid — exact-fit densening', () => {
+    it('puts 4 resources on one row instead of stranding an orphan', () => {
+        const { rows } = resolveHomepageLayout(
+            makeConfig([[resourcesWithItems('r', 4)]]),
+        );
+        expect(rows[0].columns[0].itemSpan).toBe(3);
+    });
+
+    it('keeps 5 items at the declared span — 3+2, no exact fit', () => {
+        const { rows } = resolveHomepageLayout(
+            makeConfig([[resourcesWithItems('r', 5)]]),
+        );
+        expect(rows[0].columns[0].itemSpan).toBe(4);
+    });
+
+    it('keeps 7 items at the declared span — no exact fit one step denser', () => {
+        const { rows } = resolveHomepageLayout(
+            makeConfig([[collectionWithItems('c', 7)]]),
+        );
+        expect(rows[0].columns[0].itemSpan).toBe(4);
+    });
+
+    it('never densifies inside a shared column', () => {
+        const { rows } = resolveHomepageLayout(
+            makeConfig([
+                [resourcesWithItems('r', 3), collectionWithItems('c', 3)],
+            ]),
+        );
+        // 3 items 2-up in a half column would orphan, but 3-up there is too
+        // narrow — the orphan stretches instead
+        expect(rows[0].columns[0].itemSpan).toBe(6);
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
@@ -89,6 +89,32 @@ const collectionWithItems = (id: string, count: number): HomepageBlock => ({
     },
 });
 
+const resourcesWithItems = (id: string, count: number): HomepageBlock => ({
+    id,
+    type: 'resources',
+    config: {
+        title: 't',
+        items: Array.from({ length: count }, (_, i) => ({
+            title: `r${i}`,
+            url: `https://x${i}.example`,
+            kind: 'link' as const,
+        })),
+    },
+});
+
+const metricsWithCount = (id: string, count: number): HomepageBlock => ({
+    id,
+    type: 'metrics',
+    config: {
+        title: 't',
+        items: Array.from({ length: count }, (_, i) => ({
+            tableName: 'orders',
+            metricName: `m${i}`,
+            label: `M${i}`,
+        })),
+    },
+});
+
 const makeConfig = (rows: HomepageBlock[][]): HomepageConfig => ({
     version: 1,
     rows: rows.map((blocks, i) => ({ id: `row-${i}`, blocks })),
@@ -459,7 +485,7 @@ describe('page grid — item spans', () => {
     it('uses the content span when the row stays at content width', () => {
         // resources alone, no full row on the page, so no width smoothing
         const { rows } = resolveHomepageLayout(
-            makeConfig([[block('r', 'resources')]]),
+            makeConfig([[resourcesWithItems('r', 3)]]),
         );
         expect(rows[0].widthTier).toBe('content');
         expect(rows[0].columns[0].itemSpan).toBe(4);
@@ -469,7 +495,10 @@ describe('page grid — item spans', () => {
         // metrics forces the page wide, so the resources row is promoted
         // content -> full and must take its *full* span with it
         const { rows } = resolveHomepageLayout(
-            makeConfig([[block('m', 'metrics')], [block('r', 'resources')]]),
+            makeConfig([
+                [metricsWithCount('m', 4)],
+                [resourcesWithItems('r', 3)],
+            ]),
         );
         expect(rows[1].widthTier).toBe('full');
         expect(rows[1].columns[0].itemSpan).toBe(4);
@@ -477,7 +506,9 @@ describe('page grid — item spans', () => {
 
     it('narrows the span when a block shares a row', () => {
         const { rows } = resolveHomepageLayout(
-            makeConfig([[block('m', 'metrics'), block('r', 'resources')]]),
+            makeConfig([
+                [metricsWithCount('m', 4), resourcesWithItems('r', 3)],
+            ]),
         );
         const [metrics, resources] = rows[0].columns;
         expect(metrics.itemSpan).toBe(6);
@@ -496,12 +527,94 @@ describe('page grid — item spans', () => {
     it('keeps metrics denser than content cards at the same width', () => {
         const { rows } = resolveHomepageLayout(
             makeConfig([
-                [block('m', 'metrics')],
+                [metricsWithCount('m', 4)],
                 [collectionWithItems('c', 6)],
             ]),
         );
         // 3 columns per tile => 4-up; 4 columns per card => 3-up
         expect(rows[0].columns[0].itemSpan).toBe(3);
         expect(rows[1].columns[0].itemSpan).toBe(4);
+    });
+});
+
+// The builder canvas and the published page must agree on card geometry, or
+// the WYSIWYG promise breaks: an admin arranges cards 3-up and viewers get
+// something else. These assert the two surfaces resolve identical spans.
+describe('page grid — view/build parity', () => {
+    const spansOf = (layout: ReturnType<typeof resolveHomepageLayout>) =>
+        layout.rows.map((row) => row.columns.map((c) => c.itemSpan));
+
+    it('resolves the same item spans on both surfaces', () => {
+        const config = makeConfig([
+            [collectionWithItems('c', 6)],
+            [block('m', 'metrics'), block('r', 'resources')],
+            [block('t', 'markdown')],
+        ]);
+        const view = resolveHomepageLayout(config);
+        const build = resolveHomepageLayout(config, { surface: 'build' });
+        expect(spansOf(build)).toEqual(spansOf(view));
+    });
+
+    it('still spans config-empty blocks on the build surface', () => {
+        // build keeps empty blocks editable; they must be laid out on the same
+        // grid as a populated one, not fall back to full width
+        const config = makeConfig([
+            [emptyBlock('r', 'resources'), metricsWithCount('m', 2)],
+        ]);
+        const { rows } = resolveHomepageLayout(config, { surface: 'build' });
+        expect(rows[0].columns.map((c) => c.itemSpan)).toEqual([6, 6]);
+    });
+
+    it('spans a build-surface hero row like any other row', () => {
+        // build never hoists the hero, so the ask-ai row stays in flow and the
+        // rows after it must keep the spans the view surface gives them
+        const config = makeConfig([
+            [block('a', 'ask-ai-hero')],
+            [collectionWithItems('c', 6)],
+        ]);
+        const build = resolveHomepageLayout(config, { surface: 'build' });
+        const view = resolveHomepageLayout(config);
+        expect(build.rows[1].columns[0].itemSpan).toBe(
+            view.rows[0].columns[0].itemSpan,
+        );
+    });
+});
+
+// A block with fewer items than its row holds should fill the row rather than
+// leave trailing empty tracks — a lone KPI next to a full collection looked
+// like a sliver with half its column blank.
+describe('page grid — sparse blocks stretch', () => {
+    it.each([
+        [1, 12],
+        [2, 6],
+        [3, 4],
+        [4, 3],
+    ])(
+        'stretches %i metrics to a span of %i at full width',
+        (count, expected) => {
+            const { rows } = resolveHomepageLayout(
+                makeConfig([[metricsWithCount('m', count)]]),
+            );
+            expect(rows[0].columns[0].itemSpan).toBe(expected);
+        },
+    );
+
+    it('stretches a lone metric to fill its column in a shared row', () => {
+        const { rows } = resolveHomepageLayout(
+            makeConfig([
+                [metricsWithCount('m', 1), collectionWithItems('c', 3)],
+            ]),
+        );
+        const [metrics, collection] = rows[0].columns;
+        expect(metrics.itemSpan).toBe(12);
+        // the collection fills its own row at the shared-row span, so it keeps it
+        expect(collection.itemSpan).toBe(6);
+    });
+
+    it('never narrows a block that already fills its row', () => {
+        const { rows } = resolveHomepageLayout(
+            makeConfig([[collectionWithItems('c', 7)]]),
+        );
+        expect(rows[0].columns[0].itemSpan).toBe(4);
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
@@ -691,3 +691,19 @@ describe('row alignment — narrow rows meet the page edge', () => {
         expect(rows.map((r) => r.align)).toEqual(['center', 'center']);
     });
 });
+
+describe('row fit — hug is only for card grids', () => {
+    it('fills a multi-column row of list blocks instead of hugging', () => {
+        const { rows } = resolveHomepageLayout(
+            makeConfig([[block('f', 'favorites'), block('r', 'recent')]]),
+        );
+        expect(rows[0].fit).toBe('fill');
+    });
+
+    it('still hugs when a card-grid block shares the row', () => {
+        const { rows } = resolveHomepageLayout(
+            makeConfig([[metricsWithCount('m', 2), block('r', 'recent')]]),
+        );
+        expect(rows[0].fit).toBe('hug');
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -247,13 +247,18 @@ const resolveRow = (
             ? 'grouped'
             : 'section';
     })();
+    // Hug exists to size card-grid columns from their card count. A row of
+    // list/text blocks has no cards to hug — each column shrinks to its own
+    // content and the pair floats mid-page, off the grid every other row
+    // sits on. Those rows fill like single-block rows do.
+    const anyCardGrid = columns.some((column) => column.hugUnits !== null);
     return {
         id: row.id,
         gap,
         widthTier,
         role: 'body',
         align: 'center',
-        fit: single ? 'fill' : 'hug',
+        fit: single || !anyCardGrid ? 'fill' : 'hug',
         columns,
     };
 };

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -29,6 +29,11 @@ export type RowRole = 'intro' | 'body';
 export type ResolvedColumn = {
     block: HomepageBlock;
     weight: number;
+    // How many of the page's 12 grid columns one of this block's items spans.
+    // null for blocks that render as a list or prose rather than a card grid.
+    // Derived from the row's *final* width tier, so a row promoted by width
+    // smoothing takes the wider span with it.
+    itemSpan: number | null;
     // Intrinsic width in card units for hug rows. Card-grid blocks are
     // container-relative (SimpleGrid / percentage tracks), so they have no
     // natural width — this assigns one from their item count. null = the
@@ -135,16 +140,54 @@ const hugUnitsFor = (block: HomepageBlock): ResolvedColumn['hugUnits'] => {
     }
 };
 
+// A block sharing a row gets its `narrow` span regardless of the row's tier
+// (multi-column rows are always full width, but each column is a fraction of
+// it). A block owning its row follows the row's tier — `content` and the two
+// focal tiers keep the tighter span; only `full` widens.
+const itemSpanFor = (
+    block: HomepageBlock,
+    widthTier: BlockWidthTier,
+    isShared: boolean,
+): number | null => {
+    const { itemSpan } = traitFor(block.type);
+    if (itemSpan === null) return null;
+    if (isShared) return itemSpan.narrow;
+    return widthTier === 'full' ? itemSpan.full : itemSpan.content;
+};
+
+// Re-derives every column's span from the row's final tier. Called after width
+// smoothing so a promoted row's cards widen with it instead of keeping the
+// span its original tier implied.
+const applyItemSpans = (rows: ResolvedRow[]): ResolvedRow[] =>
+    rows.map((row) => ({
+        ...row,
+        columns: row.columns.map((column) => ({
+            ...column,
+            itemSpan: itemSpanFor(
+                column.block,
+                row.widthTier,
+                row.columns.length > 1,
+            ),
+        })),
+    }));
+
 const resolveRow = (
     row: HomepageConfig['rows'][number],
     isFirst: boolean,
 ): ResolvedRow => {
+    const single = row.blocks.length === 1;
     const columns: ResolvedColumn[] = row.blocks.map((block) => ({
         block,
         weight: columnWeightFor(block),
         hugUnits: hugUnitsFor(block),
+        // Provisional — applyItemSpans re-derives this once the row's final
+        // tier is known.
+        itemSpan: itemSpanFor(
+            block,
+            single ? traitFor(block.type).widthTier : 'full',
+            !single,
+        ),
     }));
-    const single = row.blocks.length === 1;
     const widthTier: BlockWidthTier = single
         ? traitFor(row.blocks[0].type).widthTier
         : 'full';
@@ -220,7 +263,7 @@ export const resolveHomepageLayout = (
         ? visibleRows.slice(composerIdx + 1)
         : visibleRows;
     const resolved = bodyRows.map((row, index) => resolveRow(row, index === 0));
-    const smoothed = smoothWidthTiers(resolved);
+    const smoothed = applyItemSpans(smoothWidthTiers(resolved));
     const rows = hasLeadingHero ? smoothed : applyIntroRole(smoothed);
     // A hero keeps the whole viewport only when it's alone; with body rows it
     // yields so the first row peeks above the fold.

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -5,6 +5,9 @@ import {
 } from '@lightdash/common';
 import { type BlockWidthTier, traitFor } from './blockLayout';
 
+// The page grid's track count, mirrored in homepageLayout.module.css.
+const GRID_COLUMNS = 12;
+
 // Only a single-block leading row of one of these types gets the day-0 style
 // vertically-centred hero treatment.
 const LEADING_HERO_TYPES: HomepageBlock['type'][] = ['ask-ai-hero'];
@@ -140,6 +143,30 @@ const hugUnitsFor = (block: HomepageBlock): ResolvedColumn['hugUnits'] => {
     }
 };
 
+// How many items a block actually has, for blocks laid out on the page grid.
+const gridItemCountFor = (block: HomepageBlock): number => {
+    switch (block.type) {
+        case 'metrics':
+        case 'collection':
+        case 'resources':
+            return block.config.items.length;
+        default:
+            return 0;
+    }
+};
+
+// A block whose items don't fill one row stretches them across it rather than
+// leaving trailing empty tracks — a lone KPI beside a full collection should
+// span its column, not sit as a sliver with half the row blank. Blocks that do
+// fill a row keep their declared span so their cards stay on the shared
+// tracks. Sparse stretching only ever widens, never narrows.
+const stretchSparse = (declaredSpan: number, itemCount: number): number => {
+    if (itemCount === 0) return declaredSpan;
+    const perRow = Math.floor(GRID_COLUMNS / declaredSpan);
+    if (itemCount >= perRow) return declaredSpan;
+    return Math.floor(GRID_COLUMNS / itemCount);
+};
+
 // A block sharing a row gets its `narrow` span regardless of the row's tier
 // (multi-column rows are always full width, but each column is a fraction of
 // it). A block owning its row follows the row's tier — `content` and the two
@@ -151,8 +178,11 @@ const itemSpanFor = (
 ): number | null => {
     const { itemSpan } = traitFor(block.type);
     if (itemSpan === null) return null;
-    if (isShared) return itemSpan.narrow;
-    return widthTier === 'full' ? itemSpan.full : itemSpan.content;
+    const declared = (() => {
+        if (isShared) return itemSpan.narrow;
+        return widthTier === 'full' ? itemSpan.full : itemSpan.content;
+    })();
+    return stretchSparse(declared, gridItemCountFor(block));
 };
 
 // Re-derives every column's span from the row's final tier. Called after width

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -195,10 +195,18 @@ const applyIntroRole = (rows: ResolvedRow[]): ResolvedRow[] => {
     ];
 };
 
+// 'view' hides config-empty blocks and hoists the leading hero; 'build' keeps
+// every config row/block 1:1 (empty blocks stay editable) and leaves the hero
+// in flow, while sharing all width/fit/hug math — so the edit canvas and the
+// published page cannot drift.
+export type LayoutSurface = 'view' | 'build';
+
 export const resolveHomepageLayout = (
     config: HomepageConfig,
+    opts: { surface: LayoutSurface } = { surface: 'view' },
 ): ResolvedLayout => {
-    const visibleRows = toVisibleRows(config.rows);
+    const isBuild = opts.surface === 'build';
+    const visibleRows = isBuild ? config.rows : toVisibleRows(config.rows);
     // Leading chrome rows join the hero rather than demoting it: the composer
     // is still "leading" with a quick-actions strip above it.
     const composerIdx = visibleRows.findIndex(
@@ -206,7 +214,8 @@ export const resolveHomepageLayout = (
             !row.blocks.every((b) => HERO_COMPANION_TYPES.includes(b.type)),
     );
     const composerRow = composerIdx >= 0 ? visibleRows[composerIdx] : undefined;
-    const hasLeadingHero = !!composerRow && isLeadingHero(composerRow.blocks);
+    const hasLeadingHero =
+        !isBuild && !!composerRow && isLeadingHero(composerRow.blocks);
     const bodyRows = hasLeadingHero
         ? visibleRows.slice(composerIdx + 1)
         : visibleRows;

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -29,6 +29,12 @@ export type HeroPresentation = 'viewport' | 'shared';
 // room; everything else is 'body'.
 export type RowRole = 'intro' | 'body';
 
+// Where a row narrower than the page's widest sits on the horizontal axis.
+// A reading measure governs line length, not position: centred text above a
+// left-aligned card grid leaves a ragged edge, so narrow rows align to the
+// page's content edge whenever something wider shares the page.
+export type RowAlign = 'center' | 'start';
+
 export type ResolvedColumn = {
     block: HomepageBlock;
     weight: number;
@@ -55,6 +61,7 @@ export type ResolvedRow = {
     // tier; multi-column rows always span full width.
     widthTier: BlockWidthTier;
     role: RowRole;
+    align: RowAlign;
     fit: RowFit;
     columns: ResolvedColumn[];
 };
@@ -204,6 +211,7 @@ const applyItemSpans = (rows: ResolvedRow[]): ResolvedRow[] =>
 const resolveRow = (
     row: HomepageConfig['rows'][number],
     isFirst: boolean,
+    isBuild: boolean,
 ): ResolvedRow => {
     const single = row.blocks.length === 1;
     const columns: ResolvedColumn[] = row.blocks.map((block) => ({
@@ -218,9 +226,19 @@ const resolveRow = (
             !single,
         ),
     }));
-    const widthTier: BlockWidthTier = single
-        ? traitFor(row.blocks[0].type).widthTier
-        : 'full';
+    const widthTier: BlockWidthTier = (() => {
+        if (!single) return 'full';
+        const tier = traitFor(row.blocks[0].type).widthTier;
+        // Build cards are editing surfaces and read as one column: a text
+        // block indented to its 680px reading measure beside a full-width
+        // metrics card leaves a ragged left edge, and published widths are
+        // what Preview is for. The composer is the exception — its width is
+        // its design, not a published measure. This changes no card span:
+        // every non-full tier either has no card grid, or (resources)
+        // resolves to the same span at both tiers.
+        if (isBuild && tier !== 'composer') return 'full';
+        return tier;
+    })();
     const gap: RowGap = (() => {
         if (isFirst) return 'none';
         // The incoming block's rhythm drives the gap: a grouped block tucks
@@ -234,6 +252,7 @@ const resolveRow = (
         gap,
         widthTier,
         role: 'body',
+        align: 'center',
         fit: single ? 'fill' : 'hug',
         columns,
     };
@@ -247,6 +266,22 @@ const smoothWidthTiers = (rows: ResolvedRow[]): ResolvedRow[] => {
     if (!rows.some((row) => row.widthTier === 'full')) return rows;
     return rows.map((row) =>
         row.widthTier === 'content' ? { ...row, widthTier: 'full' } : row,
+    );
+};
+
+const TIER_ORDER: BlockWidthTier[] = ['reading', 'composer', 'content', 'full'];
+
+// Narrow rows align left once anything wider shares the page, so a text
+// block's left edge agrees with the card grid below it. A page where every
+// row is the same width has nothing to align to, so it stays centred.
+const applyRowAlign = (rows: ResolvedRow[]): ResolvedRow[] => {
+    const widest = Math.max(
+        ...rows.map((row) => TIER_ORDER.indexOf(row.widthTier)),
+    );
+    return rows.map((row) =>
+        TIER_ORDER.indexOf(row.widthTier) < widest
+            ? { ...row, align: 'start' as const }
+            : row,
     );
 };
 
@@ -292,8 +327,10 @@ export const resolveHomepageLayout = (
     const bodyRows = hasLeadingHero
         ? visibleRows.slice(composerIdx + 1)
         : visibleRows;
-    const resolved = bodyRows.map((row, index) => resolveRow(row, index === 0));
-    const smoothed = applyItemSpans(smoothWidthTiers(resolved));
+    const resolved = bodyRows.map((row, index) =>
+        resolveRow(row, index === 0, isBuild),
+    );
+    const smoothed = applyRowAlign(applyItemSpans(smoothWidthTiers(resolved)));
     const rows = hasLeadingHero ? smoothed : applyIntroRole(smoothed);
     // A hero keeps the whole viewport only when it's alone; with body rows it
     // yields so the first row peeks above the fold.
@@ -301,8 +338,8 @@ export const resolveHomepageLayout = (
         ? {
               companions: visibleRows
                   .slice(0, composerIdx)
-                  .map((row) => resolveRow(row, true)),
-              row: resolveRow(composerRow, true),
+                  .map((row) => resolveRow(row, true, isBuild)),
+              row: resolveRow(composerRow, true, isBuild),
               presentation:
                   rows.length > 0 ? ('shared' as const) : ('viewport' as const),
           }

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -162,16 +162,29 @@ const gridItemCountFor = (block: HomepageBlock): number => {
     }
 };
 
+const SPAN_STEPS = [3, 4, 6, 12];
+
 // A block whose items don't fill one row stretches them across it rather than
-// leaving trailing empty tracks — a lone KPI beside a full collection should
-// span its column, not sit as a sliver with half the row blank. Blocks that do
-// fill a row keep their declared span so their cards stay on the shared
-// tracks. Sparse stretching only ever widens, never narrows.
-const stretchSparse = (declaredSpan: number, itemCount: number): number => {
+// leaving trailing empty tracks. Blocks that fill a row keep their declared
+// span so their cards stay on the shared tracks — with one exception: when a
+// full-width block would strand a single orphan and going one step denser
+// fits every item on one lattice (4 items at 3-up -> 4-up), it takes the
+// exact fit. 5 stays 3+2 and 7 stays 3+3+1; only an exact fit earns it.
+const fitSpan = (
+    declaredSpan: number,
+    itemCount: number,
+    isShared: boolean,
+): number => {
     if (itemCount === 0) return declaredSpan;
     const perRow = Math.floor(GRID_COLUMNS / declaredSpan);
-    if (itemCount >= perRow) return declaredSpan;
-    return Math.floor(GRID_COLUMNS / itemCount);
+    if (itemCount < perRow) return Math.floor(GRID_COLUMNS / itemCount);
+    if (!isShared && itemCount % perRow === 1) {
+        const denser = SPAN_STEPS[SPAN_STEPS.indexOf(declaredSpan) - 1];
+        if (denser && itemCount % Math.floor(GRID_COLUMNS / denser) === 0) {
+            return denser;
+        }
+    }
+    return declaredSpan;
 };
 
 // A block sharing a row gets its `narrow` span regardless of the row's tier
@@ -189,7 +202,7 @@ const itemSpanFor = (
         if (isShared) return itemSpan.narrow;
         return widthTier === 'full' ? itemSpan.full : itemSpan.content;
     })();
-    return stretchSparse(declared, gridItemCountFor(block));
+    return fitSpan(declared, gridItemCountFor(block), isShared);
 };
 
 // Re-derives every column's span from the row's final tier. Called after width


### PR DESCRIPTION
## What

The homepage becomes one layout system: a 12-column page grid every card block subscribes to, one card-height scale, deterministic cards, and rules (not per-combination fixes) for orphans, sparse blocks, column splits and alignment.

Includes the two commits previously stacked as #25737 (the resolver `surface` param that keeps the builder canvas WYSIWYG) — this PR supersedes it.

## Why

Verified against live renders before any code: blocks each invented their own card grid, so one page showed three card widths (281/379/224), phantom empty tracks (resources reserved 5 `auto-fill` tracks for 3 cards), orphan cards in centred partial rows, 4× column-height mismatches, and five distinct card heights. Screenshots and DOM measurements in the thread; every claim below was re-measured after the change.

## The system

**Page grid.** Blocks declare `itemSpan {full, content, narrow}` — how many of the page's 12 columns one item spans — and render through a shared `PageGrid`. `itemSpan` is a required prop: a call site that forgets it fails to compile (the builder canvas did exactly that once).

**One card unit (140px).** Set by the metric card's measured content — the densest card. Content tiles are horizontal rows at exactly half a unit, so two tiles + gap = one unit; everything lands on a 75px lattice. Resource cards are deterministic: fixed body (one-line title, fixed two-line description box), image band absorbs the slack — same height at every column width.

**Rules.**
- Sparse blocks stretch: 1 metric → span 12, 2 → 6, 3 → 4, 4 → 3.
- Exact-fit densening: a full-width block stranding one orphan goes one step denser when that fits every item on one row (4 resources → 4-up); 5 stays 3+2, never inside shared columns.
- A lone item on its final row stretches across it.
- Two-column rows split into equal halves — the boundary sits at the same x in every row (measured: one value page-wide). Retires the count-based hug sizing.
- Narrow rows left-align when a wider row shares the page; uniform pages stay centred.
- Build cards render full width (editing surfaces read as one column); the composer keeps its width.
- Columns top-align so neighbouring headers share a line; a card-grid column never shrinks below one card.

**Visual pass.** Resource cards: per-kind muted duotone washes (light-dark aware) with a bare favicon — replaces the blurred-backdrop + floating-chip look; kind row removed; external-link mark on hover. Google's default favicon globe (served 16px, never 404s) detected by natural size → our kind glyph. Density pass: gaps/padding tightened proportionally. Metric foot never wraps.

**Page width experiment (flagged for review):** tiers narrowed ~14% (full 1160→1000, content 960→860, reading 680→640; composer unchanged). Isolated commit `fb28ccf20d` — one revert if product prefers wide.

## Verification

Measured, not asserted — a DOM sweep over a 19-case permutation page (every item count 1–7, list/card variants, stacked odd counts, five two-column combos, hero compositions) asserts: one left edge, one card-height lattice, one column split, cards reach both grid edges, remainder rows on-track or full-width, nothing clipped, no default globes, KPI baselines equal. Zero violations at 1440 and 1024. Below 768 the custom homepage falls back to classic (pre-existing), so mobile is out of scope.

119 unit tests (resolver exhaustive + PageGrid both-surface parity, incl. a test proven to fail when the build-surface bug is reintroduced).

## Regression analysis

All behind the HomepageBuilder flag; EE-only. Existing published homepages re-render under the new rules with no data change or migration — layout is pure presentation. Affected: any published homepage with card blocks (they get aligned tracks, uniform heights, narrower page). Not affected: classic homepage, day-0 page, dashboards, non-flagged projects. Config schema untouched, so promote/coder paths unaffected.


**Bento columns (added after the write-up above).** Elastic grids (collections, metrics) stretch to fill their column, so both sides of a split row end on the same line; rigid cards (resources) define the height and siblings adapt. A content tile that receives extra height switches from a horizontal row to a vertical card and earns the space with more meta (space name, updated time) via a container query on its grid cell — short tiles are untouched. Verified: zero column-end mismatches across all two-column permutations.
