### PR TITLE
fix: run scheduled deliveries created by service accounts

### DIFF
--- a/packages/backend/src/models/SchedulerModel/SchedulerModel.test.ts
+++ b/packages/backend/src/models/SchedulerModel/SchedulerModel.test.ts
@@ -1,6 +1,6 @@
 import { AnyType, SchedulerJobStatus, SchedulerLog } from '@lightdash/common';
 import knex from 'knex';
-import { MockClient } from 'knex-mock-client';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { SchedulerTableName } from '../../database/entities/scheduler';
 import { SchedulerModel } from './index';
 
@@ -124,6 +124,53 @@ describe('Scheduler model test', () => {
                     );
                 }
             });
+        });
+    });
+
+    describe('getAllSchedulers', () => {
+        const database = knex({ client: MockClient, dialect: 'pg' });
+        const model = new SchedulerModel({ database });
+        let tracker: Tracker;
+
+        beforeAll(() => {
+            tracker = getTracker();
+        });
+
+        afterEach(() => {
+            tracker.reset();
+        });
+
+        const schedulerSelectSql = () =>
+            tracker.history.select.find((query) =>
+                query.sql.includes(`from "${SchedulerTableName}"`),
+            )?.sql;
+
+        it('includes active human creators or existing service accounts', async () => {
+            tracker.on
+                .select(/to_regclass/)
+                .response([{ has_service_accounts: true }]);
+            tracker.on.select(SchedulerTableName).response([]);
+
+            await model.getAllSchedulers();
+
+            const sql = schedulerSelectSql();
+            expect(sql).toContain('"users"."is_active"');
+            expect(sql).toContain(
+                'exists (select * from "service_accounts" where service_accounts.service_account_user_uuid = scheduler.created_by)',
+            );
+        });
+
+        it('omits the service account clause when the table is absent (OSS)', async () => {
+            tracker.on
+                .select(/to_regclass/)
+                .response([{ has_service_accounts: false }]);
+            tracker.on.select(SchedulerTableName).response([]);
+
+            await model.getAllSchedulers();
+
+            const sql = schedulerSelectSql();
+            expect(sql).toContain('"users"."is_active"');
+            expect(sql).not.toContain('service_accounts');
         });
     });
 

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -78,6 +78,7 @@ import {
 import { SpaceTableName } from '../../database/entities/spaces';
 import { UserTableName } from '../../database/entities/users';
 import KnexPaginate from '../../database/pagination';
+import { ServiceAccountsTableName } from '../../ee/database/entities/serviceAccounts';
 
 type SelectScheduler = SchedulerDb & {
     created_by_name: string | null;
@@ -588,9 +589,36 @@ export class SchedulerModel {
     }
 
     async getAllSchedulers(): Promise<SchedulerAndTargets[]> {
+        // `service_accounts` is an EE-only table, absent in unlicensed
+        // deployments, so only reference it when it actually exists.
+        // `to_regclass` returns NULL for a missing table instead of erroring.
+        const [row] = await this.database.select<
+            { has_service_accounts: boolean }[]
+        >(
+            this.database.raw(
+                'to_regclass(?) is not null as has_service_accounts',
+                [ServiceAccountsTableName],
+            ),
+        );
+        const hasServiceAccounts = row?.has_service_accounts ?? false;
         const schedulers = SchedulerModel.getBaseSchedulerQuery(this.database)
             .where(`${SchedulerTableName}.enabled`, true)
-            .where(`${UserTableName}.is_active`, true);
+            .where(function activeUserOrServiceAccount() {
+                // Human creators run only while their account is active.
+                void this.where(`${UserTableName}.is_active`, true);
+                // Service accounts are backed by an always-inactive internal
+                // user, so gate them on the service account still existing
+                // instead — deleting the account (tombstone) stops delivery.
+                if (hasServiceAccounts) {
+                    void this.orWhereExists(function serviceAccountExists() {
+                        void this.select('*')
+                            .from(ServiceAccountsTableName)
+                            .whereRaw(
+                                `${ServiceAccountsTableName}.service_account_user_uuid = ${SchedulerTableName}.created_by`,
+                            );
+                    });
+                }
+            });
         return this.getSchedulersWithTargets(await schedulers);
     }
 


### PR DESCRIPTION
Closes: PROD-9012

### Description:

The daily-jobs worker enumerates schedulers via `SchedulerModel.getAllSchedulers()`, which only returned schedulers whose creator was an **active** user. Service accounts are backed by an always-inactive internal user record, so every scheduled delivery they created was silently skipped — permission granted, creation succeeded, delivery never ran. Same root cause as PROD-9009.

A scheduler is now included when its creator is either an active user **or** a still-existing service account. Deleting the service account (tombstone — only the `service_accounts` row is removed, the user record persists) stops its deliveries, mirroring what already happens for deactivated humans.

Notes:
- `service_accounts` is an EE-only table (its migration is gated by the license key) and is absent in unlicensed deployments, so it's referenced only when present — guarded with `to_regclass`, which returns `NULL` for a missing table rather than erroring. This keeps `getAllSchedulers` working in OSS.
- Added unit tests covering both the EE (clause present) and OSS (clause omitted) paths.