### PR TITLE
refactor(frontend): migrate NumberInput to Mantine 8

### DIFF
--- a/packages/frontend/src/components/Explorer/FormatForm/index.tsx
+++ b/packages/frontend/src/components/Explorer/FormatForm/index.tsx
@@ -25,8 +25,8 @@ import {
     Stack,
     Text,
     TextInput,
+    NumberInput,
 } from '@mantine-8/core';
-import { NumberInput } from '@mantine/core';
 import { type UseFormReturnType } from '@mantine/form';
 import {
     IconCalendar,
@@ -35,6 +35,7 @@ import {
 } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import { type ValueOf } from 'type-fest';
+import { optionalNumber } from '../../../utils/numberInputUtils';
 import MantineIcon from '../../common/MantineIcon';
 import { PolymorphicPaperButton } from '../../common/PolymorphicPaperButton';
 import { getFormatTypeLabel } from './getFormatSummary';
@@ -440,7 +441,7 @@ export const FormatForm: FC<Props> = ({
                     )}
                     <Grid.Col span={compact ? 12 : 4}>
                         <NumberInput
-                            type="number"
+                            decimalScale={0}
                             min={0}
                             label="Decimal places"
                             placeholder="Auto"
@@ -450,7 +451,7 @@ export const FormatForm: FC<Props> = ({
                                 onChange: (value) => {
                                     setFormatFieldValue(
                                         'round',
-                                        value === '' ? undefined : value,
+                                        optionalNumber(value),
                                     );
                                 },
                             }}

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/AthenaForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/AthenaForm.tsx
@@ -5,8 +5,8 @@ import {
     Anchor,
     Select,
     PasswordInput,
+    NumberInput,
 } from '@mantine-8/core';
-import { NumberInput } from '@mantine/core';
 import { useEffect, type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';
 import useHealth from '../../../hooks/health/useHealth';
@@ -233,6 +233,7 @@ const AthenaForm: FC<{
                         />
 
                         <NumberInput
+                            decimalScale={0}
                             name="warehouse.threads"
                             label="Threads"
                             description="Number of threads for dbt to use."
@@ -242,6 +243,7 @@ const AthenaForm: FC<{
                         />
 
                         <NumberInput
+                            decimalScale={0}
                             name="warehouse.numRetries"
                             label="Number of Retries"
                             description="Number of times to retry failed queries."

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -20,8 +20,8 @@ import {
     Select,
     Switch,
     Tooltip,
+    NumberInput,
 } from '@mantine-8/core';
-import { NumberInput } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconCheck, IconExclamationCircle } from '@tabler/icons-react';
 import {
@@ -833,6 +833,7 @@ const BigQueryForm: FC<{
                                 />
 
                                 <NumberInput
+                                    decimalScale={0}
                                     name="warehouse.timeoutSeconds"
                                     {...form.getInputProps(
                                         'warehouse.timeoutSeconds',
@@ -903,6 +904,7 @@ const BigQueryForm: FC<{
                                 />
 
                                 <NumberInput
+                                    decimalScale={0}
                                     name="warehouse.retries"
                                     {...form.getInputProps('warehouse.retries')}
                                     defaultValue={BigQueryDefaultValues.retries}
@@ -928,6 +930,7 @@ const BigQueryForm: FC<{
                                 />
 
                                 <NumberInput
+                                    decimalScale={0}
                                     name="warehouse.maximumBytesBilled"
                                     {...form.getInputProps(
                                         'warehouse.maximumBytesBilled',

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/ClickhouseForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/ClickhouseForm.tsx
@@ -1,6 +1,11 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { TextInput, Stack, Anchor, PasswordInput } from '@mantine-8/core';
-import { NumberInput } from '@mantine/core';
+import {
+    TextInput,
+    Stack,
+    Anchor,
+    PasswordInput,
+    NumberInput,
+} from '@mantine-8/core';
 import React, { type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';
 import FormCollapseButton from '../FormCollapseButton';
@@ -98,6 +103,7 @@ const ClickhouseForm: FC<{
                         />
 
                         <NumberInput
+                            decimalScale={0}
                             name="warehouse.port"
                             {...form.getInputProps('warehouse.port')}
                             defaultValue={ClickhouseDefaultValues.port}
@@ -134,6 +140,7 @@ const ClickhouseForm: FC<{
                         />
 
                         <NumberInput
+                            decimalScale={0}
                             name="warehouse.timeoutSeconds"
                             defaultValue={
                                 ClickhouseDefaultValues.timeoutSeconds

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DuckdbForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DuckdbForm.tsx
@@ -11,8 +11,8 @@ import {
     Select,
     Switch,
     PasswordInput,
+    NumberInput,
 } from '@mantine-8/core';
-import { NumberInput } from '@mantine/core';
 import { type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';
 import FormCollapseButton from '../FormCollapseButton';
@@ -167,6 +167,7 @@ const DucklakeFields: FC<{ disabled: boolean }> = ({ disabled }) => {
                         disabled={disabled}
                     />
                     <NumberInput
+                        decimalScale={0}
                         label="Port"
                         required
                         {...form.getInputProps('warehouse.catalog.port')}
@@ -405,6 +406,7 @@ const DuckdbForm: FC<{
             <FormSection isOpen={isOpen} name="advanced">
                 <Stack mt="sm">
                     <NumberInput
+                        decimalScale={0}
                         name="warehouse.threads"
                         label="Threads"
                         description="Number of threads for dbt to use."

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
@@ -9,8 +9,8 @@ import {
     Select,
     PasswordInput,
     Tooltip,
+    NumberInput,
 } from '@mantine-8/core';
-import { NumberInput } from '@mantine/core';
 import { IconCheck, IconCopy } from '@tabler/icons-react';
 import React, { type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';
@@ -145,6 +145,7 @@ const PostgresForm: FC<{
                             }
                         />
                         <NumberInput
+                            decimalScale={0}
                             name="warehouse.port"
                             {...form.getInputProps('warehouse.port')}
                             defaultValue={PostgresDefaultValues.port}
@@ -155,6 +156,7 @@ const PostgresForm: FC<{
                         />
 
                         <NumberInput
+                            decimalScale={0}
                             name="warehouse.keepalivesIdle"
                             {...form.getInputProps('warehouse.keepalivesIdle')}
                             defaultValue={PostgresDefaultValues.keepalivesIdle}
@@ -300,6 +302,7 @@ const PostgresForm: FC<{
                         <StartOfWeekSelect disabled={disabled} />
 
                         <NumberInput
+                            decimalScale={0}
                             name="warehouse.timeoutSeconds"
                             defaultValue={PostgresDefaultValues.timeoutSeconds}
                             {...form.getInputProps('warehouse.timeoutSeconds')}
@@ -338,6 +341,7 @@ const PostgresForm: FC<{
                                 />
 
                                 <NumberInput
+                                    decimalScale={0}
                                     name="warehouse.sshTunnelPort"
                                     {...form.getInputProps(
                                         'warehouse.sshTunnelPort',

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -9,8 +9,8 @@ import {
     Select,
     PasswordInput,
     Tooltip,
+    NumberInput,
 } from '@mantine-8/core';
-import { NumberInput } from '@mantine/core';
 import { IconCheck, IconCopy } from '@tabler/icons-react';
 import { useEffect, type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';
@@ -210,6 +210,7 @@ const RedshiftForm: FC<{
                         )}
 
                         <NumberInput
+                            decimalScale={0}
                             name="warehouse.port"
                             defaultValue={RedshiftDefaultValues.port}
                             {...form.getInputProps('warehouse.port')}
@@ -220,6 +221,7 @@ const RedshiftForm: FC<{
                         />
 
                         <NumberInput
+                            decimalScale={0}
                             name="warehouse.keepalivesIdle"
                             {...form.getInputProps('warehouse.keepalivesIdle')}
                             defaultValue={RedshiftDefaultValues.keepalivesIdle}
@@ -294,6 +296,7 @@ const RedshiftForm: FC<{
                         <StartOfWeekSelect disabled={disabled} />
 
                         <NumberInput
+                            decimalScale={0}
                             name="warehouse.timeoutSeconds"
                             {...form.getInputProps('warehouse.timeoutSeconds')}
                             defaultValue={RedshiftDefaultValues.timeoutSeconds}
@@ -335,6 +338,7 @@ const RedshiftForm: FC<{
                                 />
 
                                 <NumberInput
+                                    decimalScale={0}
                                     name="warehouse.sshTunnelPort"
                                     defaultValue={22}
                                     {...form.getInputProps(

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -16,8 +16,8 @@ import {
     Select,
     PasswordInput,
     Tooltip,
+    NumberInput,
 } from '@mantine-8/core';
-import { NumberInput } from '@mantine/core';
 import { IconCheck } from '@tabler/icons-react';
 import {
     useCallback,
@@ -760,6 +760,7 @@ const SnowflakeForm: FC<{
                                             )}
                                         />
                                         <NumberInput
+                                            decimalScale={0}
                                             name="warehouse.timeoutSeconds"
                                             {...form.getInputProps(
                                                 'warehouse.timeoutSeconds',

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/TrinoForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/TrinoForm.tsx
@@ -5,8 +5,8 @@ import {
     Anchor,
     Select,
     PasswordInput,
+    NumberInput,
 } from '@mantine-8/core';
-import { NumberInput } from '@mantine/core';
 import React, { type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';
 import FormCollapseButton from '../FormCollapseButton';
@@ -107,6 +107,7 @@ const TrinoForm: FC<{
                         />
 
                         <NumberInput
+                            decimalScale={0}
                             name="warehouse.port"
                             {...form.getInputProps('warehouse.port')}
                             defaultValue={TrinoDefaultValues.port}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinInterval.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinInterval.tsx
@@ -12,6 +12,7 @@ export const AxisMinInterval: FC<Props> = ({ label, value, onChange }) => (
     <Group wrap="nowrap" gap="xs">
         <Config.Label>{label}</Config.Label>
         <NumberInput
+            size="xs"
             placeholder="Auto"
             value={value ?? ''}
             min={0}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -18,8 +18,8 @@ import {
     Switch,
     Text,
     Select,
+    NumberInput,
 } from '@mantine-8/core';
-import { NumberInput } from '@mantine/core';
 import {
     IconChartBar,
     IconMinus,
@@ -30,6 +30,10 @@ import {
 } from '@tabler/icons-react';
 import { forwardRef, type FC } from 'react';
 import { getAxisTypeFromField } from '../../../../hooks/echarts/useEchartsCartesianConfig';
+import {
+    handleNumberInputChange,
+    optionalNumber,
+} from '../../../../utils/numberInputUtils';
 import MantineIcon from '../../../common/MantineIcon';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
@@ -284,7 +288,8 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             <Group wrap="nowrap" gap="xs" align="baseline">
                                 <Config.Label>Rotation</Config.Label>
                                 <NumberInput
-                                    type="number"
+                                    decimalScale={0}
+                                    size="xs"
                                     defaultValue={
                                         dirtyEchartsConfig?.xAxis?.[0].rotate ||
                                         0
@@ -294,9 +299,10 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                                     step={15}
                                     maw={54}
                                     rightSection="°"
-                                    onChange={(value) => {
-                                        setXAxisLabelRotation(Number(value));
-                                    }}
+                                    onChange={handleNumberInputChange(
+                                        setXAxisLabelRotation,
+                                        () => setXAxisLabelRotation(0),
+                                    )}
                                 />
                             </Group>
                         )}
@@ -351,6 +357,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                                             Visible items
                                         </Config.Label>
                                         <NumberInput
+                                            decimalScale={0}
                                             size="xs"
                                             maw={80}
                                             min={2}
@@ -359,11 +366,9 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                                                 dirtyEchartsConfig?.xAxis?.[0]
                                                     ?.dataZoomItemCount ?? 10
                                             }
-                                            onChange={(value) => {
-                                                if (typeof value === 'number') {
-                                                    setDataZoomItemCount(value);
-                                                }
-                                            }}
+                                            onChange={handleNumberInputChange(
+                                                setDataZoomItemCount,
+                                            )}
                                         />
                                     </Group>
                                 </>
@@ -606,20 +611,18 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                     <Config.Heading>Tick label size (px)</Config.Heading>
                     <Group gap="xs">
                         <NumberInput
+                            size="xs"
                             value={
                                 dirtyEchartsConfig?.axisLabelFontSize ?? 11.5
                             }
                             min={8}
                             max={24}
                             step={0.5}
-                            precision={1}
+                            decimalScale={1}
+                            fixedDecimalScale
                             maw={60}
                             onChange={(value) => {
-                                setAxisLabelFontSize(
-                                    typeof value === 'number'
-                                        ? value
-                                        : undefined,
-                                );
+                                setAxisLabelFontSize(optionalNumber(value));
                             }}
                         />
                         {dirtyEchartsConfig?.axisLabelFontSize !==
@@ -640,18 +643,16 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                     <Config.Heading>Axis title size (px)</Config.Heading>
                     <Group gap="xs">
                         <NumberInput
+                            size="xs"
                             value={dirtyEchartsConfig?.axisTitleFontSize ?? 12}
                             min={8}
                             max={24}
                             step={0.5}
-                            precision={1}
+                            decimalScale={1}
+                            fixedDecimalScale
                             maw={60}
                             onChange={(value) => {
-                                setAxisTitleFontSize(
-                                    typeof value === 'number'
-                                        ? value
-                                        : undefined,
-                                );
+                                setAxisTitleFontSize(optionalNumber(value));
                             }}
                         />
                         {dirtyEchartsConfig?.axisTitleFontSize !==

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
@@ -10,9 +10,10 @@ import {
     SegmentedControl,
     Stack,
     Tooltip,
+    NumberInput,
 } from '@mantine-8/core';
-import { NumberInput } from '@mantine/core';
 import { memo, type FC } from 'react';
+import { handleNumberInputChange } from '../../../utils/numberInputUtils';
 import FieldSelect from '../../common/FieldSelect';
 import { isGaugeVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
@@ -67,24 +68,28 @@ export const GaugeDisplayConfig: FC = memo(() => {
                 <Config.Section>
                     <Config.Heading>Scale</Config.Heading>
                     <NumberInput
+                        size="xs"
                         label="Minimum value"
                         description="Set the minimum value for the gauge scale"
                         value={min}
-                        onChange={(value) => setMin(Number(value))}
+                        onChange={handleNumberInputChange(setMin, () =>
+                            setMin(0),
+                        )}
                         placeholder="0"
-                        precision={2}
-                        removeTrailingZeros={true}
+                        decimalScale={2}
                     />
                     <Group gap="xs" align="flex-end">
                         {maxValueMode === GaugeValueMode.FIXED ? (
                             <NumberInput
+                                size="xs"
                                 label="Maximum value"
                                 description="Set the maximum value for the gauge scale"
                                 value={max}
-                                onChange={(value) => setMax(Number(value))}
+                                onChange={handleNumberInputChange(setMax, () =>
+                                    setMax(0),
+                                )}
                                 placeholder="100"
-                                precision={2}
-                                removeTrailingZeros={true}
+                                decimalScale={2}
                                 style={{ flex: 1 }}
                             />
                         ) : (

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeSection.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeSection.tsx
@@ -88,6 +88,7 @@ const GaugeSectionComponent: FC<Props> = memo(
                         <Group gap="xs" align="flex-end">
                             {minValueMode === GaugeValueMode.FIXED ? (
                                 <NumberInput
+                                    size="xs"
                                     label="Min value"
                                     description="Set the minimum value for the section"
                                     value={section.min}
@@ -155,6 +156,7 @@ const GaugeSectionComponent: FC<Props> = memo(
                         <Group gap="xs" align="flex-end">
                             {maxValueMode === GaugeValueMode.FIXED ? (
                                 <NumberInput
+                                    size="xs"
                                     label="Max value"
                                     description="Set the maximum value for the section"
                                     value={section.max}

--- a/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapDisplayConfig.tsx
@@ -34,6 +34,7 @@ export const Display: React.FC = () => {
                             />
                         </Tooltip>
                         <NumberInput
+                            size="xs"
                             value={visibleMin}
                             onChange={(value) => {
                                 if (typeof value === 'number')
@@ -60,6 +61,7 @@ export const Display: React.FC = () => {
                             />
                         </Tooltip>
                         <NumberInput
+                            size="xs"
                             value={leafDepth}
                             onChange={(value) => {
                                 if (typeof value === 'number')

--- a/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapLayoutConfig.tsx
@@ -16,9 +16,10 @@ import {
     Switch,
     Text,
     Tooltip,
+    NumberInput,
 } from '@mantine-8/core';
-import { NumberInput } from '@mantine/core';
 import { IconHelpCircle } from '@tabler/icons-react';
+import { optionalNumber } from '../../../utils/numberInputUtils';
 import FieldSelect from '../../common/FieldSelect';
 import MantineIcon from '../../common/MantineIcon';
 import { isTreemapVisualizationConfig } from '../../LightdashVisualization/types';
@@ -252,10 +253,16 @@ export const Layout: React.FC = () => {
                                     <Group gap="xs" justify="flex-end">
                                         <Config.Label>Threshold</Config.Label>
                                         <NumberInput
+                                            size="xs"
                                             value={startColorThreshold}
-                                            onChange={setStartColorThreshold}
+                                            onChange={(value) =>
+                                                setStartColorThreshold(
+                                                    optionalNumber(value),
+                                                )
+                                            }
                                             hideControls={true}
-                                            precision={2}
+                                            decimalScale={2}
+                                            fixedDecimalScale
                                             placeholder="Auto (per-level)"
                                         />
                                     </Group>
@@ -280,10 +287,16 @@ export const Layout: React.FC = () => {
                                     >
                                         <Config.Label>Threshold</Config.Label>
                                         <NumberInput
+                                            size="xs"
                                             value={endColorThreshold}
-                                            onChange={setEndColorThreshold}
+                                            onChange={(value) =>
+                                                setEndColorThreshold(
+                                                    optionalNumber(value),
+                                                )
+                                            }
                                             hideControls={true}
-                                            precision={2}
+                                            decimalScale={2}
+                                            fixedDecimalScale
                                             placeholder="Auto (per-level)"
                                         />
                                     </Group>

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -10,10 +10,10 @@ import {
     type BaseFilterRule,
     type DateFilterRule,
 } from '@lightdash/common';
-import { Flex, Text } from '@mantine-8/core';
-import { NumberInput } from '@mantine/core';
+import { Flex, Text, NumberInput } from '@mantine-8/core';
 import dayjs from 'dayjs';
 import { type FilterInputsProps } from '.';
+import { handleNumberInputChange } from '../../../../utils/numberInputUtils';
 import useFiltersContext from '../useFiltersContext';
 import { getFirstDayOfWeek } from '../utils/filterDateUtils';
 import { getPlaceholderByFilterTypeAndOperator } from '../utils/getPlaceholderByFilterTypeAndOperator';
@@ -266,23 +266,19 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
             return (
                 <Flex gap="xs" w="100%">
                     <NumberInput
+                        decimalScale={0}
                         size="xs"
-                        sx={{
-                            flexShrink: 1,
-                            flexGrow: 1,
-                            minWidth: 50,
-                        }}
+                        flex="1 1 auto"
+                        miw={50}
                         placeholder={placeholder}
                         disabled={disabled}
                         data-autofocus
                         value={isNaN(parsedValue) ? undefined : parsedValue}
                         min={0}
-                        onChange={(value) => {
-                            onChange({
-                                ...rule,
-                                values: value === '' ? [] : [value],
-                            });
-                        }}
+                        onChange={handleNumberInputChange(
+                            (value) => onChange({ ...rule, values: [value] }),
+                            () => onChange({ ...rule, values: [] }),
+                        )}
                     />
 
                     <FilterUnitOfTimeAutoComplete

--- a/packages/frontend/src/features/tableCalculation/components/FormatRow/FormatRow.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/FormatRow/FormatRow.tsx
@@ -28,8 +28,8 @@ import {
     TextInput,
     Tooltip,
     type ComboboxItem,
+    NumberInput,
 } from '@mantine-8/core';
-import { NumberInput } from '@mantine/core';
 import { type UseFormReturnType } from '@mantine/form';
 import {
     Icon123,
@@ -44,6 +44,7 @@ import {
 import { useMemo, type FC } from 'react';
 import { type ValueOf } from 'type-fest';
 import MantineIcon from '../../../../components/common/MantineIcon';
+import { optionalNumber } from '../../../../utils/numberInputUtils';
 import classes from './FormatRow.module.css';
 
 type Props = {
@@ -469,6 +470,7 @@ export const FormatRow: FC<Props> = ({
                     {isNumeric && format.type === CustomFormatType.NUMBER && (
                         <Group gap="md" wrap="wrap" align="flex-end">
                             <NumberInput
+                                decimalScale={0}
                                 className={classes.subFieldInputNarrow}
                                 size="xs"
                                 radius="md"
@@ -480,7 +482,7 @@ export const FormatRow: FC<Props> = ({
                                     onChange: (value) =>
                                         setFormatFieldValue(
                                             'round',
-                                            value === '' ? undefined : value,
+                                            optionalNumber(value),
                                         ),
                                 }}
                             />
@@ -537,6 +539,7 @@ export const FormatRow: FC<Props> = ({
                                 {...formatInputProps('currency')}
                             />
                             <NumberInput
+                                decimalScale={0}
                                 className={classes.subFieldInput}
                                 size="xs"
                                 radius="md"
@@ -548,7 +551,7 @@ export const FormatRow: FC<Props> = ({
                                     onChange: (value) =>
                                         setFormatFieldValue(
                                             'round',
-                                            value === '' ? undefined : value,
+                                            optionalNumber(value),
                                         ),
                                 }}
                             />
@@ -574,6 +577,7 @@ export const FormatRow: FC<Props> = ({
 
                     {isNumeric && format.type === CustomFormatType.PERCENT && (
                         <NumberInput
+                            decimalScale={0}
                             className={classes.subFieldInput}
                             size="xs"
                             radius="md"
@@ -585,7 +589,7 @@ export const FormatRow: FC<Props> = ({
                                 onChange: (value) =>
                                     setFormatFieldValue(
                                         'round',
-                                        value === '' ? undefined : value,
+                                        optionalNumber(value),
                                     ),
                             }}
                         />

--- a/packages/frontend/src/hooks/useTreemapChartConfig.ts
+++ b/packages/frontend/src/hooks/useTreemapChartConfig.ts
@@ -37,9 +37,9 @@ type TreemapChartConfig = {
     topLevelColors?: string[];
 
     startColorThreshold?: number;
-    setStartColorThreshold: (startColorThreshold: number) => void;
+    setStartColorThreshold: (startColorThreshold: number | undefined) => void;
     endColorThreshold?: number;
-    setEndColorThreshold: (endColorThreshold: number) => void;
+    setEndColorThreshold: (endColorThreshold: number | undefined) => void;
 
     visibleMin: number;
     setVisibleMin: (visibleMin: number) => void;

--- a/packages/frontend/src/utils/numberInputUtils.ts
+++ b/packages/frontend/src/utils/numberInputUtils.ts
@@ -1,0 +1,24 @@
+/**
+ * Mantine 8 NumberInput emits `number | string` from onChange: strings are
+ * incomplete typing states ('', '-', '12.') or values beyond the safe integer
+ * range. These helpers keep those transients out of app state.
+ */
+
+/** Maps a NumberInput value to a number, or undefined for anything non-numeric. */
+export const optionalNumber = (value: number | string): number | undefined =>
+    typeof value === 'number' ? value : undefined;
+
+/**
+ * Builds a NumberInput onChange handler that only propagates real numbers.
+ * `onClear` fires when the field is emptied; other transient strings are
+ * ignored so half-typed values never reach app state.
+ */
+export const handleNumberInputChange =
+    (onNumber: (value: number) => void, onClear?: () => void) =>
+    (value: number | string): void => {
+        if (typeof value === 'number') {
+            onNumber(value);
+        } else if (value === '') {
+            onClear?.();
+        }
+    };


### PR DESCRIPTION
### Description:

Migrates `NumberInput` from Mantine 6 to Mantine 8 (14 files, 32 inputs). Beyond the import move: `precision`/`removeTrailingZeros` → `decimalScale`/`fixedDecimalScale`, explicit `decimalScale={0}` on all integer fields (v8 would otherwise silently accept decimals), onChange handlers hardened against v8's `number | string` transient values, and all visualization-config inputs pinned to `size="xs"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
