### PR TITLE
feat: add instance-level env var to disable data app sample data

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -392,6 +392,7 @@ export const lightdashConfigMock: LightdashConfig = {
         s3: null,
         e2bApiKey: null,
         customDependenciesEnabled: true,
+        sampleDataEnabled: true,
         e2bTemplateName: 'lightdash-data-app',
         e2bTemplateTag: '',
         e2bAiWritebackTemplateName: 'lightdash-ai-writeback',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1840,6 +1840,13 @@ export type AppRuntimeConfig = {
      * `false` to keep uploading custom-dependency apps.
      */
     dependencyMalwareCheckEnabled: boolean;
+    /**
+     * When false, app generation never runs chart sample queries, so no
+     * warehouse row values are sent to the sandbox or the LLM — the per-chart
+     * "include sample data" opt-in is disabled instance-wide and hidden in
+     * the UI. Env var `LIGHTDASH_APP_SAMPLE_DATA_ENABLED`; defaults to `true`.
+     */
+    sampleDataEnabled: boolean;
 };
 
 export type DataAppOtelConfig = {
@@ -2246,6 +2253,8 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
         dependencyMalwareCheckEnabled:
             process.env.LIGHTDASH_APP_DEPENDENCY_MALWARE_CHECK_ENABLED !==
             'false',
+        sampleDataEnabled:
+            process.env.LIGHTDASH_APP_SAMPLE_DATA_ENABLED !== 'false',
     };
 };
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizGeneration.test.ts
@@ -30,7 +30,9 @@ function buildService(
         appGeneratePipeline: vi.fn().mockResolvedValue(undefined),
     };
     const service = new AppGenerateService({
-        lightdashConfig: {} as never,
+        lightdashConfig: {
+            appRuntime: { sampleDataEnabled: true },
+        } as never,
         analytics: { track: vi.fn() } as never,
         analyticsModel: {} as never,
         catalogModel: {} as never,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -4233,11 +4233,13 @@ export class AppGenerateService extends BaseService {
     }> {
         // Dedupe by uuid; if any duplicate asks for sample data or link mode,
         // the union wins so the user gets the data they opted into.
+        const { sampleDataEnabled } = this.lightdashConfig.appRuntime;
         const dedup = new Map<string, { sample: boolean; link: boolean }>();
         for (const ref of chartRefs) {
             const prev = dedup.get(ref.uuid) ?? { sample: false, link: false };
             dedup.set(ref.uuid, {
-                sample: prev.sample || ref.includeSampleData,
+                sample:
+                    sampleDataEnabled && (prev.sample || ref.includeSampleData),
                 link: prev.link || (ref.linkLive ?? false),
             });
         }

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -138,6 +138,7 @@ export const BaseResponse: HealthState = {
     },
     dataApps: {
         previewOrigin: null,
+        sampleDataEnabled: true,
     },
 };
 

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -284,6 +284,8 @@ export class HealthService extends BaseService {
             },
             dataApps: {
                 previewOrigin: this.lightdashConfig.appRuntime.previewOrigin,
+                sampleDataEnabled:
+                    this.lightdashConfig.appRuntime.sampleDataEnabled,
             },
         };
     }

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -655,6 +655,12 @@ export type HealthState = {
          * previews are served same-origin (dev / pre-cutover).
          */
         previewOrigin: string | null;
+        /**
+         * Whether app authors may attach chart row samples during app
+         * generation. When false the instance never runs sample queries and
+         * the frontend hides the per-chart "include sample data" opt-in.
+         */
+        sampleDataEnabled: boolean;
     };
 };
 

--- a/packages/frontend/src/features/apps/AppResourcePicker.test.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.test.tsx
@@ -19,6 +19,7 @@ it('calls onToggleLink when the Link live button is clicked', () => {
                 onRemove={() => {}}
                 onToggleSampleData={() => {}}
                 onToggleLink={onToggleLink}
+                sampleDataEnabled
             />
         </MantineProvider>,
     );
@@ -34,9 +35,26 @@ it('hides the sample-data control when the chart is linked', () => {
                 onRemove={() => {}}
                 onToggleSampleData={() => {}}
                 onToggleLink={() => {}}
+                sampleDataEnabled
             />
         </MantineProvider>,
     );
     expect(screen.queryByLabelText('Include sample data')).toBeNull();
     expect(screen.getByLabelText('Linked: on')).toBeInTheDocument();
+});
+
+it('hides the sample-data controls when the instance disables sample data', () => {
+    render(
+        <MantineProvider>
+            <SelectedQuerySection
+                charts={[baseChart]}
+                onRemove={() => {}}
+                onToggleSampleData={() => {}}
+                onToggleLink={() => {}}
+                sampleDataEnabled={false}
+            />
+        </MantineProvider>,
+    );
+    expect(screen.queryByLabelText('Include sample data')).toBeNull();
+    expect(screen.getByLabelText('Link live')).toBeInTheDocument();
 });

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -619,8 +619,16 @@ export const SelectedQuerySection: FC<{
     onRemove: (uuid: string) => void;
     onToggleSampleData: (uuid: string) => void;
     onToggleLink: (uuid: string) => void;
+    sampleDataEnabled: boolean;
     disabled?: boolean;
-}> = ({ charts, onRemove, onToggleSampleData, onToggleLink, disabled }) => {
+}> = ({
+    charts,
+    onRemove,
+    onToggleSampleData,
+    onToggleLink,
+    sampleDataEnabled,
+    disabled,
+}) => {
     if (charts.length === 0) return null;
 
     return (
@@ -656,6 +664,7 @@ export const SelectedQuerySection: FC<{
                                 disabled={disabled}
                             />
                         ) : (
+                            sampleDataEnabled &&
                             chart.includeSampleData && (
                                 <InlineDataToggle
                                     onClick={() =>
@@ -676,12 +685,14 @@ export const SelectedQuerySection: FC<{
                             <MantineIcon icon={IconX} size={10} />
                         </ActionIcon>
                     </Box>
-                    {!chart.linkLive && !chart.includeSampleData && (
-                        <AddDataButton
-                            onClick={() => onToggleSampleData(chart.uuid)}
-                            disabled={disabled}
-                        />
-                    )}
+                    {sampleDataEnabled &&
+                        !chart.linkLive &&
+                        !chart.includeSampleData && (
+                            <AddDataButton
+                                onClick={() => onToggleSampleData(chart.uuid)}
+                                disabled={disabled}
+                            />
+                        )}
                     {!chart.linkLive && (
                         <AddLinkButton
                             onClick={() => onToggleLink(chart.uuid)}
@@ -1188,56 +1199,65 @@ export const SelectedDashboardSection: FC<{
     dashboard: SelectedDashboard;
     onRemove: () => void;
     onToggleSampleData: () => void;
+    sampleDataEnabled: boolean;
     disabled?: boolean;
-}> = ({ dashboard, onRemove, onToggleSampleData, disabled }) => (
-    <Box className={classes.selectedQueryList}>
-        <Box className={classes.selectedQueryItemRow}>
-            <Box
-                className={`${classes.selectedQueryItem} ${
-                    dashboard.includeSampleData
-                        ? classes.selectedQueryItemActive
-                        : ''
-                }`}
-            >
-                <Box className={classes.selectedQueryItemIcon}>
-                    <MantineIcon
-                        icon={IconLayoutDashboard}
-                        size={12}
-                        color="green.6"
-                    />
-                </Box>
-                <Text
-                    fw={500}
-                    truncate
-                    className={classes.selectedQueryItemName}
+}> = ({
+    dashboard,
+    onRemove,
+    onToggleSampleData,
+    sampleDataEnabled,
+    disabled,
+}) => {
+    return (
+        <Box className={classes.selectedQueryList}>
+            <Box className={classes.selectedQueryItemRow}>
+                <Box
+                    className={`${classes.selectedQueryItem} ${
+                        dashboard.includeSampleData
+                            ? classes.selectedQueryItemActive
+                            : ''
+                    }`}
                 >
-                    {dashboard.name}
-                </Text>
-                {dashboard.includeSampleData && (
-                    <InlineDataToggle
+                    <Box className={classes.selectedQueryItemIcon}>
+                        <MantineIcon
+                            icon={IconLayoutDashboard}
+                            size={12}
+                            color="green.6"
+                        />
+                    </Box>
+                    <Text
+                        fw={500}
+                        truncate
+                        className={classes.selectedQueryItemName}
+                    >
+                        {dashboard.name}
+                    </Text>
+                    {sampleDataEnabled && dashboard.includeSampleData && (
+                        <InlineDataToggle
+                            onClick={onToggleSampleData}
+                            disabled={disabled}
+                            tooltipSuffix=" Applies to every chart in this dashboard."
+                        />
+                    )}
+                    <ActionIcon
+                        size="xs"
+                        variant="subtle"
+                        color="gray"
+                        radius="xl"
+                        onClick={onRemove}
+                        disabled={disabled}
+                    >
+                        <MantineIcon icon={IconX} size={10} />
+                    </ActionIcon>
+                </Box>
+                {sampleDataEnabled && !dashboard.includeSampleData && (
+                    <AddDataButton
                         onClick={onToggleSampleData}
                         disabled={disabled}
                         tooltipSuffix=" Applies to every chart in this dashboard."
                     />
                 )}
-                <ActionIcon
-                    size="xs"
-                    variant="subtle"
-                    color="gray"
-                    radius="xl"
-                    onClick={onRemove}
-                    disabled={disabled}
-                >
-                    <MantineIcon icon={IconX} size={10} />
-                </ActionIcon>
             </Box>
-            {!dashboard.includeSampleData && (
-                <AddDataButton
-                    onClick={onToggleSampleData}
-                    disabled={disabled}
-                    tooltipSuffix=" Applies to every chart in this dashboard."
-                />
-            )}
         </Box>
-    </Box>
-);
+    );
+};

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -765,7 +765,8 @@ const AppGenerate: FC = () => {
     const { showToastError, showToastSuccess, showToastWarning } = useToaster();
     const { mutateAsync: uploadThumbnail } = useAppThumbnailUpload();
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
-    const { user } = useApp();
+    const { user, health } = useApp();
+    const sampleDataEnabled = health.data?.dataApps.sampleDataEnabled !== false;
     const ability = useAbilityContext();
     const chatMessagesRef = useRef<HTMLDivElement>(null);
 
@@ -2718,6 +2719,9 @@ const AppGenerate: FC = () => {
                                             )}
                                             {selectedCharts.length > 0 && (
                                                 <SelectedQuerySection
+                                                    sampleDataEnabled={
+                                                        sampleDataEnabled
+                                                    }
                                                     charts={selectedCharts}
                                                     onRemove={(uuid) =>
                                                         setSelectedCharts(
@@ -2770,6 +2774,9 @@ const AppGenerate: FC = () => {
                                             )}
                                             {selectedDashboard && (
                                                 <SelectedDashboardSection
+                                                    sampleDataEnabled={
+                                                        sampleDataEnabled
+                                                    }
                                                     dashboard={
                                                         selectedDashboard
                                                     }

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -138,6 +138,7 @@ export default function mockHealthResponse(
         },
         dataApps: {
             previewOrigin: null,
+            sampleDataEnabled: true,
         },
         ...overrides,
     };


### PR DESCRIPTION
## Summary

Adds an instance-level kill switch for data-app sample data: `LIGHTDASH_APP_SAMPLE_DATA_ENABLED=false`. Some self-hosted operators need a guarantee that no warehouse row values ever leave their deployment for the sandbox/LLM during app generation — today sample data is per-chart opt-in by the app author, with no way for an admin to disallow it.

## Changes

- **Config** (`parseConfig.ts`): new `appRuntime.sampleDataEnabled`, parsed from `LIGHTDASH_APP_SAMPLE_DATA_ENABLED`. Defaults to `true` (kill-switch semantics, consistent with `LIGHTDASH_APP_DEPENDENCY_MALWARE_CHECK_ENABLED`).
- **Backend enforcement** (`AppGenerateService.resolveChartReferences`): when disabled, every chart/dashboard ref's sample opt-in is forced off before dedup, so `fetchChartSample` never runs regardless of what the API request asks for. This is the real guarantee — server-side, not UI-only.
- **Health** (`HealthService` + `HealthState`): exposes `dataApps.sampleDataEnabled` so the frontend knows the instance policy.
- **Frontend** (`AppResourcePicker`): hides the "Add data" buttons and inline sample-data toggles (chart rows and dashboard section) when the instance disables the feature. Guarded with `!== false` so an older backend without the health field behaves exactly as before.

## Regression analysis

- Default is unchanged: with the env var unset, `sampleDataEnabled` is `true` and the dedup expression reduces to the previous `prev.sample || ref.includeSampleData`. No behavior change for existing instances.
- The frontend gate defaults open when the health field is missing, so mixed-version rollouts (new frontend, old backend) keep today's behavior.
- `sampleStats` telemetry: when disabled, `requested` counts 0 — consistent with "no samples were requested", since the opt-in is forced off before counting.
- One existing test stub (`AppGenerateService.dataAppVizGeneration.test.ts`) passed `lightdashConfig: {}`; it now provides `appRuntime.sampleDataEnabled` — test-only change.

## Testing

- `pnpm -F common|backend|frontend typecheck:fast` all pass
- `pnpm -F backend test:dev:nowatch` — 280 files / 4330 tests pass
- oxlint clean on touched frontend file

Closes: PROD-8314

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011njGJy5yQ2VNE3ngXVEakz
