### PR TITLE
test: cover timestamp filter domain resolution gaps

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -7184,6 +7184,44 @@ describe('Naive timestamp domain — explicit, session-independent conversion', 
             );
         });
 
+        test('bare known-naive column (no time interval) compares data-timezone wall clocks (Postgres)', () => {
+            const { query } = buildQuery({
+                explore: buildNaiveExplore(
+                    SupportedDbtAdapter.POSTGRES,
+                    'naive',
+                ),
+                compiledMetricQuery: filteredQuery('events_occurred_at'),
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: 'Asia/Tokyo',
+                useTimezoneAwareDateTrunc: true,
+                columnTimezone: 'Asia/Tokyo',
+            });
+            const whereClause = query.slice(query.indexOf('WHERE'));
+            expect(whereClause).toContain(`('2024-01-15 02:00:00'::timestamp)`);
+            expect(whereClause).not.toContain('2024-01-14 17:00:00+00:00');
+        });
+
+        test('bare known-aware column (no time interval) keeps the instant literal (Postgres)', () => {
+            const { query } = buildQuery({
+                explore: buildNaiveExplore(
+                    SupportedDbtAdapter.POSTGRES,
+                    'aware',
+                ),
+                compiledMetricQuery: filteredQuery('events_occurred_at'),
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: 'Asia/Tokyo',
+                useTimezoneAwareDateTrunc: true,
+                columnTimezone: 'Asia/Tokyo',
+            });
+            const whereClause = query.slice(query.indexOf('WHERE'));
+            expect(whereClause).toContain(`('2024-01-14 17:00:00+00:00')`);
+            expect(whereClause).not.toContain(
+                `'2024-01-15 02:00:00'::timestamp`,
+            );
+        });
+
         test.each(['events_occurred_at', 'events_occurred_at_raw'])(
             'convert_timezone: false keeps the known-naive %s filter literal in the raw value space',
             (fieldId) => {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -7202,24 +7202,22 @@ describe('Naive timestamp domain — explicit, session-independent conversion', 
             expect(whereClause).not.toContain('2024-01-14 17:00:00+00:00');
         });
 
-        test('bare known-aware column (no time interval) keeps the instant literal (Postgres)', () => {
+        test('bare known-aware column (no time interval) keeps the instant literal (BigQuery)', () => {
             const { query } = buildQuery({
                 explore: buildNaiveExplore(
-                    SupportedDbtAdapter.POSTGRES,
+                    SupportedDbtAdapter.BIGQUERY,
                     'aware',
                 ),
                 compiledMetricQuery: filteredQuery('events_occurred_at'),
-                warehouseSqlBuilder: warehouseClientMock,
+                warehouseSqlBuilder: bigqueryClientMock,
                 intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
                 timezone: 'Asia/Tokyo',
                 useTimezoneAwareDateTrunc: true,
                 columnTimezone: 'Asia/Tokyo',
             });
             const whereClause = query.slice(query.indexOf('WHERE'));
-            expect(whereClause).toContain(`('2024-01-14 17:00:00+00:00')`);
-            expect(whereClause).not.toContain(
-                `'2024-01-15 02:00:00'::timestamp`,
-            );
+            expect(whereClause).toContain(`TIMESTAMP '2024-01-14 17:00:00+00'`);
+            expect(whereClause).not.toContain(`('2024-01-14 17:00:00')`);
         });
 
         test.each(['events_occurred_at', 'events_occurred_at_raw'])(

--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -3595,4 +3595,148 @@ describe('domain-directed timestamp filter literals', () => {
             );
         });
     });
+
+    describe('RAW instant LHS pins the legacy literal (flag-gated rebase companion)', () => {
+        test.each([
+            [
+                SupportedDbtAdapter.BIGQUERY,
+                `(${DimensionSqlMock}) = TIMESTAMP('2024-01-14 17:00:00', 'UTC')`,
+            ],
+            [
+                SupportedDbtAdapter.POSTGRES,
+                `(${DimensionSqlMock}) = ('2024-01-14 17:00:00+00:00')`,
+            ],
+        ])(
+            'RAW equals with an instant LHS on %s (only BigQuery pins to UTC)',
+            (adapter, expected) => {
+                expect(
+                    renderTimestamp(adapter, equalsInstantFilter, {
+                        sourceTimezone: 'Asia/Tokyo',
+                        timeInterval: TimeFrames.RAW,
+                        lhsMode: 'instant',
+                    }),
+                ).toStrictEqual(expected);
+            },
+        );
+    });
+});
+
+describe('resolveTimestampFilterContext', () => {
+    const base = {
+        adapterType: SupportedDbtAdapter.POSTGRES,
+        useTimezoneAwareDateTrunc: true,
+        sourceTimezone: 'Asia/Tokyo',
+        timestampDomain: 'naive' as TimestampDomain,
+        timeInterval: TimeFrames.DAY,
+        lhsMode: 'legacy' as TimestampFilterLhsMode,
+    };
+
+    describe('falls back to the legacy context', () => {
+        test('when the timezone-aware flag is off', () => {
+            expect(
+                resolveTimestampFilterContext({
+                    ...base,
+                    useTimezoneAwareDateTrunc: false,
+                }),
+            ).toStrictEqual({ mode: 'legacy', instantLhs: false });
+        });
+
+        test('when the domain is unknown (undefined)', () => {
+            expect(
+                resolveTimestampFilterContext({
+                    ...base,
+                    timestampDomain: undefined,
+                }),
+            ).toStrictEqual({ mode: 'legacy', instantLhs: false });
+        });
+
+        test('when the data timezone resolves to UTC', () => {
+            expect(
+                resolveTimestampFilterContext({
+                    ...base,
+                    sourceTimezone: 'UTC',
+                }),
+            ).toStrictEqual({ mode: 'legacy', instantLhs: false });
+        });
+
+        test('when the data timezone is omitted (defaults to UTC)', () => {
+            expect(
+                resolveTimestampFilterContext({
+                    ...base,
+                    sourceTimezone: undefined,
+                }),
+            ).toStrictEqual({ mode: 'legacy', instantLhs: false });
+        });
+
+        test('on Snowflake, whose dimension SQL is wrapped at compile time', () => {
+            expect(
+                resolveTimestampFilterContext({
+                    ...base,
+                    adapterType: SupportedDbtAdapter.SNOWFLAKE,
+                }),
+            ).toStrictEqual({ mode: 'legacy', instantLhs: false });
+        });
+    });
+
+    test('carries instantLhs on a RAW frame with an instant LHS even in the legacy context', () => {
+        expect(
+            resolveTimestampFilterContext({
+                ...base,
+                // undefined domain forces the legacy short-circuit
+                timestampDomain: undefined,
+                timeInterval: TimeFrames.RAW,
+                lhsMode: 'instant',
+            }),
+        ).toStrictEqual({ mode: 'legacy', instantLhs: true });
+    });
+
+    test('resolves a naive domain to a data-timezone wall-clock context', () => {
+        expect(resolveTimestampFilterContext(base)).toStrictEqual({
+            mode: 'naiveWall',
+            wallClockTimezone: 'Asia/Tokyo',
+        });
+    });
+
+    test('resolves an aware domain to an instant context', () => {
+        expect(
+            resolveTimestampFilterContext({
+                ...base,
+                timestampDomain: 'aware',
+            }),
+        ).toStrictEqual({ mode: 'awareInstant' });
+    });
+
+    test('coerces a naive domain to aware when the adapter has no naive representation (ClickHouse)', () => {
+        expect(
+            resolveTimestampFilterContext({
+                ...base,
+                adapterType: SupportedDbtAdapter.CLICKHOUSE,
+            }),
+        ).toStrictEqual({ mode: 'awareInstant' });
+    });
+
+    describe('sub-day truncation', () => {
+        test('wraps the literal when the LHS is wrapped', () => {
+            expect(
+                resolveTimestampFilterContext({
+                    ...base,
+                    timeInterval: TimeFrames.HOUR,
+                    lhsMode: 'wrapped',
+                }),
+            ).toStrictEqual({ mode: 'wrapped' });
+        });
+
+        test.each<TimestampFilterLhsMode>(['legacy', 'instant'])(
+            'falls back to the legacy context when the LHS is %s (not wrapped)',
+            (lhsMode) => {
+                expect(
+                    resolveTimestampFilterContext({
+                        ...base,
+                        timeInterval: TimeFrames.HOUR,
+                        lhsMode,
+                    }),
+                ).toStrictEqual({ mode: 'legacy', instantLhs: false });
+            },
+        );
+    });
 });


### PR DESCRIPTION
## What

Adds regression coverage for the timestamp-filter domain resolution introduced by the domain-aware timestamp filter literals work. These functions shipped with only indirect coverage (through the render / query-builder stack), which the release QA flagged as the highest-risk test gaps.

### `packages/common` — `resolveTimestampFilterContext`
The new pure decision function had **no direct unit test**. Adds a decision-table block asserting every branch in isolation:
- legacy fallbacks: flag off, unknown domain, UTC data timezone (explicit + defaulted), Snowflake
- `instantLhs` carried on a RAW frame with an instant LHS
- naive → `naiveWall`, aware → `awareInstant`
- naive → aware coercion where the adapter has no naive representation (ClickHouse)
- sub-day truncation: `wrapped` LHS vs the legacy fallback for non-wrapped LHS modes

Plus a compiler-level assertion that a RAW instant LHS pins BigQuery's literal to UTC (`TIMESTAMP(..., 'UTC')`) while Postgres stays byte-identical.

### `packages/backend` — `resolveFilterTimestampDomain`
Covers the one previously-unexercised branch: a **bare TIMESTAMP column with no time interval** carrying a known domain. It was only tested with `skipTimezoneConversion` enabled; now both naive (data-timezone wall clock) and aware (instant literal) are asserted.

## Why

Pins the resolver's contract independent of the rendering stack so a future refactor of the render path can't silently change the decision logic. Test-only — no source changes, no API surface change.