### PR TITLE
fix: isolate dbt target dir per compile to prevent cross-project manifest contamination

### DIFF
--- a/packages/backend/src/dbt/dbtCliClient.mock.ts
+++ b/packages/backend/src/dbt/dbtCliClient.mock.ts
@@ -45,13 +45,6 @@ export const cliMockImplementation = {
     },
 };
 
-export const dbtProjectYml = `
-name: 'jaffle_shop'
-version: '0.1'
-profile: 'jaffle_shop'
-config-version: 2
-`;
-
 export const manifestMock: DbtManifest = {
     nodes: {},
     metadata: {

--- a/packages/backend/src/dbt/dbtCliClient.test.ts
+++ b/packages/backend/src/dbt/dbtCliClient.test.ts
@@ -3,10 +3,8 @@ import execa from 'execa';
 import * as fs from 'fs/promises';
 import { DbtCliClient } from './dbtCliClient';
 import {
-    catalogMock,
     cliArgs as cliArgsWithoutVersion,
     cliMockImplementation,
-    dbtProjectYml,
     expectedCommandOptions,
     expectedDbtOptions,
     expectedPackages,
@@ -19,6 +17,8 @@ const execaMock = execa as unknown as import('vitest').Mock;
 vi.mock('fs/promises', () => ({
     readFile: vi.fn(),
     writeFile: vi.fn(),
+    mkdtemp: vi.fn(),
+    rm: vi.fn(),
 }));
 vi.mock('execa');
 
@@ -30,6 +30,9 @@ Object.values(SupportedDbtVersions).map((dbtVersion) => {
     return describe(`DbtCliClient ${dbtVersion}`, () => {
         beforeEach(() => {
             vi.resetAllMocks();
+            vi.mocked(fs.mkdtemp).mockResolvedValue(
+                '/tmp/dbt_target_test' as never,
+            );
         });
         it('should install dependencies with success', async () => {
             execaMock.mockImplementationOnce(cliMockImplementation.success);
@@ -54,9 +57,6 @@ Object.values(SupportedDbtVersions).map((dbtVersion) => {
         });
         it('should get manifest with success', async () => {
             execaMock.mockImplementationOnce(cliMockImplementation.success);
-            vi.spyOn(fs, 'readFile').mockImplementationOnce(
-                async () => dbtProjectYml,
-            );
             vi.spyOn(fs, 'readFile').mockImplementationOnce(async () =>
                 JSON.stringify(manifestMock),
             );

--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -16,53 +16,12 @@ import {
 import * as Sentry from '@sentry/node';
 import execa, { ExecaError, ExecaReturnValue } from 'execa';
 import * as fs from 'fs/promises';
-import yaml, { dump as dumpYaml, load as loadYaml } from 'js-yaml';
+import yaml from 'js-yaml';
+import os from 'os';
 import path from 'path';
 import Logger from '../logging/logger';
 import { traceSpan } from '../tracing/tracing';
 import { DbtClient } from '../types';
-
-type DbtProjectConfig = {
-    targetDir: string;
-};
-
-type RawDbtProjectConfig = {
-    'target-path'?: string;
-    'target-dir'?: string;
-};
-
-const isRawDbtConfig = (raw: AnyType): raw is RawDbtProjectConfig =>
-    typeof raw === 'object' &&
-    raw !== null &&
-    (raw['target-dir'] === undefined || typeof raw['target-dir'] === 'string');
-
-export const getDbtConfig = async (
-    dbtProjectDirectory: string,
-): Promise<DbtProjectConfig> => {
-    let config;
-    const configPath = path.join(dbtProjectDirectory, 'dbt_project.yml');
-    try {
-        config = loadYaml(await fs.readFile(configPath, 'utf-8'));
-    } catch (e) {
-        throw new ParseError(
-            `dbt_project.yml was not found or isn't a valid yaml document: ${getErrorMessage(
-                e,
-            )}`,
-            {},
-        );
-    }
-    if (!isRawDbtConfig(config)) {
-        throw new Error('dbt_project.yml not valid');
-    }
-    const updatedConfig = {
-        ...config,
-        'target-path': 'target',
-    };
-    await fs.writeFile(configPath, dumpYaml(updatedConfig), 'utf-8');
-    return {
-        targetDir: '/target',
-    };
-};
 
 type DbtCliArgs = {
     dbtProjectDirectory: string;
@@ -126,12 +85,28 @@ export class DbtCliClient implements DbtClient {
         return this.selector;
     }
 
+    // Each client gets its own dbt target directory so that concurrent
+    // compilations of different projects — which share the same on-disk
+    // project dir — cannot overwrite each other's manifest.json. The path is
+    // passed to dbt via DBT_TARGET_PATH (see _runDbtCommand); the shared
+    // dbt_project.yml is never mutated.
     private async _getTargetDirectory(): Promise<string> {
         if (!this.targetDirectory) {
-            const config = await getDbtConfig(this.dbtProjectDirectory);
-            this.targetDirectory = config.targetDir;
+            this.targetDirectory = await fs.mkdtemp(
+                path.join(os.tmpdir(), 'dbt_target_'),
+            );
         }
         return this.targetDirectory;
+    }
+
+    async cleanup(): Promise<void> {
+        if (this.targetDirectory) {
+            await fs.rm(this.targetDirectory, {
+                recursive: true,
+                force: true,
+            });
+            this.targetDirectory = undefined;
+        }
     }
 
     static parseDbtJsonLogs(logs: string | undefined): DbtLog[] {
@@ -183,6 +158,7 @@ export class DbtCliClient implements DbtClient {
         stdout: string;
     }> {
         const dbtExec = this.getDbtExec();
+        const targetPath = await this._getTargetDirectory();
         const dbtArgs = [
             '--no-use-colors',
             '--log-format',
@@ -213,6 +189,7 @@ export class DbtCliClient implements DbtClient {
                 env: {
                     DBT_PARTIAL_PARSE: 'false', // Disable dbt from storing manifest and doing partial parses. https://docs.getdbt.com/reference/parsing#partial-parsing
                     DBT_SEND_ANONYMOUS_USAGE_STATS: 'false', // Disable sending usage stats. https://docs.getdbt.com/reference/global-configs/usage-stats
+                    DBT_TARGET_PATH: targetPath,
                     ...this.environment,
                 },
             });
@@ -385,11 +362,7 @@ export class DbtCliClient implements DbtClient {
     private async loadDbtTargetArtifact(filename: string): Promise<AnyType> {
         const targetDir = await this._getTargetDirectory();
 
-        const fullPath = path.join(
-            this.dbtProjectDirectory,
-            targetDir,
-            filename,
-        );
+        const fullPath = path.join(targetDir, filename);
         return DbtCliClient.loadDbtFile(fullPath);
     }
 

--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -78,9 +78,9 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
         this.analytics = analytics;
     }
 
-    // eslint-disable-next-line class-methods-use-this
     async destroy(): Promise<void> {
         Logger.debug(`Destroy base project adapter`);
+        await this.dbtClient.cleanup?.();
     }
 
     public async test(): Promise<void> {

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -67,6 +67,8 @@ export interface DbtClient {
     getSelector(): string | undefined;
 
     test(): Promise<void>;
+
+    cleanup?(): Promise<void>;
 }
 
 export type CachedWarehouse = {


### PR DESCRIPTION
## Problem

Every local dbt-type project compiled into the **same shared** dbt target directory (`<project_dir>/target/manifest.json`), and `getDbtConfig` even rewrote the shared `dbt_project.yml` to force `target-path: target`. With no lock and no per-refresh isolation, a concurrent compile of another project sharing the same dbt dir could overwrite `manifest.json` **between** one project's `dbt ls` (which writes the manifest) and Lightdash reading it back.

When that happens, a BigQuery project can read a Postgres project's manifest. Lightdash copies `model.relation_name` from the manifest verbatim into the explore's `sqlTable`, so the BigQuery project ends up storing a Postgres-quoted table reference (`"postgres"."jaffle"."timezone_test"`). At query time that Postgres SQL is sent to BigQuery, which fails with:

```
Syntax error: Unexpected string literal "postgres"
```

This surfaced as the intermittent `queryTimezone.test.ts` "BigQuery fractional offsets" failures in the E2E API job, but it is a real backend bug: any instance running multiple local dbt projects (or refreshing one concurrently) on shared storage can hit cross-project manifest contamination.

## Fix

Give each `DbtCliClient` its own dbt target directory:

- `_getTargetDirectory()` now creates a unique temp dir via `mkdtemp` (`/tmp/dbt_target_*`), mirroring how the profiles dir is already isolated.
- The dir is passed to dbt via the `DBT_TARGET_PATH` env var, and the manifest is read back from it.
- The shared `dbt_project.yml` is no longer mutated (`getDbtConfig` removed).
- The temp dir is cleaned up on adapter `destroy()` via a new optional `DbtClient.cleanup()`.

`DBT_TARGET_PATH` is honoured by `dbt ls` across all supported dbt versions (verified 1.4–1.11) and harmlessly ignored by `deps`. The `--target-path` CLI flag was deliberately avoided because dbt 1.4 rejects it.

## Testing

- `dbtCliClient.test.ts` — 45/45 pass; logs confirm the manifest is now read from the isolated temp dir.
- `typecheck:fast` and `eslint` clean on the changed files.
- Manually confirmed in-container that `DBT_TARGET_PATH` isolates `manifest.json` on dbt 1.4, 1.5 and 1.11.

Closes: <!-- Linear ticket + GitHub bug issue to be linked (deferred) -->
