### PR TITLE
fix: prevent empty previews when access copy fails

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -138,6 +138,84 @@ describe('ProjectModel', () => {
         ).resolves.toBe(false);
     });
 
+    test('copies only eligible project access in one idempotent transaction', async () => {
+        const upstreamProjectUuid = 'upstream-project-uuid';
+        const previewProjectUuid = 'preview-project-uuid';
+        const matchSql =
+            (table: string) =>
+            ({ sql }: RawQuery) =>
+                sql.includes(table);
+
+        tracker.on.select(matchSql(ProjectTableName)).response([
+            {
+                project_id: 1,
+                project_uuid: upstreamProjectUuid,
+                organization_id: 10,
+            },
+            {
+                project_id: 2,
+                project_uuid: previewProjectUuid,
+                organization_id: 10,
+            },
+        ]);
+        tracker.on.select(matchSql(ProjectMembershipsTableName)).response([
+            {
+                user_id: 1,
+                role: ProjectMemberRole.EDITOR,
+                role_uuid: null,
+                is_internal: false,
+                organization_id: 10,
+            },
+            {
+                user_id: 2,
+                role: ProjectMemberRole.VIEWER,
+                role_uuid: null,
+                is_internal: false,
+                organization_id: null,
+            },
+            {
+                user_id: 3,
+                role: ProjectMemberRole.VIEWER,
+                role_uuid: null,
+                is_internal: true,
+                organization_id: 10,
+            },
+        ]);
+        tracker.on.select(matchSql(ProjectGroupAccessTableName)).response([
+            {
+                group_uuid: 'group-uuid',
+                role: ProjectMemberRole.VIEWER,
+                role_uuid: null,
+            },
+        ]);
+        tracker.on.insert(matchSql(ProjectMembershipsTableName)).response([]);
+        tracker.on.insert(matchSql(ProjectGroupAccessTableName)).response([]);
+
+        const copyAccess = () =>
+            model.copyProjectAccess(upstreamProjectUuid, previewProjectUuid);
+        const expectedResult = {
+            userAccessCount: 1,
+            skippedUserAccessCount: 2,
+            groupAccessCount: 1,
+        };
+
+        await expect(copyAccess()).resolves.toEqual(expectedResult);
+        await expect(copyAccess()).resolves.toEqual(expectedResult);
+
+        expect(tracker.history.insert).toHaveLength(4);
+        expect(tracker.history.insert[0].bindings).toEqual(
+            expect.arrayContaining([1, 2, ProjectMemberRole.EDITOR]),
+        );
+        expect(tracker.history.insert[0].bindings).not.toContain(3);
+        expect(tracker.history.insert[0].sql).toContain('on conflict');
+        expect(tracker.history.insert[1].sql).toContain('on conflict');
+        const groupAccessQuery = tracker.history.select.find(({ sql }) =>
+            sql.includes(ProjectGroupAccessTableName),
+        );
+        expect(groupAccessQuery?.sql).toContain('groups');
+        expect(groupAccessQuery?.bindings).toContain(10);
+    });
+
     describe('should convert outdated metric filters in explores', () => {
         test('should add fieldRef property when metric filters have fieldId', () => {
             expect(

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -73,6 +73,7 @@ import {
     DbDashboardTabs,
 } from '../../database/entities/dashboards';
 import { GroupMembershipTableName } from '../../database/entities/groupMemberships';
+import { GroupTableName } from '../../database/entities/groups';
 import { OrganizationMembershipsTableName } from '../../database/entities/organizationMemberships';
 import {
     DbOrganization,
@@ -1794,6 +1795,155 @@ export class ProjectModel {
             lastName: membership.last_name,
             roleUuid: membership.role_uuid || undefined,
         }));
+    }
+
+    async copyProjectAccess(
+        upstreamProjectUuid: string,
+        previewProjectUuid: string,
+    ): Promise<{
+        userAccessCount: number;
+        skippedUserAccessCount: number;
+        groupAccessCount: number;
+    }> {
+        return this.database.transaction(async (trx) => {
+            const projects = await trx(ProjectTableName)
+                .select<
+                    Pick<
+                        DbProject,
+                        'project_id' | 'project_uuid' | 'organization_id'
+                    >[]
+                >('project_id', 'project_uuid', 'organization_id')
+                .whereIn('project_uuid', [
+                    upstreamProjectUuid,
+                    previewProjectUuid,
+                ]);
+            const upstreamProject = projects.find(
+                ({ project_uuid }) => project_uuid === upstreamProjectUuid,
+            );
+            const previewProject = projects.find(
+                ({ project_uuid }) => project_uuid === previewProjectUuid,
+            );
+
+            if (!upstreamProject || !previewProject) {
+                throw new NotFoundError(
+                    'Upstream or preview project not found',
+                );
+            }
+            if (
+                upstreamProject.organization_id !==
+                previewProject.organization_id
+            ) {
+                throw new ParameterError(
+                    'Upstream and preview projects must be in the same organization',
+                );
+            }
+
+            type ProjectAccessRow = Pick<
+                DbProjectMembership,
+                'user_id' | 'role' | 'role_uuid'
+            > & {
+                is_internal: boolean;
+                organization_id: number | null;
+            };
+            const projectAccesses = await trx(ProjectMembershipsTableName)
+                .innerJoin(
+                    UserTableName,
+                    `${ProjectMembershipsTableName}.user_id`,
+                    `${UserTableName}.user_id`,
+                )
+                .leftJoin(
+                    OrganizationMembershipsTableName,
+                    function joinPreviewOrganizationMembership() {
+                        this.on(
+                            `${OrganizationMembershipsTableName}.user_id`,
+                            '=',
+                            `${ProjectMembershipsTableName}.user_id`,
+                        ).andOnVal(
+                            `${OrganizationMembershipsTableName}.organization_id`,
+                            previewProject.organization_id,
+                        );
+                    },
+                )
+                .select<ProjectAccessRow[]>({
+                    user_id: `${ProjectMembershipsTableName}.user_id`,
+                    role: `${ProjectMembershipsTableName}.role`,
+                    role_uuid: `${ProjectMembershipsTableName}.role_uuid`,
+                    is_internal: `${UserTableName}.is_internal`,
+                    organization_id: `${OrganizationMembershipsTableName}.organization_id`,
+                })
+                .where(
+                    `${ProjectMembershipsTableName}.project_id`,
+                    upstreamProject.project_id,
+                );
+            const eligibleProjectAccesses = projectAccesses.filter(
+                ({ is_internal, organization_id }) =>
+                    !is_internal &&
+                    organization_id === previewProject.organization_id,
+            );
+            const groupAccesses = await trx(ProjectGroupAccessTableName)
+                .innerJoin(
+                    GroupTableName,
+                    `${ProjectGroupAccessTableName}.group_uuid`,
+                    `${GroupTableName}.group_uuid`,
+                )
+                .select<
+                    {
+                        group_uuid: string;
+                        role: ProjectMemberRole;
+                        role_uuid: string | null;
+                    }[]
+                >(
+                    `${ProjectGroupAccessTableName}.group_uuid`,
+                    `${ProjectGroupAccessTableName}.role`,
+                    `${ProjectGroupAccessTableName}.role_uuid`,
+                )
+                .where(
+                    `${ProjectGroupAccessTableName}.project_uuid`,
+                    upstreamProjectUuid,
+                )
+                .andWhere(
+                    `${GroupTableName}.organization_id`,
+                    previewProject.organization_id,
+                );
+
+            if (eligibleProjectAccesses.length > 0) {
+                await trx(ProjectMembershipsTableName)
+                    .insert(
+                        eligibleProjectAccesses.map(
+                            ({ user_id, role, role_uuid }) => ({
+                                user_id,
+                                project_id: previewProject.project_id,
+                                role,
+                                role_uuid,
+                            }),
+                        ),
+                    )
+                    .onConflict(['user_id', 'project_id'])
+                    .merge(['role', 'role_uuid']);
+            }
+            if (groupAccesses.length > 0) {
+                await trx(ProjectGroupAccessTableName)
+                    .insert(
+                        groupAccesses.map(
+                            ({ group_uuid, role, role_uuid }) => ({
+                                group_uuid,
+                                project_uuid: previewProjectUuid,
+                                role,
+                                role_uuid,
+                            }),
+                        ),
+                    )
+                    .onConflict(['project_uuid', 'group_uuid'])
+                    .merge(['role', 'role_uuid']);
+            }
+
+            return {
+                userAccessCount: eligibleProjectAccesses.length,
+                skippedUserAccessCount:
+                    projectAccesses.length - eligibleProjectAccesses.length,
+                groupAccessCount: groupAccesses.length,
+            };
+        });
     }
 
     async createProjectAccess(

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -198,6 +198,10 @@ const projectModel = {
         async (_projectUuid: string, onLockAcquired: () => Promise<void>) =>
             onLockAcquired(),
     ),
+    createWithOptionalCredentials: vi.fn(
+        async () => 'created-preview-project-uuid',
+    ),
+    delete: vi.fn(async () => undefined),
 };
 const preAggregateModel = {
     upsertPreAggregateDefinitions: vi.fn(),
@@ -380,6 +384,114 @@ describe('ProjectService', () => {
                 'new',
             ),
         ).toMatchObject({ onboardingFlow: 'new' });
+    });
+
+    test('does not compile and removes a preview when copying fails', async () => {
+        const previewProjectUuid = 'failed-preview-project-uuid';
+        (
+            projectModel.getWithSensitiveFields as import('vitest').Mock
+        ).mockResolvedValueOnce({
+            ...projectWithSensitiveFields,
+            warehouseConnection: warehouseClientMock.credentials,
+        });
+        const createWithoutCompileSpy = vi
+            .spyOn(service, 'createWithoutCompile')
+            .mockResolvedValueOnce({
+                project: {
+                    ...projectWithSensitiveFields,
+                    projectUuid: previewProjectUuid,
+                    type: ProjectType.PREVIEW,
+                },
+                hasContentCopy: false,
+                accessCopyError: 'access copy failed',
+            });
+        const scheduleCompileProjectSpy = vi.spyOn(
+            service,
+            'scheduleCompileProject',
+        );
+
+        await expect(
+            service.createPreview(
+                user,
+                projectUuid,
+                { name: 'Failed preview', copyContent: true },
+                RequestMethod.WEB_APP,
+            ),
+        ).rejects.toThrow('Failed to copy preview project');
+
+        expect(projectModel.delete).toHaveBeenCalledWith(previewProjectUuid);
+        expect(scheduleCompileProjectSpy).not.toHaveBeenCalled();
+        createWithoutCompileSpy.mockRestore();
+        scheduleCompileProjectSpy.mockRestore();
+    });
+
+    test('attempts content copying when preview access copying fails', async () => {
+        const upstreamProjectUuid = 'upstream-project-uuid';
+        const previewProjectUuid = 'created-preview-project-uuid';
+        const previewUser: SessionUser = {
+            ...user,
+            organizationUuid: projectWithSensitiveFields.organizationUuid,
+            organizationName: 'Test organization',
+            organizationCreatedAt: new Date(),
+        };
+        const validateSpy = vi
+            .spyOn(
+                service as unknown as {
+                    validateProjectCreationPermissions: () => Promise<true>;
+                },
+                'validateProjectCreationPermissions',
+            )
+            .mockResolvedValue(true);
+        const expirationSpy = vi
+            .spyOn(service, 'getPreviewExpiresAt')
+            .mockResolvedValue(null);
+        const copyAccessSpy = vi
+            .spyOn(service, 'copyUserAccessOnPreview')
+            .mockRejectedValue(new Error('access copy failed'));
+        const copyContentSpy = vi
+            .spyOn(service, 'copyContentOnPreview')
+            .mockResolvedValue();
+        (projectModel.get as import('vitest').Mock)
+            .mockResolvedValueOnce({
+                ...projectWithSensitiveFields,
+                projectUuid: upstreamProjectUuid,
+            })
+            .mockResolvedValueOnce({
+                ...projectWithSensitiveFields,
+                projectUuid: previewProjectUuid,
+                type: ProjectType.PREVIEW,
+            });
+
+        try {
+            const result = await service.createWithoutCompile(
+                previewUser,
+                {
+                    name: 'Preview with failed access copy',
+                    type: ProjectType.PREVIEW,
+                    dbtConnection: { type: DbtProjectType.NONE },
+                    upstreamProjectUuid,
+                    copyContent: true,
+                    dbtVersion: projectWithSensitiveFields.dbtVersion,
+                },
+                RequestMethod.WEB_APP,
+            );
+
+            expect(copyContentSpy).toHaveBeenCalledWith(
+                upstreamProjectUuid,
+                previewProjectUuid,
+                previewUser,
+            );
+            expect(result).toMatchObject({
+                hasContentCopy: true,
+                accessCopyError: 'access copy failed',
+                contentCopyError: undefined,
+            });
+        } finally {
+            validateSpy.mockRestore();
+            expirationSpy.mockRestore();
+            copyAccessSpy.mockRestore();
+            copyContentSpy.mockRestore();
+        }
     });
 
     describe('refreshTablesAndProjectConfig for a CLI/NONE preview', () => {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2491,6 +2491,7 @@ export class ProjectService extends BaseService {
         }
 
         let hasContentCopy = false;
+        let accessCopyError: string | undefined;
         let contentCopyError: string | undefined;
 
         if (data.type === ProjectType.PREVIEW && data.upstreamProjectUuid) {
@@ -2499,8 +2500,22 @@ export class ProjectService extends BaseService {
                     data.upstreamProjectUuid,
                     projectUuid,
                 );
+            } catch (e) {
+                Sentry.captureException(e);
+                accessCopyError = getErrorMessage(e);
+                this.logger.error(
+                    `Unable to copy access on preview from ${data.upstreamProjectUuid} to ${projectUuid}`,
+                    {
+                        error: accessCopyError,
+                        stack: e instanceof Error ? e.stack : undefined,
+                        errorData:
+                            e instanceof LightdashError ? e.data : undefined,
+                    },
+                );
+            }
 
-                if (data.copyContent ?? true) {
+            if (data.copyContent ?? true) {
+                try {
                     await this.copyContentOnPreview(
                         data.upstreamProjectUuid,
                         projectUuid,
@@ -2508,19 +2523,21 @@ export class ProjectService extends BaseService {
                     );
 
                     hasContentCopy = true;
+                } catch (e) {
+                    Sentry.captureException(e);
+                    contentCopyError = getErrorMessage(e);
+                    this.logger.error(
+                        `Unable to copy content on preview from ${data.upstreamProjectUuid} to ${projectUuid}`,
+                        {
+                            error: contentCopyError,
+                            stack: e instanceof Error ? e.stack : undefined,
+                            errorData:
+                                e instanceof LightdashError
+                                    ? e.data
+                                    : undefined,
+                        },
+                    );
                 }
-            } catch (e) {
-                Sentry.captureException(e);
-                contentCopyError = e instanceof Error ? e.message : String(e);
-                this.logger.error(
-                    `Unable to copy content on preview from ${data.upstreamProjectUuid} to ${projectUuid}`,
-                    {
-                        error: contentCopyError,
-                        stack: e instanceof Error ? e.stack : undefined,
-                        errorData:
-                            e instanceof LightdashError ? e.data : undefined,
-                    },
-                );
             }
         }
 
@@ -2561,6 +2578,7 @@ export class ProjectService extends BaseService {
         return {
             hasContentCopy,
             project,
+            accessCopyError,
             contentCopyError,
         };
     }
@@ -8530,6 +8548,32 @@ export class ProjectService extends BaseService {
             });
     }
 
+    private async throwIfPreviewCopyFailed(
+        previewProject: ApiCreateProjectResults,
+    ): Promise<void> {
+        if (
+            !previewProject.accessCopyError &&
+            !previewProject.contentCopyError
+        ) {
+            return;
+        }
+
+        try {
+            await this.projectModel.delete(previewProject.project.projectUuid);
+        } catch (e) {
+            Sentry.captureException(e);
+            this.logger.error(
+                `Failed to clean up preview project ${previewProject.project.projectUuid} after copy failure`,
+                {
+                    error: getErrorMessage(e),
+                    stack: e instanceof Error ? e.stack : undefined,
+                },
+            );
+        }
+
+        throw new UnexpectedServerError('Failed to copy preview project');
+    }
+
     async createPreview(
         user: SessionUser,
         projectUuid: string,
@@ -8578,6 +8622,7 @@ export class ProjectService extends BaseService {
             previewData,
             context,
         );
+        await this.throwIfPreviewCopyFailed(previewProject);
 
         // Since the project is new, and we have copied some permissions,
         // it is possible that the user `abilities` are not uptodate
@@ -8616,43 +8661,21 @@ export class ProjectService extends BaseService {
                 upstreamProjectUuid,
             },
             async () => {
-                const projectAccesses =
-                    await this.projectModel.getProjectAccess(
-                        upstreamProjectUuid,
-                    );
-                const groupAccesses =
-                    await this.projectModel.getProjectGroupAccesses(
-                        upstreamProjectUuid,
-                    );
-
-                this.logger.info(
-                    `Copying ${projectAccesses.length} user access on ${previewProjectUuid}`,
-                );
-                this.logger.info(
-                    `Copying ${groupAccesses.length} group access on ${previewProjectUuid}`,
-                );
-                const insertProjectAccessPromises = projectAccesses.map(
-                    (projectAccess) =>
-                        this.projectModel.createProjectAccess(
-                            previewProjectUuid,
-                            projectAccess.email,
-                            projectAccess.role,
-                            projectAccess.roleUuid,
-                        ),
-                );
-                const insertGroupAccessPromises = groupAccesses.map(
-                    (groupAccess) =>
-                        this.groupsModel.addProjectAccess({
-                            groupUuid: groupAccess.groupUuid,
-                            projectUuid: previewProjectUuid,
-                            role: groupAccess.role,
-                        }),
+                const {
+                    userAccessCount,
+                    skippedUserAccessCount,
+                    groupAccessCount,
+                } = await this.projectModel.copyProjectAccess(
+                    upstreamProjectUuid,
+                    previewProjectUuid,
                 );
 
-                await Promise.all([
-                    ...insertGroupAccessPromises,
-                    ...insertProjectAccessPromises,
-                ]);
+                this.logger.info(
+                    `Copied ${userAccessCount} user access grants on ${previewProjectUuid}; skipped ${skippedUserAccessCount} ineligible grants`,
+                );
+                this.logger.info(
+                    `Copied ${groupAccessCount} group access grants on ${previewProjectUuid}`,
+                );
             },
         );
     }
@@ -9843,6 +9866,7 @@ export class ProjectService extends BaseService {
                 previewData,
                 RequestMethod.WEB_APP, // TODO: fix context
             );
+            await this.throwIfPreviewCopyFailed(newPreview);
             projectToSetExplores = newPreview.project.projectUuid;
         }
 

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -1028,6 +1028,7 @@ export type ApiInviteLinkResponse = {
 export type ApiCreateProjectResults = {
     project: Project;
     hasContentCopy: boolean;
+    accessCopyError?: string;
     contentCopyError?: string;
 };
 


### PR DESCRIPTION
## Summary

- copy eligible preview user and group access transactionally and idempotently
- skip stale organization memberships, internal principals, and cross-organization groups
- keep content copying independent from access-copy failures
- delete failed previews and avoid scheduling compilation when copying is incomplete
- apply the same strict copy-error handling to dbt Cloud webhook previews

## Root cause

Preview access grants were created concurrently through one `Promise.all`, and access copying shared a catch block with content copying. A single ineligible upstream principal could therefore leave partial grants, prevent content copying from starting, and still allow the API to report success and schedule compilation.

## Validation

- added regression coverage for stale and internal principals, idempotent access copying, continued content-copy attempts, and failed-preview cleanup
- `102 passed, 1 skipped` in the focused backend test suite
- common and backend typechecks, formatting, and lint completed with no errors
- API generation completed successfully
- repeated the local preview request with stale/internal access rows and confirmed content plus the preview mapping were copied and compilation completed

Closes: PROD-9087
