### PR TITLE
docs: clarify generated API artifact ownership

### DIFF
--- a/.github/rules/backend-review.md
+++ b/.github/rules/backend-review.md
@@ -36,7 +36,7 @@ controllers -> services -> models -> database
 
 ## Development Guidelines
 
-When building a new endpoint see `packages/backend/src/generated/routes.ts` and `packages/backend/src/generated/swagger.json`, ensure that you make changes to the controller, service, model, but also update types in `packages/common`. Remind the user to call `pnpm generate-api` to rebuild tsoa.
+When building a new endpoint, ensure that the controller, service, model, and relevant types in `packages/common` are updated. PR CI regenerates `packages/backend/src/generated/routes.ts` and `packages/backend/src/generated/swagger.json` for validation, and the release workflow commits those generated artifacts. Do not ask PR authors to commit them; suggest `pnpm generate-api` only for local validation or to refresh stale local routes.
 
 ### Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,14 @@ pnpm -F backend test:dev:nowatch # runs only tests for modified files
 
 **API Generation:**
 
-Generate OpenAPI specs from TSOA controllers. Always run this when:
+OpenAPI artifacts are generated from TSOA controllers in PR CI for compatibility
+checks and again by the release workflow. Feature PRs must not commit changes to
+`packages/backend/src/generated/routes.ts` or
+`packages/backend/src/generated/swagger.json`; the pre-commit hook unstages them
+and the release workflow commits the generated artifacts.
+
+Run generation locally when validating changes to any of the following, or when
+local generated routes are stale:
 
 - controllers change
 - return signatures of service functions called by controllers change


### PR DESCRIPTION
### Description

- Clarifies that PR CI regenerates the TSOA routes and OpenAPI schema for validation.
- Documents that the release workflow commits `routes.ts` and `swagger.json`.
- Tells reviewers not to request generated API artifacts in feature PRs; local generation remains useful for validation and stale-route recovery.

### Validation

- `git diff --check`

This corrects outdated repository guidance that implied feature PR authors owned generated API artifacts.