### PR TITLE
feat: enforce project-scoped chart slug uniqueness

### DIFF
--- a/packages/backend/src/controllers/savedChartController.ts
+++ b/packages/backend/src/controllers/savedChartController.ts
@@ -18,6 +18,7 @@ import {
     type ApiCreateSavedChartSchedulerResponse,
     type ApiSavedChartSchedulersResponse,
     type ParametersValuesMap,
+    type UUID,
 } from '@lightdash/common';
 import {
     Body,
@@ -489,6 +490,7 @@ Migrate to the v2 async query flow: [Execute saved chart](https://docs.lightdash
     async exportSavedChartImage(
         @Path() chartUuid: string,
         @Request() req: express.Request,
+        @Query() projectUuid?: UUID,
     ): Promise<ApiExportChartImageResponse> {
         assertRegisteredAccount(req.account);
         this.setStatus(200);
@@ -496,7 +498,11 @@ Migrate to the v2 async query flow: [Execute saved chart](https://docs.lightdash
             status: 'ok',
             results: await this.services
                 .getUnfurlService()
-                .exportChart(chartUuid, toSessionUser(req.account)),
+                .exportChart(
+                    chartUuid,
+                    toSessionUser(req.account),
+                    projectUuid,
+                ),
         };
     }
 

--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -79,7 +79,7 @@ export type SavedChartTable = Knex.CompositeTableType<
 export type DbSavedChart = {
     saved_query_id: number;
     saved_query_uuid: string;
-    project_uuid: string | null;
+    project_uuid: string;
     space_id: number | null;
     dashboard_uuid: string | null;
     name: string;

--- a/packages/backend/src/database/migrations/20260721170000_enforce_saved_query_project_slug_uniqueness.ts
+++ b/packages/backend/src/database/migrations/20260721170000_enforce_saved_query_project_slug_uniqueness.ts
@@ -1,0 +1,527 @@
+import { Knex } from 'knex';
+
+export const config = { transaction: false };
+
+const SavedQueriesTableName = 'saved_queries';
+const ProjectForeignKey = 'saved_queries_project_uuid_foreign';
+const ProjectNotNullCheck = 'saved_queries_project_uuid_not_null';
+const ProjectSlugUniqueConstraint = 'saved_queries_project_uuid_slug_unique';
+const OwnershipBatchSize = 1000;
+const SlugRepairBatchSize = 10000;
+const MaxGeneratedSlugLength = 255;
+const ChartSlugSuffixLength = '-chart-'.length;
+const LockTimeout = '5s';
+
+const canonicalProjectUuid = (alias: string): string => `COALESCE(
+    ${alias}_direct_project.project_uuid,
+    ${alias}_dashboard_project.project_uuid,
+    ${alias}_existing_project.project_uuid
+)`;
+
+const ownershipJoins = (alias: string): string => `
+    LEFT JOIN spaces AS ${alias}_direct_space
+        ON ${alias}_direct_space.space_id = ${alias}.space_id
+    LEFT JOIN projects AS ${alias}_direct_project
+        ON ${alias}_direct_project.project_id = ${alias}_direct_space.project_id
+    LEFT JOIN dashboards AS ${alias}_dashboard
+        ON ${alias}_dashboard.dashboard_uuid = ${alias}.dashboard_uuid
+    LEFT JOIN spaces AS ${alias}_dashboard_space
+        ON ${alias}_dashboard_space.space_id = ${alias}_dashboard.space_id
+    LEFT JOIN projects AS ${alias}_dashboard_project
+        ON ${alias}_dashboard_project.project_id =
+            ${alias}_dashboard_space.project_id
+    LEFT JOIN projects AS ${alias}_existing_project
+        ON ${alias}_existing_project.project_uuid = ${alias}.project_uuid
+`;
+
+/**
+ * Contract phase for direct saved-chart ownership and project-scoped slugs.
+ *
+ * Saved charts are owned through one of the existing FK chains:
+ *
+ * saved_queries.space_id -> spaces.project_id -> projects.project_uuid
+ *
+ * or:
+ *
+ * saved_queries.dashboard_uuid -> dashboards.space_id
+ *   -> spaces.project_id -> projects.project_uuid
+ *
+ * The application maintains exactly one of space_id or dashboard_uuid. Both
+ * ownership chains end at spaces.project_id, which is a NOT NULL project FK.
+ *
+ * The migration runs without Knex's outer transaction so repairs can commit in
+ * bounded batches and the unique index can be built concurrently. Every phase
+ * is idempotent and safe to resume after the migration lock is released:
+ *
+ * 1. Repair ambiguous dual ownership using the application's direct-space
+ *    COALESCE precedence, and log every anomalous ownership shape.
+ * 2. Reconcile direct owners from the canonical FK chains.
+ * 3. Add a NOT VALID non-null check, immediately protecting new writes.
+ * 4. Repair/reconcile again to close the window before the check was installed.
+ * 5. Validate/set NOT NULL and add/validate the project foreign key.
+ * 6. Rename only same-project duplicate slugs in committed batches.
+ * 7. Build the unique index concurrently and attach it as a constraint.
+ *
+ * Active rows win duplicate ties, but deleted rows still participate because
+ * they can be restored. Existing unique slugs are never changed. Rollback
+ * removes the database contract but intentionally keeps valid data repairs. A
+ * hard-killed runner can still require its global Knex lock to be released
+ * before another process resumes these idempotent phases.
+ */
+
+const logProgress = (message: string): void => {
+    // eslint-disable-next-line no-console
+    console.log(`  ${SavedQueriesTableName}: ${message}`);
+};
+
+const logWarning = (message: string): void => {
+    // eslint-disable-next-line no-console
+    console.warn(`  ${SavedQueriesTableName}: WARNING: ${message}`);
+};
+
+const getRowCount = (result: { rowCount?: number }): number =>
+    result.rowCount ?? 0;
+
+const isUniqueViolation = (error: unknown): boolean =>
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === '23505';
+
+async function constraintExists(
+    knex: Knex,
+    constraintName: string,
+    constraintType?: 'f' | 'u',
+): Promise<boolean> {
+    const result = await knex.raw<{ rowCount: number }>(
+        `SELECT 1
+         FROM pg_constraint
+         WHERE conname = ?
+           AND conrelid = ?::regclass
+           ${constraintType ? 'AND contype = ?' : ''}`,
+        constraintType
+            ? [constraintName, SavedQueriesTableName, constraintType]
+            : [constraintName, SavedQueriesTableName],
+    );
+    return getRowCount(result) > 0;
+}
+
+async function isProjectUuidNotNull(knex: Knex): Promise<boolean> {
+    const result = await knex.raw<{ rows: Array<{ attnotnull: boolean }> }>(
+        `SELECT attnotnull
+         FROM pg_attribute
+         WHERE attrelid = ?::regclass
+           AND attname = 'project_uuid'
+           AND NOT attisdropped`,
+        [SavedQueriesTableName],
+    );
+    return result.rows[0]?.attnotnull ?? false;
+}
+
+async function withLockTimeout<T>(
+    knex: Knex,
+    callback: (trx: Knex.Transaction) => Promise<T>,
+): Promise<T> {
+    return knex.transaction(async (trx) => {
+        await trx.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);
+        return callback(trx);
+    });
+}
+
+async function repairAndLogProjectOwnership(knex: Knex): Promise<void> {
+    const result = await knex.raw<{
+        rows: Array<{
+            conflicting_projects: string;
+            dual_owners: string;
+            missing_owners: string;
+            unresolvable_owners: string;
+        }>;
+    }>(`
+        SELECT
+            COUNT(*) FILTER (
+                WHERE saved_queries_direct_project.project_uuid IS NOT NULL
+                  AND saved_queries_dashboard_project.project_uuid IS NOT NULL
+                  AND saved_queries_direct_project.project_uuid <>
+                      saved_queries_dashboard_project.project_uuid
+            )::text AS conflicting_projects,
+            COUNT(*) FILTER (
+                WHERE saved_queries.space_id IS NOT NULL
+                  AND saved_queries.dashboard_uuid IS NOT NULL
+            )::text AS dual_owners,
+            COUNT(*) FILTER (
+                WHERE saved_queries.space_id IS NULL
+                  AND saved_queries.dashboard_uuid IS NULL
+            )::text AS missing_owners,
+            COUNT(*) FILTER (
+                WHERE ${canonicalProjectUuid('saved_queries')} IS NULL
+            )::text AS unresolvable_owners
+        FROM ${SavedQueriesTableName} AS saved_queries
+        ${ownershipJoins('saved_queries')}
+    `);
+
+    const counts = result.rows[0];
+    const conflictingProjects = Number(counts?.conflicting_projects ?? 0);
+    const dualOwners = Number(counts?.dual_owners ?? 0);
+    const missingOwners = Number(counts?.missing_owners ?? 0);
+    const unresolvableOwners = Number(counts?.unresolvable_owners ?? 0);
+
+    if (conflictingProjects > 0) {
+        logWarning(
+            `${conflictingProjects} rows reference direct spaces and dashboards in different projects; direct-space ownership takes precedence`,
+        );
+    }
+    if (dualOwners > 0) {
+        logWarning(
+            `${dualOwners} rows have both space_id and dashboard_uuid; clearing dashboard_uuid to match the application's direct-space precedence`,
+        );
+        let totalRepaired = 0;
+        for (;;) {
+            // eslint-disable-next-line no-await-in-loop
+            const repairResult = await withLockTimeout(knex, async (trx) =>
+                trx.raw<{ rowCount: number }>(`
+                    WITH batch AS (
+                        SELECT saved_query_id
+                        FROM ${SavedQueriesTableName}
+                        WHERE space_id IS NOT NULL
+                          AND dashboard_uuid IS NOT NULL
+                        ORDER BY saved_query_id
+                        LIMIT ${OwnershipBatchSize}
+                    )
+                    UPDATE ${SavedQueriesTableName} AS saved_queries
+                    SET dashboard_uuid = NULL
+                    FROM batch
+                    WHERE saved_queries.saved_query_id = batch.saved_query_id
+                `),
+            );
+            const repaired = getRowCount(repairResult);
+            if (repaired === 0) break;
+            totalRepaired += repaired;
+            logWarning(`repaired dual ownership for ${totalRepaired} rows`);
+        }
+    }
+    if (missingOwners > 0) {
+        logWarning(
+            `${missingOwners} rows have neither space_id nor dashboard_uuid; preserving their existing valid project_uuid`,
+        );
+    }
+    if (unresolvableOwners > 0) {
+        logWarning(
+            `${unresolvableOwners} rows have no ownership path or valid existing project_uuid and cannot be repaired safely`,
+        );
+        throw new Error(
+            `${SavedQueriesTableName}: ${unresolvableOwners} rows have no resolvable project ownership`,
+        );
+    }
+}
+
+async function reconcileProjectUuids(knex: Knex): Promise<void> {
+    let totalUpdated = 0;
+    for (;;) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await withLockTimeout(knex, async (trx) =>
+            trx.raw<{ rowCount: number }>(`
+                WITH batch AS (
+                    SELECT
+                        saved_queries.saved_query_id,
+                        ${canonicalProjectUuid('saved_queries')} AS project_uuid
+                    FROM ${SavedQueriesTableName} AS saved_queries
+                    ${ownershipJoins('saved_queries')}
+                    WHERE saved_queries.project_uuid IS DISTINCT FROM
+                        ${canonicalProjectUuid('saved_queries')}
+                    ORDER BY saved_queries.saved_query_id
+                    LIMIT ${OwnershipBatchSize}
+                )
+                UPDATE ${SavedQueriesTableName} AS saved_queries
+                SET project_uuid = batch.project_uuid
+                FROM batch
+                WHERE saved_queries.saved_query_id = batch.saved_query_id
+                  AND saved_queries.project_uuid IS DISTINCT FROM
+                      batch.project_uuid
+            `),
+        );
+        const updated = getRowCount(result);
+        if (updated === 0) break;
+        totalUpdated += updated;
+        logProgress(`reconciled project UUID for ${totalUpdated} rows`);
+    }
+}
+
+async function addProjectNotNullCheck(knex: Knex): Promise<void> {
+    if (
+        (await isProjectUuidNotNull(knex)) ||
+        (await constraintExists(knex, ProjectNotNullCheck))
+    ) {
+        return;
+    }
+
+    logProgress('adding the project UUID not-null check');
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${SavedQueriesTableName}
+            ADD CONSTRAINT ${ProjectNotNullCheck}
+            CHECK (project_uuid IS NOT NULL)
+            NOT VALID
+        `);
+    });
+}
+
+async function deduplicateSlugs(knex: Knex): Promise<void> {
+    let totalUpdated = 0;
+    for (;;) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await withLockTimeout(knex, async (trx) =>
+            trx.raw<{ rowCount: number }>(`
+                WITH ranked AS (
+                    SELECT
+                        saved_query_id,
+                        project_uuid,
+                        slug,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY project_uuid, slug
+                            ORDER BY
+                                (deleted_at IS NULL) DESC,
+                                created_at,
+                                saved_query_id
+                        ) AS duplicate_number
+                    FROM ${SavedQueriesTableName}
+                ), duplicate_rows AS (
+                    SELECT saved_query_id, project_uuid, slug
+                    FROM ranked
+                    WHERE duplicate_number > 1
+                    ORDER BY project_uuid, slug, saved_query_id
+                    LIMIT ${SlugRepairBatchSize}
+                ), replacements AS (
+                    SELECT
+                        duplicate_rows.saved_query_id,
+                        duplicate_rows.project_uuid,
+                        duplicate_rows.slug AS original_slug,
+                        replacement.candidate
+                    FROM duplicate_rows
+                    CROSS JOIN LATERAL (
+                        WITH RECURSIVE candidates(attempt, candidate) AS (
+                            SELECT
+                                0,
+                                LEFT(
+                                    duplicate_rows.slug,
+                                    GREATEST(
+                                        0,
+                                        ${MaxGeneratedSlugLength} -
+                                            ${ChartSlugSuffixLength} -
+                                            CHAR_LENGTH(
+                                                duplicate_rows.saved_query_id::text
+                                            )
+                                    )
+                                ) || '-chart-' ||
+                                    duplicate_rows.saved_query_id::text
+                            UNION ALL
+                            SELECT
+                                candidates.attempt + 1,
+                                LEFT(
+                                    duplicate_rows.slug,
+                                    GREATEST(
+                                        0,
+                                        ${MaxGeneratedSlugLength - 1} -
+                                            ${ChartSlugSuffixLength} -
+                                            CHAR_LENGTH(
+                                                duplicate_rows.saved_query_id::text
+                                            ) -
+                                            CHAR_LENGTH(
+                                                (candidates.attempt + 1)::text
+                                            )
+                                    )
+                                ) || '-chart-' ||
+                                    duplicate_rows.saved_query_id::text || '-' ||
+                                    (candidates.attempt + 1)::text
+                            FROM candidates
+                            WHERE EXISTS (
+                                SELECT 1
+                                FROM ${SavedQueriesTableName} AS existing
+                                WHERE existing.project_uuid =
+                                        duplicate_rows.project_uuid
+                                  AND existing.slug = candidates.candidate
+                                  AND existing.saved_query_id <>
+                                      duplicate_rows.saved_query_id
+                            )
+                        )
+                        SELECT candidates.candidate
+                        FROM candidates
+                        WHERE NOT EXISTS (
+                            SELECT 1
+                            FROM ${SavedQueriesTableName} AS existing
+                            WHERE existing.project_uuid =
+                                    duplicate_rows.project_uuid
+                              AND existing.slug = candidates.candidate
+                              AND existing.saved_query_id <>
+                                  duplicate_rows.saved_query_id
+                        )
+                        ORDER BY candidates.attempt
+                        LIMIT 1
+                    ) AS replacement
+                )
+                UPDATE ${SavedQueriesTableName} AS saved_queries
+                SET slug = replacements.candidate
+                FROM replacements
+                WHERE saved_queries.saved_query_id =
+                        replacements.saved_query_id
+                  AND saved_queries.project_uuid =
+                        replacements.project_uuid
+                  AND saved_queries.slug = replacements.original_slug
+            `),
+        );
+        const updated = getRowCount(result);
+        if (updated === 0) break;
+        totalUpdated += updated;
+        logProgress(`deduplicated slug for ${totalUpdated} rows`);
+    }
+}
+
+async function dropInvalidProjectSlugIndex(knex: Knex): Promise<void> {
+    const invalidIndex = await knex.raw<{ rowCount: number }>(
+        `SELECT 1
+         FROM pg_class
+         JOIN pg_index ON pg_index.indexrelid = pg_class.oid
+         WHERE pg_class.relname = ?
+           AND pg_index.indrelid = ?::regclass
+           AND NOT pg_index.indisvalid`,
+        [ProjectSlugUniqueConstraint, SavedQueriesTableName],
+    );
+    if (getRowCount(invalidIndex) > 0) {
+        logProgress('dropping an invalid project slug index from a prior run');
+        await knex.raw(
+            `DROP INDEX CONCURRENTLY IF EXISTS ${ProjectSlugUniqueConstraint}`,
+        );
+    }
+}
+
+async function createProjectSlugConstraint(knex: Knex): Promise<void> {
+    if (await constraintExists(knex, ProjectSlugUniqueConstraint, 'u')) {
+        return;
+    }
+
+    for (;;) {
+        // A duplicate can be written after the repair pass while the concurrent
+        // index is building. Repair and retry without operator intervention.
+        // eslint-disable-next-line no-await-in-loop
+        await dropInvalidProjectSlugIndex(knex);
+        try {
+            logProgress('building the project slug unique index concurrently');
+            // eslint-disable-next-line no-await-in-loop
+            await knex.raw(`
+                CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ${ProjectSlugUniqueConstraint}
+                ON ${SavedQueriesTableName} (project_uuid, slug)
+            `);
+            break;
+        } catch (error) {
+            if (!isUniqueViolation(error)) throw error;
+            logProgress(
+                'a concurrent duplicate appeared during index creation; repairing and retrying',
+            );
+            // eslint-disable-next-line no-await-in-loop
+            await dropInvalidProjectSlugIndex(knex);
+            // eslint-disable-next-line no-await-in-loop
+            await deduplicateSlugs(knex);
+        }
+    }
+
+    await withLockTimeout(knex, async (trx) => {
+        if (!(await constraintExists(trx, ProjectSlugUniqueConstraint, 'u'))) {
+            logProgress('attaching the project slug unique constraint');
+            await trx.raw(`
+                ALTER TABLE ${SavedQueriesTableName}
+                ADD CONSTRAINT ${ProjectSlugUniqueConstraint}
+                UNIQUE USING INDEX ${ProjectSlugUniqueConstraint}
+            `);
+        }
+    });
+}
+
+async function enforceProjectNotNull(knex: Knex): Promise<void> {
+    if (await isProjectUuidNotNull(knex)) {
+        await withLockTimeout(knex, async (trx) => {
+            await trx.raw(`
+                ALTER TABLE ${SavedQueriesTableName}
+                DROP CONSTRAINT IF EXISTS ${ProjectNotNullCheck}
+            `);
+        });
+        return;
+    }
+
+    logProgress('validating the project UUID not-null constraint');
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${SavedQueriesTableName}
+            VALIDATE CONSTRAINT ${ProjectNotNullCheck}
+        `);
+    });
+
+    logProgress('setting project UUID NOT NULL');
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${SavedQueriesTableName}
+            ALTER COLUMN project_uuid SET NOT NULL,
+            DROP CONSTRAINT IF EXISTS ${ProjectNotNullCheck}
+        `);
+    });
+}
+
+async function addAndValidateProjectForeignKey(knex: Knex): Promise<void> {
+    if (!(await constraintExists(knex, ProjectForeignKey, 'f'))) {
+        logProgress('adding the project foreign key without validation');
+        await withLockTimeout(knex, async (trx) => {
+            await trx.raw(`
+                ALTER TABLE ${SavedQueriesTableName}
+                ADD CONSTRAINT ${ProjectForeignKey}
+                FOREIGN KEY (project_uuid)
+                REFERENCES projects(project_uuid)
+                ON DELETE CASCADE
+                NOT VALID
+            `);
+        });
+    }
+
+    logProgress('validating the project foreign key');
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${SavedQueriesTableName}
+            VALIDATE CONSTRAINT ${ProjectForeignKey}
+        `);
+    });
+}
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        await repairAndLogProjectOwnership(knex);
+        await reconcileProjectUuids(knex);
+        await addProjectNotNullCheck(knex);
+        await repairAndLogProjectOwnership(knex);
+        await reconcileProjectUuids(knex);
+        await enforceProjectNotNull(knex);
+        await addAndValidateProjectForeignKey(knex);
+        await deduplicateSlugs(knex);
+        await createProjectSlugConstraint(knex);
+        logProgress('project-scoped chart slug constraint complete');
+    } finally {
+        await knex.raw('RESET statement_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        await withLockTimeout(knex, async (trx) => {
+            await trx.raw(`
+                ALTER TABLE ${SavedQueriesTableName}
+                DROP CONSTRAINT IF EXISTS ${ProjectForeignKey},
+                DROP CONSTRAINT IF EXISTS ${ProjectSlugUniqueConstraint},
+                DROP CONSTRAINT IF EXISTS ${ProjectNotNullCheck},
+                ALTER COLUMN project_uuid DROP NOT NULL
+            `);
+        });
+        await knex.raw(
+            `DROP INDEX CONCURRENTLY IF EXISTS ${ProjectSlugUniqueConstraint}`,
+        );
+    } finally {
+        await knex.raw('RESET statement_timeout');
+    }
+}

--- a/packages/backend/src/models/SavedChartModel.test.ts
+++ b/packages/backend/src/models/SavedChartModel.test.ts
@@ -1,12 +1,20 @@
 import { AnyType } from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { DatabaseError } from 'pg';
 import { lightdashConfigMock } from '../config/lightdashConfig.mock';
 import { DashboardsTableName } from '../database/entities/dashboards';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
 import { SpaceTableName } from '../database/entities/spaces';
 import { createSavedChart, SavedChartModel } from './SavedChartModel';
 import { chartSummary } from './SavedChartModel.mock';
+
+const projectSlugUniqueViolation = (): DatabaseError => {
+    const error = new DatabaseError('duplicate chart slug', 0, 'error');
+    error.code = '23505';
+    error.constraint = 'saved_queries_project_uuid_slug_unique';
+    return error;
+};
 
 describe('createSavedChart', () => {
     const database = knex({ client: MockClient, dialect: 'pg' });
@@ -34,6 +42,7 @@ describe('createSavedChart', () => {
     });
 
     beforeEach(() => {
+        tracker.on.select('pg_advisory_xact_lock').response({});
         vi.spyOn(database, 'transaction').mockImplementation(((
             callback: AnyType,
         ) => callback(database)) as AnyType);
@@ -122,6 +131,226 @@ describe('createSavedChart', () => {
         expect(chartInsert?.sql).toContain('"project_uuid"');
         expect(chartInsert?.bindings).toContain(projectUuid);
         expect(chartInsert?.bindings).toContain(dashboardUuid);
+    });
+
+    test('generates a unique slug within the project', async () => {
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+        const spaceUuid = '33333333-3333-4333-8333-333333333333';
+
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ slug: 'orders' }]);
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
+        tracker.on
+            .insert(SavedChartsTableName)
+            .responseOnce([
+                { saved_query_id: 11, saved_query_uuid: 'chart-uuid' },
+            ]);
+        tracker.on
+            .insert('saved_queries_versions')
+            .responseOnce([{ saved_queries_version_id: 13 }]);
+
+        await createSavedChart(
+            database,
+            projectUuid,
+            '11111111-1111-4111-8111-111111111111',
+            {
+                ...chartInput,
+                spaceUuid,
+                dashboardUuid: null,
+            },
+        );
+
+        const slugQuery = tracker.history.select.find((query) =>
+            query.sql.includes(`from "${SavedChartsTableName}"`),
+        );
+        expect(slugQuery?.sql).toContain(
+            `"${SavedChartsTableName}"."project_uuid"`,
+        );
+        expect(slugQuery?.bindings).toContain(projectUuid);
+
+        const chartInsert = tracker.history.insert.find((query) =>
+            query.sql.includes(`into "${SavedChartsTableName}"`),
+        );
+        expect(chartInsert?.bindings).toContain('orders-1');
+    });
+
+    test('returns an active chart that already has a forced slug', async () => {
+        tracker.on.select(SavedChartsTableName).responseOnce([
+            {
+                saved_query_uuid: 'existing-chart-uuid',
+                deleted_at: null,
+            },
+        ]);
+
+        const result = await createSavedChart(
+            database,
+            '22222222-2222-4222-8222-222222222222',
+            '11111111-1111-4111-8111-111111111111',
+            {
+                ...chartInput,
+                spaceUuid: '33333333-3333-4333-8333-333333333333',
+                dashboardUuid: null,
+                forceSlug: true,
+            },
+        );
+
+        expect(result).toBe('existing-chart-uuid');
+        expect(tracker.history.insert).toHaveLength(0);
+    });
+
+    test('rejects a forced slug owned by a deleted chart', async () => {
+        tracker.on.select(SavedChartsTableName).responseOnce([
+            {
+                saved_query_uuid: 'deleted-chart-uuid',
+                deleted_at: new Date(),
+            },
+        ]);
+
+        await expect(
+            createSavedChart(
+                database,
+                '22222222-2222-4222-8222-222222222222',
+                '11111111-1111-4111-8111-111111111111',
+                {
+                    ...chartInput,
+                    spaceUuid: '33333333-3333-4333-8333-333333333333',
+                    dashboardUuid: null,
+                    forceSlug: true,
+                },
+            ),
+        ).rejects.toThrow(
+            'Chart slug "orders" is already used by a deleted chart',
+        );
+        expect(tracker.history.insert).toHaveLength(0);
+    });
+
+    test('preserves a long forced slug', async () => {
+        tracker.on.select(SavedChartsTableName).responseOnce([
+            {
+                saved_query_uuid: 'existing-chart-uuid',
+                deleted_at: null,
+            },
+        ]);
+
+        const result = await createSavedChart(
+            database,
+            '22222222-2222-4222-8222-222222222222',
+            '11111111-1111-4111-8111-111111111111',
+            {
+                ...chartInput,
+                slug: '🌠'.repeat(300),
+                spaceUuid: '33333333-3333-4333-8333-333333333333',
+                dashboardUuid: null,
+                forceSlug: true,
+            },
+        );
+
+        expect(result).toBe('existing-chart-uuid');
+    });
+
+    test('retries a normal create after the database detects a slug race', async () => {
+        const projectUuid = '22222222-2222-4222-8222-222222222222';
+        const spaceUuid = '33333333-3333-4333-8333-333333333333';
+
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ saved_query_id: 10 }]);
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
+        tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
+        tracker.on
+            .insert(SavedChartsTableName)
+            .simulateErrorOnce(projectSlugUniqueViolation());
+        tracker.on
+            .insert(SavedChartsTableName)
+            .responseOnce([
+                { saved_query_id: 11, saved_query_uuid: 'chart-uuid' },
+            ]);
+        tracker.on
+            .insert('saved_queries_versions')
+            .responseOnce([{ saved_queries_version_id: 13 }]);
+
+        const result = await createSavedChart(
+            database,
+            projectUuid,
+            '11111111-1111-4111-8111-111111111111',
+            {
+                ...chartInput,
+                spaceUuid,
+                dashboardUuid: null,
+            },
+        );
+
+        expect(result).toBe('chart-uuid');
+        const successfulInsert = tracker.history.insert.at(-2);
+        expect(successfulInsert?.bindings).toContain('orders-1');
+    });
+
+    test('resolves a forced-slug race to the chart committed by the other writer', async () => {
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+        tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
+        tracker.on.select(SavedChartsTableName).responseOnce([
+            {
+                saved_query_uuid: 'racing-chart-uuid',
+                deleted_at: null,
+            },
+        ]);
+        tracker.on
+            .insert(SavedChartsTableName)
+            .simulateErrorOnce(projectSlugUniqueViolation());
+
+        const result = await createSavedChart(
+            database,
+            '22222222-2222-4222-8222-222222222222',
+            '11111111-1111-4111-8111-111111111111',
+            {
+                ...chartInput,
+                spaceUuid: '33333333-3333-4333-8333-333333333333',
+                dashboardUuid: null,
+                forceSlug: true,
+            },
+        );
+
+        expect(result).toBe('racing-chart-uuid');
+        expect(tracker.history.insert).toHaveLength(1);
+    });
+
+    test('reconciles a forced slug after the final retry loses a race', async () => {
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+            tracker.on.select(SavedChartsTableName).responseOnce([]);
+            tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
+            tracker.on
+                .insert(SavedChartsTableName)
+                .simulateErrorOnce(projectSlugUniqueViolation());
+            tracker.on.select(SavedChartsTableName).responseOnce(
+                attempt === 2
+                    ? [
+                          {
+                              saved_query_uuid: 'final-racing-chart-uuid',
+                              deleted_at: null,
+                          },
+                      ]
+                    : [],
+            );
+        }
+
+        const result = await createSavedChart(
+            database,
+            '22222222-2222-4222-8222-222222222222',
+            '11111111-1111-4111-8111-111111111111',
+            {
+                ...chartInput,
+                spaceUuid: '33333333-3333-4333-8333-333333333333',
+                dashboardUuid: null,
+                forceSlug: true,
+            },
+        );
+
+        expect(result).toBe('final-racing-chart-uuid');
+        expect(tracker.history.insert).toHaveLength(3);
     });
 });
 
@@ -238,6 +467,13 @@ describe('updateMultiple', () => {
         ).rejects.toThrow('Saved query not found');
 
         const [updateQuery] = tracker.history.update;
+        expect(updateQuery.sql).toContain(
+            `"${SavedChartsTableName}"."project_uuid"`,
+        );
+        expect(updateQuery.sql).toContain(
+            `"${SavedChartsTableName}"."space_id" is not null`,
+        );
+        expect(updateQuery.sql).not.toContain(' in (select ');
         expect(updateQuery.bindings).toContain(chartUuid);
         expect(updateQuery.bindings).toContain(projectUuid);
     });
@@ -273,6 +509,11 @@ describe('update', () => {
         await model.update(chartUuid, { name: 'Renamed chart' });
 
         expect(tracker.history.select).toHaveLength(1);
+        const [projectQuery] = tracker.history.select;
+        expect(projectQuery.sql).toContain(
+            `"${SavedChartsTableName}"."project_uuid"`,
+        );
+        expect(projectQuery.sql).not.toContain('join "projects"');
         const [updateQuery] = tracker.history.update;
         expect(updateQuery.sql).toContain('"project_uuid"');
         expect(updateQuery.sql).not.toContain('"space_id"');
@@ -347,6 +588,10 @@ describe('moveToSpace', () => {
         const sourceChartQuery = tracker.history.select.find((query) =>
             query.sql.includes(`from "${SavedChartsTableName}"`),
         );
+        expect(sourceChartQuery?.sql).toContain(
+            `"${SavedChartsTableName}"."project_uuid"`,
+        );
+        expect(sourceChartQuery?.sql).not.toContain('current_project');
         expect(sourceChartQuery?.bindings).toContain(chartUuid);
         expect(sourceChartQuery?.bindings).toContain(projectUuid);
 

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -7,6 +7,7 @@ import {
     ChartSourceType,
     ChartSummary,
     ChartVersionSummary,
+    ConflictError,
     ContentType,
     CreateSavedChart,
     CreateSavedChartVersion,
@@ -52,6 +53,7 @@ import {
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { Knex } from 'knex';
+import { DatabaseError } from 'pg';
 import { validate as isValidUuid } from 'uuid';
 import { LightdashConfig } from '../config/parseConfig';
 import {
@@ -75,6 +77,7 @@ import {
     CreateDbSavedChartVersionField,
     CreateDbSavedChartVersionSort,
     DBFilteredAdditionalMetrics,
+    DbSavedChart,
     DbSavedChartAdditionalMetric,
     DbSavedChartAdditionalMetricInsert,
     DbSavedChartCustomDimensionInsert,
@@ -94,7 +97,10 @@ import { UserTableName } from '../database/entities/users';
 import KnexPaginate from '../database/pagination';
 import { traceSpan } from '../tracing/tracing';
 import { wrapSentryTransaction } from '../utils';
-import { acquireProjectSlugLock, generateUniqueSlug } from '../utils/SlugUtils';
+import {
+    acquireProjectSlugLock,
+    generateUniqueSlugScopedToProject,
+} from '../utils/SlugUtils';
 import { ContentVerificationModel } from './ContentVerificationModel';
 
 type DbSavedChartDetails = {
@@ -414,6 +420,48 @@ const createSavedChartVersion = async (
     });
 };
 
+const ProjectSlugUniqueConstraint = 'saved_queries_project_uuid_slug_unique';
+const MaxChartSlugCreateAttempts = 3;
+
+type SavedChartSlugOwner = Pick<
+    DbSavedChart,
+    'saved_query_uuid' | 'deleted_at'
+>;
+
+const getSavedChartSlugOwner = async (
+    database: Knex,
+    projectUuid: string,
+    slug: string,
+): Promise<SavedChartSlugOwner | undefined> =>
+    database(SavedChartsTableName)
+        .where(`${SavedChartsTableName}.project_uuid`, projectUuid)
+        .where(`${SavedChartsTableName}.slug`, slug)
+        .select(
+            `${SavedChartsTableName}.saved_query_uuid`,
+            `${SavedChartsTableName}.deleted_at`,
+        )
+        .first();
+
+const resolveForcedChartSlug = async (
+    database: Knex,
+    projectUuid: string,
+    slug: string,
+): Promise<string | undefined> => {
+    const existing = await getSavedChartSlugOwner(database, projectUuid, slug);
+    if (!existing) return undefined;
+    if (existing.deleted_at) {
+        throw new ConflictError(
+            `Chart slug "${slug}" is already used by a deleted chart`,
+        );
+    }
+    return existing.saved_query_uuid;
+};
+
+const isProjectSlugUniqueViolation = (error: unknown): boolean =>
+    error instanceof DatabaseError &&
+    error.code === '23505' &&
+    error.constraint === ProjectSlugUniqueConstraint;
+
 export const createSavedChart = async (
     db: Knex,
     projectUuid: string,
@@ -437,121 +485,127 @@ export const createSavedChart = async (
         slug: string;
         forceSlug?: boolean;
     },
-): Promise<string> =>
-    db.transaction(async (trx) => {
-        if (forceSlug) {
-            // Forced slugs (content-as-code / promotion) skip unique-slug
-            // generation, and there is no DB unique constraint on the slug.
-            // Serialize concurrent creates of the same (project, slug) and
-            // dedupe against a row a racing upsert already created, so we never
-            // insert a duplicate slug (PROD-7883). Resolves the chart's project
-            // through either its space or its parent dashboard's space.
-            await acquireProjectSlugLock(trx, projectUuid, slug);
-            const [existing] = await trx(SavedChartsTableName)
-                .leftJoin(
-                    DashboardsTableName,
-                    `${DashboardsTableName}.dashboard_uuid`,
-                    `${SavedChartsTableName}.dashboard_uuid`,
-                )
-                .innerJoin(SpaceTableName, function spaceJoin() {
-                    this.on(
-                        `${SpaceTableName}.space_id`,
-                        '=',
-                        `${DashboardsTableName}.space_id`,
-                    ).orOn(
-                        `${SpaceTableName}.space_id`,
-                        '=',
-                        `${SavedChartsTableName}.space_id`,
-                    );
-                })
-                .innerJoin(
-                    ProjectTableName,
-                    `${SpaceTableName}.project_id`,
-                    `${ProjectTableName}.project_id`,
-                )
-                .where(`${ProjectTableName}.project_uuid`, projectUuid)
-                .where(`${SavedChartsTableName}.slug`, slug)
-                .whereNull(`${SavedChartsTableName}.deleted_at`)
-                .select(`${SavedChartsTableName}.saved_query_uuid`);
-            if (existing) {
-                return existing.saved_query_uuid;
-            }
-        }
+): Promise<string> => {
+    for (let attempt = 1; attempt <= MaxChartSlugCreateAttempts; attempt += 1) {
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            return await db.transaction(async (trx) => {
+                await acquireProjectSlugLock(trx, projectUuid, slug);
 
-        let chart: InsertChart;
-        const baseChart = {
-            name,
-            description,
-            last_version_chart_kind:
-                getChartKind(chartConfig.type, chartConfig.config) ||
-                ChartKind.VERTICAL_BAR,
-            last_version_updated_by_user_uuid: userUuid,
-            project_uuid: projectUuid,
-            slug: forceSlug
-                ? slug
-                : await generateUniqueSlug(trx, SavedChartsTableName, slug),
-        };
-        if (dashboardUuid) {
-            const dashboard = await trx(DashboardsTableName)
-                .innerJoin(
-                    SpaceTableName,
-                    `${SpaceTableName}.space_id`,
-                    `${DashboardsTableName}.space_id`,
-                )
-                .innerJoin(
-                    ProjectTableName,
-                    `${ProjectTableName}.project_id`,
-                    `${SpaceTableName}.project_id`,
-                )
-                .where(`${DashboardsTableName}.dashboard_uuid`, dashboardUuid)
-                .where(`${ProjectTableName}.project_uuid`, projectUuid)
-                .select(`${DashboardsTableName}.dashboard_uuid`)
-                .first();
-            if (!dashboard) {
-                throw new NotFoundError('Dashboard not found');
+                if (forceSlug) {
+                    const existingUuid = await resolveForcedChartSlug(
+                        trx,
+                        projectUuid,
+                        slug,
+                    );
+                    if (existingUuid) return existingUuid;
+                }
+
+                let chart: InsertChart;
+                const baseChart = {
+                    name,
+                    description,
+                    last_version_chart_kind:
+                        getChartKind(chartConfig.type, chartConfig.config) ||
+                        ChartKind.VERTICAL_BAR,
+                    last_version_updated_by_user_uuid: userUuid,
+                    project_uuid: projectUuid,
+                    slug: forceSlug
+                        ? slug
+                        : await generateUniqueSlugScopedToProject(
+                              trx,
+                              projectUuid,
+                              SavedChartsTableName,
+                              slug,
+                          ),
+                };
+                if (dashboardUuid) {
+                    const dashboard = await trx(DashboardsTableName)
+                        .innerJoin(
+                            SpaceTableName,
+                            `${SpaceTableName}.space_id`,
+                            `${DashboardsTableName}.space_id`,
+                        )
+                        .innerJoin(
+                            ProjectTableName,
+                            `${ProjectTableName}.project_id`,
+                            `${SpaceTableName}.project_id`,
+                        )
+                        .where(
+                            `${DashboardsTableName}.dashboard_uuid`,
+                            dashboardUuid,
+                        )
+                        .where(`${ProjectTableName}.project_uuid`, projectUuid)
+                        .select(`${DashboardsTableName}.dashboard_uuid`)
+                        .first();
+                    if (!dashboard) {
+                        throw new NotFoundError('Dashboard not found');
+                    }
+                    chart = {
+                        ...baseChart,
+                        dashboard_uuid: dashboardUuid,
+                        space_id: null,
+                    };
+                } else {
+                    if (!spaceUuid) {
+                        throw new NotFoundError('No space specified for chart');
+                    }
+                    const space = await trx(SpaceTableName)
+                        .innerJoin(
+                            ProjectTableName,
+                            `${ProjectTableName}.project_id`,
+                            `${SpaceTableName}.project_id`,
+                        )
+                        .where(`${SpaceTableName}.space_uuid`, spaceUuid)
+                        .where(`${ProjectTableName}.project_uuid`, projectUuid)
+                        .select(`${SpaceTableName}.space_id`)
+                        .first();
+                    if (!space) {
+                        throw new NotFoundError('Space not found');
+                    }
+                    chart = {
+                        ...baseChart,
+                        dashboard_uuid: null,
+                        space_id: space.space_id,
+                    };
+                }
+                const [newSavedChart] = await trx(SavedChartsTableName)
+                    .insert(chart)
+                    .returning('*');
+                await createSavedChartVersion(
+                    trx,
+                    newSavedChart.saved_query_id,
+                    {
+                        tableName,
+                        metricQuery,
+                        chartConfig,
+                        tableConfig,
+                        pivotConfig,
+                        parameters,
+                        updatedByUser,
+                    },
+                );
+                return newSavedChart.saved_query_uuid;
+            });
+        } catch (error) {
+            if (!isProjectSlugUniqueViolation(error)) throw error;
+
+            if (forceSlug) {
+                // eslint-disable-next-line no-await-in-loop
+                const existingUuid = await resolveForcedChartSlug(
+                    db,
+                    projectUuid,
+                    slug,
+                );
+                if (existingUuid) return existingUuid;
             }
-            chart = {
-                ...baseChart,
-                dashboard_uuid: dashboardUuid,
-                space_id: null,
-            };
-        } else {
-            if (!spaceUuid) {
-                throw new NotFoundError('No space specified for chart');
-            }
-            const space = await trx(SpaceTableName)
-                .innerJoin(
-                    ProjectTableName,
-                    `${ProjectTableName}.project_id`,
-                    `${SpaceTableName}.project_id`,
-                )
-                .where(`${SpaceTableName}.space_uuid`, spaceUuid)
-                .where(`${ProjectTableName}.project_uuid`, projectUuid)
-                .select(`${SpaceTableName}.space_id`)
-                .first();
-            if (!space) {
-                throw new NotFoundError('Space not found');
-            }
-            chart = {
-                ...baseChart,
-                dashboard_uuid: null,
-                space_id: space.space_id,
-            };
+
+            if (attempt === MaxChartSlugCreateAttempts) throw error;
         }
-        const [newSavedChart] = await trx(SavedChartsTableName)
-            .insert(chart)
-            .returning('*');
-        await createSavedChartVersion(trx, newSavedChart.saved_query_id, {
-            tableName,
-            metricQuery,
-            chartConfig,
-            tableConfig,
-            pivotConfig,
-            parameters,
-            updatedByUser,
-        });
-        return newSavedChart.saved_query_uuid;
-    });
+    }
+
+    throw new Error('Failed to create saved chart');
+};
 
 type SavedChartModelArguments = {
     database: Knex;
@@ -818,20 +872,7 @@ export class SavedChartModel {
         data: UpdateSavedChart,
     ): Promise<SavedChartDAO> {
         const savedChart = await this.database(SavedChartsTableName)
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SavedChartsTableName}.dashboard_uuid`,
-            )
-            .joinRaw(
-                `INNER JOIN ${SpaceTableName} ON ${SpaceTableName}.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id)`,
-            )
-            .innerJoin(
-                ProjectTableName,
-                `${ProjectTableName}.project_id`,
-                `${SpaceTableName}.project_id`,
-            )
-            .select(`${ProjectTableName}.project_uuid`)
+            .select(`${SavedChartsTableName}.project_uuid`)
             .where(`${SavedChartsTableName}.saved_query_uuid`, savedChartUuid)
             .whereNull(`${SavedChartsTableName}.deleted_at`)
             .first();
@@ -903,20 +944,8 @@ export class SavedChartModel {
                         space_id: space.space_id,
                     })
                     .where('saved_query_uuid', savedChart.uuid)
-                    .whereIn(
-                        'space_id',
-                        trx(SpaceTableName)
-                            .select(`${SpaceTableName}.space_id`)
-                            .innerJoin(
-                                ProjectTableName,
-                                `${ProjectTableName}.project_id`,
-                                `${SpaceTableName}.project_id`,
-                            )
-                            .where(
-                                `${ProjectTableName}.project_uuid`,
-                                projectUuid,
-                            ),
-                    )
+                    .where(`${SavedChartsTableName}.project_uuid`, projectUuid)
+                    .whereNotNull(`${SavedChartsTableName}.space_id`)
                     .whereNull('deleted_at');
 
                 if (updateCount !== 1) {
@@ -981,13 +1010,12 @@ export class SavedChartModel {
                     order by ${SavedChartVersionsTableName}.created_at desc
                     limit 1)`),
                     )
-                    .where(`${ProjectTableName}.project_uuid`, projectUuid)
+                    .where(`${SavedChartsTableName}.project_uuid`, projectUuid)
                     .orderBy(`${SavedChartsTableName}.views_count`, 'desc'),
         );
     }
 
     async getChartCountPerField(projectUuid: string, fieldIds: string[]) {
-        // First CTE: Get relevant saved_query_ids for the project through spaces and dashboards
         const relevantCharts = this.database
             .select(`${SavedChartsTableName}.saved_query_id`)
             .distinct()
@@ -1002,12 +1030,7 @@ export class SavedChartModel {
             .joinRaw(
                 `INNER JOIN ${SpaceTableName} ON ${SpaceTableName}.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id) AND ${SpaceTableName}.deleted_at IS NULL`,
             )
-            .innerJoin(
-                ProjectTableName,
-                `${SpaceTableName}.project_id`,
-                `${ProjectTableName}.project_id`,
-            )
-            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .where(`${SavedChartsTableName}.project_uuid`, projectUuid)
             .whereNull(`${SavedChartsTableName}.deleted_at`);
 
         // Get latest versions for these charts
@@ -1100,12 +1123,7 @@ export class SavedChartModel {
                     .joinRaw(
                         `INNER JOIN ${SpaceTableName} AS s ON s.space_id = COALESCE(sq.space_id, owner_dash.space_id) AND s.deleted_at IS NULL`,
                     )
-                    .innerJoin(
-                        `${ProjectTableName} as p`,
-                        'p.project_id',
-                        's.project_id',
-                    )
-                    .where('p.project_uuid', projectUuid)
+                    .where('sq.project_uuid', projectUuid)
                     .where('f.name', fieldId)
                     .whereNull('sq.deleted_at')
                     .select<FieldImpactReport['charts']>({
@@ -1349,28 +1367,11 @@ export class SavedChartModel {
                 );
             }
 
-            // Scope both probes to the project when one is provided, matching
-            // the outer query's project filter. Slugs are only unique within
-            // a project.
             if (options?.projectUuid) {
-                void lookupQuery
-                    .leftJoin(
-                        DashboardsTableName,
-                        `${DashboardsTableName}.dashboard_uuid`,
-                        `${SavedChartsTableName}.dashboard_uuid`,
-                    )
-                    .joinRaw(
-                        `INNER JOIN ${SpaceTableName} ON ${SpaceTableName}.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id)`,
-                    )
-                    .innerJoin(
-                        ProjectTableName,
-                        `${SpaceTableName}.project_id`,
-                        `${ProjectTableName}.project_id`,
-                    )
-                    .where(
-                        `${ProjectTableName}.project_uuid`,
-                        options.projectUuid,
-                    );
+                void lookupQuery.where(
+                    `${SavedChartsTableName}.project_uuid`,
+                    options.projectUuid,
+                );
             }
 
             return lookupQuery;
@@ -1473,7 +1474,7 @@ export class SavedChartModel {
                             deleted_by_user_last_name: string | null;
                         })[]
                     >([
-                        `${ProjectTableName}.project_uuid`,
+                        `${SavedChartsTableName}.project_uuid`,
                         `${SavedChartsTableName}.saved_query_id`,
                         `${SavedChartsTableName}.saved_query_uuid`,
                         `${SavedChartsTableName}.name`,
@@ -1547,7 +1548,7 @@ export class SavedChartModel {
 
                 if (options?.projectUuid) {
                     void chartQuery.where(
-                        `${ProjectTableName}.project_uuid`,
+                        `${SavedChartsTableName}.project_uuid`,
                         options.projectUuid,
                     );
                 }
@@ -1925,12 +1926,7 @@ export class SavedChartModel {
             .joinRaw(
                 `INNER JOIN ${SpaceTableName} as s ON s.space_id = COALESCE(sq.space_id, d.space_id) AND s.deleted_at IS NULL`,
             )
-            .innerJoin(
-                `${ProjectTableName} as p`,
-                'p.project_id',
-                's.project_id',
-            )
-            .where('p.project_uuid', projectUuid)
+            .where('sq.project_uuid', projectUuid)
             .whereNull('sq.deleted_at');
 
         // Select latest versions for charts in this project
@@ -1962,12 +1958,7 @@ export class SavedChartModel {
                     's.space_id',
                     'sq.space_id',
                 )
-                .innerJoin(
-                    `${ProjectTableName} as p`,
-                    'p.project_id',
-                    's.project_id',
-                )
-                .where('p.project_uuid', projectUuid)
+                .where('sq.project_uuid', projectUuid)
                 .whereNull('sq.deleted_at'),
 
             // Second part of UNION - charts saved inside dashboards
@@ -1990,12 +1981,7 @@ export class SavedChartModel {
                     'sq.dashboard_uuid',
                 )
                 .innerJoin(`${SpaceTableName} as s`, 's.space_id', 'd.space_id')
-                .innerJoin(
-                    `${ProjectTableName} as p`,
-                    'p.project_id',
-                    's.project_id',
-                )
-                .where('p.project_uuid', projectUuid)
+                .where('sq.project_uuid', projectUuid)
                 .whereNull('sq.deleted_at'),
         ]);
     }
@@ -2122,7 +2108,7 @@ export class SavedChartModel {
                 const query = this.getChartSummaryQuery();
                 if (filters.projectUuid) {
                     void query.where(
-                        'projects.project_uuid',
+                        `${SavedChartsTableName}.project_uuid`,
                         filters.projectUuid,
                     );
                 }
@@ -2252,7 +2238,7 @@ export class SavedChartModel {
                 description: `${SavedChartsTableName}.description`,
                 spaceUuid: `${SpaceTableName}.space_uuid`,
                 spaceName: `${SpaceTableName}.name`,
-                projectUuid: 'projects.project_uuid',
+                projectUuid: `${SavedChartsTableName}.project_uuid`,
                 organizationUuid: 'organizations.organization_uuid',
                 pinnedListUuid: `${PinnedListTableName}.pinned_list_uuid`,
                 chartKind: `${SavedChartsTableName}.last_version_chart_kind`,
@@ -2310,7 +2296,7 @@ export class SavedChartModel {
                 name: `${SavedChartsTableName}.name`,
                 spaceUuid: `${SpaceTableName}.space_uuid`,
                 tableName: `${SavedChartVersionsTableName}.explore_name`,
-                projectUuid: 'projects.project_uuid',
+                projectUuid: `${SavedChartsTableName}.project_uuid`,
                 organizationUuid: 'organizations.organization_uuid',
             })
             .leftJoin(
@@ -2410,7 +2396,7 @@ export class SavedChartModel {
                 `${SavedChartVersionsTableName}.updated_by_user_uuid`,
                 `${UserTableName}.user_uuid`,
             )
-            .where('projects.project_uuid', projectUuid)
+            .where(`${SavedChartsTableName}.project_uuid`, projectUuid)
             .where(
                 // filter by last version
                 `saved_queries_version_id`,
@@ -2508,22 +2494,9 @@ export class SavedChartModel {
         }
 
         const savedChart = await tx(SavedChartsTableName)
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SavedChartsTableName}.dashboard_uuid`,
-            )
-            .joinRaw(
-                `INNER JOIN ${SpaceTableName} AS current_space ON current_space.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id)`,
-            )
-            .innerJoin(
-                `${ProjectTableName} AS current_project`,
-                'current_project.project_id',
-                'current_space.project_id',
-            )
             .select(`${SavedChartsTableName}.saved_query_uuid`)
             .where(`${SavedChartsTableName}.saved_query_uuid`, savedChartUuid)
-            .where('current_project.project_uuid', projectUuid)
+            .where(`${SavedChartsTableName}.project_uuid`, projectUuid)
             .whereNull(`${SavedChartsTableName}.deleted_at`)
             .first();
         if (!savedChart) {
@@ -2612,10 +2585,10 @@ export class SavedChartModel {
                 `${UserTableName}.last_name`,
                 `${SpaceTableName}.space_uuid`,
                 `${SpaceTableName}.name as space_name`,
-                `${ProjectTableName}.project_uuid`,
+                `${SavedChartsTableName}.project_uuid`,
                 `${OrganizationTableName}.organization_uuid`,
             ])
-            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .where(`${SavedChartsTableName}.project_uuid`, projectUuid)
             .whereNotNull(`${SavedChartsTableName}.deleted_at`);
 
         // Filter by user if not admin (when userUuid is provided)

--- a/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.test.ts
@@ -49,6 +49,7 @@ const mockDownloadFileModel = {
 function createService(
     overrides: Partial<{
         savedSqlModel: Partial<SavedSqlModel>;
+        savedChartModel: Partial<SavedChartModel>;
     }> = {},
 ) {
     return new UnfurlService({
@@ -59,7 +60,8 @@ function createService(
             },
         } as unknown as LightdashConfig,
         dashboardModel: {} as unknown as DashboardModel,
-        savedChartModel: {} as unknown as SavedChartModel,
+        savedChartModel: (overrides.savedChartModel ??
+            {}) as unknown as SavedChartModel,
         savedSqlModel: (overrides.savedSqlModel ??
             {}) as unknown as SavedSqlModel,
         appModel: {} as unknown as AppModel,
@@ -81,6 +83,55 @@ function createService(
 describe('UnfurlService', () => {
     afterEach(() => {
         vi.clearAllMocks();
+    });
+
+    describe('exportChart', () => {
+        it('keeps legacy slug export compatible without a project', async () => {
+            const get = vi.fn().mockRejectedValue(new Error('stop'));
+            const service = createService({ savedChartModel: { get } });
+
+            await expect(
+                service.exportChart('shared-slug', {} as never),
+            ).rejects.toThrow('stop');
+            expect(get).toHaveBeenCalledWith(
+                'shared-slug',
+                undefined,
+                undefined,
+            );
+        });
+
+        it('scopes slug resolution to the requested project', async () => {
+            const get = vi.fn().mockRejectedValue(new Error('stop'));
+            const service = createService({ savedChartModel: { get } });
+
+            await expect(
+                service.exportChart(
+                    'shared-slug',
+                    {} as never,
+                    '22222222-2222-4222-8222-222222222222',
+                ),
+            ).rejects.toThrow('stop');
+            expect(get).toHaveBeenCalledWith('shared-slug', undefined, {
+                projectUuid: '22222222-2222-4222-8222-222222222222',
+            });
+        });
+
+        it('keeps globally unique UUID export compatible without a project', async () => {
+            const get = vi.fn().mockRejectedValue(new Error('stop'));
+            const service = createService({ savedChartModel: { get } });
+
+            await expect(
+                service.exportChart(
+                    '11111111-1111-4111-8111-111111111111',
+                    {} as never,
+                ),
+            ).rejects.toThrow('stop');
+            expect(get).toHaveBeenCalledWith(
+                '11111111-1111-4111-8111-111111111111',
+                undefined,
+                undefined,
+            );
+        });
     });
 
     describe('getPreviewSignedUrl', () => {

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -982,8 +982,13 @@ export class UnfurlService extends BaseService {
     async exportChart(
         chartUuidOrSlug: string,
         user: SessionUser,
+        projectUuid?: string,
     ): Promise<string> {
-        const chart = await this.savedChartModel.get(chartUuidOrSlug);
+        const chart = await this.savedChartModel.get(
+            chartUuidOrSlug,
+            undefined,
+            projectUuid ? { projectUuid } : undefined,
+        );
         const { inheritsFromOrgOrProject, access } =
             await this.spacePermissionService.getSpaceAccessContext(
                 user.userUuid,

--- a/packages/backend/src/utils/SlugUtils.test.ts
+++ b/packages/backend/src/utils/SlugUtils.test.ts
@@ -18,22 +18,91 @@ describe('generateUniqueSlugScopedToProject', () => {
         tracker.reset();
     });
 
-    it.each([SavedChartsTableName, DashboardsTableName] as const)(
-        'qualifies project_uuid when querying %s',
-        async (tableName) => {
-            tracker.on.select(tableName).responseOnce([]);
+    it('uses the saved chart project UUID directly', async () => {
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
 
-            await generateUniqueSlugScopedToProject(
-                database,
-                '22222222-2222-4222-8222-222222222222',
-                tableName,
-                'Orders',
-            );
+        const slug = await generateUniqueSlugScopedToProject(
+            database,
+            '22222222-2222-4222-8222-222222222222',
+            SavedChartsTableName,
+            'Orders',
+        );
 
-            const [query] = tracker.history.select;
-            expect(query.sql).toContain(`"${ProjectTableName}"."project_uuid"`);
-        },
-    );
+        const [query] = tracker.history.select;
+        expect(query.sql).toContain(`"${SavedChartsTableName}"."project_uuid"`);
+        expect(query.sql).not.toContain(`join "${ProjectTableName}"`);
+        expect(slug).toBe('orders');
+    });
+
+    it('preserves a unique long chart slug', async () => {
+        const longName = 'a'.repeat(300);
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+
+        const slug = await generateUniqueSlugScopedToProject(
+            database,
+            '22222222-2222-4222-8222-222222222222',
+            SavedChartsTableName,
+            longName,
+        );
+
+        expect(slug).toBe(longName);
+    });
+
+    it('finds a free bounded chart slug using exact candidate probes', async () => {
+        const longName = 'a'.repeat(255);
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ saved_query_id: 1 }]);
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ saved_query_id: 2 }]);
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+
+        const slug = await generateUniqueSlugScopedToProject(
+            database,
+            '22222222-2222-4222-8222-222222222222',
+            SavedChartsTableName,
+            longName,
+        );
+
+        expect(slug).toHaveLength(255);
+        expect(slug.endsWith('-2')).toBe(true);
+        expect(tracker.history.select).toHaveLength(3);
+        expect(tracker.history.select[1].sql).toContain('"slug" = $2');
+        expect(tracker.history.select[1].bindings).toContain(
+            `${'a'.repeat(253)}-1`,
+        );
+    });
+
+    it('detects collisions for long names with the same bounded prefix', async () => {
+        tracker.on
+            .select(SavedChartsTableName)
+            .responseOnce([{ saved_query_id: 1 }]);
+        tracker.on.select(SavedChartsTableName).responseOnce([]);
+
+        const slug = await generateUniqueSlugScopedToProject(
+            database,
+            '22222222-2222-4222-8222-222222222222',
+            SavedChartsTableName,
+            `${'a'.repeat(255)}-different-tail`,
+        );
+
+        expect(slug).toBe(`${'a'.repeat(253)}-1`);
+    });
+
+    it('uses the nested project UUID for dashboards', async () => {
+        tracker.on.select(DashboardsTableName).responseOnce([]);
+
+        await generateUniqueSlugScopedToProject(
+            database,
+            '22222222-2222-4222-8222-222222222222',
+            DashboardsTableName,
+            'Orders',
+        );
+
+        const [query] = tracker.history.select;
+        expect(query.sql).toContain(`"${ProjectTableName}"."project_uuid"`);
+    });
 
     it('uses native project ownership for saved SQL charts', async () => {
         tracker.on.select(SavedSqlTableName).responseOnce([]);

--- a/packages/backend/src/utils/SlugUtils.ts
+++ b/packages/backend/src/utils/SlugUtils.ts
@@ -19,6 +19,21 @@ type SlugTables =
 const CONTENT_AS_CODE_SLUG_LOCK_NAMESPACE = 2;
 const SPACE_ACCESS_LOCK_NAMESPACE = 3;
 
+const MAX_GENERATED_SAVED_CHART_SLUG_LENGTH = 255;
+
+const getSavedChartSlugCandidate = (
+    baseSlug: string,
+    increment: number,
+): string => {
+    if (increment === 0) return baseSlug;
+
+    const suffix = `-${increment}`;
+    return `${baseSlug.slice(
+        0,
+        MAX_GENERATED_SAVED_CHART_SLUG_LENGTH - suffix.length,
+    )}${suffix}`;
+};
+
 /**
  * Take a transaction-scoped Postgres advisory lock keyed on (projectUuid, slug).
  *
@@ -107,36 +122,23 @@ export const generateUniqueSlugScopedToProject = async (
     const baseSlug = generateSlug(name);
     let matchingSlugs: string[];
     switch (tableName) {
-        case SavedChartsTableName:
-            // NOTE: no `deleted_at IS NULL` filter here because
-            // we need to check for soft deleted charts as well
-            matchingSlugs = await trx(SavedChartsTableName)
-                .leftJoin(
-                    DashboardsTableName,
-                    `${DashboardsTableName}.dashboard_uuid`,
-                    `${SavedChartsTableName}.dashboard_uuid`,
-                )
-                .innerJoin(SpaceTableName, function spaceJoin() {
-                    this.on(
-                        `${SpaceTableName}.space_id`,
-                        '=',
-                        `${DashboardsTableName}.space_id`,
-                    ).orOn(
-                        `${SpaceTableName}.space_id`,
-                        '=',
-                        `${SavedChartsTableName}.space_id`,
-                    );
-                })
-                .innerJoin(
-                    ProjectTableName,
-                    `${SpaceTableName}.project_id`,
-                    `${ProjectTableName}.project_id`,
-                )
-                .where(`${ProjectTableName}.project_uuid`, projectUuid)
-                .select(`${SavedChartsTableName}.slug`)
-                .where(`${SavedChartsTableName}.slug`, 'like', `${baseSlug}%`)
-                .pluck(`${SavedChartsTableName}.slug`);
-            break;
+        case SavedChartsTableName: {
+            let increment = 0;
+            for (;;) {
+                const candidate = getSavedChartSlugCandidate(
+                    baseSlug,
+                    increment,
+                );
+                // eslint-disable-next-line no-await-in-loop
+                const existing = await trx(SavedChartsTableName)
+                    .select(`${SavedChartsTableName}.saved_query_id`)
+                    .where(`${SavedChartsTableName}.project_uuid`, projectUuid)
+                    .where(`${SavedChartsTableName}.slug`, candidate)
+                    .first();
+                if (!existing) return candidate;
+                increment += 1;
+            }
+        }
         case DashboardsTableName:
             matchingSlugs = await trx(DashboardsTableName)
                 .innerJoin(

--- a/packages/cli/src/handlers/exportChartImage.test.ts
+++ b/packages/cli/src/handlers/exportChartImage.test.ts
@@ -1,0 +1,66 @@
+import { getConfig } from '../config';
+import { lightdashApi } from './dbt/apiClient';
+import { exportChartImageHandler } from './exportChartImage';
+
+vi.mock('../config', () => ({ getConfig: vi.fn() }));
+vi.mock('./dbt/apiClient', () => ({ lightdashApi: vi.fn() }));
+vi.mock('../globalState', () => ({
+    default: {
+        setVerbose: vi.fn(),
+        startSpinner: vi.fn(() => ({ warn: vi.fn() })),
+    },
+}));
+
+describe('exportChartImageHandler', () => {
+    beforeEach(() => {
+        vi.mocked(lightdashApi).mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('scopes a slug to the selected project', async () => {
+        vi.mocked(getConfig).mockResolvedValue({
+            context: {
+                project: '22222222-2222-4222-8222-222222222222',
+            },
+        } as never);
+
+        await exportChartImageHandler('shared-slug', { output: 'chart.png' });
+
+        expect(lightdashApi).toHaveBeenCalledWith({
+            method: 'POST',
+            url: '/api/v1/saved/shared-slug/export?projectUuid=22222222-2222-4222-8222-222222222222',
+            body: undefined,
+        });
+    });
+
+    it('does not scope UUID exports to the selected project', async () => {
+        vi.mocked(getConfig).mockResolvedValue({
+            context: {
+                project: '22222222-2222-4222-8222-222222222222',
+            },
+        } as never);
+
+        await exportChartImageHandler('11111111-1111-4111-8111-111111111111', {
+            output: 'chart.png',
+        });
+
+        expect(lightdashApi).toHaveBeenCalledWith({
+            method: 'POST',
+            url: '/api/v1/saved/11111111-1111-4111-8111-111111111111/export',
+            body: undefined,
+        });
+        expect(getConfig).not.toHaveBeenCalled();
+    });
+
+    it('rejects a slug without project context', async () => {
+        vi.mocked(getConfig).mockResolvedValue({} as never);
+
+        await expect(
+            exportChartImageHandler('shared-slug', { output: 'chart.png' }),
+        ).rejects.toThrow('A project is required when exporting by slug');
+        expect(lightdashApi).not.toHaveBeenCalled();
+    });
+});

--- a/packages/cli/src/handlers/exportChartImage.ts
+++ b/packages/cli/src/handlers/exportChartImage.ts
@@ -1,11 +1,14 @@
 import { promises as fs } from 'fs';
 import fetch from 'node-fetch';
+import { validate as isValidUuid } from 'uuid';
+import { getConfig } from '../config';
 import GlobalState from '../globalState';
 import * as styles from '../styles';
 import { lightdashApi } from './dbt/apiClient';
 
 type ExportChartImageOptions = {
     output: string;
+    project?: string;
     verbose?: boolean;
 };
 
@@ -19,9 +22,22 @@ export const exportChartImageHandler = async (
         `Exporting chart image for '${chartUuidOrSlug}'...`,
     );
 
+    const isChartUuid = isValidUuid(chartUuidOrSlug);
+    const projectUuid =
+        options.project ??
+        (!isChartUuid ? (await getConfig()).context?.project : undefined);
+    if (!projectUuid && !isChartUuid) {
+        throw new Error(
+            'A project is required when exporting by slug. Pass --project <uuid> or select a project first.',
+        );
+    }
+    const projectQuery = projectUuid
+        ? `?projectUuid=${encodeURIComponent(projectUuid)}`
+        : '';
+
     const imageUrl = await lightdashApi<string>({
         method: 'POST',
-        url: `/api/v1/saved/${chartUuidOrSlug}/export`,
+        url: `/api/v1/saved/${chartUuidOrSlug}/export${projectQuery}`,
         body: undefined,
     });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1664,8 +1664,12 @@ program
     .description(
         'Export a deployed chart as a PNG image. The chart must already exist on the server.',
     )
-    .argument('<chart>', 'Chart slug')
+    .argument('<chart>', 'Chart UUID or slug')
     .requiredOption('-o, --output <file>', 'Output file path for the PNG image')
+    .option(
+        '--project <uuid>',
+        'Lightdash project UUID (defaults to the currently selected project)',
+    )
     .option('--verbose', 'Show detailed output', false)
     .action(exportChartImageHandler);
 


### PR DESCRIPTION
## Summary

Completes the saved-chart project ownership and project-scoped slug contract.

- Reconciles `saved_queries.project_uuid` from the same direct-space-first ownership resolution used by chart space joins.
- Enforces `project_uuid` `NOT NULL` and its project foreign key before doing the more expensive slug repair/index phases.
- Renames only same-project duplicate slugs; an active chart keeps the original slug before a deleted chart, while deleted charts still participate because they can be restored.
- Preserves every non-conflicting slug exactly, including long slugs. Only generated conflict replacements are capped and receive a deterministic `-chart-<saved_query_id>` suffix.
- Adds `UNIQUE (project_uuid, slug)` through a concurrently built index.
- Switches chart reads to native project ownership and makes normal and forced chart creation project-scoped and race-safe.
- Requires project context when resolving an export by slug while preserving UUID export compatibility.

## Migration safety and recovery

- Runs without Knex's outer transaction so bounded repair batches commit independently and PostgreSQL can build the index concurrently.
- Keeps ownership reconciliation at 1,000 rows per transaction.
- Repairs duplicate slugs in 10,000-row transactions, matching the repository migration guidance and reducing repeated full-table ranking passes.
- Logs anomalous ownership prominently instead of blocking on repairable conflicts.
- If both `space_id` and `dashboard_uuid` exist, direct-space ownership takes precedence, matching the model's `COALESCE` space resolution; the migration clears the contradictory dashboard reference in bounded batches and continues.
- If neither relation exists but `project_uuid` references a real project, preserves that native owner and continues. Only a row with neither a resolvable relation nor a valid native owner fails, because assigning an arbitrary project would be unsafe.
- Adds a `CHECK ... NOT VALID` before the second ownership reconciliation, then validates it before the metadata-only `SET NOT NULL`.
- Repeats ownership repair/reconciliation after the protective check to close the concurrent-write window.
- Uses a five-second `lock_timeout` for table-locking phases and disables `statement_timeout` only for this migration session.
- Adds and validates the project foreign key separately.
- Detects and removes an invalid index left by an interrupted concurrent build.
- If a duplicate is written while the unique index is building, repairs it and retries automatically.
- Every phase is idempotent after the Knex migration lock is released.

A hard-killed Knex runner leaves the global `knex_migrations_lock` set; the next runner does not automatically take it over. The data migration is resumable, but an operator must release the Knex lock before retrying. This is existing runner behavior and is explicitly documented in the repository migration guidance. Normal SQL failures, including lock timeouts and ownership/constraint validation failures, release the Knex lock automatically.

## Validation

Real `migrate:up` / `migrate:down` testing used disposable PostgreSQL databases rather than mocked migration tests.

- Final production-shaped load: 1,142,912 charts / 629 MB total relation size.
- Same-fixture baseline with 1,000-row slug batches: one 27,003-row same-project group repaired 27,002 rows and completed the contract in 88.41 seconds.
- Final 10,000-row implementation, including both ownership anomaly scans, repaired the same 27,002 duplicates and completed the full contract in 18.57 seconds, reducing 28 full-table ranking passes to 3.
- The ownership backfill was separately benchmarked at 1,000, 5,000, and 10,000 rows per batch. Larger ownership batches were slower, so it remains at 1,000.
- Injected a cross-project dual owner, a same-project dual owner, a wrong dashboard native owner, a null direct native owner, and an ownerless row with a valid native project. The migration logged every anomaly, cleared both dual dashboard references, reconciled all derived projects, preserved the valid native fallback, and completed every constraint.
- Rolled that ownership matrix down and reapplied it; the repaired data was preserved and the contract completed again without manual intervention.
- Rehearsed the final phase order with 3 missing/wrong owners and 20,011 duplicate repairs across seven groups, including one 20,005-row group. The warmed run completed in 2.60 seconds and produced zero null owners, ownership mismatches, or duplicate groups.
- Interrupted the optimized run during concurrent index creation. All committed repairs remained valid, the migration remained unrecorded, and after releasing the documented hard-kill Knex lock the rerun attached and validated the contract in 6.24 seconds.
- Held an `ACCESS EXCLUSIVE` table lock: the migration stopped after the five-second lock timeout (6.30 seconds wall time), left zero partial constraints, and automatically released the Knex lock. The next run completed without manual unlock in 2.54 seconds.
- Pre-created the invalid unique index state PostgreSQL leaves after a failed concurrent build; rerun removed it, repaired duplicates, and completed the contract.
- Verified rollback removes the FK, unique constraint, check, and `NOT NULL` while preserving repaired data; reapply restores the complete contract.
- Verified active-vs-deleted precedence, deleted-vs-deleted ordering, cross-project reuse of the same slug, replacement-candidate collisions, empty slugs, valid 300-character ASCII and Unicode slug preservation, and generated replacements capped at 255 characters.
- Verified database enforcement directly: same-project duplicates fail with `unique_violation`, null owners fail with `not_null_violation`, unknown owners fail with `foreign_key_violation`, and the same slug in another project succeeds.

Live application checks against the running backend:

- Two normal same-name creates in one project produced the base slug and `-1`; the same base slug was allowed in another project.
- Ten simultaneous same-name creates all returned 200 and produced exactly ten distinct slugs (`base` through `base-9`) with correct canonical ownership.
- Project-scoped slug reads resolved the correct chart in each project; reading a chart UUID through another project returned 404.
- Moving a chart within its project succeeded without ownership drift; moving it to another project's space returned 404 and left ownership unchanged.
- Dashboard-owned chart creation populated the dashboard's canonical project UUID; supplying that dashboard through another project returned 404.
- Repeated forced-slug upserts converged on one active chart UUID.
- A forced upsert against a soft-deleted slug returned HTTP 409 instead of overwriting or leaking content.
- Backend restart with the completed migration was healthy, the browser login/home flow loaded successfully, and all temporary live test charts were removed afterward.

Automated checks:

- Full backend suite: 336 files, 4,862 passed, 1 skipped.
- Focused final saved-chart model suite: 17 passed.
- CLI suite: 35 files, 326 passed.
- Backend, common, and CLI typechecks passed.
- Focused backend and CLI lint passed.
- Chart-as-code schema consistency passed.

## Release plan

Release only after the parent ownership PR has been deployed everywhere. The final production-shaped contract run measured 18.57 seconds locally, down from the 88.41-second baseline. A previous cold ownership test measured 114.17 seconds, so even a skip-version install running both migrations has materially more startup headroom than before.

The two PRs should still be released separately in managed Cloud so all pods dual-write ownership before `NOT NULL` is enforced. For large self-hosted installations, run migrations out of band or extend the startup budget and be prepared to release the Knex lock after a hard interruption.

Rollback removes the database constraints but intentionally preserves valid ownership and slug repairs.

test-all

Closes: PROD-9106
Relates: PROD-8968
