### PR TITLE
feat: run first data-app builds at low reasoning effort

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -194,6 +194,8 @@ How it flows through the stack:
 
 The shared enum + default live in `packages/common/src/ee/apps/types.ts` (`DATA_APP_CLAUDE_MODELS`, `DataAppClaudeModel`, `DEFAULT_DATA_APP_CLAUDE_MODEL`) so the frontend picker, the request body, and the backend validation stay in sync.
 
+Reasoning effort follows the version, not the user: first builds (`version === 1`) run `--effort low` — benchmarked ~40% faster with no regressions on the build/render/query-validity gates — while iterations (v2+) run `--effort high` (the CLI default, passed explicitly), since they make targeted edits to existing code where deeper reasoning matters more than blank-page latency. The resolved level is tracked as `claudeEffort` on the data-app analytics events. The benchmark harness behind that decision lives in `sandboxes/data-apps/benchmark/`.
+
 ### Cancellation
 
 Users can cancel a building version. This atomically marks it as `status='error'` in the database and pauses the sandbox

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1364,6 +1364,9 @@ export type SchedulerNotificationJobEvent = BaseTrack & {
     };
 };
 
+/** Reasoning-effort level passed via --effort to the claude CLI. */
+export type DataAppClaudeEffort = 'low' | 'high';
+
 export type DataAppCreatedEvent = BaseTrack & {
     event: 'data_app.created';
     userId: string;
@@ -1379,6 +1382,7 @@ export type DataAppCreatedEvent = BaseTrack & {
         samplesRequested: number;
         samplesAvailable: number;
         clarificationCount: number;
+        claudeEffort: DataAppClaudeEffort;
     };
 };
 
@@ -1396,6 +1400,7 @@ export type DataAppIteratedEvent = BaseTrack & {
         claudeModel: DataAppClaudeModel;
         themeChanged: boolean;
         designUuid: string | null;
+        claudeEffort: DataAppClaudeEffort;
         previousVersionStatus: string | null;
         msSinceLastVersion: number | null;
         samplesRequested: number;
@@ -1428,6 +1433,7 @@ export type DataAppVersionCompletedEvent = BaseTrack & {
         claudeModel: DataAppClaudeModel;
         claudeProvider: 'anthropic' | 'bedrock';
         schedulerWaitMs: number;
+        claudeEffort: DataAppClaudeEffort;
         wasResumed: boolean;
         totalDurationMs: number;
         sandboxMs?: number;
@@ -1480,6 +1486,7 @@ export type DataAppVersionFailedEvent = BaseTrack & {
         claudeModel: DataAppClaudeModel;
         claudeProvider?: 'anthropic' | 'bedrock';
         schedulerWaitMs?: number;
+        claudeEffort: DataAppClaudeEffort;
         failureStage:
             | 'sandbox'
             | 'catalog'

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -990,6 +990,17 @@ export class AppGenerateService extends BaseService {
     }
 
     /**
+     * Reasoning-effort policy for the claude CLI: first builds run low —
+     * benchmarked ~40% faster with no quality-gate regressions — while
+     * iterations run high (the CLI default, now passed explicitly), since
+     * they make targeted edits to existing code where deeper reasoning
+     * matters more than blank-page latency.
+     */
+    private static resolveClaudeEffort(version: number): 'low' | 'high' {
+        return version === 1 ? 'low' : 'high';
+    }
+
+    /**
      * Read the first few bytes of a stream, validate image magic bytes,
      * then return a new Readable that replays those bytes followed by
      * the rest of the original stream.
@@ -1425,6 +1436,9 @@ export class AppGenerateService extends BaseService {
                 claudeModel,
                 claudeProvider: telemetry.claudeProvider,
                 schedulerWaitMs: telemetry.schedulerWaitMs,
+                claudeEffort: AppGenerateService.resolveClaudeEffort(
+                    payload.version,
+                ),
                 failureStage,
                 errorMessage: AppGenerateService.truncateEnd(
                     getErrorMessage(error),
@@ -2407,6 +2421,10 @@ export class AppGenerateService extends BaseService {
             ? '--json-schema "$(cat /tmp/output-schema.json)" '
             : '';
 
+        const effortFlag = `--effort ${AppGenerateService.resolveClaudeEffort(
+            version,
+        )} `;
+
         // When the sandbox was resumed from a previous iteration, use
         // --continue so Claude has the full conversation history of what
         // it built before. For fresh sandboxes, start a new session.
@@ -2440,7 +2458,7 @@ export class AppGenerateService extends BaseService {
             const result = await sandbox.commands
                 .run(
                     `cat /tmp/prompt.txt | claude ${sessionFlags} ` +
-                        `--model ${claudeModel} ` +
+                        `--model ${claudeModel} ${effortFlag}` +
                         `--verbose --output-format stream-json --include-partial-messages ` +
                         `--allowedTools "Read(//app/**),Read(//tmp/dbt-repo/**),Read(//tmp/images/**),Read(//tmp/metric-queries/**),Read(//tmp/external-data/**),Write(//app/src/**),Edit(//app/src/**),Glob(//app/**),Glob(//tmp/dbt-repo/**),Glob(//tmp/metric-queries/**),Glob(//tmp/external-data/**),Grep(//app/**),Grep(//tmp/dbt-repo/**),Grep(//tmp/external-data/**)" ` +
                         `${jsonSchemaFlag}--append-system-prompt-file ${AppGenerateService.EFFECTIVE_SKILL_PATH}`,
@@ -2540,7 +2558,9 @@ export class AppGenerateService extends BaseService {
             onTelemetry?.(telemetry);
             const durationMs = AppGenerateService.elapsed(start);
             this.logger.info(
-                `App ${appUuid}: Claude code generation completed (model=${claudeModel}, exit=${result.exitCode}, toolCalls=${toolCallCount}, turns=${usage?.numTurns ?? 0}, outputTokens=${usage?.outputTokens ?? 0}, cacheReadTokens=${usage?.cacheReadInputTokens ?? 0}, ${durationMs}ms, attempt ${attempt}/${AppGenerateService.MAX_GENERATION_ATTEMPTS})`,
+                `App ${appUuid}: Claude code generation completed (model=${claudeModel}, effort=${AppGenerateService.resolveClaudeEffort(
+                    version,
+                )}, exit=${result.exitCode}, toolCalls=${toolCallCount}, turns=${usage?.numTurns ?? 0}, outputTokens=${usage?.outputTokens ?? 0}, cacheReadTokens=${usage?.cacheReadInputTokens ?? 0}, ${durationMs}ms, attempt ${attempt}/${AppGenerateService.MAX_GENERATION_ATTEMPTS})`,
             );
             this.logger.info(
                 `App ${appUuid}: claude turn timeline (ttft=${timeToFirstTokenMs ?? 'n/a'}ms, turnsMs=[${turnDurationsMs.join(', ')}])`,
@@ -4034,6 +4054,7 @@ export class AppGenerateService extends BaseService {
                 claudeModel,
                 claudeProvider,
                 schedulerWaitMs,
+                claudeEffort: AppGenerateService.resolveClaudeEffort(version),
                 wasResumed,
                 totalDurationMs: totalMs,
                 sandboxMs: durations.sandboxMs,
@@ -4791,6 +4812,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 imageCount: imageIds.length,
                 template: template ?? null,
                 claudeModel,
+                claudeEffort: AppGenerateService.resolveClaudeEffort(version),
                 samplesRequested: sampleStats.requested,
                 samplesAvailable: sampleStats.available,
                 clarificationCount: clarifications?.length ?? 0,
@@ -5011,6 +5033,8 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 promptLength: prompt.length,
                 imageCount: imageIds.length,
                 claudeModel,
+                claudeEffort:
+                    AppGenerateService.resolveClaudeEffort(newVersion),
                 themeChanged: isThemeChange,
                 designUuid: effectiveDesignUuid,
                 previousVersionStatus: latestVersion?.status ?? null,


### PR DESCRIPTION
## Summary

Sets the reasoning-effort policy for data-app generation based on the benchmark results from the effort re-evaluation:

- **First builds (`version === 1`) run `--effort low`** — benchmarked ~40% faster wall-clock and output tokens with no regressions on the objective quality gates (18/18 cells: build passes, renders clean under the mock host, all issued queries reference real catalog fields).
- **Iterations (v2+) run `--effort high`, passed explicitly** — the CLI default we have always effectively run at, now pinned so a future CLI/model default change can't silently shift behavior. Iterations make targeted edits to existing code, where deeper reasoning matters more than blank-page latency.

The policy lives in a single `resolveClaudeEffort(version)` helper shared by:

- the sandbox `claude` invocation (generation, build auto-fix retries, metadata call),
- the `Claude code generation completed` log line (`effort=` field),
- analytics: `data_app.created` / `data_app.iterated` / `data_app.version.completed` / `data_app.version.failed` gain a `claudeEffort: 'low' | 'high'` property, so duration/token/failure metrics can be segmented by effort. Older events lack the property, giving a clean before/after boundary.

Also documents the policy in the "Model selection" section of `docs/data-apps.md`.

Benchmark evidence: 3-effort × 6-prompt run with the render gate + blinded gallery added in #25881.

## Testing

- `pnpm -F backend typecheck` clean, backend tests for the touched files pass (871 tests).
- Live low-effort generation validated end-to-end against the local stack prior to this PR.

Closes: GLITCH-518

🤖 Generated with [Claude Code](https://claude.com/claude-code)