### PR TITLE
fix: omit agent card hero image when the chart image URL is unreachable

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -1033,6 +1033,24 @@ export class AiAgentService extends BaseService {
         ).href;
     }
 
+    // Proxy for whether Slack's servers can fetch the URL: deployments where
+    // SITE_URL is unreachable internally are the ones Slack can't reach either.
+    private static async isCardImageUrlReachable(
+        url: string,
+    ): Promise<boolean> {
+        try {
+            const response = await fetch(url, {
+                signal: AbortSignal.timeout(5000),
+            });
+            // Discard the body without downloading it — an unconsumed body
+            // keeps the connection open
+            await response.body?.cancel();
+            return response.ok;
+        } catch {
+            return false;
+        }
+    }
+
     private enqueueReviewClassifierEvent(args: {
         eventType: AiAgentReviewClassifierEventType;
         organizationUuid: string | null | undefined;
@@ -9098,6 +9116,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     null,
                     exploreName,
                 ),
+            AiAgentService.isCardImageUrlReachable,
             agent?.uuid,
             promptArtifactVersions.length > 0
                 ? promptArtifactVersions

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -252,6 +252,7 @@ describe('Slack AI agent blocks', () => {
             500,
             async () => 'https://lightdash.example.com/share/chart',
             async () => ({}) as never,
+            async () => true,
             'agent-1',
             [
                 {
@@ -324,6 +325,89 @@ describe('Slack AI agent blocks', () => {
         ]);
     });
 
+    it('omits the hero but keeps the Open image button when the image URL is unreachable', async () => {
+        const blocks = await getModernArtifactCardBlocks(
+            {
+                promptUuid: 'prompt-1',
+                projectUuid: 'project-1',
+                threadUuid: 'thread-1',
+            } as never,
+            'https://lightdash.example.com',
+            500,
+            async () => 'https://lightdash.example.com/share/chart',
+            async () => ({}) as never,
+            async () => false,
+            'agent-1',
+            [
+                {
+                    artifactUuid: 'artifact-1',
+                    threadUuid: 'thread-1',
+                    promptUuid: 'prompt-1',
+                    artifactType: 'chart',
+                    savedQueryUuid: null,
+                    savedDashboardUuid: null,
+                    createdAt: new Date(),
+                    versionNumber: 1,
+                    versionUuid: 'version-1',
+                    title: 'Orders Over Time',
+                    description: null,
+                    dashboardConfig: null,
+                    versionCreatedAt: new Date(),
+                    verifiedByUserUuid: null,
+                    verifiedAt: null,
+                    chartConfig: {
+                        title: 'Orders Over Time',
+                        description: 'Orders by month',
+                        queryConfig: {
+                            exploreName: 'orders',
+                            dimensions: ['orders_order_date_month'],
+                            metrics: ['orders_unique_order_count'],
+                            sorts: [],
+                            limit: 500,
+                            customMetrics: [],
+                            tableCalculations: [],
+                            filters: null,
+                        },
+                        chartConfig: null,
+                    },
+                },
+            ],
+            [
+                {
+                    uuid: 'result-1',
+                    promptUuid: 'prompt-1',
+                    toolCallId: 'call-1',
+                    toolType: 'built-in',
+                    toolName: 'generateVisualization',
+                    result: 'ok',
+                    createdAt: new Date(),
+                    metadata: {
+                        status: 'success',
+                        chartImageUrl:
+                            'https://internal.example.com/api/v1/slack/card-image/abc',
+                    } as never,
+                },
+            ],
+        );
+
+        expect(blocks).toMatchObject([
+            {
+                type: 'card',
+                actions: [
+                    {
+                        text: { text: 'Open image' },
+                        url: 'https://internal.example.com/api/v1/slack/card-image/abc',
+                    },
+                    {
+                        text: { text: 'Explore in Lightdash' },
+                        url: 'https://lightdash.example.com/share/chart',
+                    },
+                ],
+            },
+        ]);
+        expect(blocks[0]).not.toHaveProperty('hero_image');
+    });
+
     it('uses the latest visualization attempt image when a single artifact was retried', async () => {
         const artifact = {
             artifactUuid: 'artifact-1',
@@ -382,6 +466,7 @@ describe('Slack AI agent blocks', () => {
             500,
             async () => 'https://lightdash.example.com/share/chart',
             async () => ({}) as never,
+            async () => true,
             'agent-1',
             [artifact],
             [
@@ -484,6 +569,7 @@ describe('Slack AI agent blocks', () => {
             500,
             async () => 'https://lightdash.example.com/share/chart',
             async () => ({}) as never,
+            async () => true,
             'agent-1',
             [
                 chartVersion('version-1', 'Placed orders by month', 'placed'),
@@ -586,6 +672,7 @@ describe('Slack AI agent blocks', () => {
             500,
             async () => 'https://lightdash.example.com/share/chart',
             async () => ({}) as never,
+            async () => true,
             'agent-1',
             [
                 retryVersion('version-1'),
@@ -655,6 +742,7 @@ describe('Slack AI agent blocks', () => {
             500,
             async () => 'https://lightdash.example.com/share/chart',
             async () => ({}) as never,
+            async () => true,
             'agent-1',
             [
                 retryVersion('version-1', 'day'),
@@ -715,6 +803,7 @@ describe('Slack AI agent blocks', () => {
             500,
             async () => 'https://lightdash.example.com/share/chart',
             async () => ({}) as never,
+            async () => true,
             'agent-1',
             [
                 chartVersion('version-1', 'Placed orders', 'placed'),
@@ -800,6 +889,7 @@ describe('Slack AI agent blocks', () => {
             500,
             async () => 'https://lightdash.example.com/share/chart',
             async () => ({}) as never,
+            async () => true,
             'agent-1',
             [
                 chartVersion('version-1', 'line', 'line'),
@@ -833,6 +923,7 @@ describe('Slack AI agent blocks', () => {
             500,
             createShareUrl,
             async () => mockOrdersExplore,
+            async () => true,
             'agent-1',
             [
                 {
@@ -916,6 +1007,7 @@ describe('Slack AI agent blocks', () => {
             createShareUrl,
             // Broken explore: chart config conversion throws, table fallback kicks in
             async () => ({}) as never,
+            async () => true,
             'agent-1',
             [
                 {
@@ -977,6 +1069,7 @@ describe('Slack AI agent blocks', () => {
                 throw new Error('share service unavailable');
             },
             async () => mockOrdersExplore,
+            async () => true,
             'agent-1',
             [
                 {

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -532,6 +532,7 @@ export async function getModernArtifactCardBlocks(
     maxQueryLimit: number,
     createShareUrl: (path: string, params: string) => Promise<string>,
     getExplore: (exploreName: string) => Promise<Explore>,
+    isImageUrlReachable: (url: string) => Promise<boolean>,
     agentUuid?: string,
     artifacts?: AiArtifact[],
     toolResults?: AiAgentToolResult[],
@@ -555,6 +556,17 @@ export async function getModernArtifactCardBlocks(
                     .chartImageUrl,
         )
         .filter((url): url is string => Boolean(url));
+    // A hero image with a URL Slack's servers can't fetch renders blank, so
+    // cards only embed URLs that pass the reachability probe.
+    const reachableImageUrls = new Set(
+        (
+            await Promise.all(
+                [...new Set(chartImageUrls)].map(async (url) =>
+                    (await isImageUrlReachable(url)) ? url : null,
+                ),
+            )
+        ).filter((url): url is string => url !== null),
+    );
     // The viz type lives in chartConfig.chartConfig.defaultVizType (line, bar,
     // ...); parseVizConfig flattens the unified generateVisualization shape to
     // "query_result" and can't tell a line from a bar, so read it directly and
@@ -737,7 +749,10 @@ export async function getModernArtifactCardBlocks(
                     blockId: `ai_agent_chart_card_${artifact.versionUuid}`,
                     title: getArtifactTitle(artifact),
                     subtitle: `${vizConfig.metricQuery.exploreName} chart`,
-                    heroImageUrl: chartImageUrl,
+                    heroImageUrl:
+                        chartImageUrl && reachableImageUrls.has(chartImageUrl)
+                            ? chartImageUrl
+                            : undefined,
                     body:
                         artifact.description ||
                         `${metricCount} metric${


### PR DESCRIPTION
### Description:

AI agent chart cards embed the chart via `SITE_URL/api/v1/slack/card-image/{id}` as the card's hero image. Slack's servers must fetch that URL to render it, so on self-hosted instances where `SITE_URL` is not publicly reachable the hero renders blank.

Referencing the image as a Slack-hosted file (`slack_file`) — the fix proposed in the issue — does not work for card `hero_image`: Slack accepts the block but rewrites it to a bare `files-pri` URL without registering the file share it performs for standard image blocks (`BK_IMAGE` source), so it renders blank for every viewer regardless of upload state. Verified experimentally with both `slack_file` forms (`{id}` and `{url}`) on fully-processed files; standard image blocks are unaffected.

Instead, when building the card blocks the backend probes the public image URL:

- **reachable** → card with hero image, unchanged from today
- **unreachable** → card without an image; the "Open image" button keeps working since the viewer's browser can reach the URL from inside the network

The probe runs at block-build time (right before Slack would fetch the URL), so the tool output contract is untouched and no state is persisted.

Relates: #25800