### PR TITLE
feat(totals): pin subtotals to the visible page

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/CLAUDE.md
+++ b/packages/backend/src/utils/QueryBuilder/CLAUDE.md
@@ -83,15 +83,21 @@ totals kind and the two queries. Every use derives from that one embed; new
 rather than add another embed:
 
 - **`groupRestrictions`** — each entry derives a `SELECT DISTINCT <join dims>`
-  CTE (`source_dimension_groups`) and appends an `INNER JOIN` on null-safe
-  equality (`getNullSafeEqualJoinSql`) to `dimensionsSQL.joins`, which reaches
-  every raw scan (fan-out, distinct-metric, nested-aggregate and totals CTEs).
-  DISTINCT makes the join fan-out-free at any grain. Custom bin join dimensions
-  not selected by the totals query get their min/max CTE + CROSS JOIN added.
-  Use: enforcing metric / table-calc filters (PROD-8431 — they compile to a
-  post-aggregation WHERE at the source grain, so the collapsed totals query
-  strips them and restricts raw rows instead; totals stay exact for every
-  metric type since aggregation still runs over raw rows).
+  CTE (`source_dimension_groups`, or `visible_dimension_groups` over
+  `visible_page_rows` = `source_rows` + the source's ORDER BY/LIMIT for scope
+  `'visiblePage'`) and appends an `INNER JOIN` on null-safe equality
+  (`getNullSafeEqualJoinSql`) to `dimensionsSQL.joins`, which reaches every raw
+  scan (fan-out, distinct-metric, nested-aggregate and totals CTEs). DISTINCT
+  makes the join fan-out-free at any grain. Custom bin join dimensions not
+  selected by the totals query get their min/max CTE + CROSS JOIN added.
+  Uses: scope `'results'` enforces metric / table-calc filters (PROD-8431 —
+  they compile to a post-aggregation WHERE at the source grain, so the
+  collapsed totals query strips them and restricts raw rows instead; totals
+  stay exact for every metric type since aggregation still runs over raw
+  rows). Scope `'visiblePage'` pins subtotals to the page the user sees
+  (PROD-7570 — the subtotal response covers exactly the rendered grain groups,
+  so its inherited row limit can never truncate one; subtotal *values* stay
+  full-group aggregates).
 
 **SqlQueryComposer** — the facade for SQL charts (`extends QueryComposer`). SQL charts run user-written SQL rather than compiling a metric query, so this builds everything from raw inputs — the virtual view (`createVirtualView`) from the discovered columns, the wrapping `SqlQueryBuilder` (reference map + dialect config off the warehouse client), a mock `MetricQuery` metadata carrier, and (on the dashboard path) the applied dashboard filters/sorts — then overrides `computeCompiled()` to shape the wrapped user SQL into a `CompiledQuery`. Because `getSql()` is inherited, a request/config `pivotConfiguration` flows through the same seam as metric queries. Used by `AsyncQueryService.prepareSqlChartAsyncQueryArgs` for all three SQL execute paths (raw SQL runner, saved SQL chart, dashboard SQL chart).
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -172,8 +172,8 @@ export type BuildQueryProps = {
      * `compiledMetricQuery` + `pivotConfiguration` to the requested grain (via
      * `TotalQueryBuilder`), keeps the original query as the embedded
      * `source_rows` CTE where it must compute on top of the source results
-     * (filter restrictions), and derives what to compute from the two
-     * queries. The collapsed query /
+     * (filter restrictions, visible-page pinning), and derives what to
+     * compute from the two queries. The collapsed query /
      * pivot are exposed via `getEffectiveMetricQuery()` /
      * `getEffectivePivotConfiguration()`.
      */
@@ -182,14 +182,19 @@ export type BuildQueryProps = {
 
 /**
  * Semi-joins every raw scan of this query to the distinct dimension groups of
- * the embedded source rows (null-safe, cannot fan out).
+ * the embedded source rows (null-safe, cannot fan out). Scope 'results' uses
+ * all source result rows; 'visiblePage' first applies the source query's
+ * ORDER BY + LIMIT, i.e. the page the user sees.
  */
 type SourceQueryGroupRestriction = {
     joinDimensions: string[];
+    scope: 'results' | 'visiblePage';
 };
 
 const SOURCE_ROWS_CTE_NAME = 'source_rows';
 const SOURCE_GROUPS_CTE_NAME = 'source_dimension_groups';
+const VISIBLE_PAGE_ROWS_CTE_NAME = 'visible_page_rows';
+const VISIBLE_GROUPS_CTE_NAME = 'visible_dimension_groups';
 
 /**
  * Creates the correct interval syntax for date arithmetic operations with comparison across different warehouse types.
@@ -4619,18 +4624,27 @@ export class MetricQueryBuilder {
 
     /**
      * Derives what this query computes on top of the embedded source rows:
-     * metric / table-calc filters can't survive into a collapsed totals
-     * query, so raw rows are restricted to the source groups passing them.
+     * - metric / table-calc filters can't survive into a collapsed totals
+     *   query, so raw rows are restricted to the source groups passing them;
+     * - subtotals pin to the grain groups on the source's visible page, so a
+     *   limit-truncated response can never miss a rendered group.
      */
-    private static deriveSourceQueryUses(
-        sourceMetricQuery: CompiledMetricQuery,
-    ): {
+    private deriveSourceQueryUses(sourceMetricQuery: CompiledMetricQuery): {
         groupRestrictions: SourceQueryGroupRestriction[];
     } {
+        const grainDimensions = this.args.compiledMetricQuery.dimensions;
+
         const groupRestrictions: SourceQueryGroupRestriction[] = [];
         if (hasBlockingTotalFilters(sourceMetricQuery)) {
             groupRestrictions.push({
                 joinDimensions: sourceMetricQuery.dimensions,
+                scope: 'results',
+            });
+        }
+        if (this.args.totalConfiguration?.kind === 'columnSubtotal') {
+            groupRestrictions.push({
+                joinDimensions: grainDimensions,
+                scope: 'visiblePage',
             });
         }
 
@@ -4640,9 +4654,10 @@ export class MetricQueryBuilder {
     /**
      * Compiles the `sourceQuery` embed: the source query becomes the
      * `source_rows` CTE (embedded once), and each use derives from it —
-     * distinct-group CTEs semi-joined into every raw scan. Custom bin join
-     * dimensions not selected in this query additionally need their min/max
-     * CTE + CROSS JOIN.
+     * distinct-group CTEs semi-joined into every raw scan (optionally scoped
+     * to the visible page, i.e. source ORDER BY + LIMIT applied).
+     * Custom bin join dimensions not selected in this query additionally need
+     * their min/max CTE + CROSS JOIN.
      */
     private buildSourceQuerySQL():
         | {
@@ -4656,7 +4671,7 @@ export class MetricQueryBuilder {
         if (!sourceQuery) {
             return undefined;
         }
-        const { groupRestrictions } = MetricQueryBuilder.deriveSourceQueryUses(
+        const { groupRestrictions } = this.deriveSourceQueryUses(
             sourceQuery.compiledMetricQuery,
         );
 
@@ -4764,17 +4779,41 @@ export class MetricQueryBuilder {
             ? [unselectedBinSql.join]
             : [];
 
+        // The visible page is derived from the embed by re-applying the source
+        // query's ORDER BY + LIMIT; only added when a restriction needs it.
+        const needsVisiblePage = groupRestrictions.some(
+            (restriction) => restriction.scope === 'visiblePage',
+        );
+        if (needsVisiblePage) {
+            leadingCtes.push(
+                `${VISIBLE_PAGE_ROWS_CTE_NAME} AS (\n${MetricQueryBuilder.assembleSqlParts(
+                    [
+                        'SELECT\n  *',
+                        `FROM ${SOURCE_ROWS_CTE_NAME}`,
+                        body.sqlOrderBy,
+                        body.sqlLimit,
+                    ],
+                )}\n)`,
+            );
+        }
+
         // Every restriction joins a DISTINCT-groups CTE, so the join can never
         // fan out regardless of the join dimensions' grain.
         const cteNameCounts: Record<string, number> = {};
         groupRestrictions.forEach((restriction) => {
-            const baseCteName = SOURCE_GROUPS_CTE_NAME;
+            const baseCteName =
+                restriction.scope === 'visiblePage'
+                    ? VISIBLE_GROUPS_CTE_NAME
+                    : SOURCE_GROUPS_CTE_NAME;
             cteNameCounts[baseCteName] = (cteNameCounts[baseCteName] ?? 0) + 1;
             const cteName =
                 cteNameCounts[baseCteName] > 1
                     ? `${baseCteName}_${cteNameCounts[baseCteName]}`
                     : baseCteName;
-            const fromCteName = SOURCE_ROWS_CTE_NAME;
+            const fromCteName =
+                restriction.scope === 'visiblePage'
+                    ? VISIBLE_PAGE_ROWS_CTE_NAME
+                    : SOURCE_ROWS_CTE_NAME;
             const distinctColumns = restriction.joinDimensions.map(
                 (dimId) => `  ${fieldQuoteChar}${dimId}${fieldQuoteChar}`,
             );

--- a/packages/backend/src/utils/QueryBuilder/TotalQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/TotalQueryBuilder.test.ts
@@ -1011,3 +1011,31 @@ describe('TotalQueryBuilder: columnSubtotal', () => {
         });
     });
 });
+
+describe('TotalQueryBuilder: visible groups (PROD-7570)', () => {
+    it('columnSubtotal always restricts to the grain groups on the visible page', () => {
+        const result = new TotalQueryBuilder({
+            metricQuery: baseMetricQuery,
+            pivotConfiguration,
+            subtotalDimensions: ['orders_created_at'],
+            kind: 'columnSubtotal',
+        }).compileQuery();
+
+        expect(result.sourceQuery).toEqual({
+            // Source query verbatim: sorts and limit define the visible page.
+            metricQuery: baseMetricQuery,
+            pivotConfiguration,
+        });
+    });
+
+    it('other kinds do not emit a visible-page restriction', () => {
+        (['grandTotal', 'columnTotal', 'rowTotal'] as const).forEach((kind) => {
+            const result = new TotalQueryBuilder({
+                metricQuery: baseMetricQuery,
+                pivotConfiguration,
+                kind,
+            }).compileQuery();
+            expect(result.sourceQuery).toBeUndefined();
+        });
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/TotalQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/TotalQueryBuilder.ts
@@ -143,7 +143,8 @@ export type TotalQueryBuilderArgs = {
 /**
  * The source query the totals SQL embeds (once) to compute on top of the
  * original results. `MetricQueryBuilder` derives HOW from the totals
- * configuration and the two queries themselves (filter restrictions).
+ * configuration and the two queries themselves (filter restrictions,
+ * visible-page pinning).
  */
 export type TotalQuerySourceQuery = {
     // Source query verbatim; the builder embeds it without ORDER BY / LIMIT
@@ -158,7 +159,7 @@ export type TotalQueryResult = {
     metricQuery: MetricQuery;
     pivotConfiguration: PivotConfiguration | undefined;
     // Set only when the totals SQL must compute on top of the source query's
-    // results (blocking filters).
+    // results (blocking filters, subtotal page pinning).
     sourceQuery?: TotalQuerySourceQuery;
 };
 
@@ -200,10 +201,14 @@ export class TotalQueryBuilder {
     }
 
     private buildSourceQuery(): TotalQuerySourceQuery | undefined {
-        const { metricQuery, pivotConfiguration } = this.args;
-        // Blocking filters are enforced by restricting raw rows to the
-        // source groups that pass them.
-        if (!hasBlockingTotalFilters(metricQuery)) {
+        const { kind, metricQuery, pivotConfiguration } = this.args;
+        const needsSourceQuery =
+            // Blocking filters are enforced by restricting raw rows to the
+            // source groups that pass them.
+            hasBlockingTotalFilters(metricQuery) ||
+            // Subtotals pin to the grain groups on the visible page.
+            kind === 'columnSubtotal';
+        if (!needsSourceQuery) {
             return undefined;
         }
         return {

--- a/packages/backend/src/utils/QueryBuilder/__snapshots__/QueryComposer.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/__snapshots__/QueryComposer.test.ts.snap
@@ -18,12 +18,36 @@ LIMIT 10"
 `;
 
 exports[`QueryComposer > totalConfiguration > collapses the source query into the totals grain for kind "'columnSubtotal'" 1`] = `
-"SELECT
+"WITH source_rows AS (
+SELECT
   "table1".dim1 AS "table1_dim1",
   "table1".shared AS "table1_shared",
   MAX("table1".number_column) AS "table1_metric1"
 FROM "db"."schema"."table1" AS "table1"
 
+GROUP BY 1,2
+),
+visible_page_rows AS (
+SELECT
+  *
+FROM source_rows
+ORDER BY "table1_dim1"
+LIMIT 500
+),
+visible_dimension_groups AS (
+SELECT DISTINCT
+  "table1_dim1",
+  "table1_shared"
+FROM visible_page_rows
+)
+SELECT
+  "table1".dim1 AS "table1_dim1",
+  "table1".shared AS "table1_shared",
+  MAX("table1".number_column) AS "table1_metric1"
+FROM "db"."schema"."table1" AS "table1"
+
+INNER JOIN visible_dimension_groups ON (("table1".dim1) = visible_dimension_groups."table1_dim1" OR (("table1".dim1) IS NULL AND visible_dimension_groups."table1_dim1" IS NULL))
+  AND (("table1".shared) = visible_dimension_groups."table1_shared" OR (("table1".shared) IS NULL AND visible_dimension_groups."table1_shared" IS NULL))
 GROUP BY 1,2
 ORDER BY "table1_metric1" DESC
 LIMIT 500"
@@ -69,11 +93,24 @@ WHERE ((
   ("table1_metric1") > (10)
 ))
 ),
+visible_page_rows AS (
+SELECT
+  *
+FROM source_rows
+ORDER BY "table1_dim1"
+LIMIT 500
+),
 source_dimension_groups AS (
 SELECT DISTINCT
   "table1_dim1",
   "table1_shared"
 FROM source_rows
+),
+visible_dimension_groups AS (
+SELECT DISTINCT
+  "table1_dim1",
+  "table1_shared"
+FROM visible_page_rows
 )
 SELECT
   "table1".dim1 AS "table1_dim1",
@@ -83,6 +120,8 @@ FROM "db"."schema"."table1" AS "table1"
 
 INNER JOIN source_dimension_groups ON (("table1".dim1) = source_dimension_groups."table1_dim1" OR (("table1".dim1) IS NULL AND source_dimension_groups."table1_dim1" IS NULL))
   AND (("table1".shared) = source_dimension_groups."table1_shared" OR (("table1".shared) IS NULL AND source_dimension_groups."table1_shared" IS NULL))
+INNER JOIN visible_dimension_groups ON (("table1".dim1) = visible_dimension_groups."table1_dim1" OR (("table1".dim1) IS NULL AND visible_dimension_groups."table1_dim1" IS NULL))
+  AND (("table1".shared) = visible_dimension_groups."table1_shared" OR (("table1".shared) IS NULL AND visible_dimension_groups."table1_shared" IS NULL))
 GROUP BY 1,2
 ORDER BY "table1_metric1" DESC
 LIMIT 500"


### PR DESCRIPTION
Closes: PROD-7570
Closes: #23022

### Description:

Subtotal queries inherit the chart's row limit, so on high-cardinality grains the warehouse returned only the first N subtotal groups and rendered groups outside them showed `-`.

- The subtotal query is now restricted to the distinct grain groups of the **visible (sorted, limited) page**: the embedded `source_rows` CTE from #25859 gains a `visible_page_rows` derivation (source ORDER BY + LIMIT re-applied) and the subtotal query semi-joins to its distinct grain groups.
- The subtotal response therefore covers exactly the rendered groups; subtotal **values** stay full-group aggregates.
- Applies to the async `columnSubtotal` path; the deprecated v1 endpoint keeps its previous behavior.

| Before: `returned` group's subtotal missing | After: every rendered group has its full-group subtotal |
|---|---|
| <img alt="before: a rendered group shows a dash instead of its subtotal" src="https://github.com/user-attachments/assets/7ca73872-e93e-4a47-943a-9f45d7966ba2" /> | <img alt="after: all rendered groups show full-group subtotals" src="https://github.com/user-attachments/assets/3b139898-7247-4f6c-ab74-c4938d8298da" /> |

**Stack:** builds on #25859 (source-query embed primitive). Follow-up: per-calc total modes (PROD-8594).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
