### PR TITLE
fix: validate pivot column references in PivotQueryBuilder

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -1735,6 +1735,124 @@ SELECT * FROM group_by_query LIMIT 50`);
         });
     });
 
+    describe('Pivot column reference validation', () => {
+        const quoteCharConfigs: Array<[string, object]> = [
+            [
+                'indexColumn',
+                {
+                    indexColumn: [
+                        { reference: 'da"te', type: VizIndexType.TIME },
+                    ],
+                },
+            ],
+            [
+                'valuesColumns',
+                {
+                    valuesColumns: [
+                        {
+                            reference: 'event_id") AS "pwn',
+                            aggregation: VizAggregationOptions.SUM,
+                        },
+                    ],
+                },
+            ],
+            [
+                'sortOnlyColumns',
+                {
+                    sortOnlyColumns: [
+                        {
+                            reference: 'ev"ent_id',
+                            aggregation: VizAggregationOptions.SUM,
+                        },
+                    ],
+                },
+            ],
+            [
+                'groupByColumns',
+                { groupByColumns: [{ reference: 'cat"egory' }] },
+            ],
+            [
+                'sortBy',
+                {
+                    sortBy: [
+                        {
+                            reference: 'da"te',
+                            direction: SortByDirection.ASC,
+                        },
+                    ],
+                },
+            ],
+            [
+                'sortOnlyDimensions',
+                { sortOnlyDimensions: [{ reference: 'cat"egory' }] },
+            ],
+            [
+                'passthroughDimensions',
+                { passthroughDimensions: [{ reference: 'cat"egory' }] },
+            ],
+            [
+                'pivotColumnsOrder',
+                { pivotColumnsOrder: [{ reference: 'cat"egory' }] },
+            ],
+        ];
+
+        test.each(quoteCharConfigs)(
+            'Should reject a %s reference containing the field quote character',
+            (_name, override) => {
+                const pivotConfiguration = {
+                    indexColumn: [
+                        { reference: 'date', type: VizIndexType.TIME },
+                    ],
+                    valuesColumns: [
+                        {
+                            reference: 'event_id',
+                            aggregation: VizAggregationOptions.SUM,
+                        },
+                    ],
+                    groupByColumns: [{ reference: 'category' }],
+                    sortBy: undefined,
+                    ...override,
+                };
+
+                expect(
+                    () =>
+                        new PivotQueryBuilder(
+                            baseSql,
+                            pivotConfiguration,
+                            mockWarehouseSqlBuilder,
+                        ),
+                ).toThrow(ParameterError);
+            },
+        );
+
+        test('Should accept references without the field quote character', () => {
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'event_id',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'category name' }],
+                sortBy: [
+                    {
+                        reference: 'category name',
+                        direction: SortByDirection.ASC,
+                    },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            expect(builder.toSql()).toContain('"category name"');
+        });
+    });
+
     describe('Limit handling', () => {
         test('Should use default limit of 500 when no limit specified', () => {
             const pivotConfiguration = {

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -81,6 +81,10 @@ export class PivotQueryBuilder {
         limit?: number,
         itemsMap?: ItemsMap,
     ) {
+        PivotQueryBuilder.validatePivotReferences(
+            pivotConfiguration,
+            warehouseSqlBuilder.getFieldQuoteChar(),
+        );
         this.sql = sql;
         this.pivotConfiguration = pivotConfiguration;
         this.limit = limit;
@@ -88,6 +92,34 @@ export class PivotQueryBuilder {
         this.itemsMap = itemsMap ?? {};
         this.pivotTableCalculations = this.identifyPivotTableCalculations();
         this.implicitMetricReferences = this.getImplicitMetricReferences();
+    }
+
+    /**
+     * Pivot column references are interpolated into quoted SQL identifiers, so
+     * a reference containing the field quote character would break out of the
+     * quoted identifier. Reject them up front.
+     */
+    private static validatePivotReferences(
+        pivotConfiguration: PivotConfiguration,
+        quoteChar: string,
+    ): void {
+        const references = [
+            ...normalizeIndexColumns(pivotConfiguration.indexColumn),
+            ...(pivotConfiguration.valuesColumns ?? []),
+            ...(pivotConfiguration.sortOnlyColumns ?? []),
+            ...(pivotConfiguration.groupByColumns ?? []),
+            ...(pivotConfiguration.sortBy ?? []),
+            ...(pivotConfiguration.sortOnlyDimensions ?? []),
+            ...(pivotConfiguration.passthroughDimensions ?? []),
+            ...(pivotConfiguration.pivotColumnsOrder ?? []),
+        ].map((col) => col.reference);
+
+        const invalid = references.filter((ref) => ref.includes(quoteChar));
+        if (invalid.length > 0) {
+            throw new ParameterError(
+                `Invalid pivot column reference(s): ${invalid.join(', ')}`,
+            );
+        }
     }
 
     /**

--- a/packages/common/src/utils/warehouse.test.ts
+++ b/packages/common/src/utils/warehouse.test.ts
@@ -1,0 +1,31 @@
+import { SupportedDbtAdapter } from '../types/dbt';
+import { type WarehouseSqlBuilder } from '../types/warehouse';
+import { VizAggregationOptions } from '../visualizations/types';
+import { getAggregatedField } from './warehouse';
+
+const mockWarehouseSqlBuilder = {
+    getFieldQuoteChar: () => '"',
+    getAdapterType: () => SupportedDbtAdapter.POSTGRES,
+} as WarehouseSqlBuilder;
+
+describe('getAggregatedField', () => {
+    it('should wrap the reference in the field quote character', () => {
+        expect(
+            getAggregatedField(
+                mockWarehouseSqlBuilder,
+                VizAggregationOptions.SUM,
+                'event_id',
+            ),
+        ).toBe('sum("event_id")');
+    });
+
+    it('should escape embedded field quote characters in the reference', () => {
+        expect(
+            getAggregatedField(
+                mockWarehouseSqlBuilder,
+                VizAggregationOptions.SUM,
+                'event_id") AS "pwn',
+            ),
+        ).toBe('sum("event_id"") AS ""pwn")');
+    });
+});

--- a/packages/common/src/utils/warehouse.ts
+++ b/packages/common/src/utils/warehouse.ts
@@ -107,6 +107,7 @@ export const getAggregatedField = (
     reference: string,
 ): string => {
     const q = warehouseSqlBuilder.getFieldQuoteChar();
+    const escapedReference = reference.replaceAll(q, `${q}${q}`);
     const adapterType = warehouseSqlBuilder.getAdapterType();
     switch (adapterType) {
         case SupportedDbtAdapter.BIGQUERY:
@@ -121,18 +122,18 @@ export const getAggregatedField = (
                 aggregation === VizAggregationOptions.ANY
                     ? 'ANY_VALUE'
                     : aggregation;
-            return `${aggregationFunction}(${q}${reference}${q})`;
+            return `${aggregationFunction}(${q}${escapedReference}${q})`;
 
         case SupportedDbtAdapter.POSTGRES:
             if (aggregation === VizAggregationOptions.ANY) {
                 // ANY_VALUE on Postgres is only available from version v16+
-                return `(ARRAY_AGG(${q}${reference}${q}))[1]`;
+                return `(ARRAY_AGG(${q}${escapedReference}${q}))[1]`;
             }
             break;
         case SupportedDbtAdapter.CLICKHOUSE:
             if (aggregation === VizAggregationOptions.ANY) {
                 // ClickHouse uses any() function for ANY_VALUE equivalent
-                return `any(${q}${reference}${q})`;
+                return `any(${q}${escapedReference}${q})`;
             }
             break;
         default:
@@ -141,5 +142,5 @@ export const getAggregatedField = (
                 `Unknown warehouse type ${adapterType}`,
             );
     }
-    return `${aggregation}(${q}${reference}${q})`;
+    return `${aggregation}(${q}${escapedReference}${q})`;
 };


### PR DESCRIPTION
Reject pivot column references that contain the warehouse field quote character when building pivot queries, and escape embedded quote characters in aggregated field identifiers.

Linear: SPK-615