### PR TITLE
feat: add dashboard project ownership expansion

### DIFF
--- a/packages/backend/src/database/entities/dashboards.ts
+++ b/packages/backend/src/database/entities/dashboards.ts
@@ -22,6 +22,7 @@ export const DashboardTabsTableName = 'dashboard_tabs';
 export type DbDashboard = {
     dashboard_id: number;
     dashboard_uuid: string;
+    project_uuid: string | null;
     name: string;
     description?: string;
     search_vector: string;
@@ -76,10 +77,14 @@ type DbDashboardTileChart = {
 
 export type DashboardTable = Knex.CompositeTableType<
     DbDashboard,
-    Pick<DbDashboard, 'name' | 'description' | 'space_id' | 'slug'>,
+    Pick<
+        DbDashboard,
+        'project_uuid' | 'name' | 'description' | 'space_id' | 'slug'
+    >,
     Partial<
         Pick<
             DbDashboard,
+            | 'project_uuid'
             | 'name'
             | 'description'
             | 'views_count'

--- a/packages/backend/src/database/migrations/20260722072235_add_project_uuid_to_dashboards.ts
+++ b/packages/backend/src/database/migrations/20260722072235_add_project_uuid_to_dashboards.ts
@@ -1,0 +1,98 @@
+import { Knex } from 'knex';
+
+export const config = { transaction: false };
+
+const DashboardsTableName = 'dashboards';
+const BatchSize = 1000;
+const LockTimeout = '5s';
+
+type BackfillBatch = {
+    batch_count: number;
+    last_processed_id: number | null;
+};
+
+async function addProjectUuidColumn(knex: Knex): Promise<void> {
+    await knex.transaction(async (trx) => {
+        await trx.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);
+        await trx.raw(`
+            ALTER TABLE ${DashboardsTableName}
+            ADD COLUMN IF NOT EXISTS project_uuid uuid
+        `);
+    });
+}
+
+async function getBackfillCutoff(knex: Knex): Promise<number> {
+    const result = await knex.raw<{ rows: Array<{ cutoff: number }> }>(`
+        SELECT COALESCE(MAX(dashboard_id), 0)::integer AS cutoff
+        FROM ${DashboardsTableName}
+    `);
+    return result.rows[0]?.cutoff ?? 0;
+}
+
+async function backfillBatch(
+    knex: Knex,
+    lastProcessedId: number,
+    cutoff: number,
+): Promise<BackfillBatch | undefined> {
+    return knex.transaction(async (trx) => {
+        await trx.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);
+        const result = await trx.raw<{ rows: BackfillBatch[] }>(
+            `WITH batch AS (
+                SELECT
+                    dashboards.dashboard_id,
+                    projects.project_uuid
+                FROM ${DashboardsTableName} AS dashboards
+                LEFT JOIN spaces
+                    ON spaces.space_id = dashboards.space_id
+                LEFT JOIN projects
+                    ON projects.project_id = spaces.project_id
+                WHERE dashboards.project_uuid IS NULL
+                  AND dashboards.dashboard_id > ?
+                  AND dashboards.dashboard_id <= ?
+                ORDER BY dashboards.dashboard_id
+                LIMIT ${BatchSize}
+            ), updated AS (
+                UPDATE ${DashboardsTableName} AS dashboards
+                SET project_uuid = batch.project_uuid
+                FROM batch
+                WHERE dashboards.dashboard_id = batch.dashboard_id
+                  AND dashboards.project_uuid IS NULL
+                  AND batch.project_uuid IS NOT NULL
+            )
+            SELECT
+                COUNT(*)::integer AS batch_count,
+                MAX(dashboard_id)::integer AS last_processed_id
+            FROM batch`,
+            [lastProcessedId, cutoff],
+        );
+        return result.rows[0];
+    });
+}
+
+async function backfillProjectUuids(knex: Knex): Promise<void> {
+    const cutoff = await getBackfillCutoff(knex);
+    let lastProcessedId = 0;
+
+    for (;;) {
+        // eslint-disable-next-line no-await-in-loop
+        const batch = await backfillBatch(knex, lastProcessedId, cutoff);
+        if (!batch || batch.batch_count === 0) return;
+
+        lastProcessedId = batch.last_processed_id ?? lastProcessedId;
+    }
+}
+
+export async function up(knex: Knex): Promise<void> {
+    await addProjectUuidColumn(knex);
+    await backfillProjectUuids(knex);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.transaction(async (trx) => {
+        await trx.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);
+        await trx.raw(`
+            ALTER TABLE ${DashboardsTableName}
+            DROP COLUMN IF EXISTS project_uuid
+        `);
+    });
+}

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -166,6 +166,7 @@ export const savedChartEntry: SavedChartTable['base'] = {
 export const dashboardEntry: DashboardTable['base'] = {
     dashboard_id: 0,
     dashboard_uuid: 'my_dashboard_uuid',
+    project_uuid: projectEntry.project_uuid,
     name: 'name',
     slug: 'name',
 

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -299,6 +299,9 @@ describe('DashboardModel', () => {
         await model.create('spaceUuid', createDashboard, user, projectUuid);
 
         expect(tracker.history.select).toHaveLength(2);
+        expect(tracker.history.select[0].bindings).toEqual(
+            expect.arrayContaining(['spaceUuid', projectUuid]),
+        );
         expect(tracker.history.insert).toHaveLength(5);
         expect(tracker.history.insert[0]).toMatchObject({
             sql: expect.stringContaining(DashboardsTableName),
@@ -306,9 +309,11 @@ describe('DashboardModel', () => {
                 createDashboard.description,
                 createDashboard.name,
                 createDashboard.slug,
+                projectUuid,
                 spaceEntry.space_id,
             ]),
         });
+        expect(tracker.history.insert[0].sql).toContain('"project_uuid"');
         expect(tracker.history.insert[1]).toMatchObject({
             sql: expect.stringContaining(DashboardVersionsTableName),
             bindings: expect.arrayContaining([
@@ -354,46 +359,100 @@ describe('DashboardModel', () => {
 
     test('should update dashboard', async () => {
         const dashboardUuid = 'dashboard uuid';
-        tracker.on
-            .update(
-                queryMatcher(DashboardsTableName, [
-                    updateDashboard.name,
-                    updateDashboard.description,
-                    dashboardUuid,
-                ]),
-            )
-            .response([]);
-        tracker.on
-            .select(queryMatcher(DashboardsTableName, [dashboardUuid, 1]))
-            .response([dashboardWithVersionEntry]);
-        tracker.on
-            .select(
-                queryMatcher(DashboardViewsTableName, [
-                    dashboardWithVersionEntry.dashboard_version_id,
-                ]),
-            )
-            .response([dashboardViewEntry]);
-        tracker.on
-            .select(
-                queryMatcher(DashboardTilesTableName, [
-                    dashboardWithVersionEntry.dashboard_version_id,
-                ]),
-            )
-            .response([
-                dashboardTileWithSavedChartEntry,
-                loomTileEntry,
-                markdownTileEntry,
-            ]);
-        tracker.on
-            .select(
-                queryMatcher(DashboardTabsTableName, [
-                    dashboardWithVersionEntry.dashboard_version_id,
-                    dashboardWithVersionEntry.dashboard_id,
-                ]),
-            )
-            .response([]);
+        const getByIdOrSlugSpy = vi
+            .spyOn(model, 'getByIdOrSlug')
+            .mockResolvedValue({
+                ...expectedDashboard,
+                uuid: dashboardUuid,
+                projectUuid,
+            });
+        tracker.on.update(DashboardsTableName).response([]);
+
         await model.update(dashboardUuid, updateDashboard);
+
         expect(tracker.history.update).toHaveLength(1);
+        expect(tracker.history.update[0].sql).toContain('"project_uuid"');
+        expect(tracker.history.update[0].bindings).toContain(projectUuid);
+        getByIdOrSlugSpy.mockRestore();
+    });
+
+    test('rejects moving a dashboard to a space in another project', async () => {
+        const dashboardUuid = '11111111-1111-4111-8111-111111111111';
+        const targetSpaceUuid = '33333333-3333-4333-8333-333333333333';
+        const getByIdOrSlugSpy = vi
+            .spyOn(model, 'getByIdOrSlug')
+            .mockResolvedValueOnce({
+                ...expectedDashboard,
+                uuid: dashboardUuid,
+                projectUuid,
+            });
+        tracker.on.select(SpaceTableName).responseOnce([]);
+
+        await expect(
+            model.update(dashboardUuid, {
+                ...updateDashboard,
+                spaceUuid: targetSpaceUuid,
+            }),
+        ).rejects.toThrow('Space not found');
+
+        expect(tracker.history.select[0].bindings).toEqual(
+            expect.arrayContaining([targetSpaceUuid, projectUuid]),
+        );
+        expect(tracker.history.update).toHaveLength(0);
+        getByIdOrSlugSpy.mockRestore();
+    });
+
+    test('updates multiple dashboards within the requested project', async () => {
+        const dashboardUuid = '11111111-1111-4111-8111-111111111111';
+        const targetSpaceUuid = '33333333-3333-4333-8333-333333333333';
+        const targetSpaceId = 7;
+        const getByIdOrSlugSpy = vi
+            .spyOn(model, 'getByIdOrSlug')
+            .mockResolvedValueOnce({
+                ...expectedDashboard,
+                uuid: dashboardUuid,
+                projectUuid,
+            });
+        tracker.on
+            .select(SpaceTableName)
+            .responseOnce([{ space_id: targetSpaceId }]);
+        tracker.on.update(DashboardsTableName).responseOnce(1);
+
+        await model.updateMultiple(projectUuid, [
+            {
+                uuid: dashboardUuid,
+                name: updateDashboard.name,
+                description: updateDashboard.description,
+                spaceUuid: targetSpaceUuid,
+            },
+        ]);
+
+        expect(tracker.history.select[0].bindings).toEqual(
+            expect.arrayContaining([targetSpaceUuid, projectUuid]),
+        );
+        expect(tracker.history.update[0].sql).toContain('"project_uuid"');
+        expect(tracker.history.update[0].bindings).toEqual(
+            expect.arrayContaining([dashboardUuid, projectUuid, targetSpaceId]),
+        );
+        getByIdOrSlugSpy.mockRestore();
+    });
+
+    test('moves a dashboard within the requested project and writes ownership', async () => {
+        const dashboardUuid = '11111111-1111-4111-8111-111111111111';
+        const targetSpaceUuid = '33333333-3333-4333-8333-333333333333';
+        tracker.on.select(SpaceTableName).responseOnce([{ space_id: 7 }]);
+        tracker.on.update(DashboardsTableName).responseOnce(1);
+
+        await model.moveToSpace({
+            projectUuid,
+            itemUuid: dashboardUuid,
+            targetSpaceUuid,
+        });
+
+        expect(tracker.history.update[0].sql).toContain('"project_uuid"');
+        expect(tracker.history.update[0].bindings).toEqual(
+            expect.arrayContaining([dashboardUuid, projectUuid, 7]),
+        );
     });
 
     test('should delete dashboard', async () => {

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -85,7 +85,6 @@ import {
     generateUniqueSlug,
 } from '../../utils/SlugUtils';
 import { ContentVerificationModel } from '../ContentVerificationModel';
-import { SpaceModel } from '../SpaceModel';
 import Transaction = Knex.Transaction;
 
 export type GetDashboardQuery = Pick<
@@ -1434,8 +1433,14 @@ export class DashboardModel {
             }
 
             const [space] = await trx(SpaceTableName)
-                .where('space_uuid', spaceUuid)
-                .select(`${SpaceTableName}.*`)
+                .innerJoin(
+                    ProjectTableName,
+                    `${ProjectTableName}.project_id`,
+                    `${SpaceTableName}.project_id`,
+                )
+                .where(`${SpaceTableName}.space_uuid`, spaceUuid)
+                .where(`${ProjectTableName}.project_uuid`, projectUuid)
+                .select(`${SpaceTableName}.space_id`)
                 .limit(1);
             if (!space) {
                 throw new NotFoundError('Space not found');
@@ -1443,6 +1448,7 @@ export class DashboardModel {
 
             const [newDashboard] = await trx(DashboardsTableName)
                 .insert({
+                    project_uuid: projectUuid,
                     name: dashboard.name,
                     description: dashboard.description,
                     space_id: space.space_id,
@@ -1470,42 +1476,47 @@ export class DashboardModel {
         dashboardUuidOrSlug: string,
         dashboard: DashboardUnversionedFields,
     ): Promise<DashboardDAO> {
-        const withSpaceId = dashboard.spaceUuid
-            ? {
-                  space_id: (
-                      await SpaceModel.getSpaceIdAndName(
-                          this.database,
-                          dashboard.spaceUuid,
-                      )
-                  )?.spaceId,
-              }
-            : {};
+        const existingDashboard = await this.getByIdOrSlug(dashboardUuidOrSlug);
+        let withSpaceId: { space_id: number } | Record<string, never> = {};
+        if (dashboard.spaceUuid) {
+            const space = await this.database(SpaceTableName)
+                .innerJoin(
+                    ProjectTableName,
+                    `${ProjectTableName}.project_id`,
+                    `${SpaceTableName}.project_id`,
+                )
+                .select(`${SpaceTableName}.space_id`)
+                .where(`${SpaceTableName}.space_uuid`, dashboard.spaceUuid)
+                .where(
+                    `${ProjectTableName}.project_uuid`,
+                    existingDashboard.projectUuid,
+                )
+                .first();
+            if (!space) {
+                throw new NotFoundError('Space not found');
+            }
+            withSpaceId = { space_id: space.space_id };
+        }
         const withColorPalette =
             dashboard.colorPaletteUuid !== undefined
                 ? { color_palette_uuid: dashboard.colorPaletteUuid }
                 : {};
         const query = this.database(DashboardsTableName)
             .update({
+                project_uuid: existingDashboard.projectUuid,
                 name: dashboard.name,
                 description: dashboard.description,
                 ...withSpaceId,
                 ...withColorPalette,
             })
+            .where('dashboard_uuid', existingDashboard.uuid)
             .whereNull('deleted_at');
-
-        if (isValidUuid(dashboardUuidOrSlug)) {
-            void query.where((builder) => {
-                void builder
-                    .where('dashboard_uuid', dashboardUuidOrSlug)
-                    .orWhere('slug', dashboardUuidOrSlug);
-            });
-        } else {
-            void query.where('slug', dashboardUuidOrSlug);
-        }
 
         await query;
 
-        return this.getByIdOrSlug(dashboardUuidOrSlug);
+        return this.getByIdOrSlug(existingDashboard.uuid, {
+            projectUuid: existingDashboard.projectUuid,
+        });
     }
 
     async updateMultiple(
@@ -1515,31 +1526,64 @@ export class DashboardModel {
         await this.database.transaction(async (trx) => {
             await Promise.all(
                 dashboards.map(async (dashboard) => {
-                    const withSpaceId = dashboard.spaceUuid
-                        ? {
-                              space_id: (
-                                  await SpaceModel.getSpaceIdAndName(
-                                      trx,
-                                      dashboard.spaceUuid,
-                                  )
-                              )?.spaceId,
-                          }
-                        : {};
-                    await trx(DashboardsTableName)
+                    let withSpaceId:
+                        | { space_id: number }
+                        | Record<string, never> = {};
+                    if (dashboard.spaceUuid) {
+                        const space = await trx(SpaceTableName)
+                            .innerJoin(
+                                ProjectTableName,
+                                `${ProjectTableName}.project_id`,
+                                `${SpaceTableName}.project_id`,
+                            )
+                            .select(`${SpaceTableName}.space_id`)
+                            .where(
+                                `${SpaceTableName}.space_uuid`,
+                                dashboard.spaceUuid,
+                            )
+                            .where(
+                                `${ProjectTableName}.project_uuid`,
+                                projectUuid,
+                            )
+                            .first();
+                        if (!space) {
+                            throw new NotFoundError('Space not found');
+                        }
+                        withSpaceId = { space_id: space.space_id };
+                    }
+                    const updateCount = await trx(DashboardsTableName)
                         .update({
+                            project_uuid: projectUuid,
                             name: dashboard.name,
                             description: dashboard.description,
                             ...withSpaceId,
                         })
                         .where('dashboard_uuid', dashboard.uuid)
+                        .whereIn(
+                            'space_id',
+                            trx(SpaceTableName)
+                                .select(`${SpaceTableName}.space_id`)
+                                .innerJoin(
+                                    ProjectTableName,
+                                    `${ProjectTableName}.project_id`,
+                                    `${SpaceTableName}.project_id`,
+                                )
+                                .where(
+                                    `${ProjectTableName}.project_uuid`,
+                                    projectUuid,
+                                ),
+                        )
                         .whereNull('deleted_at');
+                    if (updateCount !== 1) {
+                        throw new NotFoundError('Dashboard not found');
+                    }
                 }),
             );
         });
 
         return Promise.all(
             dashboards.map(async (dashboard) =>
-                this.getByIdOrSlug(dashboard.uuid),
+                this.getByIdOrSlug(dashboard.uuid, { projectUuid }),
             ),
         );
     }
@@ -2465,8 +2509,8 @@ export class DashboardModel {
                 `${ProjectTableName}.project_id`,
                 `${SpaceTableName}.project_id`,
             )
-            .where('space_uuid', targetSpaceUuid)
-            .where('project_uuid', projectUuid)
+            .where(`${SpaceTableName}.space_uuid`, targetSpaceUuid)
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
             .first();
 
         if (!space) {
@@ -2474,8 +2518,22 @@ export class DashboardModel {
         }
 
         const updateCount = await tx(DashboardsTableName)
-            .update({ space_id: space.space_id })
+            .update({
+                project_uuid: projectUuid,
+                space_id: space.space_id,
+            })
             .where('dashboard_uuid', dashboardUuid)
+            .whereIn(
+                'space_id',
+                tx(SpaceTableName)
+                    .select(`${SpaceTableName}.space_id`)
+                    .innerJoin(
+                        ProjectTableName,
+                        `${ProjectTableName}.project_id`,
+                        `${SpaceTableName}.project_id`,
+                    )
+                    .where(`${ProjectTableName}.project_uuid`, projectUuid),
+            )
             .whereNull('deleted_at');
 
         if (updateCount !== 1) {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -126,7 +126,7 @@ import Logger from '../../logging/logger';
 import { wrapSentryTransaction, wrapSentryTransactionSync } from '../../utils';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import { generateUniqueSpaceSlug } from '../../utils/SlugUtils';
-import { omitProjectUuid } from './previewContent';
+import { omitProjectUuid, replaceProjectUuid } from './previewContent';
 import Transaction = Knex.Transaction;
 
 export type ProjectModelArguments = {
@@ -3167,7 +3167,10 @@ export class ProjectModel {
                                       dashboard_uuid?: string;
                                   };
                                   const createDashboard: CloneDashboard = {
-                                      ...omitProjectUuid(d),
+                                      ...replaceProjectUuid(
+                                          d,
+                                          previewProjectUuid,
+                                      ),
                                       search_vector: undefined,
                                       dashboard_id: undefined,
                                       dashboard_uuid: undefined,

--- a/packages/backend/src/models/ProjectModel/previewContent.test.ts
+++ b/packages/backend/src/models/ProjectModel/previewContent.test.ts
@@ -1,4 +1,4 @@
-import { omitProjectUuid } from './previewContent';
+import { omitProjectUuid, replaceProjectUuid } from './previewContent';
 
 describe('omitProjectUuid', () => {
     it.each([
@@ -23,4 +23,18 @@ describe('omitProjectUuid', () => {
             expect(row).toHaveProperty('project_uuid', 'source-project-uuid');
         },
     );
+});
+
+describe('replaceProjectUuid', () => {
+    it('sets destination ownership without mutating the source row', () => {
+        const row = {
+            dashboard_uuid: 'dashboard-uuid',
+            project_uuid: 'source-project-uuid',
+        };
+
+        const result = replaceProjectUuid(row, 'destination-project-uuid');
+
+        expect(result.project_uuid).toBe('destination-project-uuid');
+        expect(row.project_uuid).toBe('source-project-uuid');
+    });
 });

--- a/packages/backend/src/models/ProjectModel/previewContent.ts
+++ b/packages/backend/src/models/ProjectModel/previewContent.ts
@@ -7,3 +7,11 @@ export const omitProjectUuid = <T extends object>(
     void projectUuid;
     return rest;
 };
+
+export const replaceProjectUuid = <T extends object>(
+    row: T,
+    projectUuid: string,
+): Omit<T, 'project_uuid'> & { project_uuid: string } => ({
+    ...omitProjectUuid(row),
+    project_uuid: projectUuid,
+});


### PR DESCRIPTION
The dashboard migration is substantially faster: about **9\.1× faster end to end** than the chart ownership migration.

| Migration | Rows | Three full runs | Median | Idempotent rerun |
| --- | --- | --- | --- | --- |
| Dashboards | 79,874 | 2\.690–2.724s | **2\.696s** | 9ms |
| Charts | 1,142,407 | 21\.858–30.172s | **24\.647s** | 814ms |

Both migrations produced:

- Zero null `project_uuid` values
- Zero mismatched project owners
- Clean rollbacks
- Safe 1,000-row committed batches



Relates: PROD-8968

## Summary

This is the dashboard ownership expansion PR, stacked directly on the shared content preflight PR so it can land before the chart ownership work.

- Adds nullable `dashboards.project_uuid`.
- Backfills existing dashboards from their owning space in committed batches of 1,000 rows.
- Makes dashboard create, update, bulk update, move, and preview-clone paths write the direct project owner.
- Validates destination spaces against the requested/current project and prevents cross-project moves.
- Keeps legacy space/project joins for reads until the later dashboard contract PR makes ownership non-null.

This PR deliberately does not add `NOT NULL`, a foreign key, or `(project_uuid, slug)` uniqueness. Those belong in the dashboard contract PR after this writer-compatible expansion is deployed.

## Migration safety

- Runs outside Knex's outer transaction so each backfill batch commits independently.
- Uses a five-second lock timeout for the brief `ADD COLUMN`/rollback table locks.
- Captures a stable dashboard ID cutoff and processes at most 1,000 rows per transaction.
- Is idempotent: a rerun skips rows whose ownership is already populated.
- Leaves unresolved ownership nullable rather than guessing; the later contract migration will reconcile and validate every row before enforcement.

## Validation

- Benchmarked three cold runs against a production-shaped synthetic database with 3,409 projects and 79,874 dashboards: 2.690 s, 2.696 s, and 2.724 s (2.696 s median).
- Every dashboard had the expected direct project owner after every run: zero null and zero mismatched UUIDs.
- A completed-state rerun finished in 9 ms.
- On the same database, the existing chart ownership migration took 21.858-30.172 s for 1,142,407 charts (24.647 s median), making the dashboard migration about 9.1x faster end to end.
- Rollback removed both benchmark columns cleanly; the disposable benchmark database was deleted afterward.
- Dashboard and preview-content tests: 27 passed.
- Full backend typecheck passed.
- Full backend lint passed with only two pre-existing warnings.

## Stack order

1. #25868 — shared content ownership preflight
2. This PR — dashboard ownership expansion
3. #25871 — chart ownership expansion
4. #25891 — chart slug contract

The dashboard and chart ownership branches are siblings on the preflight branch. After this PR lands, the chart stack can be restacked and its now-superseded dashboard move-safety hunks removed.

<!-- test-frontend -->