### PR TITLE
feat(frontend): route the add-semantic-layer setup action into the coding-agent flow

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
@@ -173,7 +173,10 @@ const ActionRow: FC<{
                         onClick={() =>
                             track({
                                 name: EventName.HOMEPAGE_RECOMMENDED_ACTION_CLICKED,
-                                properties: { actionKey },
+                                properties: {
+                                    actionKey,
+                                    destination: status.url,
+                                },
                             })
                         }
                     >

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
@@ -1,4 +1,8 @@
-import { ProjectType, type OrganizationProject } from '@lightdash/common';
+import {
+    FeatureFlags,
+    ProjectType,
+    type OrganizationProject,
+} from '@lightdash/common';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useGithubConfig } from '../../../../components/common/GithubIntegration/hooks/useGithubIntegration';
 import { useGitlabRepositories } from '../../../../components/common/GitlabIntegration/hooks/useGitlabIntegration';
@@ -6,6 +10,7 @@ import { useOrganization } from '../../../../hooks/organization/useOrganization'
 import { useGetSlack } from '../../../../hooks/slack/useSlack';
 import { useProject } from '../../../../hooks/useProject';
 import { useProjects } from '../../../../hooks/useProjects';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../providers/App/useApp';
 import { useRecommendedActions } from './useRecommendedActions';
 
@@ -20,6 +25,7 @@ vi.mock('../../../../hooks/slack/useSlack');
 vi.mock('../../../../hooks/useProject');
 vi.mock('../../../../hooks/useProjects');
 vi.mock('../../../../providers/App/useApp');
+vi.mock('../../../../hooks/useServerOrClientFeatureFlag');
 
 const organizationProject = (
     overrides: Partial<OrganizationProject>,
@@ -64,6 +70,9 @@ describe('useRecommendedActions', () => {
             data: undefined,
             isSuccess: false,
         } as ReturnType<typeof useGetSlack>);
+        vi.mocked(useServerFeatureFlag).mockReturnValue({
+            data: undefined,
+        } as ReturnType<typeof useServerFeatureFlag>);
         localStorage.clear();
     });
 
@@ -151,6 +160,66 @@ describe('useRecommendedActions', () => {
             expect(
                 result.current.statuses['connect-warehouse'].isComplete,
             ).toBe(true);
+        });
+    });
+
+    describe('add-semantic-layer destination', () => {
+        it('links to the agent setup flow when both flags are enabled', () => {
+            vi.mocked(useServerFeatureFlag).mockImplementation(
+                () =>
+                    ({
+                        data: { enabled: true },
+                    }) as ReturnType<typeof useServerFeatureFlag>,
+            );
+
+            const { result } = renderHook(() =>
+                useRecommendedActions('project-uuid'),
+            );
+
+            expect(
+                result.current.statuses['add-semantic-layer'].url,
+            ).toStrictEqual('/createProject/agent');
+        });
+
+        it('keeps the settings link when coding-agent onboarding is disabled', () => {
+            vi.mocked(useServerFeatureFlag).mockImplementation(
+                (flag) =>
+                    ({
+                        data: { enabled: flag === FeatureFlags.NewOnboarding },
+                    }) as ReturnType<typeof useServerFeatureFlag>,
+            );
+
+            const { result } = renderHook(() =>
+                useRecommendedActions('project-uuid'),
+            );
+
+            expect(
+                result.current.statuses['add-semantic-layer'].url,
+            ).toStrictEqual(
+                '/generalSettings/projectManagement/project-uuid/settings',
+            );
+        });
+
+        it('keeps the settings link when new-onboarding is disabled', () => {
+            vi.mocked(useServerFeatureFlag).mockImplementation(
+                (flag) =>
+                    ({
+                        data: {
+                            enabled:
+                                flag === FeatureFlags.CodingAgentOnboarding,
+                        },
+                    }) as ReturnType<typeof useServerFeatureFlag>,
+            );
+
+            const { result } = renderHook(() =>
+                useRecommendedActions('project-uuid'),
+            );
+
+            expect(
+                result.current.statuses['add-semantic-layer'].url,
+            ).toStrictEqual(
+                '/generalSettings/projectManagement/project-uuid/settings',
+            );
         });
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    FeatureFlags,
     DbtProjectType,
     DbtProjectTypeLabels,
     ProjectType,
@@ -16,6 +17,7 @@ import { useOrganization } from '../../../../hooks/organization/useOrganization'
 import { useGetSlack } from '../../../../hooks/slack/useSlack';
 import { useProject } from '../../../../hooks/useProject';
 import { useProjects } from '../../../../hooks/useProjects';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../providers/App/useApp';
 import { isPlaygroundProvisioningSource } from '../../../../utils/playgroundProject';
 import {
@@ -41,6 +43,13 @@ const useActionStatuses = (
     const { data: projects } = useProjects();
     const { data: githubConfig } = useGithubConfig();
     const { data: slack, isSuccess: isSlackSuccess } = useGetSlack();
+    const newOnboardingFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
+    const codingAgentOnboardingFlag = useServerFeatureFlag(
+        FeatureFlags.CodingAgentOnboarding,
+    );
+    const hasAgentSemanticLayerEntry =
+        newOnboardingFlag.data?.enabled === true &&
+        codingAgentOnboardingFlag.data?.enabled === true;
 
     const hasGithub = !!health.data?.hasGithub;
     const hasGitlab = !!health.data?.hasGitlab;
@@ -88,7 +97,9 @@ const useActionStatuses = (
                 ? DbtProjectTypeLabels[dbtConnection.type]
                 : null,
             doneIcon: null,
-            url: `/generalSettings/projectManagement/${projectUuid}/settings`,
+            url: hasAgentSemanticLayerEntry
+                ? '/createProject/agent'
+                : `/generalSettings/projectManagement/${projectUuid}/settings`,
         },
         'connect-source-control': {
             isVisible: hasGithub || hasGitlab,

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -127,6 +127,7 @@ export type HomepageRecommendedActionClickedEvent = {
     name: EventName.HOMEPAGE_RECOMMENDED_ACTION_CLICKED;
     properties: {
         actionKey: HomepageRecommendedActionKey;
+        destination: string;
     };
 };
 


### PR DESCRIPTION
On the new-onboarding homepage checklist, the "Add a semantic layer" step's **Set up** button currently sends users to project settings — a dead end for a fresh user. This PR routes it into the AI semantic-layer generation experience (coding-agent project onboarding, #25597 / #25844 / #25860 / #25889 / #25902) where that experience is available.

## What changed

- `useRecommendedActions`: the `add-semantic-layer` action now links to `/createProject/agent` when **both** `new-onboarding` and `coding-agent-onboarding` server feature flags are enabled; otherwise it keeps the existing project-settings link.
- `homepage_recommended_action.clicked` gains a required `destination` property (the resolved URL) so the funnel can distinguish the two destinations. No new event or page names — the frozen analytics vocabulary in `Events.test.ts` is untouched.
- Hook tests cover the three flag combinations.

## Gating decisions

- **Entry point**: `/createProject/agent` is the front door to the coding-agent flow. This branch is based on `charlie/pg-09-analytics-event-vocab` (pre-#25902 main), where that route offers the copy-a-prompt agent setup; on current main the same route is where the managed onboarding run experience is entered, so once the stack rebases onto latest main the checklist lands users in the managed "run it for me" experience with no further change here.
- **Why not deep-link the run page**: `/projects/:projectUuid/onboarding/runs/:runUuid` needs a run UUID minted by `POST /ee/projects/:projectUuid/agent-onboarding`, and the backend returns the existing active run for a project on re-entry — so the flow entry, not the run page, is the correct stable link target. The AI-copilot commercial gate for the managed card is enforced inside `ConnectUsingAgent` itself on main; mirroring it here would duplicate gating that the destination already owns.
- **`coding-agent-onboarding` flag**: same gate main uses to show the agent option in `SelectConnectMethod`; `CreateProject` also redirects away if it's off, so the link never strands users (defence in depth).
- **`new-onboarding` flag**: this behaviour change is part of the new onboarding experience, so the old settings link is preserved verbatim whenever that flag is off.

Closes: PROD-9140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yyBaT7zSXwDXD2hqaELUm