### PR TITLE
feat(charts): label chart legend, tooltip and axis via label_dimension

### DIFF
--- a/packages/backend/src/queryCompiler.test.ts
+++ b/packages/backend/src/queryCompiler.test.ts
@@ -1,10 +1,15 @@
 import {
     BinType,
+    CompiledDimension,
     CompiledMetricQuery,
     CompileError,
     CustomDimensionType,
     DimensionType,
+    Explore,
+    FieldType,
+    MetricQuery,
     MetricType,
+    SupportedDbtAdapter,
     TableCalculation,
     TableCalculationTemplateType,
     VizIndexType,
@@ -28,7 +33,10 @@ import {
     METRIC_QUERY_WITH_ADDITIONAL_METRICS_COMPILED,
     METRIC_QUERY_WITH_INVALID_ADDITIONAL_METRIC,
 } from './queryCompiler.mock';
-import { warehouseClientMock } from './utils/QueryBuilder/MetricQueryBuilder.mock';
+import {
+    emptyTable,
+    warehouseClientMock,
+} from './utils/QueryBuilder/MetricQueryBuilder.mock';
 
 test('Should compile without table calculations', () => {
     const expected: CompiledMetricQuery = {
@@ -1343,5 +1351,138 @@ describe('compilePostCalculationMetric', () => {
         expect(result).toBe(
             '(CAST("metric" AS FLOAT) / CAST(NULLIF(LAG("metric") OVER(PARTITION BY "employee"ORDER BY "week"), 0) AS FLOAT)) - 1',
         );
+    });
+});
+
+describe('compileMetricQuery label dimensions', () => {
+    const makeDimension = (
+        name: string,
+        filterAutocomplete?: {
+            fetchFromWarehouse: boolean;
+            labelDimension: string;
+        },
+    ): CompiledDimension => ({
+        name,
+        fieldType: FieldType.DIMENSION,
+        type: DimensionType.STRING,
+        table: 'table1',
+        label: name,
+        tableLabel: 'table1',
+        hidden: false,
+        sql: `\${TABLE}.${name}`,
+        compiledSql: `\`table1\`.\`${name}\``,
+        tablesReferences: ['table1'],
+        ...(filterAutocomplete ? { filterAutocomplete } : {}),
+    });
+
+    const exploreWithLabelDimension: Pick<
+        Explore,
+        'targetDatabase' | 'tables'
+    > = {
+        targetDatabase: SupportedDbtAdapter.POSTGRES,
+        tables: {
+            table1: {
+                ...emptyTable('table1'),
+                dimensions: {
+                    customer_id: makeDimension('customer_id', {
+                        fetchFromWarehouse: true,
+                        labelDimension: 'customer_name',
+                    }),
+                    customer_name: makeDimension('customer_name'),
+                },
+            },
+        },
+    };
+
+    const baseMetricQuery: MetricQuery = {
+        exploreName: 'table1',
+        dimensions: ['table1_customer_id'],
+        metrics: [],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: [],
+    };
+
+    test('injects the companion label dimension and echoes the mapping', () => {
+        const result = compileMetricQuery({
+            explore: exploreWithLabelDimension,
+            metricQuery: baseMetricQuery,
+            warehouseSqlBuilder: warehouseClientMock,
+            availableParameters: [],
+        });
+
+        expect(result.labelDimensionMap).toEqual({
+            table1_customer_id: 'table1_customer_name',
+        });
+        expect(result.companionLabelDimensionIds).toEqual([
+            'table1_customer_name',
+        ]);
+        expect(result.dimensions).toEqual([
+            'table1_customer_id',
+            'table1_customer_name',
+        ]);
+    });
+
+    test('leaves the query untouched when no dimension has a label dimension', () => {
+        const result = compileMetricQuery({
+            explore: EXPLORE,
+            metricQuery: METRIC_QUERY_NO_CALCS,
+            warehouseSqlBuilder: warehouseClientMock,
+            availableParameters: [],
+        });
+
+        expect(result.labelDimensionMap).toBeUndefined();
+        expect(result.companionLabelDimensionIds).toBeUndefined();
+        expect(result.dimensions).toEqual(METRIC_QUERY_NO_CALCS.dimensions);
+    });
+
+    test('does not throw when the label dimension is misconfigured', () => {
+        const exploreWithBadLabel: Pick<Explore, 'targetDatabase' | 'tables'> =
+            {
+                targetDatabase: SupportedDbtAdapter.POSTGRES,
+                tables: {
+                    table1: {
+                        ...emptyTable('table1'),
+                        dimensions: {
+                            customer_id: makeDimension('customer_id', {
+                                fetchFromWarehouse: true,
+                                labelDimension: 'does_not_exist',
+                            }),
+                        },
+                    },
+                },
+            };
+
+        let result: CompiledMetricQuery | undefined;
+        expect(() => {
+            result = compileMetricQuery({
+                explore: exploreWithBadLabel,
+                metricQuery: baseMetricQuery,
+                warehouseSqlBuilder: warehouseClientMock,
+                availableParameters: [],
+            });
+        }).not.toThrow();
+        expect(result?.labelDimensionMap).toBeUndefined();
+        expect(result?.companionLabelDimensionIds).toBeUndefined();
+        expect(result?.dimensions).toEqual(['table1_customer_id']);
+    });
+
+    test('does not duplicate a label dimension already selected', () => {
+        const result = compileMetricQuery({
+            explore: exploreWithLabelDimension,
+            metricQuery: {
+                ...baseMetricQuery,
+                dimensions: ['table1_customer_id', 'table1_customer_name'],
+            },
+            warehouseSqlBuilder: warehouseClientMock,
+            availableParameters: [],
+        });
+
+        expect(result.companionLabelDimensionIds).toEqual([]);
+        expect(result.dimensions).toEqual([
+            'table1_customer_id',
+            'table1_customer_name',
+        ]);
     });
 });

--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -11,6 +11,7 @@ import {
     detectCircularDependencies,
     Explore,
     ExploreCompiler,
+    getErrorMessage,
     getItemId,
     getReservedParameterNames,
     isCustomBinDimension,
@@ -23,6 +24,7 @@ import {
     MetricQuery,
     MetricType,
     PivotConfiguration,
+    resolveLabelDimensionId,
     TableCalculation,
     type WarehouseSqlBuilder,
 } from '@lightdash/common';
@@ -32,6 +34,7 @@ import {
     parse as parseFormula,
 } from '@lightdash/formula';
 import { mapAdapterToFormulaDialect } from './formulaDialectMapper';
+import Logger from './logging/logger';
 import { compileTableCalculationFromTemplate } from './tableCalculationTemplateQueryCompiler';
 
 const formatFormulaError = (displayName: string, error: unknown): string => {
@@ -446,10 +449,51 @@ export const compileMetricQuery = ({
         customBinDimensionIds,
     );
 
+    const exploreDimensions = Object.values(explore.tables).flatMap((table) =>
+        Object.values(table.dimensions),
+    );
+    const labelDimensionMap: Record<string, string> = {};
+    metricQuery.dimensions.forEach((dimensionId) => {
+        const field = exploreDimensions.find(
+            (dimension) => getItemId(dimension) === dimensionId,
+        );
+        if (field) {
+            try {
+                const labelFieldId = resolveLabelDimensionId(field, explore);
+                if (labelFieldId) {
+                    labelDimensionMap[dimensionId] = labelFieldId;
+                }
+            } catch (error) {
+                // A misconfigured label_dimension must not break the chart query;
+                // it still surfaces on the filter-autocomplete path.
+                Logger.warn(
+                    `Skipping label dimension for '${dimensionId}': ${getErrorMessage(
+                        error,
+                    )}`,
+                );
+            }
+        }
+    });
+    const companionLabelDimensionIds = [
+        ...new Set(Object.values(labelDimensionMap)),
+    ].filter((labelFieldId) => !metricQuery.dimensions.includes(labelFieldId));
+    const hasLabelDimensions = Object.keys(labelDimensionMap).length > 0;
+
     return {
         ...metricQuery,
+        ...(companionLabelDimensionIds.length > 0
+            ? {
+                  dimensions: [
+                      ...metricQuery.dimensions,
+                      ...companionLabelDimensionIds,
+                  ],
+              }
+            : {}),
         compiledTableCalculations,
         compiledAdditionalMetrics,
         compiledCustomDimensions,
+        ...(hasLabelDimensions
+            ? { companionLabelDimensionIds, labelDimensionMap }
+            : {}),
     };
 };

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -58,6 +58,7 @@ import {
     isCustomBinDimension,
     isCustomDimension,
     isDateItem,
+    isDimension,
     isExploreError,
     isField,
     isJwtUser,
@@ -2115,12 +2116,39 @@ export class AsyncQueryService extends ProjectService {
                                         displayTimezone ?? undefined,
                                     )
                                   : String(rawValue);
+                              const labelDimension =
+                                  field && isField(field) && isDimension(field)
+                                      ? field.filterAutocomplete?.labelDimension
+                                      : undefined;
+                              let label: string | undefined;
+                              if (labelDimension && isField(field)) {
+                                  // Companion label rides along as a passthrough
+                                  // dim, so its value is on this warehouse row.
+                                  const labelFieldId = getItemId({
+                                      table: field.table,
+                                      name: labelDimension,
+                                  });
+                                  const labelRawValue = row[labelFieldId];
+                                  if (labelRawValue !== undefined) {
+                                      const labelField = itemsMap[labelFieldId];
+                                      label = labelField
+                                          ? formatItemValue(
+                                                labelField,
+                                                labelRawValue,
+                                                false,
+                                                undefined,
+                                                displayTimezone ?? undefined,
+                                            )
+                                          : String(labelRawValue);
+                                  }
+                              }
                               return {
                                   referenceField: c.reference,
                                   // value needs to be raw formatted so that dates match the subtotals and the formatted rows
                                   value: rawValue,
                                   // formatted value to match the display value in the frontend
                                   formatted: formattedValue,
+                                  ...(label !== undefined ? { label } : {}),
                               };
                           }) ?? [];
 
@@ -3470,6 +3498,9 @@ export class AsyncQueryService extends ProjectService {
         const fields = getFieldsFromMetricQuery(
             compiledMetricQuery,
             exploreWithOverride,
+            compiledMetricQuery.companionLabelDimensionIds
+                ? new Set(compiledMetricQuery.companionLabelDimensionIds)
+                : undefined,
         );
 
         return { fields, dateZoomApplied };

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -7,6 +7,7 @@ import {
     isFilterRule,
     NotFoundError,
     ParameterError,
+    resolveLabelDimensionId,
     type AndFilterGroup,
     type Dimension,
     type Explore,
@@ -109,31 +110,7 @@ export async function getFieldValuesMetricQuery({
         );
     }
 
-    let labelFieldId: string | null = null;
-    const labelDimension = field.filterAutocomplete?.labelDimension;
-    if (labelDimension) {
-        const candidateLabelFieldId = getItemId({
-            table: field.table,
-            name: labelDimension,
-        });
-        if (candidateLabelFieldId !== getItemId(field)) {
-            const resolvedLabelField = findFieldByIdInExplore(
-                explore,
-                candidateLabelFieldId,
-            );
-            if (!resolvedLabelField) {
-                throw new NotFoundError(
-                    `Can't find label dimension '${labelDimension}' in table '${field.table}'`,
-                );
-            }
-            if (!isDimension(resolvedLabelField)) {
-                throw new ParameterError(
-                    `Label field must be a dimension, but ${candidateLabelFieldId} is a ${resolvedLabelField.type}`,
-                );
-            }
-            labelFieldId = candidateLabelFieldId;
-        }
-    }
+    const labelFieldId = resolveLabelDimensionId(field, explore);
 
     // Autocomplete ignores the field's caseSensitive setting.
     const searchFilter: FilterGroupItem = labelFieldId

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -23,6 +23,7 @@ import {
     type MetricFilterRule,
     type TimestampDomain,
 } from '@lightdash/common';
+import { compileMetricQuery } from '../../queryCompiler';
 import {
     BuildQueryProps,
     CompiledQuery,
@@ -7524,5 +7525,93 @@ describe('Known-naive domains survive PoP and fanout metric paths', () => {
             `MAX((("customers".created_at) AT TIME ZONE 'Asia/Tokyo'))`,
         );
         expect(query).not.toMatch(/MAX\("customers"\.created_at\)/);
+    });
+});
+
+describe('label dimension companion in a joined query (fan-out safety)', () => {
+    const exploreWithLabel: Explore = {
+        ...EXPLORE,
+        tables: {
+            ...EXPLORE.tables,
+            table1: {
+                ...EXPLORE.tables.table1,
+                dimensions: {
+                    ...EXPLORE.tables.table1.dimensions,
+                    dim1: {
+                        ...EXPLORE.tables.table1.dimensions.dim1,
+                        filterAutocomplete: {
+                            fetchFromWarehouse: true,
+                            labelDimension: 'shared',
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const metricQuery = {
+        exploreName: 'table1',
+        dimensions: ['table1_dim1'],
+        metrics: ['table2_metric3'],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: [],
+    };
+
+    const compile = (explore: Explore) =>
+        compileMetricQuery({
+            explore,
+            metricQuery,
+            warehouseSqlBuilder: warehouseClientMock,
+            availableParameters: [],
+        });
+
+    test('selects and groups by the companion without disturbing the joined metric', () => {
+        const compiled = compile(exploreWithLabel);
+        expect(compiled.companionLabelDimensionIds).toEqual(['table1_shared']);
+
+        const query = replaceWhitespace(
+            buildQuery({
+                explore: exploreWithLabel,
+                compiledMetricQuery: compiled,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            }).query,
+        );
+
+        // Companion column is selected and grouped
+        expect(query).toContain('"table1".shared AS "table1_shared"');
+        // The joined SUM metric SQL is unchanged by the companion injection
+        expect(query).toContain('SUM("table2".number_column)');
+        // The table2 join is still present
+        expect(query).toContain('table2');
+    });
+
+    test('the base metric SQL is identical with and without the label dimension', () => {
+        const withLabel = replaceWhitespace(
+            buildQuery({
+                explore: exploreWithLabel,
+                compiledMetricQuery: compile(exploreWithLabel),
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            }).query,
+        );
+        const withoutLabel = replaceWhitespace(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: compile(EXPLORE),
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            }).query,
+        );
+
+        // Same aggregate + join; the only difference is the extra companion column
+        expect(withoutLabel).not.toContain('"table1_shared"');
+        expect(withLabel).toContain('SUM("table2".number_column)');
+        expect(withoutLabel).toContain('SUM("table2".number_column)');
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -117,6 +117,8 @@ export type CompiledQuery = {
     missingParameterReferences: Set<string>;
     usedParameters: ParametersValuesMap;
     compilationErrors: string[];
+    companionLabelDimensionIds?: string[];
+    labelDimensionMap?: Record<string, string>;
 };
 
 export type BuildQueryProps = {
@@ -4986,7 +4988,13 @@ export class MetricQueryBuilder {
         warnings: QueryWarning[];
     } {
         const { explore, compiledMetricQuery } = this.args;
-        const fields = getFieldsFromMetricQuery(compiledMetricQuery, explore);
+        const fields = getFieldsFromMetricQuery(
+            compiledMetricQuery,
+            explore,
+            compiledMetricQuery.companionLabelDimensionIds
+                ? new Set(compiledMetricQuery.companionLabelDimensionIds)
+                : undefined,
+        );
         const usedFieldCompilationErrors = this.getUsedFieldCompilationErrors();
 
         if (usedFieldCompilationErrors.length > 0) {
@@ -5694,6 +5702,9 @@ export class MetricQueryBuilder {
             missingParameterReferences,
             usedParameters,
             compilationErrors: this.compilationErrors,
+            companionLabelDimensionIds:
+                this.args.compiledMetricQuery.companionLabelDimensionIds,
+            labelDimensionMap: this.args.compiledMetricQuery.labelDimensionMap,
         };
     }
 }

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.test.ts
@@ -1,5 +1,6 @@
 import {
     CustomFormatType,
+    Explore,
     FilterOperator,
     MetricQuery,
     PivotConfiguration,
@@ -262,5 +263,59 @@ describe('QueryComposer', () => {
                 expect(sql).toMatchSnapshot();
             });
         });
+    });
+});
+
+describe('getPivotConfiguration with label dimensions', () => {
+    const exploreWithLabel: Explore = {
+        ...EXPLORE,
+        tables: {
+            ...EXPLORE.tables,
+            table1: {
+                ...EXPLORE.tables.table1,
+                dimensions: {
+                    ...EXPLORE.tables.table1.dimensions,
+                    dim1: {
+                        ...EXPLORE.tables.table1.dimensions.dim1,
+                        filterAutocomplete: {
+                            fetchFromWarehouse: true,
+                            labelDimension: 'shared',
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const metricQuery: MetricQuery = {
+        exploreName: 'table1',
+        dimensions: ['table1_dim1'],
+        metrics: ['table1_metric1'],
+        filters: {},
+        sorts: [{ fieldId: 'table1_dim1', descending: false }],
+        limit: 500,
+        tableCalculations: [],
+    };
+
+    it('folds the companion label dimension into passthroughDimensions', () => {
+        const composer = new QueryComposer(
+            { metricQuery, pivotConfiguration: PIVOT_CONFIGURATION },
+            { ...CONTEXT, explore: exploreWithLabel },
+        );
+
+        expect(composer.getPivotConfiguration()?.passthroughDimensions).toEqual(
+            [{ reference: 'table1_shared' }],
+        );
+    });
+
+    it('leaves passthroughDimensions untouched when no label dimension is set', () => {
+        const composer = new QueryComposer(
+            { metricQuery, pivotConfiguration: PIVOT_CONFIGURATION },
+            CONTEXT,
+        );
+
+        expect(
+            composer.getPivotConfiguration()?.passthroughDimensions,
+        ).toBeUndefined();
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
@@ -3,6 +3,7 @@ import {
     getMetricOverridesWithPopInheritance,
     mergeReservedDefinitions,
     mergeReservedValues,
+    normalizeIndexColumns,
     resolveReservedParameterValues,
     type DateZoom,
     type Explore,
@@ -199,18 +200,66 @@ export class QueryComposer {
 
     /** The effective (totals-collapsed) metric query the composer compiles. */
     getMetricQuery(): MetricQuery {
-        if (this.definition.totalConfiguration) {
-            return this.getQueryBuilder().getEffectiveMetricQuery();
+        const metricQuery = this.definition.totalConfiguration
+            ? this.getQueryBuilder().getEffectiveMetricQuery()
+            : this.definition.metricQuery;
+        const { labelDimensionMap } = this.compile();
+        if (!labelDimensionMap) {
+            return metricQuery;
         }
-        return this.definition.metricQuery;
+        return {
+            ...metricQuery,
+            labelDimensionMap,
+        };
     }
 
-    /** The effective (totals-collapsed) pivot configuration, if any. */
+    /**
+     * The effective pivot configuration with companion label dimensions folded
+     * in as passthrough dimensions, so their values are carried through the
+     * pivot pipeline onto each row (the pivot would otherwise drop any base
+     * dimension that isn't an index/group-by/value column).
+     */
     getPivotConfiguration(): PivotConfiguration | undefined {
-        if (this.definition.totalConfiguration) {
-            return this.getQueryBuilder().getEffectivePivotConfiguration();
+        const pivotConfiguration = this.definition.totalConfiguration
+            ? this.getQueryBuilder().getEffectivePivotConfiguration()
+            : this.definition.pivotConfiguration;
+        if (!pivotConfiguration) {
+            return undefined;
         }
-        return this.definition.pivotConfiguration;
+        const { companionLabelDimensionIds } = this.compile();
+        if (
+            !companionLabelDimensionIds ||
+            companionLabelDimensionIds.length === 0
+        ) {
+            return pivotConfiguration;
+        }
+        const existingReferences = new Set<string>([
+            ...normalizeIndexColumns(pivotConfiguration.indexColumn).map(
+                (col) => col.reference,
+            ),
+            ...(pivotConfiguration.groupByColumns ?? []).map(
+                (col) => col.reference,
+            ),
+            ...(pivotConfiguration.sortOnlyDimensions ?? []).map(
+                (col) => col.reference,
+            ),
+            ...(pivotConfiguration.passthroughDimensions ?? []).map(
+                (col) => col.reference,
+            ),
+        ]);
+        const labelPassthroughs = companionLabelDimensionIds
+            .filter((reference) => !existingReferences.has(reference))
+            .map((reference) => ({ reference }));
+        if (labelPassthroughs.length === 0) {
+            return pivotConfiguration;
+        }
+        return {
+            ...pivotConfiguration,
+            passthroughDimensions: [
+                ...(pivotConfiguration.passthroughDimensions ?? []),
+                ...labelPassthroughs,
+            ],
+        };
     }
 
     /**

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolCreateContentArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolCreateContentArgs.ts
@@ -13,6 +13,7 @@ type RequiredMetricQueryKeys = keyof Omit<
     | 'timezone'
     | 'pivotDimensions'
     | 'metadata'
+    | 'labelDimensionMap'
 >;
 
 const TOOL_CHART_AS_CODE_METRIC_QUERY_DESCRIPTION =

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -3,6 +3,7 @@ import utc from 'dayjs/plugin/utc';
 import { z } from 'zod';
 import { type AnyType } from './types/any';
 import { LightdashMode } from './types/api';
+import { NotFoundError, ParameterError } from './types/errors';
 import { type Explore } from './types/explore';
 import {
     DimensionType,
@@ -333,6 +334,7 @@ export * from './utils/exportTabs';
 export * from './utils/fields';
 export * from './utils/filters';
 export * from './utils/formatting';
+export * from './utils/labelValueMap';
 export * from './utils/github';
 export * from './utils/i18n/chartAsCode';
 export * from './utils/i18n/dashboardAsCode';
@@ -585,6 +587,32 @@ export const findFieldByIdInExplore = (
 ): Field | undefined =>
     getFields(explore).find((field) => getItemId(field) === id);
 
+export const resolveLabelDimensionId = (
+    field: Dimension,
+    explore: Pick<Explore, 'tables'>,
+): FieldId | null => {
+    const labelDimension = field.filterAutocomplete?.labelDimension;
+    if (!labelDimension) return null;
+    const candidateLabelFieldId = getItemId({
+        table: field.table,
+        name: labelDimension,
+    });
+    if (candidateLabelFieldId === getItemId(field)) return null;
+    const table = explore.tables[field.table];
+    const labelMetric = table?.metrics[labelDimension];
+    if (labelMetric) {
+        throw new ParameterError(
+            `Label field must be a dimension, but ${candidateLabelFieldId} is a ${labelMetric.type}`,
+        );
+    }
+    if (!table?.dimensions[labelDimension]) {
+        throw new NotFoundError(
+            `Can't find label dimension '${labelDimension}' in table '${field.table}'`,
+        );
+    }
+    return candidateLabelFieldId;
+};
+
 export const snakeCaseName = (text: string): string =>
     text
         .replace(/\W+/g, ' ')
@@ -768,6 +796,7 @@ export function getItemMap(
 export const getFieldsFromMetricQuery = (
     metricQuery: MetricQuery,
     explore: Explore,
+    excludeFieldIds?: Set<FieldId>,
 ): ItemsMap => {
     const itemsMap = getItemMap(
         explore,
@@ -781,6 +810,7 @@ export const getFieldsFromMetricQuery = (
         ...(metricQuery.tableCalculations || []).map(getItemId),
     ];
     return itemIdsInMetricQuery.reduce<ItemsMap>((acc, id) => {
+        if (excludeFieldIds?.has(id)) return acc;
         const item = itemsMap[id];
         if (item) acc[id] = item;
         return acc;

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -2354,6 +2354,10 @@
                     "description": "The name of the explore to query",
                     "type": "string"
                 },
+                "labelDimensionMap": {
+                    "$ref": "#/$defs/Record_string.string_",
+                    "description": "Maps a dimension field id to the dimension field id whose value labels\nit in charts (sourced from the dimension's filter_autocomplete)."
+                },
                 "limit": {
                     "description": "Maximum number of rows to return",
                     "format": "double",

--- a/packages/common/src/types/metricQuery.ts
+++ b/packages/common/src/types/metricQuery.ts
@@ -203,11 +203,16 @@ export type MetricQuery = {
     metadata?: {
         hasADateDimension: Pick<CompiledDimension, 'label' | 'name' | 'table'>;
     };
+    /** Maps a dimension field id to the dimension field id whose value labels
+     * it in charts (sourced from the dimension's filter_autocomplete). */
+    labelDimensionMap?: Record<FieldId, FieldId>;
 };
 export type CompiledMetricQuery = Omit<MetricQuery, 'customDimensions'> & {
     compiledTableCalculations: CompiledTableCalculation[];
     compiledAdditionalMetrics: CompiledMetric[];
     compiledCustomDimensions: CompiledCustomDimension[];
+    companionLabelDimensionIds?: FieldId[];
+    labelDimensionMap?: Record<FieldId, FieldId>;
 };
 /**
  * Coordinates of a single pivot column, used to anchor a row sort to that
@@ -260,6 +265,7 @@ export type MetricQueryResponse = {
     metadata?: {
         hasADateDimension: Pick<CompiledDimension, 'label' | 'name' | 'table'>;
     };
+    labelDimensionMap?: Record<FieldId, FieldId>;
 };
 
 export const countCustomDimensionsInMetricQuery = (

--- a/packages/common/src/utils/labelValueMap.test.ts
+++ b/packages/common/src/utils/labelValueMap.test.ts
@@ -1,0 +1,158 @@
+import { type ResultRow } from '../types/results';
+import { type PivotValuesColumn } from '../visualizations/types';
+import {
+    buildLabelValueMap,
+    buildLabelValueMapFromPivotValues,
+    getLabelForValue,
+    mergeLabelValueMaps,
+} from './labelValueMap';
+
+const row = (cells: Record<string, unknown>): ResultRow =>
+    Object.fromEntries(
+        Object.entries(cells).map(([key, raw]) => [
+            key,
+            { value: { raw, formatted: String(raw) } },
+        ]),
+    );
+
+describe('buildLabelValueMap', () => {
+    it('returns an empty map when there is no labelDimensionMap', () => {
+        expect(buildLabelValueMap([], undefined)).toEqual({});
+        expect(buildLabelValueMap([], {})).toEqual({});
+    });
+
+    it('maps each raw id to its label from the companion column', () => {
+        const rows = [
+            row({ orders_customer_id: 1, customers_name: 'Alice' }),
+            row({ orders_customer_id: 2, customers_name: 'Bob' }),
+        ];
+        expect(
+            buildLabelValueMap(rows, {
+                orders_customer_id: 'customers_name',
+            }),
+        ).toEqual({
+            orders_customer_id: { '1': 'Alice', '2': 'Bob' },
+        });
+    });
+
+    it('keeps the first label when a raw id maps to several labels', () => {
+        const rows = [
+            row({ orders_customer_id: 1, customers_name: 'Alice' }),
+            row({ orders_customer_id: 1, customers_name: 'Alice (dupe)' }),
+        ];
+        expect(
+            buildLabelValueMap(rows, {
+                orders_customer_id: 'customers_name',
+            }),
+        ).toEqual({
+            orders_customer_id: { '1': 'Alice' },
+        });
+    });
+
+    it('skips rows whose id value is null or undefined', () => {
+        const rows = [
+            row({ orders_customer_id: null, customers_name: 'Nobody' }),
+            row({ orders_customer_id: 3, customers_name: 'Carol' }),
+        ];
+        expect(
+            buildLabelValueMap(rows, {
+                orders_customer_id: 'customers_name',
+            }),
+        ).toEqual({
+            orders_customer_id: { '3': 'Carol' },
+        });
+    });
+});
+
+const valuesColumn = (
+    pivotValues: PivotValuesColumn['pivotValues'],
+): PivotValuesColumn => ({
+    referenceField: 'orders_model_total_amount',
+    pivotColumnName: 'orders_model_total_amount_sum',
+    aggregation: 'sum' as PivotValuesColumn['aggregation'],
+    pivotValues,
+});
+
+describe('buildLabelValueMapFromPivotValues', () => {
+    it('returns an empty map when there are no columns', () => {
+        expect(buildLabelValueMapFromPivotValues(undefined)).toEqual({});
+        expect(buildLabelValueMapFromPivotValues([])).toEqual({});
+    });
+
+    it('maps each pivot value to its companion label', () => {
+        expect(
+            buildLabelValueMapFromPivotValues([
+                valuesColumn([
+                    {
+                        referenceField: 'orders_region_cd',
+                        value: 1,
+                        formatted: '1',
+                        label: 'North',
+                    },
+                ]),
+                valuesColumn([
+                    {
+                        referenceField: 'orders_region_cd',
+                        value: 2,
+                        formatted: '2',
+                        label: 'South',
+                    },
+                ]),
+            ]),
+        ).toEqual({
+            orders_region_cd: { '1': 'North', '2': 'South' },
+        });
+    });
+
+    it('skips pivot values that have no label', () => {
+        expect(
+            buildLabelValueMapFromPivotValues([
+                valuesColumn([
+                    { referenceField: 'orders_region_cd', value: 1 },
+                ]),
+            ]),
+        ).toEqual({});
+    });
+});
+
+describe('mergeLabelValueMaps', () => {
+    it('merges maps across fields, later maps winning on key conflicts', () => {
+        expect(
+            mergeLabelValueMaps(
+                { orders_region_cd: { '1': 'North' } },
+                {
+                    orders_region_cd: { '1': 'North (dupe)', '2': 'South' },
+                    orders_other: { a: 'A' },
+                },
+            ),
+        ).toEqual({
+            orders_region_cd: { '1': 'North (dupe)', '2': 'South' },
+            orders_other: { a: 'A' },
+        });
+    });
+});
+
+describe('getLabelForValue', () => {
+    const labelValueMap = {
+        orders_customer_id: { '1': 'Alice' },
+    };
+
+    it('returns the label for a known field and value', () => {
+        expect(
+            getLabelForValue(labelValueMap, 'orders_customer_id', 1),
+        ).toEqual('Alice');
+    });
+
+    it('returns undefined for unknown field, value, or nullish input', () => {
+        expect(
+            getLabelForValue(labelValueMap, 'orders_customer_id', 9),
+        ).toBeUndefined();
+        expect(getLabelForValue(labelValueMap, 'other', 1)).toBeUndefined();
+        expect(
+            getLabelForValue(labelValueMap, 'orders_customer_id', null),
+        ).toBeUndefined();
+        expect(
+            getLabelForValue(undefined, 'orders_customer_id', 1),
+        ).toBeUndefined();
+    });
+});

--- a/packages/common/src/utils/labelValueMap.ts
+++ b/packages/common/src/utils/labelValueMap.ts
@@ -1,0 +1,77 @@
+import { type ResultRow } from '../types/results';
+import { type PivotValuesColumn } from '../visualizations/types';
+
+export type LabelValueMap = Record<string, Record<string, string>>;
+
+export const buildLabelValueMap = (
+    rows: ResultRow[],
+    labelDimensionMap: Record<string, string> | undefined,
+): LabelValueMap => {
+    if (!labelDimensionMap || Object.keys(labelDimensionMap).length === 0) {
+        return {};
+    }
+    const result: LabelValueMap = {};
+    for (const [idFieldId, labelFieldId] of Object.entries(labelDimensionMap)) {
+        const byRawValue: Record<string, string> = {};
+        for (const row of rows) {
+            const rawValue = row[idFieldId]?.value?.raw;
+            if (rawValue !== undefined && rawValue !== null) {
+                const rawKey = String(rawValue);
+                const label = row[labelFieldId]?.value?.formatted;
+                if (byRawValue[rawKey] === undefined && label !== undefined) {
+                    byRawValue[rawKey] = label;
+                }
+            }
+        }
+        result[idFieldId] = byRawValue;
+    }
+    return result;
+};
+
+// Pivoted results drop the group-by dimension from each row, so
+// buildLabelValueMap (which reads row[idField]) yields nothing for legend
+// series. The companion label is instead carried on each pivot column value.
+export const buildLabelValueMapFromPivotValues = (
+    valuesColumns: PivotValuesColumn[] | undefined,
+): LabelValueMap => {
+    const result: LabelValueMap = {};
+    if (!valuesColumns) {
+        return result;
+    }
+    for (const column of valuesColumns) {
+        for (const { label, value, referenceField } of column.pivotValues) {
+            if (label !== undefined && value !== undefined && value !== null) {
+                const byRawValue = result[referenceField] ?? {};
+                const rawKey = String(value);
+                if (byRawValue[rawKey] === undefined) {
+                    byRawValue[rawKey] = label;
+                }
+                result[referenceField] = byRawValue;
+            }
+        }
+    }
+    return result;
+};
+
+export const mergeLabelValueMaps = (
+    ...maps: LabelValueMap[]
+): LabelValueMap => {
+    const result: LabelValueMap = {};
+    for (const map of maps) {
+        for (const [fieldId, byRawValue] of Object.entries(map)) {
+            result[fieldId] = { ...(result[fieldId] ?? {}), ...byRawValue };
+        }
+    }
+    return result;
+};
+
+export const getLabelForValue = (
+    labelValueMap: LabelValueMap | undefined,
+    fieldId: string,
+    value: unknown,
+): string | undefined => {
+    if (value === undefined || value === null) {
+        return undefined;
+    }
+    return labelValueMap?.[fieldId]?.[String(value)];
+};

--- a/packages/common/src/visualizations/helpers/getCartesianAxisFormatterConfig.test.ts
+++ b/packages/common/src/visualizations/helpers/getCartesianAxisFormatterConfig.test.ts
@@ -1,0 +1,50 @@
+import {
+    DimensionType,
+    FieldType,
+    type CompiledDimension,
+} from '../../types/field';
+import { getCartesianAxisFormatterConfig } from './getCartesianAxisFormatterConfig';
+
+const dimension = (name: string, type: DimensionType): CompiledDimension => ({
+    name,
+    fieldType: FieldType.DIMENSION,
+    type,
+    table: 'orders',
+    label: name,
+    tableLabel: 'orders',
+    hidden: false,
+    sql: `\${TABLE}.${name}`,
+    compiledSql: `"orders".${name}`,
+    tablesReferences: ['orders'],
+});
+
+const labelValueMap = {
+    orders_customer_id: { '1': 'Alice' },
+};
+
+describe('getCartesianAxisFormatterConfig with labelValueMap', () => {
+    it('labels a categorical axis and falls back for unmapped values', () => {
+        const config = getCartesianAxisFormatterConfig({
+            axisItem: dimension('customer_id', DimensionType.STRING),
+            show: true,
+            labelValueMap,
+        });
+        const { formatter } = config.axisLabel as { formatter: AnyFormatter };
+        expect(formatter(1)).toEqual('Alice');
+        expect(formatter(99)).toEqual('99');
+    });
+
+    it('does not label a timestamp axis (keeps native formatting)', () => {
+        const config = getCartesianAxisFormatterConfig({
+            axisItem: dimension('created_at', DimensionType.TIMESTAMP),
+            show: true,
+            labelValueMap: { orders_created_at: { '1': 'Alice' } },
+        });
+        const axisLabel = config.axisLabel as
+            | { formatter?: AnyFormatter }
+            | undefined;
+        expect(axisLabel?.formatter).toBeUndefined();
+    });
+});
+
+type AnyFormatter = (value: unknown) => string;

--- a/packages/common/src/visualizations/helpers/getCartesianAxisFormatterConfig.ts
+++ b/packages/common/src/visualizations/helpers/getCartesianAxisFormatterConfig.ts
@@ -8,6 +8,11 @@ import {
 } from '../../types/field';
 import { TimeFrames } from '../../types/timeFrames';
 import { formatItemValue, hasFormatting } from '../../utils/formatting';
+import { getItemId } from '../../utils/item';
+import {
+    getLabelForValue,
+    type LabelValueMap,
+} from '../../utils/labelValueMap';
 import { isTimeInterval, timeFrameConfigs } from '../../utils/timeFrames';
 
 /**
@@ -29,6 +34,7 @@ export const getCartesianAxisFormatterConfig = ({
     parameters,
     timezone,
     displayTimezone,
+    labelValueMap,
 }: {
     axisItem: ItemsMap[string] | undefined;
     longestLabelWidth?: number;
@@ -38,6 +44,7 @@ export const getCartesianAxisFormatterConfig = ({
     parameters?: Record<string, unknown>;
     timezone?: string;
     displayTimezone?: string;
+    labelValueMap?: LabelValueMap;
 }) => {
     // Remove axis labels, lines, and ticks if the axis is not shown
     // This is done to prevent the grid from disappearing when the axis is not shown
@@ -198,6 +205,52 @@ export const getCartesianAxisFormatterConfig = ({
             default:
         }
     }
+    // Only categorical axes are labelled — a label dimension on a
+    // date/time-interval axis keeps its native (min-interval/rich) formatting.
+    const isCategoricalAxis =
+        !isTimestamp &&
+        !(isDimension(axisItem) && axisItem.timeInterval !== undefined);
+    const axisFieldId =
+        axisItem && isField(axisItem) && isCategoricalAxis
+            ? getItemId(axisItem)
+            : undefined;
+    const axisLabels = axisFieldId ? labelValueMap?.[axisFieldId] : undefined;
+    if (axisFieldId && axisLabels) {
+        axisConfig.axisLabel = {
+            formatter: (value: AnyType) =>
+                getLabelForValue(labelValueMap, axisFieldId, value) ??
+                formatItemValue(
+                    axisItem,
+                    value,
+                    true,
+                    parameters,
+                    timezone,
+                    displayTimezone,
+                ),
+        };
+        axisConfig.axisPointer = {
+            label: {
+                formatter: (value: unknown) => {
+                    const raw =
+                        value && typeof value === 'object' && 'value' in value
+                            ? value.value
+                            : value;
+                    return (
+                        getLabelForValue(labelValueMap, axisFieldId, raw) ??
+                        formatItemValue(
+                            axisItem,
+                            raw,
+                            true,
+                            parameters,
+                            timezone,
+                            displayTimezone,
+                        )
+                    );
+                },
+            },
+        };
+    }
+
     if (axisMinInterval) {
         axisConfig.minInterval = axisMinInterval;
     }

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -22,6 +22,10 @@ import {
 } from '../../types/savedCharts';
 import { TimeFrames } from '../../types/timeFrames';
 import { formatDateWithPattern, formatItemValue } from '../../utils/formatting';
+import {
+    getLabelForValue,
+    type LabelValueMap,
+} from '../../utils/labelValueMap';
 import { sanitizeHtml } from '../../utils/sanitizeHtml';
 import {
     StackType,
@@ -313,6 +317,7 @@ const getHeader = (
     xFieldId?: string,
     timezone?: string,
     displayTimezone?: string,
+    labelValueMap?: LabelValueMap,
 ): string => {
     const firstParam = params[0];
 
@@ -320,6 +325,17 @@ const getHeader = (
     // undefined on some stack100 tooltip fires, so fall back to value[0] and
     // then to the dataset row.
     const rawAxisValue = firstParam?.axisValue;
+
+    if (xFieldId) {
+        const headerLabel = getLabelForValue(
+            labelValueMap,
+            xFieldId,
+            rawAxisValue,
+        );
+        if (headerLabel !== undefined) {
+            return headerLabel;
+        }
+    }
     if (timezone && itemsMap && xFieldId) {
         const formatViaTz = (v: unknown) =>
             getFormattedValue(
@@ -941,6 +957,7 @@ export const buildCartesianTooltipFormatter =
         rows,
         timezone,
         displayTimezone,
+        labelValueMap,
     }: {
         itemsMap?: ItemsMap;
         stackValue: string | boolean | undefined;
@@ -957,6 +974,7 @@ export const buildCartesianTooltipFormatter =
         rows?: (ResultRow | Record<string, unknown>)[];
         timezone?: string;
         displayTimezone?: string;
+        labelValueMap?: LabelValueMap;
     }): TooltipComponentFormatterCallback<
         TooltipFormatterParams | TooltipFormatterParams[]
     > =>
@@ -996,6 +1014,7 @@ export const buildCartesianTooltipFormatter =
             xFieldId,
             timezone,
             displayTimezone,
+            labelValueMap,
         );
 
         const sortedParams = sortTooltipParams(

--- a/packages/common/src/visualizations/helpers/valueFormatter.test.ts
+++ b/packages/common/src/visualizations/helpers/valueFormatter.test.ts
@@ -1,0 +1,90 @@
+import {
+    DimensionType,
+    FieldType,
+    type CompiledDimension,
+    type ItemsMap,
+} from '../../types/field';
+import { getFormattedValue } from './valueFormatter';
+
+const dimension = (name: string): CompiledDimension => ({
+    name,
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    table: 'orders',
+    label: name,
+    tableLabel: 'orders',
+    hidden: false,
+    sql: `\${TABLE}.${name}`,
+    compiledSql: `"orders".${name}`,
+    tablesReferences: ['orders'],
+});
+
+const itemsMap: ItemsMap = {
+    orders_customer_id: dimension('customer_id'),
+};
+
+const labelValueMap = {
+    orders_customer_id: { '1': 'Alice', '2': 'Bob' },
+};
+
+describe('getFormattedValue with labelValueMap', () => {
+    it('returns the label for a known field/value', () => {
+        expect(
+            getFormattedValue(
+                1,
+                'orders_customer_id',
+                itemsMap,
+                true,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                labelValueMap,
+            ),
+        ).toEqual('Alice');
+    });
+
+    it('falls back to formatItemValue when the value has no label', () => {
+        expect(
+            getFormattedValue(
+                99,
+                'orders_customer_id',
+                itemsMap,
+                true,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                labelValueMap,
+            ),
+        ).toEqual('99');
+    });
+
+    it('resolves the label through a pivot value column referenceField', () => {
+        expect(
+            getFormattedValue(
+                2,
+                'pivot_col',
+                itemsMap,
+                true,
+                {
+                    pivot_col: {
+                        referenceField: 'orders_customer_id',
+                        pivotColumnName: 'pivot_col',
+                        pivotValues: [],
+                    } as never,
+                },
+                undefined,
+                undefined,
+                undefined,
+                labelValueMap,
+            ),
+        ).toEqual('Bob');
+    });
+
+    it('formats normally when no labelValueMap is provided', () => {
+        expect(getFormattedValue(1, 'orders_customer_id', itemsMap)).toEqual(
+            '1',
+        );
+    });
+});

--- a/packages/common/src/visualizations/helpers/valueFormatter.ts
+++ b/packages/common/src/visualizations/helpers/valueFormatter.ts
@@ -2,6 +2,10 @@ import { type AnyType } from '../../types/any';
 import { type ItemsMap } from '../../types/field';
 import { type ParametersValuesMap } from '../../types/parameters';
 import { formatItemValue } from '../../utils/formatting';
+import {
+    getLabelForValue,
+    type LabelValueMap,
+} from '../../utils/labelValueMap';
 import { type PivotValuesColumn } from '../types';
 
 export const getFormattedValue = (
@@ -13,9 +17,15 @@ export const getFormattedValue = (
     parameters?: ParametersValuesMap,
     timezone?: string,
     displayTimezone?: string,
+    labelValueMap?: LabelValueMap,
 ): string => {
     const pivotValuesColumn = pivotValuesColumnsMap?.[key];
-    const item = itemsMap[pivotValuesColumn?.referenceField ?? key];
+    const fieldId = pivotValuesColumn?.referenceField ?? key;
+    const label = getLabelForValue(labelValueMap, fieldId, value);
+    if (label !== undefined) {
+        return label;
+    }
+    const item = itemsMap[fieldId];
     return formatItemValue(
         item,
         value,

--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -133,6 +133,7 @@ export type PivotValuesColumn = {
         referenceField: string;
         value: unknown;
         formatted?: string;
+        label?: string;
     }[];
     columnIndex?: number;
 };

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -25,6 +25,9 @@ import {
     getBarTotalLabelStyle,
     getCustomFormatFromLegacy,
     getDateGroupLabel,
+    buildLabelValueMap,
+    buildLabelValueMapFromPivotValues,
+    mergeLabelValueMaps,
     getFormatExpressionLocale,
     getFormattedValue,
     getFormatterTimezone,
@@ -68,6 +71,7 @@ import {
     type GranularityMap,
     type Item,
     type ItemsMap,
+    type LabelValueMap,
     type MarkLine,
     type MarkLineData,
     type ParametersValuesMap,
@@ -782,6 +786,7 @@ type GetPivotSeriesArg = {
     parameters?: ParametersValuesMap;
     isStack100?: boolean;
     resolvedTimezone?: string;
+    labelValueMap?: LabelValueMap;
 };
 
 const seriesValueFormatter = (
@@ -1015,6 +1020,7 @@ const getPivotSeries = ({
     parameters,
     isStack100,
     resolvedTimezone,
+    labelValueMap,
 }: GetPivotSeriesArg): EChartsSeries => {
     const pivotLabel = pivotReference.pivotValues.reduce(
         (acc, { field, value }) => {
@@ -1026,6 +1032,8 @@ const getPivotSeries = ({
                 pivotValuesColumnsMap,
                 parameters,
                 resolvedTimezone,
+                undefined,
+                labelValueMap,
             );
             return acc ? `${acc} - ${formattedValue}` : formattedValue;
         },
@@ -1346,6 +1354,7 @@ const getEchartsSeriesFromPivotedData = (
     parameters?: ParametersValuesMap,
     backgroundColor?: string,
     resolvedTimezone?: string,
+    labelValueMap?: LabelValueMap,
 ): EChartsSeries[] => {
     // Check if 100% stacking is enabled
     const isStack100 = cartesianChart.layout.stack === StackType.PERCENT;
@@ -1412,6 +1421,7 @@ const getEchartsSeriesFromPivotedData = (
                     parameters,
                     isStack100,
                     resolvedTimezone,
+                    labelValueMap,
                 });
             }
 
@@ -1847,6 +1857,7 @@ const getEchartAxes = ({
     resolvedTimezone,
     displayTimezone,
     isTimeAxisShifted,
+    labelValueMap,
 }: {
     validCartesianConfig: CartesianChart;
     itemsMap: ItemsMap;
@@ -1858,6 +1869,7 @@ const getEchartAxes = ({
     resolvedTimezone?: string;
     displayTimezone?: string;
     isTimeAxisShifted?: boolean;
+    labelValueMap?: LabelValueMap;
 }) => {
     const xAxisItemId = validCartesianConfig.layout.flipAxes
         ? validCartesianConfig.layout?.yField?.[0]
@@ -2165,6 +2177,7 @@ const getEchartAxes = ({
         parameters,
         timezone: resolvedTimezone,
         displayTimezone,
+        labelValueMap,
     });
     // `bottom` (vertical) and `left` (horizontal) value labels render at the
     // value=0 baseline, overlapping the category-axis tick labels there.
@@ -2220,6 +2233,7 @@ const getEchartAxes = ({
         parameters,
         timezone: resolvedTimezone,
         displayTimezone,
+        labelValueMap,
     });
     const topAxisConfigWithStyle: Record<string, unknown> = Object.assign(
         {},
@@ -2241,6 +2255,7 @@ const getEchartAxes = ({
         parameters,
         timezone: resolvedTimezone,
         displayTimezone,
+        labelValueMap,
     });
     const leftAxisConfigWithStyle: Record<string, unknown> = Object.assign(
         {},
@@ -2276,6 +2291,7 @@ const getEchartAxes = ({
         parameters,
         timezone: resolvedTimezone,
         displayTimezone,
+        labelValueMap,
     });
     const rightAxisConfigWithStyle: Record<string, unknown> = Object.assign(
         {},
@@ -3226,6 +3242,24 @@ const useEchartsCartesianConfig = (
         return visualizationConfig.chartConfig.validConfig;
     }, [visualizationConfig]);
 
+    const labelValueMap = useMemo(
+        () =>
+            mergeLabelValueMaps(
+                buildLabelValueMap(
+                    resultsData?.rows ?? [],
+                    resultsData?.metricQuery?.labelDimensionMap,
+                ),
+                buildLabelValueMapFromPivotValues(
+                    resultsData?.pivotDetails?.valuesColumns,
+                ),
+            ),
+        [
+            resultsData?.rows,
+            resultsData?.metricQuery?.labelDimensionMap,
+            resultsData?.pivotDetails?.valuesColumns,
+        ],
+    );
+
     const { timeAxisField, axisTimezone, axisDisplayTimezone } = useMemo(
         () =>
             resolveAxisTimezone({
@@ -3293,6 +3327,7 @@ const useEchartsCartesianConfig = (
             parameters,
             undefined,
             resolvedTimezone,
+            labelValueMap,
         );
 
         return filterSeriesWithNoData(
@@ -3309,6 +3344,7 @@ const useEchartsCartesianConfig = (
         parameters,
         resultsAndMinsAndMaxes.results,
         resolvedTimezone,
+        labelValueMap,
     ]);
 
     const axes = useMemo(() => {
@@ -3331,6 +3367,7 @@ const useEchartsCartesianConfig = (
             resolvedTimezone: axisTimezone,
             displayTimezone: axisDisplayTimezone,
             isTimeAxisShifted: timeAxisField !== undefined,
+            labelValueMap,
         });
     }, [
         itemsMap,
@@ -3342,6 +3379,7 @@ const useEchartsCartesianConfig = (
         parameters,
         axisTimezone,
         axisDisplayTimezone,
+        labelValueMap,
         timeAxisField,
     ]);
 
@@ -3969,6 +4007,7 @@ const useEchartsCartesianConfig = (
                 rows: dataToRender,
                 timezone: axisTimezone,
                 displayTimezone: axisDisplayTimezone,
+                labelValueMap,
             }),
         };
     }, [
@@ -3987,6 +4026,7 @@ const useEchartsCartesianConfig = (
         isTouchDevice,
         axisTimezone,
         axisDisplayTimezone,
+        labelValueMap,
     ]);
 
     // Calculate max stack label padding for 100% stacking grid

--- a/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
@@ -87,7 +87,7 @@ const useEchartsPieConfig = (
                     sortedGroupLabels.indexOf(nameA) -
                     sortedGroupLabels.indexOf(nameB),
             )
-            .map(({ name, value, meta }) => {
+            .map(({ name, displayName, value, meta }) => {
                 const valueLabel =
                     groupValueOptionOverrides?.[name]?.valueLabel ??
                     valueLabelDefault;
@@ -110,7 +110,8 @@ const useEchartsPieConfig = (
                 const borderRadius = isDonut
                     ? calculateBorderRadiusForSlice(percent)
                     : 0;
-                const labelOverride = groupLabelOverrides?.[name] ?? name;
+                const labelOverride =
+                    groupLabelOverrides?.[name] ?? displayName ?? name;
                 const config: PieSeriesDataPoint = {
                     id: name,
                     groupId: name,

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -1,5 +1,7 @@
 import {
+    buildLabelValueMap,
     formatItemValue,
+    getLabelForValue,
     isField,
     isHexCodeColor,
     isMetric,
@@ -10,6 +12,7 @@ import {
     type Dimension,
     type ItemsMap,
     type Metric,
+    type MetricQuery,
     type ParametersValuesMap,
     type PieChart,
     type PieChartLegendPosition,
@@ -77,6 +80,7 @@ type PieChartConfig = {
     legendMaxItemLengthChange: (length: number | undefined) => void;
     data: {
         name: string;
+        displayName: string;
         value: number;
         meta: {
             value: ResultValue;
@@ -87,7 +91,10 @@ type PieChartConfig = {
 
 export type PieChartConfigFn = (
     resultsData:
-        | (InfiniteQueryResults & { resolvedTimezone?: string })
+        | (InfiniteQueryResults & {
+              resolvedTimezone?: string;
+              metricQuery?: MetricQuery;
+          })
         | undefined,
     pieChartConfig: PieChart | undefined,
     itemsMap: ItemsMap | undefined,
@@ -245,6 +252,15 @@ const usePieChartConfig: PieChartConfigFn = (
         );
     }, [groupValueOptionOverrides]);
 
+    const labelValueMap = useMemo(
+        () =>
+            buildLabelValueMap(
+                resultsData?.rows ?? [],
+                resultsData?.metricQuery?.labelDimensionMap,
+            ),
+        [resultsData?.rows, resultsData?.metricQuery?.labelDimensionMap],
+    );
+
     const data = useMemo(() => {
         if (
             !metricId ||
@@ -271,9 +287,21 @@ const usePieChartConfig: PieChartConfigFn = (
                 .filter(Boolean)
                 .join(' - ');
 
+            const displayName = groupFieldIds
+                .map(
+                    (groupFieldId) =>
+                        getLabelForValue(
+                            labelValueMap,
+                            groupFieldId,
+                            row[groupFieldId]?.value?.raw,
+                        ) ?? row[groupFieldId]?.value?.formatted,
+                )
+                .filter(Boolean)
+                .join(' - ');
+
             const value = Number(row[metricId].value.raw);
 
-            return { name, value, row };
+            return { name, displayName, value, row };
         });
 
         return Object.entries(
@@ -282,21 +310,24 @@ const usePieChartConfig: PieChartConfigFn = (
                     string,
                     {
                         value: number;
+                        displayName: string;
                         rows: ResultRow[];
                     }
                 >
-            >((acc, { name, value, row }) => {
+            >((acc, { name, displayName, value, row }) => {
                 return {
                     ...acc,
                     [name]: {
                         value: (acc[name]?.value ?? 0) + value,
+                        displayName: acc[name]?.displayName ?? displayName,
                         rows: [...(acc[name]?.rows ?? []), row],
                     },
                 };
             }, {}),
         )
-            .map(([name, { value, rows }]) => ({
+            .map(([name, { value, displayName, rows }]) => ({
                 name,
+                displayName,
                 value,
                 meta: {
                     value: {
@@ -313,7 +344,14 @@ const usePieChartConfig: PieChartConfigFn = (
                 },
             }))
             .sort((a, b) => b.value - a.value);
-    }, [resultsData, groupFieldIds, selectedMetric, metricId, parameters]);
+    }, [
+        resultsData,
+        groupFieldIds,
+        selectedMetric,
+        metricId,
+        parameters,
+        labelValueMap,
+    ]);
 
     const groupLabels = useMemo(() => {
         return data.map(({ name }) => name);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #25933

### Description:

When a chart is grouped or sliced by a code/id dimension, the legend, tooltip and category axis render the raw values, which are hard to read. Lightdash already lets a dimension point at a companion label via `filter_autocomplete.label_dimension` (used when picking filter values), but that intent didn't carry over to charts — the same field looks readable in a filter yet shows raw codes in the visualization.

This PR reuses that existing config so the companion label is shown in the legend, tooltip and category axis wherever a chart is grouped by a labelled code/id dimension.

- Carries a `labelDimensionMap` on the metric query (dimension field id → its label dimension field id), resolved from `filter_autocomplete.label_dimension`, and injects the companion label dimension into the compiled query.
- Builds a value→label map on the frontend and applies it in the cartesian and pie legend, tooltip and axis formatters. For pivoted (grouped) charts the label is carried through the pivot pipeline on each pivot column value, since pivoted rows drop the group-by dimension.
- Degrades gracefully: a missing or misconfigured `label_dimension` falls back to the raw value rather than erroring.

No new per-chart configuration is required — a dimension already annotated for filter autocomplete lights up automatically.

Example dbt config:

```yaml
columns:
  - name: product_id
    meta:
      dimension:
        filter_autocomplete:
          label_dimension: product_name
```