### PR TITLE
feat(backend): track playground provisioning through the project lifecycle

### DIFF
--- a/packages/backend/src/models/OnboardingModel/OnboardingModel.test.ts
+++ b/packages/backend/src/models/OnboardingModel/OnboardingModel.test.ts
@@ -33,10 +33,6 @@ describe('OnboardingModel', () => {
             shownSuccessAt: null,
             playgroundProjectDeletedAt: null,
         });
-
-        expect(tracker.history.insert[0].sql).toContain(
-            'on conflict ("organization_id") do nothing',
-        );
     });
 
     it('holds an organization advisory lock around playground provisioning', async () => {

--- a/packages/backend/src/models/OnboardingModel/OnboardingModel.test.ts
+++ b/packages/backend/src/models/OnboardingModel/OnboardingModel.test.ts
@@ -1,0 +1,61 @@
+import knex from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { OnboardingModel } from './OnboardingModel';
+
+describe('OnboardingModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new OnboardingModel({ database });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('creates an onboarding row atomically before selecting it', async () => {
+        tracker.on
+            .select('organizations')
+            .responseOnce([{ organization_id: 7 }]);
+        tracker.on.insert('onboarding').responseOnce([]);
+        tracker.on.select('onboarding').responseOnce({
+            ranQuery_at: null,
+            shownSuccess_at: null,
+            playground_project_deleted_at: null,
+        });
+
+        await expect(
+            model.getByOrganizationUuid('organization-uuid'),
+        ).resolves.toEqual({
+            ranQueryAt: null,
+            shownSuccessAt: null,
+            playgroundProjectDeletedAt: null,
+        });
+
+        expect(tracker.history.insert[0].sql).toContain(
+            'on conflict ("organization_id") do nothing',
+        );
+    });
+
+    it('holds an organization advisory lock around playground provisioning', async () => {
+        tracker.on.select('organizations').responseOnce({ organization_id: 7 });
+        tracker.on.select('pg_advisory_xact_lock').responseOnce({});
+        const callback = vi.fn(async () => 'result');
+        const typedCallback = vi.mocked(callback);
+
+        await expect(
+            model.runInPlaygroundProvisioningLock(
+                'organization-uuid',
+                typedCallback,
+            ),
+        ).resolves.toBe('result');
+
+        const lockQuery = tracker.history.select.find(({ sql }) =>
+            sql.includes('pg_advisory_xact_lock'),
+        );
+        expect(lockQuery?.bindings).toEqual([19350428, 7]);
+        expect(typedCallback).toHaveBeenCalledWith(expect.any(Function));
+    });
+});

--- a/packages/backend/src/models/OnboardingModel/OnboardingModel.ts
+++ b/packages/backend/src/models/OnboardingModel/OnboardingModel.ts
@@ -7,6 +7,8 @@ type OnboardingModelArguments = {
     database: Knex;
 };
 
+const PLAYGROUND_PROVISIONING_LOCK_NAMESPACE = 19350428;
+
 export class OnboardingModel {
     private database: Knex;
 
@@ -14,51 +16,85 @@ export class OnboardingModel {
         this.database = args.database;
     }
 
+    async runInPlaygroundProvisioningLock<T>(
+        organizationUuid: string,
+        callback: (trx: Knex.Transaction) => Promise<T>,
+    ): Promise<T> {
+        return this.database.transaction(async (trx) => {
+            const organization = await trx(OrganizationTableName)
+                .where('organization_uuid', organizationUuid)
+                .select('organization_id')
+                .first();
+            if (!organization) {
+                throw new NotFoundError('Cannot find organization');
+            }
+
+            await trx.raw('SELECT pg_advisory_xact_lock(?, ?)', [
+                PLAYGROUND_PROVISIONING_LOCK_NAMESPACE,
+                organization.organization_id,
+            ]);
+            return callback(trx);
+        });
+    }
+
     async getByOrganizationUuid(
         organizationUuid: string,
+        transaction?: Knex.Transaction,
     ): Promise<OnbordingRecord> {
-        const orgs = await this.database(OrganizationTableName)
+        const database = transaction ?? this.database;
+        const orgs = await database(OrganizationTableName)
             .where('organization_uuid', organizationUuid)
             .select('organization_id');
         if (orgs.length === 0) {
             throw new NotFoundError('Cannot find organization');
         }
-        const onboardings = await this.database(OnboardingTableName)
-            .select('shownSuccess_at', 'ranQuery_at')
-            .where('organization_id', orgs[0].organization_id)
-            .limit(1);
-        if (onboardings.length === 0) {
-            await this.database(OnboardingTableName).insert({
+        await database(OnboardingTableName)
+            .insert({
                 organization_id: orgs[0].organization_id,
                 ranQuery_at: null,
                 shownSuccess_at: null,
-            });
-            return {
-                ranQueryAt: null,
-                shownSuccessAt: null,
-            };
+                playground_project_deleted_at: null,
+            })
+            .onConflict('organization_id')
+            .ignore();
+        const onboarding = await database(OnboardingTableName)
+            .select(
+                'shownSuccess_at',
+                'ranQuery_at',
+                'playground_project_deleted_at',
+            )
+            .where('organization_id', orgs[0].organization_id)
+            .first();
+        if (!onboarding) {
+            throw new NotFoundError('Cannot find onboarding');
         }
+
         return {
-            ranQueryAt: onboardings[0].ranQuery_at,
-            shownSuccessAt: onboardings[0].shownSuccess_at,
+            ranQueryAt: onboarding.ranQuery_at,
+            shownSuccessAt: onboarding.shownSuccess_at,
+            playgroundProjectDeletedAt:
+                onboarding.playground_project_deleted_at,
         };
     }
 
     async update(
         organizationUuid: string,
         data: Partial<OnbordingRecord>,
+        transaction?: Knex.Transaction,
     ): Promise<void> {
-        const orgs = await this.database(OrganizationTableName)
+        const database = transaction ?? this.database;
+        const orgs = await database(OrganizationTableName)
             .where('organization_uuid', organizationUuid)
             .select('organization_id');
         if (orgs.length === 0) {
             throw new NotFoundError('Cannot find organization');
         }
 
-        await this.database(OnboardingTableName)
+        await database(OnboardingTableName)
             .update({
                 ranQuery_at: data.ranQueryAt,
                 shownSuccess_at: data.shownSuccessAt,
+                playground_project_deleted_at: data.playgroundProjectDeletedAt,
             })
             .where('organization_id', orgs[0].organization_id);
     }

--- a/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
@@ -119,6 +119,7 @@ export const expectedProject: Project = {
     hasDefaultUserSpaces: false,
     colorPaletteUuid: null,
     expiresAt: null,
+    provisioningSource: null,
 };
 
 const metricFilter: MetricFilterRule = {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -426,6 +426,7 @@ export class ProjectModel {
                 `projects.copied_from_project_uuid`,
                 `projects.created_by_user_uuid`,
                 'projects.expires_at',
+                'projects.provisioning_source',
                 `${WarehouseCredentialTableName}.warehouse_type`,
                 this.database.raw(
                     "TRIM(CONCAT(users.first_name, ' ', users.last_name)) as created_by_user_name",
@@ -467,6 +468,7 @@ export class ProjectModel {
                 copied_from_project_uuid,
                 warehouse_type,
                 expires_at,
+                provisioning_source,
             }) => ({
                 name,
                 projectUuid: project_uuid,
@@ -480,8 +482,18 @@ export class ProjectModel {
                         ? (warehouse_type as WarehouseTypes)
                         : undefined,
                 expiresAt: expires_at ?? null,
+                provisioningSource: provisioning_source ?? null,
             }),
         );
+    }
+
+    async setProvisioningSource(
+        projectUuid: string,
+        provisioningSource: string,
+    ): Promise<void> {
+        await this.database('projects')
+            .where('project_uuid', projectUuid)
+            .update({ provisioning_source: provisioningSource });
     }
 
     private async upsertWarehouseConnection(
@@ -563,6 +575,7 @@ export class ProjectModel {
         organizationUuid: string,
         data: CreateProjectOptionalCredentials,
         expiresAt?: Date | null,
+        provisioningSource?: string,
     ): Promise<string> {
         const orgs = await this.database('organizations')
             .where('organization_uuid', organizationUuid)
@@ -611,6 +624,7 @@ export class ProjectModel {
                     created_by_user_uuid: userUuid,
                     organization_warehouse_credentials_uuid:
                         data.organizationWarehouseCredentialsUuid ?? null,
+                    provisioning_source: provisioningSource ?? null,
                     ...(expiresAt !== undefined
                         ? { expires_at: expiresAt }
                         : {}),
@@ -816,11 +830,14 @@ export class ProjectModel {
         }));
     }
 
-    async delete(projectUuid: string): Promise<void> {
+    async delete(
+        projectUuid: string,
+        transaction?: Transaction,
+    ): Promise<void> {
         // Invalidate warehouse credentials cache
         warehouseCredentialsCache?.del(projectUuid);
 
-        await this.database.transaction(async (trx) => {
+        const deleteInTransaction = async (trx: Transaction): Promise<void> => {
             const [project] = await trx('projects')
                 .select('project_id')
                 .where('project_uuid', projectUuid);
@@ -851,7 +868,13 @@ export class ProjectModel {
 
             // Finally, delete the project and everything else in cascade
             await trx('projects').where('project_uuid', projectUuid).delete();
-        });
+        };
+
+        if (transaction) {
+            await deleteInTransaction(transaction);
+        } else {
+            await this.database.transaction(deleteInTransaction);
+        }
     }
 
     async getWithSensitiveFields(
@@ -880,6 +903,7 @@ export class ProjectModel {
                   project_defaults: ProjectDefaults | null;
                   color_palette_uuid: string | null;
                   expires_at: Date | null;
+                  provisioning_source: string | null;
               }
             | {
                   name: string;
@@ -903,6 +927,7 @@ export class ProjectModel {
                   project_defaults: ProjectDefaults | null;
                   color_palette_uuid: string | null;
                   expires_at: Date | null;
+                  provisioning_source: string | null;
               }
         )[];
         return wrapSentryTransaction(
@@ -987,6 +1012,9 @@ export class ProjectModel {
                         this.database
                             .ref('expires_at')
                             .withSchema(ProjectTableName),
+                        this.database
+                            .ref('provisioning_source')
+                            .withSchema(ProjectTableName),
                     ])
                     .select<QueryResult>()
                     .where('projects.project_uuid', projectUuid);
@@ -1039,6 +1067,7 @@ export class ProjectModel {
                     projectDefaults: project.project_defaults ?? undefined,
                     colorPaletteUuid: project.color_palette_uuid ?? null,
                     expiresAt: project.expires_at ?? null,
+                    provisioningSource: project.provisioning_source ?? null,
                 };
 
                 // If project uses organization warehouse credentials, load them
@@ -1095,6 +1124,7 @@ export class ProjectModel {
                     | 'project_type'
                     | 'copied_from_project_uuid'
                     | 'created_by_user_uuid'
+                    | 'provisioning_source'
                 > &
                     Pick<DbOrganization, 'organization_uuid'>
             >([
@@ -1104,6 +1134,7 @@ export class ProjectModel {
                 `${ProjectTableName}.copied_from_project_uuid`,
                 `${ProjectTableName}.project_type`,
                 `${ProjectTableName}.created_by_user_uuid`,
+                `${ProjectTableName}.provisioning_source`,
             ])
             .where('projects.project_uuid', projectUuid)
             .first();
@@ -1119,6 +1150,7 @@ export class ProjectModel {
             type: project.project_type,
             upstreamProjectUuid: project.copied_from_project_uuid || undefined,
             createdByUserUuid: project.created_by_user_uuid,
+            provisioningSource: project.provisioning_source,
         };
     }
 
@@ -1268,6 +1300,7 @@ export class ProjectModel {
             projectDefaults: project.projectDefaults,
             colorPaletteUuid: project.colorPaletteUuid ?? null,
             expiresAt: project.expiresAt,
+            provisioningSource: project.provisioningSource ?? null,
         };
     }
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -755,6 +755,39 @@ describe('AsyncQueryService', () => {
             );
         });
 
+        test('marks playground queries for exclusion from the usage event stream', async () => {
+            projectModel.getSummary.mockResolvedValueOnce({
+                ...projectSummary,
+                provisioningSource: 'playground',
+            });
+            (
+                serviceWithCache.queryHistoryModel
+                    .create as import('vitest').Mock
+            ).mockResolvedValue({ queryUuid: 'test-query-uuid' });
+            const runAsyncWarehouseQuerySpy = vi
+                .spyOn(serviceWithCache, 'runAsyncWarehouseQuery')
+                .mockResolvedValue(undefined);
+
+            await serviceWithCache['executeAsyncQuery'](
+                {
+                    account: sessionAccount,
+                    projectUuid,
+                    context: QueryExecutionContext.EXPLORE,
+                    queryTags: {
+                        query_context: QueryExecutionContext.EXPLORE,
+                    },
+                    invalidateCache: false,
+                    queryComposer: createQueryComposerMock(),
+                    warehouseCredentials: warehouseCredentialsMock,
+                },
+                { query: metricQueryMock },
+            );
+
+            expect(runAsyncWarehouseQuerySpy).toHaveBeenCalledWith(
+                expect.objectContaining({ isPreviewProject: true }),
+            );
+        });
+
         // Regression: persisted metric_query.timezone must follow the gated
         // displayTimezone, not the ungated resolvedTimezone — otherwise
         // downstream readers (formatTimestamp, downloads, worker re-exec)

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3080,7 +3080,9 @@ export class AsyncQueryService extends ProjectService {
         const warehouseCredentialsOverrides =
             await this.deriveWarehouseCredentialsOverrides(query);
         const displayTimezone = query.metricQuery.timezone ?? null;
-        const isPreviewProject = await this.isProjectPreview(query.projectUuid);
+        const isPreviewProject = await this.isExcludedFromUsage(
+            query.projectUuid,
+        );
         const onboardingFlow = await this.getOnboardingFlow({
             userUuid: actor.userUuid,
             organizationUuid: query.organizationUuid,
@@ -3107,12 +3109,18 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
-    private async isProjectPreview(
+    // Preview and sample-data queries are both kept out of the usage event
+    // stream. Every path that reports usage has to agree, or the numbers are
+    // silently inconsistent rather than uniformly excluded.
+    private async isExcludedFromUsage(
         projectUuid: string | null,
     ): Promise<boolean> {
         if (!projectUuid) return false;
         const summary = await this.projectModel.getSummary(projectUuid);
-        return summary.type === ProjectType.PREVIEW;
+        return (
+            summary.type === ProjectType.PREVIEW ||
+            summary.provisioningSource === 'playground'
+        );
     }
 
     private async buildPreAggregateQueryArgs(
@@ -3133,7 +3141,9 @@ export class AsyncQueryService extends ProjectService {
         const warehouseCredentialsOverrides =
             await this.deriveWarehouseCredentialsOverrides(query);
         const displayTimezone = query.metricQuery.timezone ?? null;
-        const isPreviewProject = await this.isProjectPreview(query.projectUuid);
+        const isPreviewProject = await this.isExcludedFromUsage(
+            query.projectUuid,
+        );
         const onboardingFlow = await this.getOnboardingFlow({
             userUuid: actor.userUuid,
             organizationUuid: query.organizationUuid,
@@ -4238,8 +4248,12 @@ export class AsyncQueryService extends ProjectService {
         );
         const organizationUuid =
             args.organizationUuid ?? projectSummary.organizationUuid;
-        // Preview project queries are excluded from the usage event stream
-        const isPreviewProject = projectSummary.type === ProjectType.PREVIEW;
+        // Preview and sample-data queries are excluded from the usage event
+        // stream while the query.completed product analytics event is retained.
+        const isPreviewProject =
+            projectSummary.type === ProjectType.PREVIEW ||
+            projectSummary.provisioningSource === 'playground';
+
         const exploreName = args.queryComposer.getExplore().name;
         const auditedAbility = this.createAuditedAbility(args.account);
         const isForbidden =
@@ -6702,7 +6716,8 @@ export class AsyncQueryService extends ProjectService {
                 {
                     account,
                     projectUuid,
-                    isPreviewProject: await this.isProjectPreview(projectUuid),
+                    isPreviewProject:
+                        await this.isExcludedFromUsage(projectUuid),
                     context,
                     queryTags: queryTagsWithUserAttributes,
                     invalidateCache,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -214,6 +214,13 @@ const onboardingModel = {
         ranQueryAt: new Date(),
         shownSuccessAt: new Date(),
     })),
+    update: vi.fn(async () => undefined),
+    runInPlaygroundProvisioningLock: vi.fn(
+        async (
+            _organizationUuid: string,
+            callback: (transaction: object) => Promise<unknown>,
+        ) => callback({}),
+    ),
 };
 const savedChartModel = {
     getAllSpaces: vi.fn(async () => spacesWithSavedCharts),
@@ -492,6 +499,44 @@ describe('ProjectService', () => {
             copyAccessSpy.mockRestore();
             copyContentSpy.mockRestore();
         }
+    });
+
+    test('deletes a playground and records its tombstone in the provisioning lock transaction', async () => {
+        const transaction = {};
+        const deletingUser = {
+            ...user,
+            ability: new Ability<PossibleAbilities>([
+                { subject: 'Project', action: 'delete' },
+            ]),
+        };
+        projectModel.getWithSensitiveFields.mockResolvedValueOnce({
+            ...projectWithSensitiveFields,
+            provisioningSource: 'playground',
+        });
+        onboardingModel.runInPlaygroundProvisioningLock.mockImplementationOnce(
+            async (_organizationUuid, callback) => callback(transaction),
+        );
+
+        await service.delete(projectUuid, deletingUser);
+
+        expect(
+            onboardingModel.runInPlaygroundProvisioningLock,
+        ).toHaveBeenCalledWith(
+            projectWithSensitiveFields.organizationUuid,
+            expect.any(Function),
+        );
+        expect(onboardingModel.update).toHaveBeenCalledWith(
+            projectWithSensitiveFields.organizationUuid,
+            { playgroundProjectDeletedAt: expect.any(Date) },
+            transaction,
+        );
+        expect(projectModel.delete).toHaveBeenCalledWith(
+            projectUuid,
+            transaction,
+        );
+        expect(onboardingModel.update.mock.invocationCallOrder[0]).toBeLessThan(
+            projectModel.delete.mock.invocationCallOrder[0],
+        );
     });
 
     describe('refreshTablesAndProjectConfig for a CLI/NONE preview', () => {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2333,6 +2333,7 @@ export class ProjectService extends BaseService {
         user: SessionUser,
         data: CreateProjectOptionalCredentials,
         method: RequestMethod,
+        internalProvisioning?: { source: 'playground' },
     ): Promise<ApiCreateProjectResults> {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
@@ -2404,6 +2405,7 @@ export class ProjectService extends BaseService {
                     createProject.upstreamProjectUuid,
                     createProject.expiresInHours,
                 ),
+                internalProvisioning?.source,
             );
 
         const onboardingFlow = await this.getOnboardingFlow(user);
@@ -3810,7 +3812,25 @@ export class ProjectService extends BaseService {
             );
         }
 
-        await this.projectModel.delete(projectUuid);
+        if (project.provisioningSource === 'playground') {
+            await this.onboardingModel.runInPlaygroundProvisioningLock(
+                project.organizationUuid,
+                async (trx) => {
+                    await this.onboardingModel.getByOrganizationUuid(
+                        project.organizationUuid,
+                        trx,
+                    );
+                    await this.onboardingModel.update(
+                        project.organizationUuid,
+                        { playgroundProjectDeletedAt: new Date() },
+                        trx,
+                    );
+                    await this.projectModel.delete(projectUuid, trx);
+                },
+            );
+        } else {
+            await this.projectModel.delete(projectUuid);
+        }
 
         this.analytics.track({
             event: 'project.deleted',

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -760,6 +760,7 @@ export type CreateProject = Omit<
     | 'hasDefaultUserSpaces'
     | 'colorPaletteUuid'
     | 'expiresAt'
+    | 'provisioningSource'
 > & {
     warehouseConnection: CreateWarehouseCredentials;
     copyWarehouseConnectionFromUpstreamProject?: boolean;

--- a/packages/common/src/types/organization.ts
+++ b/packages/common/src/types/organization.ts
@@ -89,6 +89,7 @@ export type OrganizationProject = {
     upstreamProjectUuid: string | null;
     warehouseType?: WarehouseTypes;
     expiresAt: Date | null;
+    provisioningSource?: string | null;
 };
 
 /**
@@ -102,6 +103,7 @@ export type ApiOrganizationProjects = {
 export type OnbordingRecord = {
     ranQueryAt: Date | null;
     shownSuccessAt: Date | null;
+    playgroundProjectDeletedAt?: Date | null;
 };
 
 export type OnboardingStatus = {

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -1097,6 +1097,7 @@ export type Project = {
     projectDefaults?: ProjectDefaults;
     colorPaletteUuid: string | null;
     expiresAt: Date | null;
+    provisioningSource?: string | null;
 };
 
 export type ProjectSummary = Pick<
@@ -1107,6 +1108,7 @@ export type ProjectSummary = Pick<
     | 'type'
     | 'upstreamProjectUuid'
     | 'createdByUserUuid'
+    | 'provisioningSource'
 >;
 
 export type ApiProjectResponse = {


### PR DESCRIPTION
Stack 2/9. Threads `provisioning_source` through the backend and adds the serialization primitives the provisioner (stack 5/9) will use. Inert until then.

- `OnboardingModel.runInPlaygroundProvisioningLock`: per-org `pg_advisory_xact_lock` transaction helper; reads/updates become transaction-aware and include `playgroundProjectDeletedAt`.
- `ProjectModel`: `provisioning_source` on summary/get/create/org-projects list; `delete()` can join an external transaction; `setProvisioningSource`.
- `ProjectService`: deleting a playground-sourced project runs under the lock and records the deletion tombstone; `createWithoutCompile` accepts an internal-only provisioning source.
- `AsyncQueryService`: playground queries are excluded from the usage event stream alongside preview projects (`isExcludedFromUsage` — every usage-reporting path agrees).
- Common types: `provisioningSource` on `Project`/`ProjectSummary`/`OrganizationProject`; `playgroundProjectDeletedAt` on the onboarding record.

Linear: PROD-9132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWZc9bPFq2dnCVdXAxyZiu
