### PR TITLE
feat: confirm before admin self-downgrades org role

### DIFF
--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/ConfirmAdminSelfDowngradeModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/ConfirmAdminSelfDowngradeModal.tsx
@@ -21,7 +21,7 @@ const ConfirmAdminSelfDowngradeModal: FC<
         size="md"
         description="You cannot undo this action. Another admin will have to manage your role for you."
         onConfirm={onConfirm}
-        confirmLabel="Change role"
+        confirmLabel="Downgrade role"
         confirmLoading={loading}
     />
 );

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/ConfirmAdminSelfDowngradeModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/ConfirmAdminSelfDowngradeModal.tsx
@@ -1,0 +1,34 @@
+import { IconAlertTriangle } from '@tabler/icons-react';
+import { type FC } from 'react';
+import Callout from '../../common/Callout';
+import MantineModal from '../../common/MantineModal';
+
+type ConfirmAdminSelfDowngradeModalProps = {
+    opened: boolean;
+    loading: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+};
+
+const ConfirmAdminSelfDowngradeModal: FC<
+    ConfirmAdminSelfDowngradeModalProps
+> = ({ opened, loading, onClose, onConfirm }) => (
+    <MantineModal
+        opened={opened}
+        onClose={onClose}
+        title="Change your organization role?"
+        icon={IconAlertTriangle}
+        role="alertdialog"
+        size="md"
+        onConfirm={onConfirm}
+        confirmLabel="Change role"
+        confirmLoading={loading}
+    >
+        <Callout variant="warning" title="This action cannot be undone">
+            You are about to remove your own admin access. Another admin will
+            need to restore it for you.
+        </Callout>
+    </MantineModal>
+);
+
+export default ConfirmAdminSelfDowngradeModal;

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/ConfirmAdminSelfDowngradeModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/ConfirmAdminSelfDowngradeModal.tsx
@@ -1,6 +1,5 @@
 import { IconAlertTriangle } from '@tabler/icons-react';
 import { type FC } from 'react';
-import Callout from '../../common/Callout';
 import MantineModal from '../../common/MantineModal';
 
 type ConfirmAdminSelfDowngradeModalProps = {
@@ -20,15 +19,11 @@ const ConfirmAdminSelfDowngradeModal: FC<
         icon={IconAlertTriangle}
         role="alertdialog"
         size="md"
+        description="You are about to remove your own admin access. This action cannot be undone — another admin will need to restore it for you."
         onConfirm={onConfirm}
         confirmLabel="Change role"
         confirmLoading={loading}
-    >
-        <Callout variant="warning" title="This action cannot be undone">
-            You are about to remove your own admin access. Another admin will
-            need to restore it for you.
-        </Callout>
-    </MantineModal>
+    />
 );
 
 export default ConfirmAdminSelfDowngradeModal;

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/ConfirmAdminSelfDowngradeModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/ConfirmAdminSelfDowngradeModal.tsx
@@ -15,11 +15,11 @@ const ConfirmAdminSelfDowngradeModal: FC<
     <MantineModal
         opened={opened}
         onClose={onClose}
-        title="Change your organization role?"
+        title="Downgrade your role?"
         icon={IconAlertTriangle}
         role="alertdialog"
         size="md"
-        description="You are about to remove your own admin access. This action cannot be undone — another admin will need to restore it for you."
+        description="You cannot undo this action. Another admin will have to manage your role for you."
         onConfirm={onConfirm}
         confirmLabel="Change role"
         confirmLoading={loading}

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
@@ -49,11 +49,17 @@ import {
     type ContentTableVirtualizer,
 } from '../../common/ContentTable';
 import MantineIcon from '../../common/MantineIcon';
+import ConfirmAdminSelfDowngradeModal from './ConfirmAdminSelfDowngradeModal';
 import InviteSuccess from './InviteSuccess';
 import UsersActionMenu from './UsersActionMenu';
 import { UsersTopToolbar } from './UsersTopToolbar';
 
 const fetchSize = 50;
+
+type PendingRoleChange = {
+    userId: string;
+    roleId: string;
+};
 
 interface UsersTableProps {
     onInviteClick: () => void;
@@ -73,6 +79,8 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
     const [inviteSuccessFor, setInviteSuccessFor] = useState<string | null>(
         null,
     );
+    const [pendingRoleChange, setPendingRoleChange] =
+        useState<PendingRoleChange | null>(null);
 
     // Callback to handle when an invite is sent
     const handleInviteSent = useCallback((userUuid: string) => {
@@ -142,6 +150,42 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
 
     const updateUserRole = useUpsertOrganizationUserRoleAssignmentMutation();
     const organizationRolesQuery = useOrganizationRoles();
+
+    const handleRoleChange = useCallback(
+        (user: OrganizationMemberProfile, newRole: string) => {
+            const isCurrentUser = activeUser.data?.userUuid === user.userUuid;
+            const isAdminSelfDowngrade =
+                isCurrentUser &&
+                user.role === OrganizationMemberRole.ADMIN &&
+                newRole !== OrganizationMemberRole.ADMIN;
+
+            if (isAdminSelfDowngrade) {
+                setPendingRoleChange({
+                    userId: user.userUuid,
+                    roleId: newRole,
+                });
+                return;
+            }
+
+            updateUserRole.mutate({
+                userId: user.userUuid,
+                roleId: newRole,
+            });
+        },
+        [activeUser.data?.userUuid, updateUserRole],
+    );
+
+    const handleConfirmAdminSelfDowngrade = useCallback(() => {
+        if (!pendingRoleChange) {
+            return;
+        }
+
+        updateUserRole.mutate(pendingRoleChange, {
+            onSuccess: () => {
+                setPendingRoleChange(null);
+            },
+        });
+    }, [pendingRoleChange, updateUserRole]);
 
     const organizationRoleOptions = useMemo(() => {
         const systemRoles = Object.values(OrganizationMemberRole).map(
@@ -270,10 +314,7 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
                             data={organizationRoleOptions}
                             onChange={(newRole: string | null) => {
                                 if (newRole) {
-                                    updateUserRole.mutate({
-                                        userId: user.userUuid,
-                                        roleId: newRole,
-                                    });
+                                    handleRoleChange(user, newRole);
                                 }
                             }}
                             value={user.roleUuid ?? user.role}
@@ -372,7 +413,7 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
         inviteLink,
         inviteSuccessFor,
         isGroupManagementEnabled,
-        updateUserRole,
+        handleRoleChange,
         organizationRoleOptions,
         organizationRolesQuery.isLoading,
         activeUser.data?.userUuid,
@@ -519,7 +560,17 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
         },
     });
 
-    return <ContentTable table={table} />;
+    return (
+        <>
+            <ContentTable table={table} />
+            <ConfirmAdminSelfDowngradeModal
+                opened={pendingRoleChange !== null}
+                loading={updateUserRole.isLoading}
+                onClose={() => setPendingRoleChange(null)}
+                onConfirm={handleConfirmAdminSelfDowngrade}
+            />
+        </>
+    );
 };
 
 export default UsersTable;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- When an organization admin changes **their own** role to a non-admin role in Users & Groups settings, show a confirmation modal before applying the change
- Uses existing `MantineModal` with a flat `description` (same pattern as unsaved-changes confirms) — no nested Callout/Alert

## Test plan

- [x] As an org admin, open Settings → Users & groups
- [x] Change your own role from Admin to Editor — confirm modal appears
- [x] Cancel — role stays Admin
- [x] Changing another user’s role updates immediately with **no** modal
- [x] Non-admin user has no access to Users & groups (no modal path)

## Local verification

Self-downgrade (modal shows):

[Downgrade your role confirmation modal](https://cursor.com/agents/bc-802a1bcd-8800-4062-be89-e41d4fcedd1c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftest-b-self-downgrade-modal.png)

Changing another user (no modal — only success toast):

[Changing another user role has no modal](https://cursor.com/agents/bc-802a1bcd-8800-4062-be89-e41d4fcedd1c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftest-a-other-user-no-modal.png)

Non-admin has no Users & groups access:

[Non-admin redirected away from user management](https://cursor.com/agents/bc-802a1bcd-8800-4062-be89-e41d4fcedd1c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftest-c-non-admin-no-access.png)

Copy:
- Title: **Downgrade your role?**
- Body: **You cannot undo this action. Another admin will have to manage your role for you.**
- Confirm: **Downgrade role**

Closes: PROD-9088


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-802a1bcd-8800-4062-be89-e41d4fcedd1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-802a1bcd-8800-4062-be89-e41d4fcedd1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

