### PR TITLE
fix: keep include-thumbnail checkbox visible in move-to-space modal

### DIFF
--- a/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
+++ b/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
@@ -4,7 +4,7 @@ import {
     ResourceViewItemType,
     type ResourceViewItem,
 } from '@lightdash/common';
-import { Button, LoadingOverlay, Text } from '@mantine-8/core';
+import { Button, Group, LoadingOverlay, Text } from '@mantine-8/core';
 import { IconFolderShare, IconPlus } from '@tabler/icons-react';
 import { useCallback, useMemo, type ReactNode } from 'react';
 import { useSpaceManagement } from '../../../hooks/useSpaceManagement';
@@ -24,8 +24,10 @@ type Props<T> = Pick<MantineModalProps, 'opened' | 'onClose'> & {
     description?: ReactNode;
     confirmLabel?: string;
     createSpaceConfirmLabel?: string;
-    /** Extra content rendered below the space selector — e.g. per-content-type
-     *  move options. Hidden while the create-space form is open. */
+    /** Extra content rendered in the modal's fixed footer bar, next to the
+     *  "New Space" button — e.g. per-content-type move options. Lives outside
+     *  the scrollable space list so it stays visible however many spaces there
+     *  are. Hidden while the create-space form is open. */
     footer?: ReactNode;
 };
 
@@ -152,14 +154,17 @@ const TransferItemsModal = <R extends ResourceViewItem, T extends Array<R>>({
             size="xl"
             leftActions={
                 !isCreatingNewSpace ? (
-                    <Button
-                        variant="subtle"
-                        size="xs"
-                        onClick={openCreateSpaceForm}
-                        leftSection={<MantineIcon icon={IconPlus} />}
-                    >
-                        New Space
-                    </Button>
+                    <Group gap="lg" wrap="nowrap">
+                        <Button
+                            variant="subtle"
+                            size="xs"
+                            onClick={openCreateSpaceForm}
+                            leftSection={<MantineIcon icon={IconPlus} />}
+                        >
+                            New Space
+                        </Button>
+                        {footer}
+                    </Group>
                 ) : null
             }
             actions={
@@ -230,7 +235,6 @@ const TransferItemsModal = <R extends ResourceViewItem, T extends Array<R>>({
                             </Callout>
                         ) : null}
                     </SpaceSelector>
-                    {footer}
                 </>
             )}
         </MantineModal>

--- a/packages/frontend/src/features/apps/components/MoveAppToSpaceModal.tsx
+++ b/packages/frontend/src/features/apps/components/MoveAppToSpaceModal.tsx
@@ -4,7 +4,7 @@ import {
     ResourceViewItemType,
     type ResourceViewDataAppItem,
 } from '@lightdash/common';
-import { Checkbox } from '@mantine-8/core';
+import { Box, Checkbox, Tooltip } from '@mantine-8/core';
 import { useQueryClient } from '@tanstack/react-query';
 import { useState, type FC } from 'react';
 import TransferItemsModal from '../../../components/common/TransferItemsModal/TransferItemsModal';
@@ -97,14 +97,21 @@ export const MoveAppToSpaceModal: FC<Props> = ({
             isLoading={isMovingToSpace}
             footer={
                 hasThumbnail ? (
-                    <Checkbox
-                        checked={includeThumbnail}
-                        onChange={(e) =>
-                            setIncludeThumbnail(e.currentTarget.checked)
-                        }
-                        label="Include app thumbnail"
-                        description="Uncheck to remove the app's current thumbnail when it moves."
-                    />
+                    <Tooltip
+                        label="Uncheck to remove the app's current thumbnail when it moves."
+                        withArrow
+                        position="top"
+                    >
+                        <Box>
+                            <Checkbox
+                                checked={includeThumbnail}
+                                onChange={(e) =>
+                                    setIncludeThumbnail(e.currentTarget.checked)
+                                }
+                                label="Include app thumbnail"
+                            />
+                        </Box>
+                    </Tooltip>
                 ) : null
             }
             onConfirm={async (targetSpaceUuid) => {


### PR DESCRIPTION
### Description:

Fixes include thumbnail checkbox placement. It scrolled away when there were lots of spaces. 
