### PR TITLE
feat: add managed onboarding run experience

### DIFF
--- a/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
@@ -46,8 +46,13 @@ import {
 import {
     ALLOWED_TOOLS,
     CANCELLATION_POLL_INTERVAL_MS,
+    CLAUDE_BASH_GUARD_PATH,
+    CLAUDE_BASH_GUARD_SCRIPT,
     CLAUDE_MODEL,
+    CLAUDE_SETTINGS,
+    CLAUDE_SETTINGS_PATH,
     CLAUDE_SKILLS_DIR,
+    CLAUDE_TOOLS,
     CLI_WRAPPER_PATH,
     CLI_WRAPPER_SCRIPT,
     FILE_SYNC_INTERVAL_MS,
@@ -61,9 +66,12 @@ import { OnboardingAgentFileStore } from './OnboardingAgentFileStore';
 import {
     buildManagedOnboardingPrompt,
     classifyOnboardingStage,
+    containsOnboardingSecret,
+    hasCompleteOnboardingOutput,
     isOnboardingOutputFile,
     parseWorkspaceFileListing,
     sanitizeOnboardingMessage,
+    validateOnboardingOutputFileLimits,
 } from './utils';
 
 type Dependencies = {
@@ -461,8 +469,9 @@ export class OnboardingAgentService extends BaseService {
         run: DbAgentOnboardingRun;
         sandbox: SandboxHandle;
         previousFiles: DbAgentOnboardingFile[];
+        sensitiveValues: string[];
     }): Promise<DbAgentOnboardingFile[]> {
-        const { run, sandbox, previousFiles } = args;
+        const { run, sandbox, previousFiles, sensitiveValues } = args;
         const result = await sandbox.commands.run(
             `find ${WORKDIR} -type f -printf '%P\\t%s\\t%T@\\n' | sort`,
         );
@@ -472,31 +481,68 @@ export class OnboardingAgentService extends BaseService {
         const discovered = parseWorkspaceFileListing(result.stdout).filter(
             ({ path }) => isOnboardingOutputFile(path),
         );
+        validateOnboardingOutputFileLimits(discovered);
 
-        const files = await Promise.all(
-            discovered.map(async (file): Promise<DbAgentOnboardingFile> => {
+        const contentsByPath = new Map<string, Buffer>();
+        await Promise.all(
+            discovered.map(async (file) => {
                 const previous = previousByPath.get(file.path);
                 if (
                     previous &&
                     previous.sizeBytes === file.sizeBytes &&
                     previous.updatedAt === file.updatedAt
                 ) {
-                    return previous;
+                    return;
                 }
 
-                const s3Key = [
-                    'agent-onboarding',
-                    run.organization_uuid,
-                    run.agent_onboarding_run_uuid,
-                    'files',
-                    ...file.path.split('/').map(encodeURIComponent),
-                ].join('/');
                 const contents = await sandbox.files.readBytes(
                     `${WORKDIR}/${file.path}`,
                 );
-                await this.fileStore.put(s3Key, contents);
-                return { ...file, s3Key };
+                if (containsOnboardingSecret(contents, sensitiveValues)) {
+                    throw new Error(
+                        `Onboarding file ${file.path} contains sensitive content and was not persisted`,
+                    );
+                }
+                contentsByPath.set(file.path, contents);
             }),
+        );
+
+        const filesWithActualSizes = discovered.map((file) => ({
+            ...file,
+            sizeBytes:
+                contentsByPath.get(file.path)?.byteLength ?? file.sizeBytes,
+        }));
+        validateOnboardingOutputFileLimits(filesWithActualSizes);
+
+        const files = await Promise.all(
+            filesWithActualSizes.map(
+                async (file): Promise<DbAgentOnboardingFile> => {
+                    const previous = previousByPath.get(file.path);
+                    if (
+                        previous &&
+                        previous.sizeBytes === file.sizeBytes &&
+                        previous.updatedAt === file.updatedAt
+                    ) {
+                        return previous;
+                    }
+
+                    const s3Key = [
+                        'agent-onboarding',
+                        run.organization_uuid,
+                        run.agent_onboarding_run_uuid,
+                        'files',
+                        ...file.path.split('/').map(encodeURIComponent),
+                    ].join('/');
+                    const contents = contentsByPath.get(file.path);
+                    if (!contents) {
+                        throw new Error(
+                            `Could not read onboarding file ${file.path}`,
+                        );
+                    }
+                    await this.fileStore.put(s3Key, contents);
+                    return { ...file, s3Key };
+                },
+            ),
         );
 
         const filesChanged =
@@ -526,6 +572,7 @@ export class OnboardingAgentService extends BaseService {
         anthropicApiKey: string;
     }): Promise<{
         assistantText: string;
+        files: DbAgentOnboardingFile[];
         usage: AgentOnboardingUsage | null;
     }> {
         const { run, sandbox, patToken, anthropicApiKey } = args;
@@ -546,9 +593,16 @@ export class OnboardingAgentService extends BaseService {
         });
         const sensitiveValues = [patToken, anthropicApiKey];
 
-        await sandbox.commands.run(`mkdir -p ${WORKDIR}`);
+        await sandbox.commands.run(
+            `mkdir -p ${WORKDIR}/lightdash/models ${WORKDIR}/lightdash/charts ${WORKDIR}/lightdash/dashboards && chmod -R a+rwX ${WORKDIR}`,
+        );
         await sandbox.files.write(PROMPT_PATH, prompt);
         await sandbox.files.write(CLI_WRAPPER_PATH, CLI_WRAPPER_SCRIPT);
+        await sandbox.files.write(
+            CLAUDE_BASH_GUARD_PATH,
+            CLAUDE_BASH_GUARD_SCRIPT,
+        );
+        await sandbox.files.write(CLAUDE_SETTINGS_PATH, CLAUDE_SETTINGS);
         await sandbox.commands.run(`chmod +x ${CLI_WRAPPER_PATH}`);
 
         let buffer = '';
@@ -565,6 +619,7 @@ export class OnboardingAgentService extends BaseService {
                 run,
                 sandbox,
                 previousFiles: knownFiles,
+                sensitiveValues,
             })
                 .then((files) => {
                     knownFiles = files;
@@ -683,6 +738,9 @@ export class OnboardingAgentService extends BaseService {
                     `--model ${CLAUDE_MODEL} ` +
                     '--output-format stream-json --verbose ' +
                     `--add-dir ${CLAUDE_SKILLS_DIR} ` +
+                    `--settings ${CLAUDE_SETTINGS_PATH} ` +
+                    '--permission-mode dontAsk ' +
+                    `--tools "${CLAUDE_TOOLS}" ` +
                     `--allowedTools "${ALLOWED_TOOLS}"`,
                 {
                     cwd: WORKDIR,
@@ -743,7 +801,7 @@ export class OnboardingAgentService extends BaseService {
         await Promise.all(pendingEvents);
         if (runError) throw runError.value;
         if (syncError) throw syncError.value;
-        return { assistantText, usage };
+        return { assistantText, files: knownFiles, usage };
     }
 
     private buildHandoff(
@@ -891,19 +949,23 @@ export class OnboardingAgentService extends BaseService {
             }
 
             const anthropicApiKey = this.getAnthropicApiKey();
-            const { assistantText, usage } = await this.runAgentInSandbox({
-                run,
-                sandbox: sandbox.handle,
-                patToken: pat.token,
-                anthropicApiKey,
-            });
+            const { assistantText, files, usage } =
+                await this.runAgentInSandbox({
+                    run,
+                    sandbox: sandbox.handle,
+                    patToken: pat.token,
+                    anthropicApiKey,
+                });
+            const handoff = this.buildHandoff(assistantText, sensitiveValues());
+            if (!hasCompleteOnboardingOutput(files) || !handoff.dashboardUrl) {
+                throw new Error(
+                    'The onboarding agent stopped before generating all required project files. Please try again.',
+                );
+            }
             const completed = await this.agentOnboardingRunModel.markCompleted(
                 run.agent_onboarding_run_uuid,
                 {
-                    handoff: this.buildHandoff(
-                        assistantText,
-                        sensitiveValues(),
-                    ),
+                    handoff,
                     usage,
                     stage: 'handoff',
                 },

--- a/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
@@ -7,6 +7,7 @@ import {
     MissingConfigError,
     NotFoundError,
     RequestMethod,
+    UnexpectedServerError,
     type AgentOnboardingFileContent,
     type AgentOnboardingHandoff,
     type AgentOnboardingJobPayload,
@@ -499,7 +500,7 @@ export class OnboardingAgentService extends BaseService {
                     `${WORKDIR}/${file.path}`,
                 );
                 if (containsOnboardingSecret(contents, sensitiveValues)) {
-                    throw new Error(
+                    throw new UnexpectedServerError(
                         `Onboarding file ${file.path} contains sensitive content and was not persisted`,
                     );
                 }
@@ -535,7 +536,7 @@ export class OnboardingAgentService extends BaseService {
                     ].join('/');
                     const contents = contentsByPath.get(file.path);
                     if (!contents) {
-                        throw new Error(
+                        throw new UnexpectedServerError(
                             `Could not read onboarding file ${file.path}`,
                         );
                     }
@@ -958,7 +959,7 @@ export class OnboardingAgentService extends BaseService {
                 });
             const handoff = this.buildHandoff(assistantText, sensitiveValues());
             if (!hasCompleteOnboardingOutput(files) || !handoff.dashboardUrl) {
-                throw new Error(
+                throw new UnexpectedServerError(
                     'The onboarding agent stopped before generating all required project files. Please try again.',
                 );
             }

--- a/packages/backend/src/ee/services/OnboardingAgentService/constants.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/constants.ts
@@ -2,31 +2,291 @@ export const WORKDIR = '/home/user/workspace';
 export const PROMPT_PATH = '/home/user/.ld-onboarding-prompt.txt';
 export const CLAUDE_SKILLS_DIR = '/home/user/.claude/skills';
 export const CLI_WRAPPER_PATH = '/tmp/ld';
+export const CLAUDE_SETTINGS_PATH = '/tmp/ld-claude-settings.json';
+export const CLAUDE_BASH_GUARD_PATH = '/tmp/ld-bash-guard.cjs';
 
 export const CLI_WRAPPER_SCRIPT = `#!/bin/bash
+deny() {
+    echo "Lightdash command is not permitted during onboarding" >&2
+    exit 64
+}
+
+valid_workspace_path() {
+    case "$1" in
+        .|./*|lightdash|lightdash/*|lightdash.config.yml|lightdash.config.yaml|LIGHTDASH_HANDOFF.md|${WORKDIR}|${WORKDIR}/*|*.yml|*.yaml) ;;
+        *) deny ;;
+    esac
+    case "$1" in
+        *../*|*/..*) deny ;;
+    esac
+}
+
+valid_csv_path() {
+    case "$1" in
+        *../*|*/..*|*.yml|*.yaml|*.md) deny ;;
+        /tmp/*.csv|${WORKDIR}/*.csv|*.csv) ;;
+        *) deny ;;
+    esac
+}
+
+valid_number() {
+    case "$1" in
+        ''|*[!0-9]*) deny ;;
+    esac
+}
+
 while IFS='=' read -r name _; do
     case "$name" in
         LIGHTDASH_URL|LIGHTDASH_API_KEY|LIGHTDASH_PROJECT) ;;
         ANTHROPIC_*|OPENAI_*|OPENROUTER_*|E2B_*|GITHUB_*|GH_*|GITLAB_*|AWS_*|AZURE_CLIENT_SECRET|GOOGLE_APPLICATION_CREDENTIALS|DBT_*|PGPASSWORD|POSTGRES_PASSWORD|MYSQL_PWD|SNOWFLAKE_*|BIGQUERY_*|DATABRICKS_*|REDSHIFT_*|CLICKHOUSE_*|MSSQL_*|TRINO_*|*_PASSWORD|*_TOKEN|*_SECRET|*_PRIVATE_KEY|*_API_KEY) unset "$name" ;;
     esac
 done < <(env)
-exec lightdash "$@"
+
+[ -n "$LIGHTDASH_PROJECT" ] || deny
+command="$1"
+shift || true
+original_args=("$@")
+
+for arg in "$@"; do
+    case "$arg" in
+        --url|--url=*|--token|--token=*|--api-key|--api-key=*) deny ;;
+    esac
+done
+
+case "$command" in
+    --version|--help)
+        [ "$#" -eq 0 ] || deny
+        ;;
+    config)
+        [ "$#" -eq 1 ] && [ "$1" = "get-project" ] || deny
+        ;;
+    warehouse-catalog)
+        while [ "$#" -gt 0 ]; do
+            arg="$1"
+            shift
+            case "$arg" in
+                --database|--schema|--table)
+                    [ "$#" -gt 0 ] || deny
+                    shift
+                    ;;
+                --include-fields|--json|--verbose|--help) ;;
+                *) deny ;;
+            esac
+        done
+        ;;
+    lint)
+        while [ "$#" -gt 0 ]; do
+            arg="$1"
+            shift
+            case "$arg" in
+                -p|--path)
+                    [ "$#" -gt 0 ] || deny
+                    valid_workspace_path "$1"
+                    shift
+                    ;;
+                -f|--format)
+                    [ "$#" -gt 0 ] || deny
+                    case "$1" in cli|json) ;; *) deny ;; esac
+                    shift
+                    ;;
+                --verbose|--help) ;;
+                *) deny ;;
+            esac
+        done
+        ;;
+    run-chart)
+        path_seen=false
+        while [ "$#" -gt 0 ]; do
+            arg="$1"
+            shift
+            case "$arg" in
+                -p|--path)
+                    [ "$#" -gt 0 ] || deny
+                    valid_workspace_path "$1"
+                    path_seen=true
+                    shift
+                    ;;
+                -o|--output)
+                    [ "$#" -gt 0 ] || deny
+                    valid_csv_path "$1"
+                    shift
+                    ;;
+                -l|--limit|--page-size)
+                    [ "$#" -gt 0 ] || deny
+                    valid_number "$1"
+                    shift
+                    ;;
+                --verbose) ;;
+                --help)
+                    [ "\${#original_args[@]}" = "1" ] || deny
+                    ;;
+                *) deny ;;
+            esac
+        done
+        if [ "\${original_args[0]}" != "--help" ]; then
+            [ "$path_seen" = true ] || deny
+        fi
+        ;;
+    sql)
+        query=""
+        output_seen=false
+        while [ "$#" -gt 0 ]; do
+            arg="$1"
+            shift
+            case "$arg" in
+                --project|--project=*|--output=*) deny ;;
+                -o|--output)
+                    [ "$#" -gt 0 ] || deny
+                    output="$1"
+                    shift
+                    valid_csv_path "$output"
+                    output_seen=true
+                    ;;
+                --limit|--page-size)
+                    [ "$#" -gt 0 ] || deny
+                    valid_number "$1"
+                    shift
+                    ;;
+                --verbose) ;;
+                --help)
+                    [ "\${#original_args[@]}" = "1" ] || deny
+                    ;;
+                -*) deny ;;
+                *)
+                    [ -z "$query" ] || deny
+                    query="$arg"
+                    ;;
+            esac
+        done
+        if [ "\${original_args[0]}" != "--help" ]; then
+            query_lower="$(printf '%s' "$query" | tr '[:upper:]' '[:lower:]')"
+            case "$query_lower" in
+                select\\ *|with\\ *|show\\ *|describe\\ *|explain\\ *) ;;
+                *) deny ;;
+            esac
+            query_tokens="$(printf '%s' "$query_lower" | tr '(),\t' '    ')"
+            case " $query_tokens " in
+                *" insert "*|*" update "*|*" delete "*|*" merge "*|*" drop "*|*" alter "*|*" create "*|*" truncate "*|*" grant "*|*" revoke "*|*" copy "*|*" call "*|*" execute "*) deny ;;
+            esac
+            [ "$output_seen" = true ] || deny
+        fi
+        ;;
+    deploy|upload|validate)
+        project_seen=false
+        while [ "$#" -gt 0 ]; do
+            arg="$1"
+            shift
+            case "$arg" in
+                --project)
+                    [ "$#" -gt 0 ] || deny
+                    [ "$1" = "$LIGHTDASH_PROJECT" ] || deny
+                    project_seen=true
+                    shift
+                    ;;
+                --project=*) deny ;;
+                --help)
+                    [ "\${#original_args[@]}" = "1" ] || deny
+                    ;;
+                --verbose) ;;
+                --no-version-check)
+                    [ "$command" = "deploy" ] || deny
+                    ;;
+                --project-dir)
+                    [ "$command" = "deploy" ] || [ "$command" = "validate" ] || deny
+                    [ "$#" -gt 0 ] || deny
+                    valid_workspace_path "$1"
+                    shift
+                    ;;
+                -p|--path)
+                    [ "$command" = "upload" ] || deny
+                    [ "$#" -gt 0 ] || deny
+                    valid_workspace_path "$1"
+                    shift
+                    ;;
+                -y|--assume-yes)
+                    [ "$command" = "deploy" ] || deny
+                    ;;
+                --validate|--gzip)
+                    [ "$command" = "upload" ] || deny
+                    ;;
+                *) deny ;;
+            esac
+        done
+        if [ "\${original_args[0]}" != "--help" ]; then
+            [ "$project_seen" = true ] || deny
+        fi
+        ;;
+    *) deny ;;
+esac
+
+exec lightdash "$command" "\${original_args[@]}"
 `;
+
+export const CLAUDE_BASH_GUARD_SCRIPT = `const fs = require('node:fs');
+
+let payload;
+try {
+    payload = JSON.parse(fs.readFileSync(0, 'utf8'));
+} catch {
+    console.error('Invalid Bash tool request');
+    process.exit(2);
+}
+
+const command = payload?.tool_input?.command;
+if (
+    typeof command !== 'string' ||
+    !/^\\/tmp\\/ld(?:\\s|$)/.test(command) ||
+    /[\\r\\n\`$<>|&;]/.test(command)
+) {
+    console.error('Only direct onboarding Lightdash commands are permitted');
+    process.exit(2);
+}
+`;
+
+export const CLAUDE_SETTINGS = JSON.stringify({
+    hooks: {
+        PreToolUse: [
+            {
+                matcher: 'Bash',
+                hooks: [
+                    {
+                        type: 'command',
+                        command: `node ${CLAUDE_BASH_GUARD_PATH}`,
+                    },
+                ],
+            },
+        ],
+    },
+});
 
 export const CLAUDE_MODEL = 'claude-sonnet-4-6';
 export const RUN_TIMEOUT_MS = 45 * 60 * 1000;
 export const SANDBOX_TIMEOUT_MS = 60 * 60 * 1000;
 export const PAT_EXPIRY_GRACE_MS = 15 * 60 * 1000;
-export const CANCELLATION_POLL_INTERVAL_MS = 10 * 1000;
+export const CANCELLATION_POLL_INTERVAL_MS = 2 * 1000;
 export const FILE_SYNC_INTERVAL_MS = 2 * 1000;
+export const MAX_ONBOARDING_FILE_COUNT = 100;
+export const MAX_ONBOARDING_FILE_SIZE_BYTES = 1024 * 1024;
+export const MAX_ONBOARDING_TOTAL_SIZE_BYTES = 10 * 1024 * 1024;
+
+export const CLAUDE_TOOLS = [
+    'Read',
+    'Glob',
+    'Grep',
+    'Edit',
+    'Write',
+    'Skill',
+    'TodoWrite',
+    'Bash',
+].join(',');
 
 export const ALLOWED_TOOLS = [
-    `Read(${WORKDIR}/**)`,
-    `Glob(${WORKDIR}/**)`,
-    `Grep(${WORKDIR}/**)`,
-    `Edit(${WORKDIR}/**)`,
-    `Write(${WORKDIR}/**)`,
-    `Read(${CLAUDE_SKILLS_DIR}/**)`,
+    `Read(/${WORKDIR}/**)`,
+    `Glob(/${WORKDIR}/**)`,
+    `Grep(/${WORKDIR}/**)`,
+    `Edit(/${WORKDIR}/**)`,
+    `Write(/${WORKDIR}/**)`,
+    `Read(/${CLAUDE_SKILLS_DIR}/**)`,
     'Skill',
     'TodoWrite',
     `Bash(${CLI_WRAPPER_PATH}:*)`,

--- a/packages/backend/src/ee/services/OnboardingAgentService/utils.test.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/utils.test.ts
@@ -1,6 +1,23 @@
-import { describe, expect, it } from 'vitest';
-import { ALLOWED_TOOLS, CLI_WRAPPER_SCRIPT } from './constants';
-import { classifyOnboardingStage, sanitizeOnboardingMessage } from './utils';
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+    ALLOWED_TOOLS,
+    CLAUDE_BASH_GUARD_SCRIPT,
+    CLI_WRAPPER_SCRIPT,
+    MAX_ONBOARDING_FILE_COUNT,
+    MAX_ONBOARDING_FILE_SIZE_BYTES,
+    MAX_ONBOARDING_TOTAL_SIZE_BYTES,
+} from './constants';
+import {
+    classifyOnboardingStage,
+    containsOnboardingSecret,
+    hasCompleteOnboardingOutput,
+    sanitizeOnboardingMessage,
+    validateOnboardingOutputFileLimits,
+} from './utils';
 
 describe('classifyOnboardingStage', () => {
     it.each([
@@ -51,12 +68,71 @@ describe('sanitizeOnboardingMessage', () => {
     });
 });
 
+describe('hasCompleteOnboardingOutput', () => {
+    const completeFiles = [
+        { path: 'lightdash.config.yml' },
+        { path: 'lightdash/models/orders.yml' },
+        { path: 'LIGHTDASH_HANDOFF.md' },
+    ];
+
+    it('requires every project output type', () => {
+        expect(hasCompleteOnboardingOutput(completeFiles)).toBe(true);
+        expect(hasCompleteOnboardingOutput(completeFiles.slice(0, -1))).toBe(
+            false,
+        );
+    });
+});
+
 describe('onboarding command policy', () => {
-    it('allows only the secret-stripping wrapper as a Bash command', () => {
+    let testDir: string;
+    let wrapperPath: string;
+    let hookPath: string;
+
+    beforeAll(() => {
+        testDir = mkdtempSync(join(tmpdir(), 'ld-onboarding-policy-'));
+        wrapperPath = join(testDir, 'ld');
+        hookPath = join(testDir, 'guard.cjs');
+        writeFileSync(wrapperPath, CLI_WRAPPER_SCRIPT);
+        writeFileSync(hookPath, CLAUDE_BASH_GUARD_SCRIPT);
+        writeFileSync(
+            join(testDir, 'lightdash'),
+            '#!/bin/bash\nprintf \'%s\\n\' "$@"\n',
+        );
+        chmodSync(wrapperPath, 0o755);
+        chmodSync(join(testDir, 'lightdash'), 0o755);
+    });
+
+    afterAll(() => {
+        rmSync(testDir, { recursive: true, force: true });
+    });
+
+    const runWrapper = (args: string[]) =>
+        spawnSync(wrapperPath, args, {
+            encoding: 'utf8',
+            env: {
+                ...process.env,
+                PATH: `${testDir}:${process.env.PATH ?? ''}`,
+                LIGHTDASH_PROJECT: 'prepared-project',
+                LIGHTDASH_API_KEY: 'ldpat_test',
+                ANTHROPIC_API_KEY: 'anthropic-secret',
+            },
+        });
+
+    const runHook = (command: string) =>
+        spawnSync('node', [hookPath], {
+            encoding: 'utf8',
+            input: JSON.stringify({
+                tool_name: 'Bash',
+                tool_input: { command },
+            }),
+        });
+
+    it('uses absolute workspace permissions and only pre-approves the wrapper for Bash', () => {
         expect(ALLOWED_TOOLS).toContain('Bash(/tmp/ld:*)');
         expect(ALLOWED_TOOLS).not.toContain('Bash(cat:*)');
         expect(ALLOWED_TOOLS).not.toContain('Bash(ls:*)');
         expect(ALLOWED_TOOLS).not.toContain('Bash(mkdir:*)');
+        expect(ALLOWED_TOOLS).toContain('Write(//home/user/workspace/**)');
     });
 
     it('strips provider and warehouse credentials but preserves scoped Lightdash auth', () => {
@@ -68,5 +144,135 @@ describe('onboarding command policy', () => {
         expect(CLI_WRAPPER_SCRIPT).toContain(
             'LIGHTDASH_URL|LIGHTDASH_API_KEY|LIGHTDASH_PROJECT',
         );
+    });
+
+    it('limits the wrapper to the prepared project and required commands', () => {
+        const allowed = runWrapper(['deploy', '--project', 'prepared-project']);
+        expect(allowed.status).toBe(0);
+        expect(allowed.stdout).toBe('deploy\n--project\nprepared-project\n');
+        expect(
+            runWrapper([
+                'deploy',
+                '--project',
+                'prepared-project',
+                '--project-dir',
+                '/home/user/workspace',
+                '--assume-yes',
+            ]).status,
+        ).toBe(0);
+        expect(
+            runWrapper([
+                'upload',
+                '--project',
+                'prepared-project',
+                '--path',
+                'lightdash',
+                '--validate',
+            ]).status,
+        ).toBe(0);
+        expect(
+            runWrapper(['deploy', '--project', 'another-project']).status,
+        ).toBe(64);
+        expect(
+            runWrapper(['config', 'set-project', 'another-project']).status,
+        ).toBe(64);
+        expect(runWrapper(['rename-project', 'new-name']).status).toBe(64);
+        expect(runWrapper(['--help']).status).toBe(0);
+        expect(
+            runWrapper([
+                'sql',
+                'select count(*) from orders',
+                '-o',
+                'orders-profile.csv',
+            ]).status,
+        ).toBe(0);
+        expect(
+            runWrapper([
+                'sql',
+                'select count(*) from orders',
+                '-o',
+                'lightdash/models/results.yml',
+            ]).status,
+        ).toBe(64);
+        expect(
+            runWrapper([
+                'sql',
+                'with removed as (delete from orders) select count(*) from removed',
+                '-o',
+                'orders-profile.csv',
+            ]).status,
+        ).toBe(64);
+    });
+
+    it('blocks shell access and expansion before permission evaluation', () => {
+        expect(runHook('/tmp/ld lint').status).toBe(0);
+        expect(runHook('cat /proc/self/environ').status).toBe(2);
+        expect(
+            runHook('/tmp/ld sql "select \'$ANTHROPIC_API_KEY\'" -o /tmp/x.csv')
+                .status,
+        ).toBe(2);
+        expect(runHook('/tmp/ld lint > /tmp/output').status).toBe(2);
+    });
+});
+
+describe('onboarding file persistence policy', () => {
+    const file = (
+        overrides: Partial<{ path: string; sizeBytes: number }> = {},
+    ) => ({
+        path: 'lightdash/models/orders.yml',
+        sizeBytes: 10,
+        updatedAt: new Date(0).toISOString(),
+        ...overrides,
+    });
+
+    it('rejects oversized files and excessive file counts', () => {
+        expect(() =>
+            validateOnboardingOutputFileLimits([
+                file({ sizeBytes: MAX_ONBOARDING_FILE_SIZE_BYTES + 1 }),
+            ]),
+        ).toThrow('exceeds');
+        expect(() =>
+            validateOnboardingOutputFileLimits(
+                Array.from(
+                    { length: MAX_ONBOARDING_FILE_COUNT + 1 },
+                    (_, index) =>
+                        file({ path: `lightdash/models/model-${index}.yml` }),
+                ),
+            ),
+        ).toThrow('more than');
+        expect(() =>
+            validateOnboardingOutputFileLimits(
+                Array.from({ length: 11 }, (_, index) =>
+                    file({
+                        path: `lightdash/models/model-${index}.yml`,
+                        sizeBytes: MAX_ONBOARDING_TOTAL_SIZE_BYTES / 10,
+                    }),
+                ),
+            ),
+        ).toThrow('total limit');
+    });
+
+    it('detects runtime secrets, token formats, private keys, and binary files', () => {
+        expect(
+            containsOnboardingSecret(Buffer.from('token: runtime-secret'), [
+                'runtime-secret',
+            ]),
+        ).toBe(true);
+        expect(
+            containsOnboardingSecret(Buffer.from('token: ldpat_abc123'), []),
+        ).toBe(true);
+        expect(
+            containsOnboardingSecret(
+                Buffer.from('-----BEGIN PRIVATE KEY-----'),
+                [],
+            ),
+        ).toBe(true);
+        expect(containsOnboardingSecret(Buffer.from([0xff]), [])).toBe(true);
+        expect(
+            containsOnboardingSecret(
+                Buffer.from('warehouse:\n  type: postgres'),
+                [],
+            ),
+        ).toBe(false);
     });
 });

--- a/packages/backend/src/ee/services/OnboardingAgentService/utils.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/utils.ts
@@ -2,6 +2,9 @@ import { type AgentOnboardingStage } from '@lightdash/common';
 import {
     CLAUDE_SKILLS_DIR,
     CLI_WRAPPER_PATH,
+    MAX_ONBOARDING_FILE_COUNT,
+    MAX_ONBOARDING_FILE_SIZE_BYTES,
+    MAX_ONBOARDING_TOTAL_SIZE_BYTES,
     PROMPT_PATH,
     WORKDIR,
 } from './constants';
@@ -42,9 +45,13 @@ export const buildManagedOnboardingPrompt = (
         '## Environment overrides (IMPORTANT — these replace section 1 of the instructions below)',
         '- The Lightdash CLI and skills are preinstalled. Skip section 1 entirely.',
         `- Run every \`lightdash <args>\` command as \`${CLI_WRAPPER_PATH} <args>\` (a thin wrapper around the same CLI).`,
+        '- Run each wrapper invocation as a single direct command. Do not use pipes, redirects, command chaining, command substitution, or environment expansion.',
+        `- \`warehouse-catalog\` prints its result directly and does not accept \`-o\`. For \`sql\`, always use \`-o ${WORKDIR}/<descriptive-name>.csv\`; no other output extension is permitted.`,
         '- Authentication is already configured through environment variables (LIGHTDASH_URL, LIGHTDASH_API_KEY, LIGHTDASH_PROJECT). Do NOT run `lightdash login`.',
         `- For section 1, verify the selected project with \`${CLI_WRAPPER_PATH} config get-project\` and confirm it matches the prepared project UUID, then continue from section 2.`,
         `- There is no existing repository. Create all working files under ${WORKDIR} and build a pure Lightdash semantic layer from the warehouse catalog.`,
+        '- The standard Lightdash models, charts, and dashboards directories are already prepared.',
+        '- Temporary CSV profiling files are excluded from persistence and do not need manual cleanup.',
         '',
         '---',
         '',
@@ -164,6 +171,60 @@ export type WorkspaceFileEntry = {
     updatedAt: string;
 };
 
+export const validateOnboardingOutputFileLimits = (
+    files: WorkspaceFileEntry[],
+): void => {
+    if (files.length > MAX_ONBOARDING_FILE_COUNT) {
+        throw new Error(
+            `The onboarding agent generated more than ${MAX_ONBOARDING_FILE_COUNT} files`,
+        );
+    }
+
+    const oversizedFile = files.find(
+        ({ sizeBytes }) => sizeBytes > MAX_ONBOARDING_FILE_SIZE_BYTES,
+    );
+    if (oversizedFile) {
+        throw new Error(
+            `Onboarding file ${oversizedFile.path} exceeds the ${MAX_ONBOARDING_FILE_SIZE_BYTES} byte limit`,
+        );
+    }
+
+    const totalSizeBytes = files.reduce(
+        (total, { sizeBytes }) => total + sizeBytes,
+        0,
+    );
+    if (totalSizeBytes > MAX_ONBOARDING_TOTAL_SIZE_BYTES) {
+        throw new Error(
+            `Onboarding files exceed the ${MAX_ONBOARDING_TOTAL_SIZE_BYTES} byte total limit`,
+        );
+    }
+};
+
+export const containsOnboardingSecret = (
+    contents: Buffer,
+    sensitiveValues: string[],
+): boolean => {
+    const text = contents.toString('utf8');
+    if (!Buffer.from(text, 'utf8').equals(contents)) return true;
+    if (
+        sensitiveValues.some(
+            (value) =>
+                value.length > 0 && contents.includes(Buffer.from(value)),
+        )
+    ) {
+        return true;
+    }
+
+    return [
+        /\bldpat_[A-Za-z0-9_-]+\b/,
+        /\bsk-ant-[A-Za-z0-9_-]{20,}\b/,
+        /\bgh[pousr]_[A-Za-z0-9]{20,}\b/,
+        /\bgithub_pat_[A-Za-z0-9_]{20,}\b/,
+        /\bgl(?:pat|oas|ptt|rt|cbt|soat)-[A-Za-z0-9_-]{20,}\b/,
+        /-----BEGIN (?:[A-Z]+ )?PRIVATE KEY-----/,
+    ].some((pattern) => pattern.test(text));
+};
+
 export const isOnboardingOutputFile = (path: string): boolean => {
     const segments = path.split('/');
     if (
@@ -184,6 +245,15 @@ export const isOnboardingOutputFile = (path: string): boolean => {
         )
     );
 };
+
+export const hasCompleteOnboardingOutput = (
+    files: Array<{ path: string }>,
+): boolean =>
+    [
+        /^lightdash\.config\.ya?ml$/,
+        /^lightdash\/models\/.+\.ya?ml$/,
+        /^LIGHTDASH_(?:ONBOARDING_)?HANDOFF(?:_\d{4}-\d{2}-\d{2}(?:-\d+)?)?\.md$/,
+    ].every((pattern) => files.some(({ path }) => pattern.test(path)));
 
 export const parseWorkspaceFileListing = (
     listing: string,

--- a/packages/backend/src/ee/services/OnboardingAgentService/utils.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/utils.ts
@@ -1,4 +1,7 @@
-import { type AgentOnboardingStage } from '@lightdash/common';
+import {
+    PayloadTooLargeError,
+    type AgentOnboardingStage,
+} from '@lightdash/common';
 import {
     CLAUDE_SKILLS_DIR,
     CLI_WRAPPER_PATH,
@@ -175,7 +178,7 @@ export const validateOnboardingOutputFileLimits = (
     files: WorkspaceFileEntry[],
 ): void => {
     if (files.length > MAX_ONBOARDING_FILE_COUNT) {
-        throw new Error(
+        throw new PayloadTooLargeError(
             `The onboarding agent generated more than ${MAX_ONBOARDING_FILE_COUNT} files`,
         );
     }
@@ -184,7 +187,7 @@ export const validateOnboardingOutputFileLimits = (
         ({ sizeBytes }) => sizeBytes > MAX_ONBOARDING_FILE_SIZE_BYTES,
     );
     if (oversizedFile) {
-        throw new Error(
+        throw new PayloadTooLargeError(
             `Onboarding file ${oversizedFile.path} exceeds the ${MAX_ONBOARDING_FILE_SIZE_BYTES} byte limit`,
         );
     }
@@ -194,7 +197,7 @@ export const validateOnboardingOutputFileLimits = (
         0,
     );
     if (totalSizeBytes > MAX_ONBOARDING_TOTAL_SIZE_BYTES) {
-        throw new Error(
+        throw new PayloadTooLargeError(
             `Onboarding files exceed the ${MAX_ONBOARDING_TOTAL_SIZE_BYTES} byte total limit`,
         );
     }

--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -354,6 +354,26 @@ const APP_ROUTES: RouteObject[] = [
                 children: [
                     { index: true, element: <Navigate to="home" replace /> },
                     {
+                        path: 'onboarding/runs/:agentOnboardingRunUuid',
+                        lazy: async () => {
+                            const AgentOnboardingRunPage =
+                                await loadLazyRouteDefault(
+                                    './ee/features/agentOnboarding/AgentOnboardingRunPage',
+                                    () =>
+                                        import('./ee/features/agentOnboarding/AgentOnboardingRunPage'),
+                                );
+                            return {
+                                Component: () => (
+                                    <TrackPage
+                                        name={PageName.AGENT_ONBOARDING_RUN}
+                                    >
+                                        <AgentOnboardingRunPage />
+                                    </TrackPage>
+                                ),
+                            };
+                        },
+                    },
+                    {
                         path: '/projects/:projectUuid/home',
                         lazy: async () => {
                             const MobileHome = await loadLazyRouteDefault(

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -733,6 +733,30 @@ const APP_ROUTES: RouteObject[] = [
                 ),
                 children: [
                     { index: true, element: <Navigate to="home" replace /> },
+                    {
+                        path: 'onboarding/runs/:agentOnboardingRunUuid',
+                        handle: { hideAILauncher: true },
+                        lazy: async () => {
+                            const AgentOnboardingRunPage =
+                                await loadLazyRouteDefault(
+                                    './ee/features/agentOnboarding/AgentOnboardingRunPage',
+                                    () =>
+                                        import('./ee/features/agentOnboarding/AgentOnboardingRunPage'),
+                                );
+                            return {
+                                Component: () => (
+                                    <>
+                                        <NavBar />
+                                        <TrackPage
+                                            name={PageName.AGENT_ONBOARDING_RUN}
+                                        >
+                                            <AgentOnboardingRunPage />
+                                        </TrackPage>
+                                    </>
+                                ),
+                            };
+                        },
+                    },
                     // Legacy sqlRunner redirect (no layout needed)
                     {
                         path: 'sqlRunner',

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectUsingAgent.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectUsingAgent.tsx
@@ -8,9 +8,31 @@ import {
     type Project,
     type WarehouseCredentials,
 } from '@lightdash/common';
-import { Button, Code, CopyButton, Stack, Text, Title } from '@mantine-8/core';
-import { IconCheck, IconChevronLeft, IconCopy } from '@tabler/icons-react';
+import {
+    Button,
+    Code,
+    Collapse,
+    CopyButton,
+    Divider,
+    Group,
+    Stack,
+    Text,
+    ThemeIcon,
+    Title,
+} from '@mantine-8/core';
+import {
+    IconCheck,
+    IconChevronDown,
+    IconChevronLeft,
+    IconCopy,
+    IconSparkles,
+} from '@tabler/icons-react';
 import { useMemo, useRef, useState, type FC } from 'react';
+import { useNavigate } from 'react-router';
+import { AgentOnboardingProgress } from '../../../ee/features/agentOnboarding/AgentOnboardingProgress';
+import { useStartAgentOnboardingRun } from '../../../ee/features/agentOnboarding/hooks/useAgentOnboarding';
+import { getAgentOnboardingRunUrl } from '../../../ee/features/agentOnboarding/utils';
+import { useIsCopilotEnabled } from '../../../ee/features/aiCopilot/hooks/useIsCopilotEnabled';
 import { useCreateProjectWithoutCompileMutation } from '../../../hooks/useProject';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -40,6 +62,25 @@ type ConnectionDefaults = {
 // Treats empty strings as "not configured"
 const nonEmpty = (value: string | undefined): string | undefined =>
     value || undefined;
+
+const getSchemaField = (
+    warehouseType: WarehouseTypes,
+): 'dataset' | 'database' | 'schema' => {
+    if (warehouseType === WarehouseTypes.BIGQUERY) return 'dataset';
+    if (warehouseType === WarehouseTypes.DATABRICKS) return 'database';
+    return 'schema';
+};
+
+const getAgentWarehouseValidators = (warehouseType: WarehouseTypes) => {
+    const validators = {
+        ...createWarehouseValueValidators[warehouseType],
+    } as Record<
+        string,
+        (value: string, values: ProjectConnectionForm) => string | undefined
+    >;
+    delete validators[getSchemaField(warehouseType)];
+    return validators;
+};
 
 const getConnectionDefaults = (
     credentials: WarehouseCredentials,
@@ -105,8 +146,12 @@ const ConnectUsingAgent: FC<ConnectUsingAgentProps> = ({
     onBack,
 }) => {
     const [preparedProject, setPreparedProject] = useState<PreparedProject>();
+    const [isLocalPromptOpen, setIsLocalPromptOpen] = useState(false);
     const isCreatingProjectRef = useRef(false);
+    const navigate = useNavigate();
     const createProjectMutation = useCreateProjectWithoutCompileMutation();
+    const startAgentOnboardingRun = useStartAgentOnboardingRun();
+    const { isCopilotEnabled } = useIsCopilotEnabled();
     const onProjectError = useOnProjectError();
     const { track } = useTracking();
 
@@ -119,7 +164,7 @@ const ConnectUsingAgent: FC<ConnectUsingAgentProps> = ({
             organizationWarehouseCredentialsUuid: undefined,
         },
         validate: {
-            warehouse: createWarehouseValueValidators[selectedWarehouse],
+            warehouse: getAgentWarehouseValidators(selectedWarehouse),
         },
         validateInputOnBlur: true,
     });
@@ -129,6 +174,11 @@ const ConnectUsingAgent: FC<ConnectUsingAgentProps> = ({
 
         isCreatingProjectRef.current = true;
         try {
+            const warehouseConnection = {
+                ...formValues.warehouse,
+                type: selectedWarehouse,
+                [getSchemaField(selectedWarehouse)]: '',
+            } as CreateWarehouseCredentials;
             const result = await createProjectMutation.mutateAsync({
                 name: `Coding agent onboarding ${new Date().toISOString()}`,
                 type: ProjectType.DEFAULT,
@@ -136,10 +186,7 @@ const ConnectUsingAgent: FC<ConnectUsingAgentProps> = ({
                 dbtVersion: dbtDefaults.dbtVersion,
                 organizationWarehouseCredentialsUuid:
                     formValues.organizationWarehouseCredentialsUuid,
-                warehouseConnection: {
-                    ...formValues.warehouse,
-                    type: selectedWarehouse,
-                } as CreateWarehouseCredentials,
+                warehouseConnection,
             });
 
             const project = {
@@ -186,52 +233,149 @@ const ConnectUsingAgent: FC<ConnectUsingAgentProps> = ({
         ].join('\n');
     }, [preparedProject, selectedWarehouse, siteUrl]);
 
+    const openProject = () => {
+        if (!preparedProject) return;
+        void navigate(`/projects/${preparedProject.projectUuid}`);
+    };
+
+    const startManagedSetup = async () => {
+        if (!preparedProject) return;
+        try {
+            const run = await startAgentOnboardingRun.mutateAsync(
+                preparedProject.projectUuid,
+            );
+            void navigate(
+                getAgentOnboardingRunUrl(
+                    run.agentOnboardingRunUuid,
+                    run.projectUuid,
+                ),
+            );
+        } catch {
+            return;
+        }
+    };
+
+    const localPrompt = (
+        <Stack gap="lg" className="sentry-block ph-no-capture">
+            <div>
+                <Title order={3}>Complete your project setup</Title>
+                <Text c="dimmed" mt="xs">
+                    Copy the prompt below and run it with your coding agent to
+                    finish setting up your Lightdash project.
+                </Text>
+            </div>
+
+            <Code
+                block
+                className="sentry-block ph-no-capture"
+                style={{
+                    whiteSpace: 'pre-wrap',
+                    overflowWrap: 'anywhere',
+                }}
+            >
+                {agentSetupPrompt}
+            </Code>
+
+            <CopyButton value={agentSetupPrompt ?? ''}>
+                {({ copied, copy }) => (
+                    <Button
+                        onClick={() => {
+                            copy();
+                            track({
+                                name: EventName.AGENT_SETUP_PROMPT_COPIED,
+                            });
+                        }}
+                        leftSection={
+                            <MantineIcon icon={copied ? IconCheck : IconCopy} />
+                        }
+                    >
+                        {copied ? 'Prompt copied' : 'Copy prompt'}
+                    </Button>
+                )}
+            </CopyButton>
+        </Stack>
+    );
+
     if (preparedProject) {
+        if (isCopilotEnabled) {
+            return (
+                <Stack w="100%" maw={960} mx="auto" mt="xl">
+                    <SettingsCard p="xl">
+                        <Stack gap="xl">
+                            <Group align="flex-start" wrap="nowrap" gap="md">
+                                <ThemeIcon
+                                    size={44}
+                                    radius="xl"
+                                    variant="light"
+                                    color="violet"
+                                >
+                                    <MantineIcon
+                                        icon={IconSparkles}
+                                        size="lg"
+                                    />
+                                </ThemeIcon>
+                                <Stack gap={6} style={{ flex: 1 }}>
+                                    <Title order={3}>
+                                        Let Lightdash build it for you
+                                    </Title>
+                                    <Text c="dimmed">
+                                        We’ll explore your warehouse, create a
+                                        semantic layer, and build a starter
+                                        dashboard. You can follow every step.
+                                    </Text>
+                                </Stack>
+                            </Group>
+
+                            <AgentOnboardingProgress />
+
+                            <Group justify="space-between">
+                                <Button
+                                    size="md"
+                                    leftSection={
+                                        <MantineIcon icon={IconSparkles} />
+                                    }
+                                    onClick={() => void startManagedSetup()}
+                                    loading={startAgentOnboardingRun.isLoading}
+                                >
+                                    Run it for me
+                                </Button>
+                                <Button
+                                    variant="subtle"
+                                    color="gray"
+                                    onClick={openProject}
+                                    disabled={startAgentOnboardingRun.isLoading}
+                                >
+                                    Skip to project
+                                </Button>
+                            </Group>
+
+                            <Divider />
+
+                            <Button
+                                variant="subtle"
+                                color="gray"
+                                w="fit-content"
+                                rightSection={
+                                    <MantineIcon icon={IconChevronDown} />
+                                }
+                                onClick={() =>
+                                    setIsLocalPromptOpen((value) => !value)
+                                }
+                            >
+                                Use my own coding agent instead
+                            </Button>
+                            <Collapse in={isLocalPromptOpen}>
+                                {localPrompt}
+                            </Collapse>
+                        </Stack>
+                    </SettingsCard>
+                </Stack>
+            );
+        }
+
         return (
             <Stack w="100%" maw={960} mx="auto" mt="xl">
-                <SettingsCard p="xl">
-                    <Stack gap="lg" className="sentry-block ph-no-capture">
-                        <div>
-                            <Title order={3}>Complete your project setup</Title>
-                            <Text c="dimmed" mt="xs">
-                                Copy the prompt below and run it with your
-                                coding agent to finish setting up your Lightdash
-                                project.
-                            </Text>
-                        </div>
-
-                        <Code
-                            block
-                            className="sentry-block ph-no-capture"
-                            style={{
-                                whiteSpace: 'pre-wrap',
-                                overflowWrap: 'anywhere',
-                            }}
-                        >
-                            {agentSetupPrompt}
-                        </Code>
-
-                        <CopyButton value={agentSetupPrompt ?? ''}>
-                            {({ copied, copy }) => (
-                                <Button
-                                    onClick={() => {
-                                        copy();
-                                        track({
-                                            name: EventName.AGENT_SETUP_PROMPT_COPIED,
-                                        });
-                                    }}
-                                    leftSection={
-                                        <MantineIcon
-                                            icon={copied ? IconCheck : IconCopy}
-                                        />
-                                    }
-                                >
-                                    {copied ? 'Prompt copied' : 'Copy prompt'}
-                                </Button>
-                            )}
-                        </CopyButton>
-                    </Stack>
-                </SettingsCard>
+                <SettingsCard p="xl">{localPrompt}</SettingsCard>
             </Stack>
         );
     }

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectConnectMethod.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/SelectConnectMethod.tsx
@@ -89,9 +89,9 @@ const SelectConnectMethod: FC<SelectConnectMethodProps> = ({
                                         color="black"
                                     />
                                 }
-                                description="Connect your warehouse, then let your coding agent finish setup"
+                                description="Connect your warehouse, then let Lightdash finish your project setup"
                             >
-                                Using your coding agent
+                                Set up with a coding agent
                             </OnboardingButton>
                         )}
 

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingActivity.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingActivity.tsx
@@ -1,0 +1,155 @@
+import { type AgentOnboardingRunEvent } from '@lightdash/common';
+import { Box, Button, Group, ScrollArea, Stack, Text } from '@mantine-8/core';
+import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
+import {
+    useEffect,
+    useId,
+    useRef,
+    useState,
+    type FC,
+    type UIEvent,
+} from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import classes from './AgentOnboardingRunPage.module.css';
+import { sanitizeTerminalText } from './utils';
+
+const BOTTOM_THRESHOLD_PX = 32;
+
+const getActivityLinePrefix = (message: string): string => {
+    const normalizedMessage = message.trimStart();
+    if (/^lightdash(?:\s|$)/i.test(normalizedMessage)) return 'lightdash';
+    return (
+        normalizedMessage.match(/^([a-z][\w-]*):/i)?.[1].toLowerCase() ??
+        'command'
+    );
+};
+
+const AgentOnboardingActivity: FC<{
+    events: AgentOnboardingRunEvent[];
+    isCollapsed?: boolean;
+    id?: string;
+}> = ({ events, isCollapsed = false, id }) => {
+    const viewportRef = useRef<HTMLDivElement>(null);
+    const shouldFollowRef = useRef(true);
+    const visibleEvents = isCollapsed ? events.slice(-1) : events;
+
+    useEffect(() => {
+        if (!shouldFollowRef.current || !viewportRef.current) return;
+        viewportRef.current.scrollTop = viewportRef.current.scrollHeight;
+    }, [events, isCollapsed]);
+
+    const handleScroll = (event: UIEvent<HTMLDivElement>) => {
+        const element = event.currentTarget;
+        shouldFollowRef.current =
+            element.scrollHeight - element.scrollTop - element.clientHeight <=
+            BOTTOM_THRESHOLD_PX;
+    };
+
+    return (
+        <ScrollArea
+            id={id}
+            viewportRef={viewportRef}
+            onScrollPositionChange={() => undefined}
+            className={classes.terminal}
+            data-collapsed={isCollapsed || undefined}
+            viewportProps={{ onScroll: handleScroll }}
+        >
+            <Stack
+                gap={isCollapsed ? 0 : 8}
+                px="md"
+                pt={isCollapsed ? 10 : 44}
+                pb={isCollapsed ? 10 : 'md'}
+                pr={isCollapsed ? 170 : 'md'}
+            >
+                {visibleEvents.length === 0 ? (
+                    <Text
+                        c="gray.5"
+                        fz="sm"
+                        ff="monospace"
+                        className={classes.terminalMessage}
+                    >
+                        Waiting for the onboarding agent to start…
+                    </Text>
+                ) : (
+                    visibleEvents.map((event, index) => (
+                        <Group
+                            key={`${event.createdAt}-${index}`}
+                            gap="sm"
+                            align="flex-start"
+                            wrap="nowrap"
+                            className={classes.terminalEntry}
+                        >
+                            <Text
+                                c="gray.6"
+                                fz="xs"
+                                ff="monospace"
+                                className={classes.terminalTime}
+                            >
+                                {new Date(event.createdAt).toLocaleTimeString(
+                                    [],
+                                    {
+                                        hour: '2-digit',
+                                        minute: '2-digit',
+                                        second: '2-digit',
+                                    },
+                                )}
+                            </Text>
+                            <Box
+                                component="span"
+                                fz="sm"
+                                ff="monospace"
+                                className={classes.terminalMessage}
+                                data-line-prefix={getActivityLinePrefix(
+                                    event.message,
+                                )}
+                            >
+                                {sanitizeTerminalText(event.message)}
+                            </Box>
+                        </Group>
+                    ))
+                )}
+            </Stack>
+        </ScrollArea>
+    );
+};
+
+export const AgentOnboardingActivityPanel: FC<{
+    events: AgentOnboardingRunEvent[];
+    hasGeneratedFiles: boolean;
+}> = ({ events, hasGeneratedFiles }) => {
+    const [isCollapsed, setIsCollapsed] = useState(false);
+    const activityId = useId();
+
+    useEffect(() => {
+        if (hasGeneratedFiles) setIsCollapsed(true);
+    }, [hasGeneratedFiles]);
+
+    return (
+        <Box className={classes.activityPanel}>
+            <Button
+                variant="subtle"
+                color="gray"
+                size="compact-sm"
+                leftSection={
+                    <MantineIcon
+                        icon={isCollapsed ? IconChevronDown : IconChevronUp}
+                        size={14}
+                    />
+                }
+                aria-expanded={!isCollapsed}
+                aria-controls={activityId}
+                onClick={() => setIsCollapsed((value) => !value)}
+                className={classes.activityToggle}
+            >
+                {isCollapsed
+                    ? 'Expand live activity'
+                    : 'Collapse live activity'}
+            </Button>
+            <AgentOnboardingActivity
+                id={activityId}
+                events={events}
+                isCollapsed={isCollapsed}
+            />
+        </Box>
+    );
+};

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingFileBrowser.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingFileBrowser.tsx
@@ -1,0 +1,309 @@
+import { type AgentOnboardingFile } from '@lightdash/common';
+import {
+    ActionIcon,
+    Box,
+    Center,
+    Group,
+    Loader,
+    ScrollArea,
+    Stack,
+    Text,
+    Tree,
+    getTreeExpandedState,
+    useMantineColorScheme,
+    type RenderTreeNodePayload,
+    type TreeNodeData,
+    useTree,
+} from '@mantine-8/core';
+import { Prism } from '@mantine/prism';
+import {
+    IconChevronDown,
+    IconChevronRight,
+    IconFile,
+    IconFolder,
+    IconGripVertical,
+    IconMaximize,
+} from '@tabler/icons-react';
+import MarkdownPreview from '@uiw/react-markdown-preview';
+import { useEffect, useMemo, useState, type FC } from 'react';
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
+import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
+import {
+    markdownSanitizeRehypePlugins,
+    rehypeRemoveHeaderLinks,
+} from '../../../utils/markdownUtils';
+import classes from './AgentOnboardingRunPage.module.css';
+import { useAgentOnboardingFile } from './hooks/useAgentOnboarding';
+import {
+    buildAgentOnboardingFileTree,
+    type AgentOnboardingFileTreeNode,
+} from './utils';
+
+const getPreviewLanguage = (path: string): 'json' | 'yaml' | null => {
+    if (/\.json$/i.test(path)) return 'json';
+    if (/\.ya?ml$/i.test(path)) return 'yaml';
+    return null;
+};
+
+const toTreeData = (nodes: AgentOnboardingFileTreeNode[]): TreeNodeData[] =>
+    nodes.map((node) => ({
+        value: node.path,
+        label: node.name,
+        children:
+            node.children.length > 0 ? toTreeData(node.children) : undefined,
+    }));
+
+const FilePreview: FC<{
+    content: string;
+    encoding: 'utf8' | 'base64';
+    path: string;
+}> = ({ content, encoding, path }) => {
+    const { colorScheme } = useMantineColorScheme();
+
+    if (encoding !== 'utf8') {
+        return (
+            <Center h="100%" p="xl">
+                <Stack gap="xs" align="center">
+                    <MantineIcon icon={IconFile} size="lg" />
+                    <Text fw={600}>Preview unavailable</Text>
+                    <Text c="dimmed" fz="sm" ta="center">
+                        This file is binary or uses an unsupported encoding.
+                    </Text>
+                </Stack>
+            </Center>
+        );
+    }
+
+    if (/\.md$/i.test(path)) {
+        return (
+            <Box
+                data-color-mode={colorScheme}
+                className={classes.markdownPreviewContainer}
+            >
+                <MarkdownPreview
+                    source={content}
+                    rehypePlugins={markdownSanitizeRehypePlugins}
+                    rehypeRewrite={rehypeRemoveHeaderLinks}
+                    className={classes.markdownPreview}
+                />
+            </Box>
+        );
+    }
+
+    const language = getPreviewLanguage(path);
+    if (language) {
+        return (
+            <Prism
+                language={language}
+                noCopy
+                trim={false}
+                withLineNumbers
+                className={classes.filePreviewCode}
+            >
+                {content}
+            </Prism>
+        );
+    }
+
+    return <pre className={classes.plainTextPreview}>{content}</pre>;
+};
+
+export const AgentOnboardingFileBrowser: FC<{
+    projectUuid: string;
+    runUuid: string;
+    files: AgentOnboardingFile[];
+}> = ({ projectUuid, runUuid, files }) => {
+    const [selectedPath, setSelectedPath] = useState<string>();
+    const [isExpanded, setIsExpanded] = useState(false);
+    const treeData = useMemo(
+        () => toTreeData(buildAgentOnboardingFileTree(files)),
+        [files],
+    );
+    const allNodesExpanded = useMemo<Record<string, boolean>>(
+        () => getTreeExpandedState(treeData, '*') as Record<string, boolean>,
+        [treeData],
+    );
+    const fileTree = useTree({ initialExpandedState: allNodesExpanded });
+    const { clearSelected, select, setExpandedState } = fileTree;
+    const selectedFile = files.find(({ path }) => path === selectedPath);
+    const fileQuery = useAgentOnboardingFile(
+        projectUuid,
+        runUuid,
+        selectedFile,
+    );
+
+    useEffect(() => {
+        if (files.length === 0) {
+            setSelectedPath(undefined);
+            clearSelected();
+        } else if (!files.some(({ path }) => path === selectedPath)) {
+            const nextSelectedPath = files[0].path;
+            setSelectedPath(nextSelectedPath);
+            select(nextSelectedPath);
+        }
+    }, [clearSelected, files, select, selectedPath]);
+
+    useEffect(() => {
+        setExpandedState((current) => {
+            let changed = false;
+            const next = { ...current };
+            Object.keys(allNodesExpanded).forEach((value) => {
+                if (!(value in current)) {
+                    next[value] = true;
+                    changed = true;
+                }
+            });
+            return changed ? next : current;
+        });
+    }, [allNodesExpanded, setExpandedState]);
+
+    const renderTreeNode = ({
+        node,
+        expanded,
+        hasChildren,
+        elementProps,
+        tree,
+    }: RenderTreeNodePayload) => (
+        <Group
+            gap={6}
+            align="center"
+            wrap="nowrap"
+            {...elementProps}
+            onClick={(event) => {
+                elementProps.onClick(event);
+                if (!hasChildren) {
+                    tree.select(node.value);
+                    setSelectedPath(node.value);
+                }
+            }}
+        >
+            <Box className={classes.fileTreeToggle}>
+                {hasChildren && (
+                    <MantineIcon
+                        icon={expanded ? IconChevronDown : IconChevronRight}
+                        size={14}
+                    />
+                )}
+            </Box>
+            <Box className={classes.fileTreeIcon}>
+                <MantineIcon
+                    icon={hasChildren ? IconFolder : IconFile}
+                    size={18}
+                />
+            </Box>
+            <Text fz="sm" lh="20px" truncate>
+                {node.label}
+            </Text>
+        </Group>
+    );
+
+    const preview = fileQuery.isInitialLoading ? (
+        <Center h="100%">
+            <Loader size="sm" />
+        </Center>
+    ) : fileQuery.isError ? (
+        <Center h="100%" p="lg">
+            <Text c="red" fz="sm" ta="center">
+                This file could not be loaded.
+            </Text>
+        </Center>
+    ) : fileQuery.data ? (
+        <FilePreview
+            content={fileQuery.data.content}
+            encoding={fileQuery.data.encoding}
+            path={fileQuery.data.path}
+        />
+    ) : (
+        <Center h="100%" p="lg">
+            <Text c="dimmed" fz="sm" ta="center">
+                Select a file to preview it.
+            </Text>
+        </Center>
+    );
+
+    if (files.length === 0) {
+        return (
+            <Center h="100%" p="xl">
+                <Stack gap="xs" align="center">
+                    <MantineIcon icon={IconFolder} size="lg" />
+                    <Text fw={600}>Generated files will appear here</Text>
+                    <Text c="dimmed" fz="sm" ta="center">
+                        The preview refreshes as the agent creates and updates
+                        your project files.
+                    </Text>
+                </Stack>
+            </Center>
+        );
+    }
+
+    return (
+        <>
+            <PanelGroup direction="horizontal" className={classes.fileBrowser}>
+                <Panel
+                    id="onboarding-file-tree"
+                    defaultSize={32}
+                    minSize={18}
+                    className={classes.filePanel}
+                >
+                    <Box className={classes.fileTree}>
+                        <Tree
+                            data={treeData}
+                            tree={fileTree}
+                            levelOffset={16}
+                            py={4}
+                            classNames={{ label: classes.fileTreeItem }}
+                            renderNode={renderTreeNode}
+                        />
+                    </Box>
+                </Panel>
+                <PanelResizeHandle
+                    className={classes.fileResizeHandle}
+                    aria-label="Resize file tree and preview"
+                >
+                    <MantineIcon icon={IconGripVertical} size={14} />
+                </PanelResizeHandle>
+                <Panel
+                    id="onboarding-file-preview"
+                    minSize={30}
+                    className={classes.filePanel}
+                >
+                    <Box className={classes.filePreview}>
+                        <Group
+                            justify="space-between"
+                            wrap="nowrap"
+                            px="sm"
+                            py={6}
+                            className={classes.filePreviewHeader}
+                        >
+                            <Text fz="xs" ff="monospace" truncate>
+                                {selectedPath}
+                            </Text>
+                            <ActionIcon
+                                aria-label="Expand file preview"
+                                variant="subtle"
+                                size="sm"
+                                onClick={() => setIsExpanded(true)}
+                                disabled={!fileQuery.data}
+                            >
+                                <MantineIcon icon={IconMaximize} size="sm" />
+                            </ActionIcon>
+                        </Group>
+                        <Box className={classes.filePreviewScroll}>
+                            {preview}
+                        </Box>
+                    </Box>
+                </Panel>
+            </PanelGroup>
+            <MantineModal
+                opened={isExpanded}
+                onClose={() => setIsExpanded(false)}
+                title={selectedPath ?? 'File preview'}
+                fullScreen
+                modalBodyProps={{ px: 0, py: 0 }}
+            >
+                <ScrollArea h="100%">{preview}</ScrollArea>
+            </MantineModal>
+        </>
+    );
+};

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingProgress.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingProgress.tsx
@@ -1,0 +1,133 @@
+import {
+    isAgentOnboardingRunTerminal,
+    type AgentOnboardingRun,
+} from '@lightdash/common';
+import { Stepper, Text, Tooltip, type StepperStepProps } from '@mantine-8/core';
+import {
+    IconChartBar,
+    IconCheck,
+    IconDatabaseSearch,
+    IconLayersLinked,
+    type Icon,
+} from '@tabler/icons-react';
+import { useEffect, useMemo, useState, type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import classes from './AgentOnboardingRunPage.module.css';
+import {
+    AGENT_ONBOARDING_PROGRESS_STAGES,
+    formatStageDuration,
+    getAgentOnboardingProgressStageIndex,
+    getAgentOnboardingProgressStageTimings,
+    type AgentOnboardingProgressStage,
+} from './utils';
+
+const STAGE_CONFIG: Record<
+    AgentOnboardingProgressStage,
+    { label: string; description: string; icon: Icon }
+> = {
+    explore: {
+        label: 'Explore',
+        description:
+            'Looks through your warehouse to understand your data and choose a useful starting point.',
+        icon: IconDatabaseSearch,
+    },
+    semantic_layer: {
+        label: 'Semantic layer',
+        description:
+            'Organizes your data into clear, reusable definitions for reporting.',
+        icon: IconLayersLinked,
+    },
+    dashboard: {
+        label: 'Dashboard',
+        description:
+            'Creates a starter dashboard with useful metrics, charts, filters, and details.',
+        icon: IconChartBar,
+    },
+    ready: {
+        label: 'Ready',
+        description:
+            'Checks that everything works and gets your new project ready to use.',
+        icon: IconCheck,
+    },
+};
+
+const ProgressStep: FC<StepperStepProps & { tooltip: string }> = ({
+    tooltip,
+    ...stepProps
+}) => (
+    <Tooltip label={tooltip} maw={360} multiline withArrow withinPortal>
+        <Stepper.Step {...stepProps} />
+    </Tooltip>
+);
+
+export const AgentOnboardingProgress: FC<{ run?: AgentOnboardingRun }> = ({
+    run,
+}) => {
+    const [now, setNow] = useState(Date.now());
+    const isTerminal = !run || isAgentOnboardingRunTerminal(run.status);
+
+    useEffect(() => {
+        if (isTerminal) return;
+        const timer = window.setInterval(() => setNow(Date.now()), 1_000);
+        return () => window.clearInterval(timer);
+    }, [isTerminal]);
+
+    const timings = useMemo(
+        () =>
+            run ? getAgentOnboardingProgressStageTimings(run, now) : undefined,
+        [now, run],
+    );
+    const activeStageIndex = timings?.findIndex(
+        ({ state }) => state === 'active',
+    );
+    const currentStageIndex = getAgentOnboardingProgressStageIndex(
+        run?.stage ?? null,
+    );
+    const active = !run
+        ? -1
+        : run.status === 'completed'
+          ? (timings?.length ?? 0)
+          : activeStageIndex !== undefined && activeStageIndex >= 0
+            ? activeStageIndex
+            : Math.max(currentStageIndex ?? 0, 0);
+
+    return (
+        <Stepper
+            active={active}
+            size="xs"
+            iconSize={38}
+            classNames={{
+                root: classes.progressStepper,
+                steps: classes.progressSteps,
+                step: classes.progressStep,
+                stepBody: classes.progressStepBody,
+            }}
+        >
+            {AGENT_ONBOARDING_PROGRESS_STAGES.map(({ stage }) => {
+                const timing = timings?.find(
+                    ({ stage: timingStage }) => timingStage === stage,
+                );
+                const config = STAGE_CONFIG[stage];
+                const icon = <MantineIcon icon={config.icon} size="md" />;
+                return (
+                    <ProgressStep
+                        key={stage}
+                        tooltip={config.description}
+                        label={config.label}
+                        description={
+                            timing ? (
+                                <Text fz="xs" c="dimmed" ff="monospace">
+                                    {formatStageDuration(timing.durationMs)}
+                                </Text>
+                            ) : undefined
+                        }
+                        icon={icon}
+                        completedIcon={icon}
+                        loading={timing?.state === 'active'}
+                        allowStepSelect={false}
+                    />
+                );
+            })}
+        </Stepper>
+    );
+};

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingRunPage.module.css
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingRunPage.module.css
@@ -1,0 +1,291 @@
+.page {
+    min-height: calc(100vh - var(--ld-navbar-height, 50px));
+    background:
+        radial-gradient(
+            circle at 50% 0%,
+            var(--mantine-color-blue-0),
+            transparent 34rem
+        ),
+        var(--mantine-color-gray-0);
+}
+
+.content {
+    width: 100%;
+    max-width: 1440px;
+    margin: 0 auto;
+}
+
+.progressStepper {
+    padding: var(--mantine-spacing-md) 0;
+    overflow-x: auto;
+}
+
+.progressSteps {
+    min-width: 720px;
+}
+
+.progressStep {
+    min-width: 90px;
+}
+
+.progressStepBody {
+    text-align: center;
+}
+
+.progressActivityCard {
+    overflow: hidden;
+}
+
+.activityPanel {
+    position: relative;
+    border-top: 1px solid var(--mantine-color-gray-3);
+    background: #111827;
+}
+
+.activityToggle {
+    position: absolute;
+    z-index: 2;
+    top: 8px;
+    right: 12px;
+    color: var(--mantine-color-gray-3);
+    background: #1f2937;
+}
+
+.activityToggle:hover {
+    color: var(--mantine-color-white);
+    background: rgb(255 255 255 / 8%);
+}
+
+.workspace {
+    min-height: 520px;
+    height: calc(100vh - 330px);
+    overflow: hidden;
+}
+
+.workspacePanel {
+    display: grid;
+    grid-template-rows: 49px minmax(0, 1fr);
+    min-height: 0;
+    height: 100%;
+    overflow: hidden;
+}
+
+.terminal {
+    min-height: 0;
+    height: 220px;
+    background: inherit;
+}
+
+.terminal[data-collapsed='true'] {
+    height: 42px;
+}
+
+.terminalEntry {
+    min-width: 0;
+}
+
+.terminalTime {
+    flex: 0 0 auto;
+    line-height: 1.5;
+}
+
+.terminalMessage {
+    min-width: 0;
+    color: var(--mantine-color-gray-3);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    line-height: 1.5;
+}
+
+.terminalMessage[data-line-prefix='glob'] {
+    color: var(--mantine-color-green-3);
+}
+
+.terminalMessage[data-line-prefix='grep'] {
+    color: var(--mantine-color-teal-3);
+}
+
+.terminalMessage[data-line-prefix='read'] {
+    color: var(--mantine-color-cyan-3);
+}
+
+.terminalMessage[data-line-prefix='write'] {
+    color: var(--mantine-color-blue-3);
+}
+
+.terminalMessage[data-line-prefix='edit'] {
+    color: var(--mantine-color-violet-3);
+}
+
+.terminalMessage[data-line-prefix='skill'] {
+    color: var(--mantine-color-orange-3);
+}
+
+.terminalMessage[data-line-prefix='todowrite'] {
+    color: var(--mantine-color-yellow-3);
+}
+
+.terminalMessage[data-line-prefix='lightdash'] {
+    color: var(--mantine-color-lime-3);
+}
+
+.terminalMessage[data-line-prefix='command'] {
+    color: var(--mantine-color-gray-3);
+}
+
+.terminal[data-collapsed='true'] .terminalEntry,
+.terminal[data-collapsed='true'] .terminalMessage {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.fileBrowser {
+    min-height: 0;
+    height: 100%;
+}
+
+.filePanel {
+    min-width: 0;
+    min-height: 0;
+    height: 100%;
+}
+
+.fileTree {
+    min-height: 0;
+    height: 100%;
+    overflow: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+    background: var(--mantine-color-gray-0);
+}
+
+.fileResizeHandle {
+    display: flex;
+    flex: 0 0 7px;
+    align-items: center;
+    justify-content: center;
+    width: 7px;
+    color: var(--mantine-color-gray-5);
+    cursor: col-resize;
+    background: var(--mantine-color-gray-2);
+    outline: none;
+    transition:
+        color 120ms ease,
+        background-color 120ms ease;
+}
+
+.fileResizeHandle[data-resize-handle-state='hover'],
+.fileResizeHandle[data-resize-handle-state='drag'],
+.fileResizeHandle:focus-visible {
+    color: var(--mantine-color-blue-7);
+    background: var(--mantine-color-blue-1);
+}
+
+.fileTreeItem {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    min-height: 36px;
+    padding-top: 8px;
+    padding-right: 10px;
+    padding-bottom: 8px;
+    color: var(--mantine-color-gray-7);
+}
+
+.fileTreeToggle {
+    display: flex;
+    flex: 0 0 20px;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    line-height: 0;
+}
+
+.fileTreeIcon {
+    display: flex;
+    flex: 0 0 20px;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    line-height: 0;
+}
+
+.fileTreeToggle svg,
+.fileTreeIcon svg {
+    flex: 0 0 auto;
+    display: block;
+}
+
+.fileTreeItem:hover {
+    background: var(--mantine-color-gray-1);
+}
+
+.fileTreeItem[data-selected='true'] {
+    color: var(--mantine-color-blue-8);
+    background: var(--mantine-color-blue-0);
+}
+
+.filePreview {
+    display: grid;
+    grid-template-rows: 38px minmax(0, 1fr);
+    min-width: 0;
+    min-height: 0;
+    height: 100%;
+    background: var(--mantine-color-white);
+}
+
+.filePreviewHeader {
+    height: 38px;
+    border-bottom: 1px solid var(--mantine-color-gray-3);
+    background: var(--mantine-color-gray-0);
+}
+
+.filePreviewScroll {
+    min-height: 0;
+    height: 100%;
+    overflow: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+}
+
+.filePreviewCode {
+    min-height: 100%;
+    margin: 0;
+    border-radius: 0;
+}
+
+.markdownPreviewContainer {
+    min-height: 100%;
+    padding: var(--mantine-spacing-lg);
+    color: var(--mantine-color-text);
+    background: var(--mantine-color-white);
+}
+
+.markdownPreview {
+    color: inherit;
+    font-size: var(--mantine-font-size-sm);
+    background: transparent;
+}
+
+.plainTextPreview {
+    min-height: 100%;
+    margin: 0;
+    padding: var(--mantine-spacing-md);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    font-family: var(--mantine-font-family-monospace);
+    font-size: var(--mantine-font-size-xs);
+}
+
+@media (max-width: 900px) {
+    .workspace {
+        height: auto;
+    }
+
+    .workspacePanel {
+        height: 520px;
+    }
+}

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingRunPage.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingRunPage.tsx
@@ -1,0 +1,315 @@
+import {
+    assertUnreachable,
+    isAgentOnboardingRunTerminal,
+    type AgentOnboardingRun,
+    type AgentOnboardingRunStatus,
+} from '@lightdash/common';
+import {
+    Alert,
+    Badge,
+    Box,
+    Button,
+    Group,
+    Paper,
+    Stack,
+    Text,
+    Title,
+} from '@mantine-8/core';
+import {
+    IconAlertCircle,
+    IconArrowRight,
+    IconPlayerStop,
+    IconRefresh,
+} from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import { Link, useNavigate, useParams } from 'react-router';
+import ErrorState from '../../../components/common/ErrorState';
+import MantineIcon from '../../../components/common/MantineIcon';
+import Page from '../../../components/common/Page/Page';
+import PageSpinner from '../../../components/PageSpinner';
+import { AgentOnboardingActivityPanel } from './AgentOnboardingActivity';
+import { AgentOnboardingFileBrowser } from './AgentOnboardingFileBrowser';
+import { AgentOnboardingProgress } from './AgentOnboardingProgress';
+import classes from './AgentOnboardingRunPage.module.css';
+import {
+    useAgentOnboardingRun,
+    useCancelAgentOnboardingRun,
+    useStartAgentOnboardingRun,
+} from './hooks/useAgentOnboarding';
+import {
+    getAgentOnboardingDashboardUrl,
+    getAgentOnboardingRunUrl,
+} from './utils';
+
+const STATUS_CONFIG: Record<
+    AgentOnboardingRunStatus,
+    { label: string; color: string }
+> = {
+    queued: { label: 'Queued', color: 'gray' },
+    running: { label: 'Running', color: 'blue' },
+    completed: { label: 'Complete', color: 'green' },
+    failed: { label: 'Needs attention', color: 'red' },
+    cancelled: { label: 'Cancelled', color: 'gray' },
+};
+
+const getStatusMessage = (run: AgentOnboardingRun): string => {
+    switch (run.status) {
+        case 'queued':
+            return 'Your setup is queued and will begin shortly.';
+        case 'running':
+            return 'You can leave this page and return at any time.';
+        case 'completed':
+            return 'Your semantic layer and starter dashboard are ready.';
+        case 'failed':
+            return (
+                run.errorMessage ??
+                'The setup run could not be completed. You can try again.'
+            );
+        case 'cancelled':
+            return 'This setup run was cancelled. You can start a new run.';
+        default:
+            return assertUnreachable(run.status, 'Unknown onboarding status');
+    }
+};
+
+const RunActions: FC<{
+    run: AgentOnboardingRun;
+    onCancel: () => Promise<void>;
+    onSkip: () => Promise<void>;
+    onRetry: () => Promise<void>;
+    onOpenProject: () => void;
+    isCancelling: boolean;
+    isRetrying: boolean;
+}> = ({
+    run,
+    onCancel,
+    onSkip,
+    onRetry,
+    onOpenProject,
+    isCancelling,
+    isRetrying,
+}) => {
+    if (!isAgentOnboardingRunTerminal(run.status)) {
+        return (
+            <Group gap="xs">
+                <Button
+                    variant="default"
+                    leftSection={<MantineIcon icon={IconPlayerStop} />}
+                    onClick={() => void onCancel()}
+                    loading={isCancelling}
+                >
+                    {isCancelling ? 'Cancelling…' : 'Cancel setup'}
+                </Button>
+                <Button
+                    variant="subtle"
+                    color="gray"
+                    onClick={() => void onSkip()}
+                    disabled={isCancelling}
+                >
+                    Skip to project
+                </Button>
+            </Group>
+        );
+    }
+
+    if (run.status === 'completed') {
+        return (
+            <Group gap="xs">
+                <Button
+                    component={Link}
+                    to={getAgentOnboardingDashboardUrl(run.projectUuid)}
+                    rightSection={<MantineIcon icon={IconArrowRight} />}
+                >
+                    View dashboard
+                </Button>
+                <Button variant="default" onClick={onOpenProject}>
+                    Open project
+                </Button>
+            </Group>
+        );
+    }
+
+    return (
+        <Group gap="xs">
+            <Button
+                leftSection={<MantineIcon icon={IconRefresh} />}
+                onClick={() => void onRetry()}
+                loading={isRetrying}
+            >
+                Try again
+            </Button>
+            <Button variant="default" onClick={onOpenProject}>
+                Open project
+            </Button>
+        </Group>
+    );
+};
+
+const AgentOnboardingRunPage: FC = () => {
+    const { agentOnboardingRunUuid, projectUuid } = useParams<{
+        agentOnboardingRunUuid: string;
+        projectUuid: string;
+    }>();
+    const navigate = useNavigate();
+    const [isCancellationRequested, setIsCancellationRequested] =
+        useState(false);
+    const runQuery = useAgentOnboardingRun(projectUuid, agentOnboardingRunUuid);
+    const cancelMutation = useCancelAgentOnboardingRun();
+    const startMutation = useStartAgentOnboardingRun();
+
+    if (runQuery.isInitialLoading) {
+        return <PageSpinner />;
+    }
+
+    if (runQuery.isError) {
+        return <ErrorState error={runQuery.error.error} />;
+    }
+
+    if (!runQuery.data || !projectUuid || !agentOnboardingRunUuid) {
+        return (
+            <Page title="Project setup" withPaddedContent>
+                <Alert color="red" icon={<IconAlertCircle />}>
+                    This onboarding run could not be found.
+                </Alert>
+            </Page>
+        );
+    }
+
+    const run = runQuery.data;
+    const statusConfig = STATUS_CONFIG[run.status];
+    const openProject = () => {
+        void navigate(`/projects/${run.projectUuid}`);
+    };
+    const cancel = async () => {
+        setIsCancellationRequested(true);
+        try {
+            await cancelMutation.mutateAsync({
+                projectUuid: run.projectUuid,
+                runUuid: run.agentOnboardingRunUuid,
+            });
+        } catch (error) {
+            setIsCancellationRequested(false);
+            throw error;
+        }
+    };
+    const skip = async () => {
+        try {
+            await cancel();
+            openProject();
+        } catch {
+            return;
+        }
+    };
+    const retry = async () => {
+        try {
+            const nextRun = await startMutation.mutateAsync(run.projectUuid);
+            void navigate(
+                getAgentOnboardingRunUrl(
+                    nextRun.agentOnboardingRunUuid,
+                    nextRun.projectUuid,
+                ),
+                { replace: true },
+            );
+        } catch {
+            return;
+        }
+    };
+
+    return (
+        <Page
+            title="Building your Lightdash project"
+            withPaddedContent
+            fullPageScroll
+        >
+            <Box
+                className={classes.page}
+                mx="calc(-1 * var(--mantine-spacing-md))"
+                my="calc(-1 * var(--mantine-spacing-md))"
+                p="xl"
+            >
+                <Stack gap="lg" className={classes.content}>
+                    <Group justify="space-between" align="flex-start">
+                        <Stack gap={6}>
+                            <Group gap="sm">
+                                <Title order={2}>
+                                    Building your Lightdash project
+                                </Title>
+                                <Badge
+                                    color={statusConfig.color}
+                                    variant="light"
+                                >
+                                    {statusConfig.label}
+                                </Badge>
+                            </Group>
+                            {run.status !== 'failed' ? (
+                                <Text c="dimmed">
+                                    {isCancellationRequested &&
+                                    !isAgentOnboardingRunTerminal(run.status)
+                                        ? 'Stopping the setup run…'
+                                        : getStatusMessage(run)}
+                                </Text>
+                            ) : null}
+                        </Stack>
+                        <RunActions
+                            run={run}
+                            onCancel={cancel}
+                            onSkip={skip}
+                            onRetry={retry}
+                            onOpenProject={openProject}
+                            isCancelling={
+                                cancelMutation.isLoading ||
+                                isCancellationRequested
+                            }
+                            isRetrying={startMutation.isLoading}
+                        />
+                    </Group>
+
+                    {run.status === 'failed' ? (
+                        <Alert
+                            color="red"
+                            icon={<MantineIcon icon={IconAlertCircle} />}
+                            title="Setup stopped"
+                        >
+                            {getStatusMessage(run)}
+                        </Alert>
+                    ) : null}
+
+                    <Paper
+                        withBorder
+                        radius="md"
+                        className={classes.progressActivityCard}
+                    >
+                        <Box p="lg">
+                            <AgentOnboardingProgress run={run} />
+                        </Box>
+                        <AgentOnboardingActivityPanel
+                            key={run.agentOnboardingRunUuid}
+                            events={run.events}
+                            hasGeneratedFiles={run.files.length > 0}
+                        />
+                    </Paper>
+
+                    <Paper withBorder radius="md" className={classes.workspace}>
+                        <Box className={classes.workspacePanel}>
+                            <Group h={48} px="md" justify="space-between">
+                                <Text fw={600} fz="sm">
+                                    Generated files
+                                </Text>
+                                <Text c="dimmed" fz="xs">
+                                    {run.files.length} files
+                                </Text>
+                            </Group>
+                            <AgentOnboardingFileBrowser
+                                projectUuid={run.projectUuid}
+                                runUuid={run.agentOnboardingRunUuid}
+                                files={run.files}
+                            />
+                        </Box>
+                    </Paper>
+                </Stack>
+            </Box>
+        </Page>
+    );
+};
+
+export default AgentOnboardingRunPage;

--- a/packages/frontend/src/ee/features/agentOnboarding/hooks/useAgentOnboarding.ts
+++ b/packages/frontend/src/ee/features/agentOnboarding/hooks/useAgentOnboarding.ts
@@ -1,0 +1,135 @@
+import {
+    isAgentOnboardingRunTerminal,
+    type AgentOnboardingFile,
+    type AgentOnboardingFileContent,
+    type AgentOnboardingRun,
+    type ApiAgentOnboardingFileResponse,
+    type ApiAgentOnboardingRunResponse,
+    type ApiError,
+} from '@lightdash/common';
+import {
+    useMutation,
+    useQuery,
+    useQueryClient,
+    type UseQueryOptions,
+} from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+import useToaster from '../../../../hooks/toaster/useToaster';
+
+const POLL_INTERVAL_MS = 2_000;
+
+const agentOnboardingRunQueryKey = (
+    projectUuid: string | undefined,
+    runUuid: string | undefined,
+) => ['agent-onboarding-run', projectUuid, runUuid] as const;
+
+const getAgentOnboardingRefetchInterval = (
+    run: AgentOnboardingRun | undefined,
+): number | false =>
+    !run || !isAgentOnboardingRunTerminal(run.status)
+        ? POLL_INTERVAL_MS
+        : false;
+
+const getRun = async (projectUuid: string, runUuid: string) =>
+    lightdashApi<ApiAgentOnboardingRunResponse['results']>({
+        url: `/ee/projects/${projectUuid}/agent-onboarding/${runUuid}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const startRun = async (projectUuid: string) =>
+    lightdashApi<ApiAgentOnboardingRunResponse['results']>({
+        url: `/ee/projects/${projectUuid}/agent-onboarding`,
+        method: 'POST',
+        body: undefined,
+    });
+
+const cancelRun = async (projectUuid: string, runUuid: string) =>
+    lightdashApi<ApiAgentOnboardingRunResponse['results']>({
+        url: `/ee/projects/${projectUuid}/agent-onboarding/${runUuid}/cancel`,
+        method: 'POST',
+        body: undefined,
+    });
+
+const getFile = async (projectUuid: string, runUuid: string, path: string) =>
+    lightdashApi<ApiAgentOnboardingFileResponse['results']>({
+        url: `/ee/projects/${projectUuid}/agent-onboarding/${runUuid}/file?${new URLSearchParams(
+            { path },
+        ).toString()}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useAgentOnboardingRun = (
+    projectUuid: string | undefined,
+    runUuid: string | undefined,
+    options?: Pick<UseQueryOptions<AgentOnboardingRun, ApiError>, 'enabled'>,
+) =>
+    useQuery<AgentOnboardingRun, ApiError>({
+        queryKey: agentOnboardingRunQueryKey(projectUuid, runUuid),
+        queryFn: () => getRun(projectUuid!, runUuid!),
+        enabled: !!projectUuid && !!runUuid && (options?.enabled ?? true),
+        refetchInterval: getAgentOnboardingRefetchInterval,
+        refetchIntervalInBackground: true,
+    });
+
+export const useAgentOnboardingFile = (
+    projectUuid: string | undefined,
+    runUuid: string | undefined,
+    file: AgentOnboardingFile | undefined,
+) =>
+    useQuery<AgentOnboardingFileContent, ApiError>({
+        queryKey: [
+            'agent-onboarding-file',
+            projectUuid,
+            runUuid,
+            file?.path,
+            file?.updatedAt,
+        ],
+        queryFn: () => getFile(projectUuid!, runUuid!, file!.path),
+        enabled: !!projectUuid && !!runUuid && !!file,
+    });
+
+export const useStartAgentOnboardingRun = () => {
+    const { showToastApiError } = useToaster();
+
+    return useMutation<AgentOnboardingRun, ApiError, string>({
+        mutationFn: startRun,
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to start project setup',
+                apiError: error,
+            });
+        },
+    });
+};
+
+type CancelRunArgs = {
+    projectUuid: string;
+    runUuid: string;
+};
+
+export const useCancelAgentOnboardingRun = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError } = useToaster();
+
+    return useMutation<AgentOnboardingRun, ApiError, CancelRunArgs>({
+        mutationFn: ({ projectUuid, runUuid }) =>
+            cancelRun(projectUuid, runUuid),
+        onSuccess: (run) => {
+            queryClient.setQueryData(
+                agentOnboardingRunQueryKey(
+                    run.projectUuid,
+                    run.agentOnboardingRunUuid,
+                ),
+                run,
+            );
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to cancel project setup',
+                apiError: error,
+            });
+        },
+    });
+};

--- a/packages/frontend/src/ee/features/agentOnboarding/utils.ts
+++ b/packages/frontend/src/ee/features/agentOnboarding/utils.ts
@@ -1,0 +1,304 @@
+import {
+    AGENT_ONBOARDING_STAGES,
+    isAgentOnboardingRunTerminal,
+    type AgentOnboardingFile,
+    type AgentOnboardingRun,
+    type AgentOnboardingStage,
+} from '@lightdash/common';
+
+export type AgentOnboardingStageTiming = {
+    stage: AgentOnboardingStage;
+    state: 'not_started' | 'active' | 'completed';
+    durationMs: number | null;
+};
+
+export const AGENT_ONBOARDING_PROGRESS_STAGES = [
+    {
+        stage: 'explore',
+        sourceStages: ['preparing_project', 'exploring_warehouse'],
+    },
+    {
+        stage: 'semantic_layer',
+        sourceStages: ['deploying_semantic_layer'],
+    },
+    {
+        stage: 'dashboard',
+        sourceStages: ['building_dashboard'],
+    },
+    {
+        stage: 'ready',
+        sourceStages: ['verifying', 'handoff'],
+    },
+] as const satisfies ReadonlyArray<{
+    stage: string;
+    sourceStages: readonly AgentOnboardingStage[];
+}>;
+
+export type AgentOnboardingProgressStage =
+    (typeof AGENT_ONBOARDING_PROGRESS_STAGES)[number]['stage'];
+
+export type AgentOnboardingProgressStageTiming = {
+    stage: AgentOnboardingProgressStage;
+    state: AgentOnboardingStageTiming['state'];
+    durationMs: number | null;
+};
+
+const parseTimestamp = (value: string | null | undefined): number | null => {
+    if (!value) return null;
+    const timestamp = Date.parse(value);
+    return Number.isFinite(timestamp) ? timestamp : null;
+};
+
+const isHandoffFile = ({ path }: AgentOnboardingFile): boolean =>
+    /LIGHTDASH_(?:ONBOARDING_)?HANDOFF.*\.md$/i.test(path);
+
+const getHandoffTimestamp = (files: AgentOnboardingFile[]): number | null => {
+    const timestamps = files
+        .filter(isHandoffFile)
+        .map(({ updatedAt }) => parseTimestamp(updatedAt))
+        .filter((timestamp): timestamp is number => timestamp !== null);
+
+    return timestamps.length > 0 ? Math.max(...timestamps) : null;
+};
+
+const getVisibleTimestamps = (run: AgentOnboardingRun): number[] => [
+    ...run.events
+        .map(({ createdAt }) => parseTimestamp(createdAt))
+        .filter((timestamp): timestamp is number => timestamp !== null),
+    ...run.files
+        .map(({ updatedAt }) => parseTimestamp(updatedAt))
+        .filter((timestamp): timestamp is number => timestamp !== null),
+];
+
+const getAgentOnboardingStageTimings = (
+    run: AgentOnboardingRun,
+    now = Date.now(),
+): AgentOnboardingStageTiming[] => {
+    const starts = new Map<AgentOnboardingStage, number>();
+    const orderedEvents = run.events
+        .map((event, order) => ({
+            ...event,
+            order,
+            timestamp: parseTimestamp(event.createdAt),
+        }))
+        .filter(
+            (event): event is typeof event & { timestamp: number } =>
+                event.timestamp !== null,
+        )
+        .sort(
+            (left, right) =>
+                left.timestamp - right.timestamp || left.order - right.order,
+        );
+
+    let furthestStageIndex = -1;
+    for (const event of orderedEvents) {
+        if (!event.stage) continue;
+        const stageIndex = AGENT_ONBOARDING_STAGES.indexOf(event.stage);
+        if (stageIndex <= furthestStageIndex) continue;
+        starts.set(event.stage, event.timestamp);
+        furthestStageIndex = stageIndex;
+    }
+
+    const visibleTimestamps = getVisibleTimestamps(run);
+    const earliestVisible =
+        visibleTimestamps.length > 0 ? Math.min(...visibleTimestamps) : null;
+    const fallbackStart =
+        parseTimestamp(run.startedAt) ?? parseTimestamp(run.createdAt);
+
+    if (!starts.has('preparing_project')) {
+        const preparingStart = earliestVisible ?? fallbackStart;
+        if (preparingStart !== null) {
+            starts.set('preparing_project', preparingStart);
+        }
+    } else if (earliestVisible !== null) {
+        starts.set(
+            'preparing_project',
+            Math.min(starts.get('preparing_project')!, earliestVisible),
+        );
+    }
+
+    const currentStageIndex = run.stage
+        ? AGENT_ONBOARDING_STAGES.indexOf(run.stage)
+        : -1;
+    if (
+        run.stage &&
+        !starts.has(run.stage) &&
+        currentStageIndex > furthestStageIndex
+    ) {
+        const transitionEvidence = [
+            ...orderedEvents.map(({ timestamp }) => timestamp),
+            ...run.files
+                .filter((file) => !isHandoffFile(file))
+                .map(({ updatedAt }) => parseTimestamp(updatedAt))
+                .filter((timestamp): timestamp is number => timestamp !== null),
+        ];
+        const latestTransition =
+            transitionEvidence.length > 0
+                ? Math.max(...transitionEvidence)
+                : fallbackStart;
+        if (latestTransition !== null) starts.set(run.stage, latestTransition);
+    }
+
+    const isTerminal = isAgentOnboardingRunTerminal(run.status);
+    const handoffTimestamp = getHandoffTimestamp(run.files);
+    const latestVisible =
+        visibleTimestamps.length > 0 ? Math.max(...visibleTimestamps) : null;
+    const databaseEnd =
+        parseTimestamp(run.completedAt) ?? parseTimestamp(run.updatedAt);
+    const terminalEnd =
+        run.status === 'completed' && handoffTimestamp !== null
+            ? handoffTimestamp
+            : (latestVisible ?? databaseEnd ?? now);
+    const activeStage = AGENT_ONBOARDING_STAGES.findLast((stage) =>
+        starts.has(stage),
+    );
+
+    return AGENT_ONBOARDING_STAGES.map((stage, stageIndex) => {
+        const startedAt = starts.get(stage);
+        if (startedAt === undefined) {
+            return { stage, state: 'not_started', durationMs: null };
+        }
+
+        const nextStartedAt = AGENT_ONBOARDING_STAGES.slice(stageIndex + 1)
+            .map((nextStage) => starts.get(nextStage))
+            .find((timestamp): timestamp is number => timestamp !== undefined);
+        const isActive = !isTerminal && stage === activeStage;
+        const endedAt = nextStartedAt ?? (isActive ? now : terminalEnd);
+
+        return {
+            stage,
+            state: isActive ? 'active' : 'completed',
+            durationMs: Math.max(0, endedAt - startedAt),
+        };
+    });
+};
+
+export const getAgentOnboardingProgressStageTimings = (
+    run: AgentOnboardingRun,
+    now = Date.now(),
+): AgentOnboardingProgressStageTiming[] => {
+    const stageTimings = getAgentOnboardingStageTimings(run, now);
+
+    return AGENT_ONBOARDING_PROGRESS_STAGES.map(({ stage, sourceStages }) => {
+        const timings = stageTimings.filter((timing) =>
+            sourceStages.some((sourceStage) => sourceStage === timing.stage),
+        );
+        const state = timings.some((timing) => timing.state === 'active')
+            ? 'active'
+            : timings.some((timing) => timing.state === 'completed')
+              ? 'completed'
+              : 'not_started';
+        const durations = timings
+            .map(({ durationMs }) => durationMs)
+            .filter((durationMs): durationMs is number => durationMs !== null);
+
+        return {
+            stage,
+            state,
+            durationMs:
+                durations.length > 0
+                    ? durations.reduce(
+                          (total, durationMs) => total + durationMs,
+                          0,
+                      )
+                    : null,
+        };
+    });
+};
+
+export const getAgentOnboardingProgressStageIndex = (
+    stage: AgentOnboardingStage | null,
+): number =>
+    stage === null
+        ? -1
+        : AGENT_ONBOARDING_PROGRESS_STAGES.findIndex(({ sourceStages }) =>
+              sourceStages.some((sourceStage) => sourceStage === stage),
+          );
+
+export const formatStageDuration = (durationMs: number | null): string => {
+    if (durationMs === null) return '—';
+    const totalSeconds = Math.max(0, Math.floor(durationMs / 1_000));
+    const hours = Math.floor(totalSeconds / 3_600);
+    const minutes = Math.floor((totalSeconds % 3_600) / 60);
+    const seconds = totalSeconds % 60;
+
+    if (hours > 0) return `${hours}h ${String(minutes).padStart(2, '0')}m`;
+    if (minutes > 0) return `${minutes}m ${String(seconds).padStart(2, '0')}s`;
+    return `${seconds}s`;
+};
+
+export const sanitizeTerminalText = (value: string): string => {
+    const withoutAnsi = value.replace(
+        new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, 'g'),
+        '',
+    );
+    return Array.from(withoutAnsi)
+        .filter((character) => {
+            const code = character.charCodeAt(0);
+            return character === '\n' || character === '\t' || code >= 32;
+        })
+        .join('');
+};
+
+export type AgentOnboardingFileTreeNode = {
+    name: string;
+    path: string;
+    file: AgentOnboardingFile | null;
+    children: AgentOnboardingFileTreeNode[];
+};
+
+export const buildAgentOnboardingFileTree = (
+    files: AgentOnboardingFile[],
+): AgentOnboardingFileTreeNode[] => {
+    const root: AgentOnboardingFileTreeNode[] = [];
+
+    for (const file of [...files].sort((left, right) =>
+        left.path.localeCompare(right.path),
+    )) {
+        const segments = file.path.split('/').filter(Boolean);
+        let children = root;
+        let currentPath = '';
+
+        segments.forEach((segment, index) => {
+            currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+            const isFile = index === segments.length - 1;
+            let node = children.find(({ name }) => name === segment);
+            if (!node) {
+                node = {
+                    name: segment,
+                    path: currentPath,
+                    file: isFile ? file : null,
+                    children: [],
+                };
+                children.push(node);
+            } else if (isFile) {
+                node.file = file;
+            }
+            children = node.children;
+        });
+    }
+
+    const sortNodes = (
+        nodes: AgentOnboardingFileTreeNode[],
+    ): AgentOnboardingFileTreeNode[] =>
+        nodes
+            .map((node) => ({ ...node, children: sortNodes(node.children) }))
+            .sort((left, right) => {
+                if (left.file === null && right.file !== null) return -1;
+                if (left.file !== null && right.file === null) return 1;
+                return left.name.localeCompare(right.name);
+            });
+
+    return sortNodes(root);
+};
+
+export const getAgentOnboardingRunUrl = (
+    runUuid: string,
+    projectUuid: string,
+): string =>
+    `/projects/${encodeURIComponent(projectUuid)}/onboarding/runs/${encodeURIComponent(runUuid)}`;
+
+const AGENT_ONBOARDING_DASHBOARD_SLUG = 'agent-starter-dashboard';
+
+export const getAgentOnboardingDashboardUrl = (projectUuid: string): string =>
+    `/projects/${encodeURIComponent(projectUuid)}/dashboards/${AGENT_ONBOARDING_DASHBOARD_SLUG}/view`;

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -52,6 +52,7 @@ export enum PageName {
     ORGANIZATION_SETUP = 'organization_setup',
     ONBOARDING_DATA_SOURCE = 'onboarding_data_source',
     ONBOARDING_PROJECT_READY = 'onboarding_project_ready',
+    AGENT_ONBOARDING_RUN = 'agent_onboarding_run',
     NO_PROJECT_HOMEPAGE = 'no_project_homepage',
     EMBED_DASHBOARD = 'embed_dashboard',
     EMBED_SAVED_CHART = 'embed_saved_chart',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-9040
Closes: PROD-9044
Closes: PROD-9051
Closes: PROD-9052

### Description:
Adds an entitlement-gated managed project setup entry point and a durable run page with four plain-language milestones, combined stage timing, colored collapsible activity, cancellation and retry controls, and a resizable, scrollable generated-file browser.
Adds polling, routing, file preview support, and a local coding-agent fallback for project setup.
Hardens managed execution and persisted output with command allowlists, secret and size checks, faster cancellation, and required project-file and dashboard completion validation.


<img width="3466" height="2580" alt="CleanShot 2026-07-22 at 09 30 16@2x" src="https://github.com/user-attachments/assets/73164457-1e11-4b22-904b-d178ceef7da8" />

<img width="3464" height="2576" alt="image" src="https://github.com/user-attachments/assets/f0189144-64c8-4c48-9f11-4dbea2736f5d" />
