### PR TITLE
feat: add AI agent memory page

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -16,6 +16,7 @@ import {
     ApiAiAgentEvaluationSummaryListResponse,
     ApiAiAgentExploreAccessSummaryResponse,
     ApiAiAgentMcpServerToolListResponse,
+    ApiAiAgentMemoryResponse,
     ApiAiAgentModelOptionsResponse,
     ApiAiAgentProjectThreadSummaryListResponse,
     ApiAiAgentResponse,
@@ -70,6 +71,7 @@ import {
     assertRegisteredAccount,
     KnexPaginateArgs,
     ParameterError,
+    type UUID,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import {
@@ -97,6 +99,7 @@ import {
 import { BaseController } from '../../controllers/baseController';
 import Logger from '../../logging/logger';
 import { type AiAgentCoderService } from '../services/AiAgentCoderService/AiAgentCoderService';
+import { type AiAgentMemoryService } from '../services/AiAgentMemoryService/AiAgentMemoryService';
 import { type AiAgentService } from '../services/AiAgentService/AiAgentService';
 
 @Route('/api/v1/projects/{projectUuid}/aiAgents')
@@ -487,6 +490,30 @@ export class AiAgentController extends BaseController {
         return {
             status: 'ok',
             results: agent,
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{agentUuid}/memories/{slug}')
+    @OperationId('getAiAgentMemory')
+    async getAiAgentMemory(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+        @Path() agentUuid: UUID,
+        @Path() slug: string,
+    ): Promise<ApiAiAgentMemoryResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        void agentUuid;
+
+        return {
+            status: 'ok',
+            results: await this.getAiAgentMemoryService().getMemory(
+                toSessionUser(req.account),
+                projectUuid,
+                slug,
+            ),
         };
     }
 
@@ -2040,6 +2067,10 @@ export class AiAgentController extends BaseController {
 
     protected getAiAgentService() {
         return this.services.getAiAgentService<AiAgentService>();
+    }
+
+    protected getAiAgentMemoryService() {
+        return this.services.getAiAgentMemoryService<AiAgentMemoryService>();
     }
 
     protected getAiAgentCoderService() {

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -139,6 +139,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new AiAgentMemoryService({
                     aiAgentMemoryModel:
                         models.getAiAgentMemoryModel<AiAgentMemoryModel>(),
+                    aiAgentModel: models.getAiAgentModel(),
+                    groupsModel: models.getGroupsModel(),
                     projectModel: models.getProjectModel(),
                     featureFlagService: repository.getFeatureFlagService(),
                     schedulerClient:

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.integration.test.ts
@@ -48,6 +48,7 @@ describe('AiAgentMemoryModel integration', () => {
     let schedulerClient: CommercialSchedulerClient;
     const originalFlags = new Map<string, DbFeatureFlag | undefined>();
     const threadUuids = new Set<string>();
+    const memoryUuids = new Set<string>();
 
     const setFeatureFlag = async (flagId: string, enabled: boolean) => {
         await database<FeatureFlagsTable>(FeatureFlagsTableName)
@@ -113,6 +114,12 @@ describe('AiAgentMemoryModel integration', () => {
 
     afterEach(async () => {
         await setFeatureFlag(FeatureFlags.AiAgentMemory, true);
+        if (memoryUuids.size > 0) {
+            await database(AiAgentMemoryTableName)
+                .whereIn('ai_agent_memory_uuid', [...memoryUuids])
+                .delete();
+            memoryUuids.clear();
+        }
         if (threadUuids.size === 0) {
             return;
         }
@@ -240,11 +247,13 @@ describe('AiAgentMemoryModel integration', () => {
         distillCall: AiAgentMemoryDistillCall,
         projectModel: Pick<
             ProjectModel,
-            'findExploresFromCache'
+            'findExploresFromCache' | 'getSummary'
         > = getTestContext().app.getModels().getProjectModel(),
     ) =>
         new AiAgentMemoryService({
             aiAgentMemoryModel: model,
+            aiAgentModel: getTestContext().app.getModels().getAiAgentModel(),
+            groupsModel: getTestContext().app.getModels().getGroupsModel(),
             projectModel,
             featureFlagService,
             schedulerClient,
@@ -523,6 +532,102 @@ describe('AiAgentMemoryModel integration', () => {
             second.ai_agent_memory_uuid,
             third.ai_agent_memory_uuid,
         ]);
+    });
+
+    it('reads distilled and nested consolidated provenance with the final replacement', async () => {
+        const [firstThread, secondThread] = await Promise.all([
+            createThread(),
+            createThread(),
+        ]);
+        await Promise.all([
+            database(AiThreadTableName)
+                .where('ai_thread_uuid', firstThread)
+                .update({ title: 'Revenue convention' }),
+            database(AiThreadTableName)
+                .where('ai_thread_uuid', secondThread)
+                .update({ title: 'Refund correction' }),
+        ]);
+        const [first, second] = await Promise.all([
+            model.upsertSourceThreadMemory(memoryInput(firstThread)),
+            model.upsertSourceThreadMemory(
+                memoryInput(secondThread, {
+                    rawMemory: 'Subtract refunds.',
+                    threadSummary: 'The user corrected refund handling.',
+                }),
+            ),
+        ]);
+        const [winner] = await database(AiAgentMemoryTableName)
+            .insert({
+                organization_uuid: SEED_ORG_1.organization_uuid,
+                project_uuid: SEED_PROJECT.project_uuid,
+                agent_uuid: null,
+                user_uuid: null,
+                source_thread_uuid: null,
+                slug: `winner-${crypto.randomUUID().slice(0, 8)}`,
+                title: 'Net revenue after refunds',
+                raw_memory: 'Use net revenue after refunds.',
+                thread_summary: null,
+                terms: JSON.stringify(['net revenue']),
+                objects: JSON.stringify([]),
+                unresolved_objects: JSON.stringify([]),
+                generated_at: new Date('2026-07-22T14:00:00Z'),
+            } as never)
+            .returning('*');
+        memoryUuids.add(winner.ai_agent_memory_uuid);
+        const [merged] = await database(AiAgentMemoryTableName)
+            .insert({
+                organization_uuid: SEED_ORG_1.organization_uuid,
+                project_uuid: SEED_PROJECT.project_uuid,
+                agent_uuid: null,
+                user_uuid: null,
+                source_thread_uuid: null,
+                slug: `merged-${crypto.randomUUID().slice(0, 8)}`,
+                title: 'Net revenue',
+                raw_memory: 'Use net revenue.',
+                thread_summary: null,
+                terms: JSON.stringify(['revenue']),
+                objects: JSON.stringify([]),
+                unresolved_objects: JSON.stringify([]),
+                status: 'superseded',
+                superseded_by_uuid: winner.ai_agent_memory_uuid,
+                generated_at: new Date('2026-07-22T13:00:00Z'),
+            } as never)
+            .returning('*');
+        memoryUuids.add(merged.ai_agent_memory_uuid);
+        await database(AiAgentMemoryTableName)
+            .whereIn('ai_agent_memory_uuid', [
+                first.ai_agent_memory_uuid,
+                second.ai_agent_memory_uuid,
+            ])
+            .update({
+                status: 'superseded',
+                superseded_by_uuid: merged.ai_agent_memory_uuid,
+            });
+
+        const result = await model.findByProjectAndSlug({
+            projectUuid: SEED_PROJECT.project_uuid,
+            slug: winner.slug,
+        });
+        const superseded = await model.findByProjectAndSlug({
+            projectUuid: SEED_PROJECT.project_uuid,
+            slug: merged.slug,
+        });
+
+        expect(
+            result?.sources
+                .map((source) => ({
+                    slug: source.slug,
+                    threadTitle: source.thread_title,
+                }))
+                .sort((a, b) => a.slug.localeCompare(b.slug)),
+        ).toEqual(
+            [
+                { slug: first.slug, threadTitle: 'Revenue convention' },
+                { slug: second.slug, threadTitle: 'Refund correction' },
+            ].sort((a, b) => a.slug.localeCompare(b.slug)),
+        );
+        expect(result?.replacement).toBeNull();
+        expect(superseded?.replacement).toEqual({ slug: winner.slug });
     });
 
     it('selects only idle, recent, supported threads due by watermark', async () => {
@@ -876,8 +981,10 @@ describe('AiAgentMemoryModel integration', () => {
         const findExploresFromCache = vi
             .fn<ProjectModel['findExploresFromCache']>()
             .mockRejectedValue(new Error('catalog unavailable'));
+        const projectModel = getTestContext().app.getModels().getProjectModel();
         const service = buildService(distillCall, {
             findExploresFromCache,
+            getSummary: projectModel.getSummary.bind(projectModel),
         });
 
         await expect(

--- a/packages/backend/src/ee/models/AiAgentMemoryModel.ts
+++ b/packages/backend/src/ee/models/AiAgentMemoryModel.ts
@@ -102,6 +102,19 @@ export type AiAgentMemoryThread = AiAgentMemoryThreadCandidate & {
     }>;
 };
 
+export type AiAgentMemoryLineageSource = Pick<
+    DbAiAgentMemory,
+    'slug' | 'agent_uuid' | 'source_thread_uuid' | 'thread_summary'
+> & {
+    thread_title: string | null;
+};
+
+export type AiAgentMemoryWithLineage = {
+    memory: DbAiAgentMemory;
+    sources: AiAgentMemoryLineageSource[];
+    replacement: Pick<DbAiAgentMemory, 'slug'> | null;
+};
+
 export class AiAgentMemoryModel {
     private readonly database: Knex;
 
@@ -419,6 +432,132 @@ export class AiAgentMemoryModel {
         }
 
         return query;
+    }
+
+    async findByProjectAndSlug(args: {
+        projectUuid: string;
+        slug: string;
+    }): Promise<AiAgentMemoryWithLineage | undefined> {
+        const memory = await this.database<AiAgentMemoryTable>(
+            AiAgentMemoryTableName,
+        )
+            .where('project_uuid', args.projectUuid)
+            .where('slug', args.slug)
+            .first();
+        if (!memory) return undefined;
+
+        const lineageRows =
+            memory.source_thread_uuid && memory.thread_summary
+                ? [memory]
+                : (
+                      await this.database.raw<{
+                          rows: DbAiAgentMemory[];
+                      }>(
+                          `
+                            WITH RECURSIVE lineage AS (
+                                SELECT child.*, ARRAY[?::uuid, child.ai_agent_memory_uuid] AS lineage_path
+                                FROM ${AiAgentMemoryTableName} AS child
+                                WHERE child.project_uuid = ?
+                                  AND child.superseded_by_uuid = ?
+
+                                UNION ALL
+
+                                SELECT child.*, lineage.lineage_path || child.ai_agent_memory_uuid
+                                FROM ${AiAgentMemoryTableName} AS child
+                                INNER JOIN lineage
+                                    ON child.superseded_by_uuid = lineage.ai_agent_memory_uuid
+                                WHERE child.project_uuid = ?
+                                  AND NOT child.ai_agent_memory_uuid = ANY(lineage.lineage_path)
+                            )
+                            SELECT * FROM lineage
+                            WHERE source_thread_uuid IS NOT NULL
+                              AND thread_summary IS NOT NULL
+                          `,
+                          [
+                              memory.ai_agent_memory_uuid,
+                              args.projectUuid,
+                              memory.ai_agent_memory_uuid,
+                              args.projectUuid,
+                          ],
+                      )
+                  ).rows;
+
+        const threadUuids = lineageRows.flatMap((row) =>
+            row.source_thread_uuid ? [row.source_thread_uuid] : [],
+        );
+        const threadTitles = new Map(
+            threadUuids.length === 0
+                ? []
+                : (
+                      await this.database(AiThreadTableName)
+                          .whereIn(
+                              `${AiThreadTableName}.ai_thread_uuid`,
+                              threadUuids,
+                          )
+                          .select<
+                              Array<{
+                                  ai_thread_uuid: string;
+                                  title: string | null;
+                              }>
+                          >(
+                              `${AiThreadTableName}.ai_thread_uuid`,
+                              `${AiThreadTableName}.title`,
+                          )
+                  ).map(
+                      (thread) =>
+                          [thread.ai_thread_uuid, thread.title] as const,
+                  ),
+        );
+        const sources = lineageRows.map((row) => ({
+            slug: row.slug,
+            agent_uuid: row.agent_uuid,
+            source_thread_uuid: row.source_thread_uuid,
+            thread_summary: row.thread_summary,
+            thread_title: row.source_thread_uuid
+                ? (threadTitles.get(row.source_thread_uuid) ?? null)
+                : null,
+        }));
+
+        const replacement = memory.superseded_by_uuid
+            ? ((
+                  await this.database.raw<{
+                      rows: Array<Pick<DbAiAgentMemory, 'slug'>>;
+                  }>(
+                      `
+                        WITH RECURSIVE replacements AS (
+                            SELECT next.ai_agent_memory_uuid, next.slug, next.superseded_by_uuid,
+                                   ARRAY[?::uuid, next.ai_agent_memory_uuid] AS replacement_path,
+                                   1 AS depth
+                            FROM ${AiAgentMemoryTableName} AS next
+                            WHERE next.project_uuid = ?
+                              AND next.ai_agent_memory_uuid = ?
+
+                            UNION ALL
+
+                            SELECT next.ai_agent_memory_uuid, next.slug, next.superseded_by_uuid,
+                                   replacements.replacement_path || next.ai_agent_memory_uuid,
+                                   replacements.depth + 1
+                            FROM ${AiAgentMemoryTableName} AS next
+                            INNER JOIN replacements
+                                ON next.ai_agent_memory_uuid = replacements.superseded_by_uuid
+                            WHERE next.project_uuid = ?
+                              AND NOT next.ai_agent_memory_uuid = ANY(replacements.replacement_path)
+                        )
+                        SELECT slug FROM replacements
+                        ORDER BY depth DESC
+                        LIMIT 1
+                      `,
+                      [
+                          memory.ai_agent_memory_uuid,
+                          args.projectUuid,
+                          memory.superseded_by_uuid,
+                          args.projectUuid,
+                      ],
+                  )
+              ).rows[0] ?? null)
+            : null;
+
+        return { memory, sources, replacement };
     }
 
     async incrementPulledForActiveMemories(args: {

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.test.ts
@@ -1,10 +1,19 @@
+import { Ability, AbilityBuilder } from '@casl/ability';
 import {
+    CommercialFeatureFlags,
     DimensionType,
+    FeatureFlags,
     FieldType,
     SupportedDbtAdapter,
+    type AnyType,
     type Explore,
+    type MemberAbility,
 } from '@lightdash/common';
-import { validateMemoryObjects } from './AiAgentMemoryService';
+import { vi } from 'vitest';
+import {
+    AiAgentMemoryService,
+    validateMemoryObjects,
+} from './AiAgentMemoryService';
 
 const explore: Explore = {
     targetDatabase: SupportedDbtAdapter.POSTGRES,
@@ -75,5 +84,316 @@ describe('validateMemoryObjects', () => {
             resolved: [validExplore, validField],
             unresolved: [wrongExplore, wrongCase],
         });
+    });
+});
+describe('AiAgentMemoryService', () => {
+    const buildUser = (
+        canViewProject: boolean,
+        { canManageAgents = false } = {},
+    ) => {
+        const { build: buildAbility, can } = new AbilityBuilder<MemberAbility>(
+            Ability,
+        );
+        if (canViewProject) {
+            can('view', 'Project', {
+                organizationUuid: 'org-enabled',
+            });
+            if (canManageAgents) {
+                can('manage', 'AiAgent', {
+                    projectUuid: 'project-enabled',
+                });
+            }
+        }
+        return {
+            organizationUuid: 'org-enabled',
+            userUuid: 'current-user',
+            ability: buildAbility(),
+        } as AnyType;
+    };
+
+    const build = ({ enabledOrganization = 'org-enabled' } = {}) => {
+        const getFlag = vi.fn(async ({ user, featureFlagId }) => ({
+            id: featureFlagId,
+            enabled:
+                user.organizationUuid === enabledOrganization &&
+                (featureFlagId === FeatureFlags.AiAgentMemory ||
+                    featureFlagId === CommercialFeatureFlags.AiCopilot),
+        }));
+        const findByProjectAndSlug = vi.fn();
+        const getAgent = vi.fn().mockResolvedValue({
+            uuid: 'agent-1',
+            name: 'Agent',
+            organizationUuid: 'org-enabled',
+            projectUuid: 'project-enabled',
+            adminOnly: false,
+            groupAccess: [],
+            userAccess: [],
+        });
+        const findThreadOwnership = vi.fn().mockResolvedValue({
+            threadUuid: 'thread-enabled',
+            projectUuid: 'project-enabled',
+            agentUuid: 'agent-1',
+            ownerUserUuid: 'source-user',
+        });
+        const findUserInGroups = vi.fn().mockResolvedValue([]);
+        const getProjectSummary = vi.fn(async (projectUuid: string) => ({
+            organizationUuid:
+                projectUuid === 'project-other' ? 'org-other' : 'org-enabled',
+        }));
+        const service = new AiAgentMemoryService({
+            aiAgentMemoryModel: { findByProjectAndSlug } as AnyType,
+            aiAgentModel: { getAgent, findThreadOwnership } as AnyType,
+            groupsModel: { findUserInGroups } as AnyType,
+            projectModel: { getSummary: getProjectSummary } as AnyType,
+            featureFlagService: { get: getFlag } as AnyType,
+            schedulerClient: { aiAgentMemoryDistill: vi.fn() },
+            distillCall: vi.fn(),
+        });
+        return {
+            service,
+            getFlag,
+            findByProjectAndSlug,
+            getAgent,
+            findThreadOwnership,
+        };
+    };
+
+    it('returns a project-visible memory with source provenance', async () => {
+        const { service, findByProjectAndSlug, getAgent } = build();
+        findByProjectAndSlug.mockResolvedValue({
+            memory: {
+                slug: 'net-revenue-ab12cd34',
+                title: 'Net revenue convention',
+                raw_memory: 'Use net revenue.',
+                terms: ['net revenue'],
+                objects: [
+                    {
+                        type: 'field',
+                        explore: 'orders',
+                        fieldId: 'orders_net_revenue',
+                    },
+                ],
+                status: 'active',
+                source_thread_uuid: 'thread-enabled',
+                generated_at: new Date('2026-07-22T10:00:00Z'),
+                cited_count: 3,
+            },
+            sources: [
+                {
+                    slug: 'net-revenue-ab12cd34',
+                    agent_uuid: 'agent-1',
+                    source_thread_uuid: 'thread-enabled',
+                    thread_summary: '**The user** established the convention.',
+                    thread_title: 'Revenue definitions',
+                },
+            ],
+            replacement: null,
+        });
+        getAgent.mockResolvedValue({
+            uuid: 'agent-1',
+            name: 'Agent',
+            organizationUuid: 'org-enabled',
+            projectUuid: 'project-enabled',
+            adminOnly: true,
+            groupAccess: [],
+            userAccess: [],
+        });
+        const user = buildUser(true, { canManageAgents: true });
+
+        await expect(
+            service.getMemory(user, 'project-enabled', 'net-revenue-ab12cd34'),
+        ).resolves.toMatchObject({
+            slug: 'net-revenue-ab12cd34',
+            title: 'Net revenue convention',
+            generatedAt: '2026-07-22T10:00:00.000Z',
+            citedCount: 3,
+            provenance: {
+                type: 'source_thread',
+                source: {
+                    hasThreadAccess: true,
+                    agentUuid: 'agent-1',
+                    threadUuid: 'thread-enabled',
+                    threadTitle: 'Revenue definitions',
+                },
+            },
+        });
+    });
+
+    it('redacts source thread details from users without thread access', async () => {
+        const { service, findByProjectAndSlug } = build();
+        findByProjectAndSlug.mockResolvedValue({
+            memory: {
+                slug: 'net-revenue-ab12cd34',
+                title: 'Net revenue convention',
+                raw_memory: 'Use net revenue.',
+                terms: ['net revenue'],
+                objects: [],
+                status: 'active',
+                source_thread_uuid: 'thread-enabled',
+                generated_at: new Date('2026-07-22T10:00:00Z'),
+                cited_count: 3,
+            },
+            sources: [
+                {
+                    slug: 'net-revenue-ab12cd34',
+                    agent_uuid: 'agent-1',
+                    source_thread_uuid: 'thread-enabled',
+                    thread_summary: 'Private thread summary.',
+                    thread_title: 'Private thread title',
+                },
+            ],
+            replacement: null,
+        });
+
+        const memory = await service.getMemory(
+            buildUser(true),
+            'project-enabled',
+            'net-revenue-ab12cd34',
+        );
+
+        expect(memory.provenance).toEqual({
+            type: 'source_thread',
+            source: {
+                slug: 'net-revenue-ab12cd34',
+                hasThreadAccess: false,
+            },
+        });
+    });
+
+    it('returns source details to the thread owner without manage access', async () => {
+        const { service, findByProjectAndSlug, findThreadOwnership } = build();
+        findByProjectAndSlug.mockResolvedValue({
+            memory: {
+                slug: 'net-revenue-ab12cd34',
+                title: 'Net revenue convention',
+                raw_memory: 'Use net revenue.',
+                terms: [],
+                objects: [],
+                status: 'active',
+                source_thread_uuid: 'thread-enabled',
+                generated_at: new Date('2026-07-22T10:00:00Z'),
+                cited_count: 3,
+            },
+            sources: [
+                {
+                    slug: 'net-revenue-ab12cd34',
+                    agent_uuid: 'agent-1',
+                    source_thread_uuid: 'thread-enabled',
+                    thread_summary: 'Owner-visible summary.',
+                    thread_title: 'Owner-visible title',
+                },
+            ],
+            replacement: null,
+        });
+        findThreadOwnership.mockResolvedValue({
+            threadUuid: 'thread-enabled',
+            projectUuid: 'project-enabled',
+            agentUuid: 'agent-1',
+            ownerUserUuid: 'current-user',
+        });
+
+        const memory = await service.getMemory(
+            buildUser(true),
+            'project-enabled',
+            'net-revenue-ab12cd34',
+        );
+
+        expect(memory.provenance).toMatchObject({
+            type: 'source_thread',
+            source: {
+                hasThreadAccess: true,
+                threadTitle: 'Owner-visible title',
+            },
+        });
+    });
+
+    it('redacts source details when the owner loses agent access', async () => {
+        const { service, findByProjectAndSlug, findThreadOwnership, getAgent } =
+            build();
+        findByProjectAndSlug.mockResolvedValue({
+            memory: {
+                slug: 'net-revenue-ab12cd34',
+                title: 'Net revenue convention',
+                raw_memory: 'Use net revenue.',
+                terms: [],
+                objects: [],
+                status: 'active',
+                source_thread_uuid: 'thread-enabled',
+                generated_at: new Date('2026-07-22T10:00:00Z'),
+                cited_count: 3,
+            },
+            sources: [
+                {
+                    slug: 'net-revenue-ab12cd34',
+                    agent_uuid: 'agent-1',
+                    source_thread_uuid: 'thread-enabled',
+                    thread_summary: 'Private summary.',
+                    thread_title: 'Private title',
+                },
+            ],
+            replacement: null,
+        });
+        findThreadOwnership.mockResolvedValue({
+            threadUuid: 'thread-enabled',
+            projectUuid: 'project-enabled',
+            agentUuid: 'agent-1',
+            ownerUserUuid: 'current-user',
+        });
+        getAgent.mockResolvedValue({
+            uuid: 'agent-1',
+            name: 'Agent',
+            organizationUuid: 'org-enabled',
+            projectUuid: 'project-enabled',
+            adminOnly: true,
+            groupAccess: [],
+            userAccess: [],
+        });
+
+        const memory = await service.getMemory(
+            buildUser(true),
+            'project-enabled',
+            'net-revenue-ab12cd34',
+        );
+
+        expect(memory.provenance).toEqual({
+            type: 'source_thread',
+            source: {
+                slug: 'net-revenue-ab12cd34',
+                hasThreadAccess: false,
+            },
+        });
+    });
+
+    it('returns not found without reading rows when the flag is off', async () => {
+        const { service, findByProjectAndSlug } = build({
+            enabledOrganization: 'none',
+        });
+        const user = buildUser(true);
+
+        await expect(
+            service.getMemory(user, 'project-enabled', 'net-revenue'),
+        ).rejects.toThrow('Memory not found: net-revenue');
+        expect(findByProjectAndSlug).not.toHaveBeenCalled();
+    });
+
+    it('rejects users who cannot view the project before checking flags', async () => {
+        const { service, getFlag } = build();
+        const user = buildUser(false);
+
+        await expect(
+            service.getMemory(user, 'project-enabled', 'net-revenue'),
+        ).rejects.toThrow('Cannot view project');
+        expect(getFlag).not.toHaveBeenCalled();
+    });
+
+    it('rejects an organization member for a project in another organization', async () => {
+        const { service, getFlag, findByProjectAndSlug } = build();
+        const user = buildUser(true);
+
+        await expect(
+            service.getMemory(user, 'project-other', 'net-revenue'),
+        ).rejects.toThrow('Cannot view project');
+        expect(getFlag).not.toHaveBeenCalled();
+        expect(findByProjectAndSlug).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
+++ b/packages/backend/src/ee/services/AiAgentMemoryService/AiAgentMemoryService.ts
@@ -1,29 +1,37 @@
+import { subject } from '@casl/ability';
 import {
     CommercialFeatureFlags,
     FeatureFlags,
+    ForbiddenError,
     getErrorMessage,
     getFields,
     getItemId,
     isExploreError,
+    NotFoundError,
     ProjectType,
+    type AiAgentMemory,
     type AiAgentMemoryDistillJobPayload,
     type AiProjectContextTypedObjectRef,
     type Explore,
     type ExploreError,
+    type SessionUser,
     type UUID,
 } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { createHash, randomBytes } from 'crypto';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import { type GroupsModel } from '../../../models/GroupsModel';
 import { type ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { BaseService } from '../../../services/BaseService';
 import { type FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import {
     AI_AGENT_MEMORY_THREAD_SOURCES,
     AiAgentMemoryModel,
+    type AiAgentMemoryLineageSource,
     type AiAgentMemoryThread,
 } from '../../models/AiAgentMemoryModel';
+import { type AiAgentModel } from '../../models/AiAgentModel';
 import { defaultAgentOptions } from '../ai/agents/agentV2';
 import { getModel } from '../ai/models';
 import { OrgAiCopilotConfigResolver } from '../ai/OrgAiCopilotConfigResolver';
@@ -31,6 +39,7 @@ import {
     getAiCallTelemetry,
     getLanguageModelAttribution,
 } from '../ai/utils/aiCallTelemetry';
+import { canAccessAiAgentThread } from '../AiAgentService/aiAgentAccess';
 import { distillOutputSchema, type DistillOutput } from './distillSchema';
 import { sanitizeThread } from './transcriptSanitizer';
 
@@ -59,7 +68,9 @@ type MemorySchedulerClient = {
 
 type Dependencies = {
     aiAgentMemoryModel: AiAgentMemoryModel;
-    projectModel: Pick<ProjectModel, 'findExploresFromCache'>;
+    aiAgentModel: Pick<AiAgentModel, 'getAgent' | 'findThreadOwnership'>;
+    groupsModel: Pick<GroupsModel, 'findUserInGroups'>;
+    projectModel: Pick<ProjectModel, 'findExploresFromCache' | 'getSummary'>;
     featureFlagService: FeatureFlagService;
     schedulerClient: MemorySchedulerClient;
 } & (
@@ -103,6 +114,10 @@ export const validateMemoryObjects = (
 export class AiAgentMemoryService extends BaseService {
     private readonly aiAgentMemoryModel: AiAgentMemoryModel;
 
+    private readonly aiAgentModel: Dependencies['aiAgentModel'];
+
+    private readonly groupsModel: Dependencies['groupsModel'];
+
     private readonly projectModel: Dependencies['projectModel'];
 
     private readonly featureFlagService: FeatureFlagService;
@@ -118,6 +133,8 @@ export class AiAgentMemoryService extends BaseService {
     constructor(dependencies: Dependencies) {
         super({ serviceName: 'AiAgentMemoryService' });
         this.aiAgentMemoryModel = dependencies.aiAgentMemoryModel;
+        this.aiAgentModel = dependencies.aiAgentModel;
+        this.groupsModel = dependencies.groupsModel;
         this.projectModel = dependencies.projectModel;
         this.featureFlagService = dependencies.featureFlagService;
         this.schedulerClient = dependencies.schedulerClient;
@@ -125,6 +142,45 @@ export class AiAgentMemoryService extends BaseService {
             dependencies.orgAiCopilotConfigResolver;
         this.distillCall =
             dependencies.distillCall ?? this.distillWithLlm.bind(this);
+    }
+
+    private async canViewSourceThread(
+        user: SessionUser,
+        organizationUuid: string,
+        projectUuid: string,
+        source: AiAgentMemoryLineageSource,
+    ): Promise<boolean> {
+        if (!source.agent_uuid) return false;
+
+        const [agent, ownership] = await Promise.all([
+            this.aiAgentModel.getAgent({
+                organizationUuid,
+                agentUuid: source.agent_uuid,
+            }),
+            this.aiAgentModel.findThreadOwnership({
+                organizationUuid,
+                threadUuid: source.source_thread_uuid ?? '',
+            }),
+        ]);
+        if (
+            !agent ||
+            agent.projectUuid !== projectUuid ||
+            !ownership ||
+            ownership.projectUuid !== projectUuid ||
+            ownership.agentUuid !== source.agent_uuid
+        ) {
+            return false;
+        }
+
+        return canAccessAiAgentThread(
+            user,
+            agent,
+            ownership.ownerUserUuid ?? '',
+            {
+                auditedAbility: this.createAuditedAbility(user),
+                groupsModel: this.groupsModel,
+            },
+        );
     }
 
     private async isEnabled(organizationUuid: UUID): Promise<boolean> {
@@ -171,6 +227,91 @@ export class AiAgentMemoryService extends BaseService {
             });
             return objects;
         }
+    }
+
+    async getMemory(
+        user: SessionUser,
+        projectUuid: string,
+        slug: string,
+    ): Promise<AiAgentMemory> {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        if (
+            this.createAuditedAbility(user).cannot(
+                'view',
+                subject('Project', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError('Cannot view project');
+        }
+
+        const [copilot, memoryFlag] = await Promise.all([
+            this.featureFlagService.get({
+                user,
+                featureFlagId: CommercialFeatureFlags.AiCopilot,
+            }),
+            this.featureFlagService.get({
+                user,
+                featureFlagId: FeatureFlags.AiAgentMemory,
+            }),
+        ]);
+        if (!copilot.enabled || !memoryFlag.enabled) {
+            throw new NotFoundError(`Memory not found: ${slug}`);
+        }
+
+        const result = await this.aiAgentMemoryModel.findByProjectAndSlug({
+            projectUuid,
+            slug,
+        });
+        if (!result) {
+            throw new NotFoundError(`Memory not found: ${slug}`);
+        }
+
+        const sources = (
+            await Promise.all(
+                result.sources.map(async (source) => {
+                    if (!source.source_thread_uuid || !source.thread_summary) {
+                        return null;
+                    }
+
+                    const hasThreadAccess = await this.canViewSourceThread(
+                        user,
+                        organizationUuid,
+                        projectUuid,
+                        source,
+                    );
+                    return hasThreadAccess
+                        ? {
+                              slug: source.slug,
+                              hasThreadAccess: true as const,
+                              agentUuid: source.agent_uuid,
+                              threadUuid: source.source_thread_uuid,
+                              threadTitle: source.thread_title,
+                              threadSummary: source.thread_summary,
+                          }
+                        : {
+                              slug: source.slug,
+                              hasThreadAccess: false as const,
+                          };
+                }),
+            )
+        ).filter((source) => source !== null);
+
+        return {
+            slug: result.memory.slug,
+            title: result.memory.title,
+            rawMemory: result.memory.raw_memory,
+            terms: result.memory.terms,
+            objects: result.memory.objects,
+            status: result.memory.status,
+            generatedAt: result.memory.generated_at.toISOString(),
+            citedCount: result.memory.cited_count,
+            provenance:
+                result.memory.source_thread_uuid && sources[0]
+                    ? { type: 'source_thread', source: sources[0] }
+                    : { type: 'consolidated', sources },
+            replacementSlug: result.replacement?.slug ?? null,
+        };
     }
 
     async sweep(now = new Date()): Promise<number> {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -345,6 +345,7 @@ import type { AiWritebackSource } from '../AiWritebackService/types';
 import { type WritebackPreviewService } from '../AiWritebackService/WritebackPreviewService';
 import { PreviewDeploySetupService } from '../PreviewDeploySetupService/PreviewDeploySetupService';
 import { ProjectContextService } from '../ProjectContextService/ProjectContextService';
+import { canAccessAiAgent, canAccessAiAgentThread } from './aiAgentAccess';
 import { canGeneratePostResponseSuggestions } from './suggestionAccess';
 
 type ThreadMessageContext = Array<
@@ -1143,65 +1144,10 @@ export class AiAgentService extends BaseService {
         user: SessionUser,
         agent: AiAgent,
     ): Promise<boolean> {
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.can(
-                'manage',
-                subject('AiAgent', {
-                    organizationUuid: agent.organizationUuid,
-                    projectUuid: agent.projectUuid,
-                    metadata: {
-                        agentUuid: agent.uuid,
-                        agentName: agent.name,
-                    },
-                }),
-            )
-        ) {
-            return true;
-        }
-
-        // Admin-only agents are visible to admins/developers only (granted by
-        // the manage check above); everyone else is denied regardless of the
-        // user/group access lists below.
-        if (agent.adminOnly) {
-            return false;
-        }
-
-        // Check if open access (no restrictions)
-        const hasGroupAccess =
-            agent.groupAccess && agent.groupAccess.length > 0;
-        const hasUserAccess = agent.userAccess && agent.userAccess.length > 0;
-
-        if (!hasGroupAccess && !hasUserAccess) {
-            return auditedAbility.can(
-                'view',
-                subject('Project', {
-                    organizationUuid: agent.organizationUuid,
-                    projectUuid: agent.projectUuid,
-                }),
-            );
-        }
-
-        // Check user access first (direct access)
-        if (hasUserAccess && agent.userAccess.includes(user.userUuid)) {
-            return true;
-        }
-
-        // Check group access
-        if (hasGroupAccess) {
-            const groupUuids = agent.groupAccess;
-            const userGroups = await this.groupsModel.findUserInGroups({
-                userUuid: user.userUuid,
-                organizationUuid: agent.organizationUuid,
-                groupUuids,
-            });
-
-            if (userGroups.length > 0) {
-                return true;
-            }
-        }
-
-        return false;
+        return canAccessAiAgent(user, agent, {
+            auditedAbility: this.createAuditedAbility(user),
+            groupsModel: this.groupsModel,
+        });
     }
 
     /**
@@ -1412,33 +1358,10 @@ export class AiAgentService extends BaseService {
         agent: AiAgent,
         threadUserUuid: string,
     ): Promise<boolean> {
-        const hasAccess = await this.checkAgentAccess(user, agent);
-        if (!hasAccess) {
-            return false;
-        }
-
-        if (threadUserUuid === user.userUuid) {
-            return true;
-        }
-
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.can(
-                'manage',
-                subject('AiAgent', {
-                    organizationUuid: agent.organizationUuid,
-                    projectUuid: agent.projectUuid,
-                    metadata: {
-                        agentUuid: agent.uuid,
-                        agentName: agent.name,
-                    },
-                }),
-            )
-        ) {
-            return true;
-        }
-
-        return false;
+        return canAccessAiAgentThread(user, agent, threadUserUuid, {
+            auditedAbility: this.createAuditedAbility(user),
+            groupsModel: this.groupsModel,
+        });
     }
 
     private static getEmbedAiAgentContext(

--- a/packages/backend/src/ee/services/AiAgentService/aiAgentAccess.ts
+++ b/packages/backend/src/ee/services/AiAgentService/aiAgentAccess.ts
@@ -1,0 +1,77 @@
+import { subject, type Ability } from '@casl/ability';
+import { type AiAgent, type SessionUser } from '@lightdash/common';
+import { type CaslAuditWrapper } from '../../../logging/caslAuditWrapper';
+import { type GroupsModel } from '../../../models/GroupsModel';
+
+type AccessDependencies = {
+    auditedAbility: CaslAuditWrapper<Ability>;
+    groupsModel: Pick<GroupsModel, 'findUserInGroups'>;
+};
+
+export const canAccessAiAgent = async (
+    user: SessionUser,
+    agent: AiAgent,
+    { auditedAbility, groupsModel }: AccessDependencies,
+): Promise<boolean> => {
+    if (
+        auditedAbility.can(
+            'manage',
+            subject('AiAgent', {
+                organizationUuid: agent.organizationUuid,
+                projectUuid: agent.projectUuid,
+                metadata: {
+                    agentUuid: agent.uuid,
+                    agentName: agent.name,
+                },
+            }),
+        )
+    ) {
+        return true;
+    }
+
+    if (agent.adminOnly) return false;
+
+    const hasGroupAccess = agent.groupAccess.length > 0;
+    const hasUserAccess = agent.userAccess.length > 0;
+    if (!hasGroupAccess && !hasUserAccess) {
+        return auditedAbility.can(
+            'view',
+            subject('Project', {
+                organizationUuid: agent.organizationUuid,
+                projectUuid: agent.projectUuid,
+            }),
+        );
+    }
+
+    if (hasUserAccess && agent.userAccess.includes(user.userUuid)) return true;
+    if (!hasGroupAccess) return false;
+
+    const userGroups = await groupsModel.findUserInGroups({
+        userUuid: user.userUuid,
+        organizationUuid: agent.organizationUuid,
+        groupUuids: agent.groupAccess,
+    });
+    return userGroups.length > 0;
+};
+
+export const canAccessAiAgentThread = async (
+    user: SessionUser,
+    agent: AiAgent,
+    threadUserUuid: string,
+    dependencies: AccessDependencies,
+): Promise<boolean> => {
+    if (!(await canAccessAiAgent(user, agent, dependencies))) return false;
+    if (threadUserUuid === user.userUuid) return true;
+
+    return dependencies.auditedAbility.can(
+        'manage',
+        subject('AiAgent', {
+            organizationUuid: agent.organizationUuid,
+            projectUuid: agent.projectUuid,
+            metadata: {
+                agentUuid: agent.uuid,
+                agentName: agent.name,
+            },
+        }),
+    );
+};

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -15,6 +15,7 @@ import type {
     ToolVerticalBarArgs,
 } from '../..';
 import { type AiEvalRunResultAssessment } from './aiEvalAssessment';
+import { type AiProjectContextTypedObjectRef } from './projectContext';
 import {
     type AiAgentModelConfig,
     type AiPromptContext,
@@ -334,6 +335,36 @@ export type ApiAiAgentResponse = {
     status: 'ok';
     results: AiAgent;
 };
+
+export type AiAgentMemorySource = {
+    slug: string;
+} & (
+    | { hasThreadAccess: false }
+    | {
+          hasThreadAccess: true;
+          agentUuid: string | null;
+          threadUuid: string;
+          threadTitle: string | null;
+          threadSummary: string;
+      }
+);
+
+export type AiAgentMemory = {
+    slug: string;
+    title: string;
+    rawMemory: string;
+    terms: string[];
+    objects: AiProjectContextTypedObjectRef[];
+    status: 'active' | 'superseded' | 'retired';
+    generatedAt: string;
+    citedCount: number;
+    provenance:
+        | { type: 'source_thread'; source: AiAgentMemorySource }
+        | { type: 'consolidated'; sources: AiAgentMemorySource[] };
+    replacementSlug: string | null;
+};
+
+export type ApiAiAgentMemoryResponse = ApiSuccess<AiAgentMemory>;
 
 export type ApiAiAgentAvatarUploadResponse = ApiSuccess<AiAgent>;
 

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -15,6 +15,7 @@ import type {
     ApiAiAgentEvaluationRunResultsResponse,
     ApiAiAgentEvaluationRunSummaryListResponse,
     ApiAiAgentEvaluationSummaryListResponse,
+    ApiAiAgentMemoryResponse,
     ApiAiAgentProjectThreadSummaryListResponse,
     ApiAiAgentReviewItemActivityResponse,
     ApiAiAgentReviewItemPrDiffResponse,
@@ -1236,6 +1237,7 @@ type ApiResults =
     | ApiDownloadAsyncQueryResults
     | ApiDownloadAsyncQueryResultsAsXlsx
     | ApiAiAgentThreadResponse['results']
+    | ApiAiAgentMemoryResponse['results']
     | ApiAiAgentThreadMessageVizResponse['results']
     | ApiAiAgentThreadMessageVizQueryResponse['results']
     | ApiUpdateUserAgentPreferencesResponse['results']

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -302,6 +302,16 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
                 },
             },
             {
+                path: ':agentUuid/memories/:slug',
+                lazy: async () => {
+                    const AiAgentMemoryPage = await loadLazyRouteDefault(
+                        './pages/AiAgents/AiAgentMemoryPage',
+                        () => import('./pages/AiAgents/AiAgentMemoryPage'),
+                    );
+                    return { Component: AiAgentMemoryPage };
+                },
+            },
+            {
                 path: ':agentUuid/edit',
                 lazy: async () => {
                     const ProjectAiAgentEditPage = await loadLazyRouteDefault(

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -69,6 +69,7 @@ import {
 } from './memoryCitationConfig';
 import { MessageModelIndicator } from './MessageModelIndicator';
 import { rehypeAiAgentContentLinks } from './rehypeContentLinks';
+import { rehypeMemoryCitationIndices } from './rehypeMemoryCitations';
 import { AiEditDbtProjectToolCall } from './ToolCalls/AiEditDbtProjectToolCall';
 import { AiEditRepoToolCall } from './ToolCalls/AiEditRepoToolCall';
 import { ImproveContextToolCall } from './ToolCalls/ImproveContextToolCall';
@@ -606,7 +607,10 @@ const AssistantBubbleContent: FC<{
                                     ? styles.streamingNarration
                                     : undefined
                             }
-                            rehypePlugins={[rehypeAiAgentContentLinks]}
+                            rehypePlugins={[
+                                rehypeAiAgentContentLinks,
+                                rehypeMemoryCitationIndices,
+                            ]}
                             plugins={markdownPlugins}
                             components={{
                                 ...MEMORY_CITATION_COMPONENTS,
@@ -794,7 +798,10 @@ const AssistantBubbleContent: FC<{
                             <AiMarkdown
                                 className={styles.persistedAnswer}
                                 allowedTags={MEMORY_CITATION_ALLOWED_TAGS}
-                                rehypePlugins={[rehypeAiAgentContentLinks]}
+                                rehypePlugins={[
+                                    rehypeAiAgentContentLinks,
+                                    rehypeMemoryCitationIndices,
+                                ]}
                                 plugins={markdownPlugins}
                                 components={{
                                     ...MEMORY_CITATION_COMPONENTS,

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.module.css
@@ -1,0 +1,70 @@
+.marker {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 16px;
+    height: 16px;
+    margin: 0 2px;
+    padding: 0 3px;
+    border: 1px solid var(--mantine-color-gray-3);
+    border-radius: var(--mantine-radius-xs);
+    background: var(--mantine-color-gray-0);
+    color: var(--mantine-color-gray-6);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
+    text-decoration: none;
+    vertical-align: super;
+    transition:
+        border-color 120ms ease,
+        color 120ms ease,
+        background-color 120ms ease;
+}
+
+.marker:hover {
+    border-color: var(--mantine-color-indigo-4);
+    background: var(--mantine-color-indigo-0);
+    color: var(--mantine-color-indigo-7);
+}
+
+.marker:focus-visible {
+    outline: 2px solid var(--mantine-color-indigo-5);
+    outline-offset: 2px;
+}
+
+.card {
+    border-color: var(--mantine-color-gray-3);
+}
+
+.preview {
+    max-height: 156px;
+    overflow: hidden;
+    padding-left: 0;
+    color: var(--mantine-color-ldGray-7);
+}
+
+.preview p,
+.preview li {
+    color: var(--mantine-color-ldGray-7);
+    font-size: 13px;
+}
+
+.detailsButton {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--mantine-color-indigo-6);
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.detailsButton:hover {
+    color: var(--mantine-color-indigo-8);
+}
+
+.detailsButton:focus-visible {
+    border-radius: var(--mantine-radius-xs);
+    outline: 2px solid var(--mantine-color-indigo-5);
+    outline-offset: 2px;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.test.tsx
@@ -1,35 +1,199 @@
 import { MantineProvider } from '@mantine-8/core';
-import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
+import { MemoryDetails } from '../MemoryDetails/MemoryDetails';
 import {
     MEMORY_CITATION_ALLOWED_TAGS,
     MEMORY_CITATION_COMPONENTS,
 } from './memoryCitationConfig';
 import { rehypeAiAgentContentLinks } from './rehypeContentLinks';
+import { rehypeMemoryCitationIndices } from './rehypeMemoryCitations';
+
+vi.mock('../../hooks/useAiAgentMemory', () => ({
+    useAiAgentMemory: () => ({
+        isLoading: false,
+        data: {
+            slug: 'net-revenue-ab12cd34',
+            title: 'Net revenue convention',
+            rawMemory: '**Net revenue** excludes refunds.',
+            terms: ['net revenue'],
+            objects: [],
+            status: 'active',
+            generatedAt: '2026-07-22T00:00:00.000Z',
+            citedCount: 3,
+            provenance: {
+                type: 'source_thread',
+                source: {
+                    slug: 'net-revenue',
+                    hasThreadAccess: true,
+                    threadUuid: 'thread-uuid',
+                    agentUuid: 'agent-uuid',
+                    threadTitle: 'Revenue conventions',
+                    threadSummary: '**Defined** net revenue.',
+                },
+            },
+            replacementSlug: null,
+        },
+    }),
+}));
 
 describe('MemoryCitation', () => {
     const renderMarkdown = (markdown: string) =>
         render(
-            <MantineProvider>
-                <AiMarkdown
-                    allowedTags={MEMORY_CITATION_ALLOWED_TAGS}
-                    components={MEMORY_CITATION_COMPONENTS}
-                    rehypePlugins={[rehypeAiAgentContentLinks]}
+            <QueryClientProvider client={new QueryClient()}>
+                <MemoryRouter
+                    initialEntries={[
+                        '/projects/project-uuid/ai-agents/agent-uuid/threads/thread-uuid',
+                    ]}
                 >
-                    {markdown}
-                </AiMarkdown>
-            </MantineProvider>,
+                    <MantineProvider>
+                        <Routes>
+                            <Route
+                                path="/projects/:projectUuid/ai-agents/:agentUuid/threads/:threadUuid"
+                                element={
+                                    <AiMarkdown
+                                        allowedTags={
+                                            MEMORY_CITATION_ALLOWED_TAGS
+                                        }
+                                        components={MEMORY_CITATION_COMPONENTS}
+                                        rehypePlugins={[
+                                            rehypeAiAgentContentLinks,
+                                            rehypeMemoryCitationIndices,
+                                        ]}
+                                    >
+                                        {markdown}
+                                    </AiMarkdown>
+                                }
+                            />
+                        </Routes>
+                    </MantineProvider>
+                </MemoryRouter>
+            </QueryClientProvider>,
         );
 
-    it('renders an inline non-link chip through streaming markdown', () => {
+    it('renders an inline numbered marker through streaming markdown', () => {
         renderMarkdown(
             'Supported sentence.<ld-mem-cite id="net-revenue"></ld-mem-cite>',
         );
 
-        const chip = screen.getByTitle('Memory: net-revenue');
-        expect(chip).toHaveTextContent('Memory');
-        expect(chip.closest('a')).toBeNull();
+        const marker = screen.getByTitle('Memory: net-revenue');
+        expect(marker).toHaveTextContent('1');
+        expect(marker.tagName).toBe('BUTTON');
         expect(screen.getByText(/Supported sentence/)).toBeInTheDocument();
+    });
+
+    it('increments once per unique memory in an answer', () => {
+        renderMarkdown(
+            'First.<ld-mem-cite id="net-revenue"></ld-mem-cite> Again.<ld-mem-cite id="net-revenue"></ld-mem-cite> Second.<ld-mem-cite id="order-status"></ld-mem-cite>',
+        );
+
+        expect(
+            screen
+                .getAllByTitle('Memory: net-revenue')
+                .map((marker) => marker.textContent),
+        ).toEqual(['1', '1']);
+        expect(screen.getByTitle('Memory: order-status')).toHaveTextContent(
+            '2',
+        );
+    });
+
+    it('shows memory details on hover', async () => {
+        renderMarkdown(
+            'Supported sentence.<ld-mem-cite id="net-revenue"></ld-mem-cite>',
+        );
+
+        fireEvent.mouseEnter(screen.getByTitle('Memory: net-revenue'));
+
+        const emphasizedText = await screen.findByText('Net revenue', {
+            selector: '[data-streamdown="strong"]',
+        });
+        expect(emphasizedText).toHaveAttribute('data-streamdown', 'strong');
+        expect(screen.getByText('Net revenue convention')).toBeInTheDocument();
+        expect(screen.getByText('View details')).toBeInTheDocument();
+    });
+
+    it('opens full memory details in a modal', async () => {
+        renderMarkdown(
+            'Supported sentence.<ld-mem-cite id="net-revenue"></ld-mem-cite>',
+        );
+
+        fireEvent.mouseEnter(screen.getByTitle('Memory: net-revenue'));
+        fireEvent.click(await screen.findByText('View details'));
+
+        const dialog = await screen.findByRole('dialog');
+        expect(
+            within(dialog).getByText('Net revenue convention'),
+        ).toBeInTheDocument();
+        expect(within(dialog).getByText('Memory')).toBeInTheDocument();
+        expect(within(dialog).getByText('net revenue')).toBeInTheDocument();
+        expect(within(dialog).getByText('Source')).toBeInTheDocument();
+        expect(
+            within(dialog).getByText('Extracted from one thread'),
+        ).toBeInTheDocument();
+        expect(within(dialog).getByText('Defined')).toHaveAttribute(
+            'data-streamdown',
+            'strong',
+        );
+        expect(within(dialog).getByText('Citations')).toBeInTheDocument();
+        expect(within(dialog).getByText('3')).toBeInTheDocument();
+        expect(within(dialog).getByText('Open thread')).toBeInTheDocument();
+    });
+
+    it('does not render restricted source thread details', () => {
+        render(
+            <MemoryRouter>
+                <MantineProvider>
+                    <MemoryDetails
+                        projectUuid="project-uuid"
+                        agentUuid="agent-uuid"
+                        memory={{
+                            slug: 'net-revenue',
+                            title: 'Net revenue convention',
+                            rawMemory: 'Use net revenue.',
+                            terms: [],
+                            objects: [],
+                            status: 'active',
+                            generatedAt: '2026-07-22T00:00:00.000Z',
+                            citedCount: 0,
+                            provenance: {
+                                type: 'source_thread',
+                                source: {
+                                    slug: 'net-revenue',
+                                    hasThreadAccess: false,
+                                },
+                            },
+                            replacementSlug: null,
+                        }}
+                    />
+                </MantineProvider>
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText('Source thread')).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'Thread details are only visible to its owner and agent managers.',
+            ),
+        ).toBeInTheDocument();
+        expect(screen.queryByText('Open thread')).not.toBeInTheDocument();
+        expect(
+            screen.queryByText('Private thread title'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('opens details without navigating when the marker is clicked', async () => {
+        renderMarkdown(
+            'Supported sentence.<ld-mem-cite id="net-revenue"></ld-mem-cite>',
+        );
+
+        const marker = screen.getByTitle('Memory: net-revenue');
+        fireEvent.click(marker);
+
+        expect(marker.tagName).toBe('BUTTON');
+        expect(marker).not.toHaveAttribute('href');
+        expect(await screen.findByRole('dialog')).toBeInTheDocument();
     });
 
     it('renders code-fence markers literally', () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/MemoryCitation.tsx
@@ -1,23 +1,138 @@
-import { Badge } from '@mantine-8/core';
+import {
+    Badge,
+    Box,
+    Divider,
+    Group,
+    HoverCard,
+    Loader,
+    Stack,
+    Text,
+    UnstyledButton,
+} from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
+import { IconArrowRight } from '@tabler/icons-react';
+import { useState } from 'react';
+import { useParams } from 'react-router';
+import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
+import { useAiAgentMemory } from '../../hooks/useAiAgentMemory';
+import { getAiAgentMemoryPreview } from '../../utils/memory';
+import { MemoryDetailsModal } from '../MemoryDetails/MemoryDetails';
+import styles from './MemoryCitation.module.css';
 
 type MemoryCitationProps = {
     id?: string;
+    'data-memory-index'?: number | string;
 };
 
-export const MemoryCitation = ({ id }: MemoryCitationProps) => {
-    const memoryId = id?.replace(/^user-content-/, '');
+export const MemoryCitation = ({
+    id,
+    'data-memory-index': memoryIndex,
+}: MemoryCitationProps) => {
+    const [hasOpened, setHasOpened] = useState(false);
+    const [detailsOpened, { open: openDetails, close: closeDetails }] =
+        useDisclosure(false);
+    const { projectUuid, agentUuid } = useParams();
+    const slug = id?.replace(/^user-content-/, '');
+    const memoryQuery = useAiAgentMemory({
+        projectUuid,
+        agentUuid,
+        slug,
+        enabled: hasOpened,
+    });
 
     return (
-        <Badge
-            component="span"
-            color="violet"
-            mx={2}
-            radius="sm"
-            size="xs"
-            title={memoryId ? `Memory: ${memoryId}` : 'Memory'}
-            variant="light"
-        >
-            Memory
-        </Badge>
+        <>
+            <HoverCard
+                width={360}
+                shadow="md"
+                radius="md"
+                openDelay={180}
+                closeDelay={120}
+                withArrow
+                withinPortal
+                onOpen={() => setHasOpened(true)}
+            >
+                <HoverCard.Target>
+                    <UnstyledButton
+                        type="button"
+                        className={styles.marker}
+                        aria-label={
+                            slug ? `Show memory ${slug}` : 'Show memory'
+                        }
+                        title={slug ? `Memory: ${slug}` : 'Memory'}
+                        onClick={() => {
+                            setHasOpened(true);
+                            openDetails();
+                        }}
+                    >
+                        {memoryIndex ?? '·'}
+                    </UnstyledButton>
+                </HoverCard.Target>
+                <HoverCard.Dropdown p="md" className={styles.card}>
+                    {memoryQuery.isLoading ? (
+                        <Box py="md" ta="center">
+                            <Loader size="xs" color="gray" />
+                        </Box>
+                    ) : memoryQuery.data ? (
+                        <Stack gap="sm">
+                            <Group
+                                justify="space-between"
+                                align="flex-start"
+                                wrap="nowrap"
+                            >
+                                <Text fw={650} size="sm" lh={1.3}>
+                                    {memoryQuery.data.title}
+                                </Text>
+                                {memoryQuery.data.status !== 'active' ? (
+                                    <Badge
+                                        color="gray"
+                                        variant="light"
+                                        size="xs"
+                                    >
+                                        {memoryQuery.data.status}
+                                    </Badge>
+                                ) : null}
+                            </Group>
+                            <AiMarkdown className={styles.preview}>
+                                {getAiAgentMemoryPreview(
+                                    memoryQuery.data.rawMemory,
+                                )}
+                            </AiMarkdown>
+                            <Divider />
+                            <Group justify="space-between" wrap="nowrap">
+                                <Text size="xs" c="dimmed">
+                                    Saved{' '}
+                                    {new Date(
+                                        memoryQuery.data.generatedAt,
+                                    ).toLocaleDateString()}
+                                </Text>
+                                <UnstyledButton
+                                    type="button"
+                                    className={styles.detailsButton}
+                                    onClick={openDetails}
+                                >
+                                    View details
+                                    <IconArrowRight size={13} />
+                                </UnstyledButton>
+                            </Group>
+                        </Stack>
+                    ) : (
+                        <Text size="sm" c="dimmed">
+                            Memory details unavailable
+                        </Text>
+                    )}
+                </HoverCard.Dropdown>
+            </HoverCard>
+
+            {memoryQuery.data && projectUuid && agentUuid ? (
+                <MemoryDetailsModal
+                    opened={detailsOpened}
+                    onClose={closeDetails}
+                    memory={memoryQuery.data}
+                    projectUuid={projectUuid}
+                    agentUuid={agentUuid}
+                />
+            ) : null}
+        </>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/memoryCitationConfig.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/memoryCitationConfig.ts
@@ -4,7 +4,7 @@ import { MemoryCitation } from './MemoryCitation';
 type StreamdownComponents = NonNullable<StreamdownProps['components']>;
 
 export const MEMORY_CITATION_ALLOWED_TAGS = {
-    'ld-mem-cite': ['id'],
+    'ld-mem-cite': ['id', 'data-memory-index'],
 };
 
 export const MEMORY_CITATION_COMPONENTS: StreamdownComponents = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeMemoryCitations.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeMemoryCitations.ts
@@ -1,0 +1,23 @@
+import { type Element, type Root } from 'hast';
+import { visit } from 'unist-util-visit';
+
+export const rehypeMemoryCitationIndices = () => (tree: Root) => {
+    const indices = new Map<string, number>();
+
+    visit(tree, 'element', (node: Element) => {
+        if (node.tagName !== 'ld-mem-cite') return;
+
+        const id = node.properties?.id;
+        if (typeof id !== 'string') return;
+
+        const normalizedId = id.replace(/^user-content-/, '');
+        const index =
+            indices.get(normalizedId) ??
+            (() => {
+                const nextIndex = indices.size + 1;
+                indices.set(normalizedId, nextIndex);
+                return nextIndex;
+            })();
+        node.properties['data-memory-index'] = index;
+    });
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.module.css
@@ -1,0 +1,180 @@
+.layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 1px 232px;
+    gap: 28px;
+    align-items: stretch;
+}
+
+.main {
+    min-width: 0;
+}
+
+.modalTitle {
+    color: var(--mantine-color-ldGray-9);
+    font-size: 16px;
+    font-weight: 550;
+    letter-spacing: -0.014em;
+    line-height: 1.4;
+}
+
+.sectionLabel {
+    color: var(--mantine-color-ldGray-6);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+.memoryContent {
+    padding-left: 0;
+    font-size: 14px;
+    line-height: 1.65;
+}
+
+.memoryContent p,
+.memoryContent li {
+    font-size: 14px;
+}
+
+.section {
+    margin-top: 32px;
+    padding-top: 26px;
+    border-top: 1px solid var(--mantine-color-ldGray-1);
+}
+
+.sourceList {
+    overflow: hidden;
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: 10px;
+    background: light-dark(#fff, var(--mantine-color-dark-6));
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.sourceRow {
+    padding: 12px 14px;
+}
+
+.sourceRow + .sourceRow {
+    border-top: 1px solid var(--mantine-color-ldGray-1);
+}
+
+.sourceSummary {
+    margin-top: 4px;
+    padding-left: 0;
+    color: var(--mantine-color-ldGray-6);
+    font-size: 12px;
+    line-height: 1.5;
+}
+
+.sourceSummary p,
+.sourceSummary li {
+    margin: 0;
+    color: inherit;
+    font-size: inherit;
+}
+
+.sourceLink {
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    gap: 5px;
+    color: var(--mantine-color-ldGray-6);
+    font-size: 11.5px;
+    font-weight: 500;
+    text-decoration: none;
+}
+
+.sourceLink:hover {
+    color: var(--mantine-color-indigo-7);
+}
+
+.divider {
+    height: 100%;
+    border-color: var(--mantine-color-ldGray-2);
+}
+
+.rail {
+    align-self: start;
+    position: sticky;
+    top: 0;
+}
+
+.railRow {
+    min-height: 32px;
+    padding: 3px 0;
+}
+
+.railLabel {
+    width: 54px;
+    flex: none;
+    color: var(--mantine-color-ldGray-6);
+    font-size: 11.5px;
+}
+
+.railValue {
+    min-width: 0;
+    flex: 1;
+}
+
+.railText {
+    color: var(--mantine-color-ldGray-9);
+    font-size: 12px;
+    font-weight: 500;
+    text-transform: capitalize;
+}
+
+.statusDot {
+    width: 6px;
+    height: 6px;
+    flex: none;
+    border-radius: 50%;
+    background: var(--mantine-color-gray-5);
+}
+
+.statusDot[data-status='active'] {
+    background: var(--mantine-color-teal-6);
+}
+
+.slug {
+    color: var(--mantine-color-ldGray-8);
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 11px;
+    line-height: 1.4;
+    overflow-wrap: anywhere;
+}
+
+.railSection {
+    margin-top: 20px;
+    padding-top: 18px;
+    border-top: 1px solid var(--mantine-color-ldGray-1);
+}
+
+.objectLink {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    color: var(--mantine-color-ldGray-9);
+    text-decoration: none;
+}
+
+.objectLink:hover {
+    color: var(--mantine-color-indigo-7);
+}
+
+@media (max-width: 820px) {
+    .layout {
+        grid-template-columns: minmax(0, 1fr);
+        gap: var(--mantine-spacing-xl);
+    }
+
+    .divider {
+        display: none;
+    }
+
+    .rail {
+        position: static;
+        padding-top: var(--mantine-spacing-xl);
+        border-top: 1px solid var(--mantine-color-ldGray-2);
+    }
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/MemoryDetails/MemoryDetails.tsx
@@ -1,0 +1,304 @@
+import type {
+    AiAgentMemorySource,
+    AiProjectContextTypedObjectRef,
+    ApiAiAgentMemoryResponse,
+} from '@lightdash/common';
+import {
+    Alert,
+    Anchor,
+    Badge,
+    Box,
+    Divider,
+    getDefaultZIndex,
+    Group,
+    Stack,
+    Text,
+} from '@mantine-8/core';
+import {
+    IconArrowRight,
+    IconExternalLink,
+    IconHistory,
+} from '@tabler/icons-react';
+import { type FC, type ReactNode } from 'react';
+import { Link } from 'react-router';
+import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
+import MantineModal from '../../../../../components/common/MantineModal';
+import styles from './MemoryDetails.module.css';
+
+type Memory = ApiAiAgentMemoryResponse['results'];
+
+type MemoryDetailsProps = {
+    memory: Memory;
+    projectUuid: string;
+    agentUuid: string;
+};
+
+const getObjectLabel = (object: AiProjectContextTypedObjectRef) =>
+    object.type === 'explore' ? object.name : object.fieldId;
+
+const getObjectExplore = (object: AiProjectContextTypedObjectRef) =>
+    object.type === 'explore' ? object.name : object.explore;
+
+const RailRow: FC<{ label: string; children: ReactNode }> = ({
+    label,
+    children,
+}) => (
+    <Group className={styles.railRow} wrap="nowrap" gap="sm">
+        <Text className={styles.railLabel}>{label}</Text>
+        <Box className={styles.railValue}>{children}</Box>
+    </Group>
+);
+
+const SourceRow: FC<{
+    source: AiAgentMemorySource;
+    projectUuid: string;
+}> = ({ source, projectUuid }) => {
+    if (!source.hasThreadAccess) {
+        return (
+            <Box className={styles.sourceRow}>
+                <Text fw={550} size="sm">
+                    Source thread
+                </Text>
+                <Text size="xs" c="dimmed" mt={4}>
+                    Thread details are only visible to its owner and agent
+                    managers.
+                </Text>
+            </Box>
+        );
+    }
+
+    const threadPath = source.agentUuid
+        ? `/projects/${projectUuid}/ai-agents/${source.agentUuid}/threads/${source.threadUuid}`
+        : null;
+
+    return (
+        <Box className={styles.sourceRow}>
+            <Group justify="space-between" align="flex-start" wrap="nowrap">
+                <Box miw={0}>
+                    <Text fw={550} size="sm" lineClamp={1}>
+                        {source.threadTitle ?? 'AI agent thread'}
+                    </Text>
+                    <AiMarkdown className={styles.sourceSummary}>
+                        {source.threadSummary}
+                    </AiMarkdown>
+                </Box>
+                {threadPath ? (
+                    <Anchor
+                        component={Link}
+                        to={threadPath}
+                        className={styles.sourceLink}
+                    >
+                        Open thread
+                        <IconArrowRight size={13} />
+                    </Anchor>
+                ) : null}
+            </Group>
+        </Box>
+    );
+};
+
+export const MemoryDetails: FC<MemoryDetailsProps> = ({
+    memory,
+    projectUuid,
+    agentUuid,
+}) => {
+    const replacementPath = memory.replacementSlug
+        ? `/projects/${projectUuid}/ai-agents/${agentUuid}/memories/${memory.replacementSlug}`
+        : null;
+    const sources =
+        memory.provenance.type === 'source_thread'
+            ? [memory.provenance.source]
+            : memory.provenance.sources;
+
+    return (
+        <Box className={styles.layout}>
+            <Stack className={styles.main} gap={0}>
+                {memory.status !== 'active' ? (
+                    <Alert
+                        mb="xl"
+                        color="gray"
+                        variant="light"
+                        title={`This memory is ${memory.status}`}
+                        icon={<IconHistory size={17} />}
+                    >
+                        {replacementPath ? (
+                            <Anchor
+                                component={Link}
+                                to={replacementPath}
+                                fw={600}
+                            >
+                                View the current memory
+                            </Anchor>
+                        ) : (
+                            'It remains available for audit history.'
+                        )}
+                    </Alert>
+                ) : null}
+
+                <Stack gap="md">
+                    <Text className={styles.sectionLabel}>Memory</Text>
+                    <AiMarkdown className={styles.memoryContent}>
+                        {memory.rawMemory}
+                    </AiMarkdown>
+                </Stack>
+
+                <Stack gap="md" className={styles.section}>
+                    <Group justify="space-between" align="baseline">
+                        <Text className={styles.sectionLabel}>Source</Text>
+                        <Text size="xs" c="dimmed">
+                            {memory.provenance.type === 'consolidated'
+                                ? sources.length > 0
+                                    ? `Consolidated from ${sources.length} memories`
+                                    : 'Consolidated memory'
+                                : 'Extracted from one thread'}
+                        </Text>
+                    </Group>
+                    <Box className={styles.sourceList}>
+                        {sources.length > 0 ? (
+                            sources.map((source) => (
+                                <SourceRow
+                                    key={source.slug}
+                                    source={source}
+                                    projectUuid={projectUuid}
+                                />
+                            ))
+                        ) : (
+                            <Text size="xs" c="dimmed" p="md">
+                                No source threads recorded
+                            </Text>
+                        )}
+                    </Box>
+                </Stack>
+            </Stack>
+
+            <Divider orientation="vertical" className={styles.divider} />
+
+            <Stack className={styles.rail} gap={0}>
+                <RailRow label="Status">
+                    <Group gap={8} wrap="nowrap">
+                        <Box
+                            className={styles.statusDot}
+                            data-status={memory.status}
+                        />
+                        <Text className={styles.railText}>{memory.status}</Text>
+                    </Group>
+                </RailRow>
+                <RailRow label="Saved">
+                    <Text className={styles.railText}>
+                        {new Date(memory.generatedAt).toLocaleDateString()}
+                    </Text>
+                </RailRow>
+                <RailRow label="Citations">
+                    <Text className={styles.railText}>
+                        {memory.citedCount.toLocaleString()}
+                    </Text>
+                </RailRow>
+                <RailRow label="Slug">
+                    <Text className={styles.slug} lineClamp={2}>
+                        {memory.slug}
+                    </Text>
+                </RailRow>
+
+                <Stack gap="sm" className={styles.railSection}>
+                    <Text className={styles.sectionLabel}>Terms</Text>
+                    {memory.terms.length > 0 ? (
+                        <Group gap={6}>
+                            {memory.terms.map((term) => (
+                                <Badge
+                                    key={term}
+                                    variant="light"
+                                    color="gray"
+                                    tt="none"
+                                    size="sm"
+                                >
+                                    {term}
+                                </Badge>
+                            ))}
+                        </Group>
+                    ) : (
+                        <Text size="xs" c="dimmed">
+                            No retrieval terms
+                        </Text>
+                    )}
+                </Stack>
+
+                <Stack gap="sm" className={styles.railSection}>
+                    <Text className={styles.sectionLabel}>Catalog objects</Text>
+                    {memory.objects.length > 0 ? (
+                        <Stack gap={8}>
+                            {memory.objects.map((object) => {
+                                const explore = getObjectExplore(object);
+                                return (
+                                    <Anchor
+                                        key={`${object.type}-${explore}-${getObjectLabel(object)}`}
+                                        component={Link}
+                                        to={`/projects/${projectUuid}/tables/${encodeURIComponent(explore)}`}
+                                        className={styles.objectLink}
+                                    >
+                                        <Box miw={0}>
+                                            <Text
+                                                size="xs"
+                                                fw={550}
+                                                lineClamp={1}
+                                            >
+                                                {getObjectLabel(object)}
+                                            </Text>
+                                            <Text
+                                                size="xs"
+                                                c="dimmed"
+                                                lineClamp={1}
+                                            >
+                                                {object.type === 'field'
+                                                    ? `Field in ${explore}`
+                                                    : 'Explore'}
+                                            </Text>
+                                        </Box>
+                                        <IconExternalLink size={13} />
+                                    </Anchor>
+                                );
+                            })}
+                        </Stack>
+                    ) : (
+                        <Text size="xs" c="dimmed">
+                            No catalog objects
+                        </Text>
+                    )}
+                </Stack>
+            </Stack>
+        </Box>
+    );
+};
+
+type MemoryDetailsModalProps = MemoryDetailsProps & {
+    opened: boolean;
+    onClose: () => void;
+};
+
+export const MemoryDetailsModal: FC<MemoryDetailsModalProps> = ({
+    opened,
+    onClose,
+    memory,
+    projectUuid,
+    agentUuid,
+}) => (
+    <MantineModal
+        opened={opened}
+        onClose={onClose}
+        size="72rem"
+        title={
+            <Text component="span" className={styles.modalTitle} lineClamp={2}>
+                {memory.title}
+            </Text>
+        }
+        cancelLabel={false}
+        modalRootProps={{ zIndex: getDefaultZIndex('overlay') }}
+        modalBodyProps={{ py: 'lg' }}
+        bodyScrollAreaMaxHeight="calc(85vh - 120px)"
+    >
+        <MemoryDetails
+            memory={memory}
+            projectUuid={projectUuid}
+            agentUuid={agentUuid}
+        />
+    </MantineModal>
+);

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentMemory.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentMemory.ts
@@ -1,0 +1,35 @@
+import type { ApiAiAgentMemoryResponse, ApiError } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+import { getAiAgentApiBase } from './aiAgentRouting';
+
+const getAiAgentMemory = (
+    projectUuid: string,
+    agentUuid: string,
+    slug: string,
+) =>
+    lightdashApi<ApiAiAgentMemoryResponse['results']>({
+        version: 'v1',
+        url: `${getAiAgentApiBase(projectUuid)}/${agentUuid}/memories/${slug}`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useAiAgentMemory = ({
+    projectUuid,
+    agentUuid,
+    slug,
+    enabled = true,
+}: {
+    projectUuid?: string;
+    agentUuid?: string;
+    slug?: string;
+    enabled?: boolean;
+}) =>
+    useQuery<ApiAiAgentMemoryResponse['results'], ApiError>({
+        queryKey: ['aiAgentMemory', projectUuid, slug],
+        queryFn: () => getAiAgentMemory(projectUuid!, agentUuid!, slug!),
+        enabled: enabled && Boolean(projectUuid && agentUuid && slug),
+        retry: (failureCount, error) =>
+            error.error?.statusCode !== 404 && failureCount < 2,
+    });

--- a/packages/frontend/src/ee/features/aiCopilot/utils/memory.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/memory.test.ts
@@ -1,0 +1,9 @@
+import { getAiAgentMemoryPreview } from './memory';
+
+describe('getAiAgentMemoryPreview', () => {
+    it('preserves markdown and limits the preview to 256 characters', () => {
+        const memory = `**Revenue definition** ${'a'.repeat(300)}`;
+
+        expect(getAiAgentMemoryPreview(memory)).toBe(memory.slice(0, 256));
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/utils/memory.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/utils/memory.ts
@@ -1,0 +1,1 @@
+export const getAiAgentMemoryPreview = (value: string) => value.slice(0, 256);

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentMemoryPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentMemoryPage.module.css
@@ -1,0 +1,56 @@
+.page {
+    min-height: 100%;
+    padding: 32px clamp(20px, 4vw, 48px) 64px;
+    overflow: auto;
+    background: var(--mantine-color-ldGray-0);
+}
+
+.backLink {
+    display: inline-flex;
+    align-items: center;
+    align-self: flex-start;
+    gap: 6px;
+    color: var(--mantine-color-ldGray-6);
+    font-size: 12px;
+    font-weight: 500;
+    text-decoration: none;
+}
+
+.backLink:hover {
+    color: var(--mantine-color-ldGray-9);
+}
+
+.surface {
+    overflow: hidden;
+    background: light-dark(#fff, var(--mantine-color-dark-7));
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.header {
+    min-height: 68px;
+    padding: 16px 24px;
+}
+
+.title {
+    margin: 0;
+    color: var(--mantine-color-ldGray-9);
+    font-size: 18px;
+    font-weight: 550;
+    letter-spacing: -0.014em;
+    line-height: 1.4;
+}
+
+.body {
+    padding: 24px;
+}
+
+@media (max-width: 820px) {
+    .page {
+        padding-inline: 16px;
+    }
+
+    .header,
+    .body {
+        padding-inline: 18px;
+    }
+}

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentMemoryPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentMemoryPage.tsx
@@ -1,0 +1,64 @@
+import {
+    Anchor,
+    Box,
+    Divider,
+    Group,
+    Paper,
+    Stack,
+    Text,
+} from '@mantine-8/core';
+import { IconArrowLeft } from '@tabler/icons-react';
+import { Link, useParams } from 'react-router';
+import ErrorState from '../../../components/common/ErrorState';
+import PageSpinner from '../../../components/PageSpinner';
+import { MemoryDetails } from '../../features/aiCopilot/components/MemoryDetails/MemoryDetails';
+import { useAiAgentMemory } from '../../features/aiCopilot/hooks/useAiAgentMemory';
+import styles from './AiAgentMemoryPage.module.css';
+
+const AiAgentMemoryPage = () => {
+    const { projectUuid, agentUuid, slug } = useParams();
+    const memoryQuery = useAiAgentMemory({ projectUuid, agentUuid, slug });
+
+    if (!projectUuid || !agentUuid || !slug) return <ErrorState />;
+    if (memoryQuery.isLoading) return <PageSpinner />;
+    if (memoryQuery.isError || !memoryQuery.data) {
+        return <ErrorState error={memoryQuery.error?.error} />;
+    }
+
+    return (
+        <Box className={styles.page}>
+            <Stack gap="lg" maw={1160} mx="auto">
+                <Anchor
+                    component={Link}
+                    to={`/projects/${projectUuid}/ai-agents`}
+                    className={styles.backLink}
+                >
+                    <IconArrowLeft size={14} />
+                    Back to AI agents
+                </Anchor>
+
+                <Paper withBorder radius="lg" className={styles.surface}>
+                    <Group className={styles.header} wrap="nowrap">
+                        <Text
+                            component="h1"
+                            className={styles.title}
+                            lineClamp={2}
+                        >
+                            {memoryQuery.data.title}
+                        </Text>
+                    </Group>
+                    <Divider />
+                    <Box className={styles.body}>
+                        <MemoryDetails
+                            memory={memoryQuery.data}
+                            projectUuid={projectUuid}
+                            agentUuid={agentUuid}
+                        />
+                    </Box>
+                </Paper>
+            </Stack>
+        </Box>
+    );
+};
+
+export default AiAgentMemoryPage;


### PR DESCRIPTION
## Summary

- add a flag-gated, project-authorized memory read endpoint with recursive source lineage
- redact source thread details unless the viewer owns the thread or can manage project AI agents
- render per-answer numbered memory buttons with lazy Markdown hover previews capped at 256 characters
- open full memory details in a Lightdash modal without leaving the thread, including Markdown source summaries and citation count
- reuse the same details layout inline on the permalink page for future Slack links
- expose persisted memory titles and use them across the hovercard, modal, and permalink

## Validation

- backend service tests (11/11)
- backend model integration tests (9/9)
- frontend citation and memory utility tests (8/8)
- backend and frontend `typecheck:fast`
- focused lint and formatting checks
- local Browser verification of marker activation, modal details, Markdown content, source link, citation count, and catalog links
- Standards and Spec review: clean

Closes: [ZAP-680](https://linear.app/lightdash/issue/ZAP-680/memory-slice-8-read-only-memory-page-web-cite-click-through)
