### PR TITLE
fix: re-render metric timestamp filters with query-time domain context

### DIFF
--- a/packages/backend/src/queryCompiler.test.ts
+++ b/packages/backend/src/queryCompiler.test.ts
@@ -1,12 +1,16 @@
 import {
     BinType,
+    CompiledDimension,
     CompiledMetricQuery,
     CompileError,
     CustomDimensionType,
     DimensionType,
+    FieldType,
+    FilterOperator,
     MetricType,
     TableCalculation,
     TableCalculationTemplateType,
+    UnitOfTime,
     VizIndexType,
     WindowFunctionType,
     type FormulaTableCalculation,
@@ -1244,6 +1248,111 @@ test('Should compile a formula SUMIF as a window aggregate', () => {
     expect(formulaCalc?.compiledSql).toBe(
         'SUM(CASE WHEN ("table_3_metric_1" > 100) THEN "table_3_metric_1" END) OVER ()',
     );
+});
+
+describe('compileAdditionalMetric preserves filter metadata (GLITCH-627)', () => {
+    const exploreWithTimestampDim = {
+        ...EXPLORE,
+        tables: {
+            ...EXPLORE.tables,
+            table1: {
+                ...EXPLORE.tables.table1,
+                dimensions: {
+                    ...EXPLORE.tables.table1.dimensions,
+                    created_at: {
+                        name: 'created_at',
+                        fieldType: FieldType.DIMENSION,
+                        type: DimensionType.TIMESTAMP,
+                        table: 'table1',
+                        label: 'created_at',
+                        tableLabel: 'table1',
+                        hidden: false,
+                        sql: '${TABLE}.created_at',
+                        compiledSql: '`some`.`table1`.`created_at`',
+                        tablesReferences: ['table1'],
+                    } satisfies CompiledDimension,
+                },
+            },
+        },
+    };
+
+    test('an additional metric with an absolute timestamp filter carries compiledTimestampFilters', () => {
+        const result = compileMetricQuery({
+            explore: exploreWithTimestampDim,
+            metricQuery: {
+                ...METRIC_QUERY_VALID_REFERENCES,
+                metrics: ['table1_filtered_count'],
+                tableCalculations: [],
+                additionalMetrics: [
+                    {
+                        name: 'filtered_count',
+                        table: 'table1',
+                        type: MetricType.COUNT,
+                        sql: '${TABLE}.dim_1',
+                        filters: [
+                            {
+                                id: 'f1',
+                                target: { fieldRef: 'table1.created_at' },
+                                operator: FilterOperator.EQUALS,
+                                values: ['2024-01-14T17:00:00.000Z'],
+                            },
+                        ],
+                    },
+                ],
+            },
+            warehouseSqlBuilder: warehouseClientMock,
+            availableParameters: [],
+        });
+
+        const compiled = result.compiledAdditionalMetrics?.find(
+            (m) => m.name === 'filtered_count',
+        );
+        expect(compiled?.compiledTimestampFilters).toHaveLength(1);
+        expect(compiled?.compiledTimestampFilters?.[0].fieldId).toBe(
+            'table1_created_at',
+        );
+        expect(compiled?.compiledSql).toContain(
+            compiled!.compiledTimestampFilters![0].compiledSql,
+        );
+    });
+
+    test('an additional metric with a relative date filter carries compiledRelativeDateFilters', () => {
+        const result = compileMetricQuery({
+            explore: exploreWithTimestampDim,
+            metricQuery: {
+                ...METRIC_QUERY_VALID_REFERENCES,
+                metrics: ['table1_recent_count'],
+                tableCalculations: [],
+                additionalMetrics: [
+                    {
+                        name: 'recent_count',
+                        table: 'table1',
+                        type: MetricType.COUNT,
+                        sql: '${TABLE}.dim_1',
+                        filters: [
+                            {
+                                id: 'f1',
+                                target: { fieldRef: 'table1.created_at' },
+                                operator: FilterOperator.IN_THE_PAST,
+                                values: [30],
+                                settings: {
+                                    unitOfTime: UnitOfTime.days,
+                                    completed: false,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+            warehouseSqlBuilder: warehouseClientMock,
+            availableParameters: [],
+        });
+
+        const compiled = result.compiledAdditionalMetrics?.find(
+            (m) => m.name === 'recent_count',
+        );
+        expect(compiled?.compiledRelativeDateFilters).toHaveLength(1);
+    });
 });
 
 describe('compilePostCalculationMetric', () => {

--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -301,6 +301,18 @@ const compileAdditionalMetric = ({
         ...metric,
         compiledSql: compiledMetric.sql,
         tablesReferences: Array.from(compiledMetric.tablesReferences),
+        ...(compiledMetric.compiledRelativeDateFilters
+            ? {
+                  compiledRelativeDateFilters:
+                      compiledMetric.compiledRelativeDateFilters,
+              }
+            : {}),
+        ...(compiledMetric.compiledTimestampFilters
+            ? {
+                  compiledTimestampFilters:
+                      compiledMetric.compiledTimestampFilters,
+              }
+            : {}),
     };
 };
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -7303,6 +7303,292 @@ describe('Naive timestamp domain — explicit, session-independent conversion', 
     });
 });
 
+describe('Metric filters: absolute timestamp predicates re-render at query time (GLITCH-627)', () => {
+    const BAKED_PREDICATE = `("events".occurred_at) = ('2024-01-14 17:00:00+00:00')`;
+    const FRESH_PREDICATE = `("events".occurred_at) = ('2024-01-15 02:00:00'::timestamp)`;
+
+    const withFilteredMetric = (explore: Explore): Explore => ({
+        ...explore,
+        tables: {
+            ...explore.tables,
+            events: {
+                ...explore.tables.events,
+                metrics: {
+                    ...explore.tables.events.metrics,
+                    filtered_count: {
+                        type: MetricType.COUNT,
+                        fieldType: FieldType.METRIC,
+                        table: 'events',
+                        tableLabel: 'events',
+                        name: 'filtered_count',
+                        label: 'filtered_count',
+                        sql: '${TABLE}.id',
+                        compiledSql: `COUNT(CASE WHEN (${BAKED_PREDICATE}) THEN ("events".id) ELSE NULL END)`,
+                        tablesReferences: ['events'],
+                        hidden: false,
+                        filters: [
+                            {
+                                id: 'f1',
+                                target: { fieldRef: 'events.occurred_at' },
+                                operator: FilterOperator.EQUALS,
+                                values: ['2024-01-14T17:00:00.000Z'],
+                            },
+                        ],
+                        compiledTimestampFilters: [
+                            {
+                                id: 'f1',
+                                fieldId: 'events_occurred_at',
+                                compiledSql: BAKED_PREDICATE,
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    });
+
+    const filteredMetricQuery: CompiledMetricQuery = {
+        exploreName: 'events',
+        dimensions: [],
+        metrics: ['events_filtered_count'],
+        filters: {},
+        sorts: [],
+        limit: 100,
+        tableCalculations: [],
+        compiledTableCalculations: [],
+        compiledAdditionalMetrics: [],
+        compiledCustomDimensions: [],
+    };
+
+    const build = (explore: Explore) =>
+        buildQuery({
+            explore,
+            compiledMetricQuery: filteredMetricQuery,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'UTC',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'Asia/Tokyo',
+        });
+
+    test('a classified-naive target swaps the baked predicate for the domain-aware one', () => {
+        const { query } = build(
+            withFilteredMetric(
+                buildNaiveExplore(SupportedDbtAdapter.POSTGRES, 'naive'),
+            ),
+        );
+        expect(query).toContain(FRESH_PREDICATE);
+        expect(query).not.toContain(BAKED_PREDICATE);
+    });
+
+    test('an unknown-domain target keeps the baked predicate byte-identical', () => {
+        const { query } = build(
+            withFilteredMetric(buildNaiveExplore(SupportedDbtAdapter.POSTGRES)),
+        );
+        expect(query).toContain(BAKED_PREDICATE);
+        expect(query).not.toContain(FRESH_PREDICATE);
+    });
+
+    test('a convert_timezone: false target keeps the baked predicate', () => {
+        const explore = withFilteredMetric(
+            buildNaiveExplore(SupportedDbtAdapter.POSTGRES, 'naive'),
+        );
+        explore.tables.events.dimensions.occurred_at = {
+            ...explore.tables.events.dimensions.occurred_at,
+            skipTimezoneConversion: true,
+        };
+        const { query } = build(explore);
+        expect(query).toContain(BAKED_PREDICATE);
+        expect(query).not.toContain(FRESH_PREDICATE);
+    });
+
+    test('the classified BigQuery path renders the fresh predicate as a DATETIME wall clock', () => {
+        const { query } = buildQuery({
+            explore: withFilteredMetric(
+                buildNaiveExplore(SupportedDbtAdapter.BIGQUERY, 'naive'),
+            ),
+            compiledMetricQuery: filteredMetricQuery,
+            warehouseSqlBuilder: bigqueryClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'UTC',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'Asia/Tokyo',
+        });
+        expect(query).toContain(`DATETIME '2024-01-15 02:00:00'`);
+        expect(query).not.toContain(BAKED_PREDICATE);
+    });
+
+    test('relative and absolute recorded filters both re-render on one metric', () => {
+        vi.useFakeTimers();
+        try {
+            const COMPILE_TIME = new Date('2026-05-04T00:00:00Z').getTime();
+            const QUERY_TIME = new Date('2026-06-04T00:00:00Z').getTime();
+            const explore = withFilteredMetric(
+                buildNaiveExplore(SupportedDbtAdapter.POSTGRES, 'naive'),
+            );
+            const occurredAt = explore.tables.events.dimensions
+                .occurred_at as CompiledDimension;
+            const relativeRule: MetricFilterRule = {
+                id: 'r1',
+                target: { fieldRef: 'events.occurred_at' },
+                operator: FilterOperator.IN_THE_PAST,
+                values: [30],
+                settings: { unitOfTime: UnitOfTime.days, completed: false },
+            };
+            vi.setSystemTime(COMPILE_TIME);
+            const relativeBaked = renderFilterRuleSqlFromField(
+                { ...relativeRule, target: { fieldId: getItemId(occurredAt) } },
+                occurredAt,
+                warehouseClientMock.getFieldQuoteChar(),
+                warehouseClientMock.getStringQuoteChar(),
+                warehouseClientMock.escapeString.bind(warehouseClientMock),
+                warehouseClientMock.getStartOfWeek(),
+                warehouseClientMock.getAdapterType(),
+            );
+            expect(relativeBaked).toContain('2026-04-04'); // now-30d at compile
+
+            const metric = explore.tables.events.metrics
+                .filtered_count as CompiledMetric;
+            metric.compiledSql = `COUNT(CASE WHEN (${BAKED_PREDICATE} AND ${relativeBaked}) THEN ("events".id) ELSE NULL END)`;
+            metric.filters = [...(metric.filters ?? []), relativeRule];
+            metric.compiledRelativeDateFilters = [
+                {
+                    id: 'r1',
+                    fieldId: getItemId(occurredAt),
+                    compiledSql: relativeBaked,
+                },
+            ];
+
+            vi.setSystemTime(QUERY_TIME);
+            const { query } = build(explore);
+            expect(query).toContain(FRESH_PREDICATE);
+            expect(query).not.toContain(BAKED_PREDICATE);
+            expect(query).not.toContain('2026-04-04'); // stale lower bound gone
+            expect(query).toContain('2026-05-05'); // now-30d at query time
+            expect(query).toContain('2026-06-04'); // now at query time
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    // User-attribute filtering removes restricted dimensions from the explore
+    // the filter renderer resolves against; those targets must keep their
+    // baked predicate instead of failing the whole query.
+    const restrictAwayTimestampDims = (explore: Explore): Explore => ({
+        ...explore,
+        unfilteredTables: explore.tables,
+        tables: {
+            ...explore.tables,
+            events: {
+                ...explore.tables.events,
+                dimensions: Object.fromEntries(
+                    Object.entries(explore.tables.events.dimensions).filter(
+                        ([name]) => !name.startsWith('occurred_at'),
+                    ),
+                ),
+            },
+        },
+    });
+
+    test('a timestamp target restricted away from the user keeps the baked predicate', () => {
+        const explore = restrictAwayTimestampDims(
+            withFilteredMetric(
+                buildNaiveExplore(SupportedDbtAdapter.POSTGRES, 'naive'),
+            ),
+        );
+        const { query } = build(explore);
+        expect(query).toContain(BAKED_PREDICATE);
+        expect(query).not.toContain(FRESH_PREDICATE);
+    });
+
+    test('a relative-date target restricted away from the user keeps the baked predicate', () => {
+        const RELATIVE_BAKED = `("events".occurred_at) >= ('2024-01-01 00:00:00')`;
+        const explore = restrictAwayTimestampDims(
+            buildNaiveExplore(SupportedDbtAdapter.POSTGRES, 'naive'),
+        );
+        explore.tables.events.metrics.recent_count = {
+            type: MetricType.COUNT,
+            fieldType: FieldType.METRIC,
+            table: 'events',
+            tableLabel: 'events',
+            name: 'recent_count',
+            label: 'recent_count',
+            sql: '${TABLE}.id',
+            compiledSql: `COUNT(CASE WHEN (${RELATIVE_BAKED}) THEN ("events".id) ELSE NULL END)`,
+            tablesReferences: ['events'],
+            hidden: false,
+            filters: [
+                {
+                    id: 'r1',
+                    target: { fieldRef: 'events.occurred_at' },
+                    operator: FilterOperator.IN_THE_PAST,
+                    values: [30],
+                    settings: { unitOfTime: UnitOfTime.days, completed: false },
+                },
+            ],
+            compiledRelativeDateFilters: [
+                {
+                    id: 'r1',
+                    fieldId: 'events_occurred_at',
+                    compiledSql: RELATIVE_BAKED,
+                },
+            ],
+        };
+        const { query } = buildQuery({
+            explore,
+            compiledMetricQuery: {
+                ...filteredMetricQuery,
+                metrics: ['events_recent_count'],
+            },
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'UTC',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'Asia/Tokyo',
+        });
+        expect(query).toContain(RELATIVE_BAKED);
+    });
+
+    test('a derived metric swaps via the rule on its referenced metric', () => {
+        const explore = withFilteredMetric(
+            buildNaiveExplore(SupportedDbtAdapter.POSTGRES, 'naive'),
+        );
+        explore.tables.events.metrics.derived = {
+            type: MetricType.NUMBER,
+            fieldType: FieldType.METRIC,
+            table: 'events',
+            tableLabel: 'events',
+            name: 'derived',
+            label: 'derived',
+            sql: '${events.filtered_count}',
+            compiledSql: `(COUNT(CASE WHEN (${BAKED_PREDICATE}) THEN ("events".id) ELSE NULL END))`,
+            tablesReferences: ['events'],
+            hidden: false,
+            compiledTimestampFilters: [
+                {
+                    id: 'f1',
+                    fieldId: 'events_occurred_at',
+                    compiledSql: BAKED_PREDICATE,
+                },
+            ],
+        };
+        const { query } = buildQuery({
+            explore,
+            compiledMetricQuery: {
+                ...filteredMetricQuery,
+                metrics: ['events_derived'],
+            },
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'UTC',
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: 'Asia/Tokyo',
+        });
+        expect(query).toContain(FRESH_PREDICATE);
+        expect(query).not.toContain(BAKED_PREDICATE);
+    });
+});
+
 describe('Session-independent explicit path (per-column, no session pin)', () => {
     const trinoClientMock = {
         ...warehouseClientMock,

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -1034,23 +1034,53 @@ export class MetricQueryBuilder {
     }
 
     /**
-     * Metric YAML filters that use relative date operators (inThePast/inTheNext/
-     * inTheCurrent/...) have their boundaries baked in at explore compile time,
-     * so the window is frozen to the last deploy. Re-render each such predicate
-     * against "now" in the query timezone — exactly like UI filters do — and swap
-     * it into the given metric SQL (compiledSql or compiledValueSql; the baked
-     * predicate is a substring of both).
+     * Metric filters are baked into the metric SQL at compile time, which
+     * freezes two things that must resolve at query time: relative date
+     * boundaries (inThePast/... windows frozen to the last deploy) and
+     * absolute timestamp literals (baked with no data-timezone or domain
+     * context). Re-render each recorded predicate — exactly like UI filters —
+     * and swap it into the given metric SQL (compiledSql or compiledValueSql;
+     * the baked predicate is a substring of both).
      */
     private swapRelativeDateMetricFilters(
         metric: CompiledMetric,
         baseSql: string,
     ): string {
-        const relativeDateFilters = metric.compiledRelativeDateFilters;
-        if (!relativeDateFilters || relativeDateFilters.length === 0) {
+        // getFilterRuleSQL resolves dimension filters against the
+        // access-filtered explore, so a target restricted away from this user
+        // cannot be re-rendered — leave its baked predicate untouched.
+        const resolveRenderableDimension = (fieldId: string) =>
+            this.originalExploreDimensions[fieldId] ??
+            this.exploreDimensions[fieldId];
+        const renderableRelativeDateFilters = (
+            metric.compiledRelativeDateFilters ?? []
+        ).filter(
+            (stored) =>
+                resolveRenderableDimension(stored.fieldId) !== undefined,
+        );
+        // Absolute timestamp predicates were baked with no domain context;
+        // re-render them only when the target is classified so unknown-domain
+        // and opted-out columns stay byte-identical to the compiled SQL.
+        const classifiedTimestampFilters = (
+            metric.compiledTimestampFilters ?? []
+        ).filter((stored) => {
+            const dimension = resolveRenderableDimension(stored.fieldId);
+            return (
+                dimension !== undefined &&
+                this.resolveFilterTimestampDomain(dimension) !== undefined
+            );
+        });
+        const recordedFilters = [
+            ...renderableRelativeDateFilters,
+            ...classifiedTimestampFilters,
+        ];
+        if (recordedFilters.length === 0) {
             return baseSql;
         }
-        return relativeDateFilters.reduce((sql, stored) => {
-            const rule = metric.filters?.find((f) => f.id === stored.id);
+        return recordedFilters.reduce((sql, stored) => {
+            const rule =
+                metric.filters?.find((f) => f.id === stored.id) ??
+                this.findReferencedMetricFilterRule(stored.id);
             if (!rule) {
                 return sql;
             }
@@ -1065,8 +1095,36 @@ export class MetricQueryBuilder {
             if (!freshPredicate) {
                 return sql;
             }
+            if (!sql.includes(stored.compiledSql)) {
+                // Anchor drift: the recorded predicate no longer appears in the
+                // metric SQL, so the stale baked predicate executes unswapped.
+                Logger.warn('metric_filter_rewrite.anchor_missing', {
+                    metric: metric.name,
+                    table: metric.table,
+                    filterId: stored.id,
+                    fieldId: stored.fieldId,
+                });
+                return sql;
+            }
             return sql.split(stored.compiledSql).join(freshPredicate);
         }, baseSql);
+    }
+
+    /**
+     * A derived metric inlines its referenced metrics' baked predicates and
+     * carries their filter records, but the rules live on the referenced
+     * metric definitions — resolve a record's rule across the explore metrics.
+     */
+    private findReferencedMetricFilterRule(
+        filterId: string,
+    ): MetricFilterRule | undefined {
+        for (const exploreMetric of Object.values(this.availableMetrics)) {
+            const rule = exploreMetric.filters?.find((f) => f.id === filterId);
+            if (rule) {
+                return rule;
+            }
+        }
+        return undefined;
     }
 
     /**

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -1848,3 +1848,160 @@ describe('relative date metric filters are baked at compile time', () => {
         expect(stored.compiledSql).toContain("'2026-05-05");
     });
 });
+
+describe('absolute timestamp metric filters are recorded for query-time re-rendering', () => {
+    const buildTable = (
+        dimensionType: DimensionType,
+        filter: Record<string, unknown>,
+    ): Record<string, Table> => ({
+        table1: {
+            name: 'table1',
+            label: 'table1',
+            database: 'database',
+            schema: 'schema',
+            sqlTable: '"db"."schema"."table1"',
+            sqlWhere: undefined,
+            dimensions: {
+                created_at: {
+                    type: dimensionType,
+                    name: 'created_at',
+                    label: 'created_at',
+                    table: 'table1',
+                    tableLabel: 'table1',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.created_at',
+                    hidden: false,
+                },
+            },
+            metrics: {
+                filtered_count: {
+                    type: MetricType.COUNT,
+                    fieldType: FieldType.METRIC,
+                    table: 'table1',
+                    tableLabel: 'table1',
+                    name: 'filtered_count',
+                    label: 'filtered_count',
+                    sql: '${TABLE}.created_at',
+                    hidden: false,
+                    filters: [filter as never],
+                },
+            },
+            lineageGraph: {},
+            groupLabel: undefined,
+        },
+    });
+
+    const compileFor = (
+        dimensionType: DimensionType,
+        filter: Record<string, unknown>,
+    ) => {
+        const tables = buildTable(dimensionType, filter);
+        return compiler.compileMetric(
+            tables.table1.metrics.filtered_count,
+            tables,
+            [],
+        );
+    };
+
+    test('an absolute TIMESTAMP predicate is recorded with its swap anchor', () => {
+        const compiled = compileFor(DimensionType.TIMESTAMP, {
+            id: 'f1',
+            target: { fieldRef: 'created_at' },
+            operator: FilterOperator.EQUALS,
+            values: ['2024-01-14T17:00:00.000Z'],
+        });
+        expect(compiled.compiledTimestampFilters).toHaveLength(1);
+        const [stored] = compiled.compiledTimestampFilters!;
+        expect(stored.id).toBe('f1');
+        expect(stored.fieldId).toBe('table1_created_at');
+        expect(compiled.compiledSql).toContain(stored.compiledSql);
+        expect(compiled.compiledRelativeDateFilters).toBeUndefined();
+    });
+
+    test('a relative operator stays in the relative list only', () => {
+        const compiled = compileFor(DimensionType.TIMESTAMP, {
+            id: 'f1',
+            target: { fieldRef: 'created_at' },
+            operator: FilterOperator.IN_THE_PAST,
+            values: [30],
+            settings: { unitOfTime: UnitOfTime.days, completed: false },
+        });
+        expect(compiled.compiledRelativeDateFilters).toHaveLength(1);
+        expect(compiled.compiledTimestampFilters).toBeUndefined();
+    });
+
+    const withDerivedMetric = (tables: Record<string, Table>) => {
+        // eslint-disable-next-line no-param-reassign
+        tables.table1.metrics.derived = {
+            type: MetricType.NUMBER,
+            fieldType: FieldType.METRIC,
+            table: 'table1',
+            tableLabel: 'table1',
+            name: 'derived',
+            label: 'derived',
+            sql: '${table1.filtered_count}',
+            hidden: false,
+        };
+        return tables;
+    };
+
+    test('a derived metric carries the referenced metric recorded timestamp filters', () => {
+        const tables = withDerivedMetric(
+            buildTable(DimensionType.TIMESTAMP, {
+                id: 'f1',
+                target: { fieldRef: 'created_at' },
+                operator: FilterOperator.EQUALS,
+                values: ['2024-01-14T17:00:00.000Z'],
+            }),
+        );
+        const compiled = compiler.compileMetric(
+            tables.table1.metrics.derived,
+            tables,
+            [],
+        );
+        expect(compiled.compiledTimestampFilters).toHaveLength(1);
+        const [stored] = compiled.compiledTimestampFilters!;
+        expect(stored.id).toBe('f1');
+        expect(stored.fieldId).toBe('table1_created_at');
+        expect(compiled.compiledSql).toContain(stored.compiledSql);
+    });
+
+    test('a derived metric carries the referenced metric recorded relative date filters', () => {
+        const tables = withDerivedMetric(
+            buildTable(DimensionType.TIMESTAMP, {
+                id: 'f1',
+                target: { fieldRef: 'created_at' },
+                operator: FilterOperator.IN_THE_PAST,
+                values: [30],
+                settings: { unitOfTime: UnitOfTime.days, completed: false },
+            }),
+        );
+        const compiled = compiler.compileMetric(
+            tables.table1.metrics.derived,
+            tables,
+            [],
+        );
+        expect(compiled.compiledRelativeDateFilters).toHaveLength(1);
+        const [stored] = compiled.compiledRelativeDateFilters!;
+        expect(stored.fieldId).toBe('table1_created_at');
+        expect(compiled.compiledSql).toContain(stored.compiledSql);
+    });
+
+    test('DATE targets and value-less operators are not recorded', () => {
+        const onDate = compileFor(DimensionType.DATE, {
+            id: 'f1',
+            target: { fieldRef: 'created_at' },
+            operator: FilterOperator.EQUALS,
+            values: ['2024-01-14'],
+        });
+        expect(onDate.compiledTimestampFilters).toBeUndefined();
+
+        const nullCheck = compileFor(DimensionType.TIMESTAMP, {
+            id: 'f1',
+            target: { fieldRef: 'created_at' },
+            operator: FilterOperator.NOT_NULL,
+            values: [],
+        });
+        expect(nullCheck.compiledTimestampFilters).toBeUndefined();
+    });
+});

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -10,6 +10,7 @@ import {
     type Table,
 } from '../types/explore';
 import {
+    DimensionType,
     friendlyName,
     isCustomBinDimension,
     isNonAggregateMetric,
@@ -20,6 +21,7 @@ import {
     type CompiledDimension,
     type CompiledMetric,
     type CompiledMetricRelativeDateFilter,
+    type CompiledMetricTimestampFilter,
     type CustomDimension,
     type CustomSqlDimension,
     type Dimension,
@@ -80,6 +82,13 @@ type Reference = {
  * Matches: sum(, count(, avg(, etc. with word boundary to avoid false positives
  * like "summary" matching "sum".
  */
+// Diamond metric references repeat the same recorded filter predicate
+const uniqByFilterId = <T extends { id: string }>(filters: T[]): T[] =>
+    filters.filter(
+        (filter, index) =>
+            filters.findIndex((other) => other.id === filter.id) === index,
+    );
+
 const SQL_AGGREGATION_FUNCTIONS_PATTERN =
     /\b(sum|count_if|countif|count|avg|average|max_by|min_by|min|max|median|stddev|stddev_pop|stddev_samp|variance|var_pop|var_samp|percentile|percentile_cont|percentile_disc|count_distinct|approx_count_distinct|any_value|array_agg|string_agg|group_concat|listagg|corr|covar_pop|covar_samp|mode|approx_percentile)\s*\(/i;
 
@@ -1039,6 +1048,12 @@ export class ExploreCompiler {
                           compiledMetric.compiledRelativeDateFilters,
                   }
                 : {}),
+            ...(compiledMetric.compiledTimestampFilters
+                ? {
+                      compiledTimestampFilters:
+                          compiledMetric.compiledTimestampFilters,
+                  }
+                : {}),
         };
     }
 
@@ -1052,6 +1067,7 @@ export class ExploreCompiler {
         valueSql?: string;
         compiledDistinctKeys?: string[];
         compiledRelativeDateFilters?: CompiledMetricRelativeDateFilter[];
+        compiledTimestampFilters?: CompiledMetricTimestampFilter[];
     } {
         // Metric might have references to other dimensions
         if (!tables[metric.table]) {
@@ -1064,6 +1080,13 @@ export class ExploreCompiler {
         const currentShortRef = metric.name;
         let tablesReferences = new Set([metric.table]);
         let relativeDateFilters: CompiledMetricRelativeDateFilter[] | undefined;
+        let timestampFilters: CompiledMetricTimestampFilter[] | undefined;
+        // Referenced metrics inline their baked filter predicates into this
+        // metric's SQL — carry their records too so the query-time rewrite
+        // reaches derived metrics.
+        const referencedRelativeDateFilters: CompiledMetricRelativeDateFilter[] =
+            [];
+        const referencedTimestampFilters: CompiledMetricTimestampFilter[] = [];
         if (metric.sql === undefined || metric.sql === null) {
             throw new CompileError(
                 `Metric "${metric.name}" in table "${metric.table}" is missing a sql definition`,
@@ -1111,6 +1134,8 @@ export class ExploreCompiler {
                 let compiledReference: {
                     sql: string;
                     tablesReferences: Set<string>;
+                    compiledRelativeDateFilters?: CompiledMetricRelativeDateFilter[];
+                    compiledTimestampFilters?: CompiledMetricTimestampFilter[];
                 };
 
                 if (isPostCalc) {
@@ -1176,6 +1201,12 @@ export class ExploreCompiler {
                     ...tablesReferences,
                     ...compiledReference.tablesReferences,
                 ]);
+                referencedRelativeDateFilters.push(
+                    ...(compiledReference.compiledRelativeDateFilters ?? []),
+                );
+                referencedTimestampFilters.push(
+                    ...(compiledReference.compiledTimestampFilters ?? []),
+                );
                 return compiledReference.sql;
             },
         );
@@ -1190,6 +1221,8 @@ export class ExploreCompiler {
             }
 
             const compiledRelativeDateFilters: CompiledMetricRelativeDateFilter[] =
+                [];
+            const compiledTimestampFilters: CompiledMetricTimestampFilter[] =
                 [];
             const conditions = metric.filters.map((filter) => {
                 const fieldRef =
@@ -1251,6 +1284,19 @@ export class ExploreCompiler {
                         fieldId: getItemId(compiledDimension),
                         compiledSql: conditionSql,
                     });
+                } else if (
+                    compiledDimension.type === DimensionType.TIMESTAMP &&
+                    filter.values !== undefined &&
+                    filter.values.length > 0
+                ) {
+                    // Absolute timestamp predicate: baked with no domain
+                    // context — record it so the query builder can re-render
+                    // it against a classified column at query time.
+                    compiledTimestampFilters.push({
+                        id: filter.id,
+                        fieldId: getItemId(compiledDimension),
+                        compiledSql: conditionSql,
+                    });
                 }
                 return conditionSql;
             });
@@ -1261,6 +1307,21 @@ export class ExploreCompiler {
             if (compiledRelativeDateFilters.length > 0) {
                 relativeDateFilters = compiledRelativeDateFilters;
             }
+            if (compiledTimestampFilters.length > 0) {
+                timestampFilters = compiledTimestampFilters;
+            }
+        }
+        if (referencedRelativeDateFilters.length > 0) {
+            relativeDateFilters = uniqByFilterId([
+                ...(relativeDateFilters ?? []),
+                ...referencedRelativeDateFilters,
+            ]);
+        }
+        if (referencedTimestampFilters.length > 0) {
+            timestampFilters = uniqByFilterId([
+                ...(timestampFilters ?? []),
+                ...referencedTimestampFilters,
+            ]);
         }
         if (
             metric.type === MetricType.SUM_DISTINCT ||
@@ -1294,6 +1355,7 @@ export class ExploreCompiler {
                 valueSql: renderedSql,
                 compiledDistinctKeys: compiledKeys,
                 compiledRelativeDateFilters: relativeDateFilters,
+                compiledTimestampFilters: timestampFilters,
             };
         }
 
@@ -1307,6 +1369,7 @@ export class ExploreCompiler {
             tablesReferences,
             valueSql: renderedSql,
             compiledRelativeDateFilters: relativeDateFilters,
+            compiledTimestampFilters: timestampFilters,
         };
     }
 
@@ -1525,7 +1588,12 @@ export class ExploreCompiler {
         currentTable: string,
         availableParameters: string[],
         fieldContext?: FieldContext,
-    ): { sql: string; tablesReferences: Set<string> } {
+    ): {
+        sql: string;
+        tablesReferences: Set<string>;
+        compiledRelativeDateFilters?: CompiledMetricRelativeDateFilter[];
+        compiledTimestampFilters?: CompiledMetricTimestampFilter[];
+    } {
         // Reference to current table
         if (ref === 'TABLE') {
             const fieldQuoteChar = this.warehouseClient.getFieldQuoteChar();
@@ -1565,6 +1633,9 @@ export class ExploreCompiler {
                 referencedTable?.name || refTableName,
                 ...compiledMetric.tablesReferences,
             ]),
+            compiledRelativeDateFilters:
+                compiledMetric.compiledRelativeDateFilters,
+            compiledTimestampFilters: compiledMetric.compiledTimestampFilters,
         };
     }
 

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -819,6 +819,12 @@ type CompiledProperties = {
     // these boundaries at query time by swapping the stored predicate for a
     // freshly rendered one, so the window is no longer frozen to compile time.
     compiledRelativeDateFilters?: CompiledMetricRelativeDateFilter[];
+    // Metric-only: compile-time SQL for each metric filter with an absolute
+    // operator targeting a TIMESTAMP dimension. Baked without any data
+    // timezone or timestamp-domain context, so the query builder re-renders
+    // the predicate with the query-time domain context and swaps it in when
+    // the target is classified.
+    compiledTimestampFilters?: CompiledMetricTimestampFilter[];
 };
 
 export type CompiledMetricRelativeDateFilter = {
@@ -826,6 +832,8 @@ export type CompiledMetricRelativeDateFilter = {
     fieldId: string; // resolved dimension id the filter targets
     compiledSql: string; // compile-time predicate, used as the query-time swap anchor
 };
+
+export type CompiledMetricTimestampFilter = CompiledMetricRelativeDateFilter;
 export type CompiledDimension = Dimension & CompiledProperties;
 export type CompiledMetric = Metric & CompiledProperties;
 


### PR DESCRIPTION
Closes the last correctness gap in the "Naive timestamps" milestone: **metric filters** (YAML metric `filters:` and custom-metric filters) baked their literals at metric compile time, where no data timezone or timestamp domain exists — so a filtered metric over a classified naive column still compared in the legacy domain even after #25820 fixed dimension filters, making the same condition return different rows as a query filter vs. inside a metric.

### How

Generalizes the proven `compiledRelativeDateFilters` record-and-swap pattern:

- **Compile:** absolute predicates targeting TIMESTAMP dimensions are recorded (`compiledTimestampFilters`: rule id, resolved field id, compiled predicate as the swap anchor) alongside the existing relative-date recording. DATE targets and value-less operators are not recorded.
- **Query time:** recorded predicates are re-rendered through the same domain-aware filter path dimension filters use, and string-swapped into the metric SQL — **only when the target is classified**. Unknown domains, `convert_timezone: false` dims, and old cached explores (no recorded metadata) stay byte-identical.
- **Custom metrics:** `compileAdditionalMetric` now passes the recorded metadata through — it previously dropped `compiledRelativeDateFilters` too, so custom metrics gain coverage for both absolute and relative predicates.

Before/after for the ticket's repro (BigQuery, data timezone Asia/Tokyo, naive column, filter `equals 2024-01-14T17:00Z`):

```sql
-- baked (before): UTC face vs Tokyo wall clocks → 0 rows
COUNT(CASE WHEN ((event_timestamp_ntz) = ('2024-01-14 17:00:00+00:00')) THEN ...)
-- swapped (after): typed wall-clock literal, identical to a dimension filter → 1 row
COUNT(CASE WHEN ((event_timestamp_ntz) = DATETIME '2024-01-15 02:00:00') THEN ...)
```

### Verification

- Compile recording: 181 exploreCompiler tests (absolute recorded with anchor, relative stays in its own list, DATE/value-less excluded).
- Query-time swap: 193 MetricQueryBuilder tests (classified swaps; unknown-domain and `convert_timezone: false` byte-identical; relative machinery untouched).
- Custom-metric passthrough: 45 queryCompiler tests.
- Live on BigQuery (`timezone_test`, data tz Asia/Tokyo): the ticket's exact repro — a filtered custom metric on the naive column — returns the on-screen row (1) instead of 0, with the compiled SQL above.

Closes GLITCH-627

test-timezone
