### PR TITLE
feat: support subtotals with metrics as rows

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
@@ -207,11 +207,9 @@ const GeneralSettings: FC = () => {
                 <Config.Section>
                     <Config.Heading>Metrics</Config.Heading>
                     <Tooltip
-                        disabled={!!isPivotTableEnabled && !showSubtotals}
+                        disabled={!!isPivotTableEnabled}
                         label={
-                            showSubtotals
-                                ? 'Metrics as rows are not available when subtotals are enabled'
-                                : 'To use metrics as rows, you need to move a dimension to "Columns"'
+                            'To use metrics as rows, you need to move a dimension to "Columns"'
                         }
                         w={300}
                         multiline
@@ -224,7 +222,7 @@ const GeneralSettings: FC = () => {
                                 classNames={{
                                     label: compactStyles.compactCheckboxLabel,
                                 }}
-                                disabled={!isPivotTableEnabled || showSubtotals}
+                                disabled={!isPivotTableEnabled}
                                 label="Show metrics as rows"
                                 labelPosition="right"
                                 checked={metricsAsRows}
@@ -329,13 +327,9 @@ const GeneralSettings: FC = () => {
                 />
                 <Tooltip
                     disabled={canUseSubtotals}
-                    label={
-                        metricsAsRows
-                            ? 'Subtotals cannot be used with metrics as rows'
-                            : `Subtotals can only be used on tables with at least two ${
-                                  isPivotTableEnabled ? 'un-pivoted' : ''
-                              } dimensions`
-                    }
+                    label={`Subtotals can only be used on tables with at least two ${
+                        isPivotTableEnabled ? 'un-pivoted' : ''
+                    } dimensions`}
                     w={300}
                     multiline
                     withinPortal
@@ -348,15 +342,11 @@ const GeneralSettings: FC = () => {
                                 label: compactStyles.compactCheckboxLabel,
                             }}
                             label="Show subtotals"
-                            checked={
-                                canUseSubtotals &&
-                                !metricsAsRows &&
-                                showSubtotals
-                            }
+                            checked={canUseSubtotals && showSubtotals}
                             onChange={() => {
                                 setShowSubtotals(!showSubtotals);
                             }}
-                            disabled={!canUseSubtotals || metricsAsRows}
+                            disabled={!canUseSubtotals}
                         />
                     </Box>
                 </Tooltip>
@@ -371,12 +361,12 @@ const GeneralSettings: FC = () => {
                     onChange={() => {
                         setShowSubtotalsExpanded(!showSubtotalsExpanded);
                     }}
-                    disabled={
-                        !canUseSubtotals || metricsAsRows || !showSubtotals
-                    }
+                    disabled={!canUseSubtotals || !showSubtotals}
                 />
                 <Tooltip
-                    disabled={canUseSubtotals && !showSubtotals}
+                    disabled={
+                        canUseSubtotals && !showSubtotals && !metricsAsRows
+                    }
                     label={
                         showSubtotals
                             ? 'Row grouping is always on when subtotals are enabled.'

--- a/packages/frontend/src/components/common/PivotTable/getMetricsAsRowsSubtotalRenderRows.test.ts
+++ b/packages/frontend/src/components/common/PivotTable/getMetricsAsRowsSubtotalRenderRows.test.ts
@@ -1,0 +1,92 @@
+import type { PivotData, ResultRow } from '@lightdash/common';
+import type { Row } from '@tanstack/react-table';
+import { describe, expect, it } from 'vitest';
+import {
+    getMetricsAsRowsMetricIds,
+    projectMetricsAsRowsSubtotalRenderRows,
+} from './getMetricsAsRowsSubtotalRenderRows';
+
+const createRow = ({
+    id,
+    index,
+    grouped = false,
+    subRows = [],
+}: {
+    id: string;
+    index: number;
+    grouped?: boolean;
+    subRows?: Row<ResultRow>[];
+}): Row<ResultRow> =>
+    ({
+        id,
+        index,
+        subRows,
+        getIsGrouped: () => grouped,
+    }) as Row<ResultRow>;
+
+describe('metrics-as-rows subtotal projection', () => {
+    it('projects grouped rows by visible metric while preserving row order and core indexes', () => {
+        const indexValues = [
+            [{ type: 'label', fieldId: 'metric_b' }],
+            [{ type: 'label', fieldId: 'metric_a' }],
+            [{ type: 'label', fieldId: 'metric_b' }],
+        ] satisfies PivotData['indexValues'];
+        const metricFieldIds = getMetricsAsRowsMetricIds(indexValues);
+        const leaves = [11, 12, 14, 15].map((index) =>
+            createRow({ id: `leaf-${index}`, index }),
+        );
+        const nestedGroup = createRow({
+            id: 'nested-group',
+            index: 2,
+            grouped: true,
+            subRows: leaves,
+        });
+        const outerGroup = createRow({
+            id: 'outer-group',
+            index: 1,
+            grouped: true,
+            subRows: [nestedGroup],
+        });
+        const rows = [outerGroup, nestedGroup, ...leaves];
+
+        expect(metricFieldIds).toEqual(['metric_b', 'metric_a']);
+        expect(
+            projectMetricsAsRowsSubtotalRenderRows({
+                rows,
+                metricFieldIds,
+                enabled: true,
+            }).map((renderRow) =>
+                renderRow.kind === 'metricSubtotal'
+                    ? `${renderRow.row.id}:${renderRow.metricFieldId}:${renderRow.sourceRowCount}`
+                    : `${renderRow.row.id}:${renderRow.dataRowIndex}`,
+            ),
+        ).toEqual([
+            'outer-group:metric_b:2',
+            'outer-group:metric_a:2',
+            'nested-group:metric_b:2',
+            'nested-group:metric_a:2',
+            'leaf-11:11',
+            'leaf-12:12',
+            'leaf-14:14',
+            'leaf-15:15',
+        ]);
+        expect(
+            projectMetricsAsRowsSubtotalRenderRows({
+                rows,
+                metricFieldIds,
+                enabled: false,
+            }).map((renderRow) =>
+                renderRow.kind === 'standard'
+                    ? `${renderRow.row.id}:${renderRow.dataRowIndex}`
+                    : `${renderRow.row.id}:${renderRow.metricFieldId}`,
+            ),
+        ).toEqual([
+            'outer-group:null',
+            'nested-group:null',
+            'leaf-11:11',
+            'leaf-12:12',
+            'leaf-14:14',
+            'leaf-15:15',
+        ]);
+    });
+});

--- a/packages/frontend/src/components/common/PivotTable/getMetricsAsRowsSubtotalRenderRows.ts
+++ b/packages/frontend/src/components/common/PivotTable/getMetricsAsRowsSubtotalRenderRows.ts
@@ -1,0 +1,76 @@
+import type { PivotData, ResultRow } from '@lightdash/common';
+import type { Row } from '@tanstack/react-table';
+import { countSubRows } from '../Table/utils';
+
+export type MetricsAsRowsSubtotalRenderRow =
+    | {
+          kind: 'standard';
+          row: Row<ResultRow>;
+          dataRowIndex: number | null;
+      }
+    | {
+          kind: 'metricSubtotal';
+          row: Row<ResultRow>;
+          metricFieldId: string;
+          metricIndex: number;
+          metricCount: number;
+          sourceRowCount: number;
+      };
+
+export const getMetricsAsRowsMetricIds = (
+    indexValues: PivotData['indexValues'],
+): string[] => {
+    const seenMetricFieldIds = new Set<string>();
+    const metricFieldIds: string[] = [];
+
+    for (const indexValueRow of indexValues) {
+        for (const indexValue of indexValueRow) {
+            if (
+                indexValue.type === 'label' &&
+                !seenMetricFieldIds.has(indexValue.fieldId)
+            ) {
+                seenMetricFieldIds.add(indexValue.fieldId);
+                metricFieldIds.push(indexValue.fieldId);
+            }
+        }
+    }
+
+    return metricFieldIds;
+};
+
+export const projectMetricsAsRowsSubtotalRenderRows = ({
+    rows,
+    metricFieldIds,
+    enabled,
+}: {
+    rows: Row<ResultRow>[];
+    metricFieldIds: string[];
+    enabled: boolean;
+}): MetricsAsRowsSubtotalRenderRow[] => {
+    const metricCount = metricFieldIds.length;
+
+    return rows.flatMap<MetricsAsRowsSubtotalRenderRow>((row) => {
+        const isGrouped = row.getIsGrouped();
+
+        if (!enabled || !isGrouped) {
+            return {
+                kind: 'standard',
+                row,
+                dataRowIndex: isGrouped ? null : row.index,
+            };
+        }
+
+        if (metricCount === 0) return [];
+
+        const sourceRowCount = countSubRows(row) / metricCount;
+
+        return metricFieldIds.map((metricFieldId, metricIndex) => ({
+            kind: 'metricSubtotal',
+            row,
+            metricFieldId,
+            metricIndex,
+            metricCount,
+            sourceRowCount,
+        }));
+    });
+};

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -90,6 +90,10 @@ import {
     getFrozenColumnLayout,
     type FrozenColumnEntry,
 } from './getFrozenColumnLayout';
+import {
+    getMetricsAsRowsMetricIds,
+    projectMetricsAsRowsSubtotalRenderRows,
+} from './getMetricsAsRowsSubtotalRenderRows';
 import { getGroupedDimColumnIds, getRowSpanMerges } from './getRowSpanMerges';
 import { collectPivotUnderlyingValues } from './getUnderlyingFieldValues';
 import pivotStyles from './PivotTable.module.css';
@@ -666,11 +670,29 @@ const PivotTable: FC<PivotTableProps> = ({
         },
     });
 
-    const { rows } = table.getRowModel();
+    const { rows: tableRows } = table.getRowModel();
+    const metricsAsRowsMetricIds = useMemo(
+        () => getMetricsAsRowsMetricIds(data.indexValues),
+        [data.indexValues],
+    );
+    const projectedRows = useMemo(
+        () =>
+            projectMetricsAsRowsSubtotalRenderRows({
+                rows: tableRows,
+                metricFieldIds: metricsAsRowsMetricIds,
+                enabled: data.pivotConfig.metricsAsRows && showSubtotals,
+            }),
+        [
+            tableRows,
+            metricsAsRowsMetricIds,
+            data.pivotConfig.metricsAsRows,
+            showSubtotals,
+        ],
+    );
 
     const rowVirtualizer = useVirtualizer({
         getScrollElement: () => containerRef.current,
-        count: rows.length,
+        count: projectedRows.length,
         estimateSize: () => CELL_HEIGHT,
         overscan: 25,
     });
@@ -686,25 +708,28 @@ const PivotTable: FC<PivotTableProps> = ({
         );
         if (groupedColumnIds.length === 0) return null;
         return getRowSpanMerges(
-            rows.length,
+            tableRows.length,
             groupedColumnIds,
             (rowIndex, columnId) => {
-                const cell = rows[rowIndex]?.getValue(columnId) as
+                const cell = tableRows[rowIndex]?.getValue(columnId) as
                     | { value?: ResultValue }
                     | undefined;
                 return cell?.value?.raw;
             },
         );
-    }, [groupingOnlyMode, data.indexValueTypes, columnOrder, rows]);
+    }, [groupingOnlyMode, data.indexValueTypes, columnOrder, tableRows]);
 
     // In merge mode, render every row (no virtualization) so rowSpans stay
     // contiguous — a block's first row must never be unmounted while its
     // absorbed siblings are visible.
     const renderedBodyRows = groupingOnlyMode
-        ? rows.map((row, rowIndex) => ({ row, rowIndex }))
+        ? projectedRows.map((renderRow, renderIndex) => ({
+              renderRow,
+              renderIndex,
+          }))
         : virtualRows.map((virtualRow) => ({
-              row: rows[virtualRow.index],
-              rowIndex: virtualRow.index,
+              renderRow: projectedRows[virtualRow.index],
+              renderIndex: virtualRow.index,
           }));
 
     const getColumnTotalValueFromAxis = useCallback(
@@ -759,8 +784,8 @@ const PivotTable: FC<PivotTableProps> = ({
     );
 
     const getUnderlyingFieldValues = useCallback(
-        (rowIndex: number, colIndex: number) => {
-            const visibleCells = rows[rowIndex].getVisibleCells();
+        (row: Row<ResultRow>, dataRowIndex: number, colIndex: number) => {
+            const visibleCells = row.getVisibleCells();
             const clickedItem =
                 visibleCells[colIndex].column.columnDef.meta?.item;
             const clickedValue = (
@@ -780,15 +805,15 @@ const PivotTable: FC<PivotTableProps> = ({
                     ? getItemId(clickedItem)
                     : undefined,
                 clickedValue,
-                labelFieldId: data.indexValues[rowIndex].find(
+                labelFieldId: data.indexValues[dataRowIndex].find(
                     (indexValue) => indexValue.type === 'label',
                 )?.fieldId,
                 // Hidden row-index dims are excluded from the rendered cells;
                 // merge them so drill-down stays scoped (PROD-7841).
-                hiddenIndexCells: data.hiddenIndexValues?.[rowIndex] ?? [],
+                hiddenIndexCells: data.hiddenIndexValues?.[dataRowIndex] ?? [],
             });
         },
-        [rows, data.indexValues, data.hiddenIndexValues],
+        [data.indexValues, data.hiddenIndexValues],
     );
 
     // Find the data column index from headerInfo by matching against headerValues
@@ -872,7 +897,7 @@ const PivotTable: FC<PivotTableProps> = ({
     // that share the same index dimension values (same "row group" in the original data)
     const buildRowFieldsForMetricsAsRows = useCallback(
         (
-            rowIndex: number,
+            dataRowIndex: number,
             headerInfo: Record<string, ResultValue> | undefined,
         ): ConditionalFormattingRowFields => {
             const dataColIndex = findDataColumnIndex(headerInfo);
@@ -883,7 +908,7 @@ const PivotTable: FC<PivotTableProps> = ({
                 buildRowFieldsFromHeaderInfo(headerInfo);
 
             const currentIndexDims = extractIndexDimensions(
-                data.indexValues[rowIndex] ?? [],
+                data.indexValues[dataRowIndex] ?? [],
             );
 
             // Include row dimension values from indexValues
@@ -1563,8 +1588,16 @@ const PivotTable: FC<PivotTableProps> = ({
                     />
                 )}
 
-                {renderedBodyRows.map(({ row, rowIndex }) => {
-                    if (!row) return null;
+                {renderedBodyRows.map(({ renderRow, renderIndex }) => {
+                    if (!renderRow) return null;
+
+                    const { row } = renderRow;
+                    const isMetricSubtotal =
+                        renderRow.kind === 'metricSubtotal';
+                    const dataRowIndex =
+                        renderRow.kind === 'standard'
+                            ? renderRow.dataRowIndex
+                            : null;
 
                     const toggleExpander = row.getToggleExpandedHandler();
 
@@ -1583,17 +1616,20 @@ const PivotTable: FC<PivotTableProps> = ({
                             );
                         })?.column.columnDef.meta?.headerInfo;
 
-                    const rowLevelFields = representativeHeaderInfo
-                        ? data.pivotConfig.metricsAsRows
-                            ? buildRowFieldsForMetricsAsRows(
-                                  rowIndex,
-                                  representativeHeaderInfo,
-                              )
-                            : buildRowFieldsFromVisibleCells(
-                                  row,
-                                  representativeHeaderInfo,
-                              )
-                        : buildRowFieldsFromVisibleCells(row, undefined);
+                    const rowLevelFields = isMetricSubtotal
+                        ? {}
+                        : representativeHeaderInfo
+                          ? data.pivotConfig.metricsAsRows &&
+                            dataRowIndex !== null
+                              ? buildRowFieldsForMetricsAsRows(
+                                    dataRowIndex,
+                                    representativeHeaderInfo,
+                                )
+                              : buildRowFieldsFromVisibleCells(
+                                    row,
+                                    representativeHeaderInfo,
+                                )
+                          : buildRowFieldsFromVisibleCells(row, undefined);
 
                     const rowBackgroundColor = getRowConditionalFormattingColor(
                         {
@@ -1612,15 +1648,19 @@ const PivotTable: FC<PivotTableProps> = ({
 
                     return (
                         <Table.Row
-                            key={`row-${rowIndex}-${data.pivotConfig.metricsAsRows}`}
-                            index={rowIndex}
+                            key={
+                                isMetricSubtotal
+                                    ? `subtotal-${row.id}-${renderRow.metricFieldId}`
+                                    : `row-${row.id}`
+                            }
+                            index={renderIndex}
                         >
                             {row.getVisibleCells().map((cell, colIndex) => {
                                 // Measure body cell widths in the first row only.
                                 // Column widths are uniform across rows (CSS table
                                 // layout), so one measurement per column is enough.
                                 const measureRef =
-                                    rowIndex === 0
+                                    renderIndex === 0
                                         ? measureCellRef(cell.column.id)
                                         : undefined;
                                 if (cell.column.id === ROW_NUMBER_COLUMN_ID) {
@@ -1637,7 +1677,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                               });
                                     return (
                                         <Table.Cell
-                                            key={`row-number-${rowIndex}`}
+                                            key={cell.id}
                                             ref={measureRef}
                                             className={
                                                 rowNumberStickyBody.className
@@ -1657,8 +1697,9 @@ const PivotTable: FC<PivotTableProps> = ({
                                              * them reads as a parallel
                                              * sequence interleaved with the
                                              * leaf-row counter. */}
-                                            {groupingOnlyMode &&
-                                            row.getIsGrouped()
+                                            {isMetricSubtotal ||
+                                            (groupingOnlyMode &&
+                                                row.getIsGrouped())
                                                 ? null
                                                 : flexRender(
                                                       cell.column.columnDef
@@ -1677,7 +1718,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                 const rowSpanMerge =
                                     rowSpanMergesByColumnId?.get(
                                         cell.column.id,
-                                    )?.[rowIndex];
+                                    )?.[renderIndex];
                                 if (
                                     rowSpanMerge &&
                                     !rowSpanMerge.isBlockStart
@@ -1691,38 +1732,96 @@ const PivotTable: FC<PivotTableProps> = ({
                                     meta?.type !== 'indexValue' &&
                                     meta?.type !== 'label' &&
                                     !isRowTotal;
+                                const metricFieldId = isMetricSubtotal
+                                    ? renderRow.metricFieldId
+                                    : dataRowIndex !== null
+                                      ? data.indexValues[dataRowIndex]?.find(
+                                            (indexValue) =>
+                                                indexValue.type === 'label',
+                                        )?.fieldId
+                                      : undefined;
                                 let item = meta?.item;
 
                                 if (
                                     data.pivotConfig.metricsAsRows &&
-                                    isDataColumn
+                                    isDataColumn &&
+                                    metricFieldId
                                 ) {
-                                    const metricLabelInfo = data.indexValues[
-                                        rowIndex
-                                    ]?.find(
-                                        (indexValue) =>
-                                            indexValue.type === 'label',
-                                    );
-                                    if (metricLabelInfo) {
-                                        item = getField(
-                                            metricLabelInfo.fieldId,
-                                        );
-                                    }
-                                } else if (item && isDimension(item)) {
-                                    const underlyingId = data.indexValues[
-                                        rowIndex
-                                    ]?.find(
-                                        (indexValue) =>
-                                            indexValue.type === 'label',
-                                    )?.fieldId;
-                                    item = underlyingId
-                                        ? getField(underlyingId)
+                                    item = getField(metricFieldId);
+                                } else if (
+                                    item &&
+                                    isDimension(item) &&
+                                    dataRowIndex !== null
+                                ) {
+                                    item = metricFieldId
+                                        ? getField(metricFieldId)
                                         : item;
                                 }
 
                                 const fullValue =
                                     cell.getValue() as ResultRow[0];
-                                const value = fullValue?.value;
+                                const metricSubtotalValue =
+                                    isMetricSubtotal && isDataColumn
+                                        ? (() => {
+                                              const groupingMatch =
+                                                  getGroupingValuesAndSubtotalKey(
+                                                      cell.getContext(),
+                                                  );
+                                              if (!groupingMatch) return null;
+
+                                              const subtotal =
+                                                  findMatchingSubtotal(
+                                                      data.groupedSubtotals?.[
+                                                          groupingMatch
+                                                              .subtotalGroupKey
+                                                      ],
+                                                      groupingMatch.groupingValues,
+                                                      meta?.headerInfo ?? {},
+                                                  );
+                                              return getSubtotalValueFromGroup(
+                                                  subtotal,
+                                                  renderRow.metricFieldId,
+                                              );
+                                          })()
+                                        : null;
+                                const metricSubtotalResultValue:
+                                    | ResultValue
+                                    | undefined =
+                                    isMetricSubtotal &&
+                                    isDataColumn &&
+                                    metricSubtotalValue !== null
+                                        ? {
+                                              raw: metricSubtotalValue,
+                                              formatted: formatItemValue(
+                                                  item,
+                                                  metricSubtotalValue,
+                                                  false,
+                                                  parameters,
+                                              ),
+                                          }
+                                        : undefined;
+                                const metricSubtotalLabelValue:
+                                    | ResultValue
+                                    | undefined =
+                                    isMetricSubtotal && meta?.type === 'label'
+                                        ? {
+                                              raw: renderRow.metricFieldId,
+                                              formatted:
+                                                  getFieldLabel(
+                                                      renderRow.metricFieldId,
+                                                  ) ?? renderRow.metricFieldId,
+                                          }
+                                        : undefined;
+                                const value = isMetricSubtotal
+                                    ? isDataColumn
+                                        ? metricSubtotalResultValue
+                                        : meta?.type === 'label'
+                                          ? metricSubtotalLabelValue
+                                          : meta?.type === 'indexValue' &&
+                                              cell.getIsGrouped()
+                                            ? fullValue?.value
+                                            : undefined
+                                    : fullValue?.value;
 
                                 // In merge mode an empty pivot data cell renders
                                 // blank instead of the `∅`/`-` placeholder. An
@@ -1740,37 +1839,43 @@ const PivotTable: FC<PivotTableProps> = ({
                                 const currentHeaderInfo =
                                     cell.column.columnDef.meta?.headerInfo;
 
-                                const rowFieldsForCell = data.pivotConfig
-                                    .metricsAsRows
-                                    ? buildRowFieldsForMetricsAsRows(
-                                          rowIndex,
-                                          currentHeaderInfo,
-                                      )
-                                    : buildRowFieldsFromVisibleCells(
-                                          row,
-                                          currentHeaderInfo,
-                                      );
+                                const rowFieldsForCell = isMetricSubtotal
+                                    ? {}
+                                    : data.pivotConfig.metricsAsRows &&
+                                        dataRowIndex !== null
+                                      ? buildRowFieldsForMetricsAsRows(
+                                            dataRowIndex,
+                                            currentHeaderInfo,
+                                        )
+                                      : buildRowFieldsFromVisibleCells(
+                                            row,
+                                            currentHeaderInfo,
+                                        );
 
                                 const cellConditionalFormattingConfig =
-                                    getConditionalFormattingConfig({
-                                        field: item,
-                                        value: value?.raw,
-                                        minMaxMap,
-                                        conditionalFormattings,
-                                        rowFields: rowFieldsForCell,
-                                        applyTo:
-                                            ConditionalFormattingColorApplyTo.CELL,
-                                    });
+                                    isMetricSubtotal
+                                        ? undefined
+                                        : getConditionalFormattingConfig({
+                                              field: item,
+                                              value: value?.raw,
+                                              minMaxMap,
+                                              conditionalFormattings,
+                                              rowFields: rowFieldsForCell,
+                                              applyTo:
+                                                  ConditionalFormattingColorApplyTo.CELL,
+                                          });
                                 const textConditionalFormattingConfig =
-                                    getConditionalFormattingConfig({
-                                        field: item,
-                                        value: value?.raw,
-                                        minMaxMap,
-                                        conditionalFormattings,
-                                        rowFields: rowFieldsForCell,
-                                        applyTo:
-                                            ConditionalFormattingColorApplyTo.TEXT,
-                                    });
+                                    isMetricSubtotal
+                                        ? undefined
+                                        : getConditionalFormattingConfig({
+                                              field: item,
+                                              value: value?.raw,
+                                              minMaxMap,
+                                              conditionalFormattings,
+                                              rowFields: rowFieldsForCell,
+                                              applyTo:
+                                                  ConditionalFormattingColorApplyTo.TEXT,
+                                          });
 
                                 const cellConditionalFormattingResult =
                                     getConditionalFormattingColor({
@@ -1882,29 +1987,22 @@ const PivotTable: FC<PivotTableProps> = ({
                                 const labelFieldDescription = (() => {
                                     if (meta?.type !== 'label')
                                         return undefined;
-                                    const labelInfo = data.indexValues[
-                                        rowIndex
-                                    ]?.find(
-                                        (indexValue) =>
-                                            indexValue.type === 'label',
-                                    );
-                                    if (!labelInfo) return undefined;
-                                    const labelField = getField(
-                                        labelInfo.fieldId,
-                                    );
+                                    if (!metricFieldId) return undefined;
+                                    const labelField = getField(metricFieldId);
                                     return isField(labelField)
                                         ? labelField.description
                                         : undefined;
                                 })();
 
                                 const suppressContextMenu =
-                                    (value === undefined ||
+                                    isMetricSubtotal ||
+                                    ((value === undefined ||
                                         cell.getIsPlaceholder()) &&
-                                    !cell.getIsAggregated() &&
-                                    !cell.getIsGrouped();
-                                const allowInteractions = suppressContextMenu
-                                    ? undefined
-                                    : !!value?.formatted;
+                                        !cell.getIsAggregated() &&
+                                        !cell.getIsGrouped());
+                                const allowInteractions = !suppressContextMenu
+                                    ? !!value?.formatted
+                                    : undefined;
 
                                 const cellWidth = meta?.width;
 
@@ -1917,7 +2015,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                     : Table.Cell;
                                 return (
                                     <TableCellComponent
-                                        key={`value-${rowIndex}-${colIndex}-${data.pivotConfig.metricsAsRows}`}
+                                        key={cell.id}
                                         ref={measureRef}
                                         rowSpan={
                                             rowSpanMerge &&
@@ -1966,14 +2064,25 @@ const PivotTable: FC<PivotTableProps> = ({
                                         ) => (
                                             <ValueCellMenu
                                                 opened={isOpen}
-                                                rowIndex={rowIndex}
+                                                rowIndex={
+                                                    dataRowIndex ?? undefined
+                                                }
                                                 colIndex={colIndex}
                                                 item={item}
                                                 value={value}
                                                 getUnderlyingFieldValues={
-                                                    isRowTotal
+                                                    isRowTotal ||
+                                                    dataRowIndex === null
                                                         ? undefined
-                                                        : getUnderlyingFieldValues
+                                                        : (
+                                                              _rowIndex,
+                                                              targetColIndex,
+                                                          ) =>
+                                                              getUnderlyingFieldValues(
+                                                                  row,
+                                                                  dataRowIndex,
+                                                                  targetColIndex,
+                                                              )
                                                 }
                                                 onClose={onClose}
                                                 onCopy={onCopy}
@@ -1983,7 +2092,32 @@ const PivotTable: FC<PivotTableProps> = ({
                                             </ValueCellMenu>
                                         )}
                                     >
-                                        {cell.getIsGrouped() ? (
+                                        {isMetricSubtotal &&
+                                        meta?.type === 'label' ? (
+                                            <Text span fw={600}>
+                                                {getFieldLabel(
+                                                    renderRow.metricFieldId,
+                                                ) ?? renderRow.metricFieldId}
+                                            </Text>
+                                        ) : isMetricSubtotal && isDataColumn ? (
+                                            metricSubtotalValue === undefined &&
+                                            isSubtotalsLoading &&
+                                            isNumericItem(item) ? (
+                                                <Skeleton
+                                                    height={16}
+                                                    width="min(60%, 50px)"
+                                                    ml="auto"
+                                                />
+                                            ) : metricSubtotalValue ===
+                                              null ? null : (
+                                                <Text span fw={600}>
+                                                    {value?.formatted}
+                                                </Text>
+                                            )
+                                        ) : isMetricSubtotal &&
+                                          (isRowTotal ||
+                                              (meta?.type === 'indexValue' &&
+                                                  !cell.getIsGrouped())) ? null : cell.getIsGrouped() ? (
                                             // Grouping-only mode (row dedup
                                             // without subtotals): suppress the
                                             // carat + group count chrome and
@@ -1996,7 +2130,9 @@ const PivotTable: FC<PivotTableProps> = ({
                                                     cell.column.columnDef.cell,
                                                     cell.getContext(),
                                                 )
-                                            ) : (
+                                            ) : isMetricSubtotal &&
+                                              renderRow.metricIndex >
+                                                  0 ? null : (
                                                 <Group gap="two" wrap="nowrap">
                                                     <Button
                                                         size="compact-xs"
@@ -2042,7 +2178,13 @@ const PivotTable: FC<PivotTableProps> = ({
                                                                 'inherit',
                                                         }}
                                                     >
-                                                        ({countSubRows(row)})
+                                                        {`(${
+                                                            isMetricSubtotal
+                                                                ? renderRow.sourceRowCount
+                                                                : countSubRows(
+                                                                      row,
+                                                                  )
+                                                        })`}
                                                     </Button>
                                                     {flexRender(
                                                         cell.column.columnDef

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.test.ts
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { findMatchingSubtotal } from './getDataAndColumns';
+import {
+    findMatchingSubtotal,
+    getSubtotalValueFromGroup,
+} from './getDataAndColumns';
 
 const cell = (raw: unknown) => ({ value: { raw, formatted: String(raw) } });
 const headerValue = (raw: unknown) => ({ raw, formatted: String(raw) });
@@ -38,27 +41,47 @@ describe('findMatchingSubtotal', () => {
         expect(match).toBe(recs[0]);
     });
 
-    it('matches a pivoted header dimension value alongside the grouping value', () => {
+    it('matches multiple pivoted header values alongside the grouping value', () => {
         const recs = records(
             {
                 orders_order_date_month: '2018-01-01T00:00:00.000Z',
                 orders_status: 'completed',
+                payments_payment_method: 'card',
                 payments_total_revenue: 424,
             },
             {
                 orders_order_date_month: '2018-01-01T00:00:00.000Z',
                 orders_status: 'returned',
+                payments_payment_method: 'cash',
                 payments_total_revenue: 49,
+                payments_average_revenue: 12.25,
+                payments_null_metric: null,
             },
         );
 
         const match = findMatchingSubtotal(
             recs,
             { orders_order_date_month: cell('2018-01-01T00:00:00Z') },
-            { orders_status: headerValue('returned') },
+            {
+                orders_status: headerValue('returned'),
+                payments_payment_method: headerValue('cash'),
+            },
         );
 
         expect(match).toBe(recs[1]);
+        expect(getSubtotalValueFromGroup(match, 'payments_total_revenue')).toBe(
+            49,
+        );
+        expect(
+            getSubtotalValueFromGroup(match, 'payments_average_revenue'),
+        ).toBe(12.25);
+        expect(
+            getSubtotalValueFromGroup(match, 'payments_null_metric'),
+        ).toBeUndefined();
+        expect(getSubtotalValueFromGroup(match, 'row-total-0')).toBeNull();
+        expect(
+            getSubtotalValueFromGroup(undefined, 'payments_total_revenue'),
+        ).toBeUndefined();
     });
 
     it('returns undefined when no record matches', () => {

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -43,7 +43,7 @@ type Args = {
 };
 
 export function getGroupingValuesAndSubtotalKey(
-    info: CellContext<ResultRow, ResultRow[string]>,
+    info: Pick<CellContext<ResultRow, unknown>, 'row' | 'table'>,
 ) {
     const groupingDimensions = info.table
         .getState()

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -212,12 +212,12 @@ const useTableConfig = (
     const numUnpivotedDimensions =
         dimensions.length - (pivotDimensions?.length || 0);
 
-    const canUseSubtotals = useMemo(() => {
-        return !metricsAsRows && numUnpivotedDimensions > 1;
-    }, [metricsAsRows, numUnpivotedDimensions]);
+    const canUseSubtotals = useMemo(
+        () => numUnpivotedDimensions > 1,
+        [numUnpivotedDimensions],
+    );
 
-    // Once dimensions are loaded, if there are not enough dimensions to use subtotals then
-    // turn off "Show subtotals" so that "Show metrics as rows" can be enabled.
+    // Once dimensions are loaded, turn off subtotals if there are not enough dimensions.
     useEffect(() => {
         if (dimensions.length > 0 && numUnpivotedDimensions < 2)
             setShowSubtotals(false);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-1054
Closes: #18463

### Description:
Allows metrics-as-rows table charts to enable subtotals and subtotal expansion while retaining the existing dimension eligibility rules.
Projects each grouped row into an ordered, virtualized subtotal block for every visible metric and resolves warehouse-computed values without reusing leaf-row indexes.
Subtotal row numbers and row totals remain blank, and CSV/XLSX and scheduled exports remain unchanged.
Adds focused utility coverage for render-row projection and grouped subtotal lookup.


### Example with subtotals with 1 metric

<img width="3366" height="2012" alt="CleanShot 2026-07-22 at 14 38 35@2x" src="https://github.com/user-attachments/assets/676414ee-ad0e-4114-bdb8-a273923db856" />

### Example with subtotals with 2 metrics

<img width="3386" height="2018" alt="CleanShot 2026-07-22 at 14 37 48@2x" src="https://github.com/user-attachments/assets/4409c865-a27c-481e-8376-b3d1daa4983e" />


https://github.com/user-attachments/assets/aa418647-8b4e-4c21-acc2-8aea4723c534
