### PR TITLE
fix: convert startOfWeek env values to numeric WeekDay in setup config

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -7,6 +7,7 @@ import {
     ParseError,
     SentryConfig,
     WarehouseTypes,
+    WeekDay,
 } from '@lightdash/common';
 import { VERSION } from '../version';
 import {
@@ -1160,6 +1161,52 @@ test('should set groups.enabled only when the environment variable is set', () =
     expect(falseConfig.groups.enabled).toBe(false);
 });
 
+describe('LD_SETUP_START_OF_WEEK', () => {
+    beforeEach(() => {
+        process.env.LD_SETUP_ADMIN_EMAIL = 'admin@example.com';
+        process.env.LD_SETUP_PROJECT_PAT = 'project_personal_access_token';
+    });
+
+    test('should convert day name to its numeric WeekDay value', () => {
+        process.env.LD_SETUP_START_OF_WEEK = 'THURSDAY';
+        const config = parseConfig();
+        expect(
+            config.initialSetup?.projects[0]?.warehouseConnection.startOfWeek,
+        ).toBe(WeekDay.THURSDAY);
+    });
+
+    test('should accept the numeric WeekDay value', () => {
+        process.env.LD_SETUP_START_OF_WEEK = '3';
+        const config = parseConfig();
+        expect(
+            config.initialSetup?.projects[0]?.warehouseConnection.startOfWeek,
+        ).toBe(WeekDay.THURSDAY);
+    });
+
+    test('should be undefined when unset', () => {
+        const config = parseConfig();
+        expect(
+            config.initialSetup?.projects[0]?.warehouseConnection.startOfWeek,
+        ).toBeUndefined();
+    });
+
+    test('should skip initial setup for an invalid value', () => {
+        process.env.LD_SETUP_START_OF_WEEK = 'FUNDAY';
+        const consoleError = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+        const config = parseConfig();
+        expect(config.initialSetup).toBeUndefined();
+        expect(consoleError).toHaveBeenCalledWith(
+            'Error parsing initial setup config',
+            expect.objectContaining({
+                message: expect.stringContaining('FUNDAY'),
+            }),
+        );
+        consoleError.mockRestore();
+    });
+});
+
 describe('getMultiProjectSetupConfig', () => {
     beforeEach(() => {
         delete process.env.LD_SETUP_PROJECTS;
@@ -1198,6 +1245,72 @@ describe('getMultiProjectSetupConfig', () => {
         process.env.LD_SETUP_PROJECTS = JSON.stringify(projects);
         const result = getMultiProjectSetupConfig();
         expect(result).toEqual(projects);
+    });
+
+    test('should convert day-name startOfWeek to its numeric WeekDay value', () => {
+        process.env.LD_SETUP_PROJECTS = JSON.stringify([
+            {
+                name: 'Test',
+                warehouseConnection: {
+                    type: WarehouseTypes.DATABRICKS,
+                    startOfWeek: 'THURSDAY',
+                },
+                dbtConnection: { type: DbtProjectType.NONE },
+            },
+        ]);
+        const result = getMultiProjectSetupConfig();
+        expect(result?.[0]?.warehouseConnection.startOfWeek).toBe(
+            WeekDay.THURSDAY,
+        );
+    });
+
+    test('should keep numeric startOfWeek values', () => {
+        process.env.LD_SETUP_PROJECTS = JSON.stringify([
+            {
+                name: 'Test',
+                warehouseConnection: {
+                    type: WarehouseTypes.DATABRICKS,
+                    startOfWeek: 3,
+                },
+                dbtConnection: { type: DbtProjectType.NONE },
+            },
+        ]);
+        const result = getMultiProjectSetupConfig();
+        expect(result?.[0]?.warehouseConnection.startOfWeek).toBe(
+            WeekDay.THURSDAY,
+        );
+    });
+
+    test('should keep null startOfWeek', () => {
+        process.env.LD_SETUP_PROJECTS = JSON.stringify([
+            {
+                name: 'Test',
+                warehouseConnection: {
+                    type: WarehouseTypes.DATABRICKS,
+                    startOfWeek: null,
+                },
+                dbtConnection: { type: DbtProjectType.NONE },
+            },
+        ]);
+        const result = getMultiProjectSetupConfig();
+        expect(result?.[0]?.warehouseConnection.startOfWeek).toBeNull();
+    });
+
+    test('should throw ParseError for invalid startOfWeek', () => {
+        process.env.LD_SETUP_PROJECTS = JSON.stringify([
+            {
+                name: 'Test',
+                warehouseConnection: {
+                    type: WarehouseTypes.DATABRICKS,
+                    startOfWeek: 'FUNDAY',
+                },
+                dbtConnection: { type: DbtProjectType.NONE },
+            },
+        ]);
+        expect(() => getMultiProjectSetupConfig()).toThrow(ParseError);
+        expect(() => getMultiProjectSetupConfig()).toThrow(
+            'Invalid LD_SETUP_PROJECTS',
+        );
     });
 
     test('should throw ParseError for non-array JSON', () => {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -18,6 +18,7 @@ import {
     isLightdashMode,
     isOrganizationMemberRole,
     isSchedulerTaskName,
+    isWeekDay,
     LightdashMode,
     OrganizationMemberRole,
     ParameterError,
@@ -350,6 +351,41 @@ const parseEnum = <T>(
     return value as T;
 };
 
+// WeekDay is a numeric enum, so a generic Object.values check would accept the
+// day names as-is and never convert them to the numeric value the app expects.
+const parseWeekDay = (value: unknown): WeekDay => {
+    if (isWeekDay(value)) return value;
+    if (typeof value === 'string' && value.trim() !== '') {
+        const numeric = Number(value);
+        if (isWeekDay(numeric)) return numeric;
+        const day = WeekDay[value.toUpperCase() as keyof typeof WeekDay];
+        if (isWeekDay(day)) return day;
+    }
+    throw new ParameterError(
+        `Invalid start of week value "${value}". Must be one of ${Object.values(
+            WeekDay,
+        )
+            .filter((day): day is string => typeof day === 'string')
+            .join(', ')} or a number from 0 (Monday) to 6 (Sunday)`,
+    );
+};
+
+const startOfWeekSchema = z
+    .union([z.number(), z.string()])
+    .nullish()
+    .transform((value, ctx) => {
+        if (value === null || value === undefined) return value;
+        try {
+            return parseWeekDay(value);
+        } catch (e) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: getErrorMessage(e),
+            });
+            return z.NEVER;
+        }
+    });
+
 const multiProjectSetupEntrySchema = z.object({
     name: z.string().min(1, 'Project name cannot be empty'),
     warehouseConnection: z
@@ -359,6 +395,7 @@ const multiProjectSetupEntrySchema = z.object({
                     message: `Invalid warehouse type. Must be one of: ${Object.values(WarehouseTypes).join(', ')}`,
                 }),
             }),
+            startOfWeek: startOfWeekSchema,
         })
         .passthrough(),
     dbtConnection: z
@@ -460,8 +497,9 @@ export const getMultiProjectSetupConfig = ():
         );
     }
 
-    // Zod validates structure; the full type comes from the original parsed JSON
-    return parsed as MultiProjectSetupEntry[];
+    // Both connection objects are passthrough schemas, so unvalidated fields
+    // survive; returning the zod output applies transforms like startOfWeek.
+    return result.data as unknown as MultiProjectSetupEntry[];
 };
 
 const userAttributeSetupEntrySchema = z.object({
@@ -655,10 +693,9 @@ const getInitialSetupConfig = (): LightdashConfig['initialSetup'] => {
                         httpPath: process.env.LD_SETUP_PROJECT_HTTP_PATH!,
                         personalAccessToken: projectPat,
                         requireUserCredentials: undefined,
-                        startOfWeek: parseEnum<WeekDay>(
-                            process.env.LD_SETUP_START_OF_WEEK,
-                            WeekDay,
-                        ),
+                        startOfWeek: process.env.LD_SETUP_START_OF_WEEK
+                            ? parseWeekDay(process.env.LD_SETUP_START_OF_WEEK)
+                            : undefined,
                         compute: parseCompute(),
                     },
                     dbtConnection: {


### PR DESCRIPTION
## Problem

Setting start of week via environment variables was silently broken:

* `LD_SETUP_PROJECTS` with `"startOfWeek": "THURSDAY"` stored the day **name as a string**. `WeekDay` is a numeric enum (`MONDAY=0`…`SUNDAY=6`), so the stored value matched nothing downstream — the project connection UI showed **"Auto"** and week truncation ignored the setting entirely. Because the boot-time config sync replaces the warehouse connection on every backend redeploy, fixing the value in the UI was clobbered back to the broken string on the next deploy.
* `LD_SETUP_START_OF_WEEK=THURSDAY` had the same conversion bug, and the numeric form (`LD_SETUP_START_OF_WEEK=3`) **failed at boot**: `parseEnum` compared the env string `"3"` strictly against the enum's numeric values. There was no working value for this variable.

Root cause: `parseEnum` validates against `Object.values(enum)`, which for a numeric enum contains both the reverse-mapping names and the numbers — so day names passed validation but were never converted, and numeric strings never matched.

## Fix

* New `parseWeekDay` helper: accepts day names (case-insensitive) and numeric values (`3` or `"3"`), always resolves to the numeric `WeekDay` member, and throws a descriptive validation error for anything else.
* Wired into the legacy `LD_SETUP_START_OF_WEEK` path and the `LD_SETUP_PROJECTS` zod schema (`startOfWeek` is now validated/transformed instead of passing through untyped).
* `getMultiProjectSetupConfig` now returns the zod output so the transform takes effect; both connection objects are passthrough schemas, so all other fields are unaffected.
* Instances that already persisted a day-name string self-heal on the next redeploy via the existing boot-time sync.

## Verification

* TDD: new unit tests covering name → numeric conversion, numeric passthrough, null, unset, and invalid values on both paths (they failed before the fix, 141/141 pass after).
* Reproduced and re-verified end-to-end on a local EE instance: before the fix the API returned `startOfWeek: "THURSDAY"` (string) and the UI showed "Auto"; after redeploying the same env on the fixed code, the boot-time update path converts the stored value to `3` and the UI shows **Thursday**.

Closes: lightdash/lightdash#25913<br>Closes: lightdash/lightdash#25913

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

[https://claude.ai/code/session_019b88bNVEcEytsm2tbAvQpr](<https://claude.ai/code/session_019b88bNVEcEytsm2tbAvQpr>)