### PR TITLE
feat(backend): playground project provisioning service and endpoint

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -830,6 +830,16 @@ type OnboardingHomepageProvisionedEvent = BaseTrack & {
     };
 };
 
+type PlaygroundProjectProvisionedEvent = BaseTrack & {
+    event: 'playground_project.provisioned';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        trigger: 'invite_expert';
+    };
+};
+
 type ProjectDeletedEvent = BaseTrack & {
     event: 'project.deleted';
     userId: string;
@@ -2692,6 +2702,7 @@ type TypedEvent =
     | ApiErrorEvent
     | ProjectEvent
     | OnboardingHomepageProvisionedEvent
+    | PlaygroundProjectProvisionedEvent
     | ProjectDeletedEvent
     | ProjectCompiledEvent
     | UpdatedDashboardEvent

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -1,8 +1,10 @@
+import { subject } from '@casl/ability';
 import {
     ApiColorPaletteResponse,
     ApiColorPalettesResponse,
     ApiCreatedColorPaletteResponse,
     ApiCreateGroupResponse,
+    ApiEnsurePlaygroundProjectResponse,
     ApiErrorPayload,
     ApiGroupListResponse,
     ApiImpersonationOrganizationSettingsResponse,
@@ -19,6 +21,7 @@ import {
     CreateColorPalette,
     CreateGroup,
     CreateOrganization,
+    ForbiddenError,
     getRequestMethod,
     KnexPaginateArgs,
     LightdashRequestMethodHeader,
@@ -777,6 +780,43 @@ export class OrganizationController extends BaseController {
         return {
             status: 'ok',
             results,
+        };
+    }
+
+    /**
+     * Return the organization's existing project or provision its sample-data
+     * playground when the new onboarding flow is available.
+     * @summary Ensure playground project
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @Post('/playground-projects/ensure')
+    @OperationId('EnsurePlaygroundProject')
+    async ensurePlaygroundProject(
+        @Request() req: express.Request,
+    ): Promise<ApiEnsurePlaygroundProjectResponse> {
+        assertRegisteredAccount(req.account);
+        const user = toSessionUser(req.account);
+        if (
+            user.ability.cannot(
+                'create',
+                subject('InviteLink', {
+                    organizationUuid: user.organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'User does not have permission to create invite links',
+            );
+        }
+        return {
+            status: 'ok',
+            results: await this.services
+                .getProjectService()
+                .ensurePlaygroundProject(user),
         };
     }
 

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -1,4 +1,3 @@
-import { subject } from '@casl/ability';
 import {
     ApiColorPaletteResponse,
     ApiColorPalettesResponse,
@@ -21,7 +20,6 @@ import {
     CreateColorPalette,
     CreateGroup,
     CreateOrganization,
-    ForbiddenError,
     getRequestMethod,
     KnexPaginateArgs,
     LightdashRequestMethodHeader,
@@ -800,18 +798,6 @@ export class OrganizationController extends BaseController {
     ): Promise<ApiEnsurePlaygroundProjectResponse> {
         assertRegisteredAccount(req.account);
         const user = toSessionUser(req.account);
-        if (
-            user.ability.cannot(
-                'create',
-                subject('InviteLink', {
-                    organizationUuid: user.organizationUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'User does not have permission to create invite links',
-            );
-        }
         return {
             status: 'ok',
             results: await this.services

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -90,6 +90,7 @@ import { PreviewDeploySetupService } from './services/PreviewDeploySetupService/
 import { ProjectContextService } from './services/ProjectContextService/ProjectContextService';
 import { ProjectHomepageService } from './services/ProjectHomepageService';
 import { provisionOnboardingHomepage } from './services/ProjectService/provisionOnboardingHomepage';
+import { provisionPlaygroundProject } from './services/ProjectService/provisionPlaygroundProject';
 import { SchedulerAiAugmentationService } from './services/SchedulerAiAugmentationService/SchedulerAiAugmentationService';
 import { ScimService } from './services/ScimService/ScimService';
 import { ServiceAccountService } from './services/ServiceAccountService/ServiceAccountService';
@@ -741,6 +742,22 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                             projectModel: models.getProjectModel(),
                             projectHomepageModel:
                                 models.getProjectHomepageModel<ProjectHomepageModel>(),
+                            analytics: context.lightdashAnalytics,
+                        }),
+                    provisionPlaygroundProject: ({
+                        user,
+                        projectService,
+                        canViewProject,
+                    }) =>
+                        provisionPlaygroundProject({
+                            user,
+                            projectService,
+                            canViewProject,
+                            featureFlagService:
+                                repository.getFeatureFlagService(),
+                            projectModel: models.getProjectModel(),
+                            onboardingModel: models.getOnboardingModel(),
+                            catalogService: repository.getCatalogService(),
                             analytics: context.lightdashAnalytics,
                         }),
                 }),

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.test.ts
@@ -1,0 +1,282 @@
+import { Ability } from '@casl/ability';
+import {
+    FeatureFlags,
+    OrganizationMemberRole,
+    ProjectType,
+    type OrganizationProject,
+    type PossibleAbilities,
+    type SessionUser,
+} from '@lightdash/common';
+import path from 'path';
+import {
+    provisionPlaygroundProject,
+    type ProvisionPlaygroundProjectArguments,
+} from './provisionPlaygroundProject';
+
+const organizationUuid = '00000000-0000-0000-0000-000000000001';
+const projectUuid = '00000000-0000-0000-0000-000000000002';
+const now = new Date('2026-07-20T00:00:00Z');
+const user = {
+    userUuid: '00000000-0000-0000-0000-000000000003',
+    organizationUuid,
+    organizationName: 'Organization',
+    organizationCreatedAt: now,
+    email: 'admin@example.com',
+    firstName: 'Admin',
+    lastName: 'User',
+    userId: 1,
+    role: OrganizationMemberRole.ADMIN,
+    ability: new Ability<PossibleAbilities>([
+        { action: 'view', subject: 'Project' },
+    ]),
+    abilityRules: [],
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    avatarUrl: null,
+    avatarGradient: null,
+    isSetupComplete: true,
+    isActive: true,
+    createdAt: now,
+    updatedAt: now,
+    timezone: null,
+} satisfies SessionUser;
+
+const project = (source: string | null = null): OrganizationProject => ({
+    projectUuid,
+    name: 'Project',
+    type: ProjectType.DEFAULT,
+    provisioningSource: source,
+    createdByUserUuid: user.userUuid,
+    createdByUserName: 'Admin User',
+    createdAt: now,
+    upstreamProjectUuid: null,
+    expiresAt: null,
+});
+
+const buildArguments = () => {
+    const get = vi.fn(async () => ({
+        id: FeatureFlags.NewOnboarding,
+        enabled: true,
+    }));
+    const getAllByOrganizationUuid = vi.fn(
+        async () => [] as OrganizationProject[],
+    );
+    const deleteProject = vi.fn(async () => undefined);
+    const saveExploresToCache = vi.fn(async () => ({ cachedExploreUuids: [] }));
+    const validatePlaygroundDatabase = vi.fn(async () => undefined);
+    const canViewProject = vi.fn(() => true);
+    const indexCatalog = vi.fn(async () => ({
+        catalogInserts: [],
+        catalogFieldMap: {},
+        numberOfCategoriesApplied: 0,
+    }));
+    const getByOrganizationUuid = vi.fn(async () => ({
+        ranQueryAt: null,
+        shownSuccessAt: null,
+        playgroundProjectDeletedAt: null,
+    }));
+    const onboardingModel = {
+        getByOrganizationUuid,
+        runInPlaygroundProvisioningLock: vi.fn(
+            async (_organizationUuid, callback) => callback({} as never),
+        ),
+    } satisfies ProvisionPlaygroundProjectArguments['onboardingModel'];
+    const runInPlaygroundProvisioningLock = vi.mocked(
+        onboardingModel.runInPlaygroundProvisioningLock,
+    );
+    const createWithoutCompile = vi.fn(async () => ({
+        project: { projectUuid },
+        hasContentCopy: false,
+    })) as unknown as ProvisionPlaygroundProjectArguments['projectService']['createWithoutCompile'];
+    const track = vi.fn();
+    return {
+        args: {
+            user,
+            featureFlagService: { get },
+            projectModel: {
+                getAllByOrganizationUuid,
+                delete: deleteProject,
+                saveExploresToCache,
+            },
+            onboardingModel,
+            projectService: { createWithoutCompile },
+            catalogService: { indexCatalog },
+            analytics: { track },
+            canViewProject,
+            playgroundDataDirectory: path.resolve(
+                __dirname,
+                '../../../../assets/playground',
+            ),
+            validatePlaygroundDatabase,
+        } satisfies ProvisionPlaygroundProjectArguments,
+        get,
+        getAllByOrganizationUuid,
+        deleteProject,
+        saveExploresToCache,
+        validatePlaygroundDatabase,
+        canViewProject,
+        indexCatalog,
+        createWithoutCompile,
+        runInPlaygroundProvisioningLock,
+        track,
+    };
+};
+
+describe('provisionPlaygroundProject', () => {
+    it('rejects when the new onboarding flag is disabled', async () => {
+        const mocks = buildArguments();
+        mocks.get.mockResolvedValue({
+            id: FeatureFlags.NewOnboarding,
+            enabled: false,
+        });
+        await expect(provisionPlaygroundProject(mocks.args)).rejects.toThrow(
+            'Playground projects are not available',
+        );
+        expect(mocks.getAllByOrganizationUuid).not.toHaveBeenCalled();
+    });
+
+    it('repairs an existing playground cache idempotently', async () => {
+        const mocks = buildArguments();
+        mocks.getAllByOrganizationUuid.mockResolvedValue([
+            project('playground'),
+        ]);
+        await expect(provisionPlaygroundProject(mocks.args)).resolves.toEqual({
+            projectUuid,
+            created: false,
+        });
+        expect(mocks.createWithoutCompile).not.toHaveBeenCalled();
+        expect(mocks.saveExploresToCache).toHaveBeenCalledWith(
+            projectUuid,
+            expect.any(Array),
+        );
+    });
+
+    it('returns an existing real project without creating a playground', async () => {
+        const mocks = buildArguments();
+        mocks.getAllByOrganizationUuid.mockResolvedValue([project()]);
+        await expect(provisionPlaygroundProject(mocks.args)).resolves.toEqual({
+            projectUuid,
+            created: false,
+        });
+        expect(mocks.createWithoutCompile).not.toHaveBeenCalled();
+    });
+
+    it('does not disclose an existing project the user cannot view', async () => {
+        const mocks = buildArguments();
+        mocks.getAllByOrganizationUuid.mockResolvedValue([project()]);
+
+        mocks.canViewProject.mockReturnValue(false);
+
+        await expect(provisionPlaygroundProject(mocks.args)).rejects.toThrow(
+            'User does not have permission to view an existing project',
+        );
+        expect(mocks.createWithoutCompile).not.toHaveBeenCalled();
+    });
+
+    it('creates the playground and caches bundled explores', async () => {
+        const mocks = buildArguments();
+        await expect(provisionPlaygroundProject(mocks.args)).resolves.toEqual({
+            projectUuid,
+            created: true,
+        });
+        expect(mocks.createWithoutCompile).toHaveBeenCalledExactlyOnceWith(
+            user,
+            expect.objectContaining({
+                warehouseConnection: expect.objectContaining({
+                    dataset: 'jaffle_shop',
+                }),
+            }),
+            expect.any(String),
+            { source: 'playground' },
+        );
+        expect(mocks.saveExploresToCache).toHaveBeenCalledWith(
+            projectUuid,
+            expect.any(Array),
+        );
+        expect(mocks.indexCatalog).toHaveBeenCalledWith(
+            projectUuid,
+            user.userUuid,
+        );
+        expect(mocks.runInPlaygroundProvisioningLock).toHaveBeenCalledWith(
+            organizationUuid,
+            expect.any(Function),
+        );
+        expect(mocks.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'playground_project.provisioned',
+            }),
+        );
+        expect(mocks.validatePlaygroundDatabase).toHaveBeenCalledWith(
+            path.resolve(
+                __dirname,
+                '../../../../assets/playground/jaffle_shop.duckdb',
+            ),
+        );
+    });
+
+    it('resolves the bundled data directory independently of the backend cwd', async () => {
+        const mocks = buildArguments();
+        const previousDataDirectory = process.env.PLAYGROUND_DATA_DIR;
+        delete process.env.PLAYGROUND_DATA_DIR;
+
+        try {
+            await provisionPlaygroundProject({
+                ...mocks.args,
+                playgroundDataDirectory: undefined,
+            });
+        } finally {
+            if (previousDataDirectory === undefined) {
+                delete process.env.PLAYGROUND_DATA_DIR;
+            } else {
+                process.env.PLAYGROUND_DATA_DIR = previousDataDirectory;
+            }
+        }
+
+        expect(mocks.createWithoutCompile).toHaveBeenCalledWith(
+            user,
+            expect.objectContaining({
+                warehouseConnection: expect.objectContaining({
+                    dataset: 'jaffle_shop',
+                }),
+            }),
+            expect.any(String),
+            { source: 'playground' },
+        );
+    });
+
+    it('still provisions when catalog indexing fails', async () => {
+        const mocks = buildArguments();
+        mocks.indexCatalog.mockRejectedValue(new Error('Catalog unavailable'));
+
+        await expect(provisionPlaygroundProject(mocks.args)).resolves.toEqual({
+            projectUuid,
+            created: true,
+        });
+        expect(mocks.track).toHaveBeenCalledOnce();
+    });
+
+    it('does not create a project when bundle validation fails', async () => {
+        const mocks = buildArguments();
+        mocks.validatePlaygroundDatabase.mockRejectedValue(
+            new Error('Invalid DuckDB bundle'),
+        );
+
+        await expect(provisionPlaygroundProject(mocks.args)).rejects.toThrow(
+            'Invalid DuckDB bundle',
+        );
+        expect(mocks.createWithoutCompile).not.toHaveBeenCalled();
+    });
+
+    it('removes a newly created project when explore caching fails', async () => {
+        const mocks = buildArguments();
+        mocks.saveExploresToCache.mockRejectedValue(
+            new Error('Cache unavailable'),
+        );
+
+        await expect(provisionPlaygroundProject(mocks.args)).rejects.toThrow(
+            'Cache unavailable',
+        );
+        expect(mocks.deleteProject).toHaveBeenCalledWith(projectUuid);
+        expect(mocks.track).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionPlaygroundProject.ts
@@ -1,0 +1,210 @@
+import {
+    DbtProjectType,
+    DefaultSupportedDbtVersion,
+    DuckdbConnectionType,
+    FeatureFlags,
+    ForbiddenError,
+    NotFoundError,
+    ProjectType,
+    RequestMethod,
+    WarehouseTypes,
+    type EnsurePlaygroundProjectResults,
+    type Explore,
+    type ExploreError,
+    type OrganizationProject,
+    type SessionUser,
+} from '@lightdash/common';
+import { DuckdbWarehouseClient } from '@lightdash/warehouses';
+import * as Sentry from '@sentry/node';
+import fs from 'fs/promises';
+import path from 'path';
+import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
+import Logger from '../../../logging/logger';
+import { type OnboardingModel } from '../../../models/OnboardingModel/OnboardingModel';
+import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { type CatalogService } from '../../../services/CatalogService/CatalogService';
+import { type FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
+import { type ProjectService } from '../../../services/ProjectService/ProjectService';
+
+export type ProvisionPlaygroundProjectArguments = {
+    user: SessionUser;
+    featureFlagService: Pick<FeatureFlagService, 'get'>;
+    projectModel: Pick<
+        ProjectModel,
+        'getAllByOrganizationUuid' | 'delete' | 'saveExploresToCache'
+    >;
+    onboardingModel: Pick<
+        OnboardingModel,
+        'getByOrganizationUuid' | 'runInPlaygroundProvisioningLock'
+    >;
+    projectService: Pick<ProjectService, 'createWithoutCompile'>;
+    catalogService: Pick<CatalogService, 'indexCatalog'>;
+    analytics: Pick<LightdashAnalytics, 'track'>;
+    canViewProject: (project: OrganizationProject) => boolean;
+    playgroundDataDirectory?: string;
+    validatePlaygroundDatabase?: (databasePath: string) => Promise<void>;
+};
+
+const validatePlaygroundDatabaseBundle = async (): Promise<void> => {
+    const client = new DuckdbWarehouseClient({
+        type: WarehouseTypes.DUCKDB,
+        connectionType: DuckdbConnectionType.EMBEDDED,
+        dataset: 'jaffle_shop',
+    });
+    await client.runQuery('SELECT count(*) FROM information_schema.tables');
+};
+
+const loadPlaygroundBundle = async (
+    dataDirectory: string,
+    validatePlaygroundDatabase: (databasePath: string) => Promise<void>,
+): Promise<(Explore | ExploreError)[]> => {
+    const [exploresJson] = await Promise.all([
+        fs.readFile(path.join(dataDirectory, 'explores.json'), 'utf8'),
+        validatePlaygroundDatabase(
+            path.join(dataDirectory, 'jaffle_shop.duckdb'),
+        ),
+    ]);
+    const explores: unknown = JSON.parse(exploresJson);
+    if (!Array.isArray(explores)) {
+        throw new Error('Playground explores bundle must contain an array');
+    }
+    return explores as (Explore | ExploreError)[];
+};
+
+export const provisionPlaygroundProject = async ({
+    user,
+    featureFlagService,
+    projectModel,
+    onboardingModel,
+    projectService,
+    catalogService,
+    analytics,
+    canViewProject,
+    playgroundDataDirectory,
+    validatePlaygroundDatabase = validatePlaygroundDatabaseBundle,
+}: ProvisionPlaygroundProjectArguments): Promise<EnsurePlaygroundProjectResults> => {
+    const { organizationUuid } = user;
+    if (!organizationUuid) {
+        throw new ForbiddenError('User is not part of an organization');
+    }
+
+    const featureFlag = await featureFlagService.get({
+        user,
+        featureFlagId: FeatureFlags.NewOnboarding,
+    });
+    if (!featureFlag.enabled) {
+        throw new NotFoundError('Playground projects are not available');
+    }
+
+    return onboardingModel.runInPlaygroundProvisioningLock(
+        organizationUuid,
+        async () => {
+            const dataDirectory = path.resolve(
+                playgroundDataDirectory ??
+                    process.env.PLAYGROUND_DATA_DIR ??
+                    path.join(__dirname, '../../../../assets/playground'),
+            );
+            const projects =
+                await projectModel.getAllByOrganizationUuid(organizationUuid);
+            const accessibleProjects = projects.filter(canViewProject);
+            const playground = accessibleProjects.find(
+                (project) => project.provisioningSource === 'playground',
+            );
+            if (playground) {
+                const explores = await loadPlaygroundBundle(
+                    dataDirectory,
+                    validatePlaygroundDatabase,
+                );
+                await projectModel.saveExploresToCache(
+                    playground.projectUuid,
+                    explores,
+                );
+                return {
+                    projectUuid: playground.projectUuid,
+                    created: false,
+                };
+            }
+            if (projects.length > 0) {
+                const existingProject = accessibleProjects[0];
+                if (!existingProject) {
+                    throw new ForbiddenError(
+                        'User does not have permission to view an existing project',
+                    );
+                }
+                return {
+                    projectUuid: existingProject.projectUuid,
+                    created: false,
+                };
+            }
+
+            const onboarding =
+                await onboardingModel.getByOrganizationUuid(organizationUuid);
+            if (onboarding.playgroundProjectDeletedAt) {
+                throw new NotFoundError(
+                    'Playground project was previously removed',
+                );
+            }
+
+            const explores = await loadPlaygroundBundle(
+                dataDirectory,
+                validatePlaygroundDatabase,
+            );
+
+            const creation = await projectService.createWithoutCompile(
+                user,
+                {
+                    name: 'Playground (sample data)',
+                    type: ProjectType.DEFAULT,
+                    dbtConnection: { type: DbtProjectType.NONE },
+                    dbtVersion: DefaultSupportedDbtVersion,
+                    warehouseConnection: {
+                        type: WarehouseTypes.DUCKDB,
+                        connectionType: DuckdbConnectionType.EMBEDDED,
+                        dataset: 'jaffle_shop',
+                    },
+                },
+                RequestMethod.BACKEND,
+                { source: 'playground' },
+            );
+            const { projectUuid } = creation.project;
+
+            try {
+                await projectModel.saveExploresToCache(projectUuid, explores);
+            } catch (error) {
+                await projectModel.delete(projectUuid).catch((cleanupError) => {
+                    Sentry.captureException(cleanupError);
+                    Logger.error(
+                        `Failed to remove incomplete playground project ${projectUuid}: ${
+                            cleanupError instanceof Error
+                                ? cleanupError.message
+                                : String(cleanupError)
+                        }`,
+                    );
+                });
+                throw error;
+            }
+
+            try {
+                await catalogService.indexCatalog(projectUuid, user.userUuid);
+            } catch (error) {
+                Sentry.captureException(error);
+                Logger.error(
+                    `Failed to index playground catalog for project ${projectUuid}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+
+            analytics.track({
+                event: 'playground_project.provisioned',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: organizationUuid,
+                    projectId: projectUuid,
+                    trigger: 'invite_expert',
+                },
+            });
+            return { projectUuid, created: true };
+        },
+    );
+};

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -26006,6 +26006,36 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'DuckdbConnectionType.EMBEDDED': {
+        dataType: 'refEnum',
+        enums: ['embedded'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateDuckdbEmbeddedCredentials: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                schema: { dataType: 'string' },
+                startOfWeek: { dataType: 'double' },
+                dataTimezone: { dataType: 'string' },
+                requireUserCredentials: { dataType: 'boolean' },
+                dataset: { dataType: 'string', required: true },
+                connectionType: {
+                    ref: 'DuckdbConnectionType.EMBEDDED',
+                    required: true,
+                },
+                type: { ref: 'WarehouseTypes.DUCKDB', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DuckdbEmbeddedCredentials: {
+        dataType: 'refAlias',
+        type: { ref: 'CreateDuckdbEmbeddedCredentials', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DuckdbCredentials: {
         dataType: 'refAlias',
         type: {
@@ -26013,6 +26043,7 @@ const models: TsoaRoute.Models = {
             subSchemas: [
                 { ref: 'DuckdbMotherduckCredentials' },
                 { ref: 'DuckdbDucklakeCredentials' },
+                { ref: 'DuckdbEmbeddedCredentials' },
             ],
             validators: {},
         },
@@ -26708,6 +26739,7 @@ const models: TsoaRoute.Models = {
             subSchemas: [
                 { ref: 'CreateDuckdbMotherduckCredentials' },
                 { ref: 'CreateDuckdbDucklakeCredentials' },
+                { ref: 'CreateDuckdbEmbeddedCredentials' },
             ],
             validators: {},
         },
@@ -38101,6 +38133,13 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                provisioningSource: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
                 expiresAt: {
                     dataType: 'union',
                     subSchemas: [
@@ -38183,7 +38222,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Project.name-or-projectUuid-or-organizationUuid-or-type-or-upstreamProjectUuid-or-createdByUserUuid_':
+    'Pick_Project.name-or-projectUuid-or-organizationUuid-or-type-or-upstreamProjectUuid-or-createdByUserUuid-or-provisioningSource_':
         {
             dataType: 'refAlias',
             type: {
@@ -38208,6 +38247,14 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    provisioningSource: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                 },
                 validators: {},
             },
@@ -38216,7 +38263,7 @@ const models: TsoaRoute.Models = {
     ProjectSummary: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_Project.name-or-projectUuid-or-organizationUuid-or-type-or-upstreamProjectUuid-or-createdByUserUuid_',
+            ref: 'Pick_Project.name-or-projectUuid-or-organizationUuid-or-type-or-upstreamProjectUuid-or-createdByUserUuid-or-provisioningSource_',
             validators: {},
         },
     },
@@ -41398,6 +41445,13 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                provisioningSource: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
                 expiresAt: {
                     dataType: 'union',
                     subSchemas: [
@@ -42241,6 +42295,33 @@ const models: TsoaRoute.Models = {
                     },
                 },
             ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EnsurePlaygroundProjectResults: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                created: { dataType: 'boolean', required: true },
+                projectUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiEnsurePlaygroundProjectResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    ref: 'EnsurePlaygroundProjectResults',
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
             validators: {},
         },
     },
@@ -85367,6 +85448,61 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'createProject',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsOrganizationController_ensurePlaygroundProject: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.post(
+        '/api/v1/org/playground-projects/ensure',
+        ...fetchMiddlewares<RequestHandler>(OrganizationController),
+        ...fetchMiddlewares<RequestHandler>(
+            OrganizationController.prototype.ensurePlaygroundProject,
+        ),
+
+        async function OrganizationController_ensurePlaygroundProject(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsOrganizationController_ensurePlaygroundProject,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<OrganizationController>(
+                        OrganizationController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'ensurePlaygroundProject',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -25912,6 +25912,41 @@
                     }
                 ]
             },
+            "DuckdbConnectionType.EMBEDDED": {
+                "enum": ["embedded"],
+                "type": "string"
+            },
+            "CreateDuckdbEmbeddedCredentials": {
+                "properties": {
+                    "schema": {
+                        "type": "string"
+                    },
+                    "startOfWeek": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "dataTimezone": {
+                        "type": "string"
+                    },
+                    "requireUserCredentials": {
+                        "type": "boolean"
+                    },
+                    "dataset": {
+                        "type": "string"
+                    },
+                    "connectionType": {
+                        "$ref": "#/components/schemas/DuckdbConnectionType.EMBEDDED"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/WarehouseTypes.DUCKDB"
+                    }
+                },
+                "required": ["dataset", "connectionType", "type"],
+                "type": "object"
+            },
+            "DuckdbEmbeddedCredentials": {
+                "$ref": "#/components/schemas/CreateDuckdbEmbeddedCredentials"
+            },
             "DuckdbCredentials": {
                 "anyOf": [
                     {
@@ -25919,6 +25954,9 @@
                     },
                     {
                         "$ref": "#/components/schemas/DuckdbDucklakeCredentials"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DuckdbEmbeddedCredentials"
                     }
                 ]
             },
@@ -26972,6 +27010,9 @@
                     },
                     {
                         "$ref": "#/components/schemas/CreateDuckdbDucklakeCredentials"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CreateDuckdbEmbeddedCredentials"
                     }
                 ]
             },
@@ -38279,6 +38320,10 @@
             },
             "Project": {
                 "properties": {
+                    "provisioningSource": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "expiresAt": {
                         "type": "string",
                         "format": "date-time",
@@ -38383,7 +38428,7 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "Pick_Project.name-or-projectUuid-or-organizationUuid-or-type-or-upstreamProjectUuid-or-createdByUserUuid_": {
+            "Pick_Project.name-or-projectUuid-or-organizationUuid-or-type-or-upstreamProjectUuid-or-createdByUserUuid-or-provisioningSource_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -38403,6 +38448,10 @@
                     },
                     "upstreamProjectUuid": {
                         "type": "string"
+                    },
+                    "provisioningSource": {
+                        "type": "string",
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -38416,7 +38465,7 @@
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "ProjectSummary": {
-                "$ref": "#/components/schemas/Pick_Project.name-or-projectUuid-or-organizationUuid-or-type-or-upstreamProjectUuid-or-createdByUserUuid_"
+                "$ref": "#/components/schemas/Pick_Project.name-or-projectUuid-or-organizationUuid-or-type-or-upstreamProjectUuid-or-createdByUserUuid-or-provisioningSource_"
             },
             "ApiSuccess_ProjectSummary_": {
                 "properties": {
@@ -41432,6 +41481,10 @@
             },
             "OrganizationProject": {
                 "properties": {
+                    "provisioningSource": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "expiresAt": {
                         "type": "string",
                         "format": "date-time",
@@ -42328,6 +42381,32 @@
                         "type": "object"
                     }
                 ]
+            },
+            "EnsurePlaygroundProjectResults": {
+                "properties": {
+                    "created": {
+                        "type": "boolean"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["created", "projectUuid"],
+                "type": "object"
+            },
+            "ApiEnsurePlaygroundProjectResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/EnsurePlaygroundProjectResults"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
             },
             "ImpersonationOrganizationSettings": {
                 "properties": {
@@ -72939,6 +73018,38 @@
                         }
                     }
                 ]
+            }
+        },
+        "/api/v1/org/playground-projects/ensure": {
+            "post": {
+                "operationId": "EnsurePlaygroundProject",
+                "responses": {
+                    "200": {
+                        "description": "Ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiEnsurePlaygroundProjectResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Return the organization's existing project or provision its sample-data\nplayground when the new onboarding flow is available.",
+                "summary": "Ensure playground project",
+                "tags": ["Organizations"],
+                "security": [],
+                "parameters": []
             }
         },
         "/api/v1/org/impersonation": {

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -279,7 +279,12 @@ const projectCompileLogModel = {
 
 const getMockedProjectService = (
     lightdashConfig: LightdashConfig,
-    overrides: { spacePermissionService?: SpacePermissionService } = {},
+    overrides: Partial<
+        Pick<
+            ConstructorParameters<typeof ProjectService>[0],
+            'spacePermissionService' | 'provisionPlaygroundProject'
+        >
+    > = {},
 ) =>
     new ProjectService({
         lightdashConfig,
@@ -343,6 +348,7 @@ const getMockedProjectService = (
         } as unknown as AdminNotificationService,
         spacePermissionService:
             overrides.spacePermissionService ?? ({} as SpacePermissionService),
+        provisionPlaygroundProject: overrides.provisionPlaygroundProject,
         organizationSettingsModel: {
             get: vi.fn(async () => ({
                 queryLimit: null,
@@ -375,6 +381,32 @@ describe('ProjectService', () => {
 
     afterEach(() => {
         vi.clearAllMocks();
+    });
+
+    describe('ensurePlaygroundProject', () => {
+        test('throws ForbiddenError without invoking the provisioner when the user cannot create invite links', async () => {
+            const provisionPlaygroundProject = vi.fn(async () => ({
+                projectUuid: 'project-uuid',
+                created: true,
+            }));
+            const serviceWithProvisioner = getMockedProjectService(
+                lightdashConfigMock,
+                { provisionPlaygroundProject },
+            );
+            const userWithoutInviteLinkPermission: SessionUser = {
+                ...user,
+                organizationUuid: 'organization-uuid',
+                ability: new Ability<PossibleAbilities>([]),
+            };
+
+            await expect(
+                serviceWithProvisioner.ensurePlaygroundProject(
+                    userWithoutInviteLinkPermission,
+                ),
+            ).rejects.toThrowError(ForbiddenError);
+
+            expect(provisionPlaygroundProject).not.toHaveBeenCalled();
+        });
     });
 
     test('includes onboarding flow in project analytics properties', () => {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -591,6 +591,16 @@ export class ProjectService extends BaseService {
             throw new ForbiddenError('User is not part of an organization');
         }
         const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'create',
+                subject('InviteLink', { organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'User does not have permission to create invite links',
+            );
+        }
         return this.provisionPlaygroundProject({
             user,
             projectService: this,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -64,6 +64,7 @@ import {
     DefaultSupportedDbtVersion,
     DownloadFileType,
     DuckdbConnectionType,
+    EnsurePlaygroundProjectResults,
     Explore,
     ExploreError,
     ExploreType,
@@ -189,6 +190,7 @@ import {
     type CreateDatabricksCredentials,
     type DataTimezonePreviewRequest,
     type Metric,
+    type OrganizationProject,
     type ParameterDefinitions,
     type ParametersValuesMap,
     type RunQueryTags,
@@ -362,6 +364,11 @@ export type ProjectServiceArguments = {
         projectUuid: string;
         projectType: ProjectType;
     }) => Promise<void>;
+    provisionPlaygroundProject?: (args: {
+        user: SessionUser;
+        projectService: ProjectService;
+        canViewProject: (project: OrganizationProject) => boolean;
+    }) => Promise<EnsurePlaygroundProjectResults>;
 };
 
 const isValidDbtCloudWebhookSignature = (
@@ -476,6 +483,8 @@ export class ProjectService extends BaseService {
 
     onProjectCreated: ProjectServiceArguments['onProjectCreated'];
 
+    provisionPlaygroundProject: ProjectServiceArguments['provisionPlaygroundProject'];
+
     constructor({
         lightdashConfig,
         analytics,
@@ -520,6 +529,7 @@ export class ProjectService extends BaseService {
         getAppGenerateService,
         getAiAgentService,
         onProjectCreated,
+        provisionPlaygroundProject,
     }: ProjectServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -567,6 +577,36 @@ export class ProjectService extends BaseService {
         this.getAppGenerateService = getAppGenerateService;
         this.getAiAgentService = getAiAgentService;
         this.onProjectCreated = onProjectCreated;
+        this.provisionPlaygroundProject = provisionPlaygroundProject;
+    }
+
+    async ensurePlaygroundProject(
+        user: SessionUser,
+    ): Promise<EnsurePlaygroundProjectResults> {
+        if (!this.provisionPlaygroundProject) {
+            throw new NotFoundError('Playground projects are not available');
+        }
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        const auditedAbility = this.createAuditedAbility(user);
+        return this.provisionPlaygroundProject({
+            user,
+            projectService: this,
+            canViewProject: (project) =>
+                auditedAbility.can(
+                    'view',
+                    subject('Project', {
+                        organizationUuid,
+                        projectUuid: project.projectUuid,
+                        type: project.type,
+                        upstreamProjectUuid:
+                            project.upstreamProjectUuid ?? undefined,
+                        createdByUserUuid: project.createdByUserUuid,
+                    }),
+                ),
+        });
     }
 
     protected async getOnboardingFlow(

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -200,8 +200,10 @@ export {
     WarehouseTypes,
 } from './types/projects';
 export type {
+    ApiEnsurePlaygroundProjectResponse,
     ApiGetProjectGroupAccesses,
     ApiProjectResponse,
+    EnsurePlaygroundProjectResults,
     AthenaCredentials,
     BigqueryCredentials,
     ClickhouseCredentials,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -256,6 +256,7 @@ import {
     DbtProjectType,
     type CreateWarehouseCredentials,
     type DbtProjectConfig,
+    type EnsurePlaygroundProjectResults,
     type Project,
     type WarehouseCredentials,
 } from './projects';
@@ -1045,6 +1046,7 @@ export type ApiFlashResults = Record<string, string[]>;
 
 type ApiResults =
     | BigqueryProjectRecommendation
+    | EnsurePlaygroundProjectResults
     | ApiWarehouseConnectCodeResponse['results']
     | ApiWarehouseConnectCodeClaimResponse['results']
     | ApiQueryResults

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -1130,6 +1130,16 @@ export type ApiProjectResponse = {
     results: Project;
 };
 
+export type EnsurePlaygroundProjectResults = {
+    projectUuid: string;
+    created: boolean;
+};
+
+export type ApiEnsurePlaygroundProjectResponse = {
+    status: 'ok';
+    results: EnsurePlaygroundProjectResults;
+};
+
 export type UpdateProjectDetails = Partial<Pick<Project, 'name'>>;
 
 export type ApiGetProjectGroupAccesses = {


### PR DESCRIPTION
Stack 5/9. The EE provisioner and its trigger:

- `provisionPlaygroundProject`: gated on the `new-onboarding` flag; idempotent under the per-org advisory lock; recovers from half-completed attempts; respects the deletion tombstone; indexes the catalog; fires `playground_project.provisioned`. Wired via `ee/index.ts` into `ProjectService.ensurePlaygroundProject`.
- `POST /api/v1/org/playground-projects/ensure` on the organization controller, gated on the create-InviteLink ability (the invite-an-expert trigger).

Note: generated API artifacts (`routes.ts`/`swagger.json`) are committed deliberately to keep byte-parity with the previously reviewed head; the OpenAPI compat check is red against latest main (stale aiAgents schemas, unrelated to this stack) and will be resolved by a rebase + regenerate once the stack shape is agreed.

Linear: PROD-9135

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWZc9bPFq2dnCVdXAxyZiu
