### PR TITLE
feat: golden DB VolumeSnapshot for faster preview boots

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -5,6 +5,11 @@ preview:
   - "packages/**/*"
   - "docker/**/*"
   - "okteto.preview.yaml"
+  - "okteto.golden-db.yaml"
+  - "examples/full-jaffle-shop-demo/renderDeployHook.sh"
+  - "scripts/merge-preview-golden-compose.py"
+  - "scripts/snapshot-golden-db.sh"
+  - "dockerfile-prs"
 
 cli:
   - "packages/cli/**/*"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -424,11 +424,17 @@ jobs:
           chmod +x /usr/local/bin/kubectl
           okteto version
           kubectl version --client
-      - name: Context
-        uses: okteto/context@5212ce5ebf9d3584bafd33f4a295a8521fc5abe7 # latest
-        with:
-          url: ${{ secrets.OKTETO_CONTEXT }}
-          token: ${{ secrets.OKTETO_TOKEN }}
+      - name: Configure okteto context
+        run: |
+          set -euo pipefail
+          # Use host CLI (okteto/context action writes kubeconfig into a
+          # container-mounted HOME that later steps cannot see).
+          okteto context use --token="$OKTETO_TOKEN" "$OKTETO_CONTEXT"
+          okteto kubeconfig
+          kubectl config current-context
+        env:
+          OKTETO_TOKEN: ${{ secrets.OKTETO_TOKEN }}
+          OKTETO_CONTEXT: ${{ secrets.OKTETO_CONTEXT }}
       - name: Prove PVC snapshot + restore
         run: |
           set -euo pipefail

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -402,6 +402,30 @@ jobs:
               });
             }
 
+  # Live proof of golden-DB VolumeSnapshot primitives against the preview
+  # namespace (PVC → snapshot → clone → seed data present). Temporary while
+  # landing SPK-297; remove once refresh-golden-db is trusted on main.
+  prove-golden-db:
+    name: Prove Golden DB Snapshot
+    runs-on: depot-ubuntu-24.04-4
+    needs: preview
+    timeout-minutes: 20
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Context
+        uses: okteto/context@5212ce5ebf9d3584bafd33f4a295a8521fc5abe7 # latest
+        with:
+          url: ${{ secrets.OKTETO_CONTEXT }}
+          token: ${{ secrets.OKTETO_TOKEN }}
+      - name: Prove PVC snapshot + restore
+        run: |
+          set -euo pipefail
+          chmod +x scripts/prove-golden-db.sh
+          ./scripts/prove-golden-db.sh "${{ github.event.number }}"
+
   # ============================================================================
   # Stage 3: E2E and CLI tests (only after preview is up)
   # ============================================================================

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -415,6 +415,15 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Install okteto and kubectl
+        run: |
+          set -euo pipefail
+          curl -sSfL https://get.okteto.com | sh
+          curl -sSfL "https://dl.k8s.io/release/$(curl -sSfL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+            -o /usr/local/bin/kubectl
+          chmod +x /usr/local/bin/kubectl
+          okteto version
+          kubectl version --client
       - name: Context
         uses: okteto/context@5212ce5ebf9d3584bafd33f4a295a8521fc5abe7 # latest
         with:
@@ -425,6 +434,9 @@ jobs:
           set -euo pipefail
           chmod +x scripts/prove-golden-db.sh
           ./scripts/prove-golden-db.sh "${{ github.event.number }}"
+        env:
+          OKTETO_TOKEN: ${{ secrets.OKTETO_TOKEN }}
+          OKTETO_CONTEXT: ${{ secrets.OKTETO_CONTEXT }}
 
   # ============================================================================
   # Stage 3: E2E and CLI tests (only after preview is up)

--- a/.github/workflows/refresh-golden-db.yml
+++ b/.github/workflows/refresh-golden-db.yml
@@ -1,0 +1,106 @@
+name: Refresh Golden DB Snapshot
+
+# Builds a migrated+seeded Postgres PVC in the persistent `golden-db` Okteto
+# namespace and publishes CSI VolumeSnapshots (`golden-db-latest` +
+# `golden-db-<sha>`) that PR previews clone from. See SPK-297.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "packages/backend/src/database/migrations/**"
+      - "packages/backend/src/database/seeds/**"
+      - "packages/backend/src/ee/database/migrations/**"
+      - "packages/backend/src/ee/database/seeds/**"
+      - "examples/full-jaffle-shop-demo/**"
+      - "docker/docker-compose.golden-db.yml"
+      - "docker/docker-compose.preview.yml"
+      - "okteto.golden-db.yaml"
+      - "dockerfile-prs"
+      - ".github/workflows/refresh-golden-db.yml"
+      - "scripts/snapshot-golden-db.sh"
+
+concurrency:
+  group: refresh-golden-db
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  refresh-golden-db:
+    name: Refresh golden DB snapshot
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 45
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Context
+        uses: okteto/context@5212ce5ebf9d3584bafd33f4a295a8521fc5abe7 # latest
+        with:
+          url: ${{ secrets.OKTETO_CONTEXT }}
+          token: ${{ secrets.OKTETO_TOKEN }}
+
+      - name: Ensure golden-db namespace
+        run: |
+          set -euo pipefail
+          okteto namespace list 2>/dev/null | grep -qE '(^|[[:space:]])golden-db([[:space:]]|$)' \
+            || okteto namespace create golden-db
+          okteto namespace use golden-db
+          okteto kubeconfig >/dev/null
+
+      - name: Deploy golden DB stack
+        run: |
+          set -euo pipefail
+          export PGPASSWORD="${PGPASSWORD:-lightdash-preview-golden}"
+          okteto deploy -f okteto.golden-db.yaml --wait --timeout 25m
+        env:
+          PGPASSWORD: lightdash-preview-golden
+
+      - name: Wait for demo seed
+        run: |
+          set -euo pipefail
+          okteto namespace use golden-db
+          okteto kubeconfig >/dev/null
+
+          echo "Waiting for demo@lightdash.com in db-preview..."
+          for _ in $(seq 1 180); do
+            DB_POD="$(kubectl get pods --no-headers 2>/dev/null | awk '/db-preview/ {print $1; exit}')"
+            if [[ -n "$DB_POD" ]]; then
+              if kubectl exec "$DB_POD" -- \
+                psql -U postgres -d postgres -tAc \
+                "SELECT 1 FROM emails WHERE email='demo@lightdash.com'" 2>/dev/null \
+                | grep -q 1; then
+                echo "OK: demo user present on $DB_POD"
+                exit 0
+              fi
+            fi
+            sleep 5
+          done
+          echo "Timed out waiting for seed" >&2
+          kubectl get pods -o wide >&2 || true
+          APP_POD="$(kubectl get pods --no-headers 2>/dev/null | awk '/lightdash-preview/ {print $1; exit}')"
+          [[ -n "$APP_POD" ]] && kubectl logs "$APP_POD" --tail=120 >&2 || true
+          exit 1
+
+      - name: Snapshot golden DB volume
+        run: |
+          set -euo pipefail
+          chmod +x scripts/snapshot-golden-db.sh
+          ./scripts/snapshot-golden-db.sh "${GITHUB_SHA::12}"
+
+      - name: Scale down golden stack (keep namespace + snapshots)
+        if: always()
+        run: |
+          set -euo pipefail
+          okteto namespace use golden-db || exit 0
+          okteto kubeconfig >/dev/null || exit 0
+          # Free compute; VolumeSnapshots remain in the namespace for previews to clone.
+          kubectl scale deployment --all --replicas=0 2>/dev/null || true
+          kubectl scale statefulset --all --replicas=0 2>/dev/null || true

--- a/docker/CLAUDE.md
+++ b/docker/CLAUDE.md
@@ -48,6 +48,12 @@ services:
 -   `lightdash-dev` starts with `sleep infinity` for manual setup (migrations, builds)
 -   Environment variables are deduplicated using YAML anchors (`x-lightdash-*`)
 
+**Preview / golden DB** (`docker-compose.preview.yml`, `docker-compose.golden-db.yml`):
+
+-   `db-preview` mounts a `postgres_data` PVC so PGDATA can be snapshotted
+-   PR previews optionally restore from `golden-db/golden-db-latest` (SPK-297)
+-   See `scripts/CLAUDE.md` for the golden snapshot refresh flow
+
 **Port Allocation**:
 
 -   8080: Backend API

--- a/docker/docker-compose.golden-db.yml
+++ b/docker/docker-compose.golden-db.yml
@@ -1,0 +1,81 @@
+# Lightweight stack that materialises a migrated+seeded Postgres volume for
+# CSI VolumeSnapshots consumed by PR previews (SPK-297).
+#
+# Deployed into the persistent `golden-db` Okteto namespace by
+# .github/workflows/refresh-golden-db.yml. FORCE_FULL_DB_SETUP bypasses the
+# seed guard so every refresh recomputes from scratch on a fresh PVC.
+volumes:
+    postgres_data:
+
+services:
+    db-preview:
+        image: pgvector/pgvector:pg18
+        restart: always
+        environment:
+            - POSTGRES_PASSWORD=${PGPASSWORD:-lightdash-preview-golden}
+        ports:
+            - '5432'
+        volumes:
+            - postgres_data:/var/lib/postgresql
+
+    # Minimal headless-browser so the pr-runner healthcheck / depends_on still work.
+    # Not used while building the golden DB.
+    headless-browser:
+        build:
+            dockerfile: Dockerfile.headless-browser
+        restart: always
+        ports:
+            - '3000'
+
+    lightdash-preview:
+        build:
+            target: pr-runner
+            context: ..
+            dockerfile: dockerfile-prs
+        depends_on:
+            - db-preview
+            - headless-browser
+        healthcheck:
+            interval: 10s
+            timeout: 5s
+            retries: 30
+            start_period: 60s
+            http:
+                path: /api/v1/health
+                port: 8080
+        environment:
+            NODE_ENV: production
+            IS_PULL_REQUEST: true
+            LIGHTDASH_MODE: pr
+            DBT_DEMO_DIR: /usr/app
+            INTERNAL_LIGHTDASH_HOST: http://lightdash-preview:8080
+            SITE_URL: ${SITE_URL:-https://golden-db.lightdash.okteto.dev}
+            PGMAXCONNECTIONS: 30
+            SECURE_COOKIES: true
+            TRUST_PROXY: true
+            LIGHTDASH_SECRET: not very secret
+            GROUPS_ENABLED: true
+            EXTENDED_USAGE_ANALYTICS: true
+            PGHOST: db-preview
+            PGPORT: 5432
+            PGDATABASE: postgres
+            PGPASSWORD: ${PGPASSWORD:-lightdash-preview-golden}
+            PGUSER: postgres
+            HEADLESS_BROWSER_PORT: 3000
+            HEADLESS_BROWSER_HOST: headless-browser
+            # Force a full migrate+seed even if the PVC was reused.
+            FORCE_FULL_DB_SETUP: "true"
+            SCHEDULER_ENABLED: "false"
+            ALLOW_MULTIPLE_ORGS: true
+            LIGHTDASH_LOG_LEVEL: info
+            LIGHTDASH_LOG_FORMAT: json
+            LIGHTDASH_LICENSE_KEY: ${LIGHTDASH_LICENSE_KEY}
+            S3_ACCESS_KEY: ${S3_ACCESS_KEY}
+            S3_SECRET_KEY: ${S3_SECRET_KEY}
+            S3_ENDPOINT: ${S3_ENDPOINT}
+            S3_REGION: ${S3_REGION}
+            S3_BUCKET: ${S3_BUCKET}
+        ports:
+            - '8080:8080'
+        command: ['pnpm', 'start']
+        entrypoint: ['/usr/bin/renderDeployHook.sh']

--- a/docker/docker-compose.preview.golden.yml
+++ b/docker/docker-compose.preview.golden.yml
@@ -1,0 +1,8 @@
+# Overlay for preview deploys that restore db-preview from the golden VolumeSnapshot.
+# Merged on top of docker-compose.preview.yml when golden-db-latest is ready
+# (see okteto.preview.yaml). Okteto translates volume labels → PVC annotations.
+volumes:
+    postgres_data:
+        labels:
+            dev.okteto.com/from-snapshot-name: golden-db-latest
+            dev.okteto.com/from-snapshot-namespace: golden-db

--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -1,5 +1,8 @@
 volumes:
     node_modules:
+    # Persists PGDATA so previews can boot from a CSI VolumeSnapshot of the
+    # golden DB (see docker/docker-compose.preview.golden.yml + SPK-297).
+    postgres_data:
 
 # Okteto specific
 endpoints:
@@ -15,6 +18,9 @@ services:
             - POSTGRES_PASSWORD=${PGPASSWORD}
         ports:
             - '5432'
+        volumes:
+            # Match local/dev compose: Postgres 18 image expects the parent dir.
+            - postgres_data:/var/lib/postgresql
 
     headless-browser:
         build:

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -412,6 +412,12 @@ CMD ["node", "dist/index.js"]
 
 FROM prod AS pr-runner
 
+# psql/pg_isready used by renderDeployHook.sh seed guard (golden DB / PVC reuse)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    postgresql-client \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy demo dbt project for E2E testing
 COPY ./examples/full-jaffle-shop-demo/renderDeployHook.sh /usr/bin/renderDeployHook.sh
 COPY ./examples/full-jaffle-shop-demo/dbt /usr/app/dbt

--- a/examples/full-jaffle-shop-demo/renderDeployHook.sh
+++ b/examples/full-jaffle-shop-demo/renderDeployHook.sh
@@ -1,13 +1,52 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# Idempotent dbt commands
+# Seed guard for golden-DB restores (and PVC reuse on PR redeploy).
+# When the DB already has the demo org + jaffle tables, skip the expensive
+# dbt full-refresh + knex seed and only apply pending migrations.
+# Always falls back to the full path on a blank (or partial) database.
+
+db_has() {
+    psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -tAc \
+        "SELECT CASE WHEN EXISTS($1) THEN 'yes' ELSE 'no' END" 2>/dev/null \
+        || echo "no"
+}
+
+echo "Waiting for Postgres at ${PGHOST}:${PGPORT}..."
+for _ in $(seq 1 60); do
+    if pg_isready -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 2
+done
+if ! pg_isready -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" >/dev/null 2>&1; then
+    echo "Postgres not ready after 120s" >&2
+    exit 1
+fi
+
+FORCE_FULL="${FORCE_FULL_DB_SETUP:-false}"
+SEEDED="$(db_has "SELECT 1 FROM emails WHERE email='demo@lightdash.com'")"
+DBT_BUILT="$(db_has "SELECT 1 FROM information_schema.tables WHERE table_schema='jaffle' AND table_name='orders'")"
+MIGRATED="$(db_has "SELECT 1 FROM information_schema.tables WHERE table_name='sessions'")"
+
+if [ "$FORCE_FULL" != "true" ] && [ "$SEEDED" = "yes" ] && [ "$DBT_BUILT" = "yes" ]; then
+    echo "DB already seeded (golden restore or reused PVC) — skipping dbt + seed"
+    pnpm -F backend migrate-production
+    exec "$@"
+fi
+
+echo "Running full dbt + migrate + seed (blank or partial DB)"
 dbt1.7 deps --project-dir /usr/app/dbt --profiles-dir /usr/app/profiles
 dbt1.7 seed --project-dir /usr/app/dbt --profiles-dir /usr/app/profiles --full-refresh
 dbt1.7 run --project-dir /usr/app/dbt --profiles-dir /usr/app/profiles --full-refresh
 
-# Rollback all migrations and seed
-pnpm -F backend rollback-all-production
+# Rollback only when schema exists but seed is missing (corrupt/partial state).
+# Never rollback a golden-restored DB — that path is handled above.
+if [ "$MIGRATED" = "yes" ] && [ "$SEEDED" != "yes" ]; then
+    echo "Partial schema detected without seed — rolling back before migrate+seed"
+    pnpm -F backend rollback-all-production
+fi
+
 pnpm -F backend migrate-production
 pnpm -F backend seed-production
 

--- a/okteto.golden-db.yaml
+++ b/okteto.golden-db.yaml
@@ -1,0 +1,17 @@
+# Persistent namespace that owns the golden-db VolumeSnapshot(s).
+# Previews clone from golden-db/golden-db-latest via Okteto PVC annotations.
+deploy:
+  commands:
+    - name: Configuring golden DB password...
+      command: |
+        set -euo pipefail
+        echo "PGPASSWORD=${PGPASSWORD:-lightdash-preview-golden}" >> "$OKTETO_ENV"
+    - name: Resetting previous golden stack (keep VolumeSnapshots)...
+      command: |
+        set -euo pipefail
+        # Destroy the previous compose deploy so the next deploy gets a blank PVC.
+        # VolumeSnapshots created by scripts/snapshot-golden-db.sh are not part of
+        # the compose stack and remain in this namespace for previews to clone.
+        okteto destroy -f docker/docker-compose.golden-db.yml --wait || true
+    - name: Deploying golden DB stack...
+      command: okteto deploy -f docker/docker-compose.golden-db.yml

--- a/okteto.preview.yaml
+++ b/okteto.preview.yaml
@@ -1,6 +1,48 @@
 deploy:
   commands:
-    - name: Generating postgres password...
-      command: echo "PGPASSWORD=$(openssl rand -hex 16)" >> "$OKTETO_ENV"
+    - name: Configuring preview database...
+      command: |
+        set -euo pipefail
+
+        # Stable password must match the golden DB snapshot so restored volumes
+        # accept connections (Postgres ignores POSTGRES_PASSWORD when PGDATA exists).
+        # Preview envs are ephemeral — this is not a production secret.
+        # Override via Okteto admin var PGPASSWORD if needed (must match golden).
+        echo "PGPASSWORD=${PGPASSWORD:-lightdash-preview-golden}" >> "$OKTETO_ENV"
+
+        GOLDEN_NS="${GOLDEN_DB_NAMESPACE:-golden-db}"
+        GOLDEN_SNAP="${GOLDEN_DB_SNAPSHOT:-golden-db-latest}"
+
+        if kubectl get volumesnapshot "$GOLDEN_SNAP" -n "$GOLDEN_NS" >/dev/null 2>&1; then
+          READY="$(kubectl get volumesnapshot "$GOLDEN_SNAP" -n "$GOLDEN_NS" \
+            -o jsonpath='{.status.readyToUse}' 2>/dev/null || echo false)"
+          if [ "$READY" = "true" ]; then
+            echo "Using golden DB snapshot ${GOLDEN_NS}/${GOLDEN_SNAP}"
+            echo "USE_GOLDEN_DB=true" >> "$OKTETO_ENV"
+            echo "GOLDEN_DB_NAMESPACE=${GOLDEN_NS}" >> "$OKTETO_ENV"
+            echo "GOLDEN_DB_SNAPSHOT=${GOLDEN_SNAP}" >> "$OKTETO_ENV"
+          else
+            echo "Golden snapshot ${GOLDEN_NS}/${GOLDEN_SNAP} not ready — full migrate+seed fallback"
+            echo "USE_GOLDEN_DB=false" >> "$OKTETO_ENV"
+          fi
+        else
+          echo "No golden DB snapshot at ${GOLDEN_NS}/${GOLDEN_SNAP} — full migrate+seed fallback"
+          echo "USE_GOLDEN_DB=false" >> "$OKTETO_ENV"
+        fi
+
     - name: Deploying compose...
-      command: okteto deploy -f docker/docker-compose.preview.yml
+      command: |
+        set -euo pipefail
+
+        if [ "${USE_GOLDEN_DB:-false}" = "true" ]; then
+          python3 scripts/merge-preview-golden-compose.py \
+            --output /tmp/docker-compose.preview.with-golden.yml \
+            --snapshot "${GOLDEN_DB_SNAPSHOT:-golden-db-latest}" \
+            --namespace "${GOLDEN_DB_NAMESPACE:-golden-db}"
+          if ! okteto deploy -f /tmp/docker-compose.preview.with-golden.yml; then
+            echo "Golden restore deploy failed — retrying without snapshot" >&2
+            okteto deploy -f docker/docker-compose.preview.yml
+          fi
+        else
+          okteto deploy -f docker/docker-compose.preview.yml
+        fi

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -30,3 +30,20 @@ Connect to a preview environment's Postgres database.
 ```
 
 Port-forward auto-cleans on exit for `psql` and `query` modes. `forward` mode keeps it alive but tells you how to kill it manually.
+
+## Golden DB snapshots (SPK-297)
+
+PR previews boot Postgres from a CSI `VolumeSnapshot` (`golden-db/golden-db-latest`) when available, then skip dbt + knex seed and only run delta migrations.
+
+| File | Role |
+|------|------|
+| `docker/docker-compose.preview.yml` | Preview stack; `postgres_data` PVC for PGDATA |
+| `docker/docker-compose.preview.golden.yml` | Volume labels that point the PVC at the golden snapshot |
+| `docker/docker-compose.golden-db.yml` | Stack that materialises the golden volume |
+| `okteto.preview.yaml` | Soft-fail: use golden overlay when snapshot is ready |
+| `okteto.golden-db.yaml` | Deploy/reset the golden stack |
+| `scripts/merge-preview-golden-compose.py` | Merge golden labels into a single compose file |
+| `scripts/snapshot-golden-db.sh` | Create `golden-db-<sha>` + `golden-db-latest` |
+| `.github/workflows/refresh-golden-db.yml` | Refresh snapshots on main (migrations/seeds/jaffle) |
+
+`PGPASSWORD` is stable (`lightdash-preview-golden`) across golden + previews so restored volumes accept connections. Override via Okteto admin var if needed (must match on both sides).

--- a/scripts/merge-preview-golden-compose.py
+++ b/scripts/merge-preview-golden-compose.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Merge golden VolumeSnapshot labels into the preview compose file.
+
+Writes a single compose file suitable for `okteto deploy -f` (single-file only).
+Labels are taken from docker/docker-compose.preview.golden.yml.
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+def extract_labels(overlay_text: str) -> str:
+    match = re.search(
+        r"postgres_data:\n(?P<body>(?:[ \t]+.+\n)+)",
+        overlay_text,
+    )
+    if not match:
+        raise SystemExit("Could not parse postgres_data labels from golden overlay")
+    return match.group("body")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--base",
+        default="docker/docker-compose.preview.yml",
+        type=pathlib.Path,
+    )
+    parser.add_argument(
+        "--overlay",
+        default="docker/docker-compose.preview.golden.yml",
+        type=pathlib.Path,
+    )
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    parser.add_argument("--snapshot", default="")
+    parser.add_argument("--namespace", default="")
+    args = parser.parse_args()
+
+    labels = extract_labels(args.overlay.read_text())
+    if args.snapshot:
+        labels = re.sub(
+            r"(from-snapshot-name:\s*).*",
+            rf"\1{args.snapshot}",
+            labels,
+        )
+    if args.namespace:
+        labels = re.sub(
+            r"(from-snapshot-namespace:\s*).*",
+            rf"\1{args.namespace}",
+            labels,
+        )
+
+    text = args.base.read_text()
+    needle = "    postgres_data:\n"
+    if needle not in text:
+        print(f"Could not find {needle!r} in {args.base}", file=sys.stderr)
+        return 1
+
+    head, _, tail = text.partition(needle)
+    if "services:" not in tail:
+        print("Compose file missing services: section", file=sys.stderr)
+        return 1
+
+    services_at = tail.index("services:")
+    volumes_tail = tail[:services_at]
+    rest = tail[services_at:]
+    if re.search(r"^\s+labels:", volumes_tail, re.M):
+        merged = text
+    else:
+        merged = head + needle + labels + volumes_tail + rest
+
+    args.output.write_text(merged)
+    print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prove-golden-db.sh
+++ b/scripts/prove-golden-db.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Live proof of the golden-DB path against an Okteto preview namespace.
+#
+# Expects: okteto context already configured, kubectl available.
+# Usage: ./scripts/prove-golden-db.sh <pr_number>
+set -euo pipefail
+
+PR_NUMBER="${1:?Usage: $0 <pr_number>}"
+NAMESPACE="pr-${PR_NUMBER}"
+SNAPSHOT_CLASS="${GOLDEN_DB_SNAPSHOT_CLASS:-okteto-snapshot-class}"
+PROOF_SNAP="golden-db-proof"
+
+echo "== Prove golden DB path in namespace $NAMESPACE =="
+
+okteto namespace use "$NAMESPACE" >/dev/null
+okteto kubeconfig >/dev/null
+
+echo "-- Pods --"
+kubectl get pods -o wide
+
+echo "-- PVCs --"
+kubectl get pvc -o wide
+PVC="$(kubectl get pvc -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -iE 'postgres' | head -n1 || true)"
+if [[ -z "$PVC" ]]; then
+  echo "FAIL: no postgres PVC found (db-preview volume mount missing?)" >&2
+  exit 1
+fi
+PHASE="$(kubectl get pvc "$PVC" -o jsonpath='{.status.phase}')"
+echo "OK: PVC=$PVC phase=$PHASE"
+[[ "$PHASE" == "Bound" ]] || { echo "FAIL: PVC not Bound" >&2; exit 1; }
+
+DB_POD="$(kubectl get pods --no-headers | awk '/db-preview/ {print $1; exit}')"
+APP_POD="$(kubectl get pods --no-headers | awk '/lightdash-preview/ {print $1; exit}')"
+[[ -n "$DB_POD" ]] || { echo "FAIL: no db-preview pod" >&2; exit 1; }
+echo "OK: DB_POD=$DB_POD APP_POD=${APP_POD:-none}"
+
+echo "-- Wait for demo seed --"
+for _ in $(seq 1 60); do
+  if kubectl exec "$DB_POD" -- \
+    psql -U postgres -d postgres -tAc \
+    "SELECT 1 FROM emails WHERE email='demo@lightdash.com'" 2>/dev/null | grep -q 1; then
+    echo "OK: demo@lightdash.com present"
+    break
+  fi
+  sleep 5
+done
+if ! kubectl exec "$DB_POD" -- \
+  psql -U postgres -d postgres -tAc \
+  "SELECT 1 FROM emails WHERE email='demo@lightdash.com'" 2>/dev/null | grep -q 1; then
+  echo "FAIL: demo user never appeared" >&2
+  [[ -n "$APP_POD" ]] && kubectl logs "$APP_POD" --tail=80 >&2 || true
+  exit 1
+fi
+
+if [[ -n "$APP_POD" ]]; then
+  echo "-- Entrypoint path (from app logs) --"
+  LOGS="$(kubectl logs "$APP_POD" --tail=200 2>/dev/null || true)"
+  if echo "$LOGS" | grep -q 'already seeded'; then
+    echo "OK: seed guard took golden/reuse path"
+  elif echo "$LOGS" | grep -q 'Running full dbt'; then
+    echo "OK: first-boot full migrate+seed path (expected before snapshot exists)"
+  else
+    echo "WARN: could not classify entrypoint path from recent logs"
+  fi
+fi
+
+echo "-- VolumeSnapshotClass --"
+if kubectl get volumesnapshotclass "$SNAPSHOT_CLASS" >/dev/null 2>&1; then
+  echo "OK: VolumeSnapshotClass $SNAPSHOT_CLASS exists"
+else
+  echo "WARN: cannot read VolumeSnapshotClass $SNAPSHOT_CLASS (may be cluster-scoped Forbidden)"
+  kubectl get volumesnapshotclass 2>&1 || true
+fi
+
+echo "-- Create proof VolumeSnapshot from $PVC --"
+kubectl delete volumesnapshot "$PROOF_SNAP" --ignore-not-found=true >/dev/null
+# Best-effort CHECKPOINT for cleaner crash-consistent snap
+kubectl exec "$DB_POD" -- psql -U postgres -c "CHECKPOINT;" >/dev/null || true
+
+cat <<EOF | kubectl apply -f -
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: ${PROOF_SNAP}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: lightdash-golden-db-proof
+spec:
+  volumeSnapshotClassName: ${SNAPSHOT_CLASS}
+  source:
+    persistentVolumeClaimName: ${PVC}
+EOF
+
+echo "-- Wait for snapshot ReadyToUse --"
+for _ in $(seq 1 90); do
+  READY="$(kubectl get volumesnapshot "$PROOF_SNAP" -o jsonpath='{.status.readyToUse}' 2>/dev/null || echo false)"
+  if [[ "$READY" == "true" ]]; then
+    echo "OK: VolumeSnapshot $PROOF_SNAP ready"
+    kubectl get volumesnapshot "$PROOF_SNAP" -o wide
+    break
+  fi
+  sleep 5
+done
+READY="$(kubectl get volumesnapshot "$PROOF_SNAP" -o jsonpath='{.status.readyToUse}' 2>/dev/null || echo false)"
+if [[ "$READY" != "true" ]]; then
+  echo "FAIL: VolumeSnapshot never became ready" >&2
+  kubectl describe volumesnapshot "$PROOF_SNAP" >&2 || true
+  exit 1
+fi
+
+echo "-- Clone PVC from proof snapshot --"
+CLONE_PVC="postgres-data-golden-proof"
+kubectl delete pvc "$CLONE_PVC" --ignore-not-found=true --wait=true --timeout=60s >/dev/null 2>&1 || true
+SIZE="$(kubectl get pvc "$PVC" -o jsonpath='{.spec.resources.requests.storage}')"
+SIZE="${SIZE:-10Gi}"
+STORAGE_CLASS="$(kubectl get pvc "$PVC" -o jsonpath='{.spec.storageClassName}')"
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${CLONE_PVC}
+  namespace: ${NAMESPACE}
+spec:
+  accessModes: ["ReadWriteOnce"]
+  ${STORAGE_CLASS:+storageClassName: ${STORAGE_CLASS}}
+  resources:
+    requests:
+      storage: ${SIZE}
+  dataSource:
+    name: ${PROOF_SNAP}
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+EOF
+
+echo "-- Wait for clone PVC Bound --"
+for _ in $(seq 1 60); do
+  CPHASE="$(kubectl get pvc "$CLONE_PVC" -o jsonpath='{.status.phase}' 2>/dev/null || echo Pending)"
+  if [[ "$CPHASE" == "Bound" ]]; then
+    echo "OK: clone PVC $CLONE_PVC Bound"
+    break
+  fi
+  sleep 5
+done
+CPHASE="$(kubectl get pvc "$CLONE_PVC" -o jsonpath='{.status.phase}' 2>/dev/null || echo Pending)"
+if [[ "$CPHASE" != "Bound" ]]; then
+  echo "FAIL: clone PVC not Bound (phase=$CPHASE)" >&2
+  kubectl describe pvc "$CLONE_PVC" >&2 || true
+  exit 1
+fi
+
+echo "-- Boot throwaway Postgres on clone and verify seed data --"
+kubectl delete pod golden-db-proof-pg --ignore-not-found=true --wait=true --timeout=60s >/dev/null 2>&1 || true
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: golden-db-proof-pg
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  containers:
+    - name: postgres
+      image: pgvector/pgvector:pg18
+      env:
+        - name: POSTGRES_PASSWORD
+          value: lightdash-preview-golden
+      ports:
+        - containerPort: 5432
+      volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: ${CLONE_PVC}
+EOF
+
+for _ in $(seq 1 60); do
+  if kubectl exec golden-db-proof-pg -- pg_isready -U postgres >/dev/null 2>&1; then
+    break
+  fi
+  sleep 3
+done
+if ! kubectl exec golden-db-proof-pg -- pg_isready -U postgres >/dev/null 2>&1; then
+  echo "FAIL: proof postgres pod not ready" >&2
+  kubectl describe pod golden-db-proof-pg >&2 || true
+  kubectl logs golden-db-proof-pg >&2 || true
+  exit 1
+fi
+
+# Password in snapshot is the stable preview password; POSTGRES_PASSWORD is ignored when PGDATA exists.
+if ! PGPASSWORD=lightdash-preview-golden kubectl exec golden-db-proof-pg -- \
+  env PGPASSWORD=lightdash-preview-golden \
+  psql -U postgres -d postgres -tAc \
+  "SELECT 1 FROM emails WHERE email='demo@lightdash.com'" | grep -q 1; then
+  echo "FAIL: demo user missing on cloned volume (snapshot restore broken or password mismatch)" >&2
+  kubectl exec golden-db-proof-pg -- \
+    env PGPASSWORD=lightdash-preview-golden \
+    psql -U postgres -d postgres -c '\dt' >&2 || true
+  exit 1
+fi
+
+if ! PGPASSWORD=lightdash-preview-golden kubectl exec golden-db-proof-pg -- \
+  env PGPASSWORD=lightdash-preview-golden \
+  psql -U postgres -d postgres -tAc \
+  "SELECT 1 FROM information_schema.tables WHERE table_schema='jaffle' AND table_name='orders'" | grep -q 1; then
+  echo "FAIL: jaffle.orders missing on cloned volume" >&2
+  exit 1
+fi
+
+echo "OK: cloned volume has demo user + jaffle.orders (CoW restore works)"
+
+echo "-- Cleanup proof pod/pvc/snapshot artifacts (keep original preview intact) --"
+kubectl delete pod golden-db-proof-pg --ignore-not-found=true --wait=false >/dev/null
+kubectl delete pvc "$CLONE_PVC" --ignore-not-found=true --wait=false >/dev/null
+kubectl delete volumesnapshot "$PROOF_SNAP" --ignore-not-found=true --wait=false >/dev/null
+
+echo
+echo "PASS: live golden-DB primitives proven in $NAMESPACE"
+echo "  - postgres PVC Bound"
+echo "  - VolumeSnapshot create + ReadyToUse"
+echo "  - PVC clone from snapshot Bound"
+echo "  - restored PGDATA contains seed + jaffle data"

--- a/scripts/snapshot-golden-db.sh
+++ b/scripts/snapshot-golden-db.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Create (or refresh) VolumeSnapshots from the golden-db Postgres PVC.
+#
+# Usage (from repo root, with kubectl pointed at the golden-db namespace):
+#   ./scripts/snapshot-golden-db.sh [git-sha]
+#
+# Creates:
+#   golden-db-<sha>     — immutable rollback point
+#   golden-db-latest    — stable name previews clone from
+#
+# Keeps the most recent KEEP_COUNT sha-tagged snapshots (default 5).
+set -euo pipefail
+
+NAMESPACE="${GOLDEN_DB_NAMESPACE:-golden-db}"
+SNAPSHOT_CLASS="${GOLDEN_DB_SNAPSHOT_CLASS:-okteto-snapshot-class}"
+KEEP_COUNT="${GOLDEN_DB_KEEP_COUNT:-5}"
+SHA="${1:-$(git rev-parse --short HEAD)}"
+SHA_SNAP="golden-db-${SHA}"
+LATEST_SNAP="golden-db-latest"
+
+echo "Using namespace: $NAMESPACE"
+
+okteto namespace use "$NAMESPACE" >/dev/null
+okteto kubeconfig >/dev/null
+
+# Discover the Postgres PVC created by the compose volume `postgres_data`.
+PVC="$(kubectl get pvc -n "$NAMESPACE" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+  | grep -iE 'postgres' | head -n1 || true)"
+if [[ -z "$PVC" ]]; then
+  echo "No postgres PVC found in namespace $NAMESPACE" >&2
+  kubectl get pvc -n "$NAMESPACE" >&2 || true
+  exit 1
+fi
+echo "Source PVC: $PVC"
+
+# Quiesce writers briefly for a cleaner crash-consistent snapshot.
+DB_POD="$(kubectl get pods -n "$NAMESPACE" --no-headers 2>/dev/null \
+  | awk '/db-preview/ {print $1; exit}')"
+if [[ -n "$DB_POD" ]]; then
+  echo "CHECKPOINT on $DB_POD"
+  kubectl exec -n "$NAMESPACE" "$DB_POD" -- \
+    psql -U postgres -c "CHECKPOINT;" >/dev/null || true
+fi
+
+create_snapshot() {
+  local name="$1"
+  echo "Creating VolumeSnapshot $NAMESPACE/$name from PVC $PVC"
+  kubectl delete volumesnapshot "$name" -n "$NAMESPACE" --ignore-not-found=true >/dev/null
+  cat <<EOF | kubectl apply -f -
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: ${name}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: lightdash-golden-db
+    lightdash.com/golden-db-sha: "${SHA}"
+spec:
+  volumeSnapshotClassName: ${SNAPSHOT_CLASS}
+  source:
+    persistentVolumeClaimName: ${PVC}
+EOF
+}
+
+wait_ready() {
+  local name="$1"
+  echo "Waiting for VolumeSnapshot $name to become ready..."
+  for _ in $(seq 1 90); do
+    READY="$(kubectl get volumesnapshot "$name" -n "$NAMESPACE" \
+      -o jsonpath='{.status.readyToUse}' 2>/dev/null || echo false)"
+    if [[ "$READY" == "true" ]]; then
+      echo "OK: $name ready"
+      return 0
+    fi
+    sleep 5
+  done
+  echo "Timed out waiting for VolumeSnapshot $name" >&2
+  kubectl describe volumesnapshot "$name" -n "$NAMESPACE" >&2 || true
+  return 1
+}
+
+create_snapshot "$SHA_SNAP"
+wait_ready "$SHA_SNAP"
+
+create_snapshot "$LATEST_SNAP"
+wait_ready "$LATEST_SNAP"
+
+echo "Pruning old sha-tagged snapshots (keeping last $KEEP_COUNT)..."
+kubectl get volumesnapshot -n "$NAMESPACE" \
+  -l app.kubernetes.io/name=lightdash-golden-db \
+  --sort-by=.metadata.creationTimestamp \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+  | grep -E '^golden-db-[0-9a-f]+$' \
+  | head -n -"$KEEP_COUNT" \
+  | while read -r old; do
+      [[ -z "$old" || "$old" == "$SHA_SNAP" || "$old" == "$LATEST_SNAP" ]] && continue
+      echo "Deleting old snapshot $old"
+      kubectl delete volumesnapshot "$old" -n "$NAMESPACE" --ignore-not-found=true
+    done
+
+echo "Done. Previews can clone from ${NAMESPACE}/${LATEST_SNAP}"
+kubectl get volumesnapshot -n "$NAMESPACE"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Preview environments currently rebuild the DB from scratch on every boot (`dbt` full-refresh + `rollback-all` + migrate + seed). This PR boots each preview from a CSI `VolumeSnapshot` of a pre-migrated+seeded "golden" Postgres volume, then only applies delta migrations.

## What changed

1. **`db-preview` gets a PVC** (`postgres_data` → `/var/lib/postgresql`) so there is something to snapshot/restore.
2. **Seed guard** in `renderDeployHook.sh` — if `demo@lightdash.com` + `jaffle.orders` already exist, skip dbt + seed and only run `migrate-production`. Soft-falls back to the full path on a blank DB. Never rolls back a golden-restored DB.
3. **Stable `PGPASSWORD`** (`lightdash-preview-golden`) so restored volumes accept connections (Postgres ignores `POSTGRES_PASSWORD` when PGDATA exists).
4. **Soft-fail restore** in `okteto.preview.yaml` — if `golden-db/golden-db-latest` is missing/not ready, deploy without snapshot annotations and run the full path.
5. **Refresh pipeline** — `refresh-golden-db.yml` deploys into a persistent `golden-db` namespace, seeds, and publishes `golden-db-latest` + `golden-db-<sha>` via `scripts/snapshot-golden-db.sh` (keeps last 5 sha tags).
6. **Live proof CI** — `Prove Golden DB Snapshot` job runs after preview deploy and validates PVC → VolumeSnapshot → PVC clone → restored seed data on the cluster.

## Live evidence so far

From Deploy Preview on this PR:
- Soft-fail path confirmed: `No golden DB snapshot at golden-db/golden-db-latest — full migrate+seed fallback`

Awaiting `Prove Golden DB Snapshot` for snapshot create/restore proof.

## Rollout

1. Merge this PR (previews keep working via the fallback path until a golden snapshot exists).
2. Run **Refresh Golden DB Snapshot** (`workflow_dispatch`) once to create `golden-db/golden-db-latest`.
3. Subsequent preview deploys clone the snapshot; further refreshes run automatically on main when migrations/seeds/jaffle change.

Closes: SPK-297
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa2a4043-f975-4787-8350-a0420d210960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa2a4043-f975-4787-8350-a0420d210960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

