### PR TITLE
feat(pivot-table): include grand total intersections

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1369,9 +1369,11 @@ export class AsyncQueryService extends ProjectService {
     }): Promise<{
         warehouseRowTotals?: PivotRowTotalsByIndex;
         warehouseColumnTotals?: Record<string, number>;
+        warehouseGrandTotals?: Record<string, number>;
     }> {
         let warehouseColumnTotals: Record<string, number> | undefined;
         let warehouseRowTotals: PivotRowTotalsByIndex | undefined;
+        let warehouseGrandTotals: Record<string, number> | undefined;
 
         if (pivotConfig.columnTotals) {
             try {
@@ -1428,7 +1430,35 @@ export class AsyncQueryService extends ProjectService {
             }
         }
 
-        return { warehouseRowTotals, warehouseColumnTotals };
+        if (pivotConfig.rowTotals && pivotConfig.columnTotals) {
+            try {
+                const { rows, fields } =
+                    await this.executeCalculateTotalAndGetResults({
+                        account,
+                        projectUuid,
+                        queryUuid: sourceQueryUuid,
+                        kind: 'grandTotal',
+                    });
+                warehouseGrandTotals = buildWarehouseColumnTotals(
+                    formatRows(rows, fields),
+                );
+            } catch (error) {
+                this.logger.warn(
+                    'Failed to compute grand totals for pivot export',
+                    {
+                        projectUuid,
+                        sourceQueryUuid,
+                        error: getErrorMessage(error),
+                    },
+                );
+            }
+        }
+
+        return {
+            warehouseRowTotals,
+            warehouseColumnTotals,
+            warehouseGrandTotals,
+        };
     }
 
     private async downloadAsyncQueryResults({
@@ -1593,7 +1623,11 @@ export class AsyncQueryService extends ProjectService {
 
         // Warehouse-computed totals for the pivot export — without these the
         // renderer leaves total cells blank (no client-side fallback).
-        const { warehouseRowTotals, warehouseColumnTotals } =
+        const {
+            warehouseRowTotals,
+            warehouseColumnTotals,
+            warehouseGrandTotals,
+        } =
             downloadPivotConfig &&
             pivotDetails &&
             (downloadPivotConfig.rowTotals || downloadPivotConfig.columnTotals)
@@ -1607,6 +1641,7 @@ export class AsyncQueryService extends ProjectService {
                 : {
                       warehouseRowTotals: undefined,
                       warehouseColumnTotals: undefined,
+                      warehouseGrandTotals: undefined,
                   };
 
         switch (type) {
@@ -1626,6 +1661,7 @@ export class AsyncQueryService extends ProjectService {
                         pivotDetails,
                         warehouseRowTotals,
                         warehouseColumnTotals,
+                        warehouseGrandTotals,
                         options: {
                             onlyRaw,
                             showTableNames,
@@ -1705,6 +1741,7 @@ export class AsyncQueryService extends ProjectService {
                           pivotDetails,
                           warehouseRowTotals,
                           warehouseColumnTotals,
+                          warehouseGrandTotals,
                           options: {
                               onlyRaw,
                               showTableNames,

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -409,6 +409,7 @@ export class ExcelService {
         pivotDetails,
         warehouseRowTotals,
         warehouseColumnTotals,
+        warehouseGrandTotals,
         enableImprovedExcelDates = false,
         timezone,
     }: {
@@ -420,6 +421,7 @@ export class ExcelService {
         pivotDetails: ReadyQueryResultsPage['pivotDetails'];
         warehouseRowTotals?: PivotRowTotalsByIndex;
         warehouseColumnTotals?: Record<string, number>;
+        warehouseGrandTotals?: Record<string, number>;
         enableImprovedExcelDates?: boolean;
         timezone?: string;
     }): Promise<Excel.Buffer> {
@@ -447,6 +449,7 @@ export class ExcelService {
                 pivotDetails,
                 warehouseRowTotals,
                 warehouseColumnTotals,
+                warehouseGrandTotals,
                 timezone,
             });
         }
@@ -460,6 +463,7 @@ export class ExcelService {
             pivotDetails,
             warehouseRowTotals,
             warehouseColumnTotals,
+            warehouseGrandTotals,
         });
 
         // Build date column metadata: for each data column, determine if
@@ -580,6 +584,7 @@ export class ExcelService {
         pivotDetails,
         warehouseRowTotals,
         warehouseColumnTotals,
+        warehouseGrandTotals,
         timezone,
     }: {
         formattedRows: ResultRow[];
@@ -590,6 +595,7 @@ export class ExcelService {
         pivotDetails: NonNullable<ReadyQueryResultsPage['pivotDetails']>;
         warehouseRowTotals?: PivotRowTotalsByIndex;
         warehouseColumnTotals?: Record<string, number>;
+        warehouseGrandTotals?: Record<string, number>;
         timezone?: string;
     }): Promise<Excel.Buffer> {
         const csvResults = pivotResultsAsCsv({
@@ -601,6 +607,7 @@ export class ExcelService {
             pivotDetails,
             warehouseRowTotals,
             warehouseColumnTotals,
+            warehouseGrandTotals,
         });
 
         const workbook = new Excel.Workbook();
@@ -656,6 +663,7 @@ export class ExcelService {
         pivotDetails,
         warehouseRowTotals,
         warehouseColumnTotals,
+        warehouseGrandTotals,
         timezone,
         csvCellsLimit,
     }: {
@@ -667,6 +675,7 @@ export class ExcelService {
         pivotDetails: ReadyQueryResultsPage['pivotDetails'];
         warehouseRowTotals?: PivotRowTotalsByIndex;
         warehouseColumnTotals?: Record<string, number>;
+        warehouseGrandTotals?: Record<string, number>;
         options: {
             onlyRaw: boolean;
             showTableNames: boolean;
@@ -729,6 +738,7 @@ export class ExcelService {
             pivotDetails,
             warehouseRowTotals,
             warehouseColumnTotals,
+            warehouseGrandTotals,
             enableImprovedExcelDates: lightdashConfig.enableImprovedExcelDates,
             timezone,
         });

--- a/packages/backend/src/services/PivotTableService/PivotTableService.ts
+++ b/packages/backend/src/services/PivotTableService/PivotTableService.ts
@@ -110,6 +110,7 @@ export class PivotTableService extends BaseService {
         pivotDetails,
         warehouseRowTotals,
         warehouseColumnTotals,
+        warehouseGrandTotals,
         organizationUuid,
         createdByUserUuid,
         expirationSecondsOverride,
@@ -123,6 +124,7 @@ export class PivotTableService extends BaseService {
         pivotDetails: ReadyQueryResultsPage['pivotDetails'];
         warehouseRowTotals?: PivotRowTotalsByIndex;
         warehouseColumnTotals?: Record<string, number>;
+        warehouseGrandTotals?: Record<string, number>;
         options: {
             onlyRaw: boolean;
             showTableNames: boolean;
@@ -193,6 +195,7 @@ export class PivotTableService extends BaseService {
             pivotDetails,
             warehouseRowTotals,
             warehouseColumnTotals,
+            warehouseGrandTotals,
             organizationUuid,
             createdByUserUuid,
             expirationSecondsOverride,
@@ -223,6 +226,7 @@ export class PivotTableService extends BaseService {
         pivotDetails,
         warehouseRowTotals,
         warehouseColumnTotals,
+        warehouseGrandTotals,
         organizationUuid,
         createdByUserUuid,
         expirationSecondsOverride,
@@ -236,6 +240,7 @@ export class PivotTableService extends BaseService {
         pivotDetails: ReadyQueryResultsPage['pivotDetails'];
         warehouseRowTotals?: PivotRowTotalsByIndex;
         warehouseColumnTotals?: Record<string, number>;
+        warehouseGrandTotals?: Record<string, number>;
         exploreId: string;
         onlyRaw: boolean;
         truncated: boolean;
@@ -281,6 +286,7 @@ export class PivotTableService extends BaseService {
             pivotDetails,
             warehouseRowTotals,
             warehouseColumnTotals,
+            warehouseGrandTotals,
             timezone,
             formatTemporalsForSpreadsheet: true,
         });

--- a/packages/common/src/pivot/pivotQueryResults.test.ts
+++ b/packages/common/src/pivot/pivotQueryResults.test.ts
@@ -457,6 +457,71 @@ describe('convertSqlPivotedRowsToPivotData', () => {
         ]);
     });
 
+    it.each([false, true])(
+        'maps warehouse grand totals for every visible metric when metricsAsRows is %s',
+        (metricsAsRows) => {
+            const result = convertSqlPivotedRowsToPivotData({
+                rows: COMPLEX_SQL_PIVOTED_ROWS,
+                pivotDetails: COMPLEX_SQL_PIVOT_DETAILS,
+                pivotConfig: {
+                    rowTotals: true,
+                    columnTotals: true,
+                    metricsAsRows,
+                    columnOrder: [
+                        'payments_payment_method',
+                        'orders_order_date_year',
+                        'orders_is_completed',
+                        'orders_promo_code',
+                        'payments_total_revenue',
+                        'orders_average_order_size',
+                        'orders_total_order_amount',
+                    ],
+                },
+                getField: getFieldMock,
+                getFieldLabel: (fieldId) => fieldId,
+                groupedSubtotals: undefined,
+                warehouseGrandTotals: {
+                    payments_total_revenue: 1000,
+                    orders_average_order_size_any: 42.5,
+                    orders_total_order_amount: 2000,
+                },
+            });
+
+            expect(result.grandTotals).toEqual([1000, 42.5, 2000]);
+        },
+    );
+
+    it.each([
+        { rowTotals: true, columnTotals: false },
+        { rowTotals: false, columnTotals: true },
+    ])(
+        'does not expose grand totals with only one total axis enabled: $rowTotals/$columnTotals',
+        ({ rowTotals, columnTotals }) => {
+            const result = convertSqlPivotedRowsToPivotData({
+                rows: SQL_PIVOTED_ROWS,
+                pivotDetails: SQL_PIVOT_DETAILS,
+                pivotConfig: {
+                    rowTotals,
+                    columnTotals,
+                    metricsAsRows: false,
+                    columnOrder: [
+                        'payments_payment_method',
+                        'orders_order_date_year',
+                        'payments_total_revenue',
+                    ],
+                },
+                getField: getFieldMock,
+                getFieldLabel: (fieldId) => fieldId,
+                groupedSubtotals: undefined,
+                warehouseGrandTotals: {
+                    payments_total_revenue: 999,
+                },
+            });
+
+            expect(result.grandTotals).toBeUndefined();
+        },
+    );
+
     it('leaves column totals null (no client-side fallback) without warehouse values', () => {
         const result = convertSqlPivotedRowsToPivotData({
             rows: SQL_PIVOTED_ROWS,

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -508,6 +508,7 @@ export const convertSqlPivotedRowsToPivotData = ({
     groupedSubtotals,
     warehouseRowTotals,
     warehouseColumnTotals,
+    warehouseGrandTotals,
     columnLimit,
     parameters,
 }: {
@@ -542,6 +543,12 @@ export const convertSqlPivotedRowsToPivotData = ({
      * query can't be totalled). Drives both layouts.
      */
     warehouseColumnTotals?: Record<string, number>;
+    /**
+     * Warehouse-computed grand totals from `calculate-total`
+     * (`kind: 'grandTotal'`), keyed by metric field id. These are only used
+     * when both total axes are enabled.
+     */
+    warehouseGrandTotals?: Record<string, number>;
     columnLimit?: number;
     parameters?: ParametersValuesMap;
 }): PivotData => {
@@ -970,6 +977,18 @@ export const convertSqlPivotedRowsToPivotData = ({
         warehouseColumnTotals,
     });
 
+    const grandTotals =
+        fullPivotConfig.rowTotals &&
+        fullPivotConfig.columnTotals &&
+        warehouseGrandTotals
+            ? baseMetricsArray.map((fieldId) => {
+                  const value =
+                      warehouseGrandTotals[`${fieldId}_any`] ??
+                      warehouseGrandTotals[fieldId];
+                  return typeof value === 'number' ? value : null;
+              })
+            : undefined;
+
     // Passthrough dims — hidden non-sort pivot dims whose raw values are
     // carried on each row so cross-field richText / image templates can
     // resolve `row.<table>.<field>.raw` even though the dim has no rendered
@@ -1178,6 +1197,7 @@ export const convertSqlPivotedRowsToPivotData = ({
         columnTotalFields,
         rowTotals,
         columnTotals,
+        ...(grandTotals ? { grandTotals } : {}),
         cellsCount: pivotConfig.metricsAsRows
             ? indexColumns.length +
               1 + // label column
@@ -1429,6 +1449,7 @@ type PivotResultsParams = {
     // pivot worker leaves total cells blank — there is no client-side fallback.
     warehouseRowTotals?: PivotRowTotalsByIndex;
     warehouseColumnTotals?: Record<string, number>;
+    warehouseGrandTotals?: Record<string, number>;
 };
 
 export const pivotResultsAsData = ({
@@ -1443,6 +1464,7 @@ export const pivotResultsAsData = ({
     formatTemporalsForSpreadsheet = false,
     warehouseRowTotals,
     warehouseColumnTotals,
+    warehouseGrandTotals,
 }: PivotResultsParams): PivotResultsData => {
     const getFieldLabel = (fieldId: string) => {
         const customLabel = customLabels?.[fieldId];
@@ -1459,6 +1481,7 @@ export const pivotResultsAsData = ({
         groupedSubtotals: undefined,
         warehouseRowTotals,
         warehouseColumnTotals,
+        warehouseGrandTotals,
     });
 
     const formatField = onlyRaw ? 'raw' : 'formatted';
@@ -1582,13 +1605,35 @@ export const pivotResultsAsData = ({
             },
         );
 
+        const totalFields = last(pivotedResults.rowTotalFields) ?? [];
         const rowTotalCells: PivotResultsDataCell[] =
             pivotConfig.rowTotals && pivotedResults.rowTotalFields?.[0]
-                ? pivotedResults.rowTotalFields[0].map(() => ({
-                      raw: '',
-                      formatted: '',
-                      fieldId: '',
-                  }))
+                ? pivotedResults.rowTotalFields[0].map((_, totalColIndex) => {
+                      const grandTotalIndex = pivotConfig.metricsAsRows
+                          ? totalRowIndex
+                          : totalColIndex;
+                      const grandTotal =
+                          pivotedResults.grandTotals?.[grandTotalIndex];
+                      const fieldId = pivotConfig.metricsAsRows
+                          ? lastTotalField?.fieldId
+                          : totalFields[totalColIndex]?.fieldId;
+                      if (
+                          grandTotal === null ||
+                          grandTotal === undefined ||
+                          !fieldId
+                      ) {
+                          return { raw: '', formatted: '', fieldId: '' };
+                      }
+                      const field = itemMap[fieldId];
+                      const formatted = onlyRaw
+                          ? String(grandTotal)
+                          : formatItemValue(field, grandTotal, false);
+                      return {
+                          raw: grandTotal,
+                          formatted,
+                          fieldId,
+                      };
+                  })
                 : [];
 
         return [...labelCells, ...dataCells, ...rowTotalCells];

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -162,12 +162,14 @@ export const getDateZoomFromRequestParameters = (
     params && 'dateZoom' in params ? params.dateZoom : undefined;
 
 /**
- * Kinds of totals derivable from an executed pivot query. Follow-up PRs
- * will widen the union to enable the commented-out variants below.
+ * Kinds of totals derivable from an executed pivot query.
  */
-export type CalculateTotalKind = 'columnTotal' | 'rowTotal' | 'columnSubtotal';
+export type CalculateTotalKind =
+    | 'grandTotal'
+    | 'columnTotal'
+    | 'rowTotal'
+    | 'columnSubtotal';
 // | 'rowSubtotal'
-// | 'grandTotal';
 
 export type ExecuteAsyncCalculateTotalRequestParams = {
     kind: CalculateTotalKind;

--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -117,6 +117,7 @@ export type PivotData = {
 
     rowTotals?: TotalValue[][];
     columnTotals?: TotalValue[][];
+    grandTotals?: TotalValue[];
     cellsCount: number;
     rowsCount: number;
     pivotConfig: PivotConfig;

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -233,6 +233,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
         updateColumnProperty,
         isCalculatingColumnTotals,
         isCalculatingRowTotals,
+        isCalculatingGrandTotals,
         isCalculatingSubtotals,
     } = visualizationConfig.chartConfig;
 
@@ -331,6 +332,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                     isCalculatingColumnTotals
                                 }
                                 isRowTotalsLoading={isCalculatingRowTotals}
+                                isGrandTotalsLoading={isCalculatingGrandTotals}
                                 isSubtotalsLoading={isCalculatingSubtotals}
                                 {...rest}
                             />
@@ -358,6 +360,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                     isCalculatingColumnTotals
                                 }
                                 isRowTotalsLoading={isCalculatingRowTotals}
+                                isGrandTotalsLoading={isCalculatingGrandTotals}
                                 isSubtotalsLoading={isCalculatingSubtotals}
                                 {...rest}
                             />

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -183,6 +183,8 @@ type PivotTableProps = BoxProps & // TODO: remove this
         isColumnTotalsLoading?: boolean;
         /** Row-total cells render a loading skeleton while their async query is in flight. */
         isRowTotalsLoading?: boolean;
+        /** Grand-total intersection cells render a loading skeleton while their async query is in flight. */
+        isGrandTotalsLoading?: boolean;
         /** Subtotal cells render a loading skeleton while their async query is in flight. */
         isSubtotalsLoading?: boolean;
         columnProperties?: Record<string, ColumnProperties>;
@@ -218,6 +220,7 @@ const PivotTable: FC<PivotTableProps> = ({
     showRowGrouping = false,
     isColumnTotalsLoading = false,
     isRowTotalsLoading = false,
+    isGrandTotalsLoading = false,
     isSubtotalsLoading = false,
     columnProperties = {},
     isMinimal = false,
@@ -756,6 +759,33 @@ const PivotTable: FC<PivotTableProps> = ({
             };
         },
         [data.columnTotalFields, getField, parameters],
+    );
+
+    const getGrandTotalValueFromAxis = useCallback(
+        (total: unknown, metricIndex: number): ResultValue | null => {
+            const totalField = data.pivotConfig.metricsAsRows
+                ? last(data.columnTotalFields?.[metricIndex])
+                : last(data.rowTotalFields)?.[metricIndex];
+            if (!totalField?.fieldId) throw new Error('Invalid pivot data');
+            if (total === null || total === undefined) return null;
+
+            return {
+                raw: total,
+                formatted: formatItemValue(
+                    getField(totalField.fieldId),
+                    total,
+                    false,
+                    parameters,
+                ),
+            };
+        },
+        [
+            data.columnTotalFields,
+            data.pivotConfig.metricsAsRows,
+            data.rowTotalFields,
+            getField,
+            parameters,
+        ],
     );
 
     const getUnderlyingFieldValues = useCallback(
@@ -2238,12 +2268,66 @@ const PivotTable: FC<PivotTableProps> = ({
 
                                 {hasRowTotals
                                     ? data.rowTotalFields?.[0].map(
-                                          (_, index) => (
-                                              <Table.Cell
-                                                  key={`footer-empty-${totalRowIndex}-${index}`}
-                                                  isMinimal={isMinimal}
-                                              />
-                                          ),
+                                          (_, index) => {
+                                              const metricIndex = data
+                                                  .pivotConfig.metricsAsRows
+                                                  ? totalRowIndex
+                                                  : index;
+                                              const value =
+                                                  getGrandTotalValueFromAxis(
+                                                      data.grandTotals?.[
+                                                          metricIndex
+                                                      ],
+                                                      metricIndex,
+                                                  );
+                                              return value ? (
+                                                  <Table.CellHead
+                                                      key={`grand-total-${totalRowIndex}-${index}`}
+                                                      withAlignRight
+                                                      isMinimal={isMinimal}
+                                                      withBoldFont
+                                                      withInteractions
+                                                      withValue={
+                                                          value.formatted
+                                                      }
+                                                      withMenu={(
+                                                          {
+                                                              isOpen,
+                                                              onClose,
+                                                              onCopy,
+                                                          }: MenuCallbackProps,
+                                                          render: RenderCallback,
+                                                      ) => (
+                                                          <TotalCellMenu
+                                                              opened={isOpen}
+                                                              onClose={onClose}
+                                                              onCopy={onCopy}
+                                                          >
+                                                              {render()}
+                                                          </TotalCellMenu>
+                                                      )}
+                                                  >
+                                                      {value.formatted}
+                                                  </Table.CellHead>
+                                              ) : isGrandTotalsLoading ? (
+                                                  <Table.CellHead
+                                                      key={`grand-total-${totalRowIndex}-${index}`}
+                                                      withAlignRight
+                                                      isMinimal={isMinimal}
+                                                  >
+                                                      <Skeleton
+                                                          height={16}
+                                                          width="min(60%, 50px)"
+                                                          ml="auto"
+                                                      />
+                                                  </Table.CellHead>
+                                              ) : (
+                                                  <Table.Cell
+                                                      key={`footer-empty-${totalRowIndex}-${index}`}
+                                                      isMinimal={isMinimal}
+                                                  />
+                                              );
+                                          },
                                       )
                                     : null}
                             </Table.Row>

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -766,7 +766,7 @@ const PivotTable: FC<PivotTableProps> = ({
             const totalField = data.pivotConfig.metricsAsRows
                 ? last(data.columnTotalFields?.[metricIndex])
                 : last(data.rowTotalFields)?.[metricIndex];
-            if (!totalField?.fieldId) throw new Error('Invalid pivot data');
+            if (!totalField?.fieldId) return null;
             if (total === null || total === undefined) return null;
 
             return {

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -25,6 +25,7 @@ import isEqual from 'lodash/isEqual';
 import uniq from 'lodash/uniq';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+    useAsyncCalculateGrandTotal,
     useAsyncCalculateRowTotal,
     useAsyncCalculateSubtotals,
     useAsyncCalculateTotal,
@@ -265,6 +266,20 @@ const useTableConfig = (
             invalidateCache,
         });
 
+    const canFetchAsyncGrandTotals =
+        isInitialQueryReady &&
+        !!resultsData?.queryUuid &&
+        !!resultsData?.pivotDetails &&
+        !!tableChartConfig?.showColumnCalculation &&
+        !!tableChartConfig?.showRowCalculation;
+    const { data: asyncGrandTotals, isFetching: isCalculatingGrandTotals } =
+        useAsyncCalculateGrandTotal({
+            projectUuid,
+            sourceQueryUuid: resultsData?.queryUuid,
+            enabled: canFetchAsyncGrandTotals,
+            invalidateCache,
+        });
+
     const { data: groupedSubtotals, isFetching: isCalculatingSubtotals } =
         useAsyncCalculateSubtotals({
             projectUuid,
@@ -326,39 +341,17 @@ const useTableConfig = (
         data: undefined,
         error: undefined,
     });
+    const pivotWorkerRequestIdRef = useRef(0);
 
-    useEffect(() => {
+    const pivotWorkerInput = useMemo(() => {
         if (
             !pivotDimensions ||
             pivotDimensions.length === 0 ||
             !resultsData?.metricQuery ||
             resultsData.rows.length === 0
         ) {
-            setPivotTableData((prevState) => {
-                // Only update if values are different
-                if (
-                    prevState.loading !== false ||
-                    prevState.data !== undefined ||
-                    prevState.error !== undefined
-                ) {
-                    return {
-                        loading: false,
-                        data: undefined,
-                        error: undefined,
-                    };
-                }
-                // Return previous state if no changes needed
-                return prevState;
-            });
-
-            return;
+            return null;
         }
-
-        setPivotTableData((prevState) => ({
-            ...prevState,
-            loading: true,
-            error: undefined,
-        }));
 
         const hiddenMetricFieldIds = selectedItemIds?.filter((fieldId) => {
             const field = getField(fieldId);
@@ -393,57 +386,89 @@ const useTableConfig = (
         };
 
         if (!resultsData.pivotDetails) {
-            setPivotTableData({
-                loading: false,
-                data: undefined,
-                error: undefined,
+            return null;
+        }
+
+        return {
+            rows: resultsData.rows,
+            pivotDetails: resultsData.pivotDetails,
+            pivotConfig,
+            getField,
+            getFieldLabel,
+            groupedSubtotals,
+            warehouseRowTotals: asyncRowTotals,
+            warehouseColumnTotals: asyncTotals,
+            warehouseGrandTotals: asyncGrandTotals,
+            parameters,
+        };
+    }, [
+        pivotDimensions,
+        resultsData?.metricQuery,
+        resultsData?.rows,
+        resultsData?.pivotDetails,
+        metricsAsRows,
+        columnOrder,
+        selectedItemIds,
+        getField,
+        getFieldLabel,
+        isColumnVisible,
+        tableChartConfig?.showColumnCalculation,
+        tableChartConfig?.showRowCalculation,
+        groupedSubtotals,
+        asyncRowTotals,
+        asyncTotals,
+        asyncGrandTotals,
+        parameters,
+    ]);
+
+    useEffect(() => {
+        const currentRequestId = ++pivotWorkerRequestIdRef.current;
+
+        if (!pivotWorkerInput) {
+            setPivotTableData((prevState) => {
+                if (
+                    !prevState.loading &&
+                    prevState.data === undefined &&
+                    prevState.error === undefined
+                ) {
+                    return prevState;
+                }
+                return {
+                    loading: false,
+                    data: undefined,
+                    error: undefined,
+                };
             });
             return;
         }
 
+        setPivotTableData((prevState) => ({
+            ...prevState,
+            loading: true,
+            error: undefined,
+        }));
+
         worker
-            .convertSqlPivotedRowsToPivotData({
-                rows: resultsData.rows,
-                pivotDetails: resultsData.pivotDetails,
-                pivotConfig,
-                getField,
-                getFieldLabel,
-                groupedSubtotals,
-                warehouseRowTotals: asyncRowTotals,
-                warehouseColumnTotals: asyncTotals,
-                parameters,
-            })
+            .convertSqlPivotedRowsToPivotData(pivotWorkerInput)
             .then((data) => {
-                setPivotTableData({
-                    loading: false,
-                    data: data,
-                    error: undefined,
-                });
+                if (currentRequestId === pivotWorkerRequestIdRef.current) {
+                    setPivotTableData({
+                        loading: false,
+                        data,
+                        error: undefined,
+                    });
+                }
             })
             .catch((e) => {
-                setPivotTableData({
-                    loading: false,
-                    data: undefined,
-                    error: e.message,
-                });
+                if (currentRequestId === pivotWorkerRequestIdRef.current) {
+                    setPivotTableData({
+                        loading: false,
+                        data: undefined,
+                        error: e.message,
+                    });
+                }
             });
-    }, [
-        resultsData,
-        pivotDimensions,
-        columnOrder,
-        metricsAsRows,
-        selectedItemIds,
-        isColumnVisible,
-        getField,
-        getFieldLabel,
-        tableChartConfig?.showColumnCalculation,
-        tableChartConfig?.showRowCalculation,
-        worker,
-        groupedSubtotals,
-        asyncRowTotals,
-        asyncTotals,
-        parameters,
-    ]);
+    }, [worker, pivotWorkerInput]);
 
     // Remove columnProperties from map if the column has been removed from results
     useEffect(() => {
@@ -704,6 +729,7 @@ const useTableConfig = (
             groupedSubtotals,
             isCalculatingColumnTotals,
             isCalculatingRowTotals,
+            isCalculatingGrandTotals,
             isCalculatingSubtotals,
             rowLimit,
             setRowLimit,
@@ -751,6 +777,7 @@ const useTableConfig = (
             groupedSubtotals,
             isCalculatingColumnTotals,
             isCalculatingRowTotals,
+            isCalculatingGrandTotals,
             isCalculatingSubtotals,
             rowLimit,
             setRowLimit,

--- a/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
+++ b/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
@@ -73,12 +73,11 @@ const startCalculateTotalQuery = ({
 export type AsyncTotalsMap = Record<string, number>;
 
 const fetchTotals = async (
-    args: Omit<StartCalculateTotalArgs, 'kind'>,
+    args: Omit<StartCalculateTotalArgs, 'kind'> & {
+        kind: Extract<CalculateTotalKind, 'columnTotal' | 'grandTotal'>;
+    },
 ): Promise<AsyncTotalsMap> => {
-    const { queryUuid } = await startCalculateTotalQuery({
-        ...args,
-        kind: 'columnTotal',
-    });
+    const { queryUuid } = await startCalculateTotalQuery(args);
 
     // Polling endpoint defaults to page=1, so the READY response already
     // contains the single totals row — no separate stream fetch needed.
@@ -119,20 +118,23 @@ export const useColumnTotalsEnabledByDefault = (
     return projectQuery.data?.projectDefaults?.column_totals !== false;
 };
 
-export const useAsyncCalculateTotal = ({
+const useAsyncCalculateSingleRowTotal = ({
     projectUuid,
     sourceQueryUuid,
+    kind,
     enabled,
     invalidateCache,
 }: {
     projectUuid: string | undefined;
     sourceQueryUuid: string | undefined;
+    kind: Extract<CalculateTotalKind, 'columnTotal' | 'grandTotal'>;
     enabled: boolean;
     invalidateCache?: boolean;
 }) =>
     useQuery<AsyncTotalsMap, ApiError>({
         queryKey: [
             'calculate_async_total',
+            kind,
             projectUuid,
             sourceQueryUuid,
             invalidateCache,
@@ -148,12 +150,21 @@ export const useAsyncCalculateTotal = ({
             return fetchTotals({
                 projectUuid,
                 sourceQueryUuid,
+                kind,
                 invalidateCache,
             });
         },
         enabled: enabled && !!projectUuid && !!sourceQueryUuid,
         retry: false,
     });
+
+export const useAsyncCalculateTotal = (
+    args: Omit<Parameters<typeof useAsyncCalculateSingleRowTotal>[0], 'kind'>,
+) => useAsyncCalculateSingleRowTotal({ ...args, kind: 'columnTotal' });
+
+export const useAsyncCalculateGrandTotal = (
+    args: Omit<Parameters<typeof useAsyncCalculateSingleRowTotal>[0], 'kind'>,
+) => useAsyncCalculateSingleRowTotal({ ...args, kind: 'grandTotal' });
 
 // Row totals re-run the source query collapsed across the pivot columns, so the
 // result is one flat row per index-value combination (index dims + metrics),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-854
Closes: #7989

### Description:
Adds warehouse-computed grand totals to the row/column total intersection for both metric layouts while leaving single-axis totals unchanged.
Wires the same values through CSV and XLSX exports with independent failure handling.
Stabilizes pivot worker inputs to avoid redundant conversions while asynchronous totals resolve.

#### Demo 

<img width="2914" height="718" alt="CleanShot 2026-07-22 at 16 08 16@2x" src="https://github.com/user-attachments/assets/18982eb5-352b-4d66-9603-79c4e70feba0" />
