### PR TITLE
feat(backend): playground provisioning schema and unique onboarding rows

### DIFF
--- a/packages/backend/src/database/entities/onboarding.ts
+++ b/packages/backend/src/database/entities/onboarding.ts
@@ -5,15 +5,20 @@ type DbOnboarding = {
     organization_id: number;
     ranQuery_at: Date | null;
     shownSuccess_at: Date | null;
+    playground_project_deleted_at: Date | null;
 };
 
 type CreateDbOnboarding = Pick<
     DbOnboarding,
     'organization_id' | 'ranQuery_at' | 'shownSuccess_at'
->;
+> &
+    Partial<Pick<DbOnboarding, 'playground_project_deleted_at'>>;
 
 type UpdateDbOnboarding = Partial<
-    Pick<DbOnboarding, 'ranQuery_at' | 'shownSuccess_at'>
+    Pick<
+        DbOnboarding,
+        'ranQuery_at' | 'shownSuccess_at' | 'playground_project_deleted_at'
+    >
 >;
 
 export const OnboardingTableName = 'onboarding';

--- a/packages/backend/src/database/entities/projects.ts
+++ b/packages/backend/src/database/entities/projects.ts
@@ -41,6 +41,7 @@ export type DbProject = {
     expires_at: Date | null;
     default_preview_expiration_hours: number;
     max_preview_expiration_hours: number;
+    provisioning_source: string | null;
 };
 
 type CreateDbProject = Pick<
@@ -58,6 +59,7 @@ type CreateDbProject = Pick<
     scheduler_timezone?: string; // On create it will default to 'UTC' as per migration
     query_timezone?: string | null;
     use_project_timezone_in_filters?: boolean; // On create it will default to false as per migration
+    provisioning_source?: string | null;
 };
 type UpdateDbProject = Partial<
     Pick<
@@ -83,6 +85,7 @@ type UpdateDbProject = Partial<
         | 'expires_at'
         | 'default_preview_expiration_hours'
         | 'max_preview_expiration_hours'
+        | 'provisioning_source'
     >
 >;
 

--- a/packages/backend/src/database/migrations/20260720180000_add_playground_project_provisioning.ts
+++ b/packages/backend/src/database/migrations/20260720180000_add_playground_project_provisioning.ts
@@ -1,0 +1,21 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('projects', (table) => {
+        table.text('provisioning_source').nullable();
+    });
+    await knex.schema.alterTable('onboarding', (table) => {
+        table
+            .timestamp('playground_project_deleted_at', { useTz: false })
+            .nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('onboarding', (table) => {
+        table.dropColumn('playground_project_deleted_at');
+    });
+    await knex.schema.alterTable('projects', (table) => {
+        table.dropColumn('provisioning_source');
+    });
+}

--- a/packages/backend/src/database/migrations/20260720223000_unique_onboarding_organization.ts
+++ b/packages/backend/src/database/migrations/20260720223000_unique_onboarding_organization.ts
@@ -1,0 +1,120 @@
+import { Knex } from 'knex';
+
+const ONBOARDING_TABLE_NAME = 'onboarding';
+const ONBOARDING_ORGANIZATION_UNIQUE = 'onboarding_organization_id_unique';
+const MAX_UNIQUE_INDEX_ATTEMPTS = 3;
+
+// CREATE UNIQUE INDEX CONCURRENTLY cannot run inside a transaction, so every
+// step below must be safe to re-run.
+export const config = { transaction: false };
+
+async function constraintExists(knex: Knex): Promise<boolean> {
+    const result = await knex.raw(
+        `
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = ?::regclass
+          AND conname = ?
+    `,
+        [ONBOARDING_TABLE_NAME, ONBOARDING_ORGANIZATION_UNIQUE],
+    );
+    return result.rows.length > 0;
+}
+
+async function hasInvalidUniqueIndex(knex: Knex): Promise<boolean> {
+    const result = await knex.raw(
+        `
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE c.relname = ?
+          AND NOT i.indisvalid
+    `,
+        [ONBOARDING_ORGANIZATION_UNIQUE],
+    );
+    return result.rows.length > 0;
+}
+
+// All three timestamps are first-occurrence, so MIN keeps the true first
+// date while still preserving any non-NULL value a duplicate holds.
+async function mergeAndRemoveDuplicates(knex: Knex): Promise<void> {
+    await knex.raw(`
+        WITH merged_progress AS (
+            SELECT
+                organization_id,
+                MIN(onboarding_id) AS survivor_id,
+                MIN("ranQuery_at") AS "ranQuery_at",
+                MIN("shownSuccess_at") AS "shownSuccess_at",
+                MIN(playground_project_deleted_at) AS playground_project_deleted_at
+            FROM ${ONBOARDING_TABLE_NAME}
+            GROUP BY organization_id
+            HAVING COUNT(*) > 1
+        )
+        UPDATE ${ONBOARDING_TABLE_NAME} survivor
+        SET
+            "ranQuery_at" = merged_progress."ranQuery_at",
+            "shownSuccess_at" = merged_progress."shownSuccess_at",
+            playground_project_deleted_at = merged_progress.playground_project_deleted_at
+        FROM merged_progress
+        WHERE survivor.onboarding_id = merged_progress.survivor_id
+    `);
+    await knex.raw(`
+        DELETE FROM ${ONBOARDING_TABLE_NAME} duplicate
+        USING ${ONBOARDING_TABLE_NAME} original
+        WHERE duplicate.organization_id = original.organization_id
+          AND duplicate.onboarding_id > original.onboarding_id
+    `);
+}
+
+export async function up(knex: Knex): Promise<void> {
+    if (await constraintExists(knex)) {
+        return;
+    }
+    /* eslint-disable no-await-in-loop */
+    for (let attempt = 1; attempt <= MAX_UNIQUE_INDEX_ATTEMPTS; attempt += 1) {
+        // A failed CONCURRENTLY build leaves an INVALID index behind that
+        // IF NOT EXISTS would wrongly skip.
+        if (await hasInvalidUniqueIndex(knex)) {
+            await knex.raw(`DROP INDEX ${ONBOARDING_ORGANIZATION_UNIQUE}`);
+        }
+        await mergeAndRemoveDuplicates(knex);
+        try {
+            await knex.raw(`
+                CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ${ONBOARDING_ORGANIZATION_UNIQUE}
+                ON ${ONBOARDING_TABLE_NAME} (organization_id)
+            `);
+            break;
+        } catch (error) {
+            if (attempt === MAX_UNIQUE_INDEX_ATTEMPTS) {
+                throw error;
+            }
+        }
+    }
+    /* eslint-enable no-await-in-loop */
+    await knex.raw(`
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conrelid = '${ONBOARDING_TABLE_NAME}'::regclass
+                  AND conname = '${ONBOARDING_ORGANIZATION_UNIQUE}'
+            ) THEN
+                ALTER TABLE ${ONBOARDING_TABLE_NAME}
+                ADD CONSTRAINT ${ONBOARDING_ORGANIZATION_UNIQUE}
+                UNIQUE USING INDEX ${ONBOARDING_ORGANIZATION_UNIQUE};
+            END IF;
+        END
+        $$
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`
+        ALTER TABLE ${ONBOARDING_TABLE_NAME}
+        DROP CONSTRAINT IF EXISTS ${ONBOARDING_ORGANIZATION_UNIQUE}
+    `);
+    await knex.raw(`
+        DROP INDEX IF EXISTS ${ONBOARDING_ORGANIZATION_UNIQUE}
+    `);
+}

--- a/packages/backend/src/database/migrations/__tests__/20260720223000_unique_onboarding_organization.test.ts
+++ b/packages/backend/src/database/migrations/__tests__/20260720223000_unique_onboarding_organization.test.ts
@@ -1,0 +1,158 @@
+import knex from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import {
+    config,
+    down,
+    up,
+} from '../20260720223000_unique_onboarding_organization';
+
+const isConstraintCheck = ({ sql }: { sql: string }) =>
+    sql.includes('pg_constraint') && !sql.includes('DO $$');
+const isInvalidIndexCheck = ({ sql }: { sql: string }) =>
+    sql.includes('indisvalid');
+const isMerge = ({ sql }: { sql: string }) => sql.includes('merged_progress');
+const isDelete = ({ sql }: { sql: string }) =>
+    sql.includes('DELETE FROM onboarding duplicate');
+const isCreateIndex = ({ sql }: { sql: string }) =>
+    sql.includes('CREATE UNIQUE INDEX CONCURRENTLY');
+const isDropIndex = ({ sql }: { sql: string }) =>
+    sql.trim().startsWith('DROP INDEX');
+const isAddConstraint = ({ sql }: { sql: string }) =>
+    sql.includes('ADD CONSTRAINT');
+
+describe('unique onboarding organization migration', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('runs without a transaction so CONCURRENTLY is allowed', () => {
+        expect(config).toEqual({ transaction: false });
+    });
+
+    it('merges duplicates with MIN and builds the constraint concurrently', async () => {
+        tracker.on.any(isConstraintCheck).response({ rows: [] });
+        tracker.on.any(isInvalidIndexCheck).response({ rows: [] });
+        tracker.on.any(() => true).response({});
+
+        await up(database);
+
+        const statements = tracker.history.all.map(({ sql }) => sql);
+        expect(statements).toHaveLength(6);
+
+        const [
+            constraintCheck,
+            invalidIndexCheck,
+            merge,
+            removeDuplicates,
+            createIndex,
+            addConstraint,
+        ] = statements;
+        expect(constraintCheck).toContain('pg_constraint');
+        expect(invalidIndexCheck).toContain('indisvalid');
+        expect(merge).toContain('MIN(onboarding_id) AS survivor_id');
+        expect(merge).toContain('MIN("ranQuery_at") AS "ranQuery_at"');
+        expect(merge).toContain('MIN("shownSuccess_at") AS "shownSuccess_at"');
+        expect(merge).toContain(
+            'MIN(playground_project_deleted_at) AS playground_project_deleted_at',
+        );
+        expect(merge).not.toMatch(/MAX\s*\(/);
+        expect(removeDuplicates).toContain(
+            'duplicate.onboarding_id > original.onboarding_id',
+        );
+        expect(createIndex).toContain(
+            'CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS onboarding_organization_id_unique',
+        );
+        expect(addConstraint).toContain('IF NOT EXISTS');
+        expect(addConstraint).toContain(
+            'ADD CONSTRAINT onboarding_organization_id_unique',
+        );
+        expect(addConstraint).toContain(
+            'UNIQUE USING INDEX onboarding_organization_id_unique',
+        );
+    });
+
+    it('does nothing when the constraint already exists', async () => {
+        tracker.on.any(isConstraintCheck).response({ rows: [{ exists: 1 }] });
+        tracker.on.any(() => true).response({});
+
+        await up(database);
+
+        expect(tracker.history.all).toHaveLength(1);
+        expect(tracker.history.all[0].sql).toContain('pg_constraint');
+    });
+
+    it('drops invalid leftovers, re-dedupes, and retries a failed concurrent build', async () => {
+        tracker.on.any(isConstraintCheck).response({ rows: [] });
+        tracker.on
+            .any(isInvalidIndexCheck)
+            .responseOnce({ rows: [{ exists: 1 }] });
+        tracker.on
+            .any(isInvalidIndexCheck)
+            .responseOnce({ rows: [{ exists: 1 }] });
+        tracker.on.any(isInvalidIndexCheck).response({ rows: [] });
+        tracker.on
+            .any(isCreateIndex)
+            .simulateErrorOnce(
+                'could not create unique index "onboarding_organization_id_unique"',
+            );
+        tracker.on.any(() => true).response({});
+
+        await up(database);
+
+        const statements = tracker.history.all.map(({ sql }) => sql);
+        expect(statements.filter((sql) => isDropIndex({ sql }))).toHaveLength(
+            2,
+        );
+        expect(statements.filter((sql) => isMerge({ sql }))).toHaveLength(2);
+        expect(statements.filter((sql) => isDelete({ sql }))).toHaveLength(2);
+        expect(statements.filter((sql) => isCreateIndex({ sql }))).toHaveLength(
+            2,
+        );
+        expect(
+            statements.filter((sql) => isAddConstraint({ sql })),
+        ).toHaveLength(1);
+        expect(statements[statements.length - 1]).toContain('ADD CONSTRAINT');
+    });
+
+    it('gives up after repeated concurrent build failures', async () => {
+        tracker.on.any(isConstraintCheck).response({ rows: [] });
+        tracker.on.any(isInvalidIndexCheck).response({ rows: [] });
+        tracker.on
+            .any(isCreateIndex)
+            .simulateError('could not create unique index');
+        tracker.on.any(() => true).response({});
+
+        await expect(up(database)).rejects.toThrow(
+            'could not create unique index',
+        );
+
+        const statements = tracker.history.all.map(({ sql }) => sql);
+        expect(statements.filter((sql) => isCreateIndex({ sql }))).toHaveLength(
+            3,
+        );
+        expect(
+            statements.filter((sql) => isAddConstraint({ sql })),
+        ).toHaveLength(0);
+    });
+
+    it('drops the constraint and any leftover index idempotently', async () => {
+        tracker.on.any(() => true).response({});
+
+        await down(database);
+
+        expect(tracker.history.all).toHaveLength(2);
+        expect(tracker.history.all[0].sql).toContain(
+            'DROP CONSTRAINT IF EXISTS onboarding_organization_id_unique',
+        );
+        expect(tracker.history.all[1].sql).toContain(
+            'DROP INDEX IF EXISTS onboarding_organization_id_unique',
+        );
+    });
+});

--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -110,11 +110,14 @@ export async function seed(knex: Knex): Promise<void> {
             role: seedUserRole,
         });
 
-        await knex(OnboardingTableName).insert({
-            organization_id: organizationId,
-            ranQuery_at: new Date(),
-            shownSuccess_at: new Date(),
-        });
+        await knex(OnboardingTableName)
+            .insert({
+                organization_id: organizationId,
+                ranQuery_at: new Date(),
+                shownSuccess_at: new Date(),
+            })
+            .onConflict('organization_id')
+            .ignore();
 
         return { organizationId, user, organizationUuid };
     };


### PR DESCRIPTION
Stack 1/9 (bottom) of the playground-onboarding restructure — the content of #25830 + #25901 resliced into reviewable PRs; the stack's end state is byte-identical to the previously reviewed heads.

- Migration `20260720180000`: nullable `projects.provisioning_source` and `onboarding.playground_project_deleted_at`. No consumers yet.
- Migration `20260720223000`: merges duplicate `onboarding` rows per organization (MIN of the first-occurrence timestamps, so true first-completion dates survive), then adds a unique constraint built with `CREATE UNIQUE INDEX CONCURRENTLY` — runs outside a transaction, drops invalid leftover indexes from failed builds, retries, and attaches the constraint idempotently. The migration test covers merge semantics, idempotency, retry and give-up paths.
- The dev seed inserts onboarding rows with `onConflict('organization_id').ignore()` (needs the unique index — same slice on purpose).

These migrations are not feature-flag-gated and run on every deploy — that is why they sit at the bottom of the stack, isolated.

Linear: PROD-9131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWZc9bPFq2dnCVdXAxyZiu
