### PR TITLE
fix: portal data-app action menu so animated ancestors can't displace it

### DIFF
--- a/sandboxes/data-apps/template/references/d3.md
+++ b/sandboxes/data-apps/template/references/d3.md
@@ -33,7 +33,7 @@ These are the same rules as for Recharts charts — they don't relax just becaus
 
 - **Series colors come from `CHART_COLORS`** (`@/lib/theme`). Cycle by index for multi-series; never hand-pick palettes.
 - **Apply global filters via `filtersFor(EXPLORE)`** — same rule as every other `useLightdash()` call. Wrap the filtered query in `useMemo`.
-- **Click → `addFilter({ ..., explore: EXPLORE })`** — the action menu requirement carries over. Wire it directly into `.on('click', ...)`. If you want a multi-option menu (Filter by / Drill into …) wrap the click in a state-driven `<DropdownMenu>` opened at the click coordinates, exactly like the Recharts example in the main skill.
+- **Click → `addFilter({ ..., explore: EXPLORE })`** — the action menu requirement carries over. Wire it directly into `.on('click', ...)`. If you want a multi-option menu (Filter by / Drill into …) wrap the click in a state-driven `<DropdownMenu>` opened at the click coordinates, exactly like the Recharts example in the main skill — including the `createPortal(…, document.body)` wrapper, or an animated ancestor will displace the "fixed" trigger.
 - **Drive D3 only against the SVG ref.** Don't `d3.select('body')` or attach listeners to `document`. The iframe has strict CSP and a small DOM — don't reach outside your component.
 - **Always clear before redrawing** with `svg.selectAll('*').remove()` at the top of the effect. Without this, every data update appends a new copy of the chart on top of the old one.
 - **Format display values via `format(row, fieldName)`** — even inside D3 callbacks. Don't reimplement currency / percent / date formatting.

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -869,6 +869,7 @@ Use the `DropdownMenu` component. The menu opens on click; each option triggers 
 
 ```tsx
 import { useState, useMemo, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { query, useLightdash, drillDown } from '@lightdash/query-sdk';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { useGlobalFilters } from '@/lib/filters';
@@ -912,7 +913,12 @@ function RevenueChart() {
             </BarChart>
             </div>
 
-            {menuState && (
+            {/* Portal the menu to document.body: any animated/transformed
+                ancestor (fade-in cards, slide-in sections) becomes the
+                containing block for position:fixed, which would displace the
+                menu far from the click. The portal makes the trigger truly
+                viewport-relative no matter how the surrounding card is styled. */}
+            {menuState && createPortal(
                 <DropdownMenu open onOpenChange={() => setMenuState(null)}>
                     <DropdownMenuTrigger asChild>
                         <div style={{ position: 'fixed', left: menuState.x, top: menuState.y, width: 1, height: 1 }} />
@@ -963,7 +969,8 @@ function RevenueChart() {
                             Drill into revenue
                         </DropdownMenuItem>
                     </DropdownMenuContent>
-                </DropdownMenu>
+                </DropdownMenu>,
+                document.body,
             )}
 
             {drillState && (
@@ -1143,4 +1150,5 @@ The action-menu example above shows typical `drillDown()` usage. For the full AP
 | Building drill query inside render | Infinite re-fetching | Build in onClick handler, store in state |
 | Drilling by a dimension already in the source query | Pointless — same grouping | Pick a different, more granular dimension |
 | Using `e.chartX`/`e.chartY` for menu position | Chart-relative coords — menu appears at wrong position | Recharts `onClick` has no native event; capture `clientX`/`clientY` from a wrapper `<div onPointerDown>` via `useRef` — pointerdown fires before onClick so the ref is ready (see action menu example) |
+| Action menu opens far below/right of the click | An animated/transformed ancestor (fade-in card, slide-in section) is the containing block for the `position: fixed` trigger — "fixed" coords resolve inside the card, not the viewport | `createPortal(<DropdownMenu …>, document.body)` around the menu block, exactly as in the action-menu example — never render the fixed trigger inside the component tree |
 | Combining a direction word with a contradictory sign in narrative copy (`down +12%`, `up -4%`) | Sign and verb disagree → reads as a self-contradiction, looks like a platform bug | Pick one convention per report and stick to it: either signed deltas with no direction word (`+12%`, `−4%`), or direction word with unsigned magnitude (`up 12%`, `down 4%`). Never mix. |


### PR DESCRIPTION
## Summary

Fixes a positioning bug in the action-menu pattern the data-app skill teaches: clicking a chart bar or table cell could open the Filter-by / Drill-down menu hundreds of pixels away from the click.

**Mechanism**: the skill's example renders a 1×1 `position: fixed` div at the click's `clientX`/`clientY` as the Radix `DropdownMenuTrigger` — *inside the component tree*. `position: fixed` is only viewport-relative until an ancestor has a `transform`, `filter`, `perspective`, or `will-change: transform`; that ancestor then becomes the containing block, and the trigger (menu with it) resolves at *ancestor origin + click coords*. Generated apps hit this constantly because `frontend-design` encourages staggered entrance animations (`tailwindcss-animate` slide/fade utilities put transforms on exactly the cards that contain the charts and tables).

## Fix

Template-side only, three edits:

- `skill.md` action-menu example: wrap the menu block in `createPortal(…, document.body)`, with an inline comment explaining why (so the portal doesn't get "simplified" away in later edits). The fixed trigger is then genuinely viewport-relative regardless of how the surrounding card is animated.
- `skill.md` Common Pitfalls: new row keyed on the symptom ("action menu opens far below/right of the click") → cause → fix.
- `references/d3.md`: the click-menu bullet now says to copy the example *including* the portal wrapper.

The drill-down / underlying-data `Dialog`s need no change — Radix portals dialog content itself; only the hand-positioned trigger was exposed.

Requires a sandbox template rebuild; existing apps with the old pattern baked in need a regenerate/iteration to pick it up.

## Tests

- Diagnosed from a generated app exhibiting the displacement (menu opening ~4 rows below the clicked cell, offset right by the card's origin) with entrance animations on the card ancestors.

No Linear ticket for this fix (confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)