### PR TITLE
feat(ai-agents): move Content as code into agent settings page

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -290,16 +290,31 @@ export const AiAgentFormSetup = ({
             <form>
                 <Stack gap="sm">
                     <Paper p="xl">
-                        <Group align="center" gap="xs" mb="md">
-                            <Paper p="xxs" withBorder radius="sm">
-                                <MantineIcon
-                                    icon={IconAdjustmentsAlt}
-                                    size="md"
-                                />
-                            </Paper>
-                            <Title order={5} c="ldGray.9" fw={700}>
-                                Basic information
-                            </Title>
+                        <Group align="center" justify="space-between" mb="md">
+                            <Group align="center" gap="xs">
+                                <Paper p="xxs" withBorder radius="sm">
+                                    <MantineIcon
+                                        icon={IconAdjustmentsAlt}
+                                        size="md"
+                                    />
+                                </Paper>
+                                <Title order={5} c="ldGray.9" fw={700}>
+                                    Basic information
+                                </Title>
+                            </Group>
+                            {mode === 'edit' &&
+                                agentUuid &&
+                                canViewContentAsCode && (
+                                    <Button
+                                        variant="default"
+                                        onClick={asCodeModalHandlers.open}
+                                        leftSection={
+                                            <MantineIcon icon={IconCode} />
+                                        }
+                                    >
+                                        View as code
+                                    </Button>
+                                )}
                         </Group>
                         <Stack>
                             <Group>
@@ -1086,48 +1101,6 @@ export const AiAgentFormSetup = ({
                             )}
                         </Stack>
                     </Paper>
-
-                    {mode === 'edit' && agentUuid && canViewContentAsCode && (
-                        <Paper p="xl">
-                            <Group align="center" gap="xs" mb="md">
-                                <Paper p="xxs" withBorder radius="sm">
-                                    <MantineIcon icon={IconCode} size="md" />
-                                </Paper>
-                                <Title order={5} c="ldGray.9" fw={700}>
-                                    Content as code
-                                </Title>
-                            </Group>
-                            <Group
-                                gap="xs"
-                                align="center"
-                                justify="space-between"
-                            >
-                                <Box>
-                                    <Title
-                                        order={6}
-                                        c="ldGray.7"
-                                        size="sm"
-                                        fw={500}
-                                    >
-                                        View as code
-                                    </Title>
-                                    <Text c="dimmed" size="xs">
-                                        View this agent's configuration as code
-                                        to manage it through content-as-code.
-                                    </Text>
-                                </Box>
-                                <Button
-                                    variant="default"
-                                    onClick={asCodeModalHandlers.open}
-                                    leftSection={
-                                        <MantineIcon icon={IconCode} />
-                                    }
-                                >
-                                    View as code
-                                </Button>
-                            </Group>
-                        </Paper>
-                    )}
 
                     {mode === 'edit' && (
                         <Paper p="xl" withBorder>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import { FeatureFlags, type AiAgentModelConfig } from '@lightdash/common';
 import {
     Anchor,
@@ -31,6 +32,7 @@ import {
     IconAdjustmentsAlt,
     IconAlertTriangle,
     IconBook2,
+    IconCode,
     IconInfoCircle,
     IconLock,
     IconPlug,
@@ -61,6 +63,7 @@ import {
 import { useAiOrganizationSettings } from '../hooks/useAiOrganizationSettings';
 import { useDeleteAiAgentMutation } from '../hooks/useProjectAiAgents';
 import { useGetAgentExploreAccessSummary } from '../hooks/useUserAgentPreferences';
+import AiAgentAsCodeModal from './AiAgentAsCodeModal';
 import { AiAgentKnowledgeFilesSection } from './AiAgentKnowledgeFilesSection';
 import { AiAgentMcpServersInput } from './AiAgentMcpServersInput';
 import { InstructionsGuidelines } from './InstructionsSupport';
@@ -150,6 +153,15 @@ export const AiAgentFormSetup = ({
 
     const { user } = useApp();
     const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+    const [isAsCodeModalOpen, asCodeModalHandlers] = useDisclosure(false);
+
+    const canViewContentAsCode = !!user.data?.ability.can(
+        'view',
+        subject('ContentAsCode', {
+            organizationUuid: user.data.organizationUuid,
+            projectUuid,
+        }),
+    );
 
     const handleDeleteClick = useCallback(() => {
         setDeleteModalOpen(true);
@@ -1075,6 +1087,48 @@ export const AiAgentFormSetup = ({
                         </Stack>
                     </Paper>
 
+                    {mode === 'edit' && agentUuid && canViewContentAsCode && (
+                        <Paper p="xl">
+                            <Group align="center" gap="xs" mb="md">
+                                <Paper p="xxs" withBorder radius="sm">
+                                    <MantineIcon icon={IconCode} size="md" />
+                                </Paper>
+                                <Title order={5} c="ldGray.9" fw={700}>
+                                    Content as code
+                                </Title>
+                            </Group>
+                            <Group
+                                gap="xs"
+                                align="center"
+                                justify="space-between"
+                            >
+                                <Box>
+                                    <Title
+                                        order={6}
+                                        c="ldGray.7"
+                                        size="sm"
+                                        fw={500}
+                                    >
+                                        View as code
+                                    </Title>
+                                    <Text c="dimmed" size="xs">
+                                        View this agent's configuration as code
+                                        to manage it through content-as-code.
+                                    </Text>
+                                </Box>
+                                <Button
+                                    variant="default"
+                                    onClick={asCodeModalHandlers.open}
+                                    leftSection={
+                                        <MantineIcon icon={IconCode} />
+                                    }
+                                >
+                                    View as code
+                                </Button>
+                            </Group>
+                        </Paper>
+                    )}
+
                     {mode === 'edit' && (
                         <Paper p="xl" withBorder>
                             <Group align="center" gap="xs" mb="md">
@@ -1131,6 +1185,14 @@ export const AiAgentFormSetup = ({
                 description="This action cannot be undone."
                 onConfirm={handleDelete}
             />
+            {agentUuid && (
+                <AiAgentAsCodeModal
+                    opened={isAsCodeModalOpen}
+                    onClose={asCodeModalHandlers.close}
+                    projectUuid={projectUuid}
+                    agentUuid={agentUuid}
+                />
+            )}
         </>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader.tsx
@@ -1,7 +1,5 @@
-import { ActionIcon, Box, Button, Group, Menu, Tooltip } from '@mantine-8/core';
+import { ActionIcon, Box, Button, Group, Tooltip } from '@mantine-8/core';
 import {
-    IconCode,
-    IconDots,
     IconSettings,
     IconShare2,
     IconWindowMinimize,
@@ -15,7 +13,6 @@ type Props = {
     leftSection?: ReactNode;
     onMinimize?: () => void;
     onShare?: () => void;
-    onViewAsCode?: () => void;
     isSharing?: boolean;
     settingsHref?: string;
 };
@@ -24,7 +21,6 @@ export const AgentPageHeader: FC<Props> = ({
     leftSection,
     onMinimize,
     onShare,
-    onViewAsCode,
     isSharing,
     settingsHref,
 }) => (
@@ -77,30 +73,6 @@ export const AgentPageHeader: FC<Props> = ({
                 >
                     Settings
                 </Button>
-            )}
-            {onViewAsCode && (
-                <Menu position="bottom-end" withArrow withinPortal shadow="md">
-                    <Menu.Target>
-                        <ActionIcon
-                            variant="default"
-                            size="md"
-                            radius="md"
-                            className={`${styles.action} ${styles.actionIcon}`}
-                            aria-label="More actions"
-                        >
-                            <MantineIcon icon={IconDots} />
-                        </ActionIcon>
-                    </Menu.Target>
-                    <Menu.Dropdown>
-                        <Menu.Label>Content as code</Menu.Label>
-                        <Menu.Item
-                            leftSection={<MantineIcon icon={IconCode} />}
-                            onClick={onViewAsCode}
-                        >
-                            View as code
-                        </Menu.Item>
-                    </Menu.Dropdown>
-                </Menu>
             )}
         </Group>
     </Group>

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -1,7 +1,5 @@
-import { subject } from '@casl/ability';
 import { type AiAgent } from '@lightdash/common';
 import { Box, Group, Loader, Stack, Text, TextInput } from '@mantine-8/core';
-import { useDisclosure } from '@mantine-8/hooks';
 import { IconShare2 } from '@tabler/icons-react';
 import { useCallback, useState } from 'react';
 import {
@@ -17,7 +15,6 @@ import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { AgentSelector } from '../../features/aiCopilot/components/AgentSelector';
-import AiAgentAsCodeModal from '../../features/aiCopilot/components/AiAgentAsCodeModal';
 import { AgentPageHeader } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentPageHeader';
 import { AgentSidebar } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentSidebar';
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
@@ -79,17 +76,6 @@ const AgentPage = () => {
         useCreateAgentThreadShareMutation();
     const [isShareModalOpen, setIsShareModalOpen] = useState(false);
     const [shareUrl, setShareUrl] = useState<string | null>(null);
-    const [isAgentAsCodeModalOpen, agentAsCodeModalHandlers] = useDisclosure();
-
-    const canViewContentAsCode =
-        agent &&
-        user.data?.ability.can(
-            'view',
-            subject('ContentAsCode', {
-                organizationUuid: agent.organizationUuid,
-                projectUuid: agent.projectUuid,
-            }),
-        );
 
     const handleMinimize = useCallback(
         (targetUrl?: string, options?: NavigateFromAgentChatOptions) => {
@@ -249,11 +235,6 @@ const AgentPage = () => {
                         }
                         isSharing={isCreatingShare}
                         onMinimize={() => handleMinimize()}
-                        onViewAsCode={
-                            canViewContentAsCode
-                                ? agentAsCodeModalHandlers.open
-                                : undefined
-                        }
                         settingsHref={
                             canManageAgents
                                 ? `/projects/${projectUuid}/ai-agents/${agent.uuid}/edit`
@@ -263,12 +244,6 @@ const AgentPage = () => {
                 ) : undefined
             }
         >
-            <AiAgentAsCodeModal
-                opened={isAgentAsCodeModalOpen}
-                onClose={agentAsCodeModalHandlers.close}
-                projectUuid={agent.projectUuid}
-                agentUuid={agent.uuid}
-            />
             <MantineModal
                 opened={isShareModalOpen}
                 onClose={closeShareModal}


### PR DESCRIPTION
### Description:

Moves the "Content as code" option out of the three-dots menu on the AI agent chat page and into the agent settings (edit) page.

- Removed the three-dots menu (and its `onViewAsCode` wiring / modal) from the agent chat header (`AgentPageHeader` / `AgentPage`).
- Added a "Content as code" section to the settings form (`AiAgentFormSetup`, edit mode only) with a **View as code** button that opens the existing `AiAgentAsCodeModal`. The section is gated on the same `view ContentAsCode` permission as before.
