### PR TITLE
refactor: type project context object refs

### DIFF
--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -924,7 +924,7 @@ describe('getAiAgentReviewItemWritebackEligibility', () => {
                             kind: 'context',
                             content: 'Use orders for revenue questions.',
                             terms: ['revenue'],
-                            objects: ['orders'],
+                            objects: [{ type: 'explore', name: 'orders' }],
                         },
                         createdAt: NOW,
                     },

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -1669,7 +1669,7 @@ Set projectContextEntry ONLY when primaryRootCause=project_context and a single 
 - kind: definition | context. Use "definition" for acronyms and business vocabulary ("X means Y"); use "context" for everything else (routing/join rules, guidance, durable object-scoped facts).
 - content: a single self-contained sentence stating the fact (e.g. '"HR" = the high-risk diabetes cohort, not human resources.').
 - terms: the prompt-facing trigger words/phrases that should surface this entry (e.g. ["HR","high risk"]). Required for definitions.
-- objects: the semantic objects this fact concerns, from targetRefs — explore names and/or field ids in the \`table_field\` form shown as fieldId in field results (e.g. "payments_total_amount"); [] when purely prompt-driven.
+- objects: typed semantic object refs derived from targetRefs. For an explore use {"type":"explore","name":"payments"}. For a field use {"type":"field","explore":"payments","fieldId":"payments_total_amount"}; the owning explore is required and must be one where that field exists. Use [] when purely prompt-driven.
 
 Existing review items — dedup rules. The evidence packet field existingReviewItems lists this project's existing review items (key, title, status, dismissedReason, primaryRootCause, objectSummary). Apply these rules when promoting:
 - If the finding's underlying user need matches an existing item — even when you would assign a DIFFERENT root cause or blame a DIFFERENT object — set matchedExistingItemKey to that item's key. The test is "would a human say this is the same problem?", not "same technical label". A timeout, a missing field, and a routing gap that all block the same user question are ONE problem.

--- a/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.test.ts
+++ b/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.test.ts
@@ -7,6 +7,7 @@ import {
     type ProjectContextEntry,
     type SessionUser,
 } from '@lightdash/common';
+import { ZodError } from 'zod';
 import {
     createBranch,
     createPullRequest,
@@ -256,6 +257,23 @@ describe('ProjectContextService.writebackEntry', () => {
             html_url: 'https://github.com/acme/analytics/pull/7',
             number: 7,
         });
+    });
+
+    test('rejects writeback from a persisted legacy string ref', async () => {
+        const { service } = makeService({});
+
+        const error = await service
+            .writebackEntry({
+                projectUuid: PROJECT_UUID,
+                entry: { ...judgeEntry, objects: ['orders'] },
+                branchTimestamp: 1000,
+                sourceThread: null,
+            })
+            .catch((caught: unknown) => caught);
+
+        expect(error).toBeInstanceOf(ZodError);
+        expect((error as ZodError).issues[0].path).toEqual(['objects', 0]);
+        expect(mockGetFileContent).not.toHaveBeenCalled();
     });
 
     test('creates the file and opens a PR when it does not yet exist', async () => {

--- a/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.ts
+++ b/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    aiAgentJudgeProjectContextEntrySchema,
     applyProjectContextWriteback,
     DbtProjectType,
     ForbiddenError,
@@ -66,6 +67,9 @@ type ProjectContextServiceDeps = {
     githubAppInstallationsModel: GithubAppInstallationsModel;
     projectContextModel: ProjectContextModel;
 };
+
+const parseWritebackEntry = (entry: AiAgentJudgeProjectContextEntry) =>
+    aiAgentJudgeProjectContextEntrySchema.parse(entry);
 
 export class ProjectContextService extends BaseService {
     private readonly projectModel: ProjectModel;
@@ -218,6 +222,7 @@ export class ProjectContextService extends BaseService {
         op: 'create' | 'update';
         entryId: string;
     }> {
+        const entry = parseWritebackEntry(args.entry);
         const access = await this.resolveGithubAccess(args.projectUuid);
         if (!access) {
             throw new NotFoundError(
@@ -247,7 +252,7 @@ export class ProjectContextService extends BaseService {
             content: after,
             entryId,
             op,
-        } = applyProjectContextWriteback(before, args.entry);
+        } = applyProjectContextWriteback(before, entry);
         return { fileName, before, after, op, entryId };
     }
 
@@ -263,6 +268,7 @@ export class ProjectContextService extends BaseService {
             threadUuid: string;
         } | null;
     }): Promise<ProjectContextWritebackResult> {
+        const entry = parseWritebackEntry(args.entry);
         const access = await this.resolveGithubAccess(args.projectUuid);
         if (!access) {
             throw new NotFoundError(
@@ -293,7 +299,7 @@ export class ProjectContextService extends BaseService {
             content: serialized,
             entryId,
             op,
-        } = applyProjectContextWriteback(existingContent, args.entry);
+        } = applyProjectContextWriteback(existingContent, entry);
 
         const lastCommit = await getLastCommit({
             owner,
@@ -346,9 +352,9 @@ export class ProjectContextService extends BaseService {
                 op === 'create' ? 'adds a new' : 'updates an'
             } project context entry from an AI agent review finding.`,
             `- id: \`${entryId}\``,
-            `- kind: \`${args.entry.kind}\``,
+            `- kind: \`${entry.kind}\``,
             '',
-            args.entry.content,
+            entry.content,
         ];
         if (args.sourceThread) {
             bodyLines.push(

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -4234,9 +4234,51 @@ Parameters:
           "type": "string",
         },
         "objects": {
-          "description": "The semantic objects this fact concerns — explore names and/or field ids in the table_field form (e.g. "payments_total_amount"); [] when purely prompt-driven.",
+          "description": "The semantic objects this fact concerns. Use {type:"explore",name} for explores and {type:"field",explore,fieldId} for fields; [] when purely prompt-driven.",
           "items": {
-            "type": "string",
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "minLength": 1,
+                    "type": "string",
+                  },
+                  "type": {
+                    "const": "explore",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "type",
+                  "name",
+                ],
+                "type": "object",
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "explore": {
+                    "minLength": 1,
+                    "type": "string",
+                  },
+                  "fieldId": {
+                    "minLength": 1,
+                    "type": "string",
+                  },
+                  "type": {
+                    "const": "field",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "type",
+                  "explore",
+                  "fieldId",
+                ],
+                "type": "object",
+              },
+            ],
           },
           "type": "array",
         },

--- a/packages/backend/src/ee/services/ai/tools/filterProjectContext.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/filterProjectContext.test.ts
@@ -21,7 +21,18 @@ const entries: ProjectContextEntry[] = [
         id: 'sao-def',
         content: 'A sales accepted opportunity',
         terms: ['sao'],
-        objects: ['rpt_gtm_mission_control'],
+        objects: [
+            {
+                type: 'field',
+                explore: 'rpt_gtm_mission_control',
+                fieldId: 'opportunities_sao_date',
+            },
+        ],
+    }),
+    entry({
+        id: 'legacy-ref',
+        content: 'Legacy project context entry',
+        objects: ['legacy_orders'],
     }),
     entry({ id: 'unrelated', content: 'onboarding checklist steps' }),
 ];
@@ -40,6 +51,14 @@ describe('filterProjectContext', () => {
     it('matches on terms and objects', () => {
         expect(
             filterProjectContext(entries, ['mission_control']).map((e) => e.id),
+        ).toEqual(['sao-def']);
+        expect(
+            filterProjectContext(entries, ['legacy_orders']).map((e) => e.id),
+        ).toEqual(['legacy-ref']);
+        expect(
+            filterProjectContext(entries, ['opportunities_sao_date']).map(
+                (e) => e.id,
+            ),
         ).toEqual(['sao-def']);
     });
 

--- a/packages/backend/src/ee/services/ai/tools/filterProjectContext.ts
+++ b/packages/backend/src/ee/services/ai/tools/filterProjectContext.ts
@@ -1,4 +1,7 @@
-import type { ProjectContextEntry } from '@lightdash/common';
+import {
+    serializeAiProjectContextObjectRef,
+    type ProjectContextEntry,
+} from '@lightdash/common';
 import { compileMatcher } from './grepFieldsIndex';
 
 /**
@@ -20,7 +23,7 @@ export const filterProjectContext = (
                 entry.id,
                 entry.kind,
                 ...entry.terms,
-                ...entry.objects,
+                ...entry.objects.map(serializeAiProjectContextObjectRef),
                 entry.content,
             ]
                 .join('\n')

--- a/packages/backend/src/ee/services/ai/tools/loadProjectContext.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/loadProjectContext.test.ts
@@ -15,7 +15,13 @@ const entries: ProjectContextEntry[] = [
         kind: 'context',
         content: 'A sales accepted opportunity',
         terms: ['sao'],
-        objects: [],
+        objects: [
+            {
+                type: 'field',
+                explore: 'rpt_gtm_mission_control',
+                fieldId: 'opportunities_sao_date',
+            },
+        ],
     },
     {
         id: 'unrelated',
@@ -23,6 +29,13 @@ const entries: ProjectContextEntry[] = [
         content: 'onboarding',
         terms: [],
         objects: [],
+    },
+    {
+        id: 'legacy-ref',
+        kind: 'context',
+        content: 'Use the legacy orders reference',
+        terms: [],
+        objects: ['legacy_orders'],
     },
 ];
 
@@ -47,6 +60,7 @@ describe('loadProjectContext tool', () => {
             'arr-def',
             'sao-def',
             'unrelated',
+            'legacy-ref',
         ]);
     });
 
@@ -55,6 +69,18 @@ describe('loadProjectContext tool', () => {
         expect(res.metadata.entryIds).toEqual(['arr-def']);
         expect(res.result).toContain('ARR means annual recurring revenue');
         expect(res.result).not.toContain('onboarding');
+    });
+
+    it('renders typed refs with owning explores', async () => {
+        const res = await run(['opportunities_sao_date']);
+        expect(res.result).toContain(
+            'field "opportunities_sao_date" in explore "rpt_gtm_mission_control"',
+        );
+    });
+
+    it('renders legacy string refs', async () => {
+        const res = await run(['legacy_orders']);
+        expect(res.result).toContain('refs: legacy_orders');
     });
 
     it('lists available entries when nothing matches', async () => {

--- a/packages/backend/src/ee/services/ai/tools/loadProjectContext.ts
+++ b/packages/backend/src/ee/services/ai/tools/loadProjectContext.ts
@@ -1,5 +1,7 @@
 import {
+    formatAiProjectContextObjectRef,
     loadProjectContextToolDefinition,
+    serializeAiProjectContextObjectRef,
     type ProjectContextEntry,
 } from '@lightdash/common';
 import { tool } from 'ai';
@@ -20,7 +22,7 @@ const renderEntries = (entries: ProjectContextEntry[]): string => {
                     : '';
             const refs =
                 entry.objects.length > 0
-                    ? ` refs: ${entry.objects.join(', ')};`
+                    ? ` refs: ${entry.objects.map(formatAiProjectContextObjectRef).join(', ')};`
                     : '';
             const prefix = `- id: ${entry.id}; kind: ${entry.kind};${terms}${refs}`;
             return `${prefix} content: ${entry.content}`;
@@ -78,7 +80,9 @@ export const getLoadProjectContext = ({
                             e.content.length +
                             e.id.length +
                             e.terms.join(' ').length +
-                            e.objects.join(' ').length +
+                            e.objects
+                                .map(serializeAiProjectContextObjectRef)
+                                .join(' ').length +
                             32,
                         0,
                     ) / 4,

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
@@ -321,9 +321,28 @@ describe('aiAgentJudgeProjectContextEntrySchema', () => {
             kind: 'definition',
             content: 'updated definition',
             terms: ['HR'],
-            objects: ['patient_health_scores'],
+            objects: [
+                { type: 'explore', name: 'patient_health_scores' },
+                {
+                    type: 'field',
+                    explore: 'patient_health_scores',
+                    fieldId: 'patient_health_scores_diabetes_risk_category',
+                },
+            ],
         });
         expect(result.success).toBe(true);
+    });
+
+    test('rejects legacy string object refs from new judge output', () => {
+        const result = aiAgentJudgeProjectContextEntrySchema.safeParse({
+            op: 'create',
+            id: null,
+            kind: 'context',
+            content: 'Use the payments explore.',
+            terms: [],
+            objects: ['payments'],
+        });
+        expect(result.success).toBe(false);
     });
 
     test('rejects an update entry without an id', () => {

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -4,7 +4,11 @@ import type { PullRequestProvider } from '../../types/gitIntegration';
 import type { MetricQuery } from '../../types/metricQuery';
 import type { QueryHistoryStatus } from '../../types/queryHistory';
 import type { AiAgentDocumentStructuredSummary } from './documentTypes';
-import { projectContextEntryKinds } from './projectContext';
+import {
+    aiProjectContextTypedObjectRefSchema,
+    projectContextEntryKinds,
+    type AiProjectContextObjectRef,
+} from './projectContext';
 import type { AiAgentReviewClassifierEventType } from './requestTypes';
 
 export type AiAgentReviewClassifierSubject = {
@@ -475,7 +479,7 @@ export const aiAgentJudgeProjectContextEntrySchema = z
         kind: z.enum(projectContextEntryKinds),
         content: z.string(),
         terms: z.array(z.string()),
-        objects: z.array(z.string()),
+        objects: z.array(aiProjectContextTypedObjectRefSchema),
     })
     .superRefine((entry, ctx) => {
         if (entry.op === 'update' && !entry.id) {
@@ -487,16 +491,15 @@ export const aiAgentJudgeProjectContextEntrySchema = z
         }
     });
 
-// Concrete type (not z.infer) so tsoa can resolve it where it surfaces in API
-// responses (AiAgentReviewItemSummary). Kept structurally in sync with
-// aiAgentJudgeProjectContextEntrySchema above.
+// Concrete type (not z.infer) so tsoa can resolve it in API responses. The
+// string union preserves persisted findings written before typed refs.
 export type AiAgentJudgeProjectContextEntry = {
     op: 'create' | 'update';
     id: string | null;
     kind: 'definition' | 'context';
     content: string;
     terms: string[];
-    objects: string[];
+    objects: AiProjectContextObjectRef[];
 };
 
 // Signals that describe a healthy turn — mutually exclusive with promotion.

--- a/packages/common/src/ee/AiAgent/projectContext.test.ts
+++ b/packages/common/src/ee/AiAgent/projectContext.test.ts
@@ -1,9 +1,12 @@
 import { ParseError } from '../../types/errors';
 import {
     applyProjectContextWriteback,
+    formatAiProjectContextObjectRef,
     loadProjectContextFile,
     mergeProjectContextEntry,
     PROJECT_CONTEXT_FILE_HEADER,
+    projectContextEntrySchema,
+    serializeAiProjectContextObjectRef,
     serializeProjectContextFile,
     type ProjectContextEntry,
 } from './projectContext';
@@ -18,6 +21,26 @@ const entry = (
     ...overrides,
 });
 
+describe('legacy object refs', () => {
+    test('remain readable in persisted project context entries', () => {
+        const parsed = projectContextEntrySchema.parse({
+            id: 'legacy',
+            kind: 'context',
+            content: 'Use orders.',
+            terms: [],
+            objects: ['orders'],
+        });
+
+        expect(parsed.objects).toEqual(['orders']);
+        expect(serializeAiProjectContextObjectRef(parsed.objects[0])).toBe(
+            'orders',
+        );
+        expect(formatAiProjectContextObjectRef(parsed.objects[0])).toBe(
+            'orders',
+        );
+    });
+});
+
 describe('loadProjectContextFile', () => {
     test('parses a fully-specified entry', () => {
         const yaml = `
@@ -25,7 +48,10 @@ describe('loadProjectContextFile', () => {
   kind: definition
   content: '"HR" = the high-risk diabetes cohort, not human resources.'
   terms: [HR, high risk]
-  objects: [patient_health_scores.diabetes_risk_category]
+  objects:
+    - type: field
+      explore: patient_health_scores
+      fieldId: patient_health_scores_diabetes_risk_category
 `;
         expect(loadProjectContextFile(yaml)).toEqual([
             {
@@ -34,7 +60,13 @@ describe('loadProjectContextFile', () => {
                 content:
                     '"HR" = the high-risk diabetes cohort, not human resources.',
                 terms: ['HR', 'high risk'],
-                objects: ['patient_health_scores.diabetes_risk_category'],
+                objects: [
+                    {
+                        type: 'field',
+                        explore: 'patient_health_scores',
+                        fieldId: 'patient_health_scores_diabetes_risk_category',
+                    },
+                ],
             },
         ]);
     });
@@ -91,6 +123,16 @@ describe('loadProjectContextFile', () => {
 - id: broken
   kind: nonsense
   content: 'whatever'
+`;
+        expect(() => loadProjectContextFile(yaml)).toThrow(ParseError);
+    });
+
+    test('rejects legacy string object refs in v2 files', () => {
+        const yaml = `
+- id: routing
+  kind: context
+  content: Use payments.
+  objects: [payments]
 `;
         expect(() => loadProjectContextFile(yaml)).toThrow(ParseError);
     });
@@ -163,7 +205,7 @@ describe('mergeProjectContextEntry', () => {
             kind: 'context',
             content: 'Attribute payments via customer_order_payments.',
             terms: [],
-            objects: ['payments'],
+            objects: [{ type: 'explore', name: 'payments' }],
         });
         expect(result.entryId).toBe('patient-routing');
         expect(result.entries).toHaveLength(1);
@@ -277,13 +319,13 @@ describe('serializeProjectContextFile', () => {
         const output = serializeProjectContextFile([
             entry({ id: 'hr', kind: 'definition', content: 'x' }),
         ]);
-        expect(output).toContain('version: 1');
+        expect(output).toContain('version: 2');
         expect(output).toContain('entries:');
     });
 
     test('parses the versioned { version, entries } shape', () => {
         const yaml = `
-version: 1
+version: 2
 entries:
   - id: hr
     kind: definition
@@ -301,9 +343,9 @@ entries:
         ]);
     });
 
-    test('throws on unsupported document versions', () => {
+    test('rejects v1 documents', () => {
         const yaml = `
-version: 2
+version: 1
 entries:
   - id: hr
     kind: definition
@@ -325,7 +367,7 @@ describe('applyProjectContextWriteback', () => {
         });
         expect(op).toBe('create');
         expect(entryId).toBe('mrr');
-        expect(content).toContain('version: 1');
+        expect(content).toContain('version: 2');
         expect(content.startsWith(PROJECT_CONTEXT_FILE_HEADER)).toBe(true);
         expect(loadProjectContextFile(content)).toEqual([
             {
@@ -362,7 +404,7 @@ describe('applyProjectContextWriteback', () => {
     });
 
     test('appends a new entry, preserving existing comments and entries verbatim', () => {
-        const existing = `version: 1
+        const existing = `version: 2
 entries:
   # Curated by the data team — do not reorder.
   - id: hr
@@ -391,7 +433,7 @@ entries:
     });
 
     test('updates an existing entry in place by id', () => {
-        const existing = `version: 1
+        const existing = `version: 2
 entries:
   - id: mrr
     kind: definition

--- a/packages/common/src/ee/AiAgent/projectContext.ts
+++ b/packages/common/src/ee/AiAgent/projectContext.ts
@@ -4,8 +4,9 @@ import betterAjvErrors from 'better-ajv-errors';
 import * as yaml from 'js-yaml';
 import { isMap, isSeq, parseDocument } from 'yaml';
 import { z } from 'zod';
-import lightdashProjectContextSchema from '../../schemas/json/lightdash-project-context-1.0.json';
+import lightdashProjectContextSchema from '../../schemas/json/lightdash-project-context-2.0.json';
 import { ParseError } from '../../types/errors';
+import assertUnreachable from '../../utils/assertUnreachable';
 
 // Two kinds, by retrieval intent: `definition` is term-triggered (acronyms,
 // vocabulary, "X means Y"); `context` is the object-scoped catch-all
@@ -15,7 +16,73 @@ export const projectContextEntryKinds = ['definition', 'context'] as const;
 
 // Top-level file version. The file is `{ version, entries }`; bumping this is
 // the escape hatch for a future hard schema break, without per-entry churn.
-export const PROJECT_CONTEXT_FILE_VERSION = 1;
+export const PROJECT_CONTEXT_FILE_VERSION = 2;
+
+export type AiProjectContextTypedObjectRef =
+    | { type: 'explore'; name: string }
+    | { type: 'field'; explore: string; fieldId: string };
+
+export type AiProjectContextObjectRef = string | AiProjectContextTypedObjectRef;
+
+export const aiProjectContextTypedObjectRefSchema: z.ZodType<AiProjectContextTypedObjectRef> =
+    z.discriminatedUnion('type', [
+        z
+            .object({
+                type: z.literal('explore'),
+                name: z.string().min(1),
+            })
+            .strict(),
+        z
+            .object({
+                type: z.literal('field'),
+                explore: z.string().min(1),
+                fieldId: z.string().min(1),
+            })
+            .strict(),
+    ]);
+
+export const aiProjectContextObjectRefSchema: z.ZodType<AiProjectContextObjectRef> =
+    z.union([z.string().min(1), aiProjectContextTypedObjectRefSchema]);
+
+export const serializeAiProjectContextObjectRef = (
+    ref: AiProjectContextObjectRef,
+): string => {
+    if (typeof ref === 'string') {
+        return ref;
+    }
+
+    switch (ref.type) {
+        case 'explore':
+            return ref.name;
+        case 'field':
+            return `${ref.explore}\n${ref.fieldId}`;
+        default:
+            return assertUnreachable(
+                ref,
+                'Unknown AI project context object ref type',
+            );
+    }
+};
+
+export const formatAiProjectContextObjectRef = (
+    ref: AiProjectContextObjectRef,
+): string => {
+    if (typeof ref === 'string') {
+        return ref;
+    }
+
+    switch (ref.type) {
+        case 'explore':
+            return `explore "${ref.name}"`;
+        case 'field':
+            return `field "${ref.fieldId}" in explore "${ref.explore}"`;
+        default:
+            return assertUnreachable(
+                ref,
+                'Unknown AI project context object ref type',
+            );
+    }
+};
 
 // Canonical, post-ingest entry: `id` is always present (derived if the file
 // omitted it). This is what selection, the cache, and the API speak.
@@ -24,7 +91,7 @@ export const projectContextEntrySchema = z.object({
     kind: z.enum(projectContextEntryKinds),
     content: z.string().min(1),
     terms: z.array(z.string()).default([]),
-    objects: z.array(z.string()).default([]),
+    objects: z.array(aiProjectContextObjectRefSchema).default([]),
 });
 
 export type ProjectContextEntry = z.infer<typeof projectContextEntrySchema>;
@@ -39,7 +106,7 @@ type ProjectContextFileEntry = Omit<
 > & {
     id?: string;
     terms?: string[];
-    objects?: string[];
+    objects?: AiProjectContextObjectRef[];
     [key: string]: unknown;
 };
 
@@ -52,7 +119,7 @@ export type ProjectContextWritebackEntry = {
     kind: ProjectContextEntry['kind'];
     content: string;
     terms: string[];
-    objects: string[];
+    objects: AiProjectContextTypedObjectRef[];
 };
 
 const slugifyId = (value: string): string =>

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditProjectContextArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditProjectContextArgs.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { aiProjectContextTypedObjectRefSchema } from '../../projectContext';
 
 export const TOOL_EDIT_PROJECT_CONTEXT_DESCRIPTION = [
     "Open or update a pull request that changes this project's Lightdash project context — the lightdash.project_context.yml living document of business definitions and routing/context facts the AI agents read before answering.",
@@ -37,9 +38,9 @@ export const toolEditProjectContextArgsSchema = z.object({
             'The prompt-facing trigger words/phrases that should surface this entry (e.g. ["HR","high risk"]). Required for definitions.',
         ),
     objects: z
-        .array(z.string())
+        .array(aiProjectContextTypedObjectRefSchema)
         .describe(
-            'The semantic objects this fact concerns — explore names and/or field ids in the table_field form (e.g. "payments_total_amount"); [] when purely prompt-driven.',
+            'The semantic objects this fact concerns. Use {type:"explore",name} for explores and {type:"field",explore,fieldId} for fields; [] when purely prompt-driven.',
         ),
 });
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -84,7 +84,7 @@ export * from './pivot/utils';
 export { default as chartAsCodeSchema } from './schemas/json/chart-as-code-1.0.json';
 export { default as dashboardAsCodeSchema } from './schemas/json/dashboard-as-code-1.0.json';
 export { default as lightdashDbtYamlSchema } from './schemas/json/lightdash-dbt-2.0.json';
-export { default as lightdashProjectContextSchema } from './schemas/json/lightdash-project-context-1.0.json';
+export { default as lightdashProjectContextSchema } from './schemas/json/lightdash-project-context-2.0.json';
 export { default as lightdashProjectConfigSchema } from './schemas/json/lightdash-project-config-1.0.json';
 export { default as modelAsCodeSchema } from './schemas/json/model-as-code-1.0.json';
 export * from './templating/liquidSql';

--- a/packages/common/src/schemas/json/lightdash-project-context-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-project-context-2.0.json
@@ -16,7 +16,7 @@
             "properties": {
                 "version": {
                     "type": "number",
-                    "const": 1
+                    "const": 2
                 },
                 "entries": {
                     "$ref": "#/definitions/entries"
@@ -60,7 +60,7 @@
                 "objects": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/objectRef"
                     },
                     "description": "Semantic objects this fact concerns.",
                     "default": []
@@ -68,6 +68,29 @@
             },
             "required": ["kind", "content"],
             "additionalProperties": true
+        },
+        "objectRef": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "type": { "const": "explore" },
+                        "name": { "type": "string", "minLength": 1 }
+                    },
+                    "required": ["type", "name"],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "type": { "const": "field" },
+                        "explore": { "type": "string", "minLength": 1 },
+                        "fieldId": { "type": "string", "minLength": 1 }
+                    },
+                    "required": ["type", "explore", "fieldId"],
+                    "additionalProperties": false
+                }
+            ]
         }
     }
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.test.tsx
@@ -79,7 +79,7 @@ vi.mock('../../hooks/useAiAgentAdmin', () => ({
                         content:
                             'Active user means a customer with a completed checkout in the last 28 days.',
                         terms: ['active user'],
-                        objects: ['customers'],
+                        objects: [{ type: 'explore', name: 'customers' }],
                     },
                     createdAt: new Date('2026-06-10T08:00:00.000Z'),
                 },
@@ -177,7 +177,7 @@ describe('ThreadPreviewSidebar', () => {
         fireEvent.click(screen.getByRole('button', { name: /why flagged/i }));
         expect(
             screen.getAllByText(
-                'Adds project context: Active user means a customer with a completed checkout in the last 28 days.',
+                'Adds project context: Active user means a customer with a completed checkout in the last 28 days. Objects: explore "customers".',
             ).length,
         ).toBeGreaterThan(0);
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
     formatRelativeReviewDate,
     getIssueTitle,
+    getReviewReasoningText,
     getTargetAnchor,
 } from './reviewItemDetails';
 
@@ -61,6 +62,26 @@ describe('getIssueTitle', () => {
             latestFinding: { recommendation: null },
         });
         expect(getIssueTitle(item)).toBe('No metric for weekly active users');
+    });
+});
+
+describe('getReviewReasoningText', () => {
+    it('formats a persisted legacy string ref', () => {
+        const item = makeItem({
+            primaryRootCause: 'project_context',
+            latestFinding: {
+                projectContextEntry: {
+                    op: 'create',
+                    id: null,
+                    kind: 'context',
+                    content: 'Use the orders explore.',
+                    terms: [],
+                    objects: ['orders'],
+                },
+            },
+        });
+
+        expect(getReviewReasoningText(item)).toContain('Objects: orders.');
     });
 });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
@@ -1,4 +1,5 @@
 import {
+    formatAiProjectContextObjectRef,
     type AiAgentRecommendationAction,
     type AiAgentReviewItemPriority,
     type AiAgentReviewItemSummary,
@@ -237,9 +238,14 @@ export const getReviewReasoningText = (
     const contextEntry = reviewItem.latestFinding?.projectContextEntry ?? null;
 
     if (contextEntry) {
+        const objectRefs = contextEntry.objects
+            .map(formatAiProjectContextObjectRef)
+            .join(', ');
         return `${
             contextEntry.op === 'update' ? 'Updates' : 'Adds'
-        } project context: ${contextEntry.content}`;
+        } project context: ${contextEntry.content}${
+            objectRefs ? ` Objects: ${objectRefs}.` : ''
+        }`;
     }
 
     return getWhyText(reviewItem);

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedReviewEntityCard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedReviewEntityCard.test.tsx
@@ -53,7 +53,13 @@ describe('PinnedReviewEntityCard', () => {
                     kind: 'definition',
                     content: 'Active user = signed in within 28 days',
                     terms: ['active user'],
-                    objects: [],
+                    objects: [
+                        {
+                            type: 'field',
+                            explore: 'users',
+                            fieldId: 'users_last_login_at',
+                        },
+                    ],
                 },
             },
         });
@@ -62,6 +68,29 @@ describe('PinnedReviewEntityCard', () => {
         expect(
             screen.getByText('Active user = signed in within 28 days'),
         ).toBeInTheDocument();
+        expect(
+            screen.getByText('field "users_last_login_at" in explore "users"'),
+        ).toBeInTheDocument();
+    });
+
+    it('renders a persisted legacy string ref', () => {
+        renderCard({
+            type: 'proposed_change',
+            fingerprint: 'fp-legacy',
+            payload: {
+                changeKind: 'project_context',
+                entry: {
+                    op: 'create',
+                    id: null,
+                    kind: 'context',
+                    content: 'Use the orders explore',
+                    terms: [],
+                    objects: ['orders'],
+                },
+            },
+        });
+
+        expect(screen.getByText('orders')).toBeInTheDocument();
     });
 
     it('renders a semantic-layer proposed change card with the recommendation title', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedReviewEntityCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedReviewEntityCard.tsx
@@ -1,5 +1,6 @@
 import {
     assertUnreachable,
+    formatAiProjectContextObjectRef,
     type AiAgentReviewItemPrState,
 } from '@lightdash/common';
 import {
@@ -90,12 +91,21 @@ const ProposedChangeRow: FC<{
         payload.changeKind === 'project_context'
             ? payload.entry.content
             : payload.recommendation.title;
+    const objectRefs =
+        payload.changeKind === 'project_context'
+            ? payload.entry.objects.map(formatAiProjectContextObjectRef)
+            : [];
     return (
         <Row icon={IconPencil}>
             <Text className={styles.eyebrow}>Proposed change</Text>
             <Text fz="xs" c="ldGray.8">
                 {summary}
             </Text>
+            {objectRefs.length > 0 && (
+                <Text fz={11} c="dimmed">
+                    {objectRefs.join(', ')}
+                </Text>
+            )}
         </Row>
     );
 };


### PR DESCRIPTION
### Description

- replace project-context string objects with typed explore and field refs
- bump the project-context file contract to v2 and reject v1/string refs
- preserve project-context grep/load behavior and render owning explores in review UI
- keep this as a clean alpha break with no data migration

### Validation

- common focused tests: 62 passed
- backend focused tests: 25 passed
- frontend focused tests: 14 passed
- common, backend, and frontend fast typechecks passed
- package-scoped common, backend, and frontend lint passed
- generated API command completed successfully; generated artifacts remain release-managed
- manual legacy-row verification: string ref matched and rendered without error\n- independent review: no actionable findings

Closes: ZAP-671

## API compatibility

allow-api-breaking-change — Project context is an unused alpha contract intentionally bumped from v1 to v2.