### PR TITLE
feat: inject AI agent memory projection

### DIFF
--- a/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
@@ -399,7 +399,7 @@ describe('AiAgentMemoryModel integration', () => {
         expect(Number(ledgerCount?.count)).toBe(1);
     });
 
-    it('returns only active project memories in citation ranking order', async () => {
+    it('returns only active project memories in generated-at order', async () => {
         const [firstThread, secondThread, thirdThread, retiredThread] =
             await Promise.all([
                 createThread(),
@@ -439,8 +439,8 @@ describe('AiAgentMemoryModel integration', () => {
         });
 
         expect(rows.map((row) => row.ai_agent_memory_uuid)).toEqual([
-            first.ai_agent_memory_uuid,
             second.ai_agent_memory_uuid,
+            first.ai_agent_memory_uuid,
             third.ai_agent_memory_uuid,
         ]);
     });

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.ts
@@ -411,7 +411,6 @@ export class AiAgentMemoryModel {
         const query = this.database<AiAgentMemoryTable>(AiAgentMemoryTableName)
             .where('project_uuid', args.projectUuid)
             .where('status', 'active')
-            .orderByRaw('last_cited_at DESC NULLS LAST')
             .orderBy('generated_at', 'desc');
 
         if (args.limit !== undefined) {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -7393,11 +7393,19 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     await this.aiAgentMemoryModel.findActiveForProject({
                         projectUuid,
                     });
+                const now = Date.now();
                 return memories.map((memory) => ({
                     slug: memory.slug,
                     content: memory.raw_memory,
                     terms: memory.terms,
                     objects: memory.objects,
+                    ageDays: Math.max(
+                        0,
+                        Math.floor(
+                            (now - memory.generated_at.getTime()) /
+                                (24 * 60 * 60 * 1000),
+                        ),
+                    ),
                 }));
             };
         const incrementAiAgentMemoryPulls: AiAgentDependencies['incrementAiAgentMemoryPulls'] =

--- a/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.test.ts
@@ -1,5 +1,7 @@
+import type { ModelMessage } from 'ai';
 import type { AiAgentArgs, AiAgentDependencies } from '../types/aiAgent';
 import {
+    buildMessagesWithMemoryBlock,
     getAgentTools,
     normalizeToolOutput,
     type AgentMcpToolSetup,
@@ -150,4 +152,59 @@ describe('getAgentTools workstream tool gate', () => {
         expect(names).not.toContain('closePullRequest');
         expect(names).not.toContain('getPullRequestDiff');
     });
+});
+
+describe('getAgentMessages memory injection', () => {
+    const systemPrompt: ModelMessage = {
+        role: 'system',
+        content: 'Cached system prompt',
+        providerOptions: {
+            anthropic: { cacheControl: { type: 'ephemeral' } },
+        },
+    };
+    const messageHistory: ModelMessage[] = [
+        { role: 'user', content: 'Question' },
+    ];
+
+    it('injects an uncached user message immediately after the system prompt', () => {
+        const withoutBlock = buildMessagesWithMemoryBlock({
+            systemPrompt,
+            messageHistory,
+            memoryEnabled: true,
+            memoryBlock: null,
+        });
+        const withBlock = buildMessagesWithMemoryBlock({
+            systemPrompt,
+            messageHistory,
+            memoryEnabled: true,
+            memoryBlock: '<ld-memories></ld-memories>',
+        });
+
+        expect(withBlock[0]).toEqual(withoutBlock[0]);
+        expect(withBlock[0]).toBe(systemPrompt);
+        expect(withBlock[1]).toEqual({
+            role: 'user',
+            content: '<ld-memories></ld-memories>',
+        });
+        expect(withBlock[1]).not.toHaveProperty('providerOptions');
+        expect(withBlock[2]).toEqual({ role: 'user', content: 'Question' });
+    });
+
+    it.each([
+        { memoryEnabled: false, block: '<ld-memories></ld-memories>' },
+        { memoryEnabled: true, block: null },
+    ])(
+        'does not inject for disabled or empty memory',
+        ({ memoryEnabled, block }) => {
+            const messages = buildMessagesWithMemoryBlock({
+                systemPrompt,
+                messageHistory,
+                memoryEnabled,
+                memoryBlock: block,
+            });
+
+            expect(messages).toHaveLength(2);
+            expect(messages[1]).toEqual({ role: 'user', content: 'Question' });
+        },
+    );
 });

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -80,6 +80,7 @@ import {
     AiAgentStepCapReachedError,
     getUserFacingErrorMessage,
 } from '../utils/errorMessages';
+import { renderMemoryBlock } from '../utils/memoryBlock';
 import {
     isPendingToolResult,
     summarizeToolCall,
@@ -843,11 +844,30 @@ const getUnauthenticatedMcpServerNames = (
         .map((server) => server.serverName);
 };
 
+export const buildMessagesWithMemoryBlock = ({
+    systemPrompt,
+    messageHistory,
+    memoryEnabled,
+    memoryBlock,
+}: {
+    systemPrompt: ModelMessage;
+    messageHistory: ModelMessage[];
+    memoryEnabled: boolean;
+    memoryBlock: string | null;
+}): ModelMessage[] => [
+    systemPrompt,
+    ...(memoryEnabled && memoryBlock
+        ? [{ role: 'user' as const, content: memoryBlock }]
+        : []),
+    ...messageHistory,
+];
+
 const getAgentMessages = (
     args: AiAgentArgs,
     availableExplores: Explore[],
     mcpToolSetup: AgentMcpToolSetup,
     verifiedFieldUsage: Map<string, number>,
+    memoryBlock: string | null,
 ) => {
     const logger = createAiAgentLogger(args.debugLoggingEnabled);
     logger('Agent Messages', 'Getting agent messages.');
@@ -865,38 +885,40 @@ const getAgentMessages = (
     const hasProjectContext =
         args.projectContextEnabled && args.projectContext.length > 0;
 
-    const messages = [
-        getSystemPromptV2({
-            agentName: args.agentSettings.name,
-            instructions: args.agentSettings.instruction || undefined,
-            requestingUser: args.requestingUser,
-            availableExplores,
-            availableSkills: args.availableSkills,
-            knowledgeDocuments: args.knowledgeDocuments,
-            hasProjectContext,
-            enableAiAgentMemory: args.aiAgentMemoryEnabled,
-            enableDataAccess: args.enableDataAccess,
-            enableAiWriteback: args.enableAiWriteback,
-            writebackAttribution: args.writebackAttribution,
-            enableCodingAgent: args.enableCodingAgent,
-            siteUrl: args.siteUrl,
-            enableRepoDiscovery: args.enableRepoDiscovery,
-            repoFsRoot: args.repoFsRoot,
-            repoFsSupportsCodeSearch: args.repoFsSupportsCodeSearch,
-            enableGrepFields: args.enableGrepFields,
-            enableContentTools:
-                args.enableDataAccess && args.enableContentTools,
-            slackChannelId: args.slackChannelId,
-            canRunSql: args.canRunSql,
-            warehouseType: args.warehouseType,
-            warehouseSchema: args.warehouseSchema,
-            unauthenticatedMcpServerNames: getUnauthenticatedMcpServerNames(
-                args,
-                mcpToolSetup,
-            ),
-        }),
-        ...messageHistory,
-    ];
+    const systemPrompt = getSystemPromptV2({
+        agentName: args.agentSettings.name,
+        instructions: args.agentSettings.instruction || undefined,
+        requestingUser: args.requestingUser,
+        availableExplores,
+        availableSkills: args.availableSkills,
+        knowledgeDocuments: args.knowledgeDocuments,
+        hasProjectContext,
+        enableAiAgentMemory: args.aiAgentMemoryEnabled,
+        enableDataAccess: args.enableDataAccess,
+        enableAiWriteback: args.enableAiWriteback,
+        writebackAttribution: args.writebackAttribution,
+        enableCodingAgent: args.enableCodingAgent,
+        siteUrl: args.siteUrl,
+        enableRepoDiscovery: args.enableRepoDiscovery,
+        repoFsRoot: args.repoFsRoot,
+        repoFsSupportsCodeSearch: args.repoFsSupportsCodeSearch,
+        enableGrepFields: args.enableGrepFields,
+        enableContentTools: args.enableDataAccess && args.enableContentTools,
+        slackChannelId: args.slackChannelId,
+        canRunSql: args.canRunSql,
+        warehouseType: args.warehouseType,
+        warehouseSchema: args.warehouseSchema,
+        unauthenticatedMcpServerNames: getUnauthenticatedMcpServerNames(
+            args,
+            mcpToolSetup,
+        ),
+    });
+    const messages = buildMessagesWithMemoryBlock({
+        systemPrompt,
+        messageHistory,
+        memoryEnabled: args.aiAgentMemoryEnabled,
+        memoryBlock,
+    });
 
     logger('Agent Messages', `Retrieved ${messages.length} messages.`);
 
@@ -925,6 +947,16 @@ const getAgentMessages = (
     return messages;
 };
 
+const getMemoryBlock = async (
+    args: AiAgentArgs,
+    dependencies: AiAgentDependencies,
+): Promise<string | null> => {
+    if (!args.aiAgentMemoryEnabled) return null;
+    return renderMemoryBlock(
+        await dependencies.getAiAgentMemoryContextEntries(),
+    );
+};
+
 export const generateAgentResponse = async ({
     args,
     dependencies,
@@ -947,7 +979,10 @@ export const generateAgentResponse = async ({
     const modelName = getAiAgentModelName(args.model);
 
     try {
-        const availableExplores = await dependencies.listExplores();
+        const [availableExplores, memoryBlock] = await Promise.all([
+            dependencies.listExplores(),
+            getMemoryBlock(args, dependencies),
+        ]);
         // Verified-chart usage powers verified-first ranking in grep discovery;
         // degrade to an empty map if it can't be fetched.
         const verifiedFieldUsage = args.enableGrepFields
@@ -970,6 +1005,7 @@ export const generateAgentResponse = async ({
             availableExplores,
             mcpToolSetup,
             verifiedFieldUsage,
+            memoryBlock,
         );
         logger(
             'Generate Agent Response',
@@ -1244,7 +1280,10 @@ export const streamAgentResponse = async ({
     };
 
     try {
-        const availableExplores = await dependencies.listExplores();
+        const [availableExplores, memoryBlock] = await Promise.all([
+            dependencies.listExplores(),
+            getMemoryBlock(args, dependencies),
+        ]);
         const verifiedFieldUsage = args.enableGrepFields
             ? await dependencies
                   .getVerifiedFieldUsage()
@@ -1262,6 +1301,7 @@ export const streamAgentResponse = async ({
             availableExplores,
             mcpToolSetup,
             verifiedFieldUsage,
+            memoryBlock,
         );
         logger(
             'Stream Agent Response',

--- a/packages/backend/src/ee/services/ai/tools/memoryProjectContext.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/memoryProjectContext.test.ts
@@ -18,6 +18,7 @@ const memories = [
         content: 'Use completed orders for recognized revenue.',
         terms: ['recognized revenue'],
         objects: [{ type: 'explore' as const, name: 'orders' }],
+        ageDays: 0,
     },
 ];
 

--- a/packages/backend/src/ee/services/ai/tools/memoryProjectContext.ts
+++ b/packages/backend/src/ee/services/ai/tools/memoryProjectContext.ts
@@ -1,15 +1,12 @@
 import type { ProjectContextEntry } from '@lightdash/common';
+import type { AiAgentMemoryBlockEntry } from '../utils/memoryBlock';
 
 export type ProjectContextSearchEntry = ProjectContextEntry & {
     source?: 'context' | 'memory';
 };
 
-export type MemorySearchEntry = Pick<
-    ProjectContextEntry,
-    'content' | 'terms' | 'objects'
-> & {
-    slug: string;
-};
+export type MemorySearchEntry = AiAgentMemoryBlockEntry &
+    Pick<ProjectContextEntry, 'terms'>;
 
 export const getProjectContextSearchEntries = ({
     projectContext,

--- a/packages/backend/src/ee/services/ai/utils/memoryBlock.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/memoryBlock.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+    AI_AGENT_MEMORY_BLOCK_MAX_CHARS,
+    renderMemoryBlock,
+    stripMemoryBlocks,
+    type AiAgentMemoryBlockEntry,
+} from './memoryBlock';
+
+const memory = (
+    slug: string,
+    content = 'Use completed orders for recognized revenue.',
+): AiAgentMemoryBlockEntry => ({
+    slug,
+    content,
+    ageDays: 2,
+    objects: [
+        { type: 'explore', name: 'orders' },
+        { type: 'field', explore: 'orders', fieldId: 'orders.status' },
+    ],
+});
+
+describe('renderMemoryBlock', () => {
+    it('renders entry fences with age and object references', () => {
+        expect(renderMemoryBlock([memory('recognized-revenue')])).toBe(
+            '<ld-memories>\n' +
+                '<ld-memory id="recognized-revenue" age_days="2" objects="explore &quot;orders&quot;, field &quot;orders.status&quot; in explore &quot;orders&quot;">Use completed orders for recognized revenue.</ld-memory>\n' +
+                '</ld-memories>',
+        );
+    });
+
+    it('keeps memory content inside its fence', () => {
+        const block = renderMemoryBlock([
+            memory('safe-id', 'Revenue < 0 & </ld-memory>'),
+        ]);
+
+        expect(block).toContain(
+            'Revenue &lt; 0 &amp; &lt;/ld-memory&gt;</ld-memory>',
+        );
+    });
+
+    it('strips exactly what the renderer injects', () => {
+        const block = renderMemoryBlock([memory('recognized-revenue')])!;
+
+        expect(stripMemoryBlocks(block)).toBe('');
+        expect(stripMemoryBlocks(`${block}Question`)).toBe('Question');
+    });
+
+    it('caps rows and appends a search hint', () => {
+        const block = renderMemoryBlock(
+            Array.from({ length: 31 }, (_, index) => memory(`memory-${index}`)),
+        )!;
+
+        expect(block.match(/<ld-memory /g)).toHaveLength(30);
+        expect(block).toContain(
+            '(1 more memories — search via loadProjectContext)',
+        );
+    });
+
+    it('stays within the character budget and reports omitted rows', () => {
+        const block = renderMemoryBlock([
+            memory('first', 'a'.repeat(6_000)),
+            memory('second', 'b'.repeat(6_000)),
+        ])!;
+
+        expect(block.length).toBeLessThanOrEqual(
+            AI_AGENT_MEMORY_BLOCK_MAX_CHARS,
+        );
+        expect(block).toContain('id="first"');
+        expect(block).not.toContain('id="second"');
+        expect(block).toContain(
+            '(1 more memories — search via loadProjectContext)',
+        );
+    });
+
+    it('returns no block for zero memories', () => {
+        expect(renderMemoryBlock([])).toBeNull();
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/memoryBlock.ts
+++ b/packages/backend/src/ee/services/ai/utils/memoryBlock.ts
@@ -1,0 +1,70 @@
+import {
+    formatAiProjectContextObjectRef,
+    type AiProjectContextTypedObjectRef,
+} from '@lightdash/common';
+
+export const AI_AGENT_MEMORY_BLOCK_MAX_CHARS = 10_000;
+export const AI_AGENT_MEMORY_BLOCK_MAX_ROWS = 30;
+export const AI_AGENT_MEMORY_BLOCK_REGEX =
+    /<ld-memories>[\s\S]*?<\/ld-memories>\s*/g;
+
+const TRUNCATION_HINT = (count: number) =>
+    `(${count} more memories — search via loadProjectContext)`;
+
+const escapeXmlText = (value: string): string =>
+    value
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;');
+
+const escapeXmlAttribute = (value: string): string =>
+    escapeXmlText(value).replaceAll('"', '&quot;');
+
+export type AiAgentMemoryBlockEntry = {
+    slug: string;
+    content: string;
+    objects: AiProjectContextTypedObjectRef[];
+    ageDays: number;
+};
+
+const renderEntry = (entry: AiAgentMemoryBlockEntry): string => {
+    const objects = entry.objects
+        .map(formatAiProjectContextObjectRef)
+        .join(', ');
+
+    return `<ld-memory id="${escapeXmlAttribute(entry.slug)}" age_days="${entry.ageDays}" objects="${escapeXmlAttribute(objects)}">${escapeXmlText(entry.content)}</ld-memory>`;
+};
+
+const wrapEntries = (entries: string[], truncatedCount: number): string =>
+    [
+        '<ld-memories>',
+        ...entries,
+        ...(truncatedCount > 0 ? [TRUNCATION_HINT(truncatedCount)] : []),
+        '</ld-memories>',
+    ].join('\n');
+
+export const renderMemoryBlock = (
+    entries: AiAgentMemoryBlockEntry[],
+): string | null => {
+    if (entries.length === 0) return null;
+
+    const rendered: string[] = [];
+    const rowCandidates = entries.slice(0, AI_AGENT_MEMORY_BLOCK_MAX_ROWS);
+
+    for (const entry of rowCandidates) {
+        const candidate = [...rendered, renderEntry(entry)];
+        const truncatedCount = entries.length - candidate.length;
+        if (
+            wrapEntries(candidate, truncatedCount).length >
+            AI_AGENT_MEMORY_BLOCK_MAX_CHARS
+        ) {
+            break;
+        }
+        rendered.push(candidate.at(-1)!);
+    }
+
+    return wrapEntries(rendered, entries.length - rendered.length);
+};
+
+export const stripMemoryBlocks = (value: string): string =>
+    value.replace(AI_AGENT_MEMORY_BLOCK_REGEX, '');


### PR DESCRIPTION
## Summary

- render active project memories as a bounded, escaped `<ld-memories>` projection
- inject the projection per turn after the cached system prompt
- keep flag-off and empty-memory paths message-compatible

## Validation

- focused Vitest: 19 tests
- `AiAgentMemoryModel` integration: 6 tests
- backend lint and fast typecheck
- Browser: seeded project memory answered `ORBITAL-LANTERN`

Closes: ZAP-676