### PR TITLE
feat: add manage:OrganizationColorPalette custom-role scope

### DIFF
--- a/packages/backend/src/database/migrations/20260722153938_grant_org_color_palette_scope_to_manage_org_roles.ts
+++ b/packages/backend/src/database/migrations/20260722153938_grant_org_color_palette_scope_to_manage_org_roles.ts
@@ -1,0 +1,56 @@
+import { Knex } from 'knex';
+
+const ScopedRolesTableName = 'scoped_roles';
+const MANAGE_ORGANIZATION_SCOPE = 'manage:Organization';
+const COLOR_PALETTE_SCOPE = 'manage:OrganizationColorPalette';
+
+/**
+ * Colour palette management used to be gated by `update Organization`, which
+ * custom roles obtained via the `manage:Organization` scope. That capability
+ * has been split out into the new `manage:OrganizationColorPalette` scope.
+ * Copy the new scope into every custom role that currently has
+ * `manage:Organization` so nobody loses access.
+ *
+ * Wrapped in try/catch because this is a backfill: failing it would block all
+ * later migrations, and the worst case (some roles miss the palette scope) is
+ * recoverable by re-running the SQL manually.
+ */
+export async function up(knex: Knex): Promise<void> {
+    try {
+        await knex.raw(
+            `
+            INSERT INTO ?? (role_uuid, scope_name, granted_by)
+            SELECT role_uuid, ?, granted_by
+            FROM ??
+            WHERE scope_name = ?
+            ON CONFLICT DO NOTHING
+            `,
+            [
+                ScopedRolesTableName,
+                COLOR_PALETTE_SCOPE,
+                ScopedRolesTableName,
+                MANAGE_ORGANIZATION_SCOPE,
+            ],
+        );
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+            `[migration 20260722153938] Failed to backfill ${COLOR_PALETTE_SCOPE} for roles with ${MANAGE_ORGANIZATION_SCOPE}. Affected custom roles will need to grant ${COLOR_PALETTE_SCOPE} manually.`,
+            error,
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    try {
+        await knex(ScopedRolesTableName)
+            .where('scope_name', COLOR_PALETTE_SCOPE)
+            .delete();
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+            `[migration 20260722153938] Failed to remove ${COLOR_PALETTE_SCOPE} rows during rollback.`,
+            error,
+        );
+    }
+}

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -1017,8 +1017,8 @@ export class OrganizationService extends BaseService {
         if (
             !user.organizationUuid ||
             auditedAbility.cannot(
-                'update',
-                subject('Organization', {
+                'manage',
+                subject('OrganizationColorPalette', {
                     organizationUuid: user.organizationUuid,
                 }),
             )
@@ -1060,8 +1060,8 @@ export class OrganizationService extends BaseService {
         if (
             !user.organizationUuid ||
             auditedAbility.cannot(
-                'update',
-                subject('Organization', {
+                'manage',
+                subject('OrganizationColorPalette', {
                     organizationUuid: user.organizationUuid,
                     metadata: { colorPaletteUuid },
                 }),
@@ -1091,8 +1091,8 @@ export class OrganizationService extends BaseService {
         if (
             !user.organizationUuid ||
             auditedAbility.cannot(
-                'update',
-                subject('Organization', {
+                'manage',
+                subject('OrganizationColorPalette', {
                     organizationUuid: user.organizationUuid,
                     metadata: { colorPaletteUuid },
                 }),
@@ -1115,8 +1115,8 @@ export class OrganizationService extends BaseService {
         if (
             !user.organizationUuid ||
             auditedAbility.cannot(
-                'update',
-                subject('Organization', {
+                'manage',
+                subject('OrganizationColorPalette', {
                     organizationUuid: user.organizationUuid,
                     metadata: { colorPaletteUuid },
                 }),

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -457,6 +457,9 @@ export const applyOrganizationMemberStaticAbilities: Record<
         can('manage', 'Organization', {
             organizationUuid: member.organizationUuid,
         });
+        can('manage', 'OrganizationColorPalette', {
+            organizationUuid: member.organizationUuid,
+        });
         can('view', 'Analytics', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -187,6 +187,7 @@ const BASE_ROLE_SCOPES = {
         'manage:GitIntegration',
         'manage:OrganizationWarehouseCredentials',
         'manage:Organization',
+        'manage:OrganizationColorPalette',
         'impersonate:User',
 
         // PAT management. Granted dynamically at runtime via

--- a/packages/common/src/authorization/roleToScopeParity.test.ts
+++ b/packages/common/src/authorization/roleToScopeParity.test.ts
@@ -134,6 +134,7 @@ const PROJECT_PARITY_IGNORE = new Set([
     // Case 1: org-only subjects.
     '*:OrganizationMemberProfile',
     '*:Organization',
+    '*:OrganizationColorPalette',
     '*:OrganizationDesign',
     '*:Group',
     '*:InviteLink',

--- a/packages/common/src/authorization/scopes.level.test.ts
+++ b/packages/common/src/authorization/scopes.level.test.ts
@@ -19,6 +19,7 @@ const ORG_ONLY_SCOPE_NAMES = [
     'view:OrganizationWarehouseCredentials',
     'manage:OrganizationWarehouseCredentials',
     'manage:PersonalAccessToken',
+    'manage:OrganizationColorPalette',
     'impersonate:User',
     'view:OrganizationDesign',
     'manage:OrganizationDesign',

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -835,6 +835,16 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
     {
+        name: 'manage:OrganizationColorPalette',
+        description:
+            'Create, edit, delete, and activate organization color palettes',
+        isEnterprise: false,
+        group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        dependencies: [],
+        level: 'organization',
+        getConditions: addDefaultUuidCondition,
+    },
+    {
         name: 'view:OrganizationMemberProfile',
         description: 'View organization member profiles',
         isEnterprise: false,

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -367,6 +367,9 @@ const applyServiceAccountStaticAbilities: Record<
         can('manage', 'Organization', {
             organizationUuid,
         });
+        can('manage', 'OrganizationColorPalette', {
+            organizationUuid,
+        });
         can('view', 'Analytics', {
             organizationUuid,
         });

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -52,6 +52,7 @@ export type CaslSubjectNames =
     | 'MetricsTree'
     | 'Organization'
     | 'OrganizationAiAgent'
+    | 'OrganizationColorPalette'
     | 'OrganizationDesign'
     | 'OrganizationMemberProfile'
     | 'OrganizationWarehouseCredentials'

--- a/packages/frontend/src/components/ProjectAppearance/ProjectAppearance.tsx
+++ b/packages/frontend/src/components/ProjectAppearance/ProjectAppearance.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     Anchor,
     Button,
@@ -38,7 +39,14 @@ const ProjectAppearance: FC<Props> = ({ projectUuid }) => {
 
     const isLoading = isProjectLoading || isPalettesLoading || isHealthLoading;
     const canManageOrgPalettes =
-        user.data?.ability?.can('update', 'Organization') ?? false;
+        (user.data?.ability?.can('update', 'Organization') ||
+            user.data?.ability?.can(
+                'manage',
+                subject('OrganizationColorPalette', {
+                    organizationUuid: user.data?.organizationUuid,
+                }),
+            )) ??
+        false;
 
     return (
         <Stack gap="sm" pos="relative">

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
@@ -33,6 +33,7 @@ type PaletteItemProps = {
     isActive: boolean;
     onSetActive?: ((uuid: string) => void) | undefined;
     readOnly?: boolean;
+    canManage: boolean;
 };
 
 export const PaletteItem: FC<PaletteItemProps> = ({
@@ -40,6 +41,7 @@ export const PaletteItem: FC<PaletteItemProps> = ({
     isActive,
     onSetActive,
     readOnly,
+    canManage,
 }) => {
     const [isEditModalOpen, setIsEditModalOpen] = useState(false);
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -194,25 +196,33 @@ export const PaletteItem: FC<PaletteItemProps> = ({
                                 >
                                     Copy UUID
                                 </Menu.Item>
-                                <Menu.Item
-                                    disabled={readOnly}
-                                    leftSection={
-                                        <MantineIcon icon={IconEdit} />
-                                    }
-                                    onClick={() => setIsEditModalOpen(true)}
-                                >
-                                    Edit palette
-                                </Menu.Item>
-                                <Menu.Item
-                                    leftSection={
-                                        <MantineIcon icon={IconTrash} />
-                                    }
-                                    onClick={() => setIsDeleteModalOpen(true)}
-                                    disabled={isActive || readOnly}
-                                    color="red"
-                                >
-                                    Delete palette
-                                </Menu.Item>
+                                {canManage && (
+                                    <>
+                                        <Menu.Item
+                                            disabled={readOnly}
+                                            leftSection={
+                                                <MantineIcon icon={IconEdit} />
+                                            }
+                                            onClick={() =>
+                                                setIsEditModalOpen(true)
+                                            }
+                                        >
+                                            Edit palette
+                                        </Menu.Item>
+                                        <Menu.Item
+                                            leftSection={
+                                                <MantineIcon icon={IconTrash} />
+                                            }
+                                            onClick={() =>
+                                                setIsDeleteModalOpen(true)
+                                            }
+                                            disabled={isActive || readOnly}
+                                            color="red"
+                                        >
+                                            Delete palette
+                                        </Menu.Item>
+                                    </>
+                                )}
                             </Menu.Dropdown>
                         </Menu>
                     </Group>

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/index.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     ActionIcon,
     Button,
@@ -16,13 +17,14 @@ import {
 } from '../../../hooks/appearance/useOrganizationAppearance';
 import useHealth from '../../../hooks/health/useHealth';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
+import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../../common/MantineIcon';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
 import { BrandAppearanceSettings } from './BrandAppearanceSettings';
 import { CreatePaletteModal } from './CreatePaletteModal';
 import { PaletteItem } from './PaletteItem';
 
-const AppearanceColorSettings: FC = () => {
+const AppearanceColorSettings: FC<{ canManage: boolean }> = ({ canManage }) => {
     const { data: organization } = useOrganization();
     const { data: health, isLoading: isHealthLoading } = useHealth();
     const { data: palettes = [], isLoading: isPalettesLoading } =
@@ -52,16 +54,18 @@ const AppearanceColorSettings: FC = () => {
                     visualizations.
                 </Text>
 
-                <Button
-                    leftSection={<MantineIcon icon={IconPlus} />}
-                    onClick={() => setIsCreatePaletteModalOpen(true)}
-                    variant="default"
-                    size="xs"
-                    style={{ alignSelf: 'flex-end' }}
-                    disabled={hasColorPaletteOverride}
-                >
-                    Add new palette
-                </Button>
+                {canManage && (
+                    <Button
+                        leftSection={<MantineIcon icon={IconPlus} />}
+                        onClick={() => setIsCreatePaletteModalOpen(true)}
+                        variant="default"
+                        size="xs"
+                        style={{ alignSelf: 'flex-end' }}
+                        disabled={hasColorPaletteOverride}
+                    >
+                        Add new palette
+                    </Button>
+                )}
             </Group>
 
             <Stack gap="xs">
@@ -102,8 +106,9 @@ const AppearanceColorSettings: FC = () => {
                                 isActive={
                                     palette.isActive && !hasColorPaletteOverride
                                 }
+                                readOnly={!canManage}
                                 onSetActive={
-                                    hasColorPaletteOverride
+                                    hasColorPaletteOverride || !canManage
                                         ? undefined
                                         : handleSetActive
                                 }
@@ -125,6 +130,18 @@ const AppearanceColorSettings: FC = () => {
 };
 
 const AppearanceSettingsPanel: FC = () => {
+    const { user } = useApp();
+
+    const canManageOrgSettings =
+        user.data?.ability?.can('update', 'Organization') ?? false;
+    const canManageColorPalette =
+        user.data?.ability?.can(
+            'manage',
+            subject('OrganizationColorPalette', {
+                organizationUuid: user.data?.organizationUuid,
+            }),
+        ) ?? false;
+
     return (
         <Stack gap="sm">
             <Group gap="xxs">
@@ -146,9 +163,9 @@ const AppearanceSettingsPanel: FC = () => {
                     </ActionIcon>
                 </Tooltip>
             </Group>
-            <BrandAppearanceSettings />
+            {canManageOrgSettings && <BrandAppearanceSettings />}
             <SettingsCard mb="lg">
-                <AppearanceColorSettings />
+                <AppearanceColorSettings canManage={canManageColorPalette} />
             </SettingsCard>
         </Stack>
     );

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/index.tsx
@@ -96,6 +96,7 @@ const AppearanceColorSettings: FC<{ canManage: boolean }> = ({ canManage }) => {
                                     }}
                                     isActive={true}
                                     readOnly
+                                    canManage={canManage}
                                     onSetActive={undefined}
                                 />
                             )}
@@ -106,7 +107,7 @@ const AppearanceColorSettings: FC<{ canManage: boolean }> = ({ canManage }) => {
                                 isActive={
                                     palette.isActive && !hasColorPaletteOverride
                                 }
-                                readOnly={!canManage}
+                                canManage={canManage}
                                 onSetActive={
                                     hasColorPaletteOverride || !canManage
                                         ? undefined

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -262,12 +262,20 @@ export const useSettingsNavigation = (
             });
         }
 
-        if (ability?.can('update', 'Organization')) {
+        if (
+            ability?.can('update', 'Organization') ||
+            ability?.can(
+                'manage',
+                subject('OrganizationColorPalette', {
+                    organizationUuid: organization?.organizationUuid,
+                }),
+            )
+        ) {
             organizationItems.push({
                 label: 'Appearance',
                 to: '/generalSettings/appearance',
                 icon: IconPalette,
-                keywords: ['theme', 'color', 'branding', 'logo'],
+                keywords: ['theme', 'color', 'branding', 'logo', 'palette'],
                 children: [],
                 exact: true,
             });


### PR DESCRIPTION
## Summary

Adds a dedicated org-level custom-role scope, `manage:OrganizationColorPalette`, that grants create / edit / delete / set-active on organization colour palettes only. Previously palette management was gated behind `manage:Organization`, so orgs couldn't grant it without also handing over broad org-settings control (renaming the org, deletion, etc.).

## Changes

- **New scope + subject**: `OrganizationColorPalette` CASL subject and org-level `manage:OrganizationColorPalette` scope (non-enterprise).
- **Enforcement**: `OrganizationService` palette CRUD (`create`/`update`/`delete`/`setActive`) now checks `manage:OrganizationColorPalette` instead of `update:Organization`. Listing palettes is unchanged (available to all members).
- **System roles**: granted to the admin org role, the `ORG_ADMIN` service account, and the admin entry in `roleToScopeMapping` — so existing admins keep palette access and CI/CD service accounts are unaffected.
- **Frontend gating**: the Appearance settings nav item, the palette section (add/edit/delete/set-active), and the project-level "Manage organization palettes" link now show for holders of the new scope. Brand appearance settings remain gated on org management.

## Scope vocabulary change: split → backfill migration

This is a **split** of the scope vocabulary: palette management moves out of the capability set implied by `manage:Organization` into the new scope. Custom roles that hold `manage:Organization` (the documented workaround until now) previously passed the `update Organization` check and would silently lose palette access after this change, since custom-role abilities are built only from their stored scope strings.

Migration `20260722153938_grant_org_color_palette_scope_to_manage_org_roles` backfills `manage:OrganizationColorPalette` into every custom role that has `manage:Organization` (`INSERT ... SELECT ... ON CONFLICT DO NOTHING`, preserving `granted_by`; best-effort try/catch so a failure never blocks later migrations). `down()` removes the palette-scope rows. System-role admins are unaffected either way (static abilities).

## Testing

- `pnpm -F common test` (authorization suite) — passing, including the scope-level golden list and role/scope parity tests
- `pnpm -F backend test` RolesService — passing
- Typecheck: common / backend / frontend — passing
- Lint: common / backend / frontend — clean
- Migration verified against the local dev DB: seeded a custom role with `manage:Organization`, ran `pnpm -F backend migrate`, confirmed the role gained `manage:OrganizationColorPalette` with `granted_by` preserved
