### PR TITLE
feat: enforce project-scoped dashboard slugs

### DIFF
--- a/packages/backend/src/database/migrations/20260722103000_enforce_dashboard_project_slug_uniqueness.ts
+++ b/packages/backend/src/database/migrations/20260722103000_enforce_dashboard_project_slug_uniqueness.ts
@@ -1,0 +1,369 @@
+import { Knex } from 'knex';
+
+export const config = { transaction: false };
+
+const DashboardsTableName = 'dashboards';
+const ProjectForeignKey = 'dashboards_project_uuid_foreign';
+const ProjectNotNullCheck = 'dashboards_project_uuid_not_null';
+const ProjectSlugUniqueConstraint = 'dashboards_project_uuid_slug_unique';
+const BatchSize = 1000;
+const MaxGeneratedSlugLength = 255;
+const LockTimeout = '5s';
+
+/**
+ * Contract phase for direct dashboard ownership and project-scoped slugs.
+ *
+ * Ownership is always resolvable through existing schema guarantees:
+ *
+ * dashboards.space_id (NOT NULL FK, CASCADE)
+ *   -> spaces.project_id (NOT NULL FK, CASCADE)
+ *   -> projects.project_uuid (NOT NULL)
+ *
+ * The migration runs without Knex's outer transaction so repairs can commit in
+ * bounded batches and the unique index can be built concurrently. Every phase
+ * is therefore idempotent and safe to resume after the migration lock has been
+ * released:
+ *
+ * 1. Reconcile existing direct owners from the canonical FK chain.
+ * 2. Add a NOT VALID non-null check, which immediately protects new writes.
+ * 3. Reconcile again to repair rows inserted between steps 1 and 2.
+ * 4. Rename only same-project duplicate slugs in committed batches.
+ * 5. Build the unique index concurrently and attach it as a constraint.
+ * 6. Validate/set NOT NULL and add/validate the project foreign key.
+ *
+ * Rollback removes the database contract but intentionally does not restore
+ * duplicate slug values or previous project UUIDs: those repairs are valid data
+ * independently of the constraints.
+ */
+
+const logProgress = (message: string): void => {
+    // eslint-disable-next-line no-console
+    console.log(`  ${DashboardsTableName}: ${message}`);
+};
+
+const getRowCount = (result: { rowCount?: number }): number =>
+    result.rowCount ?? 0;
+
+async function constraintExists(
+    knex: Knex,
+    constraintName: string,
+    constraintType?: 'f' | 'u',
+): Promise<boolean> {
+    const result = await knex.raw<{ rowCount: number }>(
+        `SELECT 1
+         FROM pg_constraint
+         WHERE conname = ?
+           AND conrelid = ?::regclass
+           ${constraintType ? 'AND contype = ?' : ''}`,
+        constraintType
+            ? [constraintName, DashboardsTableName, constraintType]
+            : [constraintName, DashboardsTableName],
+    );
+    return getRowCount(result) > 0;
+}
+
+async function isProjectUuidNotNull(knex: Knex): Promise<boolean> {
+    const result = await knex.raw<{ rows: Array<{ attnotnull: boolean }> }>(
+        `SELECT attnotnull
+         FROM pg_attribute
+         WHERE attrelid = ?::regclass
+           AND attname = 'project_uuid'`,
+        [DashboardsTableName],
+    );
+    return result.rows[0]?.attnotnull ?? false;
+}
+
+async function withLockTimeout<T>(
+    knex: Knex,
+    callback: (trx: Knex.Transaction) => Promise<T>,
+): Promise<T> {
+    return knex.transaction(async (trx) => {
+        await trx.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);
+        return callback(trx);
+    });
+}
+
+async function addProjectNotNullCheck(knex: Knex): Promise<void> {
+    if (
+        (await isProjectUuidNotNull(knex)) ||
+        (await constraintExists(knex, ProjectNotNullCheck))
+    ) {
+        return;
+    }
+
+    logProgress('adding the project UUID not-null check');
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${DashboardsTableName}
+            ADD CONSTRAINT ${ProjectNotNullCheck}
+            CHECK (project_uuid IS NOT NULL)
+            NOT VALID
+        `);
+    });
+}
+
+async function reconcileProjectUuids(knex: Knex): Promise<void> {
+    let totalUpdated = 0;
+    for (;;) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await withLockTimeout(knex, async (trx) =>
+            trx.raw<{ rowCount: number }>(`
+                WITH batch AS (
+                    SELECT
+                        dashboards.dashboard_id,
+                        projects.project_uuid
+                    FROM ${DashboardsTableName} AS dashboards
+                    INNER JOIN spaces
+                        ON spaces.space_id = dashboards.space_id
+                    INNER JOIN projects
+                        ON projects.project_id = spaces.project_id
+                    WHERE dashboards.project_uuid IS DISTINCT FROM projects.project_uuid
+                    ORDER BY dashboards.dashboard_id
+                    LIMIT ${BatchSize}
+                )
+                UPDATE ${DashboardsTableName} AS dashboards
+                SET project_uuid = batch.project_uuid
+                FROM batch
+                WHERE dashboards.dashboard_id = batch.dashboard_id
+                  AND dashboards.project_uuid IS DISTINCT FROM batch.project_uuid
+            `),
+        );
+        const updated = getRowCount(result);
+        if (updated === 0) break;
+        totalUpdated += updated;
+        logProgress(`reconciled project UUID for ${totalUpdated} rows`);
+    }
+}
+
+async function deduplicateSlugs(knex: Knex): Promise<void> {
+    let totalUpdated = 0;
+    for (;;) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await withLockTimeout(knex, async (trx) =>
+            trx.raw<{ rowCount: number }>(`
+                WITH ranked AS (
+                    SELECT
+                        dashboard_id,
+                        project_uuid,
+                        slug,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY project_uuid, slug
+                            -- Preserve the public slug on an active dashboard.
+                            -- Ties are resolved deterministically for reruns.
+                            ORDER BY
+                                (deleted_at IS NULL) DESC,
+                                created_at,
+                                dashboard_id
+                        ) AS duplicate_number
+                    FROM ${DashboardsTableName}
+                ), duplicate_rows AS (
+                    SELECT dashboard_id, project_uuid, slug
+                    FROM ranked
+                    WHERE duplicate_number > 1
+                    ORDER BY project_uuid, slug, dashboard_id
+                    LIMIT ${BatchSize}
+                ), replacements AS (
+                    SELECT
+                        duplicate_rows.dashboard_id,
+                        duplicate_rows.project_uuid,
+                        duplicate_rows.slug AS original_slug,
+                        replacement.candidate
+                    FROM duplicate_rows
+                    CROSS JOIN LATERAL (
+                        WITH RECURSIVE candidates(attempt, candidate) AS (
+                            -- Primary-key suffixes let a whole batch be updated without
+                            -- replacement rows colliding with one another. Only
+                            -- conflicting rows are capped to an index-safe size;
+                            -- unique existing slugs are never rewritten.
+                            SELECT
+                                0,
+                                LEFT(
+                                    duplicate_rows.slug,
+                                    GREATEST(
+                                        0,
+                                        ${MaxGeneratedSlugLength - 1} -
+                                            CHAR_LENGTH(duplicate_rows.dashboard_id::text)
+                                    )
+                                ) || '-' ||
+                                    duplicate_rows.dashboard_id::text
+                            UNION ALL
+                            SELECT
+                                candidates.attempt + 1,
+                                LEFT(
+                                    duplicate_rows.slug,
+                                    GREATEST(
+                                        0,
+                                        ${MaxGeneratedSlugLength - 2} -
+                                            CHAR_LENGTH(duplicate_rows.dashboard_id::text) -
+                                            CHAR_LENGTH((candidates.attempt + 1)::text)
+                                    )
+                                ) || '-' ||
+                                    duplicate_rows.dashboard_id::text || '-' ||
+                                    (candidates.attempt + 1)::text
+                            FROM candidates
+                            WHERE EXISTS (
+                                SELECT 1
+                                FROM ${DashboardsTableName} AS existing
+                                WHERE existing.project_uuid = duplicate_rows.project_uuid
+                                  AND existing.slug = candidates.candidate
+                                  AND existing.dashboard_id <> duplicate_rows.dashboard_id
+                            )
+                        )
+                        SELECT candidates.candidate
+                        FROM candidates
+                        WHERE NOT EXISTS (
+                            SELECT 1
+                            FROM ${DashboardsTableName} AS existing
+                            WHERE existing.project_uuid = duplicate_rows.project_uuid
+                              AND existing.slug = candidates.candidate
+                              AND existing.dashboard_id <> duplicate_rows.dashboard_id
+                        )
+                        ORDER BY candidates.attempt
+                        LIMIT 1
+                    ) AS replacement
+                )
+                UPDATE ${DashboardsTableName} AS dashboards
+                SET slug = replacements.candidate
+                FROM replacements
+                WHERE dashboards.dashboard_id = replacements.dashboard_id
+                  AND dashboards.project_uuid = replacements.project_uuid
+                  AND dashboards.slug = replacements.original_slug
+            `),
+        );
+        const updated = getRowCount(result);
+        if (updated === 0) break;
+        totalUpdated += updated;
+        logProgress(`deduplicated slug for ${totalUpdated} rows`);
+    }
+}
+
+async function createProjectSlugConstraint(knex: Knex): Promise<void> {
+    if (await constraintExists(knex, ProjectSlugUniqueConstraint, 'u')) {
+        return;
+    }
+
+    // CREATE INDEX CONCURRENTLY can leave an INVALID index if interrupted.
+    // Remove that artifact before retrying the otherwise idempotent build.
+    const invalidIndex = await knex.raw<{ rowCount: number }>(
+        `SELECT 1
+         FROM pg_class
+         JOIN pg_index ON pg_index.indexrelid = pg_class.oid
+         WHERE pg_class.relname = ?
+           AND pg_index.indrelid = ?::regclass
+           AND NOT pg_index.indisvalid`,
+        [ProjectSlugUniqueConstraint, DashboardsTableName],
+    );
+    if (getRowCount(invalidIndex) > 0) {
+        logProgress('dropping an invalid project slug index from a prior run');
+        await knex.raw(
+            `DROP INDEX CONCURRENTLY IF EXISTS ${ProjectSlugUniqueConstraint}`,
+        );
+    }
+
+    logProgress('building the project slug unique index concurrently');
+    await knex.raw(`
+        CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ${ProjectSlugUniqueConstraint}
+        ON ${DashboardsTableName} (project_uuid, slug)
+    `);
+
+    await withLockTimeout(knex, async (trx) => {
+        if (!(await constraintExists(trx, ProjectSlugUniqueConstraint, 'u'))) {
+            logProgress('attaching the project slug unique constraint');
+            await trx.raw(`
+                ALTER TABLE ${DashboardsTableName}
+                ADD CONSTRAINT ${ProjectSlugUniqueConstraint}
+                UNIQUE USING INDEX ${ProjectSlugUniqueConstraint}
+            `);
+        }
+    });
+}
+
+async function enforceProjectNotNull(knex: Knex): Promise<void> {
+    if (await isProjectUuidNotNull(knex)) {
+        await withLockTimeout(knex, async (trx) => {
+            await trx.raw(`
+                ALTER TABLE ${DashboardsTableName}
+                DROP CONSTRAINT IF EXISTS ${ProjectNotNullCheck}
+            `);
+        });
+        return;
+    }
+
+    logProgress('validating the project UUID not-null constraint');
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${DashboardsTableName}
+            VALIDATE CONSTRAINT ${ProjectNotNullCheck}
+        `);
+    });
+
+    logProgress('setting project UUID NOT NULL');
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${DashboardsTableName}
+            ALTER COLUMN project_uuid SET NOT NULL
+        `);
+        await trx.raw(`
+            ALTER TABLE ${DashboardsTableName}
+            DROP CONSTRAINT IF EXISTS ${ProjectNotNullCheck}
+        `);
+    });
+}
+
+async function addAndValidateProjectForeignKey(knex: Knex): Promise<void> {
+    if (!(await constraintExists(knex, ProjectForeignKey, 'f'))) {
+        logProgress('adding the project foreign key without validation');
+        await withLockTimeout(knex, async (trx) => {
+            await trx.raw(`
+                ALTER TABLE ${DashboardsTableName}
+                ADD CONSTRAINT ${ProjectForeignKey}
+                FOREIGN KEY (project_uuid)
+                REFERENCES projects(project_uuid)
+                ON DELETE CASCADE
+                NOT VALID
+            `);
+        });
+    }
+
+    logProgress('validating the project foreign key');
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${DashboardsTableName}
+            VALIDATE CONSTRAINT ${ProjectForeignKey}
+        `);
+    });
+}
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        await reconcileProjectUuids(knex);
+        await addProjectNotNullCheck(knex);
+        // Close the window between the initial repair and the check becoming
+        // active. Rows inserted by an older application version in that window
+        // are now protected from further null writes and can be repaired safely.
+        await reconcileProjectUuids(knex);
+        await deduplicateSlugs(knex);
+        await createProjectSlugConstraint(knex);
+        await enforceProjectNotNull(knex);
+        await addAndValidateProjectForeignKey(knex);
+        logProgress('project-scoped dashboard slug constraint complete');
+    } finally {
+        await knex.raw('RESET statement_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${DashboardsTableName}
+            DROP CONSTRAINT IF EXISTS ${ProjectForeignKey},
+            DROP CONSTRAINT IF EXISTS ${ProjectSlugUniqueConstraint},
+            DROP CONSTRAINT IF EXISTS ${ProjectNotNullCheck},
+            ALTER COLUMN project_uuid DROP NOT NULL
+        `);
+    });
+    await knex.raw(
+        `DROP INDEX CONCURRENTLY IF EXISTS ${ProjectSlugUniqueConstraint}`,
+    );
+}


### PR DESCRIPTION
## Summary

This is the dashboard contract migration after the ownership expansion in #25906.

- Reconciles missing or incorrect `dashboards.project_uuid` values from the canonical space ownership in committed batches of 1,000 rows.
- Resolves existing duplicate slugs within each project before enforcement. The active, oldest dashboard keeps the original slug; only conflicting rows receive a deterministic dashboard ID suffix.
- Leaves every non-conflicting slug unchanged. A generated replacement is capped at 255 characters so suffixing a long duplicate cannot make the index build fail.
- Builds `(project_uuid, slug)` as a unique index concurrently, then attaches it as a table constraint.
- Makes `project_uuid` `NOT NULL` through a validated check constraint and adds a validated UUID foreign key to `projects`.

This PR deliberately does not switch dashboard read paths from space/project joins to the direct ownership column. That remains a separate, security-sensitive follow-up.

## Migration safety

- Relies on the existing `dashboards.space_id` → `spaces.project_id` → `projects.project_uuid` chain, whose columns are `NOT NULL` and protected by cascading foreign keys.
- Runs without Knex's outer transaction so every repair batch commits independently.
- Disables the session statement timeout and resets it in `finally`.
- Bounds brief DDL lock acquisition to five seconds so a busy table fails retryably instead of hanging a rollout.
- Uses idempotent constraint checks and detects/removes an invalid concurrent index left by an interrupted run.
- Uses `CHECK ... NOT VALID` → `VALIDATE` → `SET NOT NULL` to avoid a full-table scan under `ACCESS EXCLUSIVE`.
- Adds the FK as `NOT VALID`, then validates it without blocking normal reads/writes.
- Logs every repair batch and DDL phase for operators following migration output.
- Relies on the leading `project_uuid` column of the unique index as the required FK index.

If a process is interrupted, committed ownership/slug batches remain and the migration resumes the remaining rows after the Knex migration lock is released. The migration was explicitly tested from interrupted data/index/constraint states.

## Observed test matrix

| Scenario | Observed result |
| --- | --- |
| Clean unique dashboard | Owner and slug remained byte-identical |
| Null `project_uuid` | Repaired from space → project |
| Valid but incorrect `project_uuid` | Replaced with the canonical space owner |
| 2,107 mixed ownership repairs | Completed across three committed batches |
| Same slug in different projects | Both original slugs remained unchanged |
| Multiple active duplicates in one project | Oldest active row kept the slug; conflicts received dashboard ID suffixes |
| Deleted row older than an active duplicate | Active row kept the public slug; deleted row was renamed |
| All duplicates deleted | Oldest row kept the original slug |
| Restored deleted duplicate | Restore remained collision-free because deleted rows are included in the constraint |
| Replacement slug already occupied | Retried deterministically with a numeric suffix |
| Unique 1,500-character slug | Length and MD5 fingerprint remained unchanged |
| Duplicate 1,500-character slug | Survivor remained unchanged; only conflict became a 255-character dashboard-ID-suffixed slug |
| Same-project duplicate insert after migration | Rejected by the unique constraint |
| Same slug inserted in another project | Accepted |
| Null owner insert after migration | Rejected by `NOT NULL` |
| Unknown project UUID insert | Rejected by the FK |
| `down()` | Removed FK, uniqueness, check, and `NOT NULL`; repair data intentionally remained |
| Rollback, inject fresh null/wrong/duplicate rows, rerun | Repaired and completed successfully |
| Failed concurrent unique build left an invalid index | Invalid index was detected, dropped concurrently, rebuilt, and attached |
| Valid unique index existed but was not attached | Existing index was attached without rebuilding |
| Existing unvalidated FK | FK was validated |
| Completed migration run again | Same full-table fingerprint before and after |
| Table held behind an `ACCESS EXCLUSIVE` blocker | Failed on lock timeout in 5.93 s; completed on retry after the blocker cleared |
| Process interrupted after 36,000 of 79,873 slug repairs | 36,000 committed repairs remained; rerun finished the remaining 43,873 in 22.42 s |
| Knex migration runner `up` → `down` → `up` | Migration metadata and lock state remained correct (`is_locked = 0`) |

## Scale results

Synthetic PostgreSQL fixtures used generic generated data only.

| Fixture | Ownership repairs | Duplicate repairs | Time | Result |
| --- | ---: | ---: | ---: | --- |
| 79,874 dashboards / 3,409 projects, mixed null/wrong owners and duplicates | 15,975 | 8,285 | **2.75 s** | Zero null owners, mismatches, or duplicate groups |
| Deliberate ceiling: all 79,874 dashboards null-owned in one project with one slug | 79,874 | 79,873 | **81.28 s** | Completed and enforced all constraints |

## Pre-merge data check

PostgreSQL B-tree entries have a physical size ceiling. A unique 1,500-character value was verified successfully, while a synthetic incompressible 5,120-character value exceeded that ceiling. Since unique slugs must not be rewritten, run this conservative check before merge:

```sql
SELECT max(octet_length(slug)),
       count(*) FILTER (WHERE octet_length(slug) > 2000)
FROM dashboards;
```

If the count is non-zero, inspect those rows before merging rather than silently changing their slugs.

## Validation

- Full CLI cycle on a fresh disposable database: all 524 migrations, 16 development seed files, this migration rolled down, edge-case data injected, migrated up, rolled down again, fresh corruption injected, and migrated up again.
- Focused migration lint and formatting passed.
- Full backend typecheck passed.
- The migration passed direct module execution and the Knex migration runner.
- All scenarios above were run against disposable PostgreSQL databases and verified with SQL assertions.

## Rollout

The ownership expansion from #25906 is the required writer-compatible phase. Knex runs that migration and this contract migration sequentially, so upgrading directly from an older version is data-safe.

A rolling upgrade from a version before #25906 can still leave old pods serving briefly after `project_uuid` becomes `NOT NULL`; those pods cannot create dashboards because they omit the new owner. The automated release-safety check therefore correctly selects the `Recreate` strategy. Use that strategy, or a controlled low-traffic deployment window, for the release containing this contract.

Closes: PROD-9105
Relates: PROD-8968





<!-- test-all -->

