### PR TITLE
feat(data-apps): enrich generation telemetry

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -199,6 +199,31 @@ The shared enum + default live in `packages/common/src/ee/apps/types.ts` (`DATA_
 Users can cancel a building version. This atomically marks it as `status='error'` in the database and pauses the sandbox
 (interrupting any running commands). The sandbox remains resumable for subsequent iterations.
 
+### Analytics and generation telemetry
+
+Data App analytics use the app version as the user-facing turn identifier: version 1 is turn 1, version 2 is turn 2,
+and so on. This is distinct from Claude's internal `numTurns`, which counts assistant/tool loops inside the generation.
+
+- `data_app.created` and `data_app.iterated` carry the version plus prompt/workload context (model, prompt and image
+  size, samples, template/clarifications on creation, and theme/design context on iteration).
+- `data_app.version.completed` carries end-to-end and stage durations (`sandboxMs`, `resumeMs`, `restoreMs`, `catalogMs`,
+  `generateMs`, `buildMs`, `metadataMs`, `packageMs`, and `uploadMs`) plus the resolved Claude provider, artifact/catalog
+  sizes, and build-fix counts. `schedulerWaitMs` separately measures how long the Graphile job waited after its scheduled
+  run time before a worker began processing it.
+- Claude usage on a completed version is aggregated across main generation, CLI retries, build-fix calls, and v1 metadata
+  generation. It includes uncached/cache-read/cache-write input tokens, output tokens, internal turns, API duration, cost,
+  main-generation attempt count, time to first token, and the slowest internal turn.
+- `data_app.version.failed` carries the completed stage timings and, when Claude had started, the partial token/cost/turn
+  telemetry incurred before failure. That usage is also emitted to the shared `ai.usage` stream so failed builds are not
+  omitted from spend accounting. Pre-generation failures leave Claude fields absent instead of reporting false zeroes.
+- `data_app.version.cancelled` records the stage and elapsed time at cancellation. It cannot include in-memory Claude
+  usage because cancellation is handled by a separate request while the worker is being interrupted.
+
+The pipeline also creates a `DataApp.generate` OpenTelemetry parent span tagged with app UUID, version, project,
+organization, user, iteration status, scheduler wait, model, and provider. Claude Code request/tool spans nest underneath
+it. Analytics events are the stable source for product dashboards; the OTEL waterfall is the deeper operational view and
+is queried in the configured GCP telemetry backend.
+
 ### Refreshing the preview
 
 A refresh button reloads the iframe to re-execute the app's metric queries against the warehouse, without kicking off a

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1374,7 +1374,11 @@ export type DataAppCreatedEvent = BaseTrack & {
         version: number;
         promptLength: number;
         imageCount: number;
+        template: DataAppTemplate | null;
         claudeModel: DataAppClaudeModel;
+        samplesRequested: number;
+        samplesAvailable: number;
+        clarificationCount: number;
     };
 };
 
@@ -1390,8 +1394,12 @@ export type DataAppIteratedEvent = BaseTrack & {
         promptLength: number;
         imageCount: number;
         claudeModel: DataAppClaudeModel;
+        themeChanged: boolean;
+        designUuid: string | null;
         previousVersionStatus: string | null;
         msSinceLastVersion: number | null;
+        samplesRequested: number;
+        samplesAvailable: number;
     };
 };
 
@@ -1418,6 +1426,8 @@ export type DataAppVersionCompletedEvent = BaseTrack & {
         version: number;
         isIteration: boolean;
         claudeModel: DataAppClaudeModel;
+        claudeProvider: 'anthropic' | 'bedrock';
+        schedulerWaitMs: number;
         wasResumed: boolean;
         totalDurationMs: number;
         sandboxMs?: number;
@@ -1426,14 +1436,15 @@ export type DataAppVersionCompletedEvent = BaseTrack & {
         catalogMs?: number;
         generateMs?: number;
         buildMs?: number;
+        metadataMs?: number;
         packageMs?: number;
         uploadMs?: number;
         buildFixAttempts: number;
         buildFixGenerationMs: number;
         toolCallCount: number;
-        // Token/turn/cost usage summed across every `claude` invocation in the
-        // build (main generation + build-fix re-runs + metadata). Used to
-        // decompose `generateMs` into output volume vs turn count and to
+        // Token/turn/cost usage summed across every `claude` invocation and
+        // retry in the build (main generation + build-fix + metadata). Used
+        // to decompose `generateMs` into output volume vs turn count and to
         // confirm prompt caching is landing (`cacheReadInputTokens > 0`).
         inputTokens: number;
         outputTokens: number;
@@ -1442,10 +1453,11 @@ export type DataAppVersionCompletedEvent = BaseTrack & {
         numTurns: number;
         durationApiMs: number;
         totalCostUsd: number;
-        // Latency shape of the main generation call: time-to-first-token and
-        // the slowest single turn. Captured from the main generation only
-        // (per-call metrics, not summed across build-fix / metadata).
-        timeToFirstTokenMs: number;
+        generationAttemptCount: number;
+        // Latency shape of the logical main generation, including retries:
+        // time-to-first-token and the slowest single turn. Not combined with
+        // build-fix or metadata calls.
+        timeToFirstTokenMs: number | null;
         slowestTurnMs: number;
         catalogTableCount: number;
         catalogDimensionCount: number;
@@ -1466,6 +1478,8 @@ export type DataAppVersionFailedEvent = BaseTrack & {
         version: number;
         isIteration: boolean;
         claudeModel: DataAppClaudeModel;
+        claudeProvider?: 'anthropic' | 'bedrock';
+        schedulerWaitMs?: number;
         failureStage:
             | 'sandbox'
             | 'catalog'
@@ -1478,12 +1492,28 @@ export type DataAppVersionFailedEvent = BaseTrack & {
         errorMessage: string;
         buildFixAttempts: number;
         totalDurationMs: number;
+        wasResumed?: boolean;
         sandboxMs?: number;
         resumeMs?: number;
         restoreMs?: number;
         catalogMs?: number;
         generateMs?: number;
         buildMs?: number;
+        metadataMs?: number;
+        packageMs?: number;
+        uploadMs?: number;
+        buildFixGenerationMs?: number;
+        toolCallCount?: number;
+        inputTokens?: number;
+        outputTokens?: number;
+        cacheReadInputTokens?: number;
+        cacheCreationInputTokens?: number;
+        numTurns?: number;
+        durationApiMs?: number;
+        totalCostUsd?: number;
+        generationAttemptCount?: number;
+        timeToFirstTokenMs?: number | null;
+        slowestTurnMs?: number;
     };
 };
 

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -436,6 +436,10 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                 payload,
                 helpers,
             ) => {
+                const schedulerWaitMs = Math.max(
+                    Date.now() - helpers.job.run_at.getTime(),
+                    0,
+                );
                 await tryJobOrTimeout(
                     SchedulerClient.processJob(
                         EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE,
@@ -443,7 +447,10 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                         helpers.job.run_at,
                         payload,
                         async () => {
-                            await this.appGenerateService.runPipeline(payload);
+                            await this.appGenerateService.runPipeline(
+                                payload,
+                                schedulerWaitMs,
+                            );
                         },
                     ),
                     helpers.job,
@@ -459,6 +466,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                             this.appGenerateService.trackTimeoutFailure(
                                 payload,
                                 e,
+                                schedulerWaitMs,
                             );
                         }
                     },

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -168,9 +168,12 @@ import {
     claudeCodeOtelAllowedHosts,
 } from './claudeCodeOtelEnv';
 import {
+    addClaudeGenerationAttempt,
     addClaudeUsage,
     ClaudeStreamProcessor,
+    ZERO_CLAUDE_GENERATION_TELEMETRY,
     ZERO_CLAUDE_USAGE,
+    type ClaudeGenerationTelemetry,
     type ClaudeGenerationUsage,
 } from './ClaudeStreamProcessor';
 import {
@@ -255,6 +258,25 @@ type GenerateAppOptions = {
 type GenerateAppResult = {
     appUuid: string;
     version: number;
+};
+
+type DataAppVersionFailureTelemetry = {
+    wasResumed?: boolean;
+    claudeProvider?: 'anthropic' | 'bedrock';
+    schedulerWaitMs?: number;
+    generationUsage?: ClaudeGenerationUsage;
+    generationAttemptCount?: number;
+    toolCallCount?: number;
+    timeToFirstTokenMs?: number | null;
+    slowestTurnMs?: number;
+    buildFixGenerationMs?: number;
+};
+
+type DataAppBuildFixTelemetry = {
+    usage: ClaudeGenerationUsage;
+    buildMs: number;
+    fixAttempts: number;
+    fixGenerationMs: number;
 };
 
 // Wall-clock heartbeat to bump status_updated_at while the pipeline is
@@ -1308,8 +1330,49 @@ export class AppGenerateService extends BaseService {
     trackTimeoutFailure(
         payload: AppGeneratePipelineJobPayload,
         error: unknown,
+        schedulerWaitMs?: number,
     ): void {
-        this.trackVersionFailed(payload, 'timeout', error, {}, null, 0);
+        this.trackVersionFailed(payload, 'timeout', error, {}, null, 0, {
+            schedulerWaitMs,
+        });
+    }
+
+    private static emitDataAppAiUsage(
+        payload: AppGeneratePipelineJobPayload,
+        model: DataAppClaudeModel,
+        provider: 'anthropic' | 'bedrock',
+        usage: ClaudeGenerationUsage,
+    ): void {
+        emitAiUsage(
+            getAiCallTelemetry({
+                functionId: 'appClaudeGeneration',
+                feature: 'data-app',
+                organizationUuid: payload.organizationUuid,
+                projectUuid: payload.projectUuid,
+                userUuid: payload.userUuid,
+                model,
+                provider,
+                extra: {
+                    appUuid: payload.appUuid,
+                    appVersion: payload.version,
+                },
+            }),
+            {
+                inputTokens:
+                    usage.inputTokens +
+                    usage.cacheReadInputTokens +
+                    usage.cacheCreationInputTokens,
+                outputTokens: usage.outputTokens,
+                cacheReadTokens: usage.cacheReadInputTokens,
+                cacheWriteTokens: usage.cacheCreationInputTokens,
+                reasoningTokens: null,
+                totalTokens:
+                    usage.inputTokens +
+                    usage.cacheReadInputTokens +
+                    usage.cacheCreationInputTokens +
+                    usage.outputTokens,
+            },
+        );
     }
 
     private trackVersionFailed(
@@ -1327,7 +1390,29 @@ export class AppGenerateService extends BaseService {
         durations: Record<string, number>,
         overallStart: number | null,
         buildFixAttempts: number,
+        telemetry: DataAppVersionFailureTelemetry = {},
     ): void {
+        const { generationUsage } = telemetry;
+        const claudeModel =
+            payload.claudeModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL;
+
+        if (
+            generationUsage &&
+            (generationUsage.inputTokens > 0 ||
+                generationUsage.outputTokens > 0 ||
+                generationUsage.cacheReadInputTokens > 0 ||
+                generationUsage.cacheCreationInputTokens > 0 ||
+                generationUsage.numTurns > 0 ||
+                generationUsage.costUsd > 0)
+        ) {
+            AppGenerateService.emitDataAppAiUsage(
+                payload,
+                claudeModel,
+                telemetry.claudeProvider ?? 'anthropic',
+                generationUsage,
+            );
+        }
+
         this.analytics.track({
             event: 'data_app.version.failed',
             userId: payload.userUuid,
@@ -1337,24 +1422,42 @@ export class AppGenerateService extends BaseService {
                 appUuid: payload.appUuid,
                 version: payload.version,
                 isIteration: payload.isIteration,
-                claudeModel:
-                    payload.claudeModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL,
+                claudeModel,
+                claudeProvider: telemetry.claudeProvider,
+                schedulerWaitMs: telemetry.schedulerWaitMs,
                 failureStage,
                 errorMessage: AppGenerateService.truncateEnd(
                     getErrorMessage(error),
                     500,
                 ),
                 buildFixAttempts,
+                buildFixGenerationMs: telemetry.buildFixGenerationMs,
                 totalDurationMs:
                     overallStart !== null
                         ? AppGenerateService.elapsed(overallStart)
                         : 0,
+                wasResumed: telemetry.wasResumed,
                 sandboxMs: durations.sandboxMs,
                 resumeMs: durations.resumeMs,
                 restoreMs: durations.restoreMs,
                 catalogMs: durations.catalogMs,
                 generateMs: durations.generateMs,
                 buildMs: durations.buildMs,
+                metadataMs: durations.metadataMs,
+                packageMs: durations.packageMs,
+                uploadMs: durations.uploadMs,
+                toolCallCount: telemetry.toolCallCount,
+                inputTokens: generationUsage?.inputTokens,
+                outputTokens: generationUsage?.outputTokens,
+                cacheReadInputTokens: generationUsage?.cacheReadInputTokens,
+                cacheCreationInputTokens:
+                    generationUsage?.cacheCreationInputTokens,
+                numTurns: generationUsage?.numTurns,
+                durationApiMs: generationUsage?.durationApiMs,
+                totalCostUsd: generationUsage?.costUsd,
+                generationAttemptCount: telemetry.generationAttemptCount,
+                timeToFirstTokenMs: telemetry.timeToFirstTokenMs,
+                slowestTurnMs: telemetry.slowestTurnMs,
             },
         });
     }
@@ -2270,16 +2373,19 @@ export class AppGenerateService extends BaseService {
         // failure) and emits the parsed object on the result event. `null`
         // for runs that don't collect a structured schema (metadata, builds).
         structuredOutputSchema: string | null,
+        onTelemetry?: (telemetry: ClaudeGenerationTelemetry) => void,
     ): Promise<{
         durationMs: number;
         responseText: string | null;
         structuredOutput: unknown;
         toolCallCount: number;
-        usage: ClaudeGenerationUsage | null;
+        usage: ClaudeGenerationUsage;
         timeToFirstTokenMs: number | null;
         turnDurationsMs: number[];
+        generationAttemptCount: number;
     }> {
         const start = performance.now();
+        let telemetry = ZERO_CLAUDE_GENERATION_TELEMETRY;
 
         if (structuredOutputSchema) {
             // A resumed sandbox may still hold a root-owned
@@ -2318,10 +2424,12 @@ export class AppGenerateService extends BaseService {
             responseText: string | null;
             structuredOutput: unknown;
             toolCallCount: number;
-            usage: ClaudeGenerationUsage | null;
+            usage: ClaudeGenerationUsage;
             timeToFirstTokenMs: number | null;
             turnDurationsMs: number[];
+            generationAttemptCount: number;
         }> => {
+            const attemptStartedAfterMs = AppGenerateService.elapsed(start);
             const sessionFlags =
                 continueSession || forceContinue ? '--continue -p' : '-p';
             const processor = new ClaudeStreamProcessor();
@@ -2419,6 +2527,17 @@ export class AppGenerateService extends BaseService {
             const toolCallCount = processor.totalToolCalls;
             const usage = processor.lastUsage;
             const { timeToFirstTokenMs, turnDurationsMs } = processor;
+            telemetry = addClaudeGenerationAttempt(
+                telemetry,
+                {
+                    usage,
+                    toolCallCount,
+                    timeToFirstTokenMs,
+                    turnDurationsMs,
+                },
+                attemptStartedAfterMs,
+            );
+            onTelemetry?.(telemetry);
             const durationMs = AppGenerateService.elapsed(start);
             this.logger.info(
                 `App ${appUuid}: Claude code generation completed (model=${claudeModel}, exit=${result.exitCode}, toolCalls=${toolCallCount}, turns=${usage?.numTurns ?? 0}, outputTokens=${usage?.outputTokens ?? 0}, cacheReadTokens=${usage?.cacheReadInputTokens ?? 0}, ${durationMs}ms, attempt ${attempt}/${AppGenerateService.MAX_GENERATION_ATTEMPTS})`,
@@ -2437,10 +2556,11 @@ export class AppGenerateService extends BaseService {
                     durationMs,
                     responseText,
                     structuredOutput,
-                    toolCallCount,
-                    usage,
-                    timeToFirstTokenMs,
-                    turnDurationsMs,
+                    toolCallCount: telemetry.toolCallCount,
+                    usage: telemetry.usage,
+                    timeToFirstTokenMs: telemetry.timeToFirstTokenMs,
+                    turnDurationsMs: telemetry.turnDurationsMs,
+                    generationAttemptCount: telemetry.attemptCount,
                 };
             }
 
@@ -2534,12 +2654,13 @@ export class AppGenerateService extends BaseService {
         version: number,
         claudeCodeEnv: Record<string, string>,
         claudeModel: DataAppClaudeModel,
+        onTelemetry?: (telemetry: ClaudeGenerationTelemetry) => void,
     ): Promise<{
-        name: string;
+        name: string | null;
         description: string;
         durationMs: number;
-        usage: ClaudeGenerationUsage | null;
-    } | null> {
+        usage: ClaudeGenerationUsage;
+    }> {
         const start = performance.now();
         const metadataPrompt =
             'Respond with ONLY a JSON object (no markdown, no explanation) ' +
@@ -2560,6 +2681,7 @@ export class AppGenerateService extends BaseService {
             claudeCodeEnv,
             claudeModel,
             null, // metadata run collects no structured schema
+            onTelemetry,
         );
 
         const durationMs = AppGenerateService.elapsed(start);
@@ -2568,7 +2690,12 @@ export class AppGenerateService extends BaseService {
             this.logger.warn(
                 `App ${appUuid}: metadata generation returned no text`,
             );
-            return null;
+            return {
+                name: null,
+                description: '',
+                durationMs,
+                usage: generation.usage,
+            };
         }
 
         // Extract JSON from the response (Claude may wrap it in markdown code fences)
@@ -2577,7 +2704,12 @@ export class AppGenerateService extends BaseService {
             this.logger.warn(
                 `App ${appUuid}: could not find JSON in metadata response`,
             );
-            return null;
+            return {
+                name: null,
+                description: '',
+                durationMs,
+                usage: generation.usage,
+            };
         }
 
         try {
@@ -2595,7 +2727,12 @@ export class AppGenerateService extends BaseService {
                 this.logger.warn(
                     `App ${appUuid}: metadata missing "name" field`,
                 );
-                return null;
+                return {
+                    name: null,
+                    description: description ?? '',
+                    durationMs,
+                    usage: generation.usage,
+                };
             }
             return {
                 name,
@@ -2610,7 +2747,12 @@ export class AppGenerateService extends BaseService {
             this.logger.warn(
                 `App ${appUuid}: failed to parse metadata JSON: ${safeLog}`,
             );
-            return null;
+            return {
+                name: null,
+                description: '',
+                durationMs,
+                usage: generation.usage,
+            };
         }
     }
 
@@ -2686,6 +2828,7 @@ export class AppGenerateService extends BaseService {
         version: number,
         claudeCodeEnv: Record<string, string>,
         claudeModel: DataAppClaudeModel,
+        onTelemetry?: (telemetry: DataAppBuildFixTelemetry) => void,
     ): Promise<{
         buildMs: number;
         fixAttempts: number;
@@ -2718,6 +2861,12 @@ export class AppGenerateService extends BaseService {
             // to decide whether to keep retrying.
             /* eslint-disable no-await-in-loop */
             fixAttempts += 1;
+            onTelemetry?.({
+                usage: fixUsage,
+                buildMs,
+                fixAttempts,
+                fixGenerationMs,
+            });
 
             const isBuildError = lastResult.exitCode !== 0;
 
@@ -2768,6 +2917,11 @@ export class AppGenerateService extends BaseService {
             );
             await sandbox.files.write('/tmp/prompt.txt', `${fixPrompt}\n`);
 
+            const fixStart = performance.now();
+            const fixUsageBeforeAttempt = fixUsage;
+            const buildMsBeforeAttempt = buildMs;
+            const currentFixAttempt = fixAttempts;
+            const fixGenerationMsBeforeAttempt = fixGenerationMs;
             const generation = await this.runClaudeGeneration(
                 sandbox,
                 appUuid,
@@ -2776,6 +2930,19 @@ export class AppGenerateService extends BaseService {
                 claudeCodeEnv,
                 claudeModel,
                 null, // build-fix run collects no structured schema
+                (telemetry) => {
+                    onTelemetry?.({
+                        usage: addClaudeUsage(
+                            fixUsageBeforeAttempt,
+                            telemetry.usage,
+                        ),
+                        buildMs: buildMsBeforeAttempt,
+                        fixAttempts: currentFixAttempt,
+                        fixGenerationMs:
+                            fixGenerationMsBeforeAttempt +
+                            AppGenerateService.elapsed(fixStart),
+                    });
+                },
             );
             fixGenerationMs += generation.durationMs;
             fixUsage = addClaudeUsage(fixUsage, generation.usage);
@@ -2794,6 +2961,12 @@ export class AppGenerateService extends BaseService {
 
             lastResult = await this.runBuild(sandbox, appUuid);
             buildMs += lastResult.durationMs;
+            onTelemetry?.({
+                usage: fixUsage,
+                buildMs,
+                fixAttempts,
+                fixGenerationMs,
+            });
             blankAppProblem =
                 lastResult.exitCode === 0
                     ? await this.detectBlankApp(sandbox, appUuid)
@@ -2989,7 +3162,10 @@ export class AppGenerateService extends BaseService {
      * On retry after pod death, reads current status from DB and skips
      * completed stages. `claude --continue` resumes the conversation.
      */
-    async runPipeline(payload: AppGeneratePipelineJobPayload): Promise<void> {
+    async runPipeline(
+        payload: AppGeneratePipelineJobPayload,
+        schedulerWaitMs: number,
+    ): Promise<void> {
         const {
             appUuid,
             version,
@@ -3037,7 +3213,9 @@ export class AppGenerateService extends BaseService {
                 userMessage,
             );
             if (marked) {
-                this.trackVersionFailed(payload, 'config', error, {}, null, 0);
+                this.trackVersionFailed(payload, 'config', error, {}, null, 0, {
+                    schedulerWaitMs,
+                });
             }
             return;
         }
@@ -3123,6 +3301,7 @@ export class AppGenerateService extends BaseService {
                         durations,
                         overallStart,
                         0,
+                        { schedulerWaitMs },
                     );
                 }
                 return;
@@ -3148,6 +3327,7 @@ export class AppGenerateService extends BaseService {
                         durations,
                         overallStart,
                         0,
+                        { schedulerWaitMs },
                     );
                 }
                 return;
@@ -3178,6 +3358,7 @@ export class AppGenerateService extends BaseService {
                         durations,
                         overallStart,
                         0,
+                        { schedulerWaitMs },
                     );
                 }
                 return;
@@ -3215,6 +3396,14 @@ export class AppGenerateService extends BaseService {
                         'organization.uuid': payload.organizationUuid,
                         'user.uuid': payload.userUuid,
                         'app.is_iteration': isIteration,
+                        'app.scheduler_wait_ms': schedulerWaitMs,
+                        'app.claude_model':
+                            payload.claudeModel ??
+                            DEFAULT_DATA_APP_CLAUDE_MODEL,
+                        'app.claude_provider':
+                            claudeCodeEnv.CLAUDE_CODE_USE_BEDROCK === '1'
+                                ? 'bedrock'
+                                : 'anthropic',
                         ...(process.env.LIGHTDASH_INSTALL_ID
                             ? { installId: process.env.LIGHTDASH_INSTALL_ID }
                             : {}),
@@ -3238,6 +3427,7 @@ export class AppGenerateService extends BaseService {
                         imageIds,
                         chartReferences,
                         versionDeps,
+                        schedulerWaitMs,
                     );
                 },
             );
@@ -3260,6 +3450,7 @@ export class AppGenerateService extends BaseService {
         imageIds: string[] | undefined,
         chartReferences: ChartReference[] | undefined,
         versionDeps: AppVersionDependencies | null,
+        schedulerWaitMs: number,
     ): Promise<void> {
         const { appUuid, version, projectUuid, prompt, template } = payload;
         // Drives the data-app-viz prompt instructions + schema collection.
@@ -3273,6 +3464,10 @@ export class AppGenerateService extends BaseService {
         // to the default so we never run with `--model undefined`.
         const claudeModel: DataAppClaudeModel =
             payload.claudeModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL;
+        const claudeProvider: 'anthropic' | 'bedrock' =
+            claudeCodeEnv.CLAUDE_CODE_USE_BEDROCK === '1'
+                ? 'bedrock'
+                : 'anthropic';
         const durations: Record<string, number> = { ...extraDurations };
         const shouldRun = (stage: AppVersionStatus) =>
             AppGenerateService.shouldRunStage(currentStatus, stage);
@@ -3299,12 +3494,24 @@ export class AppGenerateService extends BaseService {
                 this.logger.warn(
                     `App ${appUuid}: theme ${payload.designUuid} exceeds the size cap at build time (${violation.bytes} > ${violation.limit} bytes); failing fast — ${message}`,
                 );
-                await this.markError(
+                const themeError = new Error(message);
+                const marked = await this.markError(
                     appUuid,
                     version,
-                    new Error(message),
+                    themeError,
                     message,
                 );
+                if (marked) {
+                    this.trackVersionFailed(
+                        payload,
+                        'config',
+                        themeError,
+                        durations,
+                        overallStart,
+                        0,
+                        { wasResumed, claudeProvider, schedulerWaitMs },
+                    );
+                }
                 return;
             }
         }
@@ -3340,6 +3547,33 @@ export class AppGenerateService extends BaseService {
         // sum across the build-fix and metadata calls).
         let timeToFirstTokenMs: number | null = null;
         let slowestTurnMs = 0;
+        let generationAttemptCount = 0;
+        const captureMainGenerationTelemetry = (
+            telemetry: ClaudeGenerationTelemetry,
+        ) => {
+            generationUsage = telemetry.usage;
+            toolCallCount = telemetry.toolCallCount;
+            timeToFirstTokenMs = telemetry.timeToFirstTokenMs;
+            slowestTurnMs = telemetry.turnDurationsMs.length
+                ? Math.max(...telemetry.turnDurationsMs)
+                : 0;
+            generationAttemptCount = telemetry.attemptCount;
+        };
+        const failureTelemetry = (): DataAppVersionFailureTelemetry => ({
+            wasResumed,
+            claudeProvider,
+            schedulerWaitMs,
+            buildFixGenerationMs,
+            ...(generationAttemptCount > 0
+                ? {
+                      generationUsage,
+                      generationAttemptCount,
+                      toolCallCount,
+                      timeToFirstTokenMs,
+                      slowestTurnMs,
+                  }
+                : {}),
+        });
 
         // --- Stage: catalog ---
         if (shouldRun('catalog')) {
@@ -3391,6 +3625,7 @@ export class AppGenerateService extends BaseService {
                         durations,
                         overallStart,
                         buildFixAttempts,
+                        failureTelemetry(),
                     );
                 }
                 return;
@@ -3404,6 +3639,7 @@ export class AppGenerateService extends BaseService {
         // generating stage is skipped on a resumed build).
         let vizStructuredOutput: unknown = null;
         if (shouldRun('generating')) {
+            const generationStart = performance.now();
             try {
                 const advanced = await this.advanceStage(
                     appUuid,
@@ -3429,20 +3665,22 @@ export class AppGenerateService extends BaseService {
                     // Data app vizs collect a validated schema as the run's
                     // structured output; other apps don't declare one.
                     isDataAppViz ? JSON.stringify(dataAppVizJsonSchema) : null,
+                    captureMainGenerationTelemetry,
                 );
                 durations.generateMs = generation.durationMs;
                 responseText = generation.responseText;
                 vizStructuredOutput = generation.structuredOutput;
                 toolCallCount = generation.toolCallCount;
-                generationUsage = addClaudeUsage(
-                    generationUsage,
-                    generation.usage,
-                );
+                generationUsage = generation.usage;
                 timeToFirstTokenMs = generation.timeToFirstTokenMs;
                 slowestTurnMs = generation.turnDurationsMs.length
                     ? Math.max(...generation.turnDurationsMs)
                     : 0;
+                generationAttemptCount = generation.generationAttemptCount;
             } catch (error) {
+                durations.generateMs =
+                    durations.generateMs ??
+                    AppGenerateService.elapsed(generationStart);
                 const totalMs = AppGenerateService.elapsed(overallStart);
                 this.logger.error(
                     `App ${appUuid}: generation failed after ${totalMs}ms: ${getErrorMessage(error)}`,
@@ -3476,6 +3714,7 @@ export class AppGenerateService extends BaseService {
                         durations,
                         overallStart,
                         buildFixAttempts,
+                        failureTelemetry(),
                     );
                 }
                 return;
@@ -3543,6 +3782,7 @@ export class AppGenerateService extends BaseService {
                                 durations,
                                 overallStart,
                                 buildFixAttempts,
+                                failureTelemetry(),
                             );
                         }
                         return;
@@ -3560,18 +3800,28 @@ export class AppGenerateService extends BaseService {
                     }
                 }
 
+                const usageBeforeBuildFix = generationUsage;
                 const buildResult = await this.runBuildWithAutoFix(
                     sandbox,
                     appUuid,
                     version,
                     claudeCodeEnv,
                     claudeModel,
+                    (telemetry) => {
+                        durations.buildMs = telemetry.buildMs;
+                        buildFixAttempts = telemetry.fixAttempts;
+                        buildFixGenerationMs = telemetry.fixGenerationMs;
+                        generationUsage = addClaudeUsage(
+                            usageBeforeBuildFix,
+                            telemetry.usage,
+                        );
+                    },
                 );
                 durations.buildMs = buildResult.buildMs;
                 buildFixAttempts = buildResult.fixAttempts;
                 buildFixGenerationMs = buildResult.fixGenerationMs;
                 generationUsage = addClaudeUsage(
-                    generationUsage,
+                    usageBeforeBuildFix,
                     buildResult.fixUsage,
                 );
                 if (buildResult.fixAttempts > 0) {
@@ -3597,6 +3847,7 @@ export class AppGenerateService extends BaseService {
                         durations,
                         overallStart,
                         buildFixAttempts,
+                        failureTelemetry(),
                     );
                 }
                 return;
@@ -3605,6 +3856,8 @@ export class AppGenerateService extends BaseService {
 
         // --- Auto-name: first version only ---
         if (version === 1) {
+            const metadataStart = performance.now();
+            let metadataUsage = ZERO_CLAUDE_USAGE;
             try {
                 const metadata = await this.generateAppMetadata(
                     sandbox,
@@ -3612,8 +3865,16 @@ export class AppGenerateService extends BaseService {
                     version,
                     claudeCodeEnv,
                     claudeModel,
+                    (telemetry) => {
+                        metadataUsage = telemetry.usage;
+                    },
                 );
-                if (metadata) {
+                durations.metadataMs = metadata.durationMs;
+                generationUsage = addClaudeUsage(
+                    generationUsage,
+                    metadata.usage,
+                );
+                if (metadata.name) {
                     // Only fills fields the user hasn't already set — the
                     // build is async, so by the time we get here the user
                     // may have renamed the app themselves.
@@ -3628,13 +3889,14 @@ export class AppGenerateService extends BaseService {
                     this.logger.info(
                         `App ${appUuid}: auto-named "${metadata.name}"`,
                     );
-                    durations.metadataMs = metadata.durationMs;
-                    generationUsage = addClaudeUsage(
-                        generationUsage,
-                        metadata.usage,
-                    );
                 }
             } catch (error) {
+                durations.metadataMs =
+                    AppGenerateService.elapsed(metadataStart);
+                generationUsage = addClaudeUsage(
+                    generationUsage,
+                    metadataUsage,
+                );
                 // Non-fatal — the app works fine without a name
                 this.logger.warn(
                     `App ${appUuid}: failed to auto-generate name: ${getErrorMessage(error)}`,
@@ -3686,6 +3948,7 @@ export class AppGenerateService extends BaseService {
                         durations,
                         overallStart,
                         buildFixAttempts,
+                        failureTelemetry(),
                     );
                 }
                 return;
@@ -3732,6 +3995,7 @@ export class AppGenerateService extends BaseService {
                     durations,
                     overallStart,
                     buildFixAttempts,
+                    failureTelemetry(),
                 );
             }
             return;
@@ -3745,39 +4009,17 @@ export class AppGenerateService extends BaseService {
                 .map(([k, v]) => `${k}=${v}ms`)
                 .join(
                     ', ',
-                )}, numTurns=${generationUsage.numTurns}, inputTokens=${generationUsage.inputTokens}, outputTokens=${generationUsage.outputTokens}, cacheReadTokens=${generationUsage.cacheReadInputTokens}, cacheCreationTokens=${generationUsage.cacheCreationInputTokens}, costUsd=${generationUsage.costUsd})`,
+                )}, generationAttempts=${generationAttemptCount}, numTurns=${generationUsage.numTurns}, inputTokens=${generationUsage.inputTokens}, outputTokens=${generationUsage.outputTokens}, cacheReadTokens=${generationUsage.cacheReadInputTokens}, cacheCreationTokens=${generationUsage.cacheCreationInputTokens}, costUsd=${generationUsage.costUsd})`,
         );
 
         // Aggregated across every `claude` CLI invocation in the pipeline. The
-        // CLI reports inputTokens excluding cache reads/writes, but AI-SDK rows
-        // store cache-inclusive inputTokens — normalize to SDK semantics here so
-        // `SUM(input_tokens)` (and cost) is comparable across every feature.
-        emitAiUsage(
-            getAiCallTelemetry({
-                functionId: 'appClaudeGeneration',
-                feature: 'data-app',
-                organizationUuid: payload.organizationUuid,
-                projectUuid,
-                userUuid: payload.userUuid,
-                model: claudeModel,
-                provider: 'anthropic',
-                extra: { appUuid },
-            }),
-            {
-                inputTokens:
-                    generationUsage.inputTokens +
-                    generationUsage.cacheReadInputTokens +
-                    generationUsage.cacheCreationInputTokens,
-                outputTokens: generationUsage.outputTokens,
-                cacheReadTokens: generationUsage.cacheReadInputTokens,
-                cacheWriteTokens: generationUsage.cacheCreationInputTokens,
-                reasoningTokens: null,
-                totalTokens:
-                    generationUsage.inputTokens +
-                    generationUsage.cacheReadInputTokens +
-                    generationUsage.cacheCreationInputTokens +
-                    generationUsage.outputTokens,
-            },
+        // helper normalizes CLI input-token semantics to the cache-inclusive AI
+        // usage stream and stamps the app/version onto the accompanying span.
+        AppGenerateService.emitDataAppAiUsage(
+            payload,
+            claudeModel,
+            claudeProvider,
+            generationUsage,
         );
 
         this.analytics.track({
@@ -3790,6 +4032,8 @@ export class AppGenerateService extends BaseService {
                 version,
                 isIteration: payload.isIteration,
                 claudeModel,
+                claudeProvider,
+                schedulerWaitMs,
                 wasResumed,
                 totalDurationMs: totalMs,
                 sandboxMs: durations.sandboxMs,
@@ -3798,6 +4042,7 @@ export class AppGenerateService extends BaseService {
                 catalogMs: durations.catalogMs,
                 generateMs: durations.generateMs,
                 buildMs: durations.buildMs,
+                metadataMs: durations.metadataMs,
                 packageMs: durations.packageMs,
                 uploadMs: durations.uploadMs,
                 buildFixAttempts,
@@ -3811,7 +4056,8 @@ export class AppGenerateService extends BaseService {
                 numTurns: generationUsage.numTurns,
                 durationApiMs: generationUsage.durationApiMs,
                 totalCostUsd: generationUsage.costUsd,
-                timeToFirstTokenMs: timeToFirstTokenMs ?? 0,
+                generationAttemptCount,
+                timeToFirstTokenMs,
                 slowestTurnMs,
                 catalogTableCount: catalogStats.tableCount,
                 catalogDimensionCount: catalogStats.dimensionCount,

--- a/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.test.ts
@@ -1,6 +1,8 @@
 import {
+    addClaudeGenerationAttempt,
     addClaudeUsage,
     ClaudeStreamProcessor,
+    ZERO_CLAUDE_GENERATION_TELEMETRY,
     ZERO_CLAUDE_USAGE,
     type ClaudeGenerationUsage,
 } from './ClaudeStreamProcessor';
@@ -172,5 +174,73 @@ describe('addClaudeUsage', () => {
         expect(addClaudeUsage(ZERO_CLAUDE_USAGE, null)).toEqual(
             ZERO_CLAUDE_USAGE,
         );
+    });
+});
+
+describe('addClaudeGenerationAttempt', () => {
+    const usage = (n: number): ClaudeGenerationUsage => ({
+        inputTokens: n,
+        outputTokens: n,
+        cacheReadInputTokens: n,
+        cacheCreationInputTokens: n,
+        numTurns: n,
+        durationApiMs: n,
+        costUsd: n,
+    });
+
+    test('aggregates usage, tools, turns, and attempts across CLI retries', () => {
+        const first = addClaudeGenerationAttempt(
+            ZERO_CLAUDE_GENERATION_TELEMETRY,
+            {
+                usage: usage(1),
+                toolCallCount: 2,
+                timeToFirstTokenMs: null,
+                turnDurationsMs: [100],
+            },
+            0,
+        );
+        const second = addClaudeGenerationAttempt(
+            first,
+            {
+                usage: usage(2),
+                toolCallCount: 3,
+                timeToFirstTokenMs: 50,
+                turnDurationsMs: [200, 300],
+            },
+            1_000,
+        );
+
+        expect(second).toEqual({
+            usage: usage(3),
+            toolCallCount: 5,
+            timeToFirstTokenMs: 1_050,
+            turnDurationsMs: [100, 200, 300],
+            attemptCount: 2,
+        });
+    });
+
+    test('keeps the first observed token latency across later attempts', () => {
+        const first = addClaudeGenerationAttempt(
+            ZERO_CLAUDE_GENERATION_TELEMETRY,
+            {
+                usage: null,
+                toolCallCount: 0,
+                timeToFirstTokenMs: 75,
+                turnDurationsMs: [],
+            },
+            0,
+        );
+        const second = addClaudeGenerationAttempt(
+            first,
+            {
+                usage: null,
+                toolCallCount: 0,
+                timeToFirstTokenMs: 25,
+                turnDurationsMs: [],
+            },
+            500,
+        );
+
+        expect(second.timeToFirstTokenMs).toBe(75);
     });
 });

--- a/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.ts
@@ -35,6 +35,22 @@ export const ZERO_CLAUDE_USAGE: ClaudeGenerationUsage = {
     costUsd: 0,
 };
 
+export type ClaudeGenerationTelemetry = {
+    usage: ClaudeGenerationUsage;
+    toolCallCount: number;
+    timeToFirstTokenMs: number | null;
+    turnDurationsMs: number[];
+    attemptCount: number;
+};
+
+export const ZERO_CLAUDE_GENERATION_TELEMETRY: ClaudeGenerationTelemetry = {
+    usage: ZERO_CLAUDE_USAGE,
+    toolCallCount: 0,
+    timeToFirstTokenMs: null,
+    turnDurationsMs: [],
+    attemptCount: 0,
+};
+
 /**
  * Sum two usage records field-by-field. One build can invoke `claude` several
  * times (main generation, build-fix re-runs, metadata), so the pipeline totals
@@ -54,6 +70,41 @@ export function addClaudeUsage(
         numTurns: a.numTurns + b.numTurns,
         durationApiMs: a.durationApiMs + b.durationApiMs,
         costUsd: a.costUsd + b.costUsd,
+    };
+}
+
+/**
+ * Add one CLI attempt to the telemetry for a logical Claude invocation.
+ *
+ * A generation can retry the CLI while continuing the same session. Keeping
+ * the aggregation here ensures successful builds include the cost of failed
+ * attempts, and lets the caller retain partial usage when every attempt fails.
+ */
+export function addClaudeGenerationAttempt(
+    aggregate: ClaudeGenerationTelemetry,
+    attempt: {
+        usage: ClaudeGenerationUsage | null;
+        toolCallCount: number;
+        timeToFirstTokenMs: number | null;
+        turnDurationsMs: number[];
+    },
+    attemptStartedAfterMs: number,
+): ClaudeGenerationTelemetry {
+    const attemptTimeToFirstTokenMs =
+        attempt.timeToFirstTokenMs === null
+            ? null
+            : attemptStartedAfterMs + attempt.timeToFirstTokenMs;
+
+    return {
+        usage: addClaudeUsage(aggregate.usage, attempt.usage),
+        toolCallCount: aggregate.toolCallCount + attempt.toolCallCount,
+        timeToFirstTokenMs:
+            aggregate.timeToFirstTokenMs ?? attemptTimeToFirstTokenMs,
+        turnDurationsMs: [
+            ...aggregate.turnDurationsMs,
+            ...attempt.turnDurationsMs,
+        ],
+        attemptCount: aggregate.attemptCount + 1,
     };
 }
 


### PR DESCRIPTION
## Summary

- add scheduler wait, resolved Claude provider, metadata duration, and main-generation attempt count to Data App terminal telemetry
- aggregate tokens, turns, tool calls, TTFT, and cost across Claude CLI retries instead of counting only the successful attempt
- retain partial Claude/build-fix/metadata usage on failed versions and emit incurred failed-build spend to the shared `ai.usage` stream
- add model/provider/scheduler context to the `DataApp.generate` OTEL parent span and document the analytics contract

Also aligns the typed create/iterate event properties with the prompt, sample, template, clarification, theme, and design context already emitted.

## Validation

- `pnpm -F backend exec vitest run --config vitest.config.ts src/ee/services/AppGenerateService/ClaudeStreamProcessor.test.ts`
- `pnpm -F backend typecheck:fast`
- targeted backend ESLint
- oxfmt and `git diff --check`
- repository pre-commit hooks

## Analytics follow-up

The analytics semantic layer should expose `scheduler_wait_ms`, `claude_provider`, `metadata_ms`, and `generation_attempt_count`, and propagate the new optional usage fields from `data_app.version.failed`. This is intended as a follow-up to lightdash/analytics#91.