### PR TITLE
fix: populate dashboard filter columns for pivoted SQL runner charts

### DIFF
--- a/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
+++ b/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
@@ -134,7 +134,6 @@ export class QueryHistoryModel {
             | 'resultsUpdatedAt'
             | 'resultsExpiresAt'
             | 'columns'
-            | 'originalColumns'
             | 'preAggregateCompiledSql'
             | 'processingStartedAt'
             | 'createdByAccount'
@@ -176,7 +175,11 @@ export class QueryHistoryModel {
                 results_updated_at: null,
                 results_expires_at: null,
                 columns: null,
-                original_columns: null,
+                // Persist original (pre-pivot) columns up front. The NATS
+                // worker rebuilds its args from this row, so a null here would
+                // drop the columns for pivoted queries (Bar/Line/Pie SQL charts
+                // read pivotDetails.originalColumns for dashboard filters).
+                original_columns: queryHistory.originalColumns,
                 pre_aggregate_compiled_sql: null,
                 processing_started_at: null,
             })

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -2586,46 +2586,46 @@ describe('AsyncQueryService', () => {
         });
     });
 
-    describe('prepareQueuedQueryForExecution', () => {
-        const createMockQueryHistory = (
-            status: QueryHistoryStatus,
-            createdAt: Date = new Date(),
-        ): QueryHistory => ({
-            createdAt,
-            organizationUuid: sessionAccount.organization.organizationUuid!,
-            createdByUserUuid: sessionAccount.user.id,
-            createdBy: sessionAccount.user.id,
-            createdByAccount: null,
-            createdByActorType: 'session',
-            queryUuid: 'test-query-uuid',
-            projectUuid,
-            status,
-            error: null,
-            erroredAt: null,
-            metricQuery: metricQueryMock,
-            context: QueryExecutionContext.EXPLORE,
-            fields: validExplore.tables.a.dimensions,
-            compiledSql: 'SELECT * FROM test.table',
-            warehouseQueryId: 'test-warehouse-query-id',
-            warehouseQueryMetadata: null,
-            requestParameters: {} as ExecuteAsyncQueryRequestParams,
-            totalRowCount: null,
-            warehouseExecutionTimeMs: null,
-            defaultPageSize: 10,
-            cacheKey: 'test-query-key',
-            pivotConfiguration: null,
-            pivotTotalColumnCount: null,
-            pivotValuesColumns: null,
-            resultsFileName: null,
-            resultsCreatedAt: null,
-            resultsUpdatedAt: null,
-            resultsExpiresAt: null,
-            columns: null,
-            originalColumns: null,
-            preAggregateCompiledSql: null,
-            processingStartedAt: null,
-        });
+    const createMockQueryHistory = (
+        status: QueryHistoryStatus,
+        createdAt: Date = new Date(),
+    ): QueryHistory => ({
+        createdAt,
+        organizationUuid: sessionAccount.organization.organizationUuid!,
+        createdByUserUuid: sessionAccount.user.id,
+        createdBy: sessionAccount.user.id,
+        createdByAccount: null,
+        createdByActorType: 'session',
+        queryUuid: 'test-query-uuid',
+        projectUuid,
+        status,
+        error: null,
+        erroredAt: null,
+        metricQuery: metricQueryMock,
+        context: QueryExecutionContext.EXPLORE,
+        fields: validExplore.tables.a.dimensions,
+        compiledSql: 'SELECT * FROM test.table',
+        warehouseQueryId: 'test-warehouse-query-id',
+        warehouseQueryMetadata: null,
+        requestParameters: {} as ExecuteAsyncQueryRequestParams,
+        totalRowCount: null,
+        warehouseExecutionTimeMs: null,
+        defaultPageSize: 10,
+        cacheKey: 'test-query-key',
+        pivotConfiguration: null,
+        pivotTotalColumnCount: null,
+        pivotValuesColumns: null,
+        resultsFileName: null,
+        resultsCreatedAt: null,
+        resultsUpdatedAt: null,
+        resultsExpiresAt: null,
+        columns: null,
+        originalColumns: null,
+        preAggregateCompiledSql: null,
+        processingStartedAt: null,
+    });
 
+    describe('prepareQueuedQueryForExecution', () => {
         test('transitions queued queries to executing', async () => {
             const service = getMockedAsyncQueryService(lightdashConfigMock);
             (
@@ -2682,6 +2682,38 @@ describe('AsyncQueryService', () => {
             expect(
                 service.queryHistoryModel.updateStatusToExecuting,
             ).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('runAsyncWarehouseQueryFromHistory', () => {
+        test('rebuilds originalColumns from the query history row', async () => {
+            const mockOriginalColumns: ResultColumns = {
+                user_id: { reference: 'user_id', type: DimensionType.STRING },
+                amount: { reference: 'amount', type: DimensionType.NUMBER },
+            };
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            (
+                service.queryHistoryModel
+                    .getByQueryUuid as import('vitest').Mock
+            ).mockResolvedValue({
+                ...createMockQueryHistory(QueryHistoryStatus.QUEUED),
+                originalColumns: mockOriginalColumns,
+            });
+            const runAsyncWarehouseQuerySpy = vi
+                .spyOn(service, 'runAsyncWarehouseQuery')
+                .mockResolvedValue(undefined);
+
+            const ran = await service.runAsyncWarehouseQueryFromHistory(
+                'test-query-uuid',
+                'worker-1',
+            );
+
+            expect(ran).toBe(true);
+            expect(runAsyncWarehouseQuerySpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    originalColumns: mockOriginalColumns,
+                }),
+            );
         });
     });
 
@@ -2771,6 +2803,66 @@ describe('AsyncQueryService', () => {
                 expect.objectContaining({
                     originalColumns: mockOriginalColumns,
                 }),
+            );
+        });
+
+        test('cache hit against a row with null originalColumns keeps the current originalColumns', async () => {
+            const createdAt = new Date();
+            const updatedAt = new Date();
+            const expiresAt = new Date(
+                createdAt.getTime() + 1000 * 60 * 60 * 24,
+            );
+            // Cached row predates persisting original columns at creation
+            const mockCacheResult: CacheHitCacheResult = {
+                cacheHit: true,
+                cacheKey: 'test-cache-key',
+                totalRowCount: 10,
+                createdAt,
+                updatedAt,
+                expiresAt,
+                fileName: 'file-name',
+                columns: expectedColumns,
+                originalColumns: null,
+                pivotValuesColumns: null,
+                pivotTotalColumnCount: null,
+            };
+
+            (
+                serviceWithCache.findResultsCache as import('vitest').Mock
+            ).mockResolvedValueOnce(mockCacheResult);
+            (
+                serviceWithCache.queryHistoryModel
+                    .create as import('vitest').Mock
+            ).mockResolvedValue({
+                queryUuid: 'test-query-uuid',
+            });
+
+            await serviceWithCache['executeAsyncQuery'](
+                {
+                    account: sessionAccount,
+                    projectUuid,
+                    context: QueryExecutionContext.SQL_RUNNER,
+                    queryTags: {
+                        query_context: QueryExecutionContext.SQL_RUNNER,
+                    },
+                    invalidateCache: false,
+                    queryComposer: createQueryComposerMock(),
+                    originalColumns: mockOriginalColumns,
+                    warehouseCredentials: warehouseCredentialsMock,
+                },
+                { query: metricQueryMock },
+            );
+
+            expect(
+                serviceWithCache.queryHistoryModel.update,
+            ).toHaveBeenCalledWith(
+                'test-query-uuid',
+                projectUuid,
+                expect.objectContaining({
+                    status: QueryHistoryStatus.READY,
+                    original_columns: mockOriginalColumns,
+                }),
+                sessionAccount,
             );
         });
     });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -2760,6 +2760,18 @@ describe('AsyncQueryService', () => {
                     originalColumns: mockOriginalColumns,
                 }),
             );
+
+            // Verify that original columns are persisted at creation time too,
+            // so the NATS worker path (which rebuilds args from the history
+            // row) doesn't lose them for pivoted charts.
+            expect(
+                serviceWithCache.queryHistoryModel.create,
+            ).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({
+                    originalColumns: mockOriginalColumns,
+                }),
+            );
         });
     });
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1523,9 +1523,7 @@ export class AsyncQueryService extends ProjectService {
                     error: getErrorMessage(error),
                 });
                 throw new ParseError(
-                    `Failed to parse JSON from first line: ${getErrorMessage(
-                        error,
-                    )}`,
+                    `Failed to parse JSON from first line: ${getErrorMessage(error)}`,
                 );
             }
         }
@@ -3891,7 +3889,11 @@ export class AsyncQueryService extends ProjectService {
                                 error: null,
                                 total_row_count: resultsCache.totalRowCount,
                                 columns: resultsCache.columns,
-                                original_columns: resultsCache.originalColumns,
+                                // Cached rows created before original columns were persisted at creation may hold null — don't clobber the value this row was created with
+                                original_columns:
+                                    resultsCache.originalColumns ??
+                                    originalColumns ??
+                                    null,
                                 results_file_name: resultsCache.fileName,
                                 results_created_at: resultsCache.createdAt,
                                 results_updated_at: resultsCache.updatedAt,
@@ -3936,9 +3938,7 @@ export class AsyncQueryService extends ProjectService {
                         await this.queryHistoryModel.updateStatusToError(
                             queryHistoryUuid,
                             projectUuid,
-                            `Missing parameters: ${missingParameterReferences.join(
-                                ', ',
-                            )}`,
+                            `Missing parameters: ${missingParameterReferences.join(', ')}`,
                             account,
                         );
                         this.prometheusMetrics?.trackQueryStateTransition(
@@ -4749,7 +4749,9 @@ export class AsyncQueryService extends ProjectService {
         const savedChart = await this.savedChartModel.get(
             chartUuid,
             versionUuid,
-            { projectUuid },
+            {
+                projectUuid,
+            },
         );
         const {
             uuid: savedChartUuid,
@@ -6079,9 +6081,7 @@ export class AsyncQueryService extends ProjectService {
         const totalTime = performance.now() - startTime;
 
         this.logger.info(
-            `prepareSqlChartAsyncQueryArgs completed in ${totalTime.toFixed(
-                2,
-            )}`,
+            `prepareSqlChartAsyncQueryArgs completed in ${totalTime.toFixed(2)}`,
             {
                 event: 'prepare_sql_chart_async_query_args.completed',
                 projectUuid,
@@ -7342,7 +7342,9 @@ export class AsyncQueryService extends ProjectService {
 
         const dashboard = await this.dashboardModel.getByIdOrSlug(
             dashboardUuid,
-            { projectUuid },
+            {
+                projectUuid,
+            },
         );
 
         const auditedAbility = this.createAuditedAbility(account);

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3786,6 +3786,7 @@ export class AsyncQueryService extends ProjectService {
                             },
                             cacheKey,
                             pivotConfiguration: pivotConfiguration ?? null,
+                            originalColumns: originalColumns ?? null,
                         });
                     const historyCreateMs = Date.now() - historyCreateStart;
                     this.prometheusMetrics?.trackQueryStateTransition(

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -468,7 +468,7 @@ const FilterConfiguration: FC<Props> = ({
                                     allowDeselect={false}
                                     size="xs"
                                     label={
-                                        <Text>
+                                        <Text fw={500} fz="sm">
                                             Select a column to filter{' '}
                                             <Text c="red" span>
                                                 *


### PR DESCRIPTION
## Problem

On a dashboard, the "Select a column to filter" dropdown was empty for SQL runner chart tiles using **Bar / Line / Pie** visualizations, while **Table** worked. This blocked creating dashboard filters for those tiles.

## Root cause

The filter picker is populated from each SQL tile's `originalColumns` (the pre-pivot raw SQL columns):
- **Table** charts aren't pivoted, so the frontend uses `columns`, which is written to the `query_history` row at query completion.
- **Bar/Line/Pie** charts are pivoted, so the frontend uses `pivotDetails.originalColumns`, which comes from the `original_columns` column.

`original_columns` was set to `null` at history-row creation and only written at completion in the in-process execution path. On NATS-worker deployments (Cloud), the worker rebuilds its execution args from the history row (`buildWarehouseQueryArgs` reads `original_columns`), so the freshly-computed value never reached it — pivoted queries ended up with empty `originalColumns` and an empty picker. Table charts were unaffected because they don't depend on `original_columns`.

## Fix

1. Persist `originalColumns` when the `query_history` row is created, so both the in-process and NATS-worker paths retain it.
2. **Cache-hit guard**: on a results-cache hit, the READY update copies `original_columns` from the cached (older) `query_history` row. Rows created before this fix hold `null` there, which would clobber the correct value the new row was created with — re-manifesting the empty picker for the cache TTL window after deploy. The update now falls back to the current query's `originalColumns` when the cached row has none.
3. Minor UI polish: filter column picker label matches the field select label styling (`fw={500} fz="sm"`).

## Testing

- Extended the existing `executeAsyncQuery with originalColumns` unit test to assert `queryHistoryModel.create` is called with `originalColumns`.
- New unit test: cache hit against a row with `originalColumns: null` keeps the current query's `originalColumns` (the clobber regression).
- New unit test pinning the NATS worker read-side contract: `runAsyncWarehouseQueryFromHistory` rebuilds `originalColumns` from the history row.
- E2E verified locally (results cache + EE license enabled): created a dashboard with Bar/Line/Pie/Table SQL runner tiles sharing one query; nulled `original_columns` on the cached rows to simulate pre-fix Cloud rows; reloaded → cache hits (`warehouse_execution_time_ms = 0`) and the new rows kept `original_columns` populated; filter picker lists all raw columns. Reproduced the clobber first on pre-guard code (same scenario persisted `null`), confirming the guard is what closes it.
- Full backend test suite + `typecheck` pass.
