### PR TITLE
feat: make agent onboarding runs durable

### DIFF
--- a/packages/backend/src/ee/controllers/OnboardingAgentController.ts
+++ b/packages/backend/src/ee/controllers/OnboardingAgentController.ts
@@ -1,0 +1,145 @@
+import {
+    assertRegisteredAccount,
+    type ApiAgentOnboardingFileResponse,
+    type ApiAgentOnboardingRunResponse,
+    type ApiErrorPayload,
+    type UUID,
+} from '@lightdash/common';
+import {
+    Get,
+    Middlewares,
+    OperationId,
+    Path,
+    Post,
+    Query,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+} from '@tsoa/runtime';
+import express from 'express';
+import { toSessionUser } from '../../auth/account';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { OnboardingAgentService } from '../services/OnboardingAgentService/OnboardingAgentService';
+
+@Route('/api/v1/ee/projects/{projectUuid}/agent-onboarding')
+@Response<ApiErrorPayload>('default', 'Error')
+export class OnboardingAgentController extends BaseController {
+    /**
+     * Start a server-side agent onboarding run for a prepared project.
+     * Returns the existing run when one is already active for the project.
+     * @summary Start agent onboarding run
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('202', 'Accepted')
+    @Post('/')
+    @OperationId('createAgentOnboardingRun')
+    async createRun(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+    ): Promise<ApiAgentOnboardingRunResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(202);
+        return {
+            status: 'ok',
+            results: await this.getOnboardingAgentService().createRun({
+                user: toSessionUser(req.account),
+                projectUuid,
+            }),
+        };
+    }
+
+    /**
+     * Get the durable state and progress events of an agent onboarding run.
+     * @summary Get agent onboarding run
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{agentOnboardingRunUuid}')
+    @OperationId('getAgentOnboardingRun')
+    async getRun(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() agentOnboardingRunUuid: UUID,
+    ): Promise<ApiAgentOnboardingRunResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getOnboardingAgentService().getRun(
+                toSessionUser(req.account),
+                projectUuid,
+                agentOnboardingRunUuid,
+            ),
+        };
+    }
+
+    /**
+     * Read the latest persisted contents of a generated onboarding file.
+     * @summary Get onboarding run file
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{agentOnboardingRunUuid}/file')
+    @OperationId('getAgentOnboardingFile')
+    async getFile(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() agentOnboardingRunUuid: UUID,
+        @Query() path: string,
+    ): Promise<ApiAgentOnboardingFileResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getOnboardingAgentService().getFile(
+                toSessionUser(req.account),
+                projectUuid,
+                agentOnboardingRunUuid,
+                path,
+            ),
+        };
+    }
+
+    /**
+     * Request cancellation of an agent onboarding run.
+     * @summary Cancel agent onboarding run
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/{agentOnboardingRunUuid}/cancel')
+    @OperationId('cancelAgentOnboardingRun')
+    async cancelRun(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() agentOnboardingRunUuid: UUID,
+    ): Promise<ApiAgentOnboardingRunResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getOnboardingAgentService().cancelRun(
+                toSessionUser(req.account),
+                projectUuid,
+                agentOnboardingRunUuid,
+            ),
+        };
+    }
+
+    protected getOnboardingAgentService() {
+        return this.services.getOnboardingAgentService<OnboardingAgentService>();
+    }
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -214,7 +214,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,
                 }),
-            onboardingAgentService: ({ context, models, repository }) =>
+            onboardingAgentService: ({
+                context,
+                models,
+                repository,
+                clients,
+            }) =>
                 new OnboardingAgentService({
                     lightdashConfig: context.lightdashConfig,
                     agentOnboardingRunModel:
@@ -226,6 +231,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getPersonalAccessTokenService(),
                     promptService: repository.getPromptService(),
                     userService: repository.getUserService(),
+                    schedulerClient:
+                        clients.getSchedulerClient() as CommercialSchedulerClient,
                 }),
             previewDeploySetupService: ({ context, models }) =>
                 new PreviewDeploySetupService({
@@ -1017,6 +1024,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     context.serviceRepository.getAiWritebackService<AiWritebackService>(),
                 aiDeepResearchService:
                     context.serviceRepository.getAiDeepResearchService<AiDeepResearchService>(),
+                onboardingAgentService:
+                    context.serviceRepository.getOnboardingAgentService<OnboardingAgentService>(),
                 catalogService: context.serviceRepository.getCatalogService(),
                 encryptionUtil: context.utils.getEncryptionUtil(),
                 msTeamsClient: context.clients.getMsTeamsClient(),

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -1,4 +1,5 @@
 import {
+    AgentOnboardingPipelineJobPayload,
     AiAgentEditDbtProjectPipelineJobPayload,
     AiAgentEvalRunJobPayload,
     AiAgentReviewClassifierJobPayload,
@@ -212,6 +213,20 @@ export class CommercialSchedulerClient extends SchedulerClient {
                 runAt: new Date(),
                 maxAttempts: 1,
                 jobKey: `ai-writeback:${payload.aiWritebackRunUuid}`,
+            },
+        );
+        return { jobId };
+    }
+
+    async agentOnboardingRun(payload: AgentOnboardingPipelineJobPayload) {
+        const graphileClient = await this.graphileUtils;
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.AGENT_ONBOARDING_RUN,
+            payload,
+            {
+                runAt: new Date(),
+                maxAttempts: 1,
+                jobKey: `agent-onboarding:${payload.agentOnboardingRunUuid}`,
             },
         );
         return { jobId };

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -28,6 +28,7 @@ import type { AiWritebackService } from '../services/AiWritebackService/AiWriteb
 import { AppGenerateService } from '../services/AppGenerateService/AppGenerateService';
 import type { EmbedService } from '../services/EmbedService/EmbedService';
 import { ManagedAgentService } from '../services/ManagedAgentService/ManagedAgentService';
+import { type OnboardingAgentService } from '../services/OnboardingAgentService/OnboardingAgentService';
 import { ProjectContextService } from '../services/ProjectContextService/ProjectContextService';
 import { sendReviewNotification } from './tasks/sendReviewNotification';
 
@@ -39,11 +40,13 @@ const AI_AGENT_REVIEW_WRITEBACK_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const APP_GENERATE_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
 const AI_WRITEBACK_TIMEOUT_MS = 30 * 60 * 1000;
 const AI_DEEP_RESEARCH_TIMEOUT_MS = 60 * 60 * 1000;
+const AGENT_ONBOARDING_TIMEOUT_MS = 60 * 60 * 1000;
 
 type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
     aiAgentService: AiAgentService;
     aiWritebackService: AiWritebackService;
     aiDeepResearchService: AiDeepResearchService;
+    onboardingAgentService: OnboardingAgentService;
     aiAgentReviewClassifierService: AiAgentReviewClassifierService;
     aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
     aiAgentReviewNotificationModel: AiAgentReviewNotificationModel;
@@ -64,6 +67,8 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
     protected readonly aiWritebackService: AiWritebackService;
 
     protected readonly aiDeepResearchService: AiDeepResearchService;
+
+    protected readonly onboardingAgentService: OnboardingAgentService;
 
     protected readonly aiAgentReviewClassifierService: AiAgentReviewClassifierService;
 
@@ -94,6 +99,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
         this.aiAgentService = args.aiAgentService;
         this.aiWritebackService = args.aiWritebackService;
         this.aiDeepResearchService = args.aiDeepResearchService;
+        this.onboardingAgentService = args.onboardingAgentService;
         this.aiAgentReviewClassifierService =
             args.aiAgentReviewClassifierService;
         this.aiAgentReviewClassifierModel = args.aiAgentReviewClassifierModel;
@@ -514,6 +520,31 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                         await this.aiWritebackService.markRunError(
                             payload.aiWritebackRunUuid,
                             getErrorMessage(e),
+                        );
+                    },
+                );
+            },
+            [EE_SCHEDULER_TASKS.AGENT_ONBOARDING_RUN]: async (
+                payload,
+                helpers,
+            ) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        EE_SCHEDULER_TASKS.AGENT_ONBOARDING_RUN,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            await this.onboardingAgentService.executeRun(
+                                payload,
+                            );
+                        },
+                    ),
+                    helpers.job,
+                    AGENT_ONBOARDING_TIMEOUT_MS,
+                    async () => {
+                        await this.onboardingAgentService.markRunTimedOut(
+                            payload.agentOnboardingRunUuid,
                         );
                     },
                 );

--- a/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentFileStore.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentFileStore.ts
@@ -1,0 +1,55 @@
+import {
+    GetObjectCommand,
+    PutObjectCommand,
+    type S3,
+} from '@aws-sdk/client-s3';
+import { MissingConfigError } from '@lightdash/common';
+import { S3BaseClient } from '../../../clients/Aws/S3BaseClient';
+import { type LightdashConfig } from '../../../config/parseConfig';
+
+export class OnboardingAgentFileStore extends S3BaseClient {
+    private readonly bucket: string | undefined;
+
+    constructor({ lightdashConfig }: { lightdashConfig: LightdashConfig }) {
+        super(lightdashConfig.s3 ?? undefined);
+        this.bucket = lightdashConfig.s3?.bucket;
+    }
+
+    private requireClient(): { client: S3; bucket: string } {
+        if (!this.s3 || !this.bucket) {
+            throw new MissingConfigError(
+                "Missing S3 bucket configuration, can't store onboarding agent files",
+            );
+        }
+        return { client: this.s3, bucket: this.bucket };
+    }
+
+    assertConfigured(): void {
+        this.requireClient();
+    }
+
+    async put(key: string, contents: Buffer): Promise<void> {
+        const { client, bucket } = this.requireClient();
+        await client.send(
+            new PutObjectCommand({
+                Bucket: bucket,
+                Key: key,
+                Body: contents,
+                ContentType: 'application/octet-stream',
+            }),
+        );
+    }
+
+    async get(key: string): Promise<Buffer> {
+        const { client, bucket } = this.requireClient();
+        const result = await client.send(
+            new GetObjectCommand({ Bucket: bucket, Key: key }),
+        );
+        if (!result.Body) {
+            throw new MissingConfigError(
+                `Onboarding agent file not found for key ${key}`,
+            );
+        }
+        return Buffer.from(await result.Body.transformToByteArray());
+    }
+}

--- a/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
@@ -3,12 +3,17 @@ import {
     ForbiddenError,
     getConnectionDefaults,
     getErrorMessage,
+    isUserWithOrg,
     MissingConfigError,
+    NotFoundError,
     RequestMethod,
+    type AgentOnboardingFileContent,
     type AgentOnboardingHandoff,
     type AgentOnboardingJobPayload,
+    type AgentOnboardingRun,
     type AgentOnboardingStage,
     type AgentOnboardingUsage,
+    type SessionUser,
 } from '@lightdash/common';
 import { fromSession } from '../../../auth/account';
 import { type LightdashConfig } from '../../../config/parseConfig';
@@ -17,9 +22,13 @@ import { BaseService } from '../../../services/BaseService';
 import { type PersonalAccessTokenService } from '../../../services/PersonalAccessTokenService';
 import { type PromptService } from '../../../services/PromptService/PromptService';
 import { type UserService } from '../../../services/UserService';
-import { type DbAgentOnboardingRun } from '../../database/entities/agentOnboarding';
+import {
+    type DbAgentOnboardingFile,
+    type DbAgentOnboardingRun,
+} from '../../database/entities/agentOnboarding';
 import { type AgentOnboardingRunModel } from '../../models/AgentOnboardingRunModel';
 import { type SandboxRegistryModel } from '../../models/SandboxRegistryModel';
+import { type CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 import {
     interpretAgentEvent,
     resolveSandboxTemplateRef,
@@ -41,13 +50,21 @@ import {
     CLAUDE_SKILLS_DIR,
     CLI_WRAPPER_PATH,
     CLI_WRAPPER_SCRIPT,
+    FILE_SYNC_INTERVAL_MS,
     PAT_EXPIRY_GRACE_MS,
     PROMPT_PATH,
     RUN_TIMEOUT_MS,
     SANDBOX_TIMEOUT_MS,
     WORKDIR,
 } from './constants';
-import { classifyOnboardingStage, sanitizeOnboardingMessage } from './utils';
+import { OnboardingAgentFileStore } from './OnboardingAgentFileStore';
+import {
+    buildManagedOnboardingPrompt,
+    classifyOnboardingStage,
+    isOnboardingOutputFile,
+    parseWorkspaceFileListing,
+    sanitizeOnboardingMessage,
+} from './utils';
 
 type Dependencies = {
     lightdashConfig: LightdashConfig;
@@ -57,13 +74,35 @@ type Dependencies = {
     personalAccessTokenService: PersonalAccessTokenService;
     promptService: PromptService;
     userService: UserService;
+    schedulerClient: CommercialSchedulerClient;
     sandboxManager?: SandboxManager;
+    fileStore?: OnboardingAgentFileStore;
 };
 
 const ONBOARDING_WORKSPACE: PersistentWorkspace = {
     include: [WORKDIR],
     exclude: [],
 };
+
+const toRun = (run: DbAgentOnboardingRun): AgentOnboardingRun => ({
+    agentOnboardingRunUuid: run.agent_onboarding_run_uuid,
+    projectUuid: run.project_uuid,
+    status: run.status,
+    stage: run.stage,
+    events: run.events,
+    handoff: run.handoff,
+    usage: run.usage,
+    files: run.files.map(({ path, sizeBytes, updatedAt }) => ({
+        path,
+        sizeBytes,
+        updatedAt,
+    })),
+    errorMessage: run.error_message,
+    createdAt: run.created_at.toISOString(),
+    updatedAt: run.updated_at.toISOString(),
+    startedAt: run.started_at?.toISOString() ?? null,
+    completedAt: run.completed_at?.toISOString() ?? null,
+});
 
 export class OnboardingAgentService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
@@ -80,6 +119,10 @@ export class OnboardingAgentService extends BaseService {
 
     private readonly userService: UserService;
 
+    private readonly schedulerClient: CommercialSchedulerClient;
+
+    private readonly fileStore: OnboardingAgentFileStore;
+
     private sandboxManager: SandboxManager | undefined;
 
     constructor(dependencies: Dependencies) {
@@ -92,7 +135,215 @@ export class OnboardingAgentService extends BaseService {
             dependencies.personalAccessTokenService;
         this.promptService = dependencies.promptService;
         this.userService = dependencies.userService;
+        this.schedulerClient = dependencies.schedulerClient;
+        this.fileStore =
+            dependencies.fileStore ??
+            new OnboardingAgentFileStore({
+                lightdashConfig: dependencies.lightdashConfig,
+            });
         this.sandboxManager = dependencies.sandboxManager;
+    }
+
+    private async assertCanViewProject(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<void> {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        if (
+            user.organizationUuid !== organizationUuid ||
+            this.createAuditedAbility(user).cannot(
+                'view',
+                subject('Project', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+    }
+
+    private async assertCanManageProject(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<{ organizationUuid: string }> {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        if (
+            user.organizationUuid !== organizationUuid ||
+            this.createAuditedAbility(user).cannot(
+                'manage',
+                subject('Project', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        return { organizationUuid };
+    }
+
+    async createRun(args: {
+        user: SessionUser;
+        projectUuid: string;
+    }): Promise<AgentOnboardingRun> {
+        if (!isUserWithOrg(args.user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        const { organizationUuid } = await this.assertCanManageProject(
+            args.user,
+            args.projectUuid,
+        );
+        if (
+            this.createAuditedAbility(args.user).cannot(
+                'create',
+                subject('PersonalAccessToken', {
+                    organizationUuid,
+                    metadata: { userUuid: args.user.userUuid },
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        const activeRun =
+            await this.agentOnboardingRunModel.findActiveRunForProject(
+                args.projectUuid,
+            );
+        if (activeRun) return toRun(activeRun);
+
+        const run = await this.agentOnboardingRunModel.create({
+            organizationUuid,
+            projectUuid: args.projectUuid,
+            createdByUserUuid: args.user.userUuid,
+        });
+
+        try {
+            await this.schedulerClient.agentOnboardingRun({
+                agentOnboardingRunUuid: run.agent_onboarding_run_uuid,
+                organizationUuid: run.organization_uuid,
+                projectUuid: run.project_uuid,
+                userUuid: run.created_by_user_uuid,
+            });
+        } catch (error) {
+            await this.agentOnboardingRunModel.markFailed(
+                run.agent_onboarding_run_uuid,
+                'Could not start the onboarding agent. Please try again.',
+            );
+            throw error;
+        }
+        return toRun(run);
+    }
+
+    private async findOrganizationScopedRun(
+        user: SessionUser,
+        agentOnboardingRunUuid: string,
+    ): Promise<DbAgentOnboardingRun> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        const run = await this.agentOnboardingRunModel.findByUuid(
+            agentOnboardingRunUuid,
+        );
+        if (!run || run.organization_uuid !== user.organizationUuid) {
+            throw new NotFoundError(
+                `Onboarding run ${agentOnboardingRunUuid} not found`,
+            );
+        }
+        return run;
+    }
+
+    private async findScopedRun(
+        user: SessionUser,
+        projectUuid: string,
+        agentOnboardingRunUuid: string,
+    ): Promise<DbAgentOnboardingRun> {
+        const run = await this.findOrganizationScopedRun(
+            user,
+            agentOnboardingRunUuid,
+        );
+        if (run.project_uuid !== projectUuid) {
+            throw new NotFoundError(
+                `Onboarding run ${agentOnboardingRunUuid} not found`,
+            );
+        }
+        await this.assertCanViewProject(user, projectUuid);
+        return run;
+    }
+
+    async getRun(
+        user: SessionUser,
+        projectUuid: string,
+        agentOnboardingRunUuid: string,
+    ): Promise<AgentOnboardingRun> {
+        return toRun(
+            await this.findScopedRun(user, projectUuid, agentOnboardingRunUuid),
+        );
+    }
+
+    async getFile(
+        user: SessionUser,
+        projectUuid: string,
+        agentOnboardingRunUuid: string,
+        path: string,
+    ): Promise<AgentOnboardingFileContent> {
+        if (!isOnboardingOutputFile(path)) {
+            throw new NotFoundError(`Onboarding file ${path} not found`);
+        }
+        const run = await this.findScopedRun(
+            user,
+            projectUuid,
+            agentOnboardingRunUuid,
+        );
+        if (
+            this.createAuditedAbility(user).cannot(
+                'view',
+                subject('SourceCode', {
+                    organizationUuid: run.organization_uuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to view this project source code',
+            );
+        }
+        const file = run.files.find((candidate) => candidate.path === path);
+        if (!file) {
+            throw new NotFoundError(`Onboarding file ${path} not found`);
+        }
+
+        const contents = await this.fileStore.get(file.s3Key);
+        const utf8 = contents.toString('utf8');
+        const isUtf8 = Buffer.from(utf8, 'utf8').equals(contents);
+        return {
+            path: file.path,
+            sizeBytes: file.sizeBytes,
+            updatedAt: file.updatedAt,
+            content: isUtf8 ? utf8 : contents.toString('base64'),
+            encoding: isUtf8 ? 'utf8' : 'base64',
+        };
+    }
+
+    async cancelRun(
+        user: SessionUser,
+        projectUuid: string,
+        agentOnboardingRunUuid: string,
+    ): Promise<AgentOnboardingRun> {
+        const run = await this.findScopedRun(
+            user,
+            projectUuid,
+            agentOnboardingRunUuid,
+        );
+        await this.assertCanManageProject(user, projectUuid);
+        const updatedRun =
+            await this.agentOnboardingRunModel.requestCancellation(
+                run.agent_onboarding_run_uuid,
+            );
+        return toRun(updatedRun ?? run);
+    }
+
+    async markRunTimedOut(agentOnboardingRunUuid: string): Promise<void> {
+        await this.agentOnboardingRunModel.markFailed(
+            agentOnboardingRunUuid,
+            'The onboarding agent took too long and was stopped.',
+        );
     }
 
     private getSandboxManager(): SandboxManager {
@@ -177,31 +428,11 @@ export class OnboardingAgentService extends BaseService {
         const basePrompt =
             await this.promptService.getPrompt('project-onboarding');
         const siteUrl = this.lightdashConfig.siteUrl.replace(/\/+$/, '');
-        const preamble = [
-            '# Lightdash cloud onboarding run',
-            '',
-            'You are running inside a managed sandbox on Lightdash Cloud, completing project setup on behalf of a user.',
-            '',
-            '## Context',
-            `- Lightdash instance URL: ${siteUrl}`,
-            `- Warehouse type: ${args.warehouseType}`,
-            `- Prepared project UUID: ${args.projectUuid}`,
-            ...(args.database
-                ? [`- Configured database: ${args.database}`]
-                : []),
-            ...(args.schema ? [`- Configured schema: ${args.schema}`] : []),
-            '',
-            '## Managed environment',
-            '- The Lightdash CLI and skills are preinstalled. Skip local setup.',
-            `- Run every \`lightdash <args>\` command as \`${CLI_WRAPPER_PATH} <args>\`.`,
-            '- Authentication is already configured. Do not run `lightdash login` or inspect environment variables.',
-            `- Verify the selected project with \`${CLI_WRAPPER_PATH} config get-project\` and confirm it matches the prepared project UUID.`,
-            `- Create all working files under ${WORKDIR} and build a pure Lightdash semantic layer from the warehouse catalog.`,
-            '',
-            '---',
-            '',
-        ].join('\n');
-        return preamble + basePrompt;
+        return buildManagedOnboardingPrompt({
+            ...args,
+            basePrompt,
+            siteUrl,
+        });
     }
 
     private startCancellationPoll(
@@ -226,6 +457,68 @@ export class OnboardingAgentService extends BaseService {
         return () => clearInterval(timer);
     }
 
+    private async syncWorkspaceFiles(args: {
+        run: DbAgentOnboardingRun;
+        sandbox: SandboxHandle;
+        previousFiles: DbAgentOnboardingFile[];
+    }): Promise<DbAgentOnboardingFile[]> {
+        const { run, sandbox, previousFiles } = args;
+        const result = await sandbox.commands.run(
+            `find ${WORKDIR} -type f -printf '%P\\t%s\\t%T@\\n' | sort`,
+        );
+        const previousByPath = new Map(
+            previousFiles.map((file) => [file.path, file]),
+        );
+        const discovered = parseWorkspaceFileListing(result.stdout).filter(
+            ({ path }) => isOnboardingOutputFile(path),
+        );
+
+        const files = await Promise.all(
+            discovered.map(async (file): Promise<DbAgentOnboardingFile> => {
+                const previous = previousByPath.get(file.path);
+                if (
+                    previous &&
+                    previous.sizeBytes === file.sizeBytes &&
+                    previous.updatedAt === file.updatedAt
+                ) {
+                    return previous;
+                }
+
+                const s3Key = [
+                    'agent-onboarding',
+                    run.organization_uuid,
+                    run.agent_onboarding_run_uuid,
+                    'files',
+                    ...file.path.split('/').map(encodeURIComponent),
+                ].join('/');
+                const contents = await sandbox.files.readBytes(
+                    `${WORKDIR}/${file.path}`,
+                );
+                await this.fileStore.put(s3Key, contents);
+                return { ...file, s3Key };
+            }),
+        );
+
+        const filesChanged =
+            files.length !== previousFiles.length ||
+            files.some((file) => {
+                const previous = previousByPath.get(file.path);
+                return (
+                    !previous ||
+                    previous.sizeBytes !== file.sizeBytes ||
+                    previous.updatedAt !== file.updatedAt ||
+                    previous.s3Key !== file.s3Key
+                );
+            });
+        if (filesChanged) {
+            await this.agentOnboardingRunModel.replaceFiles(
+                run.agent_onboarding_run_uuid,
+                files,
+            );
+        }
+        return files;
+    }
+
     private async runAgentInSandbox(args: {
         run: DbAgentOnboardingRun;
         sandbox: SandboxHandle;
@@ -236,6 +529,7 @@ export class OnboardingAgentService extends BaseService {
         usage: AgentOnboardingUsage | null;
     }> {
         const { run, sandbox, patToken, anthropicApiKey } = args;
+        this.fileStore.assertConfigured();
         const { warehouseConnection } =
             await this.projectModel.getWithSensitiveFields(run.project_uuid);
         if (!warehouseConnection) {
@@ -262,6 +556,36 @@ export class OnboardingAgentService extends BaseService {
         let usage: AgentOnboardingUsage | null = null;
         let lastStep = '';
         const pendingEvents: Promise<void>[] = [];
+        let knownFiles = run.files;
+        let syncPromise: Promise<void> | undefined;
+
+        const syncFiles = (): Promise<void> => {
+            if (syncPromise) return syncPromise;
+            syncPromise = this.syncWorkspaceFiles({
+                run,
+                sandbox,
+                previousFiles: knownFiles,
+            })
+                .then((files) => {
+                    knownFiles = files;
+                })
+                .finally(() => {
+                    syncPromise = undefined;
+                });
+            return syncPromise;
+        };
+
+        const fileSyncTimer = setInterval(() => {
+            void syncFiles().catch((error) => {
+                this.logger.warn(
+                    `OnboardingAgent: could not sync files: ${sanitizeOnboardingMessage(
+                        getErrorMessage(error),
+                        sensitiveValues,
+                    )}`,
+                );
+            });
+        }, FILE_SYNC_INTERVAL_MS);
+        fileSyncTimer.unref();
 
         const recordStep = (
             rawMessage: string,
@@ -352,6 +676,7 @@ export class OnboardingAgentService extends BaseService {
             }
         };
 
+        let runError: { value: unknown } | undefined;
         try {
             await sandbox.commands.run(
                 `cat ${PROMPT_PATH} | claude -p ` +
@@ -379,18 +704,45 @@ export class OnboardingAgentService extends BaseService {
                     },
                 },
             );
-        } finally {
-            if (buffer.trim()) {
-                try {
-                    handleEvent(JSON.parse(buffer));
-                } catch {
-                    this.logger.debug(
-                        'OnboardingAgent: received an unparseable trailing Claude event',
-                    );
-                }
-            }
-            await Promise.all(pendingEvents);
+        } catch (error) {
+            runError = { value: error };
         }
+
+        clearInterval(fileSyncTimer);
+        let syncError: { value: unknown } | undefined;
+        try {
+            if (syncPromise) {
+                await syncPromise.catch((error) => {
+                    this.logger.warn(
+                        `OnboardingAgent: periodic file sync failed before final sync: ${sanitizeOnboardingMessage(
+                            getErrorMessage(error),
+                            sensitiveValues,
+                        )}`,
+                    );
+                });
+            }
+            await syncFiles();
+        } catch (error) {
+            syncError = { value: error };
+            this.logger.warn(
+                `OnboardingAgent: could not complete file sync: ${sanitizeOnboardingMessage(
+                    getErrorMessage(error),
+                    sensitiveValues,
+                )}`,
+            );
+        }
+        if (buffer.trim()) {
+            try {
+                handleEvent(JSON.parse(buffer));
+            } catch {
+                this.logger.debug(
+                    'OnboardingAgent: received an unparseable trailing Claude event',
+                );
+            }
+        }
+        await Promise.all(pendingEvents);
+        if (runError) throw runError.value;
+        if (syncError) throw syncError.value;
         return { assistantText, usage };
     }
 

--- a/packages/backend/src/ee/services/OnboardingAgentService/constants.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/constants.ts
@@ -18,6 +18,7 @@ export const RUN_TIMEOUT_MS = 45 * 60 * 1000;
 export const SANDBOX_TIMEOUT_MS = 60 * 60 * 1000;
 export const PAT_EXPIRY_GRACE_MS = 15 * 60 * 1000;
 export const CANCELLATION_POLL_INTERVAL_MS = 10 * 1000;
+export const FILE_SYNC_INTERVAL_MS = 2 * 1000;
 
 export const ALLOWED_TOOLS = [
     `Read(${WORKDIR}/**)`,

--- a/packages/backend/src/ee/services/OnboardingAgentService/utils.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/utils.ts
@@ -15,6 +15,44 @@ const LIGHTDASH_COMMAND_PATTERN = new RegExp(
     )})\\s+([\\w-]+)`,
 );
 
+type BuildManagedOnboardingPromptArgs = {
+    basePrompt: string;
+    siteUrl: string;
+    projectUuid: string;
+    warehouseType: string;
+    database: string | undefined;
+    schema: string | undefined;
+};
+
+export const buildManagedOnboardingPrompt = (
+    args: BuildManagedOnboardingPromptArgs,
+): string => {
+    const preamble = [
+        '# Lightdash cloud onboarding run',
+        '',
+        'You are running inside a managed sandbox on Lightdash Cloud, completing project setup on behalf of a user.',
+        '',
+        '## Context',
+        `- Lightdash instance URL: ${args.siteUrl}`,
+        `- Warehouse type: ${args.warehouseType}`,
+        `- Prepared project UUID: ${args.projectUuid}`,
+        ...(args.database ? [`- Configured database: ${args.database}`] : []),
+        ...(args.schema ? [`- Configured schema: ${args.schema}`] : []),
+        '',
+        '## Environment overrides (IMPORTANT — these replace section 1 of the instructions below)',
+        '- The Lightdash CLI and skills are preinstalled. Skip section 1 entirely.',
+        `- Run every \`lightdash <args>\` command as \`${CLI_WRAPPER_PATH} <args>\` (a thin wrapper around the same CLI).`,
+        '- Authentication is already configured through environment variables (LIGHTDASH_URL, LIGHTDASH_API_KEY, LIGHTDASH_PROJECT). Do NOT run `lightdash login`.',
+        `- For section 1, verify the selected project with \`${CLI_WRAPPER_PATH} config get-project\` and confirm it matches the prepared project UUID, then continue from section 2.`,
+        `- There is no existing repository. Create all working files under ${WORKDIR} and build a pure Lightdash semantic layer from the warehouse catalog.`,
+        '',
+        '---',
+        '',
+    ].join('\n');
+
+    return preamble + args.basePrompt;
+};
+
 const normalizeToolPath = (path: string): string =>
     path
         .replaceAll('\\', '/')
@@ -119,3 +157,62 @@ export const sanitizeOnboardingMessage = (
             '$1[sandbox path]',
         );
 };
+
+export type WorkspaceFileEntry = {
+    path: string;
+    sizeBytes: number;
+    updatedAt: string;
+};
+
+export const isOnboardingOutputFile = (path: string): boolean => {
+    const segments = path.split('/');
+    if (
+        path.startsWith('/') ||
+        path.includes('\\') ||
+        path.includes('\0') ||
+        segments.some(
+            (segment) => !segment || segment === '.' || segment === '..',
+        )
+    ) {
+        return false;
+    }
+    return (
+        /^lightdash\.config\.ya?ml$/.test(path) ||
+        /^lightdash\/.+\.ya?ml$/.test(path) ||
+        /^LIGHTDASH_(?:ONBOARDING_)?HANDOFF(?:_\d{4}-\d{2}-\d{2}(?:-\d+)?)?\.md$/.test(
+            path,
+        )
+    );
+};
+
+export const parseWorkspaceFileListing = (
+    listing: string,
+): WorkspaceFileEntry[] =>
+    listing
+        .split('\n')
+        .filter(Boolean)
+        .flatMap((line) => {
+            const fields = line.split('\t');
+            if (fields.length < 3) return [];
+            const modifiedAt = Number(fields.pop());
+            const sizeBytes = Number(fields.pop());
+            const path = fields.join('\t');
+            const updatedAtMs = Math.floor(modifiedAt * 1000);
+            if (
+                !path ||
+                path.startsWith('/') ||
+                path.split('/').includes('..') ||
+                !Number.isFinite(sizeBytes) ||
+                sizeBytes < 0 ||
+                !Number.isFinite(updatedAtMs)
+            ) {
+                return [];
+            }
+            return [
+                {
+                    path,
+                    sizeBytes,
+                    updatedAt: new Date(updatedAtMs).toISOString(),
+                },
+            ];
+        });

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -268,6 +268,12 @@ const getTagsForTask: {
         'user.uuid': payload.userUuid,
         'project.uuid': payload.projectUuid,
     }),
+    [SCHEDULER_TASKS.AGENT_ONBOARDING_RUN]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'user.uuid': payload.userUuid,
+        'project.uuid': payload.projectUuid,
+        'agent_onboarding.run_uuid': payload.agentOnboardingRunUuid,
+    }),
     [SCHEDULER_TASKS.AI_AGENT_EDIT_DBT_PROJECT_PIPELINE]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,

--- a/packages/backend/src/services/PromptService/prompts/projectOnboarding.md
+++ b/packages/backend/src/services/PromptService/prompts/projectOnboarding.md
@@ -13,6 +13,16 @@ Use the warehouse type, prepared project UUID, and, when listed, the configured 
 - If a required CLI capability is unavailable, stop and report the blocker instead of bypassing the CLI.
 - Work only in the prepared repository. Preserve unrelated files and uncommitted work.
 
+## Progressive handoff
+
+Maintain a durable handoff report during the run. During the initial repository inspection, choose the first unused path from this sequence and keep it for the entire run:
+
+1. `LIGHTDASH_HANDOFF.md`
+2. `LIGHTDASH_ONBOARDING_HANDOFF_<YYYY-MM-DD>.md`
+3. `LIGHTDASH_ONBOARDING_HANDOFF_<YYYY-MM-DD>-2.md`, incrementing the suffix until the path is unused
+
+Never overwrite an existing report. Create or update the chosen report only at the four milestones specified below. Mark incomplete sections as `Pending`; never present planned or unverified work as complete. Reuse evidence already gathered for the current gate and do not make extra authenticated calls solely for the report.
+
 ## 1. Bootstrap, authenticate, and bind the project
 
 1. Run `command -v lightdash && lightdash --version`.
@@ -30,21 +40,23 @@ Do not rename the prepared project. Keep its existing name for compatibility wit
 
 ## 2. Discover, author, and deploy the semantic layer
 
-1. Inspect repository documentation, project metadata, and the working tree. Detect whether there is a usable dbt project or an existing pure Lightdash project.
+1. Inspect repository documentation, project metadata, the working tree, and the available handoff paths. Detect whether there is a usable dbt project or an existing pure Lightdash project.
 2. Start discovery in the configured database and schema from the original prompt, matching names case-insensitively: `lightdash warehouse-catalog --database <database> --schema <schema> --json`. Run the broader `lightdash warehouse-catalog --json` only when that configured scope has no coherent analytics use case or when no database and schema were provided. Store large output only in a gitignored temporary location. If a broad catalog spans many databases or schemas and repository evidence does not identify where to look, ask the user which database and schema to use and wait before continuing.
 3. Choose the smallest coherent analytics use case supported by repository and warehouse evidence. Do not infer business meaning from names alone.
 4. Fetch fields for each shortlisted relation exactly once with `lightdash warehouse-catalog --database <database> --schema <schema> --table <table> --include-fields --json`. Do not repeat field discovery through `information_schema`, another catalog call, or a raw SQL query.
 5. Use `lightdash sql "<aggregate query>" -o <temporary-output-file>` for aggregate-only profiling; the output file is required. Combine compatible grain, date range, measure, category, and join profiles into as few queries as practical. Read each output file once, extract the evidence needed for authoring, then delete it. Never output raw identifiers or row samples.
-6. Follow the installed skill and read each semantic-layer reference required for the detected project type at most once. Start from its basic example. Read a full schema or run `--help` only after a concrete command or lint failure cannot be resolved from the already-read reference.
-7. Extend a usable dbt project when present. Otherwise, build a minimal pure Lightdash semantic layer from the catalog evidence. A pure project must include the prepared warehouse type before its first deploy:
+6. **Handoff milestone 1 — discovery:** Create the chosen report with the selected use case, warehouse scope, selected relations and rationale, important assumptions, and concise summaries of skipped candidates. Add `Pending` sections for the semantic layer, dashboard content, validation, limitations, and next steps.
+7. Follow the installed skill and read each semantic-layer reference required for the detected project type at most once. Start from its basic example. Read a full schema or run `--help` only after a concrete command or lint failure cannot be resolved from the already-read reference.
+8. Extend a usable dbt project when present. Otherwise, build a minimal pure Lightdash semantic layer from the catalog evidence. A pure project must include the prepared warehouse type before its first deploy:
 
     ```yaml
     warehouse:
         type: <Prepared warehouse type>
     ```
 
-8. Preserve existing semantic content and use only evidenced dimensions, metrics, joins, and filter values.
-9. Run `lightdash lint`, resolve errors, then deploy with `lightdash deploy --project <Prepared project UUID>`.
+9. Preserve existing semantic content and use only evidenced dimensions, metrics, joins, and filter values.
+10. Run `lightdash lint`, resolve errors, then deploy with `lightdash deploy --project <Prepared project UUID>`.
+11. **Handoff milestone 2 — semantic layer:** Replace the pending semantic-layer section with a model-to-source mapping, grains, generated files, key dimensions, metrics, joins, assumptions, and the verified lint and deploy outcomes.
 
 **Gate:** The semantic layer compiles and deploys to the prepared project UUID without errors.
 
@@ -79,13 +91,15 @@ Use deterministic `agent-starter-*` chart slugs so reruns update the same conten
 
 After the batch is authored, run `lightdash lint` once, execute every chart with `lightdash run-chart -p <chart-yaml-path>`, and upload with `lightdash upload --project <Prepared project UUID> --validate`. Resolve every compile, field, filter, formatting, and query failure by changing only the reported files, then repeat only the failed check.
 
+**Handoff milestone 3 — dashboard:** Replace the pending dashboard section with every generated chart's title, slug, type, source model, purpose, dashboard slug, and space slug. Record chart execution and validated upload outcomes, and add the project and dashboard URLs. Do not perform extra verification calls for the report.
+
 **Gate:** Lint passes, every chart executes successfully, and validated upload succeeds.
 
 ## 4. Validate and hand off
 
 1. Run `lightdash validate --project <Prepared project UUID>` and resolve every reported semantic-layer error. Repeat validation only when it failed.
 2. Do not perform a round-trip download, repeat successful chart executions or uploads, or call internal APIs for additional verification.
-3. Create `LIGHTDASH_HANDOFF.md` in the repository root as the durable, secret-free audit report for this setup. If that file already exists, preserve it and create `LIGHTDASH_ONBOARDING_HANDOFF_<YYYY-MM-DD>.md` using the current date. If that path also exists, append `-2` before `.md`, incrementing the suffix until the path is unused. Never overwrite an existing handoff file.
+3. **Handoff milestone 4 — final validation:** Record project validation, complete the limitations and recommended follow-up work, add a generated-files table with repository-relative links where possible, and include next steps to merge the semantic-layer files into the user's analytics Git repository and connect the Lightdash project to it. List only roles, groups, or permissions actually observed or changed; otherwise state that none were observed or changed. Remove every `Pending` marker.
 
 The report must describe what was discovered, why the use case was selected, what was built, and how it was verified. Make it easy to audit with concise prose and Markdown tables. Include:
 

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -1,5 +1,6 @@
 import includes from 'lodash/includes';
 import {
+    type AgentOnboardingJobPayload,
     type AiAgentEvalRunJobPayload,
     type AiAgentReviewClassifierJobPayload,
     type AiAgentReviewRemediationCompileJobPayload,
@@ -84,6 +85,9 @@ export type AiWritebackPipelineJobPayload = TraceTaskBase & {
 export type AiDeepResearchPipelineJobPayload = TraceTaskBase &
     AiDeepResearchJobPayload;
 
+export type AgentOnboardingPipelineJobPayload = TraceTaskBase &
+    AgentOnboardingJobPayload;
+
 export type AiAgentEditDbtProjectPipelineJobPayload = TraceTaskBase & {
     aiWritebackRunUuid: string;
     // Serializes back-to-back edits in the same thread: the pipeline job runs on
@@ -115,6 +119,7 @@ export const EE_SCHEDULER_TASKS = {
     APP_BUILD_FROM_SOURCE: 'appBuildFromSource',
     AI_WRITEBACK_PIPELINE: 'aiWritebackPipeline',
     AI_DEEP_RESEARCH: 'aiDeepResearch',
+    AGENT_ONBOARDING_RUN: 'agentOnboardingRun',
     AI_AGENT_EDIT_DBT_PROJECT_PIPELINE: 'aiAgentEditDbtProjectPipeline',
     SWEEP_STALE_APP_LOCKS: 'sweepStaleAppLocks',
     SWEEP_STALE_AI_WRITEBACK_RUNS: 'sweepStaleAiWritebackRuns',
@@ -223,6 +228,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: TraceTaskBase;
     [SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: AiWritebackPipelineJobPayload;
     [SCHEDULER_TASKS.AI_DEEP_RESEARCH]: AiDeepResearchPipelineJobPayload;
+    [SCHEDULER_TASKS.AGENT_ONBOARDING_RUN]: AgentOnboardingPipelineJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_EDIT_DBT_PROJECT_PIPELINE]: AiAgentEditDbtProjectPipelineJobPayload;
 }
 
@@ -245,6 +251,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.CLEAN_MCP_TOOL_CALLS]: TraceTaskBase;
     [EE_SCHEDULER_TASKS.AI_WRITEBACK_PIPELINE]: AiWritebackPipelineJobPayload;
     [EE_SCHEDULER_TASKS.AI_DEEP_RESEARCH]: AiDeepResearchPipelineJobPayload;
+    [EE_SCHEDULER_TASKS.AGENT_ONBOARDING_RUN]: AgentOnboardingPipelineJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_EDIT_DBT_PROJECT_PIPELINE]: AiAgentEditDbtProjectPipelineJobPayload;
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-9041
Closes: PROD-9042
Closes: PROD-9048
Closes: PROD-9049
Closes: PROD-9050

### Description:
Makes cloud agent onboarding durable by routing prepared projects through scheduled jobs with tracing, timeouts, cancellation, and authenticated project-scoped APIs.
Synchronizes allowlisted workspace outputs to object storage and serves persisted files with project and source-code permission checks.
Updates the canonical onboarding prompt to use managed-environment gates and progressively maintain a collision-safe handoff report.