### PR TITLE
fix(homepage): resolver tolerates configs from other code versions

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.test.ts
@@ -741,3 +741,54 @@ describe('page grid — exact-fit densening', () => {
         expect(rows[0].columns[0].itemSpan).toBe(6);
     });
 });
+
+// Config is persisted data: a newer builder can store shapes this bundle has
+// never seen (a rolling deploy serves old bundles against new configs). The
+// resolver must degrade, never throw — this reproduces the crash a
+// feed-driven announcements config ({ title } with no items) caused on a
+// bundle that expected items.
+describe('tolerates configs from other code versions', () => {
+    it('renders a config whose block configs miss expected fields', () => {
+        const foreign = JSON.parse(
+            JSON.stringify({
+                version: 1,
+                rows: [
+                    {
+                        id: 'r0',
+                        blocks: [
+                            {
+                                id: 'a',
+                                type: 'announcements',
+                                config: { title: 'News' },
+                            },
+                        ],
+                    },
+                    {
+                        id: 'r1',
+                        blocks: [
+                            {
+                                id: 'c',
+                                type: 'collection',
+                                config: { title: 'T' },
+                            },
+                        ],
+                    },
+                    {
+                        id: 'r2',
+                        blocks: [
+                            { id: 'q', type: 'quick-actions', config: {} },
+                        ],
+                    },
+                    {
+                        id: 'r3',
+                        blocks: [{ id: 'm', type: 'markdown', config: {} }],
+                    },
+                ],
+            }),
+        ) as HomepageConfig;
+        expect(() => resolveHomepageLayout(foreign)).not.toThrow();
+        const { rows } = resolveHomepageLayout(foreign);
+        // field-less blocks read as empty and drop out instead of crashing
+        expect(rows).toEqual([]);
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/resolveHomepageLayout.ts
@@ -82,7 +82,9 @@ const isLeadingHero = (blocks: HomepageBlock[]): boolean =>
     blocks.length === 1 && LEADING_HERO_TYPES.includes(blocks[0].type);
 
 // Blocks whose config makes them provably render nothing (their Views return
-// null). The layout reasons about what will actually paint: an invisible block
+// null). Config is persisted data that crosses code versions in both
+// directions during rolling deploys — reads tolerate missing fields rather
+// than trusting the current schema. The layout reasons about what will actually paint: an invisible block
 // must not demote the hero, leave a phantom row gap, or hold a ghost column.
 const isConfigEmptyBlock = (block: HomepageBlock): boolean => {
     switch (block.type) {
@@ -90,11 +92,11 @@ const isConfigEmptyBlock = (block: HomepageBlock): boolean => {
         case 'collection':
         case 'resources':
         case 'metrics':
-            return block.config.items.length === 0;
+            return (block.config.items?.length ?? 0) === 0;
         case 'quick-actions':
-            return block.config.actions.length === 0;
+            return (block.config.actions?.length ?? 0) === 0;
         case 'markdown':
-            return block.config.content.trim() === '';
+            return (block.config.content ?? '').trim() === '';
         // Visibility depends on runtime data (viewer, AI availability), not
         // config — always treat as visible.
         case 'ask-ai-hero':
@@ -120,7 +122,7 @@ const toVisibleRows = (rows: HomepageConfig['rows']): HomepageConfig['rows'] =>
 // the row with — so weight follows actual item count, not just block type.
 const columnWeightFor = (block: HomepageBlock): number => {
     if (block.type === 'collection') {
-        return block.config.items.length >= 3 ? 2 : 1;
+        return (block.config.items?.length ?? 0) >= 3 ? 2 : 1;
     }
     return traitFor(block.type).columnWeight;
 };
@@ -133,9 +135,9 @@ const clampUnits = (count: number, max: 1 | 2 | 3 | 4): 1 | 2 | 3 | 4 => {
 const hugUnitsFor = (block: HomepageBlock): ResolvedColumn['hugUnits'] => {
     switch (block.type) {
         case 'metrics':
-            return clampUnits(block.config.items.length, 4);
+            return clampUnits(block.config.items?.length ?? 0, 4);
         case 'collection':
-            return clampUnits(block.config.items.length, 3);
+            return clampUnits(block.config.items?.length ?? 0, 3);
         // Resources render as a self-sizing list/media grid — natural width.
         case 'resources':
         case 'announcements':
@@ -156,7 +158,7 @@ const gridItemCountFor = (block: HomepageBlock): number => {
         case 'metrics':
         case 'collection':
         case 'resources':
-            return block.config.items.length;
+            return block.config.items?.length ?? 0;
         default:
             return 0;
     }


### PR DESCRIPTION
## Problem

Homepage configs are persisted data and cross code versions in both directions during a rolling deploy. `resolveHomepageLayout` read `block.config.items.length` (and `actions` / `content`) as if the current schema were guaranteed. A config authored by a newer builder — concretely, #25741's feed-driven announcements shape `{ title }` with no `items` — crashes the published homepage into the error boundary for **every viewer** of that project on any bundle built before the schema change. Reproduced on a dev environment mixing a branch-authored config with a main-built bundle.

## Fix

Every config read tolerates missing fields (`?.length ?? 0`, `?? ''`): shapeless blocks read as empty and drop out of the layout instead of throwing. No behaviour change for well-formed configs.

## Regression analysis

Affects only HomepageBuilder-flagged projects (flag-off and mobile users render the classic homepage and never reach this code). Well-formed configs resolve identically — the change is unreachable for them. This should merge **before** #25740/#25741 so the release preceding the announcements schema change already tolerates it.

## Verification

New resolver test renders a foreign-shaped config end to end (previously threw); 60 resolver tests green; typecheck + oxlint clean.
