### PR TITLE
fix(ai-agent): surface warehouse errors instead of going silent in Slack

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -10181,51 +10181,60 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     ): Promise<void> {
         const slackPrompt: SlackPrompt = initialSlackPrompt;
 
-        const user = await this.userModel.findSessionUserAndOrgByUuid(
-            slackPrompt.createdByUserUuid,
-            slackPrompt.organizationUuid,
-        );
-
-        const auditedAbility = this.createAuditedAbility(user);
-        const canManageAgent = auditedAbility.can(
-            'manage',
-            subject('AiAgent', {
-                organizationUuid: slackPrompt.organizationUuid,
-                projectUuid: slackPrompt.projectUuid,
-                metadata: {
-                    promptUuid,
-                    threadUuid: slackPrompt.threadUuid,
-                },
-            }),
-        );
-
-        const threadMessages = await this.aiAgentModel.getThreadMessages(
-            slackPrompt.organizationUuid,
-            slackPrompt.projectUuid,
-            slackPrompt.threadUuid,
-        );
-
-        const thread = await this.aiAgentModel.findThread(
-            slackPrompt.threadUuid,
-        );
-        if (!thread) {
-            throw new Error('Thread not found');
-        }
-
+        // Resolved inside the try so it's available to the catch when a later
+        // step fails; the catch tolerates it being undefined.
         let agent: AiAgent | undefined;
-        if (thread.agentUuid) {
-            agent = await this.getAgent(user, thread.agentUuid);
-        }
 
-        if (slackPrompt.prompt.trim().length === 0) {
-            await this.editPlaceholderOrPost(
-                slackPrompt,
-                AiAgentService.EMPTY_PROMPT_WELCOME,
-            );
-            return;
-        }
-
+        // Everything runs inside this try so ANY failure — thread/agent lookup,
+        // chat-history assembly, or generation itself — posts an explicit error
+        // to the Slack thread instead of letting the worker job die silently
+        // (leaving a stuck "thinking" card and no reply). The status/card path
+        // in replyToSlackPromptWithStatus only rethrows when it never posted a
+        // card, so this remains the single error post.
         try {
+            const user = await this.userModel.findSessionUserAndOrgByUuid(
+                slackPrompt.createdByUserUuid,
+                slackPrompt.organizationUuid,
+            );
+
+            const auditedAbility = this.createAuditedAbility(user);
+            const canManageAgent = auditedAbility.can(
+                'manage',
+                subject('AiAgent', {
+                    organizationUuid: slackPrompt.organizationUuid,
+                    projectUuid: slackPrompt.projectUuid,
+                    metadata: {
+                        promptUuid,
+                        threadUuid: slackPrompt.threadUuid,
+                    },
+                }),
+            );
+
+            const threadMessages = await this.aiAgentModel.getThreadMessages(
+                slackPrompt.organizationUuid,
+                slackPrompt.projectUuid,
+                slackPrompt.threadUuid,
+            );
+
+            const thread = await this.aiAgentModel.findThread(
+                slackPrompt.threadUuid,
+            );
+            if (!thread) {
+                throw new Error('Thread not found');
+            }
+
+            if (thread.agentUuid) {
+                agent = await this.getAgent(user, thread.agentUuid);
+            }
+
+            if (slackPrompt.prompt.trim().length === 0) {
+                await this.editPlaceholderOrPost(
+                    slackPrompt,
+                    AiAgentService.EMPTY_PROMPT_WELCOME,
+                );
+                return;
+            }
+
             const chatHistoryMessages =
                 await this.getChatHistoryFromThreadMessages(threadMessages, {
                     organizationUuid: slackPrompt.organizationUuid,
@@ -10275,7 +10284,11 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     },
                 ],
                 channel: slackPrompt.slackChannelId,
-                thread_ts: slackPrompt.slackThreadTs,
+                // On a brand-new thread slackThreadTs is undefined; fall back to
+                // the prompt's ts (matching threadTs in
+                // replyToSlackPromptWithStatus) so the error still threads.
+                thread_ts:
+                    slackPrompt.slackThreadTs ?? slackPrompt.promptSlackTs,
                 username: agent?.name,
             });
 

--- a/packages/backend/src/ee/services/ai/agents/queryRetryCap.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/queryRetryCap.test.ts
@@ -51,6 +51,24 @@ describe('classifyQueryResult', () => {
         ).toBe('fixable');
     });
 
+    it('classifies a BigQuery Access Denied as non-retryable', () => {
+        expect(
+            classifyQueryResult({
+                type: 'error-text',
+                value: 'Error running query. Access Denied: Table my-project:dataset.table: User does not have permission to query table',
+            }),
+        ).toBe('non-retryable');
+    });
+
+    it('classifies a bytesBilledLimitExceeded as non-retryable', () => {
+        expect(
+            classifyQueryResult({
+                type: 'error-text',
+                value: 'Error running query. Query exceeded limit for bytesBilledLimitExceeded',
+            }),
+        ).toBe('non-retryable');
+    });
+
     it('classifies an unknown error as other', () => {
         expect(
             classifyQueryResult({
@@ -67,6 +85,15 @@ describe('shouldCapQueryRetries', () => {
         expect(shouldCapQueryRetries(['warehouse-slow', 'ok']).capped).toBe(
             false,
         );
+        expect(shouldCapQueryRetries(['non-retryable', 'ok']).capped).toBe(
+            false,
+        );
+    });
+
+    it('caps after two non-retryable errors', () => {
+        expect(
+            shouldCapQueryRetries(['non-retryable', 'non-retryable']).capped,
+        ).toBe(true);
     });
 
     it('caps after two warehouse-slow errors', () => {
@@ -110,6 +137,18 @@ describe('collectQueryResultClasses', () => {
         ]);
     });
 
+    it('collects runSql results', () => {
+        const messages: ModelMessage[] = [
+            toolResultMessage('runSql', {
+                type: 'error-text',
+                value: 'Error running SQL query. Access Denied: no permission',
+            }),
+        ];
+        expect(collectQueryResultClasses(messages, QUERY_TOOL_NAMES)).toEqual([
+            'non-retryable',
+        ]);
+    });
+
     it('ignores non-query tools', () => {
         const messages: ModelMessage[] = [
             toolResultMessage('searchFieldValues', {
@@ -124,7 +163,12 @@ describe('collectQueryResultClasses', () => {
 });
 
 describe('buildQueryRetryStepOverride', () => {
-    const allTools = ['generateVisualization', 'runQuery', 'grepFields'];
+    const allTools = [
+        'generateVisualization',
+        'runQuery',
+        'runSql',
+        'grepFields',
+    ];
 
     it('returns null when the cap has not tripped', () => {
         const messages: ModelMessage[] = [
@@ -148,5 +192,24 @@ describe('buildQueryRetryStepOverride', () => {
         const override = buildQueryRetryStepOverride(messages, allTools);
         expect(override?.activeTools).toEqual(['grepFields']);
         expect(override?.nudge.toLowerCase()).toContain('do not');
+    });
+
+    it('surfaces the warehouse error and instructs the agent to report it', () => {
+        const err = {
+            type: 'error-text',
+            value: 'Error running SQL query. Access Denied: User does not have permission to query table my-project:dataset.orders\n\nTry again if you believe the error can be resolved.',
+        };
+        const messages: ModelMessage[] = [
+            toolResultMessage('runSql', err),
+            toolResultMessage('runSql', err),
+        ];
+        const override = buildQueryRetryStepOverride(messages, allTools);
+        expect(override?.activeTools).not.toContain('runSql');
+        // The wrapping prefix/suffix are stripped; the real warehouse text stays.
+        expect(override?.nudge).toContain(
+            'Access Denied: User does not have permission to query table',
+        );
+        expect(override?.nudge).not.toContain('Try again if you believe');
+        expect(override?.nudge.toLowerCase()).toContain('report this error');
     });
 });

--- a/packages/backend/src/ee/services/ai/agents/queryRetryCap.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/queryRetryCap.test.ts
@@ -42,34 +42,21 @@ describe('classifyQueryResult', () => {
         ).toBe('warehouse-slow');
     });
 
-    it('classifies an invalid custom metric as fixable', () => {
+    it('does not bucket warehouse-specific errors — any non-timeout failure is other', () => {
+        // Permission / scan-limit / bad-SQL errors are all treated the same;
+        // we never match warehouse-specific prose.
         expect(
             classifyQueryResult({
                 type: 'error-text',
-                value: 'Error running query. Invalid custom metric: unknown field foo',
+                value: 'Error running query. Access Denied: User does not have permission to query table',
             }),
-        ).toBe('fixable');
-    });
-
-    it('classifies a BigQuery Access Denied as non-retryable', () => {
-        expect(
-            classifyQueryResult({
-                type: 'error-text',
-                value: 'Error running query. Access Denied: Table my-project:dataset.table: User does not have permission to query table',
-            }),
-        ).toBe('non-retryable');
-    });
-
-    it('classifies a bytesBilledLimitExceeded as non-retryable', () => {
+        ).toBe('other');
         expect(
             classifyQueryResult({
                 type: 'error-text',
                 value: 'Error running query. Query exceeded limit for bytesBilledLimitExceeded',
             }),
-        ).toBe('non-retryable');
-    });
-
-    it('classifies an unknown error as other', () => {
+        ).toBe('other');
         expect(
             classifyQueryResult({
                 type: 'error-text',
@@ -81,19 +68,10 @@ describe('classifyQueryResult', () => {
 
 describe('shouldCapQueryRetries', () => {
     it('does not cap below the thresholds', () => {
-        expect(shouldCapQueryRetries(['ok', 'fixable']).capped).toBe(false);
+        expect(shouldCapQueryRetries(['ok', 'other']).capped).toBe(false);
         expect(shouldCapQueryRetries(['warehouse-slow', 'ok']).capped).toBe(
             false,
         );
-        expect(shouldCapQueryRetries(['non-retryable', 'ok']).capped).toBe(
-            false,
-        );
-    });
-
-    it('caps after two non-retryable errors', () => {
-        expect(
-            shouldCapQueryRetries(['non-retryable', 'non-retryable']).capped,
-        ).toBe(true);
     });
 
     it('caps after two warehouse-slow errors', () => {
@@ -103,14 +81,14 @@ describe('shouldCapQueryRetries', () => {
     });
 
     it('caps after three errors of any kind', () => {
-        expect(
-            shouldCapQueryRetries(['fixable', 'other', 'fixable']).capped,
-        ).toBe(true);
+        expect(shouldCapQueryRetries(['other', 'other', 'other']).capped).toBe(
+            true,
+        );
     });
 
     it('does not count successful (ok) calls toward the cap', () => {
         expect(
-            shouldCapQueryRetries(['ok', 'ok', 'ok', 'ok', 'fixable']).capped,
+            shouldCapQueryRetries(['ok', 'ok', 'ok', 'ok', 'other']).capped,
         ).toBe(false);
     });
 });
@@ -133,7 +111,7 @@ describe('collectQueryResultClasses', () => {
         ];
         expect(collectQueryResultClasses(messages, QUERY_TOOL_NAMES)).toEqual([
             'warehouse-slow',
-            'fixable',
+            'other',
         ]);
     });
 
@@ -145,7 +123,7 @@ describe('collectQueryResultClasses', () => {
             }),
         ];
         expect(collectQueryResultClasses(messages, QUERY_TOOL_NAMES)).toEqual([
-            'non-retryable',
+            'other',
         ]);
     });
 
@@ -194,12 +172,13 @@ describe('buildQueryRetryStepOverride', () => {
         expect(override?.nudge.toLowerCase()).toContain('do not');
     });
 
-    it('surfaces the warehouse error and instructs the agent to report it', () => {
+    it('surfaces the warehouse error and instructs the agent to relay it', () => {
         const err = {
             type: 'error-text',
             value: 'Error running SQL query. Access Denied: User does not have permission to query table my-project:dataset.orders\n\nTry again if you believe the error can be resolved.',
         };
         const messages: ModelMessage[] = [
+            toolResultMessage('runSql', err),
             toolResultMessage('runSql', err),
             toolResultMessage('runSql', err),
         ];
@@ -210,6 +189,8 @@ describe('buildQueryRetryStepOverride', () => {
             'Access Denied: User does not have permission to query table',
         );
         expect(override?.nudge).not.toContain('Try again if you believe');
-        expect(override?.nudge.toLowerCase()).toContain('report this error');
+        expect(override?.nudge.toLowerCase()).toContain(
+            'relay this warehouse error',
+        );
     });
 });

--- a/packages/backend/src/ee/services/ai/agents/queryRetryCap.ts
+++ b/packages/backend/src/ee/services/ai/agents/queryRetryCap.ts
@@ -15,12 +15,7 @@ export const QUERY_TOOL_NAMES: ReadonlySet<string> = new Set([
     'runSql',
 ]);
 
-export type QueryResultClass =
-    | 'ok'
-    | 'warehouse-slow'
-    | 'fixable'
-    | 'non-retryable'
-    | 'other';
+export type QueryResultClass = 'ok' | 'warehouse-slow' | 'other';
 
 // A tool result as it appears in the model messages (see toModelOutput):
 // success → { type: 'text' }, error → { type: 'error-text' }.
@@ -28,29 +23,23 @@ type ToolResultOutput = { type: string; value: string };
 
 const WAREHOUSE_SLOW =
     /timed out|timeout|polling|connection (terminated|lost)|econnreset/i;
-// Errors where re-running the identical query cannot help: the warehouse
-// rejected it for permissions or a hard scan/quota limit, not a transient or
-// fixable reason. e.g. BigQuery `Access Denied` on a table the service account
-// can't read, or `bytesBilledLimitExceeded` when the scan exceeds the
-// connection's "Maximum bytes per run".
-const NON_RETRYABLE =
-    /access denied|permission denied|not authorized|does not have permission|bytesbilledlimitexceeded|bytes billed|maximum bytes|scan(ned)? limit|quota exceeded|exceeded quota|billing tier/i;
-const FIXABLE =
-    /invalid|unknown|not found|custom metric|dimension|filter|axis|chart ?config/i;
 
 /**
  * Classify a single query-tool result. Only `error-text` outputs count as
  * failures; a successful result is `ok` and never contributes to the cap.
- * Non-retryable (permissions / scan limits) is checked before the others
- * because retrying those is always futile.
+ * We deliberately do NOT try to bucket errors by warehouse-specific meaning
+ * (permissions, scan limits, bad SQL, ...) — that would mean matching each
+ * warehouse's error prose, which is brittle and only ever covers whichever
+ * warehouse we hard-coded. Any repeated failure is treated the same, and the
+ * actual warehouse message is relayed to the user (see buildQueryRetryStepOverride).
+ * The one exception is warehouse-slow (timeouts), which trips sooner because
+ * re-running a heavy scan that already timed out is especially wasteful.
  */
 export const classifyQueryResult = (
     output: ToolResultOutput,
 ): QueryResultClass => {
     if (output.type !== 'error-text') return 'ok';
-    if (NON_RETRYABLE.test(output.value)) return 'non-retryable';
     if (WAREHOUSE_SLOW.test(output.value)) return 'warehouse-slow';
-    if (FIXABLE.test(output.value)) return 'fixable';
     return 'other';
 };
 
@@ -58,23 +47,14 @@ export const classifyQueryResult = (
  * Decide whether to stop the agent re-issuing query tools this turn. Trips on
  * repeated *failures* only, so legitimate multi-chart turns (several successful
  * queries) are never capped.
- *  - ≥2 non-retryable: the warehouse rejected the query (permissions / scan
- *    limit); re-running it never helps and only burns steps + context.
  *  - ≥2 warehouse-slow: re-running a heavy scan that already timed out won't help.
  *  - ≥3 errors total: the model is looping instead of converging.
  */
 export const shouldCapQueryRetries = (
     classes: QueryResultClass[],
 ): { capped: boolean; reason: string } => {
-    const nonRetryable = classes.filter((c) => c === 'non-retryable').length;
     const warehouseSlow = classes.filter((c) => c === 'warehouse-slow').length;
     const errors = classes.filter((c) => c !== 'ok').length;
-    if (nonRetryable >= 2) {
-        return {
-            capped: true,
-            reason: 'the warehouse rejected the query (permissions or a query-size limit)',
-        };
-    }
     if (warehouseSlow >= 2) {
         return {
             capped: true,
@@ -181,7 +161,7 @@ export const buildQueryRetryStepOverride = (
         ...(snippet
             ? [
                   `The warehouse reported: "${snippet}".`,
-                  'Report this error to the user so they can fix it (for example, table permissions or the connection’s "Maximum bytes per run" limit),',
+                  'Relay this warehouse error to the user in your reply so they can address it (for example a permissions or query-size-limit issue on their side),',
                   'then answer with whatever information you already have.',
               ]
             : [

--- a/packages/backend/src/ee/services/ai/agents/queryRetryCap.ts
+++ b/packages/backend/src/ee/services/ai/agents/queryRetryCap.ts
@@ -1,15 +1,26 @@
 import type { ModelMessage } from 'ai';
 
 /**
- * Query-execution tools whose repeated failures we bound within a turn. Both
- * names resolve to the same underlying runQuery implementation.
+ * Warehouse query-execution tools whose repeated failures we bound within a
+ * turn. All of them run a warehouse query and surface failures as
+ * `error-text` results (see defaultAgentToModelOutput), so a loop of any of
+ * them can stack multi-minute scans or grow the context until it overflows.
  */
 export const QUERY_TOOL_NAMES: ReadonlySet<string> = new Set([
     'generateVisualization',
     'runQuery',
+    'runMetricQuery',
+    'runContentQuery',
+    'runSavedChart',
+    'runSql',
 ]);
 
-export type QueryResultClass = 'ok' | 'warehouse-slow' | 'fixable' | 'other';
+export type QueryResultClass =
+    | 'ok'
+    | 'warehouse-slow'
+    | 'fixable'
+    | 'non-retryable'
+    | 'other';
 
 // A tool result as it appears in the model messages (see toModelOutput):
 // success → { type: 'text' }, error → { type: 'error-text' }.
@@ -17,17 +28,27 @@ type ToolResultOutput = { type: string; value: string };
 
 const WAREHOUSE_SLOW =
     /timed out|timeout|polling|connection (terminated|lost)|econnreset/i;
+// Errors where re-running the identical query cannot help: the warehouse
+// rejected it for permissions or a hard scan/quota limit, not a transient or
+// fixable reason. e.g. BigQuery `Access Denied` on a table the service account
+// can't read, or `bytesBilledLimitExceeded` when the scan exceeds the
+// connection's "Maximum bytes per run".
+const NON_RETRYABLE =
+    /access denied|permission denied|not authorized|does not have permission|bytesbilledlimitexceeded|bytes billed|maximum bytes|scan(ned)? limit|quota exceeded|exceeded quota|billing tier/i;
 const FIXABLE =
     /invalid|unknown|not found|custom metric|dimension|filter|axis|chart ?config/i;
 
 /**
  * Classify a single query-tool result. Only `error-text` outputs count as
  * failures; a successful result is `ok` and never contributes to the cap.
+ * Non-retryable (permissions / scan limits) is checked before the others
+ * because retrying those is always futile.
  */
 export const classifyQueryResult = (
     output: ToolResultOutput,
 ): QueryResultClass => {
     if (output.type !== 'error-text') return 'ok';
+    if (NON_RETRYABLE.test(output.value)) return 'non-retryable';
     if (WAREHOUSE_SLOW.test(output.value)) return 'warehouse-slow';
     if (FIXABLE.test(output.value)) return 'fixable';
     return 'other';
@@ -37,14 +58,23 @@ export const classifyQueryResult = (
  * Decide whether to stop the agent re-issuing query tools this turn. Trips on
  * repeated *failures* only, so legitimate multi-chart turns (several successful
  * queries) are never capped.
+ *  - ≥2 non-retryable: the warehouse rejected the query (permissions / scan
+ *    limit); re-running it never helps and only burns steps + context.
  *  - ≥2 warehouse-slow: re-running a heavy scan that already timed out won't help.
  *  - ≥3 errors total: the model is looping instead of converging.
  */
 export const shouldCapQueryRetries = (
     classes: QueryResultClass[],
 ): { capped: boolean; reason: string } => {
+    const nonRetryable = classes.filter((c) => c === 'non-retryable').length;
     const warehouseSlow = classes.filter((c) => c === 'warehouse-slow').length;
     const errors = classes.filter((c) => c !== 'ok').length;
+    if (nonRetryable >= 2) {
+        return {
+            capped: true,
+            reason: 'the warehouse rejected the query (permissions or a query-size limit)',
+        };
+    }
     if (warehouseSlow >= 2) {
         return {
             capped: true,
@@ -54,21 +84,23 @@ export const shouldCapQueryRetries = (
     if (errors >= 3) {
         return {
             capped: true,
-            reason: 'the visualization query failed repeatedly',
+            reason: 'the query failed repeatedly',
         };
     }
     return { capped: false, reason: '' };
 };
 
+type QueryResult = { class: QueryResultClass; value: string };
+
 /**
- * Walk the model messages and classify every query-tool result, in order.
- * Non-query tool results are ignored.
+ * Walk the model messages and collect every query-tool result, in order, with
+ * both its class and the raw error text. Non-query tool results are ignored.
  */
-export const collectQueryResultClasses = (
+export const collectQueryResults = (
     messages: ModelMessage[],
     queryToolNames: ReadonlySet<string>,
-): QueryResultClass[] => {
-    const classes: QueryResultClass[] = [];
+): QueryResult[] => {
+    const results: QueryResult[] = [];
     for (const message of messages) {
         if (message.role === 'tool' && Array.isArray(message.content)) {
             for (const part of message.content) {
@@ -81,36 +113,85 @@ export const collectQueryResultClasses = (
                     queryToolNames.has(part.toolName as string) &&
                     'output' in part
                 ) {
-                    classes.push(
-                        classifyQueryResult(part.output as ToolResultOutput),
-                    );
+                    const output = part.output as ToolResultOutput;
+                    results.push({
+                        class: classifyQueryResult(output),
+                        value:
+                            typeof output.value === 'string'
+                                ? output.value
+                                : '',
+                    });
                 }
             }
         }
     }
-    return classes;
+    return results;
 };
+
+/**
+ * Walk the model messages and classify every query-tool result, in order.
+ * Non-query tool results are ignored.
+ */
+export const collectQueryResultClasses = (
+    messages: ModelMessage[],
+    queryToolNames: ReadonlySet<string>,
+): QueryResultClass[] =>
+    collectQueryResults(messages, queryToolNames).map((r) => r.class);
+
+// toolErrorHandler wraps the underlying warehouse error with a fixed prefix and
+// a "Try again..." suffix; strip both so the snippet we relay to the user is
+// the actual warehouse message and nothing that re-encourages retrying.
+const cleanWarehouseError = (value: string): string =>
+    value
+        .replace(/^Error running (query|SQL query)\.?\s*/i, '')
+        .replace(
+            /\s*Try again if you believe the error can be resolved\.?\s*$/i,
+            '',
+        )
+        .trim();
+
+const MAX_ERROR_SNIPPET_CHARS = 500;
 
 /**
  * Given the current model messages and the full tool set, decide the
  * `prepareStep` override that bounds query-tool retries: returns the reduced
  * `activeTools` (query tools removed) and a nudge message, or null when the cap
- * has not tripped. Pure so the `prepareStep` wiring stays trivial.
+ * has not tripped. The nudge carries the actual warehouse error so the agent
+ * relays it to the user (permissions / query-size limit) instead of failing
+ * silently. Pure so the `prepareStep` wiring stays trivial.
  */
 export const buildQueryRetryStepOverride = (
     messages: ModelMessage[],
     allToolNames: string[],
 ): { activeTools: string[]; nudge: string } | null => {
-    const decision = shouldCapQueryRetries(
-        collectQueryResultClasses(messages, QUERY_TOOL_NAMES),
-    );
+    const results = collectQueryResults(messages, QUERY_TOOL_NAMES);
+    const decision = shouldCapQueryRetries(results.map((r) => r.class));
     if (!decision.capped) return null;
+
+    const lastError = [...results]
+        .reverse()
+        .find((r) => r.class !== 'ok')?.value;
+    const snippet = lastError
+        ? cleanWarehouseError(lastError).slice(0, MAX_ERROR_SNIPPET_CHARS)
+        : '';
+
+    const nudge = [
+        `The data query has repeatedly failed (${decision.reason}).`,
+        'Do not run it again.',
+        ...(snippet
+            ? [
+                  `The warehouse reported: "${snippet}".`,
+                  'Report this error to the user so they can fix it (for example, table permissions or the connection’s "Maximum bytes per run" limit),',
+                  'then answer with whatever information you already have.',
+              ]
+            : [
+                  'Answer using the information you already have,',
+                  'or briefly explain what is blocking the result.',
+              ]),
+    ].join(' ');
+
     return {
         activeTools: allToolNames.filter((name) => !QUERY_TOOL_NAMES.has(name)),
-        nudge: [
-            `The visualization query has repeatedly failed (${decision.reason}).`,
-            'Do not run it again — answer using the information you already have,',
-            'or briefly explain what is blocking the result.',
-        ].join(' '),
+        nudge,
     };
 };


### PR DESCRIPTION
## Problem

When an AI agent's warehouse queries keep failing in a Slack conversation (e.g. BigQuery `Access Denied` on referenced tables, or `bytesBilledLimitExceeded` when a query exceeds the connection's "Maximum bytes per run" limit), the agent retries the failing query tool calls until it exhausts its step budget — or the accumulated retry results overflow the model context window — and then posts nothing back to Slack. The user is left with a stuck "thinking" card and no answer or error.

## Approach

Builds on the existing query-retry cap (ZAP-574) and the Slack error-surfacing path:

- **Cover all warehouse query executors** in the retry cap (`runSql`, `runContentQuery`, `runSavedChart`, `runMetricQuery`), not just `generateVisualization`/`runQuery` — so a loop of any warehouse query gets bounded.
- **Relay the actual warehouse error to the user.** When the cap trips, the concrete warehouse message is carried into the nudge (with the `Error running query.` / `Try again…` boilerplate stripped so it isn't re-encouraged to retry) and the agent is told to relay it. This is warehouse-agnostic — we do **not** try to bucket errors by warehouse-specific prose (permissions vs scan-limit vs bad SQL), which would only ever match whichever warehouse we hard-coded. Any repeated failure trips the generic cap and surfaces whatever the warehouse actually said.
- **Widen `generateSlackPromptReply`'s try/catch** to also cover thread/agent lookup and chat-history assembly, so any in-process failure posts an explicit Slack error rather than the worker job dying silently. The fallback post now threads under `promptSlackTs` for brand-new threads.

Note: the 👀 ack reaction / "working…" placeholder mentioned in the report aren't added by this codebase, and a process OOM can't be caught in-process — those symptoms are addressed indirectly by preventing the runaway loop/overflow and never letting an in-process failure go unposted.

## Testing

- Unit tests in `queryRetryCap.test.ts` (expanded tool coverage incl. `runSql`, warehouse-agnostic classification, nudge carrying the real warehouse error snippet).
- `pnpm -F backend typecheck:fast`, lint, and format pass.
