### PR TITLE
chore: remove data-apps-scheduled-deliveries feature flag

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -188,14 +188,6 @@ export enum FeatureFlags {
     DashboardFilterRequirements = 'dashboard-filter-requirements',
 
     /**
-     * Gate the "Schedule delivery" entry point for data apps. Disabled by
-     * default while the screenshot pipeline is producing blank pages in
-     * production. Enable per-org once the underlying rendering issue is
-     * fixed.
-     */
-    DataAppsScheduledDeliveries = 'data-apps-scheduled-deliveries',
-
-    /**
      * Show a persistent trial warning banner for an organization on shared
      * instances. This does not block product access.
      */

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -1,8 +1,4 @@
-import {
-    FeatureFlags,
-    getAppDisplayName,
-    type AppVersionStatus,
-} from '@lightdash/common';
+import { getAppDisplayName, type AppVersionStatus } from '@lightdash/common';
 import { ActionIcon, Menu, Tooltip } from '@mantine-8/core';
 import {
     IconArrowsUpDown,
@@ -23,7 +19,6 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import AppDeleteModal from '../../../components/common/modal/AppDeleteModal';
 import AppUpdateModal from '../../../components/common/modal/AppUpdateModal';
 import { useProject } from '../../../hooks/useProject';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { AppSchedulersModal } from '../../scheduler/components/SchedulerModals';
 import { useCanCreateDataApp } from '../hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../hooks/useCanEditDataApp';
@@ -100,10 +95,6 @@ const AppHeaderActions: FC<Props> = ({
     // Duplicating forks the app into the user's own personal app, so it only
     // needs `create:DataApp` — not manage rights on this app.
     const canDuplicate = useCanCreateDataApp(projectUuid);
-
-    const scheduledDeliveriesFlag = useServerFeatureFlag(
-        FeatureFlags.DataAppsScheduledDeliveries,
-    );
 
     // Promotion is only offered from a preview project linked to an upstream.
     const { data: project } = useProject(projectUuid);
@@ -187,7 +178,7 @@ const AppHeaderActions: FC<Props> = ({
                     >
                         View network
                     </Menu.Item>
-                    {canEdit && scheduledDeliveriesFlag.data?.enabled && (
+                    {canEdit && (
                         <Menu.Item
                             leftSection={
                                 <MantineIcon icon={IconSend} size={14} />


### PR DESCRIPTION
Removes the `data-apps-scheduled-deliveries` feature flag, making the **Schedule delivery** entry point for data apps always available to app editors.

The flag existed to hold the feature back while the screenshot pipeline was producing blank pages in production; that gating is no longer needed. The only usages were the enum entry in `packages/common/src/types/featureFlags.ts` and the menu-item gate in `AppHeaderActions.tsx` — no backend checks, no PostHog defaults, no other references.

After this change, the "Schedule delivery" menu item is gated only by app edit rights (`useCanEditDataApp`), matching the other edit actions in the menu.

Closes: GLITCH-626

🤖 Generated with [Claude Code](https://claude.com/claude-code)