### PR TITLE
fix: route managed onboarding to semantic discovery

### DIFF
--- a/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
@@ -47,7 +47,11 @@ import {
     SANDBOX_TIMEOUT_MS,
     WORKDIR,
 } from './constants';
-import { classifyOnboardingStage, sanitizeOnboardingMessage } from './utils';
+import {
+    buildManagedOnboardingPrompt,
+    classifyOnboardingStage,
+    sanitizeOnboardingMessage,
+} from './utils';
 
 type Dependencies = {
     lightdashConfig: LightdashConfig;
@@ -177,31 +181,11 @@ export class OnboardingAgentService extends BaseService {
         const basePrompt =
             await this.promptService.getPrompt('project-onboarding');
         const siteUrl = this.lightdashConfig.siteUrl.replace(/\/+$/, '');
-        const preamble = [
-            '# Lightdash cloud onboarding run',
-            '',
-            'You are running inside a managed sandbox on Lightdash Cloud, completing project setup on behalf of a user.',
-            '',
-            '## Context',
-            `- Lightdash instance URL: ${siteUrl}`,
-            `- Warehouse type: ${args.warehouseType}`,
-            `- Prepared project UUID: ${args.projectUuid}`,
-            ...(args.database
-                ? [`- Configured database: ${args.database}`]
-                : []),
-            ...(args.schema ? [`- Configured schema: ${args.schema}`] : []),
-            '',
-            '## Managed environment',
-            '- The Lightdash CLI and skills are preinstalled. Skip local setup.',
-            `- Run every \`lightdash <args>\` command as \`${CLI_WRAPPER_PATH} <args>\`.`,
-            '- Authentication is already configured. Do not run `lightdash login` or inspect environment variables.',
-            `- Verify the selected project with \`${CLI_WRAPPER_PATH} config get-project\` and confirm it matches the prepared project UUID.`,
-            `- Create all working files under ${WORKDIR} and build a pure Lightdash semantic layer from the warehouse catalog.`,
-            '',
-            '---',
-            '',
-        ].join('\n');
-        return preamble + basePrompt;
+        return buildManagedOnboardingPrompt({
+            ...args,
+            basePrompt,
+            siteUrl,
+        });
     }
 
     private startCancellationPoll(

--- a/packages/backend/src/ee/services/OnboardingAgentService/utils.test.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/utils.test.ts
@@ -1,6 +1,42 @@
 import { describe, expect, it } from 'vitest';
 import { ALLOWED_TOOLS, CLI_WRAPPER_SCRIPT } from './constants';
-import { classifyOnboardingStage, sanitizeOnboardingMessage } from './utils';
+import {
+    buildManagedOnboardingPrompt,
+    classifyOnboardingStage,
+    sanitizeOnboardingMessage,
+} from './utils';
+
+describe('buildManagedOnboardingPrompt', () => {
+    it('replaces only section 1 and resumes at semantic-layer discovery', () => {
+        const prompt = buildManagedOnboardingPrompt({
+            basePrompt:
+                '# Complete Lightdash project setup\n\n## 1. Bootstrap\n\n## 2. Discover, author, and deploy the semantic layer',
+            siteUrl: 'https://example.lightdash.cloud',
+            projectUuid: 'project-uuid',
+            warehouseType: 'snowflake',
+            database: 'analytics',
+            schema: 'public',
+        });
+
+        expect(prompt).toContain('these replace section 1');
+        expect(prompt).toContain('Skip section 1 entirely');
+        expect(prompt).toContain('Do NOT run `lightdash login`');
+        expect(prompt).toContain(
+            '`/tmp/ld config get-project` and confirm it matches the prepared project UUID, then continue from section 2',
+        );
+        expect(prompt).toContain(
+            '## 2. Discover, author, and deploy the semantic layer',
+        );
+        expect(prompt.indexOf('`/tmp/ld config get-project`')).toBeLessThan(
+            prompt.indexOf(
+                '## 2. Discover, author, and deploy the semantic layer',
+            ),
+        );
+        expect(prompt).not.toMatch(/skip(?:ping)? (?:section )?2/i);
+        expect(prompt).not.toMatch(/skip[^\n]*semantic/i);
+        expect(prompt).not.toMatch(/six[- ]gate|six gates|first six/i);
+    });
+});
 
 describe('classifyOnboardingStage', () => {
     it.each([

--- a/packages/backend/src/ee/services/OnboardingAgentService/utils.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/utils.ts
@@ -15,6 +15,44 @@ const LIGHTDASH_COMMAND_PATTERN = new RegExp(
     )})\\s+([\\w-]+)`,
 );
 
+type BuildManagedOnboardingPromptArgs = {
+    basePrompt: string;
+    siteUrl: string;
+    projectUuid: string;
+    warehouseType: string;
+    database: string | undefined;
+    schema: string | undefined;
+};
+
+export const buildManagedOnboardingPrompt = (
+    args: BuildManagedOnboardingPromptArgs,
+): string => {
+    const preamble = [
+        '# Lightdash cloud onboarding run',
+        '',
+        'You are running inside a managed sandbox on Lightdash Cloud, completing project setup on behalf of a user.',
+        '',
+        '## Context',
+        `- Lightdash instance URL: ${args.siteUrl}`,
+        `- Warehouse type: ${args.warehouseType}`,
+        `- Prepared project UUID: ${args.projectUuid}`,
+        ...(args.database ? [`- Configured database: ${args.database}`] : []),
+        ...(args.schema ? [`- Configured schema: ${args.schema}`] : []),
+        '',
+        '## Environment overrides (IMPORTANT — these replace section 1 of the instructions below)',
+        '- The Lightdash CLI and skills are preinstalled. Skip section 1 entirely.',
+        `- Run every \`lightdash <args>\` command as \`${CLI_WRAPPER_PATH} <args>\` (a thin wrapper around the same CLI).`,
+        '- Authentication is already configured through environment variables (LIGHTDASH_URL, LIGHTDASH_API_KEY, LIGHTDASH_PROJECT). Do NOT run `lightdash login`.',
+        `- For section 1, verify the selected project with \`${CLI_WRAPPER_PATH} config get-project\` and confirm it matches the prepared project UUID, then continue from section 2.`,
+        `- There is no existing repository. Create all working files under ${WORKDIR} and build a pure Lightdash semantic layer from the warehouse catalog.`,
+        '',
+        '---',
+        '',
+    ].join('\n');
+
+    return preamble + args.basePrompt;
+};
+
 const normalizeToolPath = (path: string): string =>
     path
         .replaceAll('\\', '/')


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-9041

### Description:
The managed onboarding preamble now replaces only section 1, skips installation and OAuth, verifies the prepared project UUID through the CLI wrapper, and then resumes at semantic-layer discovery.
Focused assertions protect the gate order and prevent stale six-gate routing from returning.
Verified with focused backend tests, lint, formatting, and the backend typecheck.
