### PR TITLE
feat: enforce project-scoped SQL chart slugs

### DIFF
--- a/packages/backend/src/database/migrations/20260722180000_enforce_saved_sql_project_slug_contract.ts
+++ b/packages/backend/src/database/migrations/20260722180000_enforce_saved_sql_project_slug_contract.ts
@@ -1,0 +1,335 @@
+import { Knex } from 'knex';
+
+export const config = { transaction: false };
+
+const SavedSqlTableName = 'saved_sql';
+const ProjectSlugUniqueConstraint = 'saved_sql_project_uuid_slug_unique';
+const ProjectNotNullCheck = 'saved_sql_project_uuid_not_null_check';
+const SlugNotNullCheck = 'saved_sql_slug_not_null_check';
+const BatchSize = 1000;
+const LockTimeout = '5s';
+
+const canonicalProjectUuid = (alias: string): string => `COALESCE(
+    ${alias}_direct_project.project_uuid,
+    ${alias}_dashboard_project.project_uuid
+)`;
+
+const ownershipJoins = (alias: string): string => `
+    LEFT JOIN spaces AS ${alias}_direct_space
+        ON ${alias}_direct_space.space_uuid = ${alias}.space_uuid
+    LEFT JOIN projects AS ${alias}_direct_project
+        ON ${alias}_direct_project.project_id = ${alias}_direct_space.project_id
+    LEFT JOIN dashboards AS ${alias}_dashboard
+        ON ${alias}_dashboard.dashboard_uuid = ${alias}.dashboard_uuid
+    LEFT JOIN spaces AS ${alias}_dashboard_space
+        ON ${alias}_dashboard_space.space_id = ${alias}_dashboard.space_id
+    LEFT JOIN projects AS ${alias}_dashboard_project
+        ON ${alias}_dashboard_project.project_id = ${alias}_dashboard_space.project_id
+`;
+
+/**
+ * saved_sql has had a native project UUID FK and UNIQUE(project_uuid, slug)
+ * since its creation. This migration closes the nullable loopholes without
+ * changing valid slugs.
+ *
+ * Ownership is always resolvable through one of the existing FK chains:
+ *
+ * saved_sql.space_uuid -> spaces.project_id -> projects.project_uuid
+ *
+ * or:
+ *
+ * saved_sql.dashboard_uuid -> dashboards.space_id
+ *   -> spaces.project_id -> projects.project_uuid
+ *
+ * Project UUIDs are reconciled from their space, or from their dashboard's
+ * space. Only a slug that would conflict after an ownership repair is
+ * deterministically suffixed with the chart UUID. Deleted rows participate
+ * because they can be restored. NULL slugs receive a UUID-based value.
+ *
+ * Repairs commit in bounded batches. Every phase is idempotent, so an
+ * interrupted run can be retried after releasing the Knex migration lock.
+ */
+
+const logProgress = (message: string): void => {
+    // eslint-disable-next-line no-console
+    console.log(`  ${SavedSqlTableName}: ${message}`);
+};
+
+const getRowCount = (result: { rowCount?: number }): number =>
+    result.rowCount ?? 0;
+
+async function withLockTimeout<T>(
+    knex: Knex,
+    callback: (trx: Knex.Transaction) => Promise<T>,
+): Promise<T> {
+    return knex.transaction(async (trx) => {
+        await trx.raw(`SET LOCAL lock_timeout = '${LockTimeout}'`);
+        return callback(trx);
+    });
+}
+
+async function assertHistoricalConstraint(knex: Knex): Promise<void> {
+    const constraint = await knex.raw<{ rowCount: number }>(
+        `SELECT 1
+         FROM pg_constraint
+         WHERE conname = ?
+           AND conrelid = ?::regclass
+           AND contype = 'u'`,
+        [ProjectSlugUniqueConstraint, SavedSqlTableName],
+    );
+    if (getRowCount(constraint) === 0) {
+        throw new Error(
+            `${SavedSqlTableName}: historical project slug constraint is missing`,
+        );
+    }
+}
+
+async function backfillNullSlugs(knex: Knex): Promise<void> {
+    let totalUpdated = 0;
+    for (;;) {
+        // UUID-based values are deterministic. The recursive fallback handles
+        // even a deliberately colliding pre-existing slug.
+        // eslint-disable-next-line no-await-in-loop
+        const result = await withLockTimeout(knex, async (trx) =>
+            trx.raw<{ rowCount: number }>(`
+                WITH batch AS (
+                    SELECT saved_sql.saved_sql_uuid,
+                        ${canonicalProjectUuid('saved_sql')} AS project_uuid
+                    FROM ${SavedSqlTableName} AS saved_sql
+                    ${ownershipJoins('saved_sql')}
+                    WHERE saved_sql.slug IS NULL
+                    ORDER BY saved_sql.saved_sql_uuid
+                    LIMIT ${BatchSize}
+                ), replacements AS (
+                    SELECT batch.saved_sql_uuid, replacement.candidate
+                    FROM batch
+                    CROSS JOIN LATERAL (
+                        WITH RECURSIVE candidates(attempt, candidate) AS (
+                            SELECT 0,
+                                'sql-chart-' || batch.saved_sql_uuid::text
+                            UNION ALL
+                            SELECT candidates.attempt + 1,
+                                'sql-chart-' || batch.saved_sql_uuid::text ||
+                                    '-' || (candidates.attempt + 1)::text
+                            FROM candidates
+                            WHERE EXISTS (
+                                SELECT 1
+                                FROM ${SavedSqlTableName} AS existing
+                                WHERE existing.project_uuid = batch.project_uuid
+                                  AND existing.slug = candidates.candidate
+                            )
+                        )
+                        SELECT candidates.candidate
+                        FROM candidates
+                        WHERE NOT EXISTS (
+                            SELECT 1
+                            FROM ${SavedSqlTableName} AS existing
+                            WHERE existing.project_uuid = batch.project_uuid
+                              AND existing.slug = candidates.candidate
+                        )
+                        ORDER BY candidates.attempt
+                        LIMIT 1
+                    ) AS replacement
+                )
+                UPDATE ${SavedSqlTableName} AS saved_sql
+                SET slug = replacements.candidate
+                FROM replacements
+                WHERE saved_sql.saved_sql_uuid = replacements.saved_sql_uuid
+                  AND saved_sql.slug IS NULL
+            `),
+        );
+        const updated = getRowCount(result);
+        if (updated === 0) break;
+        totalUpdated += updated;
+        logProgress(`backfilled slug for ${totalUpdated} rows`);
+    }
+}
+
+async function repairOwnershipSlugConflicts(knex: Knex): Promise<void> {
+    let totalUpdated = 0;
+    for (;;) {
+        // Rank canonical ownership groups before reconciliation so an active
+        // chart keeps its slug over a deleted one.
+        // eslint-disable-next-line no-await-in-loop
+        const result = await withLockTimeout(knex, async (trx) =>
+            trx.raw<{ rowCount: number }>(`
+                WITH resolved AS (
+                    SELECT saved_sql.saved_sql_uuid, saved_sql.slug,
+                        ${canonicalProjectUuid('saved_sql')} AS project_uuid,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY ${canonicalProjectUuid('saved_sql')}, saved_sql.slug
+                            ORDER BY
+                                (saved_sql.deleted_at IS NULL) DESC,
+                                saved_sql.created_at,
+                                saved_sql.saved_sql_uuid
+                        ) AS duplicate_number
+                    FROM ${SavedSqlTableName} AS saved_sql
+                    ${ownershipJoins('saved_sql')}
+                ), conflicts AS (
+                    SELECT resolved.*
+                    FROM resolved
+                    WHERE resolved.duplicate_number > 1
+                    ORDER BY resolved.project_uuid, resolved.slug,
+                        resolved.saved_sql_uuid
+                    LIMIT ${BatchSize}
+                ), replacements AS (
+                    SELECT conflicts.saved_sql_uuid, replacement.candidate
+                    FROM conflicts
+                    CROSS JOIN LATERAL (
+                        WITH RECURSIVE candidates(attempt, candidate) AS (
+                            SELECT 0,
+                                LEFT(conflicts.slug, 210) || '-sql-' ||
+                                    conflicts.saved_sql_uuid::text
+                            UNION ALL
+                            SELECT candidates.attempt + 1,
+                                LEFT(conflicts.slug, 200) || '-sql-' ||
+                                    conflicts.saved_sql_uuid::text || '-' ||
+                                    (candidates.attempt + 1)::text
+                            FROM candidates
+                            WHERE EXISTS (
+                                SELECT 1
+                                FROM ${SavedSqlTableName} AS existing
+                                ${ownershipJoins('existing')}
+                                WHERE ${canonicalProjectUuid('existing')} =
+                                        conflicts.project_uuid
+                                  AND existing.slug = candidates.candidate
+                                  AND existing.saved_sql_uuid <>
+                                      conflicts.saved_sql_uuid
+                            )
+                        )
+                        SELECT candidates.candidate
+                        FROM candidates
+                        WHERE NOT EXISTS (
+                            SELECT 1
+                            FROM ${SavedSqlTableName} AS existing
+                            ${ownershipJoins('existing')}
+                            WHERE ${canonicalProjectUuid('existing')} =
+                                    conflicts.project_uuid
+                              AND existing.slug = candidates.candidate
+                              AND existing.saved_sql_uuid <>
+                                  conflicts.saved_sql_uuid
+                        )
+                        ORDER BY candidates.attempt
+                        LIMIT 1
+                    ) AS replacement
+                )
+                UPDATE ${SavedSqlTableName} AS saved_sql
+                SET slug = replacements.candidate
+                FROM replacements
+                WHERE saved_sql.saved_sql_uuid = replacements.saved_sql_uuid
+                  AND saved_sql.slug IS DISTINCT FROM replacements.candidate
+            `),
+        );
+        const updated = getRowCount(result);
+        if (updated === 0) break;
+        totalUpdated += updated;
+        logProgress(
+            `repaired ownership slug conflict for ${totalUpdated} rows`,
+        );
+    }
+}
+
+async function reconcileProjectUuids(knex: Knex): Promise<void> {
+    let totalUpdated = 0;
+    for (;;) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await withLockTimeout(knex, async (trx) =>
+            trx.raw<{ rowCount: number }>(`
+                WITH batch AS (
+                    SELECT saved_sql.saved_sql_uuid,
+                        ${canonicalProjectUuid('saved_sql')} AS project_uuid
+                    FROM ${SavedSqlTableName} AS saved_sql
+                    ${ownershipJoins('saved_sql')}
+                    WHERE saved_sql.project_uuid IS DISTINCT FROM
+                        ${canonicalProjectUuid('saved_sql')}
+                    ORDER BY saved_sql.saved_sql_uuid
+                    LIMIT ${BatchSize}
+                )
+                UPDATE ${SavedSqlTableName} AS saved_sql
+                SET project_uuid = batch.project_uuid
+                FROM batch
+                WHERE saved_sql.saved_sql_uuid = batch.saved_sql_uuid
+                  AND saved_sql.project_uuid IS DISTINCT FROM batch.project_uuid
+            `),
+        );
+        const updated = getRowCount(result);
+        if (updated === 0) break;
+        totalUpdated += updated;
+        logProgress(`reconciled project UUID for ${totalUpdated} rows`);
+    }
+}
+
+async function enforceNotNull(
+    knex: Knex,
+    columnName: 'project_uuid' | 'slug',
+    checkName: string,
+): Promise<void> {
+    const column = await knex.raw<{ rows: Array<{ attnotnull: boolean }> }>(
+        `SELECT attnotnull
+         FROM pg_attribute
+         WHERE attrelid = ?::regclass
+           AND attname = ?
+           AND NOT attisdropped`,
+        [SavedSqlTableName, columnName],
+    );
+    if (column.rows[0]?.attnotnull) return;
+
+    const check = await knex.raw<{ rowCount: number }>(
+        `SELECT 1 FROM pg_constraint
+         WHERE conname = ? AND conrelid = ?::regclass`,
+        [checkName, SavedSqlTableName],
+    );
+    if (getRowCount(check) === 0) {
+        await withLockTimeout(knex, async (trx) => {
+            await trx.raw(`
+                ALTER TABLE ${SavedSqlTableName}
+                ADD CONSTRAINT ${checkName}
+                CHECK (${columnName} IS NOT NULL) NOT VALID
+            `);
+        });
+    }
+
+    logProgress(`validating ${columnName} non-nullability`);
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${SavedSqlTableName}
+            VALIDATE CONSTRAINT ${checkName}
+        `);
+    });
+
+    await withLockTimeout(knex, async (trx) => {
+        logProgress(`enforcing ${columnName} NOT NULL`);
+        await trx.raw(`
+            ALTER TABLE ${SavedSqlTableName}
+            ALTER COLUMN ${columnName} SET NOT NULL,
+            DROP CONSTRAINT IF EXISTS ${checkName}
+        `);
+    });
+}
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        await assertHistoricalConstraint(knex);
+        await backfillNullSlugs(knex);
+        await repairOwnershipSlugConflicts(knex);
+        await reconcileProjectUuids(knex);
+        await enforceNotNull(knex, 'project_uuid', ProjectNotNullCheck);
+        await enforceNotNull(knex, 'slug', SlugNotNullCheck);
+        logProgress('project-scoped SQL chart slug contract complete');
+    } finally {
+        await knex.raw('RESET statement_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await withLockTimeout(knex, async (trx) => {
+        await trx.raw(`
+            ALTER TABLE ${SavedSqlTableName}
+            ALTER COLUMN project_uuid DROP NOT NULL,
+            ALTER COLUMN slug DROP NOT NULL,
+            DROP CONSTRAINT IF EXISTS ${ProjectNotNullCheck},
+            DROP CONSTRAINT IF EXISTS ${SlugNotNullCheck}
+        `);
+    });
+}

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -2986,7 +2986,14 @@ export class ProjectModel {
                                       );
                                   }
                                   const createSavedSQL: CloneSavedSQL = {
-                                      ...d,
+                                      // The dashboard UUID is remapped after
+                                      // dashboards are cloned below. Keep the
+                                      // destination project UUID throughout
+                                      // this transaction.
+                                      ...replaceProjectUuid(
+                                          d,
+                                          previewProjectUuid,
+                                      ),
                                       dashboard_uuid: d.dashboard_uuid,
                                       search_vector: undefined,
                                       saved_sql_uuid: undefined,

--- a/packages/backend/src/models/SavedSqlModel.ts
+++ b/packages/backend/src/models/SavedSqlModel.ts
@@ -1,6 +1,7 @@
 import {
     AllVizChartConfig,
     CreateSqlChart,
+    generateSlug,
     NotFoundError,
     ResolvedProjectColorPalette,
     SpaceSummary,
@@ -24,7 +25,10 @@ import {
 } from '../database/entities/savedSql';
 import { DbSpace, SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
-import { generateUniqueSlug } from '../utils/SlugUtils';
+import {
+    acquireProjectSlugLock,
+    generateUniqueSlugScopedToProject,
+} from '../utils/SlugUtils';
 
 type SelectSavedSql = Pick<
     DbSavedSql,
@@ -337,10 +341,21 @@ export class SavedSqlModel {
         savedSqlVersionUuid: string;
     }> {
         return this.database.transaction(async (trx) => {
-            // Use provided slug or generate one from the name
-            const finalSlug =
-                data.slug ??
-                (await generateUniqueSlug(trx, SavedSqlTableName, data.name));
+            let finalSlug = data.slug;
+            if (finalSlug === undefined) {
+                const baseSlug = generateSlug(data.name);
+                await acquireProjectSlugLock(
+                    trx,
+                    projectUuid,
+                    `saved-sql:${baseSlug}`,
+                );
+                finalSlug = await generateUniqueSlugScopedToProject(
+                    trx,
+                    projectUuid,
+                    SavedSqlTableName,
+                    baseSlug,
+                );
+            }
 
             const [{ saved_sql_uuid: savedSqlUuid, slug }] = await trx(
                 SavedSqlTableName,

--- a/packages/backend/src/utils/SlugUtils.test.ts
+++ b/packages/backend/src/utils/SlugUtils.test.ts
@@ -3,6 +3,7 @@ import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { DashboardsTableName } from '../database/entities/dashboards';
 import { ProjectTableName } from '../database/entities/projects';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
+import { SavedSqlTableName } from '../database/entities/savedSql';
 import { generateUniqueSlugScopedToProject } from './SlugUtils';
 
 describe('generateUniqueSlugScopedToProject', () => {
@@ -33,4 +34,19 @@ describe('generateUniqueSlugScopedToProject', () => {
             expect(query.sql).toContain(`"${ProjectTableName}"."project_uuid"`);
         },
     );
+
+    it('uses native project ownership for saved SQL charts', async () => {
+        tracker.on.select(SavedSqlTableName).responseOnce([]);
+
+        await generateUniqueSlugScopedToProject(
+            database,
+            '22222222-2222-4222-8222-222222222222',
+            SavedSqlTableName,
+            'Orders',
+        );
+
+        const [query] = tracker.history.select;
+        expect(query.sql).toContain(`"${SavedSqlTableName}"."project_uuid"`);
+        expect(query.sql).not.toContain(`join "${ProjectTableName}"`);
+    });
 });

--- a/packages/backend/src/utils/SlugUtils.ts
+++ b/packages/backend/src/utils/SlugUtils.ts
@@ -155,6 +155,12 @@ export const generateUniqueSlugScopedToProject = async (
                 .pluck(`${DashboardsTableName}.slug`);
             break;
         case SavedSqlTableName:
+            matchingSlugs = await trx(SavedSqlTableName)
+                .where(`${SavedSqlTableName}.project_uuid`, projectUuid)
+                .select(`${SavedSqlTableName}.slug`)
+                .where(`${SavedSqlTableName}.slug`, 'like', `${baseSlug}%`)
+                .pluck(`${SavedSqlTableName}.slug`);
+            break;
         case SpaceTableName:
             throw new Error('Not implemented');
         default:


### PR DESCRIPTION
### Description

Enforces the existing project-scoped slug contract for SQL Runner saved charts.

`saved_sql` already has a native `project_uuid` foreign key and `UNIQUE (project_uuid, slug)` from its original migration. This PR closes the remaining nullable loopholes, repairs canonical ownership, and makes normal slug generation project-scoped without rebuilding the existing unique index.

Runtime changes:

- Generate automatic SQL chart slugs against `saved_sql.project_uuid`, including soft-deleted charts.
- Serialize concurrent automatic slug generation by `(project_uuid, base_slug)` with the existing transaction-scoped advisory lock.
- Continue allowing the same slug in different projects.
- Ensure dashboard-owned SQL charts copied into a preview retain the destination `project_uuid` while their dashboard UUID is remapped later in the transaction.

Migration assumptions and flow:

1. Saved SQL ownership is resolved through the existing canonical FK chain: direct space ownership, or dashboard → space ownership. `spaces.project_id` and `dashboards.space_id` are non-null foreign keys, and `projects.project_uuid` is non-null.
2. Verify the historical project/slug unique constraint exists.
3. Fill null slugs deterministically from `saved_sql_uuid`, including collision fallback.
4. Rank charts by canonical project ownership and rename only same-project conflicts. Active rows keep the public slug ahead of deleted rows; deleted rows remain unique because they can be restored.
5. Reconcile both null and incorrect non-null `project_uuid` values from canonical ownership.
6. Validate temporary non-null checks, promote `project_uuid` and `slug` to `NOT NULL`, then remove the temporary checks.

The migration runs without Knex's outer transaction, disables the session statement timeout, commits repairs in batches of 1,000, bounds schema-lock waits to five seconds, and is idempotent after a partial run. Rollback removes the new non-nullability only; repaired ownership and slug values remain valid data.

### Real PostgreSQL migration matrix

Executed through actual `knex migrate:up` / `migrate:down`, not migration mocks:

- Fresh database applied all 532 migrations on the final branch, including dashboard, space, and SQL chart contracts in release order.
- Already-valid rows remained unchanged.
- Null and incorrect non-null owners were reconciled through both direct-space and dashboard-space ownership.
- Null slugs received deterministic values; pre-existing generated candidates advanced to the next deterministic suffix.
- Canonical-project collisions caused by incorrect ownership were repaired before ownership reconciliation.
- Active/deleted duplicate: the active chart kept the original slug and the deleted chart was suffixed.
- Same slug in different projects remained unchanged and valid.
- A unique 2,000-character slug remained byte-for-byte unchanged; only its conflicting duplicate was capped and suffixed.
- Replacement-suffix collisions advanced to the next candidate.
- Same-project duplicate insertion was rejected after migration; cross-project duplicate insertion succeeded.
- Preview's temporary source-dashboard/destination-project sequence completed and ended with canonical destination ownership.
- Rollback restored nullable columns while preserving repaired values; reapply succeeded.
- Completed-state rerun produced an identical data hash.
- 1,505 duplicates exercised multiple committed repair and ownership batches and finished with zero nulls, ownership mismatches, or duplicate groups.
- An impossible ownerless fixture failed with the migration unrecorded; after explicit ownership repair, rerunning resumed from the retained `NOT VALID` check and completed.

Production-shaped local load on the final migration logic:

- 100,013 SQL charts
- 13 canonical ownership/slug conflicts
- 1.60 seconds wall time, including Knex/Node startup
- Zero null owners, ownership mismatches, null slugs, or same-project duplicate groups afterward

Local verification:

- Migration and model ESLint/formatting passed.
- Focused preview/slug tests passed (6/6).
- `git diff --check` passed.

Closes: PROD-9108
Relates: PROD-8968
