### PR TITLE
feat: add AI agent memory storage

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -402,6 +402,12 @@ import {
     AiAgentDocumentTableName,
 } from '../ee/database/entities/aiAgentDocument';
 import {
+    AiAgentMemoryTable,
+    AiAgentMemoryTableName,
+    AiAgentThreadDistillTable,
+    AiAgentThreadDistillTableName,
+} from '../ee/database/entities/aiAgentMemory';
+import {
     AiAgentReviewClassifierRunTable,
     AiAgentReviewClassifierRunTableName,
     AiAgentReviewItemTable,
@@ -621,6 +627,8 @@ declare module 'knex/types/tables' {
         [AiAgentTableName]: AiAgentTable;
         [AiAgentDocumentTableName]: AiAgentDocumentTable;
         [AiAgentDocumentAccessTableName]: AiAgentDocumentAccessTable;
+        [AiAgentMemoryTableName]: AiAgentMemoryTable;
+        [AiAgentThreadDistillTableName]: AiAgentThreadDistillTable;
         [AiAgentReviewClassifierRunTableName]: AiAgentReviewClassifierRunTable;
         [AiAgentTurnSignalTableName]: AiAgentTurnSignalTable;
         [AiAgentReviewItemTableName]: AiAgentReviewItemTable;

--- a/packages/backend/src/ee/database/entities/aiAgentMemory.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentMemory.ts
@@ -1,0 +1,107 @@
+import type { AiProjectContextTypedObjectRef } from '@lightdash/common';
+import { Knex } from 'knex';
+
+export const AiAgentMemoryTableName = 'ai_agent_memory';
+export const AiAgentThreadDistillTableName = 'ai_agent_thread_distill';
+
+export type AiAgentMemoryStatus = 'active' | 'superseded' | 'retired';
+export type AiAgentThreadDistillOutcome =
+    | 'memory'
+    | 'no_op'
+    | 'skipped'
+    | 'failed';
+
+export type DbAiAgentMemory = {
+    ai_agent_memory_uuid: string;
+    organization_uuid: string;
+    project_uuid: string;
+    agent_uuid: string | null;
+    user_uuid: string | null;
+    source_thread_uuid: string | null;
+    slug: string;
+    title: string;
+    raw_memory: string;
+    thread_summary: string | null;
+    terms: string[];
+    objects: AiProjectContextTypedObjectRef[];
+    unresolved_objects: AiProjectContextTypedObjectRef[];
+    status: AiAgentMemoryStatus;
+    superseded_by_uuid: string | null;
+    generated_at: Date;
+    cited_count: number;
+    last_cited_at: Date | null;
+    pulled_count: number;
+    last_pulled_at: Date | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+type AiAgentMemoryJsonbWrite = {
+    terms: string;
+    objects: string;
+    unresolved_objects: string;
+};
+
+export type AiAgentMemoryTable = Knex.CompositeTableType<
+    DbAiAgentMemory,
+    Omit<
+        DbAiAgentMemory,
+        | keyof AiAgentMemoryJsonbWrite
+        | 'ai_agent_memory_uuid'
+        | 'status'
+        | 'superseded_by_uuid'
+        | 'cited_count'
+        | 'last_cited_at'
+        | 'pulled_count'
+        | 'last_pulled_at'
+        | 'created_at'
+        | 'updated_at'
+    > &
+        Partial<
+            Pick<
+                DbAiAgentMemory,
+                | 'status'
+                | 'superseded_by_uuid'
+                | 'cited_count'
+                | 'last_cited_at'
+                | 'pulled_count'
+                | 'last_pulled_at'
+            >
+        >,
+    Partial<
+        Omit<
+            DbAiAgentMemory,
+            | keyof AiAgentMemoryJsonbWrite
+            | 'ai_agent_memory_uuid'
+            | 'created_at'
+            | 'updated_at'
+        > &
+            AiAgentMemoryJsonbWrite
+    > & { updated_at?: Knex.Raw }
+>;
+
+export type DbAiAgentThreadDistill = {
+    ai_agent_thread_distill_uuid: string;
+    ai_thread_uuid: string;
+    outcome: AiAgentThreadDistillOutcome;
+    no_op_reason: string | null;
+    error_message: string | null;
+    distill_prompt_hash: string | null;
+    distilled_up_to: Date;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type AiAgentThreadDistillTable = Knex.CompositeTableType<
+    DbAiAgentThreadDistill,
+    Omit<
+        DbAiAgentThreadDistill,
+        'ai_agent_thread_distill_uuid' | 'created_at' | 'updated_at'
+    >,
+    Partial<
+        Omit<
+            DbAiAgentThreadDistill,
+            'ai_agent_thread_distill_uuid' | 'ai_thread_uuid' | 'created_at'
+        >
+    > & { updated_at: Knex.Raw }
+>;

--- a/packages/backend/src/ee/database/migrations/20260722153729_add_ai_agent_memory_tables.ts
+++ b/packages/backend/src/ee/database/migrations/20260722153729_add_ai_agent_memory_tables.ts
@@ -1,0 +1,121 @@
+import { Knex } from 'knex';
+
+const AiAgentMemoryTableName = 'ai_agent_memory';
+const AiAgentThreadDistillTableName = 'ai_agent_thread_distill';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(AiAgentThreadDistillTableName, (table) => {
+        table
+            .uuid('ai_agent_thread_distill_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('ai_thread_uuid')
+            .notNullable()
+            .references('ai_thread_uuid')
+            .inTable('ai_thread')
+            .onDelete('CASCADE')
+            .unique();
+        table.text('outcome').notNullable();
+        table.text('no_op_reason').nullable();
+        table.text('error_message').nullable();
+        table.text('distill_prompt_hash').nullable();
+        table.timestamp('distilled_up_to', { useTz: false }).notNullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+    await knex.schema.createTable(AiAgentMemoryTableName, (table) => {
+        table
+            .uuid('ai_agent_memory_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('organization_uuid')
+            .notNullable()
+            .references('organization_uuid')
+            .inTable('organizations')
+            .onDelete('CASCADE')
+            .index();
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE')
+            .index();
+        table
+            .uuid('agent_uuid')
+            .nullable()
+            .references('ai_agent_uuid')
+            .inTable('ai_agent')
+            .onDelete('SET NULL')
+            .index();
+        table
+            .uuid('user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('SET NULL')
+            .index();
+        table
+            .uuid('source_thread_uuid')
+            .nullable()
+            .references('ai_thread_uuid')
+            .inTable('ai_thread')
+            .onDelete('SET NULL')
+            .index();
+        table.text('slug').notNullable();
+        table.text('title').notNullable();
+        table.text('raw_memory').notNullable();
+        table.text('thread_summary').nullable();
+        table.jsonb('terms').notNullable().defaultTo('[]');
+        table.jsonb('objects').notNullable().defaultTo('[]');
+        table.jsonb('unresolved_objects').notNullable().defaultTo('[]');
+        table.text('status').notNullable().defaultTo('active');
+        table
+            .uuid('superseded_by_uuid')
+            .nullable()
+            .references('ai_agent_memory_uuid')
+            .inTable(AiAgentMemoryTableName)
+            .onDelete('SET NULL')
+            .index();
+        table
+            .timestamp('generated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table.integer('cited_count').notNullable().defaultTo(0);
+        table.timestamp('last_cited_at', { useTz: false }).nullable();
+        table.integer('pulled_count').notNullable().defaultTo(0);
+        table.timestamp('last_pulled_at', { useTz: false }).nullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table.unique(['project_uuid', 'slug']);
+    });
+    await knex.raw(`
+        CREATE UNIQUE INDEX ai_agent_memory_one_active_per_thread
+        ON ${AiAgentMemoryTableName} (source_thread_uuid)
+        WHERE status = 'active' AND source_thread_uuid IS NOT NULL
+    `);
+    await knex.raw(`
+        CREATE INDEX ai_agent_memory_injection_ranking
+        ON ${AiAgentMemoryTableName} (project_uuid, last_cited_at DESC NULLS LAST, generated_at DESC)
+        WHERE status = 'active'
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(AiAgentMemoryTableName);
+    await knex.schema.dropTableIfExists(AiAgentThreadDistillTableName);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -30,6 +30,7 @@ import OpenAi from './clients/OpenAi';
 import { CommercialSlackClient } from './clients/Slack/SlackClient';
 import { AgentOnboardingRunModel } from './models/AgentOnboardingRunModel';
 import { AiAgentDocumentModel } from './models/AiAgentDocumentModel';
+import { AiAgentMemoryModel } from './models/AiAgentMemoryModel';
 import { AiAgentModel } from './models/AiAgentModel';
 import { AiAgentReviewClassifierModel } from './models/AiAgentReviewClassifierModel';
 import { AiAgentReviewNotificationModel } from './models/AiAgentReviewNotificationModel';
@@ -965,6 +966,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     lightdashConfig,
                     encryptionUtil: utils.getEncryptionUtil(),
                 }),
+            aiAgentMemoryModel: ({ database }) =>
+                new AiAgentMemoryModel({ database }),
             aiAgentDocumentModel: ({ database }) =>
                 new AiAgentDocumentModel({ database }),
             aiWritebackThreadModel: ({ database }) =>

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
@@ -1,0 +1,245 @@
+import { SEED_ORG_1, SEED_PROJECT } from '@lightdash/common';
+import type { Knex } from 'knex';
+import { getTestContext } from '../../vitest.setup.integration';
+import { AiThreadTableName } from '../database/entities/ai';
+import {
+    AiAgentMemoryTableName,
+    AiAgentThreadDistillTableName,
+} from '../database/entities/aiAgentMemory';
+import { AiAgentMemoryModel } from './AiAgentMemoryModel';
+
+describe('AiAgentMemoryModel integration', () => {
+    let database: Knex;
+    let model: AiAgentMemoryModel;
+    const threadUuids = new Set<string>();
+
+    beforeAll(() => {
+        database = getTestContext().db;
+        model = getTestContext()
+            .app.getModels()
+            .getAiAgentMemoryModel<AiAgentMemoryModel>();
+    });
+
+    afterEach(async () => {
+        if (threadUuids.size === 0) {
+            return;
+        }
+
+        const ids = [...threadUuids];
+        await database(AiAgentMemoryTableName)
+            .whereIn('source_thread_uuid', ids)
+            .delete();
+        await database(AiAgentThreadDistillTableName)
+            .whereIn('ai_thread_uuid', ids)
+            .delete();
+        await database(AiThreadTableName)
+            .whereIn('ai_thread_uuid', ids)
+            .delete();
+        threadUuids.clear();
+    });
+
+    const createThread = async () => {
+        const [thread] = await database(AiThreadTableName)
+            .insert({
+                organization_uuid: SEED_ORG_1.organization_uuid,
+                project_uuid: SEED_PROJECT.project_uuid,
+                created_from: 'web_app',
+                agent_uuid: null,
+            })
+            .returning('ai_thread_uuid');
+        threadUuids.add(thread.ai_thread_uuid);
+        return thread.ai_thread_uuid;
+    };
+
+    const memoryInput = (
+        sourceThreadUuid: string,
+        overrides: Partial<
+            Parameters<AiAgentMemoryModel['upsertSourceThreadMemory']>[0]
+        > = {},
+    ) => ({
+        organizationUuid: SEED_ORG_1.organization_uuid,
+        projectUuid: SEED_PROJECT.project_uuid,
+        agentUuid: null,
+        userUuid: null,
+        sourceThreadUuid,
+        slug: `memory-${crypto.randomUUID().slice(0, 8)}`,
+        title: 'Net revenue convention',
+        rawMemory: 'Use net revenue.',
+        threadSummary: 'The user established the revenue convention.',
+        terms: ['revenue'],
+        objects: [
+            {
+                type: 'field' as const,
+                explore: 'orders',
+                fieldId: 'orders_net_revenue',
+            },
+        ],
+        unresolvedObjects: [],
+        generatedAt: new Date('2026-07-22T10:00:00Z'),
+        ...overrides,
+    });
+
+    it('replaces source-thread content while keeping slug and telemetry', async () => {
+        const sourceThreadUuid = await createThread();
+        const first = await model.upsertSourceThreadMemory(
+            memoryInput(sourceThreadUuid),
+        );
+        const citedAt = new Date('2026-07-22T11:00:00Z');
+        const pulledAt = new Date('2026-07-22T12:00:00Z');
+        await database(AiAgentMemoryTableName)
+            .where('ai_agent_memory_uuid', first.ai_agent_memory_uuid)
+            .update({
+                cited_count: 3,
+                last_cited_at: citedAt,
+                pulled_count: 5,
+                last_pulled_at: pulledAt,
+            });
+
+        const generatedAt = new Date('2026-07-22T13:00:00Z');
+        const updated = await model.upsertSourceThreadMemory(
+            memoryInput(sourceThreadUuid, {
+                slug: 'replacement-slug-is-ignored',
+                title: 'Recognized net revenue convention',
+                rawMemory: 'Use recognized net revenue.',
+                threadSummary: 'The resumed thread confirmed the convention.',
+                terms: ['net revenue'],
+                objects: [{ type: 'explore', name: 'orders' }],
+                unresolvedObjects: [
+                    { type: 'explore', name: 'missing_orders' },
+                ],
+                generatedAt,
+            }),
+        );
+
+        expect(updated).toMatchObject({
+            ai_agent_memory_uuid: first.ai_agent_memory_uuid,
+            slug: first.slug,
+            title: 'Recognized net revenue convention',
+            raw_memory: 'Use recognized net revenue.',
+            thread_summary: 'The resumed thread confirmed the convention.',
+            terms: ['net revenue'],
+            objects: [{ type: 'explore', name: 'orders' }],
+            unresolved_objects: [{ type: 'explore', name: 'missing_orders' }],
+            generated_at: generatedAt,
+            cited_count: 3,
+            last_cited_at: citedAt,
+            pulled_count: 5,
+            last_pulled_at: pulledAt,
+        });
+    });
+
+    it('upserts one ledger row and clears stale outcome details', async () => {
+        const aiThreadUuid = await createThread();
+        const memory = await model.upsertSourceThreadMemory(
+            memoryInput(aiThreadUuid),
+        );
+        const first = await model.upsertThreadDistill({
+            aiThreadUuid,
+            outcome: 'memory',
+            distillPromptHash: 'hash-1',
+            distilledUpTo: new Date('2026-07-22T10:00:00Z'),
+        });
+
+        const noOp = await model.upsertThreadDistill({
+            aiThreadUuid,
+            outcome: 'no_op',
+            noOpReason: 'insufficient_signal',
+            distillPromptHash: 'hash-2',
+            distilledUpTo: new Date('2026-07-22T11:00:00Z'),
+        });
+        expect(noOp).toMatchObject({
+            ai_agent_thread_distill_uuid: first.ai_agent_thread_distill_uuid,
+            outcome: 'no_op',
+            no_op_reason: 'insufficient_signal',
+            error_message: null,
+            distilled_up_to: new Date('2026-07-22T11:00:00Z'),
+        });
+        const activeMemory = await database(AiAgentMemoryTableName)
+            .where('source_thread_uuid', aiThreadUuid)
+            .where('status', 'active')
+            .first();
+        expect(activeMemory?.ai_agent_memory_uuid).toBe(
+            memory.ai_agent_memory_uuid,
+        );
+
+        const failed = await model.upsertThreadDistill({
+            aiThreadUuid,
+            outcome: 'failed',
+            errorMessage: 'provider timeout',
+            distillPromptHash: 'hash-3',
+            distilledUpTo: new Date('2026-07-22T12:00:00Z'),
+        });
+        expect(failed).toMatchObject({
+            ai_agent_thread_distill_uuid: first.ai_agent_thread_distill_uuid,
+            outcome: 'failed',
+            no_op_reason: null,
+            error_message: 'provider timeout',
+            distill_prompt_hash: 'hash-3',
+        });
+
+        const succeeded = await model.upsertThreadDistill({
+            aiThreadUuid,
+            outcome: 'memory',
+            distillPromptHash: null,
+            distilledUpTo: new Date('2026-07-22T13:00:00Z'),
+        });
+        expect(succeeded).toMatchObject({
+            ai_agent_thread_distill_uuid: first.ai_agent_thread_distill_uuid,
+            outcome: 'memory',
+            no_op_reason: null,
+            error_message: null,
+            distill_prompt_hash: null,
+        });
+        const ledgerCount = await database(AiAgentThreadDistillTableName)
+            .where('ai_thread_uuid', aiThreadUuid)
+            .count<{ count: bigint }>('* as count')
+            .first();
+        expect(Number(ledgerCount?.count)).toBe(1);
+    });
+
+    it('returns only active project memories in citation ranking order', async () => {
+        const [firstThread, secondThread, thirdThread, retiredThread] =
+            await Promise.all([
+                createThread(),
+                createThread(),
+                createThread(),
+                createThread(),
+            ]);
+        const first = await model.upsertSourceThreadMemory(
+            memoryInput(firstThread, {
+                generatedAt: new Date('2026-07-22T12:00:00Z'),
+            }),
+        );
+        const second = await model.upsertSourceThreadMemory(
+            memoryInput(secondThread, {
+                generatedAt: new Date('2026-07-22T13:00:00Z'),
+            }),
+        );
+        const third = await model.upsertSourceThreadMemory(
+            memoryInput(thirdThread, {
+                generatedAt: new Date('2026-07-22T11:00:00Z'),
+            }),
+        );
+        const retired = await model.upsertSourceThreadMemory(
+            memoryInput(retiredThread, {
+                generatedAt: new Date('2026-07-22T14:00:00Z'),
+            }),
+        );
+        await database(AiAgentMemoryTableName)
+            .where('ai_agent_memory_uuid', first.ai_agent_memory_uuid)
+            .update({ last_cited_at: new Date('2026-07-22T09:00:00Z') });
+        await database(AiAgentMemoryTableName)
+            .where('ai_agent_memory_uuid', retired.ai_agent_memory_uuid)
+            .update({ status: 'retired' });
+
+        const rows = await model.findActiveForProject({
+            projectUuid: SEED_PROJECT.project_uuid,
+        });
+
+        expect(rows.map((row) => row.ai_agent_memory_uuid)).toEqual([
+            first.ai_agent_memory_uuid,
+            second.ai_agent_memory_uuid,
+            third.ai_agent_memory_uuid,
+        ]);
+    });
+});

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.ts
@@ -1,0 +1,175 @@
+import type { AiProjectContextTypedObjectRef } from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    AiAgentMemoryTableName,
+    AiAgentThreadDistillTableName,
+    type AiAgentMemoryTable,
+    type AiAgentThreadDistillTable,
+    type DbAiAgentMemory,
+    type DbAiAgentThreadDistill,
+} from '../database/entities/aiAgentMemory';
+
+type SourceThreadMemory = {
+    organizationUuid: string;
+    projectUuid: string;
+    agentUuid: string | null;
+    userUuid: string | null;
+    sourceThreadUuid: string;
+    slug: string;
+    title: string;
+    rawMemory: string;
+    threadSummary: string;
+    terms: string[];
+    objects: AiProjectContextTypedObjectRef[];
+    unresolvedObjects: AiProjectContextTypedObjectRef[];
+    generatedAt: Date;
+};
+
+type ThreadDistillResult = {
+    aiThreadUuid: string;
+    distillPromptHash: string | null;
+    distilledUpTo: Date;
+} & (
+    | {
+          outcome: 'memory';
+          noOpReason?: never;
+          errorMessage?: never;
+      }
+    | {
+          outcome: 'no_op';
+          noOpReason: string;
+          errorMessage?: never;
+      }
+    | {
+          outcome: 'failed';
+          noOpReason?: never;
+          errorMessage: string;
+      }
+);
+
+export class AiAgentMemoryModel {
+    private readonly database: Knex;
+
+    constructor({ database }: { database: Knex }) {
+        this.database = database;
+    }
+
+    async upsertSourceThreadMemory(
+        memory: SourceThreadMemory,
+    ): Promise<DbAiAgentMemory> {
+        const content = {
+            title: memory.title,
+            raw_memory: memory.rawMemory,
+            thread_summary: memory.threadSummary,
+            terms: JSON.stringify(memory.terms),
+            objects: JSON.stringify(memory.objects),
+            unresolved_objects: JSON.stringify(memory.unresolvedObjects),
+            generated_at: memory.generatedAt,
+        };
+        const [row] = await this.database<AiAgentMemoryTable>(
+            AiAgentMemoryTableName,
+        )
+            .insert({
+                organization_uuid: memory.organizationUuid,
+                project_uuid: memory.projectUuid,
+                agent_uuid: memory.agentUuid,
+                user_uuid: memory.userUuid,
+                source_thread_uuid: memory.sourceThreadUuid,
+                slug: memory.slug,
+                ...content,
+            })
+            .onConflict(
+                this.database.raw(
+                    "(source_thread_uuid) WHERE status = 'active' AND source_thread_uuid IS NOT NULL",
+                ),
+            )
+            .merge({
+                ...content,
+                updated_at: this.database.fn.now(),
+            })
+            .returning([
+                'ai_agent_memory_uuid',
+                'organization_uuid',
+                'project_uuid',
+                'agent_uuid',
+                'user_uuid',
+                'source_thread_uuid',
+                'slug',
+                'title',
+                'raw_memory',
+                'thread_summary',
+                'terms',
+                'objects',
+                'unresolved_objects',
+                'status',
+                'superseded_by_uuid',
+                'generated_at',
+                'cited_count',
+                'last_cited_at',
+                'pulled_count',
+                'last_pulled_at',
+                'created_at',
+                'updated_at',
+            ]);
+
+        return row;
+    }
+
+    async upsertThreadDistill(
+        result: ThreadDistillResult,
+    ): Promise<DbAiAgentThreadDistill> {
+        const noOpReason =
+            result.outcome === 'no_op' ? result.noOpReason : null;
+        const errorMessage =
+            result.outcome === 'failed' ? result.errorMessage : null;
+        const content = {
+            outcome: result.outcome,
+            no_op_reason: noOpReason,
+            error_message: errorMessage,
+            distill_prompt_hash: result.distillPromptHash,
+            distilled_up_to: result.distilledUpTo,
+        };
+        const [row] = await this.database<AiAgentThreadDistillTable>(
+            AiAgentThreadDistillTableName,
+        )
+            .insert({
+                ai_thread_uuid: result.aiThreadUuid,
+                ...content,
+            })
+            .onConflict('ai_thread_uuid')
+            .merge({
+                ...content,
+                updated_at: this.database.fn.now(),
+            })
+            .returning([
+                'ai_agent_thread_distill_uuid',
+                'ai_thread_uuid',
+                'outcome',
+                'no_op_reason',
+                'error_message',
+                'distill_prompt_hash',
+                'distilled_up_to',
+                'created_at',
+                'updated_at',
+            ]);
+
+        return row;
+    }
+
+    async findActiveForProject(args: {
+        projectUuid: string;
+        limit?: number;
+    }): Promise<DbAiAgentMemory[]> {
+        const query = this.database<AiAgentMemoryTable>(AiAgentMemoryTableName)
+            .where('project_uuid', args.projectUuid)
+            .where('status', 'active')
+            .orderByRaw('last_cited_at DESC NULLS LAST')
+            .orderBy('generated_at', 'desc');
+
+        if (args.limit !== undefined) {
+            void query.limit(args.limit);
+        }
+
+        return query;
+    }
+}

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -148,6 +148,7 @@ export type ModelManifest = {
     preAggregateDailyStatsModel: PreAggregateDailyStatsModel;
     projectParametersModel: ProjectParametersModel;
     /** An implementation signature for these models are not available at this stage */
+    aiAgentMemoryModel: unknown;
     aiAgentModel: unknown;
     projectHomepageModel: unknown;
     aiAgentDocumentModel: unknown;
@@ -810,6 +811,10 @@ export class ModelRepository
 
     public getAiAgentModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiAgentModel');
+    }
+
+    public getAiAgentMemoryModel<ModelImplT>(): ModelImplT {
+        return this.getModel('aiAgentMemoryModel');
     }
 
     public getProjectHomepageModel<ModelImplT>(): ModelImplT {


### PR DESCRIPTION
### Description

- add inert `ai_agent_memory` and per-thread distill-ledger tables with typed object refs, provenance, telemetry, and ranking constraints
- register `AiAgentMemoryModel` with atomic source-thread and ledger upserts plus ranked active-set reads
- add real-Postgres integration coverage for stable slugs/telemetry, ledger outcome replacement, and ranking

### Validation

- `pnpm -F backend typecheck:fast`
- focused backend ESLint
- `AiAgentMemoryModel.integration.test.ts`: 3 passed
- `postgres` migration applied, rolled back, and reapplied; both tables verified after reapply
- independent review: no findings

Closes: ZAP-673