### PR TITLE
feat(table-calculations): per-calc total modes (formula, sum of rows, none)

### DIFF
--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -15,6 +15,7 @@ import {
     MetricType,
     PivotSortAnchor,
     TableCalculationTemplate,
+    TableCalculationTotalMode,
     TableCalculationType,
     TimezoneSetting,
 } from '@lightdash/common';
@@ -190,6 +191,7 @@ export type DbSavedChartTableCalculation = {
     type?: TableCalculationType;
     template?: TableCalculationTemplate;
     formula?: string;
+    total_mode?: TableCalculationTotalMode;
 };
 
 export type DbSavedChartTableCalculationInsert = Omit<

--- a/packages/backend/src/database/migrations/20260712000000_add_total_mode_to_table_calculations.ts
+++ b/packages/backend/src/database/migrations/20260712000000_add_total_mode_to_table_calculations.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const TABLE_NAME = 'saved_queries_version_table_calculations';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TABLE_NAME, (tableBuilder) => {
+        tableBuilder.text('total_mode').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TABLE_NAME, (tableBuilder) => {
+        tableBuilder.dropColumn('total_mode');
+    });
+}

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -306,6 +306,7 @@ const createSavedChartVersion = async (
                 formula: isFormulaTableCalculation(tableCalculation)
                     ? tableCalculation.formula
                     : undefined,
+                total_mode: tableCalculation.totalMode,
             })),
         );
         await createSavedChartVersionCustomDimensions(
@@ -1501,6 +1502,7 @@ export class SavedChartModel {
                         'type',
                         'template',
                         'formula',
+                        'total_mode',
                     ])
                     .where('saved_queries_version_id', savedQueriesVersionId);
 
@@ -1655,6 +1657,9 @@ export class SavedChartModel {
                                         tableCalculation.template || undefined,
                                     formula:
                                         tableCalculation.formula || undefined,
+                                    totalMode:
+                                        tableCalculation.total_mode ||
+                                        undefined,
                                 }) as TableCalculation,
                         ),
                         additionalMetrics,

--- a/packages/backend/src/utils/QueryBuilder/CLAUDE.md
+++ b/packages/backend/src/utils/QueryBuilder/CLAUDE.md
@@ -98,6 +98,16 @@ rather than add another embed:
   (PROD-7570 — the subtotal response covers exactly the rendered grain groups,
   so its inherited row limit can never truncate one; subtotal *values* stay
   full-group aggregates).
+- **`aggregations`** — aggregates source-row columns at the totals grain in a
+  `source_aggregations` CTE (grain columns prefixed `sa_` to avoid alias
+  collisions), forces the post-agg CTE path, and LEFT JOINs (CROSS JOIN at the
+  grand grain) the results onto the final select. Used for table calcs with
+  `totalMode: 'sum_of_rows'` (PROD-8594): their totals are SUMs of row-level
+  values, which also gives correct totals to calcs that can't be re-applied to
+  a collapsed row (window functions, templates). The `'formula'` default keeps
+  the existing re-apply behavior; `'none'` opts the calc out of totals entirely
+  (dropped from the collapsed query, never aggregated). Persisted per-calc in
+  `saved_queries_version_table_calculations.total_mode`.
 
 **SqlQueryComposer** — the facade for SQL charts (`extends QueryComposer`). SQL charts run user-written SQL rather than compiling a metric query, so this builds everything from raw inputs — the virtual view (`createVirtualView`) from the discovered columns, the wrapping `SqlQueryBuilder` (reference map + dialect config off the warehouse client), a mock `MetricQuery` metadata carrier, and (on the dashboard path) the applied dashboard filters/sorts — then overrides `computeCompiled()` to shape the wrapped user SQL into a `CompiledQuery`. Because `getSql()` is inherited, a request/config `pivotConfiguration` flows through the same seam as metric queries. Used by `AsyncQueryService.prepareSqlChartAsyncQueryArgs` for all three SQL execute paths (raw SQL runner, saved SQL chart, dashboard SQL chart).
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -1,4 +1,5 @@
 import {
+    assertUnreachable,
     buildTotalFieldRegex,
     CompiledDimension,
     CompiledMetric,
@@ -96,6 +97,7 @@ import {
     getDimensionFromId,
     getJoinedTables,
     getJoinType,
+    getSumOfRowsTableCalculations,
     hasBlockingTotalFilters,
     isInflationProofMetric,
     replaceUserAttributesAsStrings,
@@ -172,8 +174,8 @@ export type BuildQueryProps = {
      * `compiledMetricQuery` + `pivotConfiguration` to the requested grain (via
      * `TotalQueryBuilder`), keeps the original query as the embedded
      * `source_rows` CTE where it must compute on top of the source results
-     * (filter restrictions, visible-page pinning), and derives what to
-     * compute from the two queries. The collapsed query /
+     * (filter restrictions, visible-page pinning, sum-of-rows calcs), and
+     * derives what to compute from the two queries. The collapsed query /
      * pivot are exposed via `getEffectiveMetricQuery()` /
      * `getEffectivePivotConfiguration()`.
      */
@@ -191,10 +193,43 @@ type SourceQueryGroupRestriction = {
     scope: 'results' | 'visiblePage';
 };
 
+type SourceQueryAggregationFunction = 'sum';
+
+/**
+ * Aggregations computed over the embedded source rows at a grain and joined
+ * onto this query's final select ([] grain = one global row, CROSS JOINed).
+ */
+type SourceQueryAggregations = {
+    grainDimensions: string[];
+    columns: Array<{
+        reference: string;
+        aggregation: SourceQueryAggregationFunction;
+    }>;
+};
+
 const SOURCE_ROWS_CTE_NAME = 'source_rows';
 const SOURCE_GROUPS_CTE_NAME = 'source_dimension_groups';
 const VISIBLE_PAGE_ROWS_CTE_NAME = 'visible_page_rows';
 const VISIBLE_GROUPS_CTE_NAME = 'visible_dimension_groups';
+const SOURCE_AGGREGATIONS_CTE_NAME = 'source_aggregations';
+// Prefix for the grain columns of the source-aggregations CTE, so they can't
+// collide with this query's own column aliases.
+const SOURCE_AGGREGATIONS_GRAIN_PREFIX = 'sa_';
+
+const getSourceAggregationSql = (
+    aggregation: SourceQueryAggregationFunction,
+    quotedReference: string,
+): string => {
+    switch (aggregation) {
+        case 'sum':
+            return `SUM(${quotedReference})`;
+        default:
+            return assertUnreachable(
+                aggregation,
+                `Unknown source aggregation "${aggregation}"`,
+            );
+    }
+};
 
 /**
  * Creates the correct interval syntax for date arithmetic operations with comparison across different warehouse types.
@@ -4627,10 +4662,13 @@ export class MetricQueryBuilder {
      * - metric / table-calc filters can't survive into a collapsed totals
      *   query, so raw rows are restricted to the source groups passing them;
      * - subtotals pin to the grain groups on the source's visible page, so a
-     *   limit-truncated response can never miss a rendered group.
+     *   limit-truncated response can never miss a rendered group;
+     * - 'sum_of_rows' table calcs are aggregated over the source rows at the
+     *   totals grain (this query's own dimensions).
      */
     private deriveSourceQueryUses(sourceMetricQuery: CompiledMetricQuery): {
         groupRestrictions: SourceQueryGroupRestriction[];
+        aggregations: SourceQueryAggregations | undefined;
     } {
         const grainDimensions = this.args.compiledMetricQuery.dimensions;
 
@@ -4648,14 +4686,26 @@ export class MetricQueryBuilder {
             });
         }
 
-        return { groupRestrictions };
+        const sumOfRowsColumns = getSumOfRowsTableCalculations(
+            sourceMetricQuery,
+        ).map((calc) => ({
+            reference: calc.name,
+            aggregation: 'sum' as const,
+        }));
+        const aggregations: SourceQueryAggregations | undefined =
+            sumOfRowsColumns.length > 0
+                ? { grainDimensions, columns: sumOfRowsColumns }
+                : undefined;
+
+        return { groupRestrictions, aggregations };
     }
 
     /**
      * Compiles the `sourceQuery` embed: the source query becomes the
      * `source_rows` CTE (embedded once), and each use derives from it —
      * distinct-group CTEs semi-joined into every raw scan (optionally scoped
-     * to the visible page, i.e. source ORDER BY + LIMIT applied).
+     * to the visible page, i.e. source ORDER BY + LIMIT applied), and an
+     * aggregations CTE joined onto the final select by `buildQueryParts`.
      * Custom bin join dimensions not selected in this query additionally need
      * their min/max CTE + CROSS JOIN.
      */
@@ -4664,6 +4714,8 @@ export class MetricQueryBuilder {
               leadingCtes: string[];
               binCtes: string[];
               joins: string[];
+              aggregations: SourceQueryAggregations | undefined;
+              aggregationFields: ItemsMap;
               warnings: QueryWarning[];
           }
         | undefined {
@@ -4671,7 +4723,7 @@ export class MetricQueryBuilder {
         if (!sourceQuery) {
             return undefined;
         }
-        const { groupRestrictions } = this.deriveSourceQueryUses(
+        const { groupRestrictions, aggregations } = this.deriveSourceQueryUses(
             sourceQuery.compiledMetricQuery,
         );
 
@@ -4830,10 +4882,52 @@ export class MetricQueryBuilder {
             );
         });
 
+        let aggregationFields: ItemsMap = {};
+        if (aggregations) {
+            const grainSelects = aggregations.grainDimensions.map(
+                (dimId) =>
+                    `  ${fieldQuoteChar}${dimId}${fieldQuoteChar} AS ${fieldQuoteChar}${SOURCE_AGGREGATIONS_GRAIN_PREFIX}${dimId}${fieldQuoteChar}`,
+            );
+            const aggregationSelects = aggregations.columns.map(
+                (column) =>
+                    `  ${getSourceAggregationSql(
+                        column.aggregation,
+                        `${fieldQuoteChar}${column.reference}${fieldQuoteChar}`,
+                    )} AS ${fieldQuoteChar}${column.reference}${fieldQuoteChar}`,
+            );
+            leadingCtes.push(
+                `${SOURCE_AGGREGATIONS_CTE_NAME} AS (\n${MetricQueryBuilder.assembleSqlParts(
+                    [
+                        `SELECT\n${[
+                            ...grainSelects,
+                            ...aggregationSelects,
+                        ].join(',\n')}`,
+                        `FROM ${SOURCE_ROWS_CTE_NAME}`,
+                        aggregations.grainDimensions.length > 0
+                            ? `GROUP BY ${aggregations.grainDimensions
+                                  .map((_, index) => index + 1)
+                                  .join(',')}`
+                            : undefined,
+                    ],
+                )}\n)`,
+            );
+            // The aggregated columns are not part of this query's own fields,
+            // so surface them from the embed for response metadata / pivots.
+            aggregationFields = Object.fromEntries(
+                aggregations.columns.flatMap(({ reference }) =>
+                    body.fields[reference]
+                        ? [[reference, body.fields[reference]]]
+                        : [],
+                ),
+            );
+        }
+
         return {
             leadingCtes,
             binCtes: unselectedBinSql?.ctes ?? [],
             joins,
+            aggregations,
+            aggregationFields,
             warnings,
         };
     }
@@ -4874,6 +4968,7 @@ export class MetricQueryBuilder {
             dimensionsSQL.ctes.unshift(...sourceQuerySQL.leadingCtes);
             dimensionsSQL.ctes.push(...sourceQuerySQL.binCtes);
             dimensionsSQL.joins.push(...sourceQuerySQL.joins);
+            Object.assign(fields, sourceQuerySQL.aggregationFields);
         }
 
         const sqlSelect = `SELECT\n${[
@@ -5260,10 +5355,14 @@ export class MetricQueryBuilder {
             this.createSimpleTableCalculationSelects(simpleTableCalcs);
         const tableCalculationFilters = this.createTableCalculationFilters();
 
-        const needsPostAgg = this.needsPostAggCte({
-            requiresQueryInCTE,
-            metricsSQL,
-        });
+        const needsPostAgg =
+            this.needsPostAggCte({
+                requiresQueryInCTE,
+                metricsSQL,
+            }) ||
+            // Source-query aggregations join onto the final select, which
+            // needs the grouped rows behind a CTE.
+            sourceQuerySQL?.aggregations !== undefined;
 
         const needsMetricFiltersCte =
             interdependentTableCalcs.length > 0 && !!metricsSQL.filtersSQL;
@@ -5396,11 +5495,51 @@ export class MetricQueryBuilder {
                     : metricsSQL.filtersSQL;
 
             const finalFromName = currentCteName; // last dependent CTE if any, otherwise `current`
-            finalSelectParts = [
-                `SELECT\n${finalSelectColumns.join(',\n')}`,
-                `FROM ${finalFromName}`,
-                whereClause,
-            ];
+            const aggregations = sourceQuerySQL?.aggregations;
+            if (aggregations) {
+                // Qualify the grouped-rows columns so the joined aggregations
+                // CTE can't make unqualified aliases ambiguous.
+                const qualifiedColumns = finalSelectColumns.map((column) => {
+                    const trimmed = column.trimStart();
+                    if (trimmed === '*') {
+                        return `  ${finalFromName}.*`;
+                    }
+                    if (trimmed.startsWith(fieldQuoteChar)) {
+                        return `  ${finalFromName}.${trimmed}`;
+                    }
+                    return column;
+                });
+                const aggregationColumns = aggregations.columns.map(
+                    ({ reference }) =>
+                        `  ${SOURCE_AGGREGATIONS_CTE_NAME}.${fieldQuoteChar}${reference}${fieldQuoteChar} AS ${fieldQuoteChar}${reference}${fieldQuoteChar}`,
+                );
+                const aggregationsJoin =
+                    aggregations.grainDimensions.length > 0
+                        ? `LEFT JOIN ${SOURCE_AGGREGATIONS_CTE_NAME} ON ${aggregations.grainDimensions
+                              .map((dimId) =>
+                                  this.args.warehouseSqlBuilder.getNullSafeEqualJoinSql(
+                                      `${finalFromName}.${fieldQuoteChar}${dimId}${fieldQuoteChar}`,
+                                      `${SOURCE_AGGREGATIONS_CTE_NAME}.${fieldQuoteChar}${SOURCE_AGGREGATIONS_GRAIN_PREFIX}${dimId}${fieldQuoteChar}`,
+                                  ),
+                              )
+                              .join('\n  AND ')}`
+                        : `CROSS JOIN ${SOURCE_AGGREGATIONS_CTE_NAME}`;
+                finalSelectParts = [
+                    `SELECT\n${[
+                        ...qualifiedColumns,
+                        ...aggregationColumns,
+                    ].join(',\n')}`,
+                    `FROM ${finalFromName}`,
+                    aggregationsJoin,
+                    whereClause,
+                ];
+            } else {
+                finalSelectParts = [
+                    `SELECT\n${finalSelectColumns.join(',\n')}`,
+                    `FROM ${finalFromName}`,
+                    whereClause,
+                ];
+            }
             ctes.push(...ctesToAdd);
         }
 

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.test.ts
@@ -4,6 +4,8 @@ import {
     MetricQuery,
     PivotConfiguration,
     SortByDirection,
+    TableCalculationTotalMode,
+    TableCalculationType,
     VizAggregationOptions,
     VizIndexType,
 } from '@lightdash/common';
@@ -227,6 +229,38 @@ describe('QueryComposer', () => {
                     expect(sql).toMatchSnapshot();
                 },
             );
+
+            it('sums sum-of-rows table calcs over the shared filtered-groups CTE', () => {
+                const composer = new QueryComposer(
+                    {
+                        metricQuery: {
+                            ...METRIC_FILTERED_TOTALS_SOURCE,
+                            tableCalculations: [
+                                {
+                                    name: 'metric_plus_two',
+                                    displayName: 'Metric plus two',
+                                    sql: '${table1.metric1} + 2',
+                                    type: TableCalculationType.NUMBER,
+                                    totalMode:
+                                        TableCalculationTotalMode.SUM_OF_ROWS,
+                                },
+                            ],
+                        },
+                        pivotConfiguration: undefined,
+                        totalConfiguration: {
+                            kind: 'grandTotal',
+                            subtotalDimensions: undefined,
+                        },
+                    },
+                    CONTEXT,
+                );
+
+                const sql = composer.getSql({ columnLimit: 100 });
+                expect(sql).toContain('source_aggregations');
+                // Restriction and aggregations share one source embed.
+                expect(sql.match(/source_rows AS \(/g)).toHaveLength(1);
+                expect(sql).toMatchSnapshot();
+            });
         });
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/TotalQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/TotalQueryBuilder.test.ts
@@ -1,6 +1,7 @@
 import {
     NotSupportedError,
     SortByDirection,
+    TableCalculationTotalMode,
     VizAggregationOptions,
     VizIndexType,
     type MetricQuery,
@@ -358,7 +359,7 @@ describe('TotalQueryBuilder: grandTotal', () => {
         expect(result.additionalMetrics).toEqual([]);
     });
 
-    it('returns no sourceQuery when the source has no metric/table-calc filters', () => {
+    it('returns no sourceQuery when the source has no metric/table-calc filters or sum-of-rows calcs', () => {
         const result = new TotalQueryBuilder({
             metricQuery: baseMetricQuery,
             pivotConfiguration: null,
@@ -1037,5 +1038,92 @@ describe('TotalQueryBuilder: visible groups (PROD-7570)', () => {
             }).compileQuery();
             expect(result.sourceQuery).toBeUndefined();
         });
+    });
+});
+
+describe('TotalQueryBuilder: sum-of-rows table calculations (PROD-8594)', () => {
+    const sumModeCalc = {
+        name: 'revenue_plus_two',
+        displayName: 'Revenue plus two',
+        sql: '${orders.total_revenue} + 2',
+        totalMode: TableCalculationTotalMode.SUM_OF_ROWS,
+    };
+    const formulaModeCalc = {
+        name: 'revenue_ratio',
+        displayName: 'Revenue ratio',
+        sql: '${orders.total_revenue} / ${orders.total_revenue}',
+    };
+    const noneModeCalc = {
+        name: 'revenue_no_total',
+        displayName: 'Revenue no total',
+        sql: '${orders.total_revenue} + 1',
+        totalMode: TableCalculationTotalMode.NONE,
+    };
+    const sourceMetricQuery: MetricQuery = {
+        ...baseMetricQuery,
+        tableCalculations: [sumModeCalc, formulaModeCalc, noneModeCalc],
+    };
+
+    it('emits the source query and excludes sum and none calcs from the collapsed query', () => {
+        const result = new TotalQueryBuilder({
+            metricQuery: sourceMetricQuery,
+            pivotConfiguration: null,
+            kind: 'grandTotal',
+        }).compileQuery();
+
+        expect(result.sourceQuery).toEqual({
+            metricQuery: sourceMetricQuery,
+            pivotConfiguration: undefined,
+        });
+        // Sum-mode calcs are not re-applied to the collapsed totals row and
+        // none-mode calcs are dropped entirely; formula-mode calcs keep the
+        // existing behavior.
+        expect(
+            result.metricQuery.tableCalculations.map((calc) => calc.name),
+        ).toEqual(['revenue_ratio']);
+    });
+
+    it('does not emit a source query for none-mode calcs alone', () => {
+        const result = new TotalQueryBuilder({
+            metricQuery: {
+                ...baseMetricQuery,
+                tableCalculations: [noneModeCalc],
+            },
+            pivotConfiguration: null,
+            kind: 'grandTotal',
+        }).compileQuery();
+
+        expect(result.sourceQuery).toBeUndefined();
+        expect(result.metricQuery.tableCalculations).toEqual([]);
+    });
+
+    it('keeps sum-of-rows but drops none calc references in the pivoted values columns', () => {
+        const result = new TotalQueryBuilder({
+            metricQuery: sourceMetricQuery,
+            pivotConfiguration: {
+                ...pivotConfiguration,
+                valuesColumns: [
+                    {
+                        reference: 'orders_total_revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                    {
+                        reference: 'revenue_plus_two',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                    {
+                        reference: 'revenue_no_total',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+            },
+            kind: 'columnTotal',
+        }).compileQuery();
+
+        expect(
+            result.pivotConfiguration?.valuesColumns.map(
+                (col) => col.reference,
+            ),
+        ).toEqual(['orders_total_revenue', 'revenue_plus_two']);
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/TotalQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/TotalQueryBuilder.ts
@@ -9,6 +9,7 @@ import {
     lightdashVariablePattern,
     NotSupportedError,
     parseTableCalculationFunctions,
+    TableCalculationTotalMode,
     type MetricQuery,
     type PivotConfiguration,
     type TableCalculation,
@@ -18,7 +19,11 @@ import {
     extractColumnRefs,
     parse as parseFormula,
 } from '@lightdash/formula';
-import { hasBlockingTotalFilters, type TotalQueryKind } from './utils';
+import {
+    getSumOfRowsTableCalculations,
+    hasBlockingTotalFilters,
+    type TotalQueryKind,
+} from './utils';
 
 export type { TotalQueryKind } from './utils';
 
@@ -81,12 +86,20 @@ const getTotalableReferences = (calc: TableCalculation): string[] | null => {
 // A table calc can be totaled when it depends only on aggregated metrics:
 // applying its formula to the collapsed totals row reproduces the correct
 // total. Calcs that reference dimensions, dropped PoP metrics, sibling table
-// calcs, or use window functions are excluded (their total stays blank).
+// calcs, or use window functions are excluded (their total stays blank), as
+// are 'sum_of_rows' calcs (aggregated over the embedded source rows instead)
+// and 'none' calcs (totals disabled by the user).
 const getTotalableTableCalculations = (
     metricQuery: MetricQuery,
     keptMetricIds: Set<string>,
 ): TableCalculation[] =>
     metricQuery.tableCalculations.filter((calc) => {
+        if (
+            calc.totalMode === TableCalculationTotalMode.SUM_OF_ROWS ||
+            calc.totalMode === TableCalculationTotalMode.NONE
+        ) {
+            return false;
+        }
         const references = getTotalableReferences(calc);
         return (
             references !== null &&
@@ -98,15 +111,18 @@ const getTotalableTableCalculations = (
 // Drop value columns that reference fields not present in the totals query:
 // PoP metrics and non-totalable table calcs are stripped from the metric query,
 // but the pivot still lists them. Keeping them makes PivotQueryBuilder aggregate
-// a column that was never selected, failing the whole totals SQL.
+// a column that was never selected, failing the whole totals SQL. Sum-of-rows
+// calcs stay: their columns are joined into the flat totals SQL.
 const filterTotalsValuesColumns = (
     valuesColumns: PivotConfiguration['valuesColumns'],
     keptMetricIds: Set<string>,
     totalableCalcs: TableCalculation[],
+    sumOfRowsCalcs: TableCalculation[],
 ): PivotConfiguration['valuesColumns'] => {
     const allowed = new Set<string>([
         ...keptMetricIds,
         ...totalableCalcs.map((calc) => calc.name),
+        ...sumOfRowsCalcs.map((calc) => calc.name),
     ]);
     return valuesColumns.filter((col) => allowed.has(col.reference));
 };
@@ -144,7 +160,7 @@ export type TotalQueryBuilderArgs = {
  * The source query the totals SQL embeds (once) to compute on top of the
  * original results. `MetricQueryBuilder` derives HOW from the totals
  * configuration and the two queries themselves (filter restrictions,
- * visible-page pinning).
+ * visible-page pinning, sum-of-rows aggregations).
  */
 export type TotalQuerySourceQuery = {
     // Source query verbatim; the builder embeds it without ORDER BY / LIMIT
@@ -159,7 +175,7 @@ export type TotalQueryResult = {
     metricQuery: MetricQuery;
     pivotConfiguration: PivotConfiguration | undefined;
     // Set only when the totals SQL must compute on top of the source query's
-    // results (blocking filters, subtotal page pinning).
+    // results (blocking filters, subtotal page pinning, sum-of-rows calcs).
     sourceQuery?: TotalQuerySourceQuery;
 };
 
@@ -207,7 +223,9 @@ export class TotalQueryBuilder {
             // source groups that pass them.
             hasBlockingTotalFilters(metricQuery) ||
             // Subtotals pin to the grain groups on the visible page.
-            kind === 'columnSubtotal';
+            kind === 'columnSubtotal' ||
+            // Sum-of-rows calcs aggregate over the source rows.
+            getSumOfRowsTableCalculations(metricQuery).length > 0;
         if (!needsSourceQuery) {
             return undefined;
         }
@@ -308,6 +326,7 @@ export class TotalQueryBuilder {
                 pivotConfiguration.valuesColumns,
                 keptMetricIds,
                 totalableCalcs,
+                getSumOfRowsTableCalculations(metricQuery),
             ),
         };
 
@@ -457,6 +476,7 @@ export class TotalQueryBuilder {
                 pivotConfiguration.valuesColumns,
                 keptMetricIds,
                 totalableCalcs,
+                getSumOfRowsTableCalculations(metricQuery),
             ),
         };
 

--- a/packages/backend/src/utils/QueryBuilder/__snapshots__/QueryComposer.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/__snapshots__/QueryComposer.test.ts.snap
@@ -135,6 +135,52 @@ filtered_rows AS (SELECT * FROM pivot_query WHERE "row_index" <= 500)
 SELECT "table1_shared", "table1_metric1_sum", "row_index", "column_index", total_columns FROM (SELECT p.*, SUM(CASE WHEN p."__grp_rn" = 1 THEN 1 ELSE 0 END) OVER () AS total_columns FROM (SELECT f.*, ROW_NUMBER() OVER (PARTITION BY "table1_shared" ORDER BY "table1_shared") AS "__grp_rn" FROM filtered_rows f) p) pivoted WHERE "column_index" <= 100 order by "row_index", "column_index""
 `;
 
+exports[`QueryComposer > totalConfiguration > metric-filtered source (filtered dimension groups) > sums sum-of-rows table calcs over the shared filtered-groups CTE 1`] = `
+"WITH source_rows AS (
+WITH metrics AS (
+SELECT
+  "table1".dim1 AS "table1_dim1",
+  "table1".shared AS "table1_shared",
+  MAX("table1".number_column) AS "table1_metric1"
+FROM "db"."schema"."table1" AS "table1"
+
+GROUP BY 1,2
+)
+SELECT
+  *,
+  "table1_metric1" + 2 AS "metric_plus_two"
+FROM metrics
+WHERE ((
+  ("table1_metric1") > (10)
+))
+),
+source_dimension_groups AS (
+SELECT DISTINCT
+  "table1_dim1",
+  "table1_shared"
+FROM source_rows
+),
+source_aggregations AS (
+SELECT
+  SUM("metric_plus_two") AS "metric_plus_two"
+FROM source_rows
+),
+metrics AS (
+SELECT
+  MAX("table1".number_column) AS "table1_metric1"
+FROM "db"."schema"."table1" AS "table1"
+
+INNER JOIN source_dimension_groups ON (("table1".dim1) = source_dimension_groups."table1_dim1" OR (("table1".dim1) IS NULL AND source_dimension_groups."table1_dim1" IS NULL))
+  AND (("table1".shared) = source_dimension_groups."table1_shared" OR (("table1".shared) IS NULL AND source_dimension_groups."table1_shared" IS NULL))
+)
+SELECT
+  metrics.*,
+  source_aggregations."metric_plus_two" AS "metric_plus_two"
+FROM metrics
+CROSS JOIN source_aggregations
+LIMIT 1"
+`;
+
 exports[`QueryComposer > wraps the base query with the pivot query when a pivot configuration is set 1`] = `
 "WITH original_query AS (WITH metrics AS ( SELECT "table1".dim1 AS "table1_dim1", MAX("table1".number_column) AS "table1_metric1" FROM "db"."schema"."table1" AS "table1" GROUP BY 1 ) SELECT *, "table1_dim1" + "table1_metric1" AS "calc3" FROM metrics ORDER BY "table1_metric1" DESC),
 group_by_query AS (SELECT "table1_dim1", sum("table1_metric1") AS "table1_metric1_sum" FROM original_query group by "table1_dim1")

--- a/packages/backend/src/utils/QueryBuilder/utils.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.test.ts
@@ -9,6 +9,8 @@ import {
     JoinRelationship,
     MetricType,
     SupportedDbtAdapter,
+    TableCalculationTotalMode,
+    TableCalculationType,
     TimeFrames,
     WeekDay,
     type TableCalculation,
@@ -36,11 +38,49 @@ import {
     getCustomBinDimensionSql,
     getCustomSqlDimensionSql,
     getJoinedTables,
+    getSumOfRowsTableCalculations,
     replaceUserAttributesAsStrings,
     replaceUserAttributesInSqlTable,
     sortDayOfWeekName,
     sortMonthName,
 } from './utils';
+
+describe('getSumOfRowsTableCalculations', () => {
+    const tableCalculation = (
+        name: string,
+        type?: TableCalculationType,
+        totalMode = TableCalculationTotalMode.SUM_OF_ROWS,
+    ): TableCalculation => ({
+        name,
+        displayName: name,
+        sql: '1',
+        type,
+        totalMode,
+    });
+
+    it('returns only numeric sum-of-rows calculations', () => {
+        const metricQuery = {
+            ...METRIC_QUERY_WITH_CUSTOM_DIMENSION,
+            tableCalculations: [
+                tableCalculation('implicit-number'),
+                tableCalculation('number', TableCalculationType.NUMBER),
+                tableCalculation('string', TableCalculationType.STRING),
+                tableCalculation('date', TableCalculationType.DATE),
+                tableCalculation(
+                    'formula',
+                    TableCalculationType.NUMBER,
+                    TableCalculationTotalMode.FORMULA,
+                ),
+            ],
+        };
+
+        expect(
+            getSumOfRowsTableCalculations(metricQuery).map(
+                (calculation) => calculation.name,
+            ),
+        ).toEqual(['implicit-number', 'number']);
+    });
+});
 
 describe('replaceUserAttributes', () => {
     it('method with no user attribute should return same sqlFilter', () => {

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -40,6 +40,7 @@ import {
     SupportedDbtAdapter,
     TableCalculation,
     TableCalculationTotalMode,
+    TableCalculationType,
     UserAttributeValueMap,
     WeekDay,
     type WarehouseSqlBuilder,
@@ -84,7 +85,9 @@ export const getSumOfRowsTableCalculations = (
     metricQuery: MetricQuery,
 ): TableCalculation[] =>
     metricQuery.tableCalculations.filter(
-        (calc) => calc.totalMode === TableCalculationTotalMode.SUM_OF_ROWS,
+        (calc) =>
+            calc.totalMode === TableCalculationTotalMode.SUM_OF_ROWS &&
+            (!calc.type || calc.type === TableCalculationType.NUMBER),
     );
 
 export const getDimensionFromId = ({

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -39,6 +39,7 @@ import {
     QueryWarning,
     SupportedDbtAdapter,
     TableCalculation,
+    TableCalculationTotalMode,
     UserAttributeValueMap,
     WeekDay,
     type WarehouseSqlBuilder,
@@ -75,6 +76,16 @@ export const hasBlockingTotalFilters = (metricQuery: MetricQuery): boolean => {
 
     return hasMetricFilters || hasTableCalculationFilters;
 };
+
+// Calcs whose total is the SUM of their row-level values over the source
+// result rows (totalMode 'sum_of_rows') rather than the calc re-applied to
+// the collapsed totals row.
+export const getSumOfRowsTableCalculations = (
+    metricQuery: MetricQuery,
+): TableCalculation[] =>
+    metricQuery.tableCalculations.filter(
+        (calc) => calc.totalMode === TableCalculationTotalMode.SUM_OF_ROWS,
+    );
 
 export const getDimensionFromId = ({
     dimId,

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -2901,6 +2901,10 @@
                     "description": "Internal name of the table calculation",
                     "type": "string"
                 },
+                "totalMode": {
+                    "$ref": "#/$defs/TableCalculationTotalMode",
+                    "description": "How column totals are computed for this calculation"
+                },
                 "type": {
                     "$ref": "#/$defs/TableCalculationType",
                     "description": "Data type of the calculation result"
@@ -3110,6 +3114,10 @@
         },
         "TableCalculationTemplateType.WINDOW_FUNCTION": {
             "enum": ["window_function"],
+            "type": "string"
+        },
+        "TableCalculationTotalMode": {
+            "enum": ["formula", "sum_of_rows", "none"],
             "type": "string"
         },
         "TableCalculationType": {

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -511,6 +511,15 @@ export type TableCalculationTemplate =
           frame?: FrameClause;
       };
 
+export enum TableCalculationTotalMode {
+    /** Apply the calculation to the aggregated totals row (default) — right for ratios */
+    FORMULA = 'formula',
+    /** Sum the calculation's row-level values — right for row-level transformations */
+    SUM_OF_ROWS = 'sum_of_rows',
+    /** Show no total for this calculation */
+    NONE = 'none',
+}
+
 export type TableCalculationBase = {
     /** Display order index */
     index?: number;
@@ -522,6 +531,8 @@ export type TableCalculationBase = {
     format?: CustomFormat;
     /** Data type of the calculation result */
     type?: TableCalculationType;
+    /** How column totals are computed for this calculation */
+    totalMode?: TableCalculationTotalMode;
 };
 
 export type SqlTableCalculation = TableCalculationBase & {

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -7,6 +7,7 @@ import {
     isSqlTableCalculation,
     isTemplateTableCalculation,
     NumberSeparator,
+    TableCalculationTotalMode,
     TableCalculationType,
     type CustomFormat,
     type GeneratedFormulaTableCalculation,
@@ -25,10 +26,12 @@ import {
     HoverCard,
     Loader,
     Popover,
+    Select,
     Stack,
     Text,
     TextInput,
     Tooltip,
+    type ComboboxItem,
 } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import {
@@ -102,6 +105,54 @@ type TableCalculationFormInputs = {
     formula: string;
     format: CustomFormat;
     type?: TableCalculationType;
+    totalMode?: TableCalculationTotalMode;
+};
+
+const totalModeMeta: Record<
+    TableCalculationTotalMode,
+    { label: string; description: string }
+> = {
+    [TableCalculationTotalMode.FORMULA]: {
+        label: 'Apply calculation to the totals',
+        description:
+            'Runs the formula over the totals of the columns it references. Best for ratios and percentages.',
+    },
+    [TableCalculationTotalMode.SUM_OF_ROWS]: {
+        label: 'Sum of the row values',
+        description:
+            "Adds up the calculation's value from every row. Best for row-level transformations.",
+    },
+    [TableCalculationTotalMode.NONE]: {
+        label: 'No totals',
+        description: 'Shows no totals for this calculation.',
+    },
+};
+
+const totalModeOptions = Object.entries(totalModeMeta).map(
+    ([value, { label }]) => ({ value, label }),
+);
+
+// renderOption replaces Mantine's whole option node, including the built-in
+// selection check — render it manually from `checked`.
+const renderTotalModeOption = ({
+    option,
+    checked,
+}: {
+    option: ComboboxItem;
+    checked?: boolean;
+}) => {
+    const meta = totalModeMeta[option.value as TableCalculationTotalMode];
+    return (
+        <Group flex={1} justify="space-between" wrap="nowrap" gap="xs">
+            <Stack gap={0}>
+                <Text size="sm">{meta.label}</Text>
+                <Text size="xs" c="dimmed">
+                    {meta.description}
+                </Text>
+            </Stack>
+            {checked && <MantineIcon icon={IconCheck} size="sm" />}
+        </Group>
+    );
 };
 
 enum EditMode {
@@ -206,6 +257,9 @@ const TableCalculationModal: FC<Props> = ({
                     ? tableCalculation.formula
                     : '',
             type: tableCalculation?.type || TableCalculationType.NUMBER,
+            totalMode:
+                tableCalculation?.totalMode ||
+                TableCalculationTotalMode.FORMULA,
             format: {
                 type:
                     tableCalculation?.format?.type || CustomFormatType.DEFAULT,
@@ -399,7 +453,7 @@ const TableCalculationModal: FC<Props> = ({
             return;
         }
 
-        const { name, sql, formula, format, type } = form.values;
+        const { name, sql, formula, format, type, totalMode } = form.values;
         try {
             const isNewCalculation = !tableCalculation;
             const nameChanged =
@@ -427,6 +481,7 @@ const TableCalculationModal: FC<Props> = ({
                         displayName: name,
                         format,
                         type,
+                        totalMode,
                         template: editedTemplate ?? tableCalculation.template,
                     },
                     { mode: 'template', generatedByAi: false },
@@ -441,6 +496,7 @@ const TableCalculationModal: FC<Props> = ({
                         displayName: name,
                         format,
                         type,
+                        totalMode,
                         formula: normalizedFormula,
                     },
                     {
@@ -455,6 +511,7 @@ const TableCalculationModal: FC<Props> = ({
                         displayName: name,
                         format,
                         type,
+                        totalMode,
                         sql,
                     },
                     {
@@ -523,6 +580,17 @@ const TableCalculationModal: FC<Props> = ({
                     type: CustomFormatType.DEFAULT,
                     separator: NumberSeparator.DEFAULT,
                 });
+            }
+            // Summing row values only makes sense for numeric results;
+            // 'none' stays valid for any type.
+            if (
+                next !== TableCalculationType.NUMBER &&
+                form.values.totalMode === TableCalculationTotalMode.SUM_OF_ROWS
+            ) {
+                form.setFieldValue(
+                    'totalMode',
+                    TableCalculationTotalMode.FORMULA,
+                );
             }
             form.setFieldValue('type', next);
         },
@@ -968,6 +1036,27 @@ const TableCalculationModal: FC<Props> = ({
                     dataType={selectedTableCalculationType}
                     onDataTypeChange={handleDataTypeChange}
                 />
+
+                {selectedTableCalculationType ===
+                    TableCalculationType.NUMBER && (
+                    <Select
+                        label="Totals"
+                        data={totalModeOptions}
+                        allowDeselect={false}
+                        renderOption={renderTotalModeOption}
+                        value={
+                            form.values.totalMode ??
+                            TableCalculationTotalMode.FORMULA
+                        }
+                        onChange={(value) =>
+                            value &&
+                            form.setFieldValue(
+                                'totalMode',
+                                value as TableCalculationTotalMode,
+                            )
+                        }
+                    />
+                )}
 
                 <TextInput
                     ref={nameInputRef}


### PR DESCRIPTION
Closes: PROD-8594
Closes: #24940

### Description:

Adds a per-calculation **totals mode** so users choose how each table calculation's totals are computed. Because the setting is per calculation, one table can mix behaviors.

- **`formula`** (default): re-applies the calc to the collapsed totals row. Right for ratios and percentages; unchanged from today.
- **`sum_of_rows`**: sums the calc's row-level values over the embedded source rows (a `source_aggregations` CTE at the totals grain, joined onto the final select). Right for row-level transforms like `${metric} + 2`, and also produces correct totals for calcs that can't be re-applied to a collapsed row (window functions, templates), which previously always showed blank.
- **`none`**: shows no totals for the calc (dropped from the collapsed query, never aggregated).

The mode applies to every total of the calc: column totals, pivot row totals, and subtotals.

| Before: `${amount} + 2` totals to 4,151.12 (formula on the totals row) | After: 4,159.12 (sum of the row values) |
|---|---|
| <img alt="before: calc total re-applies the formula to the grand total" src="https://github.com/user-attachments/assets/6a94af1d-7a7e-4aa5-b205-27d718c6c4f3" /> | <img alt="after: calc total sums the row-level values" src="https://github.com/user-attachments/assets/a86f51d9-7a76-439e-b28c-0925ea1c922c" /> |

Configured via a **Totals** select in the table calculation modal, with a custom-rendered dropdown describing each option:

<img width="1570" alt="Totals setting in the table calculation modal, dropdown open with a description per option" src="https://raw.githubusercontent.com/lightdash/lightdash/pr-25859-assets/modal-total-mode-3.png" />

Persisted per calc via a new nullable `total_mode` column on `saved_queries_version_table_calculations` (+ migration).

**Stack:** builds on #25859 (source-query embed) and #25892 (visible-page derivation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


test-all