### PR TITLE
refactor: unify timestamp filter context

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -6786,6 +6786,21 @@ const buildNaiveExplore = (
                     timeIntervalBaseDimensionName: 'occurred_at',
                     timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
                 },
+                occurred_at_custom: {
+                    type: DimensionType.TIMESTAMP,
+                    name: 'occurred_at_custom',
+                    label: 'occurred_at_custom',
+                    table: 'events',
+                    tableLabel: 'events',
+                    fieldType: FieldType.DIMENSION,
+                    sql: `DATETIME(\${TABLE}.occurred_at, 'Asia/Tokyo')`,
+                    compiledSql: `DATETIME("events".occurred_at, 'Asia/Tokyo')`,
+                    tablesReferences: ['events'],
+                    hidden: false,
+                    customTimeInterval: 'tokyo_wall_clock',
+                    timeIntervalBaseDimensionName: 'occurred_at',
+                    timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+                },
                 occurred_at_day: {
                     type: DimensionType.DATE,
                     name: 'occurred_at_day',
@@ -7224,6 +7239,66 @@ describe('Naive timestamp domain — explicit, session-independent conversion', 
             expect(query).toContain(
                 `(DATE_TRUNC('HOUR', CAST("events".occurred_at AS TIMESTAMP))) = CAST('2024-01-14 17:00:00+00:00' AS timestamp)`,
             );
+        });
+
+        test('known-aware hour filter uses the actual unwrapped LHS to retain the legacy literal (Trino)', () => {
+            const { query } = buildQuery({
+                explore: buildNaiveExplore(SupportedDbtAdapter.TRINO, 'aware'),
+                compiledMetricQuery: filteredQuery('events_occurred_at_hour'),
+                warehouseSqlBuilder: trinoClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: 'Asia/Tokyo',
+                useTimezoneAwareDateTrunc: true,
+                columnTimezone: 'Asia/Tokyo',
+            });
+            expect(query).toContain(
+                `(DATE_TRUNC('HOUR', CAST("events".occurred_at AS TIMESTAMP))) = CAST('2024-01-14 17:00:00+00:00' AS timestamp)`,
+            );
+        });
+
+        test.each([SupportedDbtAdapter.DATABRICKS, SupportedDbtAdapter.SPARK])(
+            '%s known-aware RAW filter keeps a bare LHS and offset-bearing instant',
+            (adapter) => {
+                const { query } = buildQuery({
+                    explore: buildNaiveExplore(adapter, 'aware'),
+                    compiledMetricQuery: filteredQuery(
+                        'events_occurred_at_raw',
+                    ),
+                    warehouseSqlBuilder: {
+                        ...warehouseClientMock,
+                        getAdapterType: () => adapter,
+                    },
+                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                    timezone: 'UTC',
+                    useTimezoneAwareDateTrunc: true,
+                    columnTimezone: 'Asia/Tokyo',
+                });
+                const whereClause = query.slice(query.indexOf('WHERE'));
+                expect(whereClause).toContain(
+                    `("events".occurred_at) = ('2024-01-14 17:00:00+00:00')`,
+                );
+                expect(whereClause).not.toContain('to_utc_timestamp');
+            },
+        );
+
+        test('custom granularity output stays unknown and keeps its legacy literal (BigQuery)', () => {
+            const { query } = buildQuery({
+                explore: buildNaiveExplore(
+                    SupportedDbtAdapter.BIGQUERY,
+                    'naive',
+                ),
+                compiledMetricQuery: filteredQuery('events_occurred_at_custom'),
+                warehouseSqlBuilder: bigqueryClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: 'UTC',
+                useTimezoneAwareDateTrunc: true,
+                columnTimezone: 'Asia/Tokyo',
+            });
+            const whereClause = query.slice(query.indexOf('WHERE'));
+            expect(whereClause).toContain(
+                `(DATETIME("events".occurred_at, 'Asia/Tokyo')) = ('2024-01-14 17:00:00')`,
+            );
+            expect(whereClause).not.toContain(`DATETIME '2024-01-15 02:00:00'`);
         });
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -47,6 +47,7 @@ import {
     isNonAggregateMetric,
     isPeriodOverPeriodAdditionalMetric,
     isPostCalculationMetric,
+    isTimezoneRoundTripNoOp,
     ItemsMap,
     lightdashVariablePattern,
     MetricFilterRule,
@@ -59,6 +60,7 @@ import {
     QueryWarning,
     renderFilterRuleSqlFromField,
     renderTableCalculationFilterRuleSql,
+    resolveTimestampFilterContext,
     snakeCaseName,
     SortField,
     sqlAggregationWrapsReferences,
@@ -73,6 +75,8 @@ import {
     type ParameterDefinitions,
     type ParametersValuesMap,
     type TimestampDomain,
+    type TimestampFilterContext,
+    type TimestampFilterLhsMode,
     type WarehouseSqlBuilder,
     type WeekDay,
 } from '@lightdash/common';
@@ -789,23 +793,23 @@ export class MetricQueryBuilder {
      * in its raw warehouse value. Pass `respectConvertTimezone: false` from
      * filter rendering so WHERE clauses keep wrapping regardless.
      */
-    private getTimezoneAwareDimensionSql(
+    private resolveTimezoneAwareDimensionSql(
         dimension: CompiledDimension,
         adapterType: SupportedDbtAdapter,
         startOfWeek: WeekDay | null | undefined,
         respectConvertTimezone: boolean = true,
-    ): string {
+    ): { sql: string; lhsMode: TimestampFilterLhsMode } {
         const { timezone, useTimezoneAwareDateTrunc } = this.args;
 
         if (!useTimezoneAwareDateTrunc || !dimension.timeInterval) {
-            return dimension.compiledSql;
+            return { sql: dimension.compiledSql, lhsMode: 'legacy' };
         }
 
         const isRaw = dimension.timeInterval === TimeFrames.RAW;
         const isTruncatable = truncatableTimeFrames.has(dimension.timeInterval);
         const isExtractable = extractableTimeFrames.has(dimension.timeInterval);
         if (!isRaw && !isTruncatable && !isExtractable) {
-            return dimension.compiledSql;
+            return { sql: dimension.compiledSql, lhsMode: 'legacy' };
         }
 
         const baseDimensionId = dimension.timeIntervalBaseDimensionName
@@ -822,11 +826,11 @@ export class MetricQueryBuilder {
             !baseDimension?.compiledSql ||
             baseDimension.type !== DimensionType.TIMESTAMP
         ) {
-            return dimension.compiledSql;
+            return { sql: dimension.compiledSql, lhsMode: 'legacy' };
         }
 
         if (respectConvertTimezone && baseDimension.skipTimezoneConversion) {
-            return dimension.compiledSql;
+            return { sql: dimension.compiledSql, lhsMode: 'legacy' };
         }
 
         // Effective domain: the child dim's own value, falling back to the
@@ -840,7 +844,7 @@ export class MetricQueryBuilder {
         // explicit data-timezone rebase when the column is known-naive.
         if (isRaw) {
             if (this.columnTimezone === 'UTC') {
-                return dimension.compiledSql;
+                return { sql: dimension.compiledSql, lhsMode: 'legacy' };
             }
             // Filter LHS: a known domain keeps the bare column (the literal
             // side carries the conversion, so predicates stay sargable); the
@@ -853,27 +857,62 @@ export class MetricQueryBuilder {
                     baseDimension.skipTimezoneConversion ||
                     !naiveTimestampRebaseAdapters.has(adapterType))
             ) {
-                return dimension.compiledSql;
+                return { sql: dimension.compiledSql, lhsMode: 'legacy' };
             }
             const { castToInstant, castNaiveToInstant, castAwareToInstant } =
                 dateTruncTimezoneConversions[adapterType];
             if (timestampDomain === 'naive' && castNaiveToInstant) {
-                return castNaiveToInstant(
-                    baseDimension.compiledSql,
-                    this.columnTimezone,
-                );
+                return {
+                    sql: castNaiveToInstant(
+                        baseDimension.compiledSql,
+                        this.columnTimezone,
+                    ),
+                    lhsMode: 'instant',
+                };
             }
             // Known-aware columns are bare instants everywhere except
             // Databricks/Spark, where the wire face follows the session — the
             // explicit cast freezes it.
             if (timestampDomain === 'aware' && castAwareToInstant) {
-                return castAwareToInstant(baseDimension.compiledSql);
+                return {
+                    sql: castAwareToInstant(baseDimension.compiledSql),
+                    lhsMode: 'instant',
+                };
             }
-            return castToInstant(baseDimension.compiledSql);
+            return {
+                sql: castToInstant(baseDimension.compiledSql),
+                lhsMode: 'instant',
+            };
         }
 
         if (isTruncatable) {
-            return getSqlForTruncatedDate(
+            return {
+                sql: getSqlForTruncatedDate(
+                    adapterType,
+                    dimension.timeInterval,
+                    baseDimension.compiledSql,
+                    baseDimension.type,
+                    startOfWeek,
+                    timezone,
+                    this.columnTimezone,
+                    timestampDomain,
+                    // GLITCH-452: reached only when useTimezoneAwareDateTrunc is on,
+                    // so day-or-coarser grains emit a real DATE (matches metadata).
+                    true,
+                ),
+                lhsMode: isTimezoneRoundTripNoOp(
+                    adapterType,
+                    timezone,
+                    this.columnTimezone,
+                    timestampDomain,
+                )
+                    ? 'legacy'
+                    : 'wrapped',
+            };
+        }
+
+        return {
+            sql: timeFrameConfigs[dimension.timeInterval].getSql(
                 adapterType,
                 dimension.timeInterval,
                 baseDimension.compiledSql,
@@ -882,22 +921,23 @@ export class MetricQueryBuilder {
                 timezone,
                 this.columnTimezone,
                 timestampDomain,
-                // GLITCH-452: reached only when useTimezoneAwareDateTrunc is on,
-                // so day-or-coarser grains emit a real DATE (matches metadata).
-                true,
-            );
-        }
+            ),
+            lhsMode: 'legacy',
+        };
+    }
 
-        return timeFrameConfigs[dimension.timeInterval].getSql(
+    private getTimezoneAwareDimensionSql(
+        dimension: CompiledDimension,
+        adapterType: SupportedDbtAdapter,
+        startOfWeek: WeekDay | null | undefined,
+        respectConvertTimezone: boolean = true,
+    ): string {
+        return this.resolveTimezoneAwareDimensionSql(
+            dimension,
             adapterType,
-            dimension.timeInterval,
-            baseDimension.compiledSql,
-            baseDimension.type,
             startOfWeek,
-            timezone,
-            this.columnTimezone,
-            timestampDomain,
-        );
+            respectConvertTimezone,
+        ).sql;
     }
 
     /**
@@ -937,6 +977,34 @@ export class MetricQueryBuilder {
             return undefined;
         }
         return dimension.timestampDomain ?? baseDimension.timestampDomain;
+    }
+
+    private resolveTimezoneAwareFilterDimension(
+        dimension: CompiledDimension,
+        adapterType: SupportedDbtAdapter,
+        startOfWeek: WeekDay | null | undefined,
+    ): {
+        field: CompiledDimension;
+        timestampFilterContext: TimestampFilterContext;
+    } {
+        const { sql, lhsMode } = this.resolveTimezoneAwareDimensionSql(
+            dimension,
+            adapterType,
+            startOfWeek,
+            false,
+        );
+
+        return {
+            field: { ...dimension, compiledSql: sql },
+            timestampFilterContext: resolveTimestampFilterContext({
+                adapterType,
+                useTimezoneAwareDateTrunc: this.args.useTimezoneAwareDateTrunc,
+                sourceTimezone: this.columnTimezone,
+                timestampDomain: this.resolveFilterTimestampDomain(dimension),
+                timeInterval: dimension.timeInterval,
+                lhsMode,
+            }),
+        };
     }
 
     /**
@@ -2085,31 +2153,18 @@ export class MetricQueryBuilder {
             throw new FieldReferenceError(errorMessage);
         }
 
-        // Override filter dimension SQL to match the timezone-aware SELECT
-        // clause. Filters always wrap by project tz — even for dims with
-        // `convert_timezone: false` — so pass `respectConvertTimezone: false`.
-        const filterField = isDimension(field)
-            ? {
-                  ...field,
-                  compiledSql: this.getTimezoneAwareDimensionSql(
-                      field,
-                      adapterType,
-                      startOfWeek,
-                      false,
-                  ),
-              }
-            : field;
-
-        // A rebased RAW filter LHS is an instant — tag the literal to match.
-        // Decided here, where the wrap happened, so the two cannot diverge.
-        const rawFilterLhsIsInstant =
-            isDimension(field) &&
-            field.timeInterval === TimeFrames.RAW &&
-            filterField.compiledSql !== field.compiledSql;
-
-        const timestampDomain = isDimension(field)
-            ? this.resolveFilterTimestampDomain(field)
+        // Resolve the actual filter LHS and its matching literal mode together.
+        // Filters always wrap by project tz — even for dims with
+        // `convert_timezone: false` — so the resolver passes
+        // `respectConvertTimezone: false` to the dimension SQL path.
+        const resolvedFilterDimension = isDimension(field)
+            ? this.resolveTimezoneAwareFilterDimension(
+                  field,
+                  adapterType,
+                  startOfWeek,
+              )
             : undefined;
+        const filterField = resolvedFilterDimension?.field ?? field;
 
         // For period-to-date filters on truncated dimensions, resolve the
         // base (raw) dimension SQL so EXTRACT operates on the actual date
@@ -2149,9 +2204,7 @@ export class MetricQueryBuilder {
                     DEFAULT_FILTER_CASE_SENSITIVE,
                 baseDimensionSql,
                 this.args.useTimezoneAwareDateTrunc,
-                this.columnTimezone,
-                rawFilterLhsIsInstant,
-                timestampDomain,
+                resolvedFilterDimension?.timestampFilterContext,
             );
         });
 

--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -14,6 +14,8 @@ import {
     renderNumberFilterSql,
     renderStringFilterSql,
     renderTimestampFilterSql,
+    resolveTimestampFilterContext,
+    type TimestampFilterLhsMode,
 } from './filtersCompiler';
 import {
     adapterType,
@@ -3016,7 +3018,6 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
                 undefined,
                 true,
                 DimensionType.TIMESTAMP,
-                'UTC',
             );
             expect(sql).not.toContain('TIMESTAMP(');
             expect(sql).toContain("'2024-01-15'");
@@ -3054,7 +3055,6 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
                 undefined,
                 true,
                 DimensionType.TIMESTAMP,
-                'America/New_York',
             );
             expect(sql).not.toContain('TIMESTAMP(');
         });
@@ -3075,7 +3075,6 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
                 undefined,
                 true,
                 DimensionType.TIMESTAMP,
-                'UTC',
             );
             expect(sql).not.toContain('TIMESTAMP(');
             expect(sql).toContain("'2024-01-15'");
@@ -3095,7 +3094,6 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
                 undefined,
                 true,
                 DimensionType.TIMESTAMP,
-                'UTC',
             );
             expect(sql).not.toContain('AT TIME ZONE');
             expect(sql).not.toContain('::timestamp');
@@ -3115,7 +3113,6 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
                 undefined,
                 true,
                 DimensionType.TIMESTAMP,
-                'UTC',
             );
             expect(sql).not.toContain('toDateTime(');
         });
@@ -3134,7 +3131,6 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
                 undefined,
                 true,
                 DimensionType.TIMESTAMP,
-                'UTC',
             );
             expect(sql).not.toContain('AT TIME ZONE');
             expect(sql).not.toContain('::timestamp');
@@ -3154,7 +3150,6 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
                 undefined,
                 true,
                 DimensionType.TIMESTAMP,
-                'UTC',
             );
             expect(sql).not.toContain('toDateTime(');
             expect(sql).toContain("'2024-01-15'");
@@ -3186,15 +3181,26 @@ describe('domain-directed timestamp filter literals', () => {
             timestampDomain,
             timeInterval = TimeFrames.RAW,
             useTimezoneAwareDateTrunc = true,
+            lhsMode = 'legacy',
         }: {
             timezone?: string;
             sourceTimezone?: string;
             timestampDomain?: TimestampDomain;
             timeInterval?: TimeFrames;
             useTimezoneAwareDateTrunc?: boolean;
+            lhsMode?: TimestampFilterLhsMode;
         },
-    ) =>
-        renderFilterRuleSql(
+    ) => {
+        const timestampFilterContext = resolveTimestampFilterContext({
+            adapterType: adapter,
+            useTimezoneAwareDateTrunc,
+            sourceTimezone,
+            timestampDomain,
+            timeInterval,
+            lhsMode,
+        });
+
+        return renderFilterRuleSql(
             filter,
             DimensionType.TIMESTAMP,
             DimensionSqlMock,
@@ -3207,11 +3213,9 @@ describe('domain-directed timestamp filter literals', () => {
             undefined,
             useTimezoneAwareDateTrunc,
             DimensionType.TIMESTAMP,
-            sourceTimezone,
-            undefined,
-            timestampDomain,
-            timeInterval,
+            timestampFilterContext,
         );
+    };
 
     describe('bare naive LHS (RAW frame) renders typed data-timezone wall clocks', () => {
         test.each([
@@ -3228,7 +3232,15 @@ describe('domain-directed timestamp filter literals', () => {
                 `(${DimensionSqlMock}) = TIMESTAMP '2024-01-15 02:00:00'`,
             ],
             [
+                SupportedDbtAdapter.ATHENA,
+                `(${DimensionSqlMock}) = TIMESTAMP '2024-01-15 02:00:00'`,
+            ],
+            [
                 SupportedDbtAdapter.DATABRICKS,
+                `(${DimensionSqlMock}) = TIMESTAMP_NTZ '2024-01-15 02:00:00'`,
+            ],
+            [
+                SupportedDbtAdapter.SPARK,
                 `(${DimensionSqlMock}) = TIMESTAMP_NTZ '2024-01-15 02:00:00'`,
             ],
         ])('equals on %s', (adapter, expected) => {
@@ -3254,7 +3266,15 @@ describe('domain-directed timestamp filter literals', () => {
                 `((${DimensionSqlMock}) >= TIMESTAMP '2024-01-15 01:30:00' AND (${DimensionSqlMock}) <= TIMESTAMP '2024-01-15 02:30:00')`,
             ],
             [
+                SupportedDbtAdapter.ATHENA,
+                `((${DimensionSqlMock}) >= TIMESTAMP '2024-01-15 01:30:00' AND (${DimensionSqlMock}) <= TIMESTAMP '2024-01-15 02:30:00')`,
+            ],
+            [
                 SupportedDbtAdapter.DATABRICKS,
+                `((${DimensionSqlMock}) >= TIMESTAMP_NTZ '2024-01-15 01:30:00' AND (${DimensionSqlMock}) <= TIMESTAMP_NTZ '2024-01-15 02:30:00')`,
+            ],
+            [
+                SupportedDbtAdapter.SPARK,
                 `((${DimensionSqlMock}) >= TIMESTAMP_NTZ '2024-01-15 01:30:00' AND (${DimensionSqlMock}) <= TIMESTAMP_NTZ '2024-01-15 02:30:00')`,
             ],
         ])('inBetween on %s', (adapter, expected) => {
@@ -3264,6 +3284,31 @@ describe('domain-directed timestamp filter literals', () => {
                     timestampDomain: 'naive',
                 }),
             ).toStrictEqual(expected);
+        });
+
+        test('relative boundaries use the same data-timezone wall-clock context', () => {
+            vi.setSystemTime(new Date('2024-01-14T17:00:00Z').getTime());
+            const sql = renderTimestamp(
+                SupportedDbtAdapter.POSTGRES,
+                {
+                    id: 'id',
+                    target: { fieldId: 'fieldId' },
+                    operator: FilterOperator.IN_THE_PAST,
+                    values: [1],
+                    settings: {
+                        unitOfTime: UnitOfTime.hours,
+                        completed: false,
+                    },
+                },
+                {
+                    sourceTimezone: 'Asia/Tokyo',
+                    timestampDomain: 'naive',
+                },
+            );
+
+            expect(sql).toStrictEqual(
+                `((${DimensionSqlMock}) >= ('2024-01-15 01:00:00'::timestamp) AND (${DimensionSqlMock}) <= ('2024-01-15 02:00:00'::timestamp))`,
+            );
         });
     });
 
@@ -3313,20 +3358,33 @@ describe('domain-directed timestamp filter literals', () => {
             );
         });
 
-        test('Trino emits a zoned TIMESTAMP literal', () => {
-            expect(
-                renderTimestamp(
-                    SupportedDbtAdapter.TRINO,
-                    equalsInstantFilter,
-                    {
+        test.each([SupportedDbtAdapter.TRINO, SupportedDbtAdapter.ATHENA])(
+            '%s emits a zoned TIMESTAMP literal',
+            (adapter) => {
+                expect(
+                    renderTimestamp(adapter, equalsInstantFilter, {
                         sourceTimezone: 'Asia/Tokyo',
                         timestampDomain: 'aware',
-                    },
-                ),
-            ).toStrictEqual(
-                `(${DimensionSqlMock}) = TIMESTAMP '2024-01-14 17:00:00 UTC'`,
-            );
-        });
+                    }),
+                ).toStrictEqual(
+                    `(${DimensionSqlMock}) = TIMESTAMP '2024-01-14 17:00:00 UTC'`,
+                );
+            },
+        );
+
+        test.each([SupportedDbtAdapter.DATABRICKS, SupportedDbtAdapter.SPARK])(
+            '%s keeps the offset-bearing instant literal',
+            (adapter) => {
+                expect(
+                    renderTimestamp(adapter, equalsInstantFilter, {
+                        sourceTimezone: 'Asia/Tokyo',
+                        timestampDomain: 'aware',
+                    }),
+                ).toStrictEqual(
+                    `(${DimensionSqlMock}) = ('2024-01-14 17:00:00+00:00')`,
+                );
+            },
+        );
 
         test('Postgres keeps the offset-string form byte-identical', () => {
             expect(
@@ -3345,22 +3403,22 @@ describe('domain-directed timestamp filter literals', () => {
     });
 
     describe('wrapped LHS (sub-day trunc) wraps the literal with the same round trip', () => {
-        test('Trino known-naive at display == data timezone wraps both sides', () => {
-            expect(
-                renderTimestamp(
-                    SupportedDbtAdapter.TRINO,
-                    equalsInstantFilter,
-                    {
+        test.each([SupportedDbtAdapter.TRINO, SupportedDbtAdapter.ATHENA])(
+            '%s known-naive at display == data timezone wraps both sides',
+            (adapter) => {
+                expect(
+                    renderTimestamp(adapter, equalsInstantFilter, {
                         timezone: 'Asia/Tokyo',
                         sourceTimezone: 'Asia/Tokyo',
                         timestampDomain: 'naive',
                         timeInterval: TimeFrames.HOUR,
-                    },
-                ),
-            ).toStrictEqual(
-                `(${DimensionSqlMock}) = CAST(with_timezone(CAST('2024-01-15 02:00:00' AS timestamp), 'Asia/Tokyo') AT TIME ZONE 'UTC' AS timestamp)`,
-            );
-        });
+                        lhsMode: 'wrapped',
+                    }),
+                ).toStrictEqual(
+                    `(${DimensionSqlMock}) = CAST(with_timezone(CAST('2024-01-15 02:00:00' AS timestamp), 'Asia/Tokyo') AT TIME ZONE 'UTC' AS timestamp)`,
+                );
+            },
+        );
 
         test('BigQuery emits a single explicit TIMESTAMP(s, tz) wrap', () => {
             expect(
@@ -3372,6 +3430,7 @@ describe('domain-directed timestamp filter literals', () => {
                         sourceTimezone: 'Asia/Tokyo',
                         timestampDomain: 'naive',
                         timeInterval: TimeFrames.HOUR,
+                        lhsMode: 'wrapped',
                     },
                 ),
             ).toStrictEqual(
@@ -3389,6 +3448,7 @@ describe('domain-directed timestamp filter literals', () => {
                         sourceTimezone: 'Asia/Tokyo',
                         timestampDomain: 'aware',
                         timeInterval: TimeFrames.HOUR,
+                        lhsMode: 'wrapped',
                     },
                 ),
             ).toStrictEqual(
@@ -3415,22 +3475,22 @@ describe('domain-directed timestamp filter literals', () => {
             );
         });
 
-        test('Databricks freezes the wrapped literal as TIMESTAMP_NTZ to match the frozen LHS', () => {
-            expect(
-                renderTimestamp(
-                    SupportedDbtAdapter.DATABRICKS,
-                    equalsInstantFilter,
-                    {
+        test.each([SupportedDbtAdapter.DATABRICKS, SupportedDbtAdapter.SPARK])(
+            '%s freezes the wrapped literal as TIMESTAMP_NTZ to match the frozen LHS',
+            (adapter) => {
+                expect(
+                    renderTimestamp(adapter, equalsInstantFilter, {
                         timezone: 'Asia/Tokyo',
                         sourceTimezone: 'Asia/Tokyo',
                         timestampDomain: 'naive',
                         timeInterval: TimeFrames.HOUR,
-                    },
-                ),
-            ).toStrictEqual(
-                `(${DimensionSqlMock}) = CAST(to_utc_timestamp('2024-01-15 02:00:00', 'Asia/Tokyo') AS TIMESTAMP_NTZ)`,
-            );
-        });
+                        lhsMode: 'wrapped',
+                    }),
+                ).toStrictEqual(
+                    `(${DimensionSqlMock}) = CAST(to_utc_timestamp('2024-01-15 02:00:00', 'Asia/Tokyo') AS TIMESTAMP_NTZ)`,
+                );
+            },
+        );
     });
 
     describe('unknown domain stays byte-identical (the flag-gated LHS rebase owns this case)', () => {

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -22,7 +22,7 @@ import {
     type FilterRule,
 } from '../types/filter';
 import { type WarehouseTypes } from '../types/projects';
-import { type TimeFrames } from '../types/timeFrames';
+import { TimeFrames } from '../types/timeFrames';
 import assertUnreachable from '../utils/assertUnreachable';
 import { convertToBooleanValue } from '../utils/booleanConverter';
 import { formatDate } from '../utils/formatting';
@@ -30,7 +30,6 @@ import { getItemId } from '../utils/item';
 import { getMomentDateWithCustomStartOfWeek } from '../utils/time';
 import {
     dateTruncTimezoneConversions,
-    isTimezoneRoundTripNoOp,
     SUB_DAY_TIME_FRAMES,
     WeekDay,
 } from '../utils/timeFrames';
@@ -92,7 +91,62 @@ const formatTimestampAsWallClock =
     (date: Date): string =>
         moment(date).tz(zone).format('YYYY-MM-DD HH:mm:ss');
 
-type TimestampLiteralMode = 'legacy' | 'wrapped' | 'naiveWall' | 'awareInstant';
+export type TimestampFilterContext =
+    | { mode: 'legacy'; instantLhs: boolean }
+    | { mode: 'wrapped' }
+    | { mode: 'naiveWall'; wallClockTimezone: string }
+    | { mode: 'awareInstant' };
+
+export type TimestampFilterLhsMode = 'legacy' | 'instant' | 'wrapped';
+
+const legacyTimestampFilterContext: TimestampFilterContext = {
+    mode: 'legacy',
+    instantLhs: false,
+};
+
+export const resolveTimestampFilterContext = ({
+    adapterType,
+    useTimezoneAwareDateTrunc,
+    sourceTimezone,
+    timestampDomain,
+    timeInterval,
+    lhsMode,
+}: {
+    adapterType: SupportedDbtAdapter;
+    useTimezoneAwareDateTrunc?: boolean;
+    sourceTimezone?: string;
+    timestampDomain?: TimestampDomain;
+    timeInterval?: TimeFrames;
+    lhsMode: TimestampFilterLhsMode;
+}): TimestampFilterContext => {
+    const legacyContext: TimestampFilterContext = {
+        mode: 'legacy',
+        instantLhs: timeInterval === TimeFrames.RAW && lhsMode === 'instant',
+    };
+    const domainZone = sourceTimezone ?? 'UTC';
+    const effectiveDomain =
+        timestampDomain === 'naive' &&
+        dateTruncTimezoneConversions[adapterType].castNaiveToInstant === null
+            ? 'aware'
+            : timestampDomain;
+
+    if (
+        !useTimezoneAwareDateTrunc ||
+        effectiveDomain === undefined ||
+        domainZone === 'UTC' ||
+        adapterType === SupportedDbtAdapter.SNOWFLAKE
+    ) {
+        return legacyContext;
+    }
+
+    if (timeInterval !== undefined && SUB_DAY_TIME_FRAMES.has(timeInterval)) {
+        return lhsMode === 'wrapped' ? { mode: 'wrapped' } : legacyContext;
+    }
+
+    return effectiveDomain === 'naive'
+        ? { mode: 'naiveWall', wallClockTimezone: domainZone }
+        : { mode: 'awareInstant' };
+};
 
 /**
  * Cast a date/timestamp string to warehouse-specific SQL literal.
@@ -296,6 +350,155 @@ export const renderNumberFilterSql = (
     }
 };
 
+const getAwareInstantFormatter = (
+    adapterType: SupportedDbtAdapter,
+): ((date: Date) => string) | null => {
+    switch (adapterType) {
+        case SupportedDbtAdapter.BIGQUERY:
+        case SupportedDbtAdapter.CLICKHOUSE:
+        case SupportedDbtAdapter.TRINO:
+        case SupportedDbtAdapter.ATHENA:
+            return formatTimestampAsWallClock('UTC');
+        case SupportedDbtAdapter.DATABRICKS:
+        case SupportedDbtAdapter.SPARK:
+        case SupportedDbtAdapter.SNOWFLAKE:
+        case SupportedDbtAdapter.REDSHIFT:
+        case SupportedDbtAdapter.POSTGRES:
+        case SupportedDbtAdapter.DUCKDB:
+            return null;
+        default:
+            return assertUnreachable(
+                adapterType,
+                `Unknown adapter ${adapterType}`,
+            );
+    }
+};
+
+const castWrappedTimestampLiteral = (
+    value: string,
+    adapterType: SupportedDbtAdapter,
+    timezone: string,
+): string => {
+    const { toUTC, freezeInstantOutput } =
+        dateTruncTimezoneConversions[adapterType];
+    let naiveLiteral: string;
+
+    switch (adapterType) {
+        case SupportedDbtAdapter.BIGQUERY:
+            return `TIMESTAMP('${value}', '${timezone}')`;
+        case SupportedDbtAdapter.TRINO:
+        case SupportedDbtAdapter.ATHENA:
+            naiveLiteral = `CAST('${value}' AS timestamp)`;
+            break;
+        case SupportedDbtAdapter.DATABRICKS:
+        case SupportedDbtAdapter.SPARK:
+            naiveLiteral = `'${value}'`;
+            break;
+        case SupportedDbtAdapter.CLICKHOUSE:
+            naiveLiteral = `toDateTime('${value}', '${timezone}')`;
+            break;
+        case SupportedDbtAdapter.SNOWFLAKE:
+        case SupportedDbtAdapter.REDSHIFT:
+        case SupportedDbtAdapter.POSTGRES:
+        case SupportedDbtAdapter.DUCKDB:
+            naiveLiteral = `'${value}'::timestamp`;
+            break;
+        default:
+            return assertUnreachable(
+                adapterType,
+                `Unknown adapter ${adapterType}`,
+            );
+    }
+
+    const wrapped = toUTC(naiveLiteral, timezone);
+    return freezeInstantOutput ? freezeInstantOutput(wrapped) : wrapped;
+};
+
+const castNaiveWallTimestampLiteral = (
+    value: string,
+    adapterType: SupportedDbtAdapter,
+): string => {
+    switch (adapterType) {
+        case SupportedDbtAdapter.BIGQUERY:
+            return `DATETIME '${value}'`;
+        case SupportedDbtAdapter.DATABRICKS:
+        case SupportedDbtAdapter.SPARK:
+            return `TIMESTAMP_NTZ '${value}'`;
+        case SupportedDbtAdapter.TRINO:
+        case SupportedDbtAdapter.ATHENA:
+            return `TIMESTAMP '${value}'`;
+        case SupportedDbtAdapter.REDSHIFT:
+        case SupportedDbtAdapter.POSTGRES:
+        case SupportedDbtAdapter.DUCKDB:
+            return `('${value}'::timestamp)`;
+        case SupportedDbtAdapter.SNOWFLAKE:
+            return `('${value}'::timestamp_ntz)`;
+        case SupportedDbtAdapter.CLICKHOUSE:
+            throw new CompileError(
+                'ClickHouse does not support naive timestamp filter literals',
+            );
+        default:
+            return assertUnreachable(
+                adapterType,
+                `Unknown adapter ${adapterType}`,
+            );
+    }
+};
+
+const castAwareInstantTimestampLiteral = (
+    value: string,
+    adapterType: SupportedDbtAdapter,
+): string => {
+    switch (adapterType) {
+        case SupportedDbtAdapter.CLICKHOUSE:
+            return `toDateTime64('${value}', 3, 'UTC')`;
+        case SupportedDbtAdapter.BIGQUERY:
+            return `TIMESTAMP '${value}+00'`;
+        case SupportedDbtAdapter.TRINO:
+        case SupportedDbtAdapter.ATHENA:
+            return `TIMESTAMP '${value} UTC'`;
+        case SupportedDbtAdapter.DATABRICKS:
+        case SupportedDbtAdapter.SPARK:
+        case SupportedDbtAdapter.SNOWFLAKE:
+        case SupportedDbtAdapter.REDSHIFT:
+        case SupportedDbtAdapter.POSTGRES:
+        case SupportedDbtAdapter.DUCKDB:
+            return `('${value}')`;
+        default:
+            return assertUnreachable(
+                adapterType,
+                `Unknown adapter ${adapterType}`,
+            );
+    }
+};
+
+const castLegacyTimestampLiteral = (
+    value: string,
+    adapterType: SupportedDbtAdapter,
+    instantLhs: boolean,
+): string => {
+    switch (adapterType) {
+        case SupportedDbtAdapter.BIGQUERY:
+            return instantLhs ? `TIMESTAMP('${value}', 'UTC')` : `('${value}')`;
+        case SupportedDbtAdapter.TRINO:
+        case SupportedDbtAdapter.ATHENA:
+            return `CAST('${value}' AS timestamp)`;
+        case SupportedDbtAdapter.DATABRICKS:
+        case SupportedDbtAdapter.SPARK:
+        case SupportedDbtAdapter.SNOWFLAKE:
+        case SupportedDbtAdapter.REDSHIFT:
+        case SupportedDbtAdapter.POSTGRES:
+        case SupportedDbtAdapter.DUCKDB:
+        case SupportedDbtAdapter.CLICKHOUSE:
+            return `('${value}')`;
+        default:
+            return assertUnreachable(
+                adapterType,
+                `Unknown adapter ${adapterType}`,
+            );
+    }
+};
+
 /**
  * Shared filter SQL for date and timestamp dimensions.
  * literalFormatter handles user-provided values; boundaryFormatter handles computed boundaries.
@@ -309,11 +512,7 @@ const renderDateOrTimestampFilterSql = ({
     boundaryFormatter: baseBoundaryFormatter,
     startOfWeek,
     baseDimensionSql,
-    useTimezoneAwareDateTrunc,
-    sourceTimezone,
-    instantLhs,
-    timestampDomain,
-    timeInterval,
+    timestampFilterContext = legacyTimestampFilterContext,
 }: {
     dimensionSql: string;
     filter: FilterRule<FilterOperator, unknown>;
@@ -323,88 +522,29 @@ const renderDateOrTimestampFilterSql = ({
     boundaryFormatter: (date: Date) => string;
     startOfWeek?: WeekDay | null;
     baseDimensionSql?: string;
-    useTimezoneAwareDateTrunc?: boolean;
-    sourceTimezone?: string;
-    instantLhs?: boolean;
-    timestampDomain?: TimestampDomain;
-    timeInterval?: TimeFrames;
+    timestampFilterContext?: TimestampFilterContext;
 }): string => {
     // When startOfWeek is not explicitly configured, use the warehouse's default
     // to ensure JS-side week boundaries match the warehouse's DATE_TRUNC behavior.
     const effectiveStartOfWeek =
         startOfWeek ?? getDefaultStartOfWeek(adapterType);
 
-    // Domain-directed literal rendering: when the column's naive/aware domain
-    // is known, render the literal in the same domain the LHS compares in.
-    // Unknown domain, flag off, UTC data timezone, and Snowflake (compile-time
-    // wrap) keep today's literals byte-identical.
-    const domainZone = sourceTimezone ?? 'UTC';
-    // Adapters with no naive representation (ClickHouse) treat known-naive
-    // like aware, mirroring the LHS fallback to `castToInstant`.
-    const effectiveDomain =
-        timestampDomain === 'naive' &&
-        dateTruncTimezoneConversions[adapterType].castNaiveToInstant === null
-            ? 'aware'
-            : timestampDomain;
-    const domainDirected =
-        !!useTimezoneAwareDateTrunc &&
-        effectiveDomain !== undefined &&
-        domainZone !== 'UTC' &&
-        adapterType !== SupportedDbtAdapter.SNOWFLAKE;
-    // A truncated sub-day LHS round-trips through the project tz into a UTC
-    // instant; sharing `isTimezoneRoundTripNoOp` with the SELECT side keeps
-    // both sides of the comparison symmetric by construction.
-    const subDayLhs =
-        timeInterval !== undefined && SUB_DAY_TIME_FRAMES.has(timeInterval);
-    const lhsWrapped =
-        domainDirected &&
-        subDayLhs &&
-        !isTimezoneRoundTripNoOp(
-            adapterType,
-            timezone,
-            sourceTimezone,
-            timestampDomain,
-        );
-    let literalMode: TimestampLiteralMode = 'legacy';
-    if (domainDirected) {
-        if (lhsWrapped) {
-            literalMode = 'wrapped';
-        } else if (subDayLhs) {
-            // Equal-zones no-op: the LHS is the legacy unwrapped trunc (a
-            // naive value), so a typed instant literal would lean on session
-            // coercion — keep the legacy literal, which matches it exactly.
-            // Known-naive columns never reach this state: their round trip
-            // is never a no-op.
-            literalMode = 'legacy';
-        } else {
-            literalMode =
-                effectiveDomain === 'naive' ? 'naiveWall' : 'awareInstant';
-        }
-    }
-
     const domainFormatter = ((): ((date: Date) => string) | null => {
-        switch (literalMode) {
+        switch (timestampFilterContext.mode) {
             case 'wrapped':
                 return formatTimestampAsWallClock(timezone);
             case 'naiveWall':
-                return formatTimestampAsWallClock(domainZone);
+                return formatTimestampAsWallClock(
+                    timestampFilterContext.wallClockTimezone,
+                );
             case 'awareInstant':
-                switch (adapterType) {
-                    case SupportedDbtAdapter.BIGQUERY:
-                    case SupportedDbtAdapter.CLICKHOUSE:
-                    case SupportedDbtAdapter.TRINO:
-                    case SupportedDbtAdapter.ATHENA:
-                        return formatTimestampAsWallClock('UTC');
-                    default:
-                        // Offset-bearing legacy literal is already an instant.
-                        return null;
-                }
+                return getAwareInstantFormatter(adapterType);
             case 'legacy':
                 return null;
             default:
                 return assertUnreachable(
-                    literalMode,
-                    `Unknown literal mode ${literalMode}`,
+                    timestampFilterContext,
+                    'Unknown timestamp filter context',
                 );
         }
     })();
@@ -412,90 +552,27 @@ const renderDateOrTimestampFilterSql = ({
     const boundaryFormatter = domainFormatter ?? baseBoundaryFormatter;
 
     const castValue = (value: string): string => {
-        switch (literalMode) {
-            case 'wrapped': {
-                // Column is a UTC instant (round-trip through project TZ).
-                // Convert the project-TZ wall-clock literal the same way so
-                // coercion aligns with the column.
-                if (adapterType === SupportedDbtAdapter.BIGQUERY) {
-                    // TIMESTAMP(s, tz) already yields the UTC instant,
-                    // independent of the job timezone — no outer toUTC.
-                    return `TIMESTAMP('${value}', '${timezone}')`;
-                }
-                const { toUTC, freezeInstantOutput } =
-                    dateTruncTimezoneConversions[adapterType];
-                const naive = (() => {
-                    switch (adapterType) {
-                        case SupportedDbtAdapter.TRINO:
-                        case SupportedDbtAdapter.ATHENA:
-                            return `CAST('${value}' AS timestamp)`;
-                        case SupportedDbtAdapter.DATABRICKS:
-                        case SupportedDbtAdapter.SPARK:
-                            return `'${value}'`;
-                        case SupportedDbtAdapter.CLICKHOUSE:
-                            return `toDateTime('${value}', '${timezone}')`;
-                        default:
-                            return `'${value}'::timestamp`;
-                    }
-                })();
-                const wrapped = toUTC(naive, timezone);
-                // The truncated LHS is frozen as TIMESTAMP_NTZ on
-                // Databricks/Spark — freeze the literal identically so the
-                // comparison never relies on session coercion.
-                return freezeInstantOutput
-                    ? freezeInstantOutput(wrapped)
-                    : wrapped;
-            }
+        switch (timestampFilterContext.mode) {
+            case 'wrapped':
+                return castWrappedTimestampLiteral(
+                    value,
+                    adapterType,
+                    timezone,
+                );
             case 'naiveWall':
-                // Bare naive column: compare wall clocks in the data timezone.
-                switch (adapterType) {
-                    case SupportedDbtAdapter.BIGQUERY:
-                        return `DATETIME '${value}'`;
-                    case SupportedDbtAdapter.DATABRICKS:
-                    case SupportedDbtAdapter.SPARK:
-                        return `TIMESTAMP_NTZ '${value}'`;
-                    case SupportedDbtAdapter.TRINO:
-                    case SupportedDbtAdapter.ATHENA:
-                        return `TIMESTAMP '${value}'`;
-                    default:
-                        return `('${value}'::timestamp)`;
-                }
+                return castNaiveWallTimestampLiteral(value, adapterType);
             case 'awareInstant':
-                // Bare aware column: typed instant literal, immune to the
-                // session/job timezone.
-                switch (adapterType) {
-                    case SupportedDbtAdapter.CLICKHOUSE:
-                        return `toDateTime64('${value}', 3, 'UTC')`;
-                    case SupportedDbtAdapter.BIGQUERY:
-                        return `TIMESTAMP '${value}+00'`;
-                    case SupportedDbtAdapter.TRINO:
-                    case SupportedDbtAdapter.ATHENA:
-                        return `TIMESTAMP '${value} UTC'`;
-                    default:
-                        return `('${value}')`;
-                }
+                return castAwareInstantTimestampLiteral(value, adapterType);
             case 'legacy':
-                // The LHS is a flag-rebased instant; BigQuery's offset-less
-                // literal would otherwise be parsed in the job-level
-                // time_zone — pin it to UTC.
-                if (
-                    instantLhs &&
-                    adapterType === SupportedDbtAdapter.BIGQUERY
-                ) {
-                    return `TIMESTAMP('${value}', 'UTC')`;
-                }
-                switch (adapterType) {
-                    case SupportedDbtAdapter.TRINO:
-                    case SupportedDbtAdapter.ATHENA: {
-                        return `CAST('${value}' AS timestamp)`;
-                    }
-                    default:
-                        return `('${value}')`;
-                }
+                return castLegacyTimestampLiteral(
+                    value,
+                    adapterType,
+                    timestampFilterContext.instantLhs,
+                );
             default:
                 return assertUnreachable(
-                    literalMode,
-                    `Unknown literal mode ${literalMode}`,
+                    timestampFilterContext,
+                    'Unknown timestamp filter context',
                 );
         }
     };
@@ -785,8 +862,6 @@ export const renderDateFilterSql = ({
     boundaryDateFormatter,
     startOfWeek,
     baseDimensionSql,
-    useTimezoneAwareDateTrunc,
-    sourceTimezone,
 }: {
     dimensionSql: string;
     filter: FilterRule<FilterOperator, unknown>;
@@ -795,8 +870,6 @@ export const renderDateFilterSql = ({
     boundaryDateFormatter?: (date: Date) => string;
     startOfWeek?: WeekDay | null;
     baseDimensionSql?: string;
-    useTimezoneAwareDateTrunc?: boolean;
-    sourceTimezone?: string;
 }): string => {
     const effectiveTimezone = boundaryDateFormatter ? timezone : 'UTC';
     const effectiveFormatter =
@@ -811,8 +884,6 @@ export const renderDateFilterSql = ({
         boundaryFormatter: effectiveFormatter,
         startOfWeek,
         baseDimensionSql,
-        useTimezoneAwareDateTrunc,
-        sourceTimezone,
     });
 };
 
@@ -825,11 +896,7 @@ export const renderTimestampFilterSql = ({
     timestampFormatter,
     startOfWeek,
     baseDimensionSql,
-    useTimezoneAwareDateTrunc,
-    sourceTimezone,
-    instantLhs,
-    timestampDomain,
-    timeInterval,
+    timestampFilterContext,
 }: {
     dimensionSql: string;
     filter: FilterRule<FilterOperator, unknown>;
@@ -838,11 +905,7 @@ export const renderTimestampFilterSql = ({
     timestampFormatter: (date: Date) => string;
     startOfWeek?: WeekDay | null;
     baseDimensionSql?: string;
-    useTimezoneAwareDateTrunc?: boolean;
-    sourceTimezone?: string;
-    instantLhs?: boolean;
-    timestampDomain?: TimestampDomain;
-    timeInterval?: TimeFrames;
+    timestampFilterContext?: TimestampFilterContext;
 }): string =>
     renderDateOrTimestampFilterSql({
         dimensionSql,
@@ -853,11 +916,7 @@ export const renderTimestampFilterSql = ({
         boundaryFormatter: timestampFormatter,
         startOfWeek,
         baseDimensionSql,
-        useTimezoneAwareDateTrunc,
-        sourceTimezone,
-        instantLhs,
-        timestampDomain,
-        timeInterval,
+        timestampFilterContext,
     });
 
 export const renderBooleanFilterSql = (
@@ -976,10 +1035,7 @@ export const renderFilterRuleSql = (
     baseDimensionSql?: string,
     useTimezoneAwareDateTrunc?: boolean,
     baseTimeIntervalDimensionType?: DimensionType,
-    sourceTimezone?: string,
-    instantLhs?: boolean,
-    timestampDomain?: TimestampDomain,
-    timeInterval?: TimeFrames,
+    timestampFilterContext?: TimestampFilterContext,
 ): string => {
     if (filterRule.disabled) {
         return `1=1`; // When filter is disabled, we want to return all rows
@@ -1028,12 +1084,6 @@ export const renderFilterRuleSql = (
                     : undefined,
                 startOfWeek,
                 baseDimensionSql,
-                // GLITCH-452: day-or-coarser dims now compile to a real DATE
-                // (CAST(... AS DATE)), so the literal stays a bare date —
-                // wrapping it as a timestamptz would re-introduce the tz drift
-                // the cast removes (and break BigQuery's DATE vs TIMESTAMP check).
-                useTimezoneAwareDateTrunc: false,
-                sourceTimezone,
             });
         }
         case DimensionType.TIMESTAMP:
@@ -1050,11 +1100,7 @@ export const renderFilterRuleSql = (
                         : formatTimestampAsUTC,
                 startOfWeek,
                 baseDimensionSql,
-                useTimezoneAwareDateTrunc,
-                sourceTimezone,
-                instantLhs,
-                timestampDomain,
-                timeInterval,
+                timestampFilterContext,
             });
         }
         case DimensionType.BOOLEAN:
@@ -1083,9 +1129,7 @@ export const renderFilterRuleSqlFromField = (
     exploreCaseSensitive: boolean = DEFAULT_FILTER_CASE_SENSITIVE,
     baseDimensionSql?: string,
     useTimezoneAwareDateTrunc?: boolean,
-    sourceTimezone?: string,
-    instantLhs?: boolean,
-    timestampDomain?: TimestampDomain,
+    timestampFilterContext?: TimestampFilterContext,
 ): string => {
     const fieldType = isCompiledCustomSqlDimension(field)
         ? field.dimensionType
@@ -1112,11 +1156,6 @@ export const renderFilterRuleSqlFromField = (
             ? field.timeIntervalBaseDimensionType
             : undefined;
 
-    const timeInterval =
-        !isCompiledCustomSqlDimension(field) && !isMetric(field)
-            ? field.timeInterval
-            : undefined;
-
     return renderFilterRuleSql(
         filterRule,
         fieldType,
@@ -1130,9 +1169,6 @@ export const renderFilterRuleSqlFromField = (
         baseDimensionSql,
         useTimezoneAwareDateTrunc,
         baseTimeIntervalDimensionType,
-        sourceTimezone,
-        instantLhs,
-        timestampDomain,
-        timeInterval,
+        timestampFilterContext,
     );
 };


### PR DESCRIPTION
Follow-up to #25820.

### Description

- Resolve timestamp filter SQL and its literal-rendering context together in `MetricQueryBuilder`.
- Pass a discriminated `TimestampFilterContext` through the compiler instead of independently reconstructing LHS/RHS timezone behavior.
- Model semantic LHS modes explicitly so equal-zone SQL re-rendering is handled correctly even when the SQL text changes.
- Make timestamp literal adapter handling exhaustive and expand regression coverage across BigQuery, Trino, Databricks, Spark, and Athena paths.

### Verification

- `pnpm -F common test -- --run packages/common/src/compiler/filtersCompiler.test.ts` (419 passed)
- `pnpm -F backend test -- --run packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts` (189 passed)
- Common and backend fast typechecks
- Focused common and backend ESLint
- oxfmt checks and `git diff --check`