### PR TITLE
feat(data-apps): connection-level custom request headers for the external connections proxy

### DIFF
--- a/packages/backend/src/ee/database/entities/externalConnections.ts
+++ b/packages/backend/src/ee/database/entities/externalConnections.ts
@@ -30,6 +30,7 @@ export type DbExternalConnection = {
     api_key_name: string | null;
     api_key_location: ApiKeyLocation | null;
     oauth_scopes: string[] | null;
+    custom_headers: Record<string, string> | null;
     created_by_user_uuid: string | null;
     updated_by_user_uuid: string | null;
     created_at: Date;
@@ -48,6 +49,7 @@ export type ExternalConnectionsTable = Knex.CompositeTableType<
         allowed_methods: string;
         allowed_content_types: string;
         oauth_scopes?: string | null;
+        custom_headers?: string | null;
     } & Partial<
             Pick<
                 DbExternalConnection,
@@ -85,6 +87,7 @@ export type ExternalConnectionsTable = Knex.CompositeTableType<
             allowed_methods: string;
             allowed_content_types: string;
             oauth_scopes: string | null;
+            custom_headers: string | null;
         }
     >
 >;

--- a/packages/backend/src/ee/database/migrations/20260722100000_add_external_connection_custom_headers.ts
+++ b/packages/backend/src/ee/database/migrations/20260722100000_add_external_connection_custom_headers.ts
@@ -1,0 +1,18 @@
+import { Knex } from 'knex';
+
+const ExternalConnectionsTableName = 'external_connections';
+const CustomHeadersColumn = 'custom_headers';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ExternalConnectionsTableName, (table) => {
+        // Static non-secret request headers injected on every proxied request
+        // (e.g. anthropic-version). Null when the connection has none.
+        table.jsonb(CustomHeadersColumn).nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(ExternalConnectionsTableName, (table) => {
+        table.dropColumn(CustomHeadersColumn);
+    });
+}

--- a/packages/backend/src/ee/models/ExternalConnectionModel.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.ts
@@ -72,6 +72,7 @@ export class ExternalConnectionModel {
             apiKeyName: row.api_key_name,
             apiKeyLocation: row.api_key_location,
             oauthScopes: row.oauth_scopes,
+            customHeaders: row.custom_headers,
             hasSecret,
             createdByUserUuid: row.created_by_user_uuid,
             updatedByUserUuid: row.updated_by_user_uuid,
@@ -132,6 +133,11 @@ export class ExternalConnectionModel {
                     oauth_scopes: data.oauthScopes?.length
                         ? JSON.stringify(data.oauthScopes)
                         : null,
+                    custom_headers:
+                        data.customHeaders &&
+                        Object.keys(data.customHeaders).length
+                            ? JSON.stringify(data.customHeaders)
+                            : null,
                     created_by_user_uuid: userUuid,
                     updated_by_user_uuid: userUuid,
                 })
@@ -200,6 +206,9 @@ export class ExternalConnectionModel {
                         api_key_location: src.api_key_location,
                         oauth_scopes: src.oauth_scopes
                             ? JSON.stringify(src.oauth_scopes)
+                            : null,
+                        custom_headers: src.custom_headers
+                            ? JSON.stringify(src.custom_headers)
                             : null,
                         created_by_user_uuid: src.created_by_user_uuid,
                         updated_by_user_uuid: src.updated_by_user_uuid,
@@ -412,6 +421,11 @@ export class ExternalConnectionModel {
                 updatePayload.oauth_scopes = data.oauthScopes?.length
                     ? JSON.stringify(data.oauthScopes)
                     : null;
+            if (data.customHeaders !== undefined)
+                updatePayload.custom_headers =
+                    data.customHeaders && Object.keys(data.customHeaders).length
+                        ? JSON.stringify(data.customHeaders)
+                        : null;
 
             await trx(ExternalConnectionsTableName)
                 .where('external_connection_uuid', uuid)

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
@@ -32,6 +32,7 @@ const baseConnection = (
     apiKeyName: null,
     apiKeyLocation: null,
     oauthScopes: null,
+    customHeaders: null,
     hasSecret: false,
     createdByUserUuid: 'user-1',
     updatedByUserUuid: 'user-1',
@@ -435,6 +436,46 @@ describe('ExternalConnectionService.proxyFetch', () => {
             service.proxyFetch(user, 'proj-1', 'app-1', {
                 connectionAlias: 'weather',
                 path: '/v1/x',
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(mockSecureFetch).not.toHaveBeenCalled();
+    });
+
+    it('sends the connection custom headers alongside the injected auth', async () => {
+        const { service } = buildService({
+            connection: baseConnection({
+                type: 'bearer_token',
+                customHeaders: {
+                    'anthropic-version': '2023-06-01',
+                    Accept: 'application/json',
+                },
+            }),
+            secret: 'tok_abc',
+        });
+        await service.proxyFetch(user, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            path: '/v1/x',
+        });
+        const [, opts] = mockSecureFetch.mock.calls[0];
+        expect(opts.headers!['anthropic-version']).toBe('2023-06-01');
+        expect(opts.headers!.Accept).toBe('application/json');
+        expect(opts.headers!.Authorization).toBe('Bearer tok_abc');
+    });
+
+    it('fails closed on a stored forbidden custom header (Content-Type)', async () => {
+        // Belt-and-braces: content-type is rejected at write time, but even a
+        // row that bypassed validation must fail closed rather than override.
+        const { service } = buildService({
+            connection: baseConnection({
+                customHeaders: { 'Content-Type': 'text/evil' },
+            }),
+        });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                method: 'POST',
+                path: '/v1/echo',
+                body: {},
             }),
         ).rejects.toBeInstanceOf(ParameterError);
         expect(mockSecureFetch).not.toHaveBeenCalled();

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -35,6 +35,7 @@ const connection: ExternalConnection = {
     apiKeyName: null,
     apiKeyLocation: null,
     oauthScopes: null,
+    customHeaders: null,
     hasSecret: true,
     createdByUserUuid: 'user-1',
     updatedByUserUuid: 'user-1',

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -39,6 +39,7 @@ import {
     computeMinuteWindow,
     normalizeAndValidatePath,
     serializeRequestBody,
+    validateCustomHeaders,
 } from './proxyValidation';
 
 type ExternalConnectionServiceArguments = {
@@ -353,6 +354,10 @@ export class ExternalConnectionService extends BaseService {
                 apiKeyName: resolvedApiKeyName,
                 apiKeyLocation: resolvedApiKeyLocation,
                 oauthScopes: resolvedOauthScopes,
+                customHeaders:
+                    data.customHeaders !== undefined
+                        ? data.customHeaders
+                        : existing.customHeaders,
             },
             hasSecretAfter,
         );
@@ -683,6 +688,19 @@ export class ExternalConnectionService extends BaseService {
         // Start from the app's query; add api_key-in-query if configured.
         const query: Record<string, string> = { ...(req.query ?? {}) };
         const headers: Record<string, string> = {};
+
+        // Admin-configured static headers (e.g. anthropic-version), applied
+        // BEFORE auth and Content-Type so proxy-set headers always win.
+        // Re-validated at send time so a bad stored row fails closed.
+        if (connection.customHeaders) {
+            validateCustomHeaders(
+                connection.customHeaders,
+                connection.apiKeyLocation === 'header'
+                    ? connection.apiKeyName
+                    : null,
+            );
+            Object.assign(headers, connection.customHeaders);
+        }
 
         if (connection.type === 'bearer_token') {
             // Fail closed: an authenticated connection must never fall through
@@ -1152,6 +1170,7 @@ export class ExternalConnectionService extends BaseService {
             apiKeyName: data.apiKeyName ?? null,
             apiKeyLocation: data.apiKeyLocation ?? null,
             oauthScopes: data.oauthScopes ?? null,
+            customHeaders: data.customHeaders ?? null,
             hasSecret: Boolean(data.secret),
             createdByUserUuid: null,
             updatedByUserUuid: null,

--- a/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.test.ts
@@ -349,3 +349,47 @@ describe('validateExternalConnectionConfig', () => {
         });
     });
 });
+
+describe('validateExternalConnectionConfig customHeaders', () => {
+    it('accepts a config with valid custom headers', () => {
+        expect(() =>
+            validateExternalConnectionConfig(
+                {
+                    ...base,
+                    customHeaders: { 'anthropic-version': '2023-06-01' },
+                },
+                false,
+            ),
+        ).not.toThrow();
+    });
+
+    it('rejects a custom header colliding with the api key header', () => {
+        expect(() =>
+            validateExternalConnectionConfig(
+                {
+                    ...base,
+                    type: 'api_key',
+                    apiKeyName: 'X-Service-Key',
+                    apiKeyLocation: 'header',
+                    customHeaders: { 'x-service-key': 'clobber' },
+                },
+                true,
+            ),
+        ).toThrow(ParameterError);
+    });
+
+    it('allows the same name when the api key is sent as a query param', () => {
+        expect(() =>
+            validateExternalConnectionConfig(
+                {
+                    ...base,
+                    type: 'api_key',
+                    apiKeyName: 'X-Service-Key',
+                    apiKeyLocation: 'query',
+                    customHeaders: { 'x-service-key': 'header-plane-value' },
+                },
+                true,
+            ),
+        ).not.toThrow();
+    });
+});

--- a/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.ts
@@ -5,6 +5,7 @@ import {
     type ApiKeyLocation,
     type ExternalConnectionAuthType,
 } from '@lightdash/common';
+import { validateCustomHeaders } from './proxyValidation';
 
 // Defense-in-depth caps for the numeric limits. The runtime proxy enforces
 // these too, but bad config should never be persisted in the first place.
@@ -43,6 +44,7 @@ export type ValidatableExternalConnectionConfig = {
     apiKeyName?: string | null;
     apiKeyLocation?: ApiKeyLocation | null;
     oauthScopes?: string[] | null;
+    customHeaders?: Record<string, string> | null;
 };
 
 /**
@@ -203,6 +205,12 @@ export function validateExternalConnectionConfig(
             MAX_RATE_LIMIT,
         );
     }
+
+    // --- custom request headers ---
+    validateCustomHeaders(
+        config.customHeaders,
+        config.apiKeyLocation === 'header' ? (config.apiKeyName ?? null) : null,
+    );
 
     // --- auth invariants ---
     if (

--- a/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.test.ts
@@ -1,10 +1,11 @@
-import { ParameterError } from '@lightdash/common';
+import { CUSTOM_HEADER_LIMITS, ParameterError } from '@lightdash/common';
 import {
     assertSafeApiKeyHeaderName,
     buildOutboundUrl,
     computeMinuteWindow,
     normalizeAndValidatePath,
     serializeRequestBody,
+    validateCustomHeaders,
 } from './proxyValidation';
 
 describe('normalizeAndValidatePath', () => {
@@ -322,4 +323,72 @@ describe('assertSafeApiKeyHeaderName', () => {
             );
         },
     );
+});
+
+describe('validateCustomHeaders', () => {
+    it('accepts a valid header set', () => {
+        expect(() =>
+            validateCustomHeaders(
+                {
+                    'anthropic-version': '2023-06-01',
+                    Accept: 'application/vnd.github+json',
+                    'User-Agent': 'my-app/1.0',
+                },
+                null,
+            ),
+        ).not.toThrow();
+    });
+
+    it.each([['Authorization'], ['Host'], ['Content-Type'], ['X-Api-Key']])(
+        'rejects the forbidden header name %s (case-insensitive)',
+        (name) => {
+            expect(() => validateCustomHeaders({ [name]: 'v' }, null)).toThrow(
+                ParameterError,
+            );
+        },
+    );
+
+    it.each([['Bad Header'], ['häder'], ['a'.repeat(129)]])(
+        'rejects the invalid header name %j',
+        (name) => {
+            expect(() => validateCustomHeaders({ [name]: 'v' }, null)).toThrow(
+                ParameterError,
+            );
+        },
+    );
+
+    it.each([
+        ['CRLF injection', 'a\r\nX-Evil: 1'],
+        ['NUL', 'a\x00b'],
+        ['empty', ''],
+        ['over the length cap', 'v'.repeat(1025)],
+    ])('rejects a value with %s', (_label, value) => {
+        expect(() =>
+            validateCustomHeaders({ 'X-Custom': value }, null),
+        ).toThrow(ParameterError);
+    });
+
+    it('rejects case-insensitive duplicate names', () => {
+        expect(() =>
+            validateCustomHeaders({ 'X-Version': '1', 'x-version': '2' }, null),
+        ).toThrow(ParameterError);
+    });
+
+    it('rejects more than the header count cap', () => {
+        const headers = Object.fromEntries(
+            Array.from(
+                { length: CUSTOM_HEADER_LIMITS.maxCount + 1 },
+                (_, i) => [`X-H-${i}`, 'v'],
+            ),
+        );
+        expect(() => validateCustomHeaders(headers, null)).toThrow(
+            ParameterError,
+        );
+    });
+
+    it('rejects a collision with the api key header (case-insensitive)', () => {
+        expect(() =>
+            validateCustomHeaders({ 'x-service-key': 'v' }, 'X-Service-Key'),
+        ).toThrow(ParameterError);
+    });
 });

--- a/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.ts
@@ -1,4 +1,8 @@
-import { ParameterError } from '@lightdash/common';
+import {
+    CUSTOM_HEADER_LIMITS,
+    FORBIDDEN_CUSTOM_HEADER_NAMES,
+    ParameterError,
+} from '@lightdash/common';
 
 // Throwaway base used only to resolve a relative path through the WHATWG URL
 // parser for segment-collapse normalization — its `.pathname` is read and the
@@ -230,5 +234,70 @@ export function assertSafeApiKeyHeaderName(name: string): void {
     }
     if (FORBIDDEN_API_KEY_HEADERS.has(name.toLowerCase())) {
         throw new ParameterError(`api key header "${name}" is not allowed`);
+    }
+}
+
+// The shared name blocklist (routing/framing + credential-shaped headers) —
+// see FORBIDDEN_CUSTOM_HEADER_NAMES in @lightdash/common for the rationale.
+const FORBIDDEN_CUSTOM_HEADERS = new Set<string>(FORBIDDEN_CUSTOM_HEADER_NAMES);
+
+// Printable ASCII + tab. No CR/LF or other control chars (header injection).
+// eslint-disable-next-line no-control-regex
+const HTTP_HEADER_VALUE = /^[\t\x20-\x7e]+$/;
+
+/**
+ * Validate a connection's custom request headers. Enforced at write time AND
+ * at send time in the proxy core, so a row that bypassed validation can never
+ * inject an unsafe header. A custom header may not collide with
+ * `apiKeyHeaderName` so the injected credential is never shadowed.
+ */
+export function validateCustomHeaders(
+    customHeaders: Record<string, string> | null | undefined,
+    apiKeyHeaderName: string | null,
+): void {
+    if (!customHeaders) return;
+    const entries = Object.entries(customHeaders);
+    if (entries.length > CUSTOM_HEADER_LIMITS.maxCount) {
+        throw new ParameterError(
+            `At most ${CUSTOM_HEADER_LIMITS.maxCount} custom headers are allowed`,
+        );
+    }
+    const seen = new Set<string>();
+    for (const [name, value] of entries) {
+        if (
+            !HTTP_HEADER_TOKEN.test(name) ||
+            name.length > CUSTOM_HEADER_LIMITS.maxNameChars
+        ) {
+            throw new ParameterError(
+                `Custom header name ${JSON.stringify(name)} is not a valid HTTP header name`,
+            );
+        }
+        if (FORBIDDEN_CUSTOM_HEADERS.has(name.toLowerCase())) {
+            throw new ParameterError(
+                `Custom header "${name}" is not allowed — credentials belong in the connection secret`,
+            );
+        }
+        if (
+            typeof value !== 'string' ||
+            value.length === 0 ||
+            value.length > CUSTOM_HEADER_LIMITS.maxValueChars ||
+            !HTTP_HEADER_VALUE.test(value)
+        ) {
+            throw new ParameterError(
+                `Custom header "${name}" has an invalid value`,
+            );
+        }
+        const lower = name.toLowerCase();
+        if (seen.has(lower)) {
+            throw new ParameterError(
+                `Duplicate custom header "${name}" (names are case-insensitive)`,
+            );
+        }
+        seen.add(lower);
+        if (apiKeyHeaderName && lower === apiKeyHeaderName.toLowerCase()) {
+            throw new ParameterError(
+                `Custom header "${name}" conflicts with the connection's api key header`,
+            );
+        }
     }
 }

--- a/packages/common/src/ee/externalConnections/types.ts
+++ b/packages/common/src/ee/externalConnections/types.ts
@@ -17,6 +17,38 @@ export type ExternalConnectionMethod =
     (typeof EXTERNAL_CONNECTION_METHODS)[number];
 export type ApiKeyLocation = 'header' | 'query';
 
+/** Bounds for a connection's custom request headers — shared by backend
+ *  validation and the frontend form so both reject the same shapes. */
+export const CUSTOM_HEADER_LIMITS = {
+    maxCount: 20,
+    maxNameChars: 128,
+    maxValueChars: 1024,
+} as const;
+
+/** Header names custom request headers may never use: routing/framing headers
+ *  the proxy owns, plus credential-shaped names — header values are plaintext
+ *  config returned by the read API, so secrets belong in the encrypted secret. */
+export const FORBIDDEN_CUSTOM_HEADER_NAMES = [
+    'host',
+    'content-length',
+    'content-type',
+    'connection',
+    'transfer-encoding',
+    'te',
+    'trailer',
+    'upgrade',
+    'keep-alive',
+    'expect',
+    'authorization',
+    'proxy-authorization',
+    'proxy-connection',
+    'cookie',
+    'x-api-key',
+    'api-key',
+    'x-auth-token',
+    'x-access-token',
+] as const;
+
 /** READ shape returned by the API — NEVER includes the secret value. */
 export type ExternalConnection = {
     externalConnectionUuid: string;
@@ -37,6 +69,9 @@ export type ExternalConnection = {
     apiKeyLocation: ApiKeyLocation | null;
     // OAuth scopes for type 'google_service_account'; null for other types.
     oauthScopes: string[] | null;
+    // Static non-secret headers sent on every proxied request, applied before
+    // auth so the injected credential always wins (e.g. anthropic-version).
+    customHeaders: Record<string, string> | null;
     hasSecret: boolean;
     createdByUserUuid: string | null;
     updatedByUserUuid: string | null;
@@ -60,6 +95,7 @@ export type CreateExternalConnection = {
     apiKeyName?: string | null;
     apiKeyLocation?: ApiKeyLocation | null;
     oauthScopes?: string[] | null; // OAuth scopes for type 'google_service_account'
+    customHeaders?: Record<string, string> | null; // static non-secret headers sent on every request
     secret?: string | null; // bearer token, api key, or service account keyfile JSON; null for type 'none'
 };
 
@@ -101,11 +137,17 @@ export type ApiTestExternalConnectionRequest = {
 };
 
 /** Test an unsaved connection config (incl. plaintext secret) before creating
- *  it. Runs through the same SSRF-guarded proxy core, persisting nothing. */
-export type ApiTestExternalConnectionConfigRequest =
-    ApiTestExternalConnectionRequest & {
-        config: CreateExternalConnection;
-    };
+ *  it. Runs through the same SSRF-guarded proxy core, persisting nothing.
+ *  Deliberately a flat object, NOT `ApiTestExternalConnectionRequest & {...}`:
+ *  TSOA validates intersection bodies in remove-extras mode, which empties
+ *  Record<string, string> fields (query, config.customHeaders). */
+export type ApiTestExternalConnectionConfigRequest = {
+    method?: ExternalConnectionMethod;
+    path: string;
+    query?: Record<string, string>;
+    body?: unknown;
+    config: CreateExternalConnection;
+};
 
 export type ApiTestExternalConnectionResponse = {
     status: 'ok';

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/AddConnectionWizard.tsx
@@ -20,6 +20,7 @@ import {
 import { useForm, type UseFormReturnType } from '@mantine/form';
 import { IconPlugConnected } from '@tabler/icons-react';
 import { type FC, useState } from 'react';
+import { CustomHeadersField } from '../../../features/externalConnections/components/CustomHeadersField';
 import { MethodsField } from '../../../features/externalConnections/components/MethodsField';
 import { PathRulesField } from '../../../features/externalConnections/components/PathRulesField';
 import {
@@ -28,6 +29,11 @@ import {
 } from '../../../features/externalConnections/constants';
 import { useCreateExternalConnection } from '../../../features/externalConnections/hooks/useCreateExternalConnection';
 import { useSaveConnectionSample } from '../../../features/externalConnections/hooks/useSaveConnectionSample';
+import {
+    customHeaderRowsToRecord,
+    validateCustomHeaderRows,
+    type CustomHeaderRow,
+} from '../../../features/externalConnections/utils/customHeaders';
 import {
     resolvePathPrefixes,
     type PathMode,
@@ -55,6 +61,7 @@ type WizardValues = {
     apiKeyName: string;
     apiKeyLocation: ApiKeyLocation;
     oauthScopes: string[];
+    customHeaders: CustomHeaderRow[];
     allowedMethods: ExternalConnectionMethod[];
     pathMode: PathMode;
     allowedPathPrefixes: PathPrefix[];
@@ -90,6 +97,7 @@ const toCreatePayload = (values: WizardValues): CreateExternalConnection => ({
     apiKeyLocation: values.type === 'api_key' ? values.apiKeyLocation : null,
     oauthScopes:
         values.type === 'google_service_account' ? values.oauthScopes : null,
+    customHeaders: customHeaderRowsToRecord(values.customHeaders),
     allowedMethods: values.allowedMethods,
     allowedPathPrefixes: resolvePathPrefixes(
         values.pathMode,
@@ -205,6 +213,13 @@ const AuthStep: FC<{ form: UseFormReturnType<WizardValues> }> = ({ form }) => {
                     />
                 </>
             )}
+
+            <CustomHeadersField
+                label="Custom headers (optional)"
+                value={form.values.customHeaders}
+                onChange={(value) => form.setFieldValue('customHeaders', value)}
+                error={form.errors.customHeaders}
+            />
         </Stack>
     );
 };
@@ -263,6 +278,7 @@ export const AddConnectionWizard: FC<Props> = ({
             apiKeyName: '',
             apiKeyLocation: 'header',
             oauthScopes: [],
+            customHeaders: [],
             allowedMethods: ['GET'],
             pathMode: 'all',
             allowedPathPrefixes: [],
@@ -300,6 +316,7 @@ export const AddConnectionWizard: FC<Props> = ({
                     ? null
                     : 'Use a valid header or query parameter name';
             },
+            customHeaders: validateCustomHeaderRows,
             allowedMethods: (value) =>
                 value.length === 0 ? 'Select at least one method' : null,
             allowedPathPrefixes: (value, values) => {
@@ -337,7 +354,13 @@ export const AddConnectionWizard: FC<Props> = ({
         const secret = form.validateField('secret');
         const apiKeyName = form.validateField('apiKeyName');
         const oauthScopes = form.validateField('oauthScopes');
-        if (!secret.hasError && !apiKeyName.hasError && !oauthScopes.hasError) {
+        const customHeaders = form.validateField('customHeaders');
+        if (
+            !secret.hasError &&
+            !apiKeyName.hasError &&
+            !oauthScopes.hasError &&
+            !customHeaders.hasError
+        ) {
             setActive(2);
         }
     };

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/EditConnectionModal.tsx
@@ -9,6 +9,11 @@ import { type FC } from 'react';
 import { isValidOAuthScope } from '../../../features/externalConnections/constants';
 import { useUpdateExternalConnection } from '../../../features/externalConnections/hooks/useUpdateExternalConnection';
 import {
+    customHeaderRowsToRecord,
+    recordToCustomHeaderRows,
+    validateCustomHeaderRows,
+} from '../../../features/externalConnections/utils/customHeaders';
+import {
     derivePathRules,
     resolvePathPrefixes,
 } from '../../../features/externalConnections/utils/pathRules';
@@ -46,6 +51,7 @@ const EditConnectionModalContent: FC<Props> = ({
             apiKeyName: connection.apiKeyName ?? '',
             apiKeyLocation: connection.apiKeyLocation ?? 'header',
             oauthScopes: connection.oauthScopes ?? [],
+            customHeaders: recordToCustomHeaderRows(connection.customHeaders),
             allowedMethods: connection.allowedMethods,
             pathMode: pathRules.mode,
             allowedPathPrefixes: pathRules.prefixes,
@@ -81,6 +87,7 @@ const EditConnectionModalContent: FC<Props> = ({
                     ? `Invalid OAuth scope: ${invalid} (use an https:// scope)`
                     : null;
             },
+            customHeaders: validateCustomHeaderRows,
             allowedMethods: (value) =>
                 value.length === 0 ? 'Select at least one method' : null,
             allowedPathPrefixes: (value, values) => {
@@ -118,6 +125,7 @@ const EditConnectionModalContent: FC<Props> = ({
                 values.type === 'google_service_account'
                     ? values.oauthScopes
                     : null,
+            customHeaders: customHeaderRowsToRecord(values.customHeaders),
             // Blank => omit so the stored secret is unchanged. A non-blank
             // value on a non-"none" type rotates it via PATCH.
             ...(values.type !== 'none' && values.secret

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.tsx
@@ -16,9 +16,11 @@ import {
 } from '@mantine-8/core';
 import { type UseFormReturnType } from '@mantine/form';
 import { type FC, useState } from 'react';
+import { CustomHeadersField } from '../../../features/externalConnections/components/CustomHeadersField';
 import { MethodsField } from '../../../features/externalConnections/components/MethodsField';
 import { PathRulesField } from '../../../features/externalConnections/components/PathRulesField';
 import { SUGGESTED_GOOGLE_SCOPES } from '../../../features/externalConnections/constants';
+import { type CustomHeaderRow } from '../../../features/externalConnections/utils/customHeaders';
 import {
     type PathMode,
     type PathPrefix,
@@ -35,6 +37,7 @@ export type ExternalConnectionFormValues = {
     apiKeyName: string;
     apiKeyLocation: 'header' | 'query';
     oauthScopes: string[];
+    customHeaders: CustomHeaderRow[];
     allowedMethods: ExternalConnectionMethod[];
     pathMode: PathMode;
     allowedPathPrefixes: PathPrefix[];
@@ -164,6 +167,14 @@ export const ExternalConnectionForm: FC<Props> = ({
                     />
                 </Group>
             )}
+
+            <CustomHeadersField
+                label="Custom headers"
+                value={form.values.customHeaders}
+                onChange={(value) => form.setFieldValue('customHeaders', value)}
+                error={form.errors.customHeaders}
+                disabled={disabled}
+            />
 
             <Divider label="Request policy" labelPosition="left" />
 

--- a/packages/frontend/src/features/externalConnections/components/CustomHeadersField.tsx
+++ b/packages/frontend/src/features/externalConnections/components/CustomHeadersField.tsx
@@ -1,0 +1,106 @@
+import {
+    ActionIcon,
+    Button,
+    Group,
+    Stack,
+    Text,
+    TextInput,
+} from '@mantine-8/core';
+import { IconPlus, IconTrash } from '@tabler/icons-react';
+import { type FC, type ReactNode } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { type CustomHeaderRow } from '../utils/customHeaders';
+
+type Props = {
+    label: string;
+    value: CustomHeaderRow[];
+    onChange: (value: CustomHeaderRow[]) => void;
+    error?: ReactNode;
+    disabled?: boolean;
+};
+
+/** Key/value editor for a connection's static custom request headers
+ *  (e.g. anthropic-version). Shared by the onboarding wizard's Auth step
+ *  and the Edit connection form. */
+export const CustomHeadersField: FC<Props> = ({
+    label,
+    value,
+    onChange,
+    error,
+    disabled,
+}) => {
+    const updateRow = (index: number, patch: Partial<CustomHeaderRow>) => {
+        onChange(
+            value.map((row, i) => (i === index ? { ...row, ...patch } : row)),
+        );
+    };
+
+    return (
+        <Stack gap={4}>
+            <Text fz="sm" fw={500}>
+                {label}
+            </Text>
+            <Text c="ldGray.6" fz="xs">
+                Sent with every request — e.g. anthropic-version or
+                X-GitHub-Api-Version. Never put secrets here; use the
+                connection's authentication instead.
+            </Text>
+            {value.map((row, index) => (
+                // Rows have no stable identity — index keys are intentional.
+                // eslint-disable-next-line react/no-array-index-key
+                <Group key={index} gap="xs" align="flex-start">
+                    <TextInput
+                        aria-label="Header name"
+                        placeholder="anthropic-version"
+                        style={{ flexGrow: 1 }}
+                        value={row.name}
+                        disabled={disabled}
+                        onChange={(e) =>
+                            updateRow(index, { name: e.currentTarget.value })
+                        }
+                    />
+                    <TextInput
+                        aria-label="Header value"
+                        placeholder="2023-06-01"
+                        style={{ flexGrow: 1 }}
+                        value={row.value}
+                        disabled={disabled}
+                        onChange={(e) =>
+                            updateRow(index, { value: e.currentTarget.value })
+                        }
+                    />
+                    <ActionIcon
+                        aria-label="Remove header"
+                        variant="subtle"
+                        color="ldGray.6"
+                        mt={4}
+                        disabled={disabled}
+                        onClick={() =>
+                            onChange(value.filter((_, i) => i !== index))
+                        }
+                    >
+                        <MantineIcon icon={IconTrash} />
+                    </ActionIcon>
+                </Group>
+            ))}
+            <Group>
+                <Button
+                    variant="subtle"
+                    size="compact-sm"
+                    leftSection={<MantineIcon icon={IconPlus} />}
+                    disabled={disabled}
+                    onClick={() =>
+                        onChange([...value, { name: '', value: '' }])
+                    }
+                >
+                    Add header
+                </Button>
+            </Group>
+            {error && (
+                <Text c="red" fz="xs">
+                    {error}
+                </Text>
+            )}
+        </Stack>
+    );
+};

--- a/packages/frontend/src/features/externalConnections/utils/customHeaders.ts
+++ b/packages/frontend/src/features/externalConnections/utils/customHeaders.ts
@@ -1,0 +1,70 @@
+import {
+    CUSTOM_HEADER_LIMITS,
+    FORBIDDEN_CUSTOM_HEADER_NAMES,
+} from '@lightdash/common';
+
+/** One editable row in the custom headers form field. */
+export type CustomHeaderRow = { name: string; value: string };
+
+// Mirrors the backend's custom-header validators (proxyValidation.ts) so bad
+// headers are caught inline before submit.
+const HTTP_HEADER_TOKEN = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/;
+// eslint-disable-next-line no-control-regex
+const HTTP_HEADER_VALUE = /^[\t\x20-\x7e]+$/;
+const FORBIDDEN_NAMES = new Set<string>(FORBIDDEN_CUSTOM_HEADER_NAMES);
+
+export const recordToCustomHeaderRows = (
+    headers: Record<string, string> | null | undefined,
+): CustomHeaderRow[] =>
+    Object.entries(headers ?? {}).map(([name, value]) => ({ name, value }));
+
+/** Fully blank rows are dropped; returns null when nothing remains. */
+export const customHeaderRowsToRecord = (
+    rows: CustomHeaderRow[],
+): Record<string, string> | null => {
+    const entries = rows
+        .map((row) => [row.name.trim(), row.value.trim()] as const)
+        .filter(([name, value]) => name.length > 0 && value.length > 0);
+    return entries.length > 0 ? Object.fromEntries(entries) : null;
+};
+
+/** Returns a user-facing error for the first invalid row, or null. */
+export const validateCustomHeaderRows = (
+    rows: CustomHeaderRow[],
+): string | null => {
+    const seen = new Set<string>();
+    for (const row of rows) {
+        const name = row.name.trim();
+        const value = row.value.trim();
+        // A fully blank row is dropped on submit.
+        if (!name && !value) continue;
+        if (
+            !name ||
+            !HTTP_HEADER_TOKEN.test(name) ||
+            name.length > CUSTOM_HEADER_LIMITS.maxNameChars
+        ) {
+            return `"${row.name}" is not a valid header name`;
+        }
+        if (FORBIDDEN_NAMES.has(name.toLowerCase())) {
+            return `Header "${name}" is not allowed — use the connection's authentication for credentials`;
+        }
+        if (!value) {
+            return `Header "${name}" needs a value`;
+        }
+        if (value.length > CUSTOM_HEADER_LIMITS.maxValueChars) {
+            return `The value of "${name}" is too long (max ${CUSTOM_HEADER_LIMITS.maxValueChars} characters)`;
+        }
+        if (!HTTP_HEADER_VALUE.test(value)) {
+            return `The value of "${name}" contains unsupported characters`;
+        }
+        const lower = name.toLowerCase();
+        if (seen.has(lower)) {
+            return `Duplicate header "${name}"`;
+        }
+        seen.add(lower);
+    }
+    if (seen.size > CUSTOM_HEADER_LIMITS.maxCount) {
+        return `At most ${CUSTOM_HEADER_LIMITS.maxCount} custom headers are allowed`;
+    }
+    return null;
+};


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9100/data-apps-external-connections-proxy-support-custom-request-headers


### Description
Adds admin-configured static request headers to external connections (e.g. `anthropic-version: 2023-06-01`), injected by the proxy on every outbound request. Unblocks upstream APIs that require headers beyond auth — Anthropic, GitHub, Notion.

Tested end-to-end locally against Anthropic (`POST /v1/messages` → 200 through the proxy).

<img width="1142" height="1114" alt="Screenshot 2026-07-22 at 14 04 18" src="https://github.com/user-attachments/assets/fc41721e-33d7-4b0e-8d0d-236a31a114ce" />
<img width="1142" height="1114" alt="Screenshot 2026-07-22 at 14 04 09" src="https://github.com/user-attachments/assets/713cfd90-a1d4-42a2-9ead-6775e17ab6ba" />

