### PR TITLE
feat: benchmark effort variants, runtime render gate, and blinded gallery

### DIFF
--- a/sandboxes/data-apps/benchmark/README.md
+++ b/sandboxes/data-apps/benchmark/README.md
@@ -36,6 +36,20 @@ benchmark leans on two better ones:
    toolExec, plus tokens and turns. Compare medians per bucket, paired by
    prompt: an intervention should move *its* bucket.
 
+3. **Render gate + gallery** (`renderGate.ts`, `mockHost.ts`, `harness.js`,
+   `gallery.ts`) — every built app is loaded in headless Chromium under a
+   mock Lightdash host that answers the SDK's postMessage protocol with
+   deterministic rows synthesized from the fixture catalog (seeded by query
+   content, so identical queries get identical data across variants). This
+   yields three runtime rules folded into the rubric — `renders-clean` (no
+   uncaught errors, no ErrorBoundary/fatal fallback, non-empty root),
+   `made-metric-queries`, and `queries-valid-fields` (every issued query
+   references real catalog fields on a real explore) — plus a full-height
+   screenshot per run and a blinded side-by-side gallery
+   (`runs/<ts>/gallery.html`) for human quality ranking: vote per row, then
+   "Reveal variants" to see the per-variant win tally. Requires Chromium
+   once: `npx playwright install chromium`.
+
 ## Usage
 
 From `sandboxes/data-apps/` (needs `E2B_API_KEY` + `ANTHROPIC_API_KEY` in
@@ -54,15 +68,45 @@ pnpm bench \
 # Quick iteration on a subset
 pnpm bench --variant candidate=lukas-dev-template:latest \
     --prompts pdf-report,sheets-export --reps 2
+
+# Reasoning-effort comparison: prod default vs lowered effort, same template
+pnpm bench \
+    --variant prod=lightdash-data-app \
+    --variant medium=lightdash-data-app,effort=medium \
+    --variant low=lightdash-data-app,effort=low \
+    --reps 3
 ```
 
-Flags: `--variant name=templateRef` (repeatable; first is the baseline for
-paired deltas), `--reps` (default 3), `--prompts id,id`, `--concurrency`
-(default 8), `--model` (default sonnet), `--out`.
+Flags: `--variant name=templateRef[,effort=<level>][,env.KEY=VAL]`
+(repeatable; first is the baseline for paired deltas), `--reps` (default 3),
+`--prompts id,id`, `--concurrency` (default 8), `--model` (default sonnet),
+`--out`.
+
+Variant options beyond the template ref:
+
+- `effort=low|medium|high|xhigh|max` — passed as `--effort` to the Claude
+  CLI. Omitted = no flag, which is exactly what production runs (the model's
+  default; `high` for Sonnet 5). Values are validated locally because the
+  CLI warns-and-ignores bad values, which would silently benchmark the
+  default.
+- `env.KEY=VAL` — extra env for the sandbox (e.g.
+  `env.CLAUDE_CODE_EFFORT_LEVEL=low`, which is equivalent to the flag and
+  overrides it). Note `MAX_THINKING_TOKENS` is a no-op on adaptive-reasoning
+  models (Sonnet 5+) — use effort levels there.
 
 Results land in `benchmark/runs/<timestamp>/`: `raw/*.jsonl` (timestamped
-stream events per run), `src/<cell>/` (generated sources), `results.json`,
-`summary.txt` (also printed).
+stream events per run), `src/<cell>/` (generated sources), `dist/<cell>/`
+(built assets), `render/<cell>.json` (render-gate diagnostics incl. every
+issued query), `screenshots/<cell>.png`, `gallery.html`, `config.json`,
+`results.json`, `summary.txt` (also printed).
+
+The render gate and gallery run automatically at the end of `pnpm bench`;
+to re-run them on an existing run dir (e.g. after tweaking the harness):
+
+```bash
+pnpm bench:render runs/<timestamp>/   # re-render + refresh gallery
+pnpm bench:gallery runs/<timestamp>/  # regenerate gallery.html only
+```
 
 ## Fixtures
 
@@ -82,6 +126,14 @@ stream events per run), `src/<cell>/` (generated sources), `results.json`,
 
 - A rule at 5/5 across the suite is working; a rule flipping between runs is
   a skill-wording problem — fix the skill, not the stats.
+- For effort comparisons, hold the template constant and read the `think`
+  bucket for the speed win and the rule pass rates for the quality cost —
+  `build-passes`, `renders-clean`, `queries-valid-fields`,
+  `axes-have-tick-formatters`, and `no-oversized-files` are the ones that
+  degrade first when the model under-thinks. The objective rules only catch
+  breakage; the subjective half (skimpier layouts, worse chart choices) is
+  what `gallery.html` is for — vote blind, then reveal. Each run's
+  `config.json` records the exact variant specs.
 - Treat wall-clock deltas under ~20% at n≤5 as noise. Bucket medians
   (thinking vs toolInput) are more stable and attribute the change to a
   mechanism.

--- a/sandboxes/data-apps/benchmark/gallery.ts
+++ b/sandboxes/data-apps/benchmark/gallery.ts
@@ -1,0 +1,304 @@
+/**
+ * Blinded screenshot gallery for a benchmark run: one row per prompt×rep,
+ * one card per variant in deterministically-shuffled order with blinded
+ * labels. You vote for the best card per row; "Reveal" shows which variant
+ * each card was and tallies wins. Votes persist in localStorage.
+ *
+ *   npx tsx benchmark/gallery.ts runs/<timestamp>/
+ *
+ * Reads screenshots/ + render/*.json (from renderGate.ts) and results.json
+ * (build gate); writes <runDir>/gallery.html referencing screenshots
+ * relatively, so the file works straight from disk.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+type GalleryEntry = {
+    variant: string;
+    cell: string;
+    screenshot: string | null;
+    badges: string[];
+};
+
+type GalleryRow = {
+    id: string;
+    promptId: string;
+    rep: number;
+    entries: GalleryEntry[];
+};
+
+const CELL_RE = /^(.*)__([a-z0-9-]+)__r(\d+)$/i;
+
+const hashStr = (s: string): number => {
+    let h = 2166136261 >>> 0;
+    for (let i = 0; i < s.length; i += 1) {
+        h ^= s.charCodeAt(i);
+        h = Math.imul(h, 16777619);
+    }
+    return h >>> 0;
+};
+
+function shuffled<T>(items: T[], seed: number): T[] {
+    const out = [...items];
+    let t = seed >>> 0;
+    const rand = () => {
+        t = (t + 0x6d2b79f5) >>> 0;
+        let x = Math.imul(t ^ (t >>> 15), t | 1);
+        x ^= x + Math.imul(x ^ (x >>> 7), x | 61);
+        return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+    };
+    for (let i = out.length - 1; i > 0; i -= 1) {
+        const j = Math.floor(rand() * (i + 1));
+        [out[i], out[j]] = [out[j], out[i]];
+    }
+    return out;
+}
+
+const esc = (s: string): string =>
+    s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+
+function readJsonIfExists<T>(filePath: string): T | null {
+    if (!fs.existsSync(filePath)) return null;
+    try {
+        return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as T;
+    } catch {
+        return null;
+    }
+}
+
+function collectRows(runDir: string): GalleryRow[] {
+    // Cell universe: every source that knows about a cell contributes, so
+    // failed builds still show up as placeholders.
+    const cells = new Set<string>();
+    const results =
+        readJsonIfExists<
+            { variant: string; promptId: string; rep: number; rules?: Record<string, boolean> }[]
+        >(path.join(runDir, 'results.json')) ?? [];
+    for (const r of results) {
+        cells.add(`${r.variant}__${r.promptId}__r${r.rep}`);
+    }
+    for (const dir of ['screenshots', 'render', 'dist', 'src']) {
+        const full = path.join(runDir, dir);
+        if (!fs.existsSync(full)) continue;
+        for (const name of fs.readdirSync(full)) {
+            cells.add(name.replace(/\.(png|json)$/, ''));
+        }
+    }
+
+    const buildRules = new Map<string, Record<string, boolean>>();
+    for (const r of results) {
+        buildRules.set(
+            `${r.variant}__${r.promptId}__r${r.rep}`,
+            r.rules ?? {},
+        );
+    }
+
+    const rows = new Map<string, GalleryRow>();
+    for (const cell of [...cells].sort()) {
+        const match = cell.match(CELL_RE);
+        if (!match) continue;
+        const [, variant, promptId, repStr] = match;
+        const rep = Number(repStr);
+        const rowId = `${promptId}__r${rep}`;
+
+        const screenshotRel = `screenshots/${cell}.png`;
+        const hasScreenshot = fs.existsSync(path.join(runDir, screenshotRel));
+        const render = readJsonIfExists<{ rules?: Record<string, boolean> }>(
+            path.join(runDir, 'render', `${cell}.json`),
+        );
+
+        const badges: string[] = [];
+        const rules = { ...buildRules.get(cell), ...render?.rules };
+        if (rules['build-passes'] === false) badges.push('build ✗');
+        if (rules['renders-clean'] === false) badges.push('render ✗');
+        if (rules['queries-valid-fields'] === false) badges.push('queries ✗');
+        if (rules['made-metric-queries'] === false) badges.push('no queries');
+        if (!hasScreenshot) badges.push('no screenshot');
+
+        if (!rows.has(rowId)) {
+            rows.set(rowId, { id: rowId, promptId, rep, entries: [] });
+        }
+        rows.get(rowId)!.entries.push({
+            variant,
+            cell,
+            screenshot: hasScreenshot ? screenshotRel : null,
+            badges,
+        });
+    }
+
+    return [...rows.values()].sort(
+        (a, b) =>
+            a.promptId.localeCompare(b.promptId) || a.rep - b.rep,
+    );
+}
+
+export function writeGallery(runDir: string): string {
+    const runId = path.basename(path.resolve(runDir));
+    const rows = collectRows(runDir);
+
+    const rowsHtml = rows
+        .map((row) => {
+            const entries = shuffled(row.entries, hashStr(row.id));
+            const cards = entries
+                .map((entry, i) => {
+                    const blind = String.fromCharCode(65 + i);
+                    const badges = entry.badges
+                        .map((b) => `<span class="badge">${esc(b)}</span>`)
+                        .join('');
+                    const img = entry.screenshot
+                        ? `<div class="shot"><img loading="lazy" src="${esc(entry.screenshot)}" alt="${esc(entry.cell)}"></div>`
+                        : '<div class="missing">not built</div>';
+                    const open = entry.screenshot
+                        ? `<a class="open" href="${esc(entry.screenshot)}" target="_blank">open ↗</a>`
+                        : '';
+                    return [
+                        `<div class="card" data-row="${esc(row.id)}" data-cell="${esc(entry.cell)}" data-variant="${esc(entry.variant)}">`,
+                        `<div class="card-head"><span class="blind">${blind}</span><span class="variant-name">${esc(entry.variant)}</span>${badges}${open}</div>`,
+                        img,
+                        `<button class="vote" type="button">Pick ${blind}</button>`,
+                        '</div>',
+                    ].join('');
+                })
+                .join('\n');
+            return [
+                `<section class="row" data-row="${esc(row.id)}">`,
+                `<h2>${esc(row.promptId)} <span class="rep">r${row.rep}</span></h2>`,
+                `<div class="cards" style="--cols:${entries.length}">${cards}</div>`,
+                '</section>',
+            ].join('\n');
+        })
+        .join('\n');
+
+    const html = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Benchmark gallery — ${esc(runId)}</title>
+<style>
+:root { color-scheme: dark; }
+* { box-sizing: border-box; }
+body { margin: 0; background: #101418; color: #dbe2e8; font: 14px/1.5 ui-sans-serif, system-ui, sans-serif; }
+header { position: sticky; top: 0; z-index: 2; display: flex; align-items: center; gap: 16px; padding: 12px 20px; background: #171c22; border-bottom: 1px solid #2a323b; }
+header h1 { font-size: 15px; margin: 0; font-weight: 600; }
+header .spacer { flex: 1; }
+button { background: #2a323b; color: #dbe2e8; border: 1px solid #3a444f; border-radius: 6px; padding: 6px 12px; cursor: pointer; font: inherit; }
+button:hover { background: #343e49; }
+.row { padding: 18px 20px 6px; }
+.row h2 { font-size: 14px; margin: 0 0 10px; font-weight: 600; }
+.row .rep { color: #7b8794; font-weight: 400; }
+.cards { display: grid; grid-template-columns: repeat(var(--cols), minmax(320px, 1fr)); gap: 14px; }
+.card { background: #171c22; border: 1px solid #2a323b; border-radius: 10px; overflow: hidden; display: flex; flex-direction: column; }
+.card.voted { border-color: #4c9aff; box-shadow: 0 0 0 1px #4c9aff; }
+.card-head { display: flex; align-items: center; gap: 8px; padding: 8px 10px; }
+.blind { font-weight: 700; color: #9fb3c8; }
+.variant-name { display: none; color: #7ee2a8; font-weight: 600; }
+body.revealed .variant-name { display: inline; }
+.badge { background: #3b2a2a; color: #e8a0a0; border-radius: 5px; padding: 1px 7px; font-size: 12px; }
+.card-head .open { margin-left: auto; color: #9fb3c8; font-size: 12px; text-decoration: none; }
+.card-head .open:hover { color: #dbe2e8; }
+.shot { max-height: 78vh; overflow-y: auto; background: #fff; }
+.card img { display: block; width: 100%; height: auto; }
+.missing { display: flex; align-items: center; justify-content: center; height: 200px; color: #7b8794; }
+.vote { margin: 10px; }
+#tally { display: none; padding: 12px 20px; }
+body.revealed #tally { display: block; }
+#tally table { border-collapse: collapse; }
+#tally td, #tally th { border: 1px solid #2a323b; padding: 5px 12px; text-align: left; }
+</style>
+</head>
+<body>
+<header>
+<h1>Blinded gallery — ${esc(runId)}</h1>
+<span id="progress"></span>
+<span class="spacer"></span>
+<button id="clear" type="button">Clear votes</button>
+<button id="reveal" type="button">Reveal variants</button>
+</header>
+<div id="tally"></div>
+${rowsHtml}
+<script>
+(function () {
+    'use strict';
+    var KEY = 'bench-gallery:' + ${JSON.stringify(runId)};
+    var votes = {};
+    try { votes = JSON.parse(localStorage.getItem(KEY) || '{}') || {}; } catch (e) { votes = {}; }
+    var save = function () { try { localStorage.setItem(KEY, JSON.stringify(votes)); } catch (e) {} };
+    var rowCount = document.querySelectorAll('.row').length;
+
+    function refresh() {
+        document.querySelectorAll('.card').forEach(function (card) {
+            var isVote = votes[card.dataset.row] === card.dataset.cell;
+            card.classList.toggle('voted', isVote);
+        });
+        var voted = Object.keys(votes).length;
+        document.getElementById('progress').textContent = voted + ' / ' + rowCount + ' rows voted';
+        renderTally();
+    }
+
+    function renderTally() {
+        var wins = {};
+        var counted = 0;
+        Object.keys(votes).forEach(function (rowId) {
+            var card = document.querySelector('.card[data-row="' + CSS.escape(rowId) + '"][data-cell="' + CSS.escape(votes[rowId]) + '"]');
+            if (!card) return;
+            counted += 1;
+            var v = card.dataset.variant;
+            wins[v] = (wins[v] || 0) + 1;
+        });
+        var html = '<table><tr><th>variant</th><th>wins</th></tr>';
+        Object.keys(wins).sort().forEach(function (v) {
+            html += '<tr><td>' + v + '</td><td>' + wins[v] + ' / ' + counted + '</td></tr>';
+        });
+        html += '</table>';
+        document.getElementById('tally').innerHTML = html;
+    }
+
+    document.querySelectorAll('.vote').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var card = btn.closest('.card');
+            if (votes[card.dataset.row] === card.dataset.cell) {
+                delete votes[card.dataset.row];
+            } else {
+                votes[card.dataset.row] = card.dataset.cell;
+            }
+            save();
+            refresh();
+        });
+    });
+    document.getElementById('reveal').addEventListener('click', function () {
+        document.body.classList.toggle('revealed');
+    });
+    document.getElementById('clear').addEventListener('click', function () {
+        votes = {};
+        save();
+        refresh();
+    });
+    refresh();
+})();
+</script>
+</body>
+</html>
+`;
+
+    const outPath = path.join(runDir, 'gallery.html');
+    fs.writeFileSync(outPath, html);
+    return outPath;
+}
+
+const isMain =
+    process.argv[1] &&
+    path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+    const runDir = path.resolve(process.argv[2] ?? '');
+    if (!process.argv[2] || !fs.existsSync(runDir)) {
+        console.error('Usage: npx tsx benchmark/gallery.ts <runDir>');
+        process.exit(1);
+    }
+    console.log(`Gallery: ${writeGallery(runDir)}`);
+}

--- a/sandboxes/data-apps/benchmark/harness.js
+++ b/sandboxes/data-apps/benchmark/harness.js
@@ -1,0 +1,587 @@
+/**
+ * Browser-side mock Lightdash host for the render gate.
+ *
+ * Loaded into the harness page by mockHost.ts with `__BENCH_CONFIG__`
+ * replaced by `{ projectUuid, explores, charts }`. Speaks the query-sdk
+ * postMessage protocol (see packages/query-sdk/src/postMessageTransport.ts):
+ * posts `lightdash:sdk:ready`, answers `lightdash:sdk:fetch` with the
+ * UNWRAPPED `results` payload (mirroring useAppSdkBridge), and serves
+ * deterministic synthesized rows so identical queries produce identical
+ * data across runs and variants.
+ *
+ * Everything observable is exposed on `window.__bench` for the Playwright
+ * driver: issued queries (with field validation against the catalog),
+ * blocked fetches, and an activity timestamp used for settle detection.
+ */
+'use strict';
+
+var CONFIG = __BENCH_CONFIG__;
+
+var state = {
+    queries: [],
+    blocked: [],
+    exports: [],
+    externalFetches: [],
+    fetchCount: 0,
+    activityAt: Date.now(),
+};
+window.__bench = state;
+
+function touch() {
+    state.activityAt = Date.now();
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic pseudo-randomness (FNV-1a hash + mulberry32-style scramble)
+// ---------------------------------------------------------------------------
+
+function hashStr(s) {
+    var h = 2166136261 >>> 0;
+    for (var i = 0; i < s.length; i += 1) {
+        h ^= s.charCodeAt(i);
+        h = Math.imul(h, 16777619);
+    }
+    return h >>> 0;
+}
+
+function rand01(seed) {
+    var t = (seed + 0x6d2b79f5) >>> 0;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+
+// ---------------------------------------------------------------------------
+// Dimension domains
+// ---------------------------------------------------------------------------
+
+var MONTH_NAMES = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+// Fixed end of the synthetic timeline so screenshots are reproducible.
+var END_YEAR = 2026;
+var END_MONTH = 5; // June (0-indexed)
+var END_DAY = 15;
+
+function isoDate(d) {
+    return d.toISOString().slice(0, 10);
+}
+
+function dateDomain(interval, isTimestamp) {
+    var points = [];
+    var i;
+    var d;
+    if (interval === 'year') {
+        for (i = 4; i >= 0; i -= 1) {
+            d = new Date(Date.UTC(END_YEAR - i, 0, 1));
+            points.push({
+                raw: isoDate(d),
+                formatted: String(END_YEAR - i),
+                idx: 4 - i,
+            });
+        }
+    } else if (interval === 'quarter') {
+        for (i = 7; i >= 0; i -= 1) {
+            d = new Date(Date.UTC(END_YEAR, END_MONTH - i * 3, 1));
+            var q = Math.floor(d.getUTCMonth() / 3) + 1;
+            points.push({
+                raw: isoDate(new Date(Date.UTC(d.getUTCFullYear(), (q - 1) * 3, 1))),
+                formatted: 'Q' + q + ' ' + d.getUTCFullYear(),
+                idx: 7 - i,
+            });
+        }
+    } else if (interval === 'month') {
+        for (i = 11; i >= 0; i -= 1) {
+            d = new Date(Date.UTC(END_YEAR, END_MONTH - i, 1));
+            points.push({
+                raw: isoDate(d),
+                formatted: MONTH_NAMES[d.getUTCMonth()] + ' ' + d.getUTCFullYear(),
+                idx: 11 - i,
+            });
+        }
+    } else if (interval === 'week') {
+        for (i = 15; i >= 0; i -= 1) {
+            d = new Date(Date.UTC(END_YEAR, END_MONTH, END_DAY - i * 7));
+            points.push({ raw: isoDate(d), formatted: isoDate(d), idx: 15 - i });
+        }
+    } else {
+        // day / raw
+        for (i = 29; i >= 0; i -= 1) {
+            d = new Date(Date.UTC(END_YEAR, END_MONTH, END_DAY - i));
+            var raw = isTimestamp
+                ? d.toISOString().replace(/\.\d+Z$/, 'Z')
+                : isoDate(d);
+            points.push({ raw: raw, formatted: isoDate(d), idx: 29 - i });
+        }
+    }
+    return points;
+}
+
+var PERSON_NAMES = [
+    'Ava Thompson', 'Liam Chen', 'Sofia Reyes', 'Noah Patel',
+    'Emma Fischer', 'Lucas Moreau', 'Mia Novak', 'Oliver Haddad',
+];
+var GENERIC_CATEGORIES = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo'];
+
+function stringDomain(fieldId, meta) {
+    var values;
+    if (meta && meta.values && meta.values.length) {
+        values = meta.values;
+    } else if (/name/.test(fieldId)) {
+        values = PERSON_NAMES;
+    } else {
+        values = GENERIC_CATEGORIES;
+    }
+    return values.map(function mapValue(v) {
+        return { raw: v, formatted: v, idx: null };
+    });
+}
+
+function dimensionDomain(fieldId, meta) {
+    var type = meta ? meta.type : 'string';
+    if (type === 'date' || type === 'timestamp') {
+        var interval = meta && meta.interval ? meta.interval : 'day';
+        if (interval === 'raw') interval = 'day';
+        return dateDomain(interval, type === 'timestamp');
+    }
+    if (type === 'number') {
+        var out = [];
+        for (var n = 1; n <= 12; n += 1) {
+            out.push({ raw: n * 100 + (hashStr(fieldId) % 97), formatted: null, idx: null });
+        }
+        out.forEach(function fmt(p) {
+            p.formatted = String(p.raw);
+        });
+        return out;
+    }
+    if (type === 'boolean') {
+        return [
+            { raw: true, formatted: 'True', idx: null },
+            { raw: false, formatted: 'False', idx: null },
+        ];
+    }
+    return stringDomain(fieldId, meta);
+}
+
+// ---------------------------------------------------------------------------
+// Metric synthesis
+// ---------------------------------------------------------------------------
+
+function metricSpec(meta) {
+    var format = meta ? meta.format : null;
+    var metricType = meta ? meta.metricType : null;
+    if (format === 'percent') return { lo: 0.42, hi: 0.97, kind: 'percent' };
+    if (format === 'usd') {
+        if (metricType === 'average') return { lo: 60, hi: 480, kind: 'usd' };
+        return { lo: 24000, hi: 180000, kind: 'usd' };
+    }
+    if (metricType === 'count' || metricType === 'count_distinct') {
+        return { lo: 80, hi: 2600, kind: 'int' };
+    }
+    return { lo: 100, hi: 5000, kind: 'num' };
+}
+
+function metricValue(fieldId, comboKey, dateIdx, dateMax, spec) {
+    var r = rand01(hashStr(fieldId + '|' + comboKey));
+    var x;
+    if (dateIdx !== null && dateMax > 0) {
+        // Gentle upward trend plus seasonal wobble so time series look real.
+        var t = dateIdx / dateMax;
+        x = 0.25 + 0.35 * r + 0.3 * t + 0.1 * Math.sin(dateIdx * 2.1 + r * 6);
+    } else {
+        x = 0.3 + 0.5 * r;
+    }
+    x = Math.min(1, Math.max(0.02, x));
+    var v = spec.lo + (spec.hi - spec.lo) * x;
+
+    if (spec.kind === 'percent') {
+        var pct = Math.round(v * 1000) / 1000;
+        return { raw: pct, formatted: Math.round(pct * 100) + '%' };
+    }
+    if (spec.kind === 'usd') {
+        var usd = Math.round(v);
+        return { raw: usd, formatted: '$' + usd.toLocaleString('en-US') };
+    }
+    if (spec.kind === 'int') {
+        var count = Math.round(v);
+        return { raw: count, formatted: count.toLocaleString('en-US') };
+    }
+    var num = Math.round(v * 100) / 100;
+    return { raw: num, formatted: num.toLocaleString('en-US') };
+}
+
+// ---------------------------------------------------------------------------
+// Query synthesis + validation
+// ---------------------------------------------------------------------------
+
+function declaredFieldIds(query) {
+    var out = {};
+    (query.tableCalculations || []).forEach(function eachTc(tc) {
+        if (tc && tc.name) out[tc.name] = true;
+    });
+    (query.additionalMetrics || []).forEach(function eachAm(am) {
+        if (!am) return;
+        if (am.name && am.table) out[am.table + '_' + am.name] = true;
+        if (am.name) out[am.name] = true;
+        if (am.uuid) out[am.uuid] = true;
+    });
+    (query.customDimensions || []).forEach(function eachCd(cd) {
+        if (!cd) return;
+        if (cd.id) out[cd.id] = true;
+        if (cd.name) out[cd.name] = true;
+    });
+    return out;
+}
+
+function synthesizeRows(exploreName, dimensions, metrics, limit, sorts) {
+    var explore = CONFIG.explores[exploreName] || null;
+    var fields = explore ? explore.fields : {};
+    var cap = Math.min(Math.max(1, limit || 500), 500);
+
+    var domains = dimensions.map(function eachDim(d) {
+        return dimensionDomain(d, fields[d]);
+    });
+
+    var combos = [[]];
+    for (var i = 0; i < domains.length; i += 1) {
+        var next = [];
+        for (var c = 0; c < combos.length && next.length <= 5000; c += 1) {
+            for (var p = 0; p < domains[i].length; p += 1) {
+                next.push(combos[c].concat([domains[i][p]]));
+            }
+        }
+        combos = next;
+    }
+    combos = combos.slice(0, cap);
+
+    var rows = combos.map(function eachCombo(combo) {
+        var row = {};
+        var comboKey = combo
+            .map(function key(point) {
+                return String(point.raw);
+            })
+            .join('~');
+        var dateIdx = null;
+        var dateMax = 0;
+        combo.forEach(function eachPoint(point, idx) {
+            if (point.idx !== null && dateIdx === null) {
+                dateIdx = point.idx;
+                dateMax = domains[idx].length - 1;
+            }
+            row[dimensions[idx]] = {
+                value: { raw: point.raw, formatted: point.formatted },
+            };
+        });
+        metrics.forEach(function eachMetric(m) {
+            row[m] = {
+                value: metricValue(m, comboKey, dateIdx, dateMax, metricSpec(fields[m])),
+            };
+        });
+        return row;
+    });
+
+    (sorts || [])
+        .slice()
+        .reverse()
+        .forEach(function eachSort(s) {
+            if (!s || !s.fieldId) return;
+            rows.sort(function cmp(a, b) {
+                var av = a[s.fieldId] ? a[s.fieldId].value.raw : null;
+                var bv = b[s.fieldId] ? b[s.fieldId].value.raw : null;
+                var base = av === bv ? 0 : av === null ? -1 : bv === null ? 1 : av < bv ? -1 : 1;
+                return s.descending ? -base : base;
+            });
+        });
+
+    var allIds = dimensions.concat(metrics);
+    var columns = {};
+    var fieldsMeta = {};
+    allIds.forEach(function eachId(id) {
+        var meta = fields[id];
+        var isMetric = meta ? meta.kind === 'metric' : metrics.indexOf(id) !== -1;
+        var type = meta ? meta.type : isMetric ? 'number' : 'string';
+        columns[id] = { reference: id, type: type };
+        fieldsMeta[id] = {
+            fieldType: isMetric ? 'metric' : 'dimension',
+            type: type,
+            label: meta && meta.label ? meta.label : id,
+        };
+    });
+
+    return { rows: rows, columns: columns, fieldsMeta: fieldsMeta };
+}
+
+var queryCounter = 0;
+var queryStore = {};
+
+function startQuery(record, exploreName, dimensions, metrics, limit, sorts) {
+    var explore = CONFIG.explores[exploreName];
+    var declared = record.declared || {};
+    delete record.declared;
+    var requested = dimensions.concat(metrics);
+    record.exploreName = exploreName || null;
+    record.dimensions = dimensions;
+    record.metrics = metrics;
+    record.limit = limit || null;
+    record.unknownExplore = !explore;
+    record.invalidFields = !explore
+        ? []
+        : requested.filter(function unknownField(id) {
+              return !explore.fields[id] && !declared[id];
+          });
+
+    var synth = synthesizeRows(exploreName, dimensions, metrics, limit, sorts);
+    queryCounter += 1;
+    var queryUuid = 'bench-query-' + queryCounter;
+    queryStore[queryUuid] = synth;
+    record.rowCount = synth.rows.length;
+    state.queries.push(record);
+
+    return {
+        queryUuid: queryUuid,
+        metricQuery: {
+            exploreName: exploreName,
+            dimensions: dimensions,
+            metrics: metrics,
+            limit: limit,
+        },
+        fields: synth.fieldsMeta,
+    };
+}
+
+function inferExploreForField(fieldId) {
+    var best = null;
+    Object.keys(CONFIG.explores).forEach(function eachExplore(name) {
+        if (fieldId && fieldId.indexOf(name + '_') === 0) {
+            if (!best || name.length > best.length) best = name;
+        }
+    });
+    return best || Object.keys(CONFIG.explores)[0] || null;
+}
+
+function pollResult(queryUuid, page, pageSize) {
+    var synth = queryStore[queryUuid];
+    if (!synth) return { error: 'Unknown query ' + queryUuid };
+    var size = pageSize || 500;
+    var current = page || 1;
+    var start = (current - 1) * size;
+    var slice = synth.rows.slice(start, start + size);
+    var hasMore = start + size < synth.rows.length;
+    return {
+        result: {
+            status: 'ready',
+            queryUuid: queryUuid,
+            columns: synth.columns,
+            rows: slice,
+            totalResults: synth.rows.length,
+            ...(hasMore ? { nextPage: current + 1 } : {}),
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Route handling — mirrors the prod bridge allowlist
+// ---------------------------------------------------------------------------
+
+var QUERY_POST = /^\/api\/v2\/projects\/[^/]+\/query\/metric-query$/;
+var UNDERLYING_POST = /^\/api\/v2\/projects\/[^/]+\/query\/underlying-data$/;
+var CHART_POST = /^\/api\/v2\/projects\/[^/]+\/query\/chart$/;
+var DOWNLOAD_POST = /^\/api\/v2\/projects\/[^/]+\/query\/([^/?]+)\/schedule-download$/;
+var QUERY_GET = /^\/api\/v2\/projects\/[^/]+\/query\/([^/?]+)(\?.*)?$/;
+var JOB_GET = /^\/api\/v1\/schedulers\/job\/[^/]+\/status$/;
+
+function handleSdkFetch(method, path, body) {
+    var upper = (method || '').toUpperCase();
+
+    if (upper === 'POST' && QUERY_POST.test(path)) {
+        var q = (body && body.query) || {};
+        return {
+            result: startQuery(
+                { kind: 'metric', declared: declaredFieldIds(q) },
+                q.exploreName,
+                q.dimensions || [],
+                q.metrics || [],
+                q.limit,
+                q.sorts || [],
+            ),
+        };
+    }
+
+    if (upper === 'POST' && UNDERLYING_POST.test(path)) {
+        var metricId = (body && body.underlyingDataItemId) || '';
+        var exploreName = inferExploreForField(metricId);
+        var explore = exploreName ? CONFIG.explores[exploreName] : null;
+        var dims = [];
+        if (explore) {
+            Object.keys(explore.fields).forEach(function eachField(id) {
+                var meta = explore.fields[id];
+                if (meta.kind === 'dimension' && meta.interval === null && dims.length < 6) {
+                    dims.push(id);
+                }
+            });
+        }
+        var underlyingMetrics = explore && explore.fields[metricId] ? [metricId] : [];
+        return {
+            result: startQuery(
+                { kind: 'underlying', declared: {} },
+                exploreName,
+                dims,
+                underlyingMetrics,
+                (body && body.limit) || 10,
+                [],
+            ),
+        };
+    }
+
+    if (upper === 'POST' && CHART_POST.test(path)) {
+        var chartUuid = body && body.chartUuid;
+        var chart = chartUuid ? CONFIG.charts[chartUuid] : null;
+        if (!chart) {
+            state.queries.push({
+                kind: 'chart',
+                exploreName: null,
+                dimensions: [],
+                metrics: [],
+                limit: null,
+                unknownExplore: false,
+                unknownChart: true,
+                invalidFields: [],
+                rowCount: 0,
+            });
+            return { error: 'Chart not found: ' + chartUuid };
+        }
+        var mq = chart.metricQuery || {};
+        var response = startQuery(
+            { kind: 'chart', declared: {} },
+            chart.exploreName,
+            mq.dimensions || [],
+            mq.metrics || [],
+            (body && body.limit) || mq.limit,
+            mq.sorts || [],
+        );
+        response.metricQuery = mq;
+        return { result: response };
+    }
+
+    if (upper === 'POST' && DOWNLOAD_POST.test(path)) {
+        return { result: { jobId: 'bench-job-1' } };
+    }
+
+    if (upper === 'GET' && JOB_GET.test(path)) {
+        return {
+            result: {
+                status: 'completed',
+                details: {
+                    fileUrl: 'data:text/csv;charset=utf-8,benchmark%0Amock',
+                    truncated: false,
+                },
+            },
+        };
+    }
+
+    if (upper === 'GET' && QUERY_GET.test(path)) {
+        var match = path.match(QUERY_GET);
+        var params = new URLSearchParams(match[2] ? match[2].slice(1) : '');
+        return pollResult(
+            match[1],
+            Number(params.get('page') || '1'),
+            Number(params.get('pageSize') || '500'),
+        );
+    }
+
+    if (upper === 'GET' && path === '/api/v1/user') {
+        return {
+            result: {
+                userUuid: 'bench-user-uuid',
+                firstName: 'Benchmark',
+                lastName: 'User',
+                email: 'bench@lightdash.com',
+                role: 'editor',
+                organizationUuid: 'bench-org-uuid',
+            },
+        };
+    }
+
+    state.blocked.push(upper + ' ' + path);
+    return { error: 'Blocked: ' + method + ' ' + path };
+}
+
+// ---------------------------------------------------------------------------
+// postMessage wiring
+// ---------------------------------------------------------------------------
+
+var iframe = document.getElementById('app-frame');
+
+function postToApp(message) {
+    if (iframe && iframe.contentWindow) {
+        iframe.contentWindow.postMessage(message, '*');
+    }
+}
+
+window.addEventListener('message', function onMessage(event) {
+    if (!iframe || !iframe.contentWindow || event.source !== iframe.contentWindow) {
+        return;
+    }
+    var data = event.data;
+    if (!data || typeof data !== 'object' || typeof data.type !== 'string') {
+        return;
+    }
+    touch();
+
+    if (data.type === 'lightdash:sdk:fetch') {
+        state.fetchCount += 1;
+        var response;
+        try {
+            response = handleSdkFetch(data.method, data.path, data.body);
+        } catch (err) {
+            response = { error: String((err && err.message) || err) };
+        }
+        Promise.resolve().then(function respond() {
+            touch();
+            postToApp(
+                Object.assign(
+                    { type: 'lightdash:sdk:fetch-response', id: data.id },
+                    response,
+                ),
+            );
+        });
+    } else if (data.type === 'lightdash:sdk:gsheet-export-request') {
+        state.exports.push({
+            title: data.title || null,
+            rows: (data.rows || []).length,
+            columns: (data.columns || []).length,
+        });
+        postToApp({
+            type: 'lightdash:sdk:gsheet-export-response',
+            id: data.id,
+            fileUrl: 'https://docs.google.com/spreadsheets/d/benchmark-mock',
+        });
+    } else if (data.type === 'lightdash:sdk:external-fetch') {
+        state.externalFetches.push({ alias: data.alias || null, path: data.path || null });
+        postToApp({
+            type: 'lightdash:sdk:external-fetch-response',
+            id: data.id,
+            result: {
+                status: 200,
+                contentType: 'application/json',
+                body: {},
+                truncated: false,
+            },
+        });
+    }
+    // Inspector / screenshot / url-state announces are ignored on purpose.
+});
+
+// Pump readiness for a while — the SDK latches the first one and ignores the
+// rest, and pumping dodges the load-order race without an onload dependency.
+var readyPumps = 0;
+var readyTimer = setInterval(function pumpReady() {
+    readyPumps += 1;
+    if (readyPumps > 40) {
+        clearInterval(readyTimer);
+        return;
+    }
+    postToApp({ type: 'lightdash:sdk:ready' });
+}, 250);

--- a/sandboxes/data-apps/benchmark/mockHost.ts
+++ b/sandboxes/data-apps/benchmark/mockHost.ts
@@ -1,0 +1,229 @@
+/**
+ * Node-side half of the render gate's mock Lightdash host: parses the fixture
+ * catalog (schema.yml) into explore/field metadata, loads chart-reference
+ * fixtures, and assembles the harness page that embeds harness.js with that
+ * config. The browser half (harness.js) answers the SDK postMessage protocol.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import YAML from 'yaml';
+
+const BENCH_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+export type CatalogFieldMeta = {
+    kind: 'dimension' | 'metric';
+    /** dimension: date|timestamp|string|number|boolean; metric: warehouse-ish type */
+    type: string;
+    label: string;
+    /** raw|day|week|month|quarter|year for time-interval dimension variants */
+    interval: string | null;
+    /** category values parsed from the column description, when enumerable */
+    values: string[] | null;
+    metricType: string | null;
+    format: string | null;
+};
+
+export type Catalog = {
+    explores: Record<
+        string,
+        { tables: string[]; fields: Record<string, CatalogFieldMeta> }
+    >;
+};
+
+export type ChartFixture = {
+    exploreName: string;
+    metricQuery: Record<string, unknown>;
+};
+
+type SchemaColumn = {
+    name: string;
+    description?: string;
+    meta?: {
+        dimension?: { type?: string; time_intervals?: string[] };
+    };
+};
+
+type SchemaModel = {
+    name: string;
+    meta?: {
+        joins?: { join: string }[];
+        metrics?: Record<
+            string,
+            { type?: string; label?: string; format?: string }
+        >;
+    };
+    columns?: SchemaColumn[];
+};
+
+/**
+ * Pull enumerable category values out of a column description like
+ * "Order status: placed, shipped, completed, returned." so synthesized rows
+ * carry the values generated apps expect to see (and filter on).
+ */
+function extractCategoryValues(description: string | undefined): string[] | null {
+    if (!description) return null;
+    const colon = description.lastIndexOf(':');
+    const candidate = colon === -1 ? description : description.slice(colon + 1);
+    const tokens = candidate
+        .split(',')
+        .map((t) => t.trim().replace(/\.$/, ''))
+        .filter(Boolean);
+    const enumerable =
+        tokens.length >= 2 &&
+        tokens.length <= 8 &&
+        tokens.every((t) => /^[A-Za-z][A-Za-z0-9_ -]{0,23}$/.test(t));
+    return enumerable ? tokens : null;
+}
+
+const TIME_INTERVAL_TYPES: Record<string, string> = {
+    day: 'date',
+    week: 'date',
+    month: 'date',
+    quarter: 'date',
+    year: 'date',
+};
+
+export function parseCatalog(schemaYmlPath: string): Catalog {
+    const doc = YAML.parse(fs.readFileSync(schemaYmlPath, 'utf-8')) as {
+        models?: SchemaModel[];
+    };
+    const models = doc.models ?? [];
+
+    // Unqualified field maps per model, used to assemble explores below.
+    const tableFields = new Map<string, Record<string, CatalogFieldMeta>>();
+    for (const model of models) {
+        const fields: Record<string, CatalogFieldMeta> = {};
+        for (const column of model.columns ?? []) {
+            const dim = column.meta?.dimension ?? {};
+            const baseType = dim.type ?? 'string';
+            const values = extractCategoryValues(column.description);
+            fields[column.name] = {
+                kind: 'dimension',
+                type: baseType,
+                label: column.name,
+                interval: null,
+                values,
+                metricType: null,
+                format: null,
+            };
+            for (const rawInterval of dim.time_intervals ?? []) {
+                const interval = rawInterval.toLowerCase();
+                fields[`${column.name}_${interval}`] = {
+                    kind: 'dimension',
+                    type: TIME_INTERVAL_TYPES[interval] ?? baseType,
+                    label: `${column.name} (${interval})`,
+                    interval,
+                    values: null,
+                    metricType: null,
+                    format: null,
+                };
+            }
+        }
+        for (const [name, metric] of Object.entries(
+            model.meta?.metrics ?? {},
+        )) {
+            fields[name] = {
+                kind: 'metric',
+                type: metric.type ?? 'number',
+                label: metric.label ?? name,
+                interval: null,
+                values: null,
+                metricType: metric.type ?? null,
+                format: metric.format ?? null,
+            };
+        }
+        tableFields.set(model.name, fields);
+    }
+
+    const catalog: Catalog = { explores: {} };
+    for (const model of models) {
+        const tables = [
+            model.name,
+            ...(model.meta?.joins ?? []).map((j) => j.join),
+        ].filter((t) => tableFields.has(t));
+        const fields: Record<string, CatalogFieldMeta> = {};
+        for (const table of tables) {
+            for (const [name, meta] of Object.entries(tableFields.get(table)!)) {
+                fields[`${table}_${name}`] = meta;
+            }
+        }
+        catalog.explores[model.name] = { tables, fields };
+    }
+    return catalog;
+}
+
+/**
+ * Chart fixtures for a prompt: every /tmp/metric-queries/*.json sandbox file
+ * declared in prompts.json, keyed by chartUuid so the harness can answer
+ * /query/chart calls for linked charts.
+ */
+export function loadChartFixtures(
+    promptsJsonPath: string,
+    promptId: string,
+): Record<string, ChartFixture> {
+    const suite = JSON.parse(fs.readFileSync(promptsJsonPath, 'utf-8')) as {
+        prompts: {
+            id: string;
+            sandboxFiles?: Record<string, string>;
+        }[];
+    };
+    const spec = suite.prompts.find((p) => p.id === promptId);
+    const charts: Record<string, ChartFixture> = {};
+    for (const [sandboxPath, localRel] of Object.entries(
+        spec?.sandboxFiles ?? {},
+    )) {
+        if (!sandboxPath.startsWith('/tmp/metric-queries/')) continue;
+        try {
+            const fixture = JSON.parse(
+                fs.readFileSync(path.join(BENCH_DIR, localRel), 'utf-8'),
+            ) as {
+                chartUuid?: string;
+                exploreName?: string;
+                metricQuery?: Record<string, unknown>;
+            };
+            if (fixture.chartUuid && fixture.exploreName) {
+                charts[fixture.chartUuid] = {
+                    exploreName: fixture.exploreName,
+                    metricQuery: fixture.metricQuery ?? {},
+                };
+            }
+        } catch {
+            // A malformed fixture shouldn't kill the gate — the app's own
+            // /query/chart call will just get "Chart not found".
+        }
+    }
+    return charts;
+}
+
+export function buildHarnessHtml(
+    catalog: Catalog,
+    charts: Record<string, ChartFixture>,
+    projectUuid: string,
+): string {
+    const harnessJs = fs.readFileSync(path.join(BENCH_DIR, 'harness.js'), 'utf-8');
+    const config = { projectUuid, explores: catalog.explores, charts };
+    // <-escape so a stray "</script>" inside config can't break the page.
+    const configJson = JSON.stringify(config).replace(/</g, '\\u003c');
+    // Target the assignment specifically — the docblock also mentions the
+    // placeholder, and a bare .replace() would only hit that first mention.
+    const script = harnessJs.replace(
+        'var CONFIG = __BENCH_CONFIG__;',
+        `var CONFIG = ${configJson};`,
+    );
+    if (script === harnessJs) {
+        throw new Error('harness.js is missing the CONFIG assignment marker');
+    }
+    const iframeSrc = `./app/index.html#transport=postMessage&projectUuid=${encodeURIComponent(
+        projectUuid,
+    )}`;
+    return [
+        '<!doctype html>',
+        '<html><head><meta charset="utf-8"><title>bench harness</title>',
+        '<style>html,body{margin:0;padding:0;background:#fff}iframe{border:0;width:1440px;height:900px;display:block}</style>',
+        '</head><body>',
+        `<iframe id="app-frame" src="${iframeSrc}"></iframe>`,
+        `<script>${script}</script>`,
+        '</body></html>',
+    ].join('\n');
+}

--- a/sandboxes/data-apps/benchmark/renderGate.ts
+++ b/sandboxes/data-apps/benchmark/renderGate.ts
@@ -1,0 +1,383 @@
+/**
+ * Render gate: load each benchmark cell's built app (dist/) in headless
+ * Chromium under a mock Lightdash host (mockHost.ts + harness.js) and score
+ * what actually happens at runtime — uncaught errors, error-boundary trips,
+ * blank screens, and whether the queries the app issues reference real
+ * catalog fields. Also captures a full-height screenshot per cell for the
+ * gallery.
+ *
+ * Used inline by run.ts after a benchmark run, or standalone to (re)render
+ * an existing run directory:
+ *
+ *   npx tsx benchmark/renderGate.ts runs/<timestamp>/
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium, type Browser } from 'playwright';
+import { writeGallery } from './gallery.ts';
+import {
+    buildHarnessHtml,
+    loadChartFixtures,
+    parseCatalog,
+} from './mockHost.ts';
+
+const BENCH_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+export type IssuedQuery = {
+    kind: 'metric' | 'chart' | 'underlying';
+    exploreName: string | null;
+    dimensions: string[];
+    metrics: string[];
+    limit: number | null;
+    unknownExplore: boolean;
+    unknownChart?: boolean;
+    invalidFields: string[];
+    rowCount: number;
+};
+
+export type RenderResult = {
+    cell: string;
+    /** Harness-level failure (navigation, missing dist, …); null when the page ran. */
+    error: string | null;
+    settled: boolean;
+    durationMs: number;
+    pageErrors: string[];
+    consoleErrors: string[];
+    fatalMarker: boolean;
+    boundaryMarker: boolean;
+    rootChildren: number;
+    rootTextLength: number;
+    queries: IssuedQuery[];
+    blockedFetches: string[];
+    exports: unknown[];
+    screenshot: string | null;
+    rules: Record<string, boolean>;
+};
+
+export function renderRules(
+    result: Omit<RenderResult, 'rules'>,
+): Record<string, boolean> {
+    return {
+        'renders-clean':
+            result.error === null &&
+            result.pageErrors.length === 0 &&
+            !result.fatalMarker &&
+            !result.boundaryMarker &&
+            result.rootChildren > 0,
+        'made-metric-queries': result.queries.some(
+            (q) => q.kind === 'metric' || q.kind === 'chart',
+        ),
+        // Vacuously true with no queries — made-metric-queries covers that.
+        'queries-valid-fields': result.queries.every(
+            (q) =>
+                !q.unknownExplore &&
+                !q.unknownChart &&
+                q.invalidFields.length === 0,
+        ),
+    };
+}
+
+const MIME_TYPES: Record<string, string> = {
+    '.html': 'text/html',
+    '.js': 'text/javascript',
+    '.mjs': 'text/javascript',
+    '.css': 'text/css',
+    '.svg': 'image/svg+xml',
+    '.json': 'application/json',
+    '.map': 'application/json',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.ico': 'image/x-icon',
+    '.woff': 'font/woff',
+    '.woff2': 'font/woff2',
+    '.txt': 'text/plain',
+};
+
+const promptIdOfCell = (cell: string): string | null =>
+    cell.match(/__([a-z0-9-]+)__r\d+$/i)?.[1] ?? null;
+
+async function renderCell(
+    browser: Browser,
+    runDir: string,
+    cell: string,
+    harnessHtml: string,
+): Promise<RenderResult> {
+    const distDir = path.join(runDir, 'dist', cell);
+    const screenshotDir = path.join(runDir, 'screenshots');
+    const renderDir = path.join(runDir, 'render');
+    fs.mkdirSync(screenshotDir, { recursive: true });
+    fs.mkdirSync(renderDir, { recursive: true });
+
+    const result: Omit<RenderResult, 'rules'> = {
+        cell,
+        error: null,
+        settled: false,
+        durationMs: 0,
+        pageErrors: [],
+        consoleErrors: [],
+        fatalMarker: false,
+        boundaryMarker: false,
+        rootChildren: 0,
+        rootTextLength: 0,
+        queries: [],
+        blockedFetches: [],
+        exports: [],
+        screenshot: null,
+    };
+    const startedAt = Date.now();
+    let context: Awaited<ReturnType<Browser['newContext']>> | null = null;
+
+    try {
+        context = await browser.newContext({
+            viewport: { width: 1440, height: 900 },
+        });
+        await context.route('**/*', async (route) => {
+            const url = new URL(route.request().url());
+            if (url.hostname !== 'ldbench.test') {
+                await route.fulfill({ status: 404, body: '' });
+                return;
+            }
+            if (url.pathname === '/' || url.pathname === '/index.html') {
+                await route.fulfill({
+                    contentType: 'text/html',
+                    body: harnessHtml,
+                });
+                return;
+            }
+            if (url.pathname === '/favicon.ico') {
+                await route.fulfill({ status: 204, body: '' });
+                return;
+            }
+            if (url.pathname.startsWith('/app/')) {
+                const rel =
+                    decodeURIComponent(url.pathname.slice('/app/'.length)) ||
+                    'index.html';
+                const filePath = path.resolve(distDir, rel);
+                if (
+                    filePath.startsWith(distDir + path.sep) &&
+                    fs.existsSync(filePath) &&
+                    fs.statSync(filePath).isFile()
+                ) {
+                    await route.fulfill({
+                        contentType:
+                            MIME_TYPES[path.extname(filePath)] ??
+                            'application/octet-stream',
+                        body: fs.readFileSync(filePath),
+                    });
+                    return;
+                }
+            }
+            await route.fulfill({ status: 404, body: '' });
+        });
+
+        const page = await context.newPage();
+        page.on('pageerror', (err) => {
+            if (result.pageErrors.length < 20) {
+                result.pageErrors.push(String(err.message ?? err).slice(0, 300));
+            }
+        });
+        page.on('console', (msg) => {
+            if (msg.type() !== 'error') return;
+            const text = msg.text();
+            if (text.includes('[lightdash] fatal app error:')) {
+                result.fatalMarker = true;
+            }
+            if (text.includes('render error caught by ErrorBoundary')) {
+                result.boundaryMarker = true;
+            }
+            if (result.consoleErrors.length < 20) {
+                result.consoleErrors.push(text.slice(0, 300));
+            }
+        });
+
+        // https so the page is a secure context — the SDK's postMessage
+        // adapter needs crypto.randomUUID. Playwright fulfills the routed
+        // requests directly; no real TLS handshake happens.
+        await page.goto('https://ldbench.test/', {
+            waitUntil: 'load',
+            timeout: 15_000,
+        });
+
+        // Settle: quiet on the postMessage channel for 3s with a mounted root,
+        // after at least 5s total; hard cap 30s.
+        const readState = () =>
+            page.evaluate(() => {
+                /* eslint-disable @typescript-eslint/no-explicit-any */
+                const w = window as any;
+                const bench = w.__bench ?? {};
+                let rootChildren = 0;
+                let rootTextLength = 0;
+                try {
+                    const frame = document.getElementById(
+                        'app-frame',
+                    ) as any;
+                    const root =
+                        frame?.contentDocument?.getElementById('root');
+                    if (root) {
+                        rootChildren = root.childElementCount;
+                        rootTextLength = (root.innerText ?? '').length;
+                    }
+                } catch {
+                    // cross-origin shouldn't happen; treat as unmounted
+                }
+                return {
+                    activityAt: bench.activityAt ?? 0,
+                    queries: bench.queries ?? [],
+                    blocked: bench.blocked ?? [],
+                    exports: bench.exports ?? [],
+                    rootChildren,
+                    rootTextLength,
+                };
+                /* eslint-enable @typescript-eslint/no-explicit-any */
+            });
+
+        const deadline = Date.now() + 30_000;
+        while (Date.now() < deadline) {
+            await page.waitForTimeout(500);
+            const s = await readState();
+            result.rootChildren = s.rootChildren;
+            result.rootTextLength = s.rootTextLength;
+            if (
+                Date.now() - startedAt > 5_000 &&
+                Date.now() - s.activityAt > 3_000 &&
+                s.rootChildren > 0
+            ) {
+                result.settled = true;
+                break;
+            }
+        }
+
+        // Let chart mount animations finish before capturing.
+        await page.waitForTimeout(1_500);
+
+        const final = await readState();
+        result.rootChildren = final.rootChildren;
+        result.rootTextLength = final.rootTextLength;
+        result.queries = final.queries as IssuedQuery[];
+        result.blockedFetches = final.blocked as string[];
+        result.exports = final.exports as unknown[];
+
+        // Expand the iframe to its content height (same-origin) so the
+        // screenshot captures the whole app, not just the top viewport.
+        await page.evaluate(() => {
+            /* eslint-disable @typescript-eslint/no-explicit-any */
+            const frame = document.getElementById('app-frame') as any;
+            const doc = frame?.contentDocument;
+            if (frame && doc) {
+                const height = Math.min(
+                    Math.max(900, doc.documentElement.scrollHeight),
+                    4000,
+                );
+                frame.style.height = `${height}px`;
+            }
+            /* eslint-enable @typescript-eslint/no-explicit-any */
+        });
+        await page.waitForTimeout(400);
+        const screenshotPath = path.join(screenshotDir, `${cell}.png`);
+        await page.screenshot({ path: screenshotPath, fullPage: true });
+        result.screenshot = `screenshots/${cell}.png`;
+    } catch (err) {
+        result.error = err instanceof Error ? err.message : String(err);
+    } finally {
+        await context?.close().catch(() => {});
+    }
+    result.durationMs = Date.now() - startedAt;
+
+    const full: RenderResult = { ...result, rules: renderRules(result) };
+    fs.writeFileSync(
+        path.join(renderDir, `${cell}.json`),
+        JSON.stringify(full, null, 2),
+    );
+    return full;
+}
+
+export async function renderRun(
+    runDir: string,
+    opts: { concurrency?: number } = {},
+): Promise<Record<string, RenderResult>> {
+    const distRoot = path.join(runDir, 'dist');
+    if (!fs.existsSync(distRoot)) return {};
+    const cells = fs
+        .readdirSync(distRoot)
+        .filter((cell) =>
+            fs.existsSync(path.join(distRoot, cell, 'index.html')),
+        )
+        .sort();
+    if (cells.length === 0) return {};
+
+    const catalog = parseCatalog(
+        path.join(BENCH_DIR, 'fixtures', 'schema.yml'),
+    );
+    const promptsJsonPath = path.join(BENCH_DIR, 'prompts.json');
+    const harnessByPrompt = new Map<string, string>();
+    const harnessFor = (cell: string): string => {
+        const promptId = promptIdOfCell(cell) ?? '';
+        if (!harnessByPrompt.has(promptId)) {
+            harnessByPrompt.set(
+                promptId,
+                buildHarnessHtml(
+                    catalog,
+                    loadChartFixtures(promptsJsonPath, promptId),
+                    'bench-project-uuid',
+                ),
+            );
+        }
+        return harnessByPrompt.get(promptId)!;
+    };
+
+    const browser = await chromium.launch();
+    const results: Record<string, RenderResult> = {};
+    let next = 0;
+    const workers = Array.from(
+        { length: Math.min(opts.concurrency ?? 4, cells.length) },
+        async () => {
+            while (next < cells.length) {
+                const cell = cells[next];
+                next += 1;
+                results[cell] = await renderCell(
+                    browser,
+                    runDir,
+                    cell,
+                    harnessFor(cell),
+                );
+            }
+        },
+    );
+    await Promise.all(workers);
+    await browser.close();
+    return results;
+}
+
+// ---------------------------------------------------------------------------
+// CLI: re-render an existing run dir and regenerate its gallery
+// ---------------------------------------------------------------------------
+
+const isMain =
+    process.argv[1] &&
+    path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+    const runDir = path.resolve(process.argv[2] ?? '');
+    if (!process.argv[2] || !fs.existsSync(runDir)) {
+        console.error('Usage: npx tsx benchmark/renderGate.ts <runDir>');
+        process.exit(1);
+    }
+    const results = await renderRun(runDir);
+    const cells = Object.keys(results).sort();
+    if (cells.length === 0) {
+        console.error(`No built cells under ${path.join(runDir, 'dist')}`);
+        process.exit(1);
+    }
+    for (const cell of cells) {
+        const r = results[cell];
+        const rulesSummary = Object.entries(r.rules)
+            .map(([name, ok]) => `${ok ? '✓' : '✗'} ${name}`)
+            .join('  ');
+        console.log(
+            `${cell}: ${r.error ? `ERROR ${r.error.slice(0, 80)}` : rulesSummary}`,
+        );
+    }
+    const galleryPath = writeGallery(runDir);
+    console.log(`\nGallery: ${galleryPath}`);
+}

--- a/sandboxes/data-apps/benchmark/run.ts
+++ b/sandboxes/data-apps/benchmark/run.ts
@@ -25,6 +25,8 @@ import {
     type PromptSpec,
     type RuleResults,
 } from './assertions.ts';
+import { writeGallery } from './gallery.ts';
+import { renderRun } from './renderGate.ts';
 import { analyzeStream, type StreamAnalysis } from './stream.ts';
 
 const BENCH_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -47,14 +49,71 @@ function loadDotEnv() {
     }
 }
 
+const EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+type EffortLevel = (typeof EFFORT_LEVELS)[number];
+
+type VariantSpec = {
+    name: string;
+    templateRef: string;
+    // null = no --effort flag, i.e. the CLI default the production pipeline runs with.
+    effort: EffortLevel | null;
+    envs: Record<string, string>;
+};
+
 type Config = {
-    variants: { name: string; templateRef: string }[];
+    variants: VariantSpec[];
     reps: number;
     promptIds: string[] | null;
     concurrency: number;
     model: string;
     outDir: string;
 };
+
+// The CLI warns-and-ignores unknown --effort values, which would silently run
+// a whole variant at default effort — validate up front instead.
+function parseVariant(value: string): VariantSpec {
+    const eq = value.indexOf('=');
+    if (eq === -1)
+        throw new Error(
+            '--variant expects name=templateRef[,effort=<level>][,env.KEY=VAL]',
+        );
+    const [templateRef, ...options] = value.slice(eq + 1).split(',');
+    const variant: VariantSpec = {
+        name: value.slice(0, eq),
+        templateRef,
+        effort: null,
+        envs: {},
+    };
+    for (const option of options) {
+        const optEq = option.indexOf('=');
+        if (optEq === -1)
+            throw new Error(`--variant option "${option}" expects key=value`);
+        const key = option.slice(0, optEq);
+        const optValue = option.slice(optEq + 1);
+        if (key === 'effort') {
+            if (!EFFORT_LEVELS.includes(optValue as EffortLevel))
+                throw new Error(
+                    `Invalid effort "${optValue}" (expected ${EFFORT_LEVELS.join('|')})`,
+                );
+            variant.effort = optValue as EffortLevel;
+        } else if (key.startsWith('env.') && key.length > 4) {
+            variant.envs[key.slice(4)] = optValue;
+        } else {
+            throw new Error(
+                `Unknown --variant option "${key}" (expected effort or env.KEY)`,
+            );
+        }
+    }
+    return variant;
+}
+
+function describeVariant(variant: VariantSpec): string {
+    const parts = [variant.templateRef];
+    if (variant.effort) parts.push(`effort=${variant.effort}`);
+    for (const [key, value] of Object.entries(variant.envs))
+        parts.push(`${key}=${value}`);
+    return parts.join(', ');
+}
 
 function parseArgs(argv: string[]): Config {
     const config: Config = {
@@ -73,16 +132,9 @@ function parseArgs(argv: string[]): Config {
         const [flag, value] = [argv[i], argv[i + 1]];
         if (value === undefined) throw new Error(`Missing value for ${flag}`);
         switch (flag) {
-            case '--variant': {
-                const eq = value.indexOf('=');
-                if (eq === -1)
-                    throw new Error('--variant expects name=templateRef');
-                config.variants.push({
-                    name: value.slice(0, eq),
-                    templateRef: value.slice(eq + 1),
-                });
+            case '--variant':
+                config.variants.push(parseVariant(value));
                 break;
-            }
             case '--reps':
                 config.reps = Number(value);
                 break;
@@ -107,6 +159,8 @@ function parseArgs(argv: string[]): Config {
             name: 'default',
             templateRef:
                 process.env.E2B_TEMPLATE_NAME || 'lightdash-data-app',
+            effort: null,
+            envs: {},
         });
     }
     return config;
@@ -129,7 +183,7 @@ type RunResult = {
 
 async function runOne(
     config: Config,
-    variant: { name: string; templateRef: string },
+    variant: VariantSpec,
     spec: PromptSpec,
     rep: number,
 ): Promise<RunResult> {
@@ -149,7 +203,10 @@ async function runOne(
     try {
         sandbox = await Sandbox.create(variant.templateRef, {
             timeoutMs: 30 * 60 * 1000,
-            envs: { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY! },
+            envs: {
+                ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
+                ...variant.envs,
+            },
         });
 
         // Fixture catalog + prompt (+ per-prompt extra files).
@@ -199,6 +256,7 @@ async function runOne(
             const generate = await sandbox.commands.run(
                 `cat /tmp/prompt.txt | claude -p ` +
                     `--model ${config.model} ` +
+                    (variant.effort ? `--effort ${variant.effort} ` : '') +
                     `--verbose --output-format stream-json --include-partial-messages ` +
                     `--allowedTools "${ALLOWED_TOOLS}" ` +
                     `--append-system-prompt-file /app/skill.md`,
@@ -236,6 +294,23 @@ async function runOne(
             buildPasses = false;
         }
         result.rules['build-passes'] = buildPasses;
+
+        // Download the built assets for the local render gate.
+        if (buildPasses) {
+            await sandbox.commands.run('tar -cf /tmp/dist.tar -C /app/dist .', {
+                timeoutMs: 30_000,
+            });
+            const distBytes = await sandbox.files.read('/tmp/dist.tar', {
+                format: 'bytes',
+            });
+            const distDir = path.join(config.outDir, 'dist', cell);
+            fs.mkdirSync(distDir, { recursive: true });
+            fs.writeFileSync(
+                path.join(distDir, 'dist.tar'),
+                Buffer.from(distBytes),
+            );
+            execSync('tar -xf dist.tar && rm dist.tar', { cwd: distDir });
+        }
 
         // Download the generated source for the mechanical gates.
         await sandbox.commands.run('tar -cf /tmp/src.tar -C /app src', {
@@ -286,7 +361,7 @@ function summarize(results: RunResult[], config: Config): string {
     const failed = results.filter((r) => r.error !== null);
 
     for (const variant of config.variants) {
-        lines.push(`\n=== ${variant.name} (${variant.templateRef}) ===`);
+        lines.push(`\n=== ${variant.name} (${describeVariant(variant)}) ===`);
         const rows = ok.filter((r) => r.variant === variant.name);
 
         lines.push(
@@ -427,6 +502,10 @@ async function main() {
     );
     console.log(`Output: ${config.outDir}\n`);
     fs.mkdirSync(config.outDir, { recursive: true });
+    fs.writeFileSync(
+        path.join(config.outDir, 'config.json'),
+        JSON.stringify(config, null, 2),
+    );
 
     // Simple concurrency pool.
     const results: RunResult[] = [];
@@ -454,6 +533,28 @@ async function main() {
     );
     await Promise.all(workers);
 
+    // Render gate: run every built app under the local mock host and fold
+    // the runtime rules (renders-clean, query validity) into the rubric.
+    console.log('\nRendering built apps through the mock host…');
+    try {
+        const rendered = await renderRun(config.outDir, {
+            concurrency: Math.min(4, config.concurrency),
+        });
+        for (const result of results) {
+            const render =
+                rendered[
+                    `${result.variant}__${result.promptId}__r${result.rep}`
+                ];
+            if (render) Object.assign(result.rules, render.rules);
+        }
+    } catch (err) {
+        console.error(
+            `Render gate failed (rules skipped): ${
+                err instanceof Error ? err.message : String(err)
+            }`,
+        );
+    }
+
     fs.writeFileSync(
         path.join(config.outDir, 'results.json'),
         JSON.stringify(results, null, 2),
@@ -461,6 +562,7 @@ async function main() {
     const summary = summarize(results, config);
     fs.writeFileSync(path.join(config.outDir, 'summary.txt'), summary);
     console.log(summary);
+    console.log(`\nGallery: ${writeGallery(config.outDir)}`);
 }
 
 await main();

--- a/sandboxes/data-apps/package.json
+++ b/sandboxes/data-apps/package.json
@@ -4,10 +4,16 @@
     "scripts": {
         "build": "tsx build-sandbox.ts",
         "test": "tsx test-generate.ts",
-        "bench": "tsx benchmark/run.ts"
+        "bench": "tsx benchmark/run.ts",
+        "bench:render": "tsx benchmark/renderGate.ts",
+        "bench:gallery": "tsx benchmark/gallery.ts"
     },
     "dependencies": {
         "e2b": "2.15.0",
         "tsx": "4.0.0"
+    },
+    "devDependencies": {
+        "playwright": "1.57.0",
+        "yaml": "2.8.2"
     }
 }

--- a/sandboxes/data-apps/pnpm-lock.yaml
+++ b/sandboxes/data-apps/pnpm-lock.yaml
@@ -14,6 +14,13 @@ importers:
       tsx:
         specifier: 4.0.0
         version: 4.0.0
+    devDependencies:
+      playwright:
+        specifier: 1.57.0
+        version: 1.57.0
+      yaml:
+        specifier: 2.8.2
+        version: 2.8.2
 
 packages:
 
@@ -213,6 +220,11 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -270,6 +282,16 @@ packages:
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
+  playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.57.0:
+    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -315,6 +337,11 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
 snapshots:
 
@@ -469,6 +496,9 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -520,6 +550,14 @@ snapshots:
 
   platform@1.3.6: {}
 
+  playwright-core@1.57.0: {}
+
+  playwright@1.57.0:
+    dependencies:
+      playwright-core: 1.57.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
   resolve-pkg-maps@1.0.0: {}
 
   shebang-command@2.0.0:
@@ -562,3 +600,5 @@ snapshots:
       isexe: 2.0.0
 
   yallist@5.0.0: {}
+
+  yaml@2.8.2: {}


### PR DESCRIPTION
## Summary

Extends the data-app skill benchmark (`sandboxes/data-apps/benchmark/`) so we can re-evaluate reasoning-effort defaults for data-app generation with both speed *and* quality signals.

### Per-variant reasoning effort

`--variant` now accepts options after the template ref:

```bash
pnpm bench \
    --variant high=lightdash-data-app,effort=high \
    --variant medium=lightdash-data-app,effort=medium \
    --variant low=lightdash-data-app,effort=low \
    --reps 1
```

- `effort=<low|medium|high|xhigh|max>` is passed as `--effort` to the Claude CLI. Values are validated locally because the CLI warns-and-ignores unknown values, which would silently benchmark the default on real sandbox spend.
- `env.KEY=VAL` injects arbitrary sandbox env (e.g. `CLAUDE_CODE_EFFORT_LEVEL`).
- A bare variant still runs the exact production invocation (no flag → model default effort), so the baseline stays honest.
- Each run persists `config.json` with the resolved variant specs.

### Runtime render gate

Previously nothing ever *ran* the generated apps — `pnpm build` passing was the only quality gate. Now every built app is loaded in headless Chromium under a mock Lightdash host: a harness page embeds the app's `dist/` in an iframe and answers the query-sdk postMessage protocol with deterministic rows synthesized from the fixture catalog (category values parsed from column descriptions, format-aware metrics, seeded by query content so identical queries return identical data across variants).

This folds three new rules into the rubric:

- `renders-clean` — no uncaught errors, no ErrorBoundary/fatal-handler trip, non-empty root
- `made-metric-queries` — the app actually queried data
- `queries-valid-fields` — every issued query references a real explore and real catalog fields (hallucinated field names are now a hard fail)

Per-cell diagnostics (every query issued, console/page errors) land in `render/<cell>.json`, plus a full-height screenshot per run.

### Blinded gallery

Each run now emits `gallery.html`: one row per prompt×rep, variant screenshots side by side in deterministically-shuffled order with blinded labels, click-to-vote (persisted in localStorage), and a "Reveal variants" toggle with a per-variant win tally — for the subjective half (layout, chart choice, polish) that mechanical rules can't judge.

`pnpm bench:render <runDir>` / `pnpm bench:gallery <runDir>` re-process existing runs. One-time setup: `npx playwright install chromium`.

## Testing

- Validated the mock host against real generated apps (built two cells from a prior run locally): queries flow, apps render with plausible data, all rules and diagnostics populate.
- Full 3-variant × 6-prompt live run completed end to end (18/18 cells built, rendered clean, and issued valid queries) with the gallery used for review.

Relates: GLITCH-518

🤖 Generated with [Claude Code](https://claude.com/claude-code)