### PR TITLE
fix(charts): format 100% stacked bar tooltip count with field format

### DIFF
--- a/packages/common/src/visualizations/helpers/tooltipFormatter.test.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.test.ts
@@ -1,5 +1,14 @@
+import {
+    CustomFormatType,
+    FieldType,
+    Format,
+    MetricType,
+    type ItemsMap,
+    type Metric,
+} from '../../types/field';
 import { VizAggregationOptions, type EChartsSeries } from '../types';
 import {
+    createStack100TooltipFormatter,
     findPivotColumnFromSeriesRef,
     transformToPercentageStacking,
     translatePivotRef,
@@ -320,5 +329,68 @@ describe('transformToPercentageStacking', () => {
         );
 
         expect(transformedResults[0]).toEqual({ date: '2024-01-01', a: 3 });
+    });
+});
+
+describe('createStack100TooltipFormatter', () => {
+    const metric: Metric = {
+        fieldType: FieldType.METRIC,
+        type: MetricType.SUM,
+        name: 'total_order_amount',
+        label: 'Total order amount',
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: '${TABLE}.amount',
+        hidden: false,
+        formatOptions: {
+            type: CustomFormatType.CURRENCY,
+            currency: Format.USD,
+        },
+    };
+    const itemsMap: ItemsMap = { orders_total_order_amount: metric };
+
+    const params = [
+        {
+            seriesName: 'completed',
+            marker: '',
+            data: {
+                orders_status: 'completed',
+                orders_total_order_amount: 46.9,
+            },
+        },
+    ];
+
+    test('formats the count with the field format for 100% stacked charts', () => {
+        const originalValues = new Map([
+            ['completed', new Map([['orders_total_order_amount', 1125.25]])],
+        ]);
+
+        const formatter = createStack100TooltipFormatter(
+            originalValues,
+            () => 'orders_total_order_amount',
+            'orders_status',
+            itemsMap,
+        );
+
+        const html = formatter(params);
+
+        expect(html).toContain('46.9% ($1,125.25)');
+        expect(html).not.toContain('(1,125.25)');
+    });
+
+    test('falls back to toLocaleString when no itemsMap is available', () => {
+        const originalValues = new Map([
+            ['completed', new Map([['orders_total_order_amount', 1125.25]])],
+        ]);
+
+        const formatter = createStack100TooltipFormatter(
+            originalValues,
+            () => 'orders_total_order_amount',
+            'orders_status',
+        );
+
+        const html = formatter(params);
+
+        expect(html).toContain('46.9% (1,125.25)');
     });
 });

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.test.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.test.ts
@@ -393,4 +393,52 @@ describe('createStack100TooltipFormatter', () => {
 
         expect(html).toContain('46.9% (1,125.25)');
     });
+
+    test('resolves a pivoted count via pivotValuesColumnsMap.referenceField', () => {
+        const pivotColumn = 'orders_total_order_amount_any_web';
+        const pivotValuesColumnsMap = {
+            [pivotColumn]: {
+                referenceField: 'orders_total_order_amount',
+                pivotColumnName: pivotColumn,
+                aggregation: VizAggregationOptions.ANY,
+                pivotValues: [
+                    {
+                        referenceField: 'orders_source',
+                        value: 'web',
+                        formatted: 'web',
+                    },
+                ],
+            },
+        };
+
+        const originalValues = new Map([
+            ['completed', new Map([[pivotColumn, 1125.25]])],
+        ]);
+
+        const pivotedParams = [
+            {
+                seriesName: 'web',
+                marker: '',
+                data: {
+                    orders_status: 'completed',
+                    [pivotColumn]: 46.9,
+                },
+            },
+        ];
+
+        const formatter = createStack100TooltipFormatter(
+            originalValues,
+            () => pivotColumn,
+            'orders_status',
+            itemsMap,
+            undefined,
+            undefined,
+            undefined,
+            pivotValuesColumnsMap,
+        );
+
+        const html = formatter(pivotedParams);
+
+        expect(html).toContain('46.9% ($1,125.25)');
+    });
 });

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -549,6 +549,8 @@ export function createStack100TooltipFormatter(
     xAxisDateFormat?: string,
     timezone?: string,
     displayTimezone?: string,
+    pivotValuesColumnsMap?: Record<string, PivotValuesColumn>,
+    parameters?: ParametersValuesMap,
 ) {
     return (params: TooltipParams) => {
         if (!Array.isArray(params)) return '';
@@ -622,9 +624,21 @@ export function createStack100TooltipFormatter(
                         ? `${percentage.toFixed(1)}%`
                         : '0.0%';
                 const countStr =
-                    typeof originalValue === 'number'
-                        ? originalValue.toLocaleString()
-                        : '0';
+                    // eslint-disable-next-line no-nested-ternary
+                    typeof originalValue !== 'number'
+                        ? '0'
+                        : itemsMap
+                        ? getFormattedValue(
+                              originalValue,
+                              dimensionName,
+                              itemsMap,
+                              undefined,
+                              pivotValuesColumnsMap,
+                              parameters,
+                              timezone,
+                              displayTimezone,
+                          )
+                        : originalValue.toLocaleString();
 
                 const colorIndicator = formatColorIndicator(
                     extractColor(marker),
@@ -971,6 +985,8 @@ export const buildCartesianTooltipFormatter =
                 undefined,
                 timezone,
                 displayTimezone,
+                pivotValuesColumnsMap,
+                parameters,
             )(params as TooltipParam[]);
         }
 

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -628,17 +628,17 @@ export function createStack100TooltipFormatter(
                     typeof originalValue !== 'number'
                         ? '0'
                         : itemsMap
-                        ? getFormattedValue(
-                              originalValue,
-                              dimensionName,
-                              itemsMap,
-                              undefined,
-                              pivotValuesColumnsMap,
-                              parameters,
-                              timezone,
-                              displayTimezone,
-                          )
-                        : originalValue.toLocaleString();
+                          ? getFormattedValue(
+                                originalValue,
+                                dimensionName,
+                                itemsMap,
+                                undefined,
+                                pivotValuesColumnsMap,
+                                parameters,
+                                timezone,
+                                displayTimezone,
+                            )
+                          : originalValue.toLocaleString();
 
                 const colorIndicator = formatColorIndicator(
                     extractColor(marker),


### PR DESCRIPTION
## Problem

On a **100% stacked** bar chart, the tooltip showed the raw, unformatted metric value in parentheses (e.g. `46.9% (1,125.25)`) instead of applying the field's configured format (`$1,125.25`). Regular "Stack" and unstacked charts formatted it correctly. Reported via customer support (Pylon #14567).

## Fix

`createStack100TooltipFormatter` formatted the count with `originalValue.toLocaleString()`. It now uses `getFormattedValue(...)` with the `itemsMap` (and `pivotValuesColumnsMap`/`parameters`, threaded through from `buildCartesianTooltipFormatter`) so the count respects the field format — matching the results table and the regular-stack tooltip. The SQL Runner path has no `itemsMap`, so it keeps the `toLocaleString()` fallback (unchanged behaviour).

Added unit tests covering both the formatted (currency) and fallback cases.
