### PR TITLE
feat: add project ownership expansion for saved charts

### DIFF
--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -32,6 +32,7 @@ type InsertChartInSpace = Pick<
     | 'last_version_updated_by_user_uuid'
     | 'slug'
 > & {
+    project_uuid: string;
     space_id: number;
     dashboard_uuid: null;
 };
@@ -42,7 +43,9 @@ type InsertChartInDashboard = Pick<
     | 'description'
     | 'last_version_chart_kind'
     | 'last_version_updated_by_user_uuid'
+    | 'slug'
 > & {
+    project_uuid: string;
     space_id: null;
     dashboard_uuid: string;
 };
@@ -55,6 +58,7 @@ export type SavedChartTable = Knex.CompositeTableType<
     Partial<
         Pick<
             DbSavedChart,
+            | 'project_uuid'
             | 'space_id'
             | 'name'
             | 'description'
@@ -75,6 +79,7 @@ export type SavedChartTable = Knex.CompositeTableType<
 export type DbSavedChart = {
     saved_query_id: number;
     saved_query_uuid: string;
+    project_uuid: string | null;
     space_id: number | null;
     dashboard_uuid: string | null;
     name: string;

--- a/packages/backend/src/database/migrations/20260721112833_add_project_uuid_to_saved_queries.ts
+++ b/packages/backend/src/database/migrations/20260721112833_add_project_uuid_to_saved_queries.ts
@@ -1,0 +1,129 @@
+import { Knex } from 'knex';
+
+export const config = { transaction: false };
+
+const SavedQueriesTableName = 'saved_queries';
+const BatchSize = 1000;
+const LockTimeout = '5s';
+
+/**
+ * Expand phase for direct saved-chart project ownership.
+ *
+ * Each bounded batch commits independently and reruns skip populated rows. A
+ * hard-killed runner can still require its global Knex lock to be released
+ * before another process resumes the remaining batches.
+ */
+
+type BackfillBatch = {
+    batch_count: number;
+    last_processed_id: number | null;
+    updated_count: number;
+};
+
+async function addProjectUuidColumn(knex: Knex): Promise<void> {
+    await knex.transaction(async (trx) => {
+        await trx.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);
+        await trx.raw(`
+            ALTER TABLE ${SavedQueriesTableName}
+            ADD COLUMN IF NOT EXISTS project_uuid uuid
+        `);
+    });
+}
+
+async function getBackfillCutoff(knex: Knex): Promise<number> {
+    const result = await knex.raw<{ rows: Array<{ cutoff: number }> }>(`
+        SELECT COALESCE(MAX(saved_query_id), 0)::integer AS cutoff
+        FROM ${SavedQueriesTableName}
+    `);
+    return result.rows[0]?.cutoff ?? 0;
+}
+
+async function backfillBatch(
+    knex: Knex,
+    lastProcessedId: number,
+    cutoff: number,
+): Promise<BackfillBatch | undefined> {
+    return knex.transaction(async (trx) => {
+        await trx.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);
+        const result = await trx.raw<{ rows: BackfillBatch[] }>(
+            `WITH batch AS (
+                SELECT
+                    saved_queries.saved_query_id,
+                    CASE
+                        WHEN direct_projects.project_uuid IS NOT NULL
+                         AND dashboard_projects.project_uuid IS NOT NULL
+                         AND direct_projects.project_uuid <> dashboard_projects.project_uuid
+                            THEN NULL
+                        ELSE COALESCE(
+                            direct_projects.project_uuid,
+                            dashboard_projects.project_uuid
+                        )
+                    END AS project_uuid
+                FROM ${SavedQueriesTableName} AS saved_queries
+                LEFT JOIN spaces AS direct_spaces
+                    ON direct_spaces.space_id = saved_queries.space_id
+                LEFT JOIN projects AS direct_projects
+                    ON direct_projects.project_id = direct_spaces.project_id
+                LEFT JOIN dashboards
+                    ON dashboards.dashboard_uuid = saved_queries.dashboard_uuid
+                LEFT JOIN spaces AS dashboard_spaces
+                    ON dashboard_spaces.space_id = dashboards.space_id
+                LEFT JOIN projects AS dashboard_projects
+                    ON dashboard_projects.project_id = dashboard_spaces.project_id
+                WHERE saved_queries.project_uuid IS NULL
+                  AND saved_queries.saved_query_id > ?
+                  AND saved_queries.saved_query_id <= ?
+                ORDER BY saved_queries.saved_query_id
+                LIMIT ${BatchSize}
+            ), updated AS (
+                UPDATE ${SavedQueriesTableName} AS saved_queries
+                SET project_uuid = batch.project_uuid
+                FROM batch
+                WHERE saved_queries.saved_query_id = batch.saved_query_id
+                  AND saved_queries.project_uuid IS NULL
+                  AND batch.project_uuid IS NOT NULL
+                RETURNING saved_queries.saved_query_id
+            )
+            SELECT
+                COUNT(*)::integer AS batch_count,
+                MAX(saved_query_id)::integer AS last_processed_id,
+                (SELECT COUNT(*)::integer FROM updated) AS updated_count
+            FROM batch`,
+            [lastProcessedId, cutoff],
+        );
+        return result.rows[0];
+    });
+}
+
+async function backfillProjectUuids(knex: Knex): Promise<void> {
+    const cutoff = await getBackfillCutoff(knex);
+    let lastProcessedId = 0;
+
+    for (;;) {
+        // eslint-disable-next-line no-await-in-loop
+        const batch = await backfillBatch(knex, lastProcessedId, cutoff);
+        if (!batch || batch.batch_count === 0) return;
+
+        lastProcessedId = batch.last_processed_id ?? lastProcessedId;
+    }
+}
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        await addProjectUuidColumn(knex);
+        await backfillProjectUuids(knex);
+    } finally {
+        await knex.raw('RESET statement_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.transaction(async (trx) => {
+        await trx.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);
+        await trx.raw(`
+            ALTER TABLE ${SavedQueriesTableName}
+            DROP COLUMN IF EXISTS project_uuid
+        `);
+    });
+}

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -145,6 +145,7 @@ export const spaceEntry: SpaceTable['base'] = {
 export const savedChartEntry: SavedChartTable['base'] = {
     saved_query_id: 0,
     saved_query_uuid: '123',
+    project_uuid: 'project_uuid',
     space_id: 0,
     name: 'chart name',
     slug: 'chart-name',

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -455,6 +455,65 @@ describe('DashboardModel', () => {
         );
     });
 
+    test('moves a dashboard to a space in the same project on update', async () => {
+        const requestedProjectUuid = '22222222-2222-4222-8222-222222222222';
+        const dashboardUuid = '11111111-1111-4111-8111-111111111111';
+        const targetSpaceUuid = '33333333-3333-4333-8333-333333333333';
+        const targetSpaceId = 7;
+        const dashboard = {
+            ...expectedDashboard,
+            uuid: dashboardUuid,
+            projectUuid: requestedProjectUuid,
+        };
+        const getByIdOrSlugSpy = vi
+            .spyOn(model, 'getByIdOrSlug')
+            .mockResolvedValueOnce(dashboard)
+            .mockResolvedValueOnce(dashboard);
+
+        tracker.on
+            .select(SpaceTableName)
+            .responseOnce([{ space_id: targetSpaceId }]);
+        tracker.on.update(DashboardsTableName).responseOnce(1);
+
+        const result = await model.update(dashboardUuid, {
+            ...updateDashboard,
+            spaceUuid: targetSpaceUuid,
+        });
+
+        expect(result).toEqual(dashboard);
+        expect(tracker.history.select).toHaveLength(1);
+        expect(tracker.history.select[0].bindings).toEqual(
+            expect.arrayContaining([targetSpaceUuid, requestedProjectUuid]),
+        );
+        expect(tracker.history.update).toHaveLength(1);
+        expect(tracker.history.update[0].bindings).toEqual(
+            expect.arrayContaining([targetSpaceId, dashboardUuid]),
+        );
+
+        getByIdOrSlugSpy.mockRestore();
+    });
+
+    test('only moves dashboards between spaces in the requested project', async () => {
+        const requestedProjectUuid = '22222222-2222-4222-8222-222222222222';
+        const dashboardUuid = '11111111-1111-4111-8111-111111111111';
+        const targetSpaceUuid = '33333333-3333-4333-8333-333333333333';
+
+        tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
+        tracker.on.update(DashboardsTableName).responseOnce(0);
+
+        await expect(
+            model.moveToSpace({
+                projectUuid: requestedProjectUuid,
+                itemUuid: dashboardUuid,
+                targetSpaceUuid,
+            }),
+        ).rejects.toThrow('Failed to move dashboard to space');
+
+        const [updateQuery] = tracker.history.update;
+        expect(updateQuery.bindings).toContain(dashboardUuid);
+        expect(updateQuery.bindings).toContain(requestedProjectUuid);
+    });
+
     test('should delete dashboard', async () => {
         const dashboardUuid = 'dashboard uuid';
         tracker.on

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -3107,7 +3107,7 @@ export class ProjectModel {
                                   );
                               }
                               const createChart: CloneChart = {
-                                  ...omitProjectUuid(d),
+                                  ...replaceProjectUuid(d, previewProjectUuid),
                                   search_vector: undefined,
                                   saved_query_id: undefined,
                                   saved_query_uuid: undefined,
@@ -3162,7 +3162,7 @@ export class ProjectModel {
                                   );
                               }
                               const createChart: CloneChart = {
-                                  ...omitProjectUuid(d),
+                                  ...replaceProjectUuid(d, previewProjectUuid),
                                   search_vector: undefined,
                                   space_id: null,
                                   dashboard_uuid: d.dashboard_uuid,

--- a/packages/backend/src/models/ProjectModel/previewContent.test.ts
+++ b/packages/backend/src/models/ProjectModel/previewContent.test.ts
@@ -26,15 +26,26 @@ describe('omitProjectUuid', () => {
 });
 
 describe('replaceProjectUuid', () => {
-    it('sets destination ownership without mutating the source row', () => {
-        const row = {
-            dashboard_uuid: 'dashboard-uuid',
-            project_uuid: 'source-project-uuid',
-        };
+    it.each([
+        {
+            row: {
+                saved_query_uuid: 'chart-uuid',
+                project_uuid: 'source-project-uuid',
+            },
+        },
+        {
+            row: {
+                dashboard_uuid: 'dashboard-uuid',
+                project_uuid: 'source-project-uuid',
+            },
+        },
+    ])(
+        'sets destination ownership without mutating the source row',
+        ({ row }) => {
+            const result = replaceProjectUuid(row, 'destination-project-uuid');
 
-        const result = replaceProjectUuid(row, 'destination-project-uuid');
-
-        expect(result.project_uuid).toBe('destination-project-uuid');
-        expect(row.project_uuid).toBe('source-project-uuid');
-    });
+            expect(result.project_uuid).toBe('destination-project-uuid');
+            expect(row.project_uuid).toBe('source-project-uuid');
+        },
+    );
 });

--- a/packages/backend/src/models/SavedChartModel.test.ts
+++ b/packages/backend/src/models/SavedChartModel.test.ts
@@ -1,10 +1,129 @@
+import { AnyType } from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { lightdashConfigMock } from '../config/lightdashConfig.mock';
+import { DashboardsTableName } from '../database/entities/dashboards';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
 import { SpaceTableName } from '../database/entities/spaces';
-import { SavedChartModel } from './SavedChartModel';
+import { createSavedChart, SavedChartModel } from './SavedChartModel';
 import { chartSummary } from './SavedChartModel.mock';
+
+describe('createSavedChart', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const chartInput = {
+        name: 'Orders',
+        description: undefined,
+        tableName: 'orders',
+        metricQuery: {
+            dimensions: [],
+            metrics: [],
+            filters: {},
+            sorts: [],
+            limit: 500,
+            tableCalculations: [],
+        },
+        tableConfig: { columnOrder: [] },
+        chartConfig: { type: 'table', config: {} },
+        slug: 'orders',
+        updatedByUser: null,
+    } as AnyType;
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    beforeEach(() => {
+        vi.spyOn(database, 'transaction').mockImplementation(((
+            callback: AnyType,
+        ) => callback(database)) as AnyType);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        tracker.reset();
+    });
+
+    test('writes project_uuid and validates the destination project', async () => {
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+        const spaceUuid = '33333333-3333-4333-8333-333333333333';
+
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
+        tracker.on
+            .insert(SavedChartsTableName)
+            .responseOnce([
+                { saved_query_id: 11, saved_query_uuid: 'chart-uuid' },
+            ]);
+        tracker.on
+            .insert('saved_queries_versions')
+            .responseOnce([{ saved_queries_version_id: 13 }]);
+
+        await createSavedChart(
+            database,
+            projectUuid,
+            '11111111-1111-4111-8111-111111111111',
+            {
+                ...chartInput,
+                spaceUuid,
+                dashboardUuid: null,
+            },
+        );
+
+        const spaceQuery = tracker.history.select.find((query) =>
+            query.sql.includes(`from "${SpaceTableName}"`),
+        );
+        expect(spaceQuery?.bindings).toContain(spaceUuid);
+        expect(spaceQuery?.bindings).toContain(projectUuid);
+
+        const chartInsert = tracker.history.insert.find((query) =>
+            query.sql.includes(`into "${SavedChartsTableName}"`),
+        );
+        expect(chartInsert?.sql).toContain('"project_uuid"');
+        expect(chartInsert?.bindings).toContain(projectUuid);
+    });
+
+    test('writes project_uuid for charts created in dashboards', async () => {
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+        const dashboardUuid = '44444444-4444-4444-8444-444444444444';
+
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on
+            .select(DashboardsTableName)
+            .responseOnce([{ dashboard_uuid: dashboardUuid }]);
+        tracker.on
+            .insert(SavedChartsTableName)
+            .responseOnce([
+                { saved_query_id: 11, saved_query_uuid: 'chart-uuid' },
+            ]);
+        tracker.on
+            .insert('saved_queries_versions')
+            .responseOnce([{ saved_queries_version_id: 13 }]);
+
+        await createSavedChart(
+            database,
+            projectUuid,
+            '11111111-1111-4111-8111-111111111111',
+            {
+                ...chartInput,
+                dashboardUuid,
+            },
+        );
+
+        const dashboardQuery = tracker.history.select.find((query) =>
+            query.sql.includes(`from "${DashboardsTableName}"`),
+        );
+        expect(dashboardQuery?.bindings).toContain(dashboardUuid);
+        expect(dashboardQuery?.bindings).toContain(projectUuid);
+
+        const chartInsert = tracker.history.insert.find((query) =>
+            query.sql.includes(`into "${SavedChartsTableName}"`),
+        );
+        expect(chartInsert?.sql).toContain('"project_uuid"');
+        expect(chartInsert?.bindings).toContain(projectUuid);
+        expect(chartInsert?.bindings).toContain(dashboardUuid);
+    });
+});
 
 describe('getLatestVersionSummaries', () => {
     const model = new SavedChartModel({
@@ -121,5 +240,144 @@ describe('updateMultiple', () => {
         const [updateQuery] = tracker.history.update;
         expect(updateQuery.bindings).toContain(chartUuid);
         expect(updateQuery.bindings).toContain(projectUuid);
+    });
+});
+
+describe('update', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new SavedChartModel({
+        database,
+        lightdashConfig: lightdashConfigMock,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        tracker.reset();
+    });
+
+    test('preserves dashboard linkage on name-only updates while writing the resolved project', async () => {
+        const chartUuid = '11111111-1111-4111-8111-111111111111';
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ project_uuid: projectUuid }]);
+        tracker.on.update(SavedChartsTableName).responseOnce(1);
+        vi.spyOn(model, 'get').mockResolvedValue(chartSummary as AnyType);
+
+        await model.update(chartUuid, { name: 'Renamed chart' });
+
+        expect(tracker.history.select).toHaveLength(1);
+        const [updateQuery] = tracker.history.update;
+        expect(updateQuery.sql).toContain('"project_uuid"');
+        expect(updateQuery.sql).not.toContain('"space_id"');
+        expect(updateQuery.sql).not.toContain('"dashboard_uuid"');
+        expect(updateQuery.bindings).toContain(projectUuid);
+        expect(updateQuery.bindings).toContain(chartUuid);
+    });
+
+    test('rejects moving a chart to a space in another project', async () => {
+        const chartUuid = '11111111-1111-4111-8111-111111111111';
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+        const targetSpaceUuid = '33333333-3333-4333-8333-333333333333';
+
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ project_uuid: projectUuid }]);
+        tracker.on.select(SpaceTableName).responseOnce([]);
+
+        await expect(
+            model.update(chartUuid, {
+                name: 'Moved chart',
+                spaceUuid: targetSpaceUuid,
+            }),
+        ).rejects.toThrow('Space not found');
+
+        expect(tracker.history.select[1].bindings).toEqual(
+            expect.arrayContaining([targetSpaceUuid, projectUuid]),
+        );
+        expect(tracker.history.update).toHaveLength(0);
+    });
+});
+
+describe('moveToSpace', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new SavedChartModel({
+        database,
+        lightdashConfig: lightdashConfigMock,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    test('moves a chart within the requested project and writes project_uuid', async () => {
+        const chartUuid = '11111111-1111-4111-8111-111111111111';
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+        const targetSpaceUuid = '33333333-3333-4333-8333-333333333333';
+
+        tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ saved_query_uuid: chartUuid }]);
+        tracker.on.update(SavedChartsTableName).responseOnce(1);
+
+        await model.moveToSpace({
+            projectUuid,
+            itemUuid: chartUuid,
+            targetSpaceUuid,
+        });
+
+        const targetSpaceQuery = tracker.history.select.find((query) =>
+            query.sql.includes(`from "${SpaceTableName}"`),
+        );
+        expect(targetSpaceQuery?.bindings).toContain(targetSpaceUuid);
+        expect(targetSpaceQuery?.bindings).toContain(projectUuid);
+
+        const sourceChartQuery = tracker.history.select.find((query) =>
+            query.sql.includes(`from "${SavedChartsTableName}"`),
+        );
+        expect(sourceChartQuery?.bindings).toContain(chartUuid);
+        expect(sourceChartQuery?.bindings).toContain(projectUuid);
+
+        const [updateQuery] = tracker.history.update;
+        expect(updateQuery.sql).toContain('"project_uuid"');
+        expect(updateQuery.bindings).toContain(projectUuid);
+        expect(updateQuery.bindings).toContain(7);
+        expect(updateQuery.bindings).toContain(chartUuid);
+    });
+
+    test('rejects charts outside the requested project before updating', async () => {
+        const chartUuid = '11111111-1111-4111-8111-111111111111';
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+        const targetSpaceUuid = '33333333-3333-4333-8333-333333333333';
+
+        tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+
+        await expect(
+            model.moveToSpace({
+                projectUuid,
+                itemUuid: chartUuid,
+                targetSpaceUuid,
+            }),
+        ).rejects.toThrow('Saved chart not found');
+
+        const sourceChartQuery = tracker.history.select.find((query) =>
+            query.sql.includes(`from "${SavedChartsTableName}"`),
+        );
+        expect(sourceChartQuery?.bindings).toContain(chartUuid);
+        expect(sourceChartQuery?.bindings).toContain(projectUuid);
+        expect(tracker.history.update).toHaveLength(0);
     });
 });

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -96,7 +96,6 @@ import { traceSpan } from '../tracing/tracing';
 import { wrapSentryTransaction } from '../utils';
 import { acquireProjectSlugLock, generateUniqueSlug } from '../utils/SlugUtils';
 import { ContentVerificationModel } from './ContentVerificationModel';
-import { SpaceModel } from './SpaceModel';
 
 type DbSavedChartDetails = {
     project_uuid: string;
@@ -487,11 +486,30 @@ export const createSavedChart = async (
                 getChartKind(chartConfig.type, chartConfig.config) ||
                 ChartKind.VERTICAL_BAR,
             last_version_updated_by_user_uuid: userUuid,
+            project_uuid: projectUuid,
             slug: forceSlug
                 ? slug
                 : await generateUniqueSlug(trx, SavedChartsTableName, slug),
         };
         if (dashboardUuid) {
+            const dashboard = await trx(DashboardsTableName)
+                .innerJoin(
+                    SpaceTableName,
+                    `${SpaceTableName}.space_id`,
+                    `${DashboardsTableName}.space_id`,
+                )
+                .innerJoin(
+                    ProjectTableName,
+                    `${ProjectTableName}.project_id`,
+                    `${SpaceTableName}.project_id`,
+                )
+                .where(`${DashboardsTableName}.dashboard_uuid`, dashboardUuid)
+                .where(`${ProjectTableName}.project_uuid`, projectUuid)
+                .select(`${DashboardsTableName}.dashboard_uuid`)
+                .first();
+            if (!dashboard) {
+                throw new NotFoundError('Dashboard not found');
+            }
             chart = {
                 ...baseChart,
                 dashboard_uuid: dashboardUuid,
@@ -501,14 +519,23 @@ export const createSavedChart = async (
             if (!spaceUuid) {
                 throw new NotFoundError('No space specified for chart');
             }
-            const space = await SpaceModel.getSpaceIdAndName(trx, spaceUuid);
-            if (space === undefined)
-                throw Error(`Missing space with uuid ${spaceUuid}`);
-            const { spaceId } = space;
+            const space = await trx(SpaceTableName)
+                .innerJoin(
+                    ProjectTableName,
+                    `${ProjectTableName}.project_id`,
+                    `${SpaceTableName}.project_id`,
+                )
+                .where(`${SpaceTableName}.space_uuid`, spaceUuid)
+                .where(`${ProjectTableName}.project_uuid`, projectUuid)
+                .select(`${SpaceTableName}.space_id`)
+                .first();
+            if (!space) {
+                throw new NotFoundError('Space not found');
+            }
             chart = {
                 ...baseChart,
                 dashboard_uuid: null,
-                space_id: spaceId,
+                space_id: space.space_id,
             };
         }
         const [newSavedChart] = await trx(SavedChartsTableName)
@@ -790,16 +817,55 @@ export class SavedChartModel {
         savedChartUuid: string,
         data: UpdateSavedChart,
     ): Promise<SavedChartDAO> {
+        const savedChart = await this.database(SavedChartsTableName)
+            .leftJoin(
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_uuid`,
+                `${SavedChartsTableName}.dashboard_uuid`,
+            )
+            .joinRaw(
+                `INNER JOIN ${SpaceTableName} ON ${SpaceTableName}.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id)`,
+            )
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .select(`${ProjectTableName}.project_uuid`)
+            .where(`${SavedChartsTableName}.saved_query_uuid`, savedChartUuid)
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .first();
+        if (!savedChart) {
+            throw new NotFoundError('Saved chart not found');
+        }
+
+        let targetSpaceId: number | undefined;
+        if (data.spaceUuid !== undefined) {
+            const space = await this.database(SpaceTableName)
+                .innerJoin(
+                    ProjectTableName,
+                    `${ProjectTableName}.project_id`,
+                    `${SpaceTableName}.project_id`,
+                )
+                .select(`${SpaceTableName}.space_id`)
+                .where(`${SpaceTableName}.space_uuid`, data.spaceUuid)
+                .where(
+                    `${ProjectTableName}.project_uuid`,
+                    savedChart.project_uuid,
+                )
+                .first();
+            if (!space) {
+                throw new NotFoundError('Space not found');
+            }
+            targetSpaceId = space.space_id;
+        }
+
         await this.database(SavedChartsTableName)
             .update({
                 name: data.name,
                 description: data.description,
-                space_id: (
-                    await SpaceModel.getSpaceIdAndName(
-                        this.database,
-                        data.spaceUuid,
-                    )
-                )?.spaceId,
+                project_uuid: savedChart.project_uuid,
+                space_id: targetSpaceId,
                 dashboard_uuid: data.spaceUuid ? null : undefined, // remove dashboard_uuid when moving chart to space
                 color_palette_uuid: data.colorPaletteUuid,
             })
@@ -833,6 +899,7 @@ export class SavedChartModel {
                     .update({
                         name: savedChart.name,
                         description: savedChart.description,
+                        project_uuid: projectUuid,
                         space_id: space.space_id,
                     })
                     .where('saved_query_uuid', savedChart.uuid)
@@ -2440,9 +2507,36 @@ export class SavedChartModel {
             throw new NotFoundError('Space not found');
         }
 
+        const savedChart = await tx(SavedChartsTableName)
+            .leftJoin(
+                DashboardsTableName,
+                `${DashboardsTableName}.dashboard_uuid`,
+                `${SavedChartsTableName}.dashboard_uuid`,
+            )
+            .joinRaw(
+                `INNER JOIN ${SpaceTableName} AS current_space ON current_space.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id)`,
+            )
+            .innerJoin(
+                `${ProjectTableName} AS current_project`,
+                'current_project.project_id',
+                'current_space.project_id',
+            )
+            .select(`${SavedChartsTableName}.saved_query_uuid`)
+            .where(`${SavedChartsTableName}.saved_query_uuid`, savedChartUuid)
+            .where('current_project.project_uuid', projectUuid)
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .first();
+        if (!savedChart) {
+            throw new NotFoundError('Saved chart not found');
+        }
+
         const updateCount = await tx(SavedChartsTableName)
             // if we move a chart from a dashboard to a space, we need to set the dashboard_uuid to null
-            .update({ space_id: space.space_id, dashboard_uuid: null })
+            .update({
+                project_uuid: projectUuid,
+                space_id: space.space_id,
+                dashboard_uuid: null,
+            })
             .where('saved_query_uuid', savedChartUuid)
             .whereNull('deleted_at');
 

--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -229,7 +229,7 @@ export class ValidationModel {
     ): Promise<void> {
         await this.database(ValidationTableName)
             .where('saved_chart_uuid', chartUuid)
-            .where('project_uuid', projectUuid)
+            .where(`${ValidationTableName}.project_uuid`, projectUuid)
             .delete();
     }
 
@@ -239,7 +239,7 @@ export class ValidationModel {
     ): Promise<void> {
         await this.database(ValidationTableName)
             .where('dashboard_uuid', dashboardUuid)
-            .where('project_uuid', projectUuid)
+            .where(`${ValidationTableName}.project_uuid`, projectUuid)
             .delete();
     }
 
@@ -543,7 +543,7 @@ export class ValidationModel {
         const tableValidationErrorsRows: DbValidationTable[] =
             await this.database(ValidationTableName)
                 .select(`${ValidationTableName}.*`)
-                .where('project_uuid', projectUuid)
+                .where(`${ValidationTableName}.project_uuid`, projectUuid)
                 .andWhere((queryBuilder) => {
                     if (jobId) {
                         void queryBuilder.where('job_id', jobId);


### PR DESCRIPTION
## Summary

Adds the expand and dual-write phase for saved-chart project ownership.

- Adds nullable, no-default `saved_queries.project_uuid`.
- Backfills existing ownership from either the chart space or its dashboard space in 1,000-row keyset batches.
- Writes `project_uuid` on chart create, preview clone, update, bulk update, and move paths.
- Prevents chart and dashboard moves across project boundaries that could make direct ownership drift.

Relationship-derived ownership remains authoritative for reads in this phase. The foreign key, `NOT NULL`, direct-column read cutover, duplicate-slug repair, and `(project_uuid, slug)` uniqueness are intentionally deferred to the contract PR.

## Migration safety

- Adding a nullable column without a default avoids a table rewrite.
- The migration has no outer transaction; the column change and every backfill batch commit independently.
- Batches contain at most 1,000 rows and advance by `saved_query_id`, avoiding repeated scans of completed ranges.
- A start-of-migration cutoff keeps the work finite while compatible pods can still create rows.
- `statement_timeout` is disabled for the migration session and a five-second `lock_timeout` bounds DDL and row-lock waits.
- `ADD COLUMN IF NOT EXISTS` plus null-only updates make the data work idempotent.
- A hard-killed Knex runner can leave the global migration lock set. The committed batches remain safe, but an operator must release that lock before retrying, as documented in the repository migration guidance.

## Deployment and rollback

Release this PR by itself and allow every pod to start dual-writing before releasing the contract PR. This preserves compatibility for rolling and skip-version upgrades while avoiding the combined cold-start time of both migrations.

Do not run `down()` while this application version is serving traffic. Roll the application back first; leaving the nullable expanded schema in place is backward-compatible.

## Validation

- Production-shaped disposable database: 1,142,929 charts populated in 114.17 seconds, with zero null or mismatched owners.
- Real `down()` / `up()` cycle restored every owner.
- A completed backfill with the Knex migration record removed reran successfully.
- Read-only production invariant checks found zero unresolved owners, zero rows with both ownership columns, and zero conflicting project chains in both regions.
- Full backend suite passed on the complete stack: 330 files, 4,821 passed, 1 skipped.
- Backend, common, and CLI typechecks passed.
- Focused backend and CLI lint passed.
- Chart-as-code schema consistency passed.

test-all

Closes: PROD-9104
Relates: PROD-8968
