### PR TITLE
fix: prepare content for project ownership columns

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -126,6 +126,7 @@ import Logger from '../../logging/logger';
 import { wrapSentryTransaction, wrapSentryTransactionSync } from '../../utils';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import { generateUniqueSpaceSlug } from '../../utils/SlugUtils';
+import { omitProjectUuid } from './previewContent';
 import Transaction = Knex.Transaction;
 
 export type ProjectModelArguments = {
@@ -2916,7 +2917,7 @@ export class ProjectModel {
                                   );
                               }
                               const createChart: CloneChart = {
-                                  ...d,
+                                  ...omitProjectUuid(d),
                                   search_vector: undefined,
                                   saved_query_id: undefined,
                                   saved_query_uuid: undefined,
@@ -2971,7 +2972,7 @@ export class ProjectModel {
                                   );
                               }
                               const createChart: CloneChart = {
-                                  ...d,
+                                  ...omitProjectUuid(d),
                                   search_vector: undefined,
                                   space_id: null,
                                   dashboard_uuid: d.dashboard_uuid,
@@ -3166,7 +3167,7 @@ export class ProjectModel {
                                       dashboard_uuid?: string;
                                   };
                                   const createDashboard: CloneDashboard = {
-                                      ...d,
+                                      ...omitProjectUuid(d),
                                       search_vector: undefined,
                                       dashboard_id: undefined,
                                       dashboard_uuid: undefined,

--- a/packages/backend/src/models/ProjectModel/previewContent.test.ts
+++ b/packages/backend/src/models/ProjectModel/previewContent.test.ts
@@ -1,0 +1,26 @@
+import { omitProjectUuid } from './previewContent';
+
+describe('omitProjectUuid', () => {
+    it.each([
+        {
+            row: {
+                saved_query_uuid: 'chart-uuid',
+                project_uuid: 'source-project-uuid',
+            },
+        },
+        {
+            row: {
+                dashboard_uuid: 'dashboard-uuid',
+                project_uuid: 'source-project-uuid',
+            },
+        },
+    ])(
+        'omits ownership from preview rows without mutating the source',
+        ({ row }) => {
+            const result = omitProjectUuid(row);
+
+            expect(result).not.toHaveProperty('project_uuid');
+            expect(row).toHaveProperty('project_uuid', 'source-project-uuid');
+        },
+    );
+});

--- a/packages/backend/src/models/ProjectModel/previewContent.ts
+++ b/packages/backend/src/models/ProjectModel/previewContent.ts
@@ -1,0 +1,9 @@
+export const omitProjectUuid = <T extends object>(
+    row: T,
+): Omit<T, 'project_uuid'> => {
+    const { project_uuid: projectUuid, ...rest } = row as T & {
+        project_uuid?: unknown;
+    };
+    void projectUuid;
+    return rest;
+};

--- a/packages/backend/src/models/ValidationModel/ValidationModel.test.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.test.ts
@@ -1,6 +1,8 @@
 import { DashboardFilterValidationErrorType } from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { DashboardsTableName } from '../../database/entities/dashboards';
+import { SavedChartsTableName } from '../../database/entities/savedCharts';
 import { ValidationTableName } from '../../database/entities/validation';
 import { ValidationModel } from './ValidationModel';
 
@@ -46,6 +48,38 @@ describe('ValidationModel', () => {
             const [query] = tracker.history.delete;
             expect(query.bindings).toContain(dashboardUuid);
             expect(query.bindings).toContain(projectUuid);
+        });
+    });
+
+    describe('project ownership column compatibility', () => {
+        const database = knex({ client: MockClient, dialect: 'pg' });
+        const model = new ValidationModel({ database });
+        let tracker: Tracker;
+
+        beforeAll(() => {
+            tracker = getTracker();
+        });
+
+        afterEach(() => {
+            tracker.reset();
+        });
+
+        it('qualifies project_uuid in queries that join content tables', async () => {
+            tracker.on.select(({ sql }) => sql.length > 0).response([]);
+
+            await model.get('22222222-2222-4222-8222-222222222222');
+
+            const joinedContentQueries = tracker.history.select.filter(
+                ({ sql }) =>
+                    sql.includes(`join "${SavedChartsTableName}"`) ||
+                    sql.includes(`join "${DashboardsTableName}"`),
+            );
+            expect(joinedContentQueries).toHaveLength(2);
+            joinedContentQueries.forEach(({ sql }) => {
+                expect(sql).toContain(
+                    `"${ValidationTableName}"."project_uuid"`,
+                );
+            });
         });
     });
 

--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -351,7 +351,7 @@ export class ValidationModel {
                 `${SavedChartsTableName}.last_version_updated_by_user_uuid`,
                 `${UserTableName}.user_uuid`,
             )
-            .where('project_uuid', projectUuid)
+            .where(`${ValidationTableName}.project_uuid`, projectUuid)
             .andWhere((queryBuilder) => {
                 if (jobId) {
                     void queryBuilder.where('job_id', jobId);
@@ -460,7 +460,7 @@ export class ValidationModel {
                 `${UserTableName}.user_uuid`,
                 `${DashboardVersionsTableName}.updated_by_user_uuid`,
             )
-            .where('project_uuid', projectUuid)
+            .where(`${ValidationTableName}.project_uuid`, projectUuid)
             .andWhere((queryBuilder) => {
                 if (jobId) {
                     void queryBuilder.where('job_id', jobId);

--- a/packages/backend/src/utils/SlugUtils.test.ts
+++ b/packages/backend/src/utils/SlugUtils.test.ts
@@ -1,0 +1,36 @@
+import knex from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { DashboardsTableName } from '../database/entities/dashboards';
+import { ProjectTableName } from '../database/entities/projects';
+import { SavedChartsTableName } from '../database/entities/savedCharts';
+import { generateUniqueSlugScopedToProject } from './SlugUtils';
+
+describe('generateUniqueSlugScopedToProject', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it.each([SavedChartsTableName, DashboardsTableName] as const)(
+        'qualifies project_uuid when querying %s',
+        async (tableName) => {
+            tracker.on.select(tableName).responseOnce([]);
+
+            await generateUniqueSlugScopedToProject(
+                database,
+                '22222222-2222-4222-8222-222222222222',
+                tableName,
+                'Orders',
+            );
+
+            const [query] = tracker.history.select;
+            expect(query.sql).toContain(`"${ProjectTableName}"."project_uuid"`);
+        },
+    );
+});

--- a/packages/backend/src/utils/SlugUtils.ts
+++ b/packages/backend/src/utils/SlugUtils.ts
@@ -132,7 +132,7 @@ export const generateUniqueSlugScopedToProject = async (
                     `${SpaceTableName}.project_id`,
                     `${ProjectTableName}.project_id`,
                 )
-                .where('project_uuid', projectUuid)
+                .where(`${ProjectTableName}.project_uuid`, projectUuid)
                 .select(`${SavedChartsTableName}.slug`)
                 .where(`${SavedChartsTableName}.slug`, 'like', `${baseSlug}%`)
                 .pluck(`${SavedChartsTableName}.slug`);
@@ -149,7 +149,7 @@ export const generateUniqueSlugScopedToProject = async (
                     `${SpaceTableName}.project_id`,
                     `${ProjectTableName}.project_id`,
                 )
-                .where('project_uuid', projectUuid)
+                .where(`${ProjectTableName}.project_uuid`, projectUuid)
                 .select(`${DashboardsTableName}.slug`)
                 .where(`${DashboardsTableName}.slug`, 'like', `${baseSlug}%`)
                 .pluck(`${DashboardsTableName}.slug`);


### PR DESCRIPTION
Relates: PROD-8968

### Description

Prepares the current backend for adding direct `project_uuid` ownership columns to charts and dashboards in later releases.

- Qualifies existing ownership predicates in validation and project-scoped slug queries so the future columns do not make SQL references ambiguous.
- Removes any future `project_uuid` value from preview-clone rows before reinserting them, preventing old pods from copying source-project ownership after the schema expands.
- Adds focused regressions for chart/dashboard query generation and preview-row sanitization.

This PR contains no database migration and does not read or write the future content ownership columns.

### Rollout

Deploy this PR before the chart ownership migration. The code is compatible with both the current schema and the later expanded schema.

### Testing

- `pnpm -F backend typecheck`
- `pnpm -F backend format`
- `pnpm -F backend test:dev:nowatch` — 389 passed, 1 skipped
- Focused compatibility suite — 22 passed