### PR TITLE
refactor(frontend): add shared NumberInput wrapper with safe onNumberChange

### DIFF
--- a/.claude/skills/frontend-style-guide/SKILL.md
+++ b/.claude/skills/frontend-style-guide/SKILL.md
@@ -353,6 +353,27 @@ Both accept all props of their base component (`GroupProps` / `PaperProps`) plus
 </UnstyledButton>
 ```
 
+### NumberInput
+
+- **Always use `NumberInput` from `components/common/NumberInput`** — never Mantine's NumberInput directly
+- Mantine 8's onChange emits `number | string` (empty field, half-typed values like `-`/`12.`, unsafe-large integers). The wrapper's `onNumberChange` shields you: it fires with a `number`, or `undefined` when the field is cleared — transient strings never fire
+- **Integer-only by default** — the wrapper defaults `decimalScale={0}` (most fields are ports, counts, timeouts). Decimal fields opt in with `decimalScale={2}` etc., or `decimalScale="unlimited"` to remove the cap
+- The raw `onChange` prop remains available only for `form.getInputProps()` spreads, where the form library owns parsing
+
+```tsx
+// ✅ Good - cleared field maps to a domain decision at the call site
+<NumberInput onNumberChange={(v) => setLimit(v ?? DEFAULT)} />
+
+// ✅ Good - number-or-undefined sinks take the callback directly
+<NumberInput decimalScale={2} onNumberChange={setThreshold} />
+
+// ✅ OK - form spread owns value/onChange
+<NumberInput {...form.getInputProps('warehouse.port')} />
+
+// ❌ Avoid - hand-rolled typeof guards on the raw Mantine component
+<MantineNumberInput onChange={(v) => { if (typeof v === 'number') setX(v); }} />
+```
+
 ### EmptyStateLoader
 
 - Use `EmptyStateLoader` from `components/common/EmptyStateLoader` for **any** centered loading state: page-level guards, panels, tables, empty containers

--- a/packages/frontend/CLAUDE.md
+++ b/packages/frontend/CLAUDE.md
@@ -18,6 +18,7 @@ the [Frontend Style Guide](STYLE_GUIDE.md). Key points:
 
 -   **Modals**: Always use `MantineModal` from `components/common/MantineModal`. See `stories/Modal.stories.tsx` for examples.
 -   **Callouts**: Use `Callout` from `components/common/Callout` with variants: `danger`, `warning`, `info`
+-   **Number inputs**: Always use `NumberInput` from `components/common/NumberInput`. Prefer `onNumberChange` (fires `number`, or `undefined` on clear; never transient strings). Integer-only by default; decimal fields opt in via `decimalScale={n}` or `decimalScale="unlimited"`. Raw `onChange` only for `form.getInputProps()` spreads.
 
 ## ⚛️ State Management
 

--- a/packages/frontend/src/components/CronInput/HourlyInputs.tsx
+++ b/packages/frontend/src/components/CronInput/HourlyInputs.tsx
@@ -1,5 +1,6 @@
-import { Group, Input, NumberInput } from '@mantine-8/core';
+import { Group, Input } from '@mantine-8/core';
 import { type FC } from 'react';
+import { NumberInput } from '../common/NumberInput';
 import { getHourlyCronExpression, parseCronExpression } from './cronInputUtils';
 
 const MIN_MINUTES = 0;

--- a/packages/frontend/src/components/CronInput/MonthlyInputs.tsx
+++ b/packages/frontend/src/components/CronInput/MonthlyInputs.tsx
@@ -1,5 +1,6 @@
-import { Group, Input, NumberInput } from '@mantine-8/core';
+import { Group, Input } from '@mantine-8/core';
 import React, { type FC } from 'react';
+import { NumberInput } from '../common/NumberInput';
 import {
     getMonthlyCronExpression,
     parseCronExpression,

--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModal.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModal.tsx
@@ -21,7 +21,6 @@ import {
     Flex,
     Group,
     Menu,
-    NumberInput,
     Radio,
     Select,
     Stack,
@@ -46,6 +45,7 @@ import {
 import useToaster from '../../../hooks/toaster/useToaster';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
+import { NumberInput } from '../../common/NumberInput';
 import classes from './CustomBinDimensionModal.module.css';
 
 // TODO: preview custom dimension results
@@ -725,6 +725,7 @@ export const CustomBinDimensionModal: FC<{
 
                     {form.values.binType === BinType.FIXED_WIDTH && (
                         <NumberInput
+                            decimalScale="unlimited"
                             w={100}
                             label="Bin width"
                             required

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -24,7 +24,6 @@ import {
     Accordion,
     Button,
     Group,
-    NumberInput,
     Select,
     Stack,
     Text,
@@ -48,6 +47,7 @@ import Callout from '../../common/Callout';
 import FieldIcon from '../../common/Filters/FieldIcon';
 import FiltersProvider from '../../common/Filters/FiltersProvider';
 import MantineModal from '../../common/MantineModal';
+import { NumberInput } from '../../common/NumberInput';
 import { FormatForm } from '../FormatForm';
 import { FilterForm, type MetricFilterRuleWithFieldId } from './FilterForm';
 import { useDataForFiltersProvider } from './hooks/useDataForFiltersProvider';
@@ -612,6 +612,7 @@ export const CustomMetricModal = memo(() => {
                             w={100}
                             max={100}
                             min={0}
+                            decimalScale={2}
                             required
                             label="Percentile"
                             {...form.getInputProps('percentile')}

--- a/packages/frontend/src/components/Explorer/FormatForm/index.tsx
+++ b/packages/frontend/src/components/Explorer/FormatForm/index.tsx
@@ -25,7 +25,6 @@ import {
     Stack,
     Text,
     TextInput,
-    NumberInput,
 } from '@mantine-8/core';
 import { type UseFormReturnType } from '@mantine/form';
 import {
@@ -37,6 +36,7 @@ import { useMemo, type FC } from 'react';
 import { type ValueOf } from 'type-fest';
 import { optionalNumber } from '../../../utils/numberInputUtils';
 import MantineIcon from '../../common/MantineIcon';
+import { NumberInput } from '../../common/NumberInput';
 import { PolymorphicPaperButton } from '../../common/PolymorphicPaperButton';
 import { getFormatTypeLabel } from './getFormatSummary';
 
@@ -441,7 +441,6 @@ export const FormatForm: FC<Props> = ({
                     )}
                     <Grid.Col span={compact ? 12 : 4}>
                         <NumberInput
-                            decimalScale={0}
                             min={0}
                             label="Decimal places"
                             placeholder="Auto"

--- a/packages/frontend/src/components/Explorer/PeriodOverPeriodComparisonModal/PeriodOverPeriodComparisonModal.tsx
+++ b/packages/frontend/src/components/Explorer/PeriodOverPeriodComparisonModal/PeriodOverPeriodComparisonModal.tsx
@@ -12,14 +12,7 @@ import {
     type Metric,
     type TimeFrames,
 } from '@lightdash/common';
-import {
-    Group,
-    NumberInput,
-    Select,
-    Stack,
-    Text,
-    Tooltip,
-} from '@mantine-8/core';
+import { Group, Select, Stack, Text, Tooltip } from '@mantine-8/core';
 import { IconTimelineEvent } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import {
@@ -31,6 +24,7 @@ import {
 } from '../../../features/explorer/store';
 import Callout from '../../common/Callout';
 import MantineModal from '../../common/MantineModal';
+import { NumberInput } from '../../common/NumberInput';
 
 const PeriodOverPeriodComparisonModalContent: FC<{
     metric: Metric;

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -10,7 +10,6 @@ import {
     Alert,
     Button,
     Group,
-    NumberInput,
     Paper,
     SegmentedControl,
     Stack,
@@ -32,6 +31,7 @@ import { scheduleDownloadQuery } from '../../hooks/useQueryResults';
 import useUser from '../../hooks/user/useUser';
 import { Can } from '../../providers/Ability';
 import MantineIcon from '../common/MantineIcon';
+import { NumberInput } from '../common/NumberInput';
 import { Limit } from './types';
 
 type ExportCsvRenderProps = {

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/AthenaForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/AthenaForm.tsx
@@ -5,11 +5,11 @@ import {
     Anchor,
     Select,
     PasswordInput,
-    NumberInput,
 } from '@mantine-8/core';
 import { useEffect, type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';
 import useHealth from '../../../hooks/health/useHealth';
+import { NumberInput } from '../../common/NumberInput';
 import FormCollapseButton from '../FormCollapseButton';
 import { useFormContext } from '../formContext';
 import FormSection from '../Inputs/FormSection';
@@ -233,7 +233,6 @@ const AthenaForm: FC<{
                         />
 
                         <NumberInput
-                            decimalScale={0}
                             name="warehouse.threads"
                             label="Threads"
                             description="Number of threads for dbt to use."
@@ -243,7 +242,6 @@ const AthenaForm: FC<{
                         />
 
                         <NumberInput
-                            decimalScale={0}
                             name="warehouse.numRetries"
                             label="Number of Retries"
                             description="Number of times to retry failed queries."

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -20,7 +20,6 @@ import {
     Select,
     Switch,
     Tooltip,
-    NumberInput,
 } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconCheck, IconExclamationCircle } from '@tabler/icons-react';
@@ -46,6 +45,7 @@ import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import MantineIcon from '../../common/MantineIcon';
+import { NumberInput } from '../../common/NumberInput';
 import DocumentationHelpButton from '../../DocumentationHelpButton';
 import FormCollapseButton from '../FormCollapseButton';
 import { useFormContext } from '../formContext';
@@ -833,7 +833,6 @@ const BigQueryForm: FC<{
                                 />
 
                                 <NumberInput
-                                    decimalScale={0}
                                     name="warehouse.timeoutSeconds"
                                     {...form.getInputProps(
                                         'warehouse.timeoutSeconds',
@@ -904,7 +903,6 @@ const BigQueryForm: FC<{
                                 />
 
                                 <NumberInput
-                                    decimalScale={0}
                                     name="warehouse.retries"
                                     {...form.getInputProps('warehouse.retries')}
                                     defaultValue={BigQueryDefaultValues.retries}
@@ -930,7 +928,6 @@ const BigQueryForm: FC<{
                                 />
 
                                 <NumberInput
-                                    decimalScale={0}
                                     name="warehouse.maximumBytesBilled"
                                     {...form.getInputProps(
                                         'warehouse.maximumBytesBilled',

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/ClickhouseForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/ClickhouseForm.tsx
@@ -1,13 +1,8 @@
 import { WarehouseTypes } from '@lightdash/common';
-import {
-    TextInput,
-    Stack,
-    Anchor,
-    PasswordInput,
-    NumberInput,
-} from '@mantine-8/core';
+import { TextInput, Stack, Anchor, PasswordInput } from '@mantine-8/core';
 import React, { type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';
+import { NumberInput } from '../../common/NumberInput';
 import FormCollapseButton from '../FormCollapseButton';
 import { useFormContext } from '../formContext';
 import BooleanSwitch from '../Inputs/BooleanSwitch';
@@ -103,7 +98,6 @@ const ClickhouseForm: FC<{
                         />
 
                         <NumberInput
-                            decimalScale={0}
                             name="warehouse.port"
                             {...form.getInputProps('warehouse.port')}
                             defaultValue={ClickhouseDefaultValues.port}
@@ -140,7 +134,6 @@ const ClickhouseForm: FC<{
                         />
 
                         <NumberInput
-                            decimalScale={0}
                             name="warehouse.timeoutSeconds"
                             defaultValue={
                                 ClickhouseDefaultValues.timeoutSeconds

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DuckdbForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DuckdbForm.tsx
@@ -11,10 +11,10 @@ import {
     Select,
     Switch,
     PasswordInput,
-    NumberInput,
 } from '@mantine-8/core';
 import { type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';
+import { NumberInput } from '../../common/NumberInput';
 import FormCollapseButton from '../FormCollapseButton';
 import { useFormContext } from '../formContext';
 import FormSection from '../Inputs/FormSection';
@@ -167,7 +167,6 @@ const DucklakeFields: FC<{ disabled: boolean }> = ({ disabled }) => {
                         disabled={disabled}
                     />
                     <NumberInput
-                        decimalScale={0}
                         label="Port"
                         required
                         {...form.getInputProps('warehouse.catalog.port')}
@@ -406,7 +405,6 @@ const DuckdbForm: FC<{
             <FormSection isOpen={isOpen} name="advanced">
                 <Stack mt="sm">
                     <NumberInput
-                        decimalScale={0}
                         name="warehouse.threads"
                         label="Threads"
                         description="Number of threads for dbt to use."

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
@@ -9,12 +9,12 @@ import {
     Select,
     PasswordInput,
     Tooltip,
-    NumberInput,
 } from '@mantine-8/core';
 import { IconCheck, IconCopy } from '@tabler/icons-react';
 import React, { type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';
 import MantineIcon from '../../common/MantineIcon';
+import { NumberInput } from '../../common/NumberInput';
 import FormCollapseButton from '../FormCollapseButton';
 import { useFormContext } from '../formContext';
 import BooleanSwitch from '../Inputs/BooleanSwitch';
@@ -145,7 +145,6 @@ const PostgresForm: FC<{
                             }
                         />
                         <NumberInput
-                            decimalScale={0}
                             name="warehouse.port"
                             {...form.getInputProps('warehouse.port')}
                             defaultValue={PostgresDefaultValues.port}
@@ -156,7 +155,6 @@ const PostgresForm: FC<{
                         />
 
                         <NumberInput
-                            decimalScale={0}
                             name="warehouse.keepalivesIdle"
                             {...form.getInputProps('warehouse.keepalivesIdle')}
                             defaultValue={PostgresDefaultValues.keepalivesIdle}
@@ -302,7 +300,6 @@ const PostgresForm: FC<{
                         <StartOfWeekSelect disabled={disabled} />
 
                         <NumberInput
-                            decimalScale={0}
                             name="warehouse.timeoutSeconds"
                             defaultValue={PostgresDefaultValues.timeoutSeconds}
                             {...form.getInputProps('warehouse.timeoutSeconds')}
@@ -341,7 +338,6 @@ const PostgresForm: FC<{
                                 />
 
                                 <NumberInput
-                                    decimalScale={0}
                                     name="warehouse.sshTunnelPort"
                                     {...form.getInputProps(
                                         'warehouse.sshTunnelPort',

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -9,12 +9,12 @@ import {
     Select,
     PasswordInput,
     Tooltip,
-    NumberInput,
 } from '@mantine-8/core';
 import { IconCheck, IconCopy } from '@tabler/icons-react';
 import { useEffect, type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';
 import MantineIcon from '../../common/MantineIcon';
+import { NumberInput } from '../../common/NumberInput';
 import FormCollapseButton from '../FormCollapseButton';
 import { useFormContext } from '../formContext';
 import BooleanSwitch from '../Inputs/BooleanSwitch';
@@ -210,7 +210,6 @@ const RedshiftForm: FC<{
                         )}
 
                         <NumberInput
-                            decimalScale={0}
                             name="warehouse.port"
                             defaultValue={RedshiftDefaultValues.port}
                             {...form.getInputProps('warehouse.port')}
@@ -221,7 +220,6 @@ const RedshiftForm: FC<{
                         />
 
                         <NumberInput
-                            decimalScale={0}
                             name="warehouse.keepalivesIdle"
                             {...form.getInputProps('warehouse.keepalivesIdle')}
                             defaultValue={RedshiftDefaultValues.keepalivesIdle}
@@ -296,7 +294,6 @@ const RedshiftForm: FC<{
                         <StartOfWeekSelect disabled={disabled} />
 
                         <NumberInput
-                            decimalScale={0}
                             name="warehouse.timeoutSeconds"
                             {...form.getInputProps('warehouse.timeoutSeconds')}
                             defaultValue={RedshiftDefaultValues.timeoutSeconds}
@@ -338,7 +335,6 @@ const RedshiftForm: FC<{
                                 />
 
                                 <NumberInput
-                                    decimalScale={0}
                                     name="warehouse.sshTunnelPort"
                                     defaultValue={22}
                                     {...form.getInputProps(

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -16,7 +16,6 @@ import {
     Select,
     PasswordInput,
     Tooltip,
-    NumberInput,
 } from '@mantine-8/core';
 import { IconCheck } from '@tabler/icons-react';
 import {
@@ -39,6 +38,7 @@ import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import MantineIcon from '../../common/MantineIcon';
+import { NumberInput } from '../../common/NumberInput';
 import FormCollapseButton from '../FormCollapseButton';
 import { useFormContext } from '../formContext';
 import BooleanSwitch from '../Inputs/BooleanSwitch';
@@ -760,7 +760,6 @@ const SnowflakeForm: FC<{
                                             )}
                                         />
                                         <NumberInput
-                                            decimalScale={0}
                                             name="warehouse.timeoutSeconds"
                                             {...form.getInputProps(
                                                 'warehouse.timeoutSeconds',

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/TrinoForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/TrinoForm.tsx
@@ -5,10 +5,10 @@ import {
     Anchor,
     Select,
     PasswordInput,
-    NumberInput,
 } from '@mantine-8/core';
 import React, { type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';
+import { NumberInput } from '../../common/NumberInput';
 import FormCollapseButton from '../FormCollapseButton';
 import { useFormContext } from '../formContext';
 import BooleanSwitch from '../Inputs/BooleanSwitch';
@@ -107,7 +107,6 @@ const TrinoForm: FC<{
                         />
 
                         <NumberInput
-                            decimalScale={0}
                             name="warehouse.port"
                             {...form.getInputProps('warehouse.port')}
                             defaultValue={TrinoDefaultValues.port}

--- a/packages/frontend/src/components/ProjectPreviewExpiration/index.tsx
+++ b/packages/frontend/src/components/ProjectPreviewExpiration/index.tsx
@@ -4,7 +4,6 @@ import {
     Code,
     Group,
     Loader,
-    NumberInput,
     Stack,
     Text,
     Title,
@@ -15,6 +14,7 @@ import {
     usePreviewExpirationSettings,
     useUpdatePreviewExpirationSettings,
 } from '../../hooks/useProjectPreviewExpirationSettings';
+import { NumberInput } from '../common/NumberInput';
 import { SettingsGridCard } from '../common/Settings/SettingsCard';
 
 const formatHoursAsDays = (hours: number) => {

--- a/packages/frontend/src/components/RunQuerySettings/LimitInput.tsx
+++ b/packages/frontend/src/components/RunQuerySettings/LimitInput.tsx
@@ -1,4 +1,5 @@
-import { NumberInput, type NumberInputProps } from '@mantine-8/core';
+import { type NumberInputProps } from '@mantine-8/core';
+import { NumberInput } from '../common/NumberInput';
 import { type Props } from './index';
 
 type LimitInputProps = Pick<

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ExternalConnectionForm.tsx
@@ -7,7 +7,6 @@ import {
     Group,
     JsonInput,
     MultiSelect,
-    NumberInput,
     PasswordInput,
     Select,
     Stack,
@@ -25,6 +24,7 @@ import {
     type PathMode,
     type PathPrefix,
 } from '../../../features/externalConnections/utils/pathRules';
+import { NumberInput } from '../../common/NumberInput';
 import FormCollapseButton from '../../ProjectConnection/FormCollapseButton';
 import FormSection from '../../ProjectConnection/Inputs/FormSection';
 

--- a/packages/frontend/src/components/UserSettings/ExportingPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ExportingPanel/index.tsx
@@ -9,7 +9,6 @@ import {
     Checkbox,
     Group,
     Loader,
-    NumberInput,
     Stack,
     Text,
     Tooltip,
@@ -25,6 +24,7 @@ import {
 import { useGetSlack } from '../../../hooks/slack/useSlack';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../../common/MantineIcon';
+import { NumberInput } from '../../common/NumberInput';
 
 const SECONDS_PER_DAY = 86400;
 // Generous UI guardrail. There's no backend cap: longer links transparently

--- a/packages/frontend/src/components/UserSettings/LimitsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/LimitsPanel/index.tsx
@@ -2,7 +2,7 @@ import {
     type OrganizationSettings,
     type UpdateOrganizationSettings,
 } from '@lightdash/common';
-import { Button, Group, Loader, NumberInput, Stack } from '@mantine-8/core';
+import { Button, Group, Loader, Stack } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import { type FC } from 'react';
 import useHealth from '../../../hooks/health/useHealth';
@@ -10,6 +10,7 @@ import {
     useOrganizationSettings,
     useUpdateOrganizationSettings,
 } from '../../../hooks/organization/useOrganizationSettings';
+import { NumberInput } from '../../common/NumberInput';
 
 /**
  * Editable form for the org's export limits. Split out from the panel so the

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/SnowflakeCredentialsForm.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/SnowflakeCredentialsForm.tsx
@@ -1,6 +1,5 @@
 import {
     Anchor,
-    NumberInput,
     Select,
     Stack,
     Switch,
@@ -11,6 +10,7 @@ import { type UseFormReturnType } from '@mantine/form';
 import { type FC } from 'react';
 import { useToggle } from 'react-use';
 import { SnowflakeOAuthInput } from '../../common/Authentication/SnowflakeOAuthInput';
+import { NumberInput } from '../../common/NumberInput';
 import FormCollapseButton from '../../ProjectConnection/FormCollapseButton';
 import FormSection from '../../ProjectConnection/Inputs/FormSection';
 

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinInterval.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinInterval.tsx
@@ -1,5 +1,6 @@
-import { Group, NumberInput } from '@mantine-8/core';
+import { Group } from '@mantine-8/core';
 import { type FC } from 'react';
+import { NumberInput } from '../../../common/NumberInput';
 import { Config } from '../../common/Config';
 
 type Props = {
@@ -12,6 +13,7 @@ export const AxisMinInterval: FC<Props> = ({ label, value, onChange }) => (
     <Group wrap="nowrap" gap="xs">
         <Config.Label>{label}</Config.Label>
         <NumberInput
+            decimalScale="unlimited"
             size="xs"
             placeholder="Auto"
             value={value ?? ''}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -18,7 +18,6 @@ import {
     Switch,
     Text,
     Select,
-    NumberInput,
 } from '@mantine-8/core';
 import {
     IconChartBar,
@@ -30,11 +29,8 @@ import {
 } from '@tabler/icons-react';
 import { forwardRef, type FC } from 'react';
 import { getAxisTypeFromField } from '../../../../hooks/echarts/useEchartsCartesianConfig';
-import {
-    handleNumberInputChange,
-    optionalNumber,
-} from '../../../../utils/numberInputUtils';
 import MantineIcon from '../../../common/MantineIcon';
+import { NumberInput } from '../../../common/NumberInput';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../../common/Config';
@@ -288,7 +284,6 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             <Group wrap="nowrap" gap="xs" align="baseline">
                                 <Config.Label>Rotation</Config.Label>
                                 <NumberInput
-                                    decimalScale={0}
                                     size="xs"
                                     defaultValue={
                                         dirtyEchartsConfig?.xAxis?.[0].rotate ||
@@ -299,10 +294,9 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                                     step={15}
                                     maw={54}
                                     rightSection="°"
-                                    onChange={handleNumberInputChange(
-                                        setXAxisLabelRotation,
-                                        () => setXAxisLabelRotation(0),
-                                    )}
+                                    onNumberChange={(value) =>
+                                        setXAxisLabelRotation(value ?? 0)
+                                    }
                                 />
                             </Group>
                         )}
@@ -357,7 +351,6 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                                             Visible items
                                         </Config.Label>
                                         <NumberInput
-                                            decimalScale={0}
                                             size="xs"
                                             maw={80}
                                             min={2}
@@ -366,9 +359,10 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                                                 dirtyEchartsConfig?.xAxis?.[0]
                                                     ?.dataZoomItemCount ?? 10
                                             }
-                                            onChange={handleNumberInputChange(
-                                                setDataZoomItemCount,
-                                            )}
+                                            onNumberChange={(value) => {
+                                                if (value !== undefined)
+                                                    setDataZoomItemCount(value);
+                                            }}
                                         />
                                     </Group>
                                 </>
@@ -621,9 +615,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             decimalScale={1}
                             fixedDecimalScale
                             maw={60}
-                            onChange={(value) => {
-                                setAxisLabelFontSize(optionalNumber(value));
-                            }}
+                            onNumberChange={setAxisLabelFontSize}
                         />
                         {dirtyEchartsConfig?.axisLabelFontSize !==
                             undefined && (
@@ -651,9 +643,7 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             decimalScale={1}
                             fixedDecimalScale
                             maw={60}
-                            onChange={(value) => {
-                                setAxisTitleFontSize(optionalNumber(value));
-                            }}
+                            onNumberChange={setAxisTitleFontSize}
                         />
                         {dirtyEchartsConfig?.axisTitleFontSize !==
                             undefined && (

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -15,7 +15,6 @@ import {
     ActionIcon,
     CloseButton,
     Group,
-    NumberInput,
     SegmentedControl,
     Stack,
     Tooltip,
@@ -25,6 +24,7 @@ import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { EMPTY_X_AXIS } from '../../../../hooks/cartesianChartConfig/useCartesianChartConfig';
 import FieldSelect from '../../../common/FieldSelect';
 import MantineIcon from '../../../common/MantineIcon';
+import { NumberInput } from '../../../common/NumberInput';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
 import { AddButton } from '../../common/AddButton';

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
@@ -10,11 +10,10 @@ import {
     SegmentedControl,
     Stack,
     Tooltip,
-    NumberInput,
 } from '@mantine-8/core';
 import { memo, type FC } from 'react';
-import { handleNumberInputChange } from '../../../utils/numberInputUtils';
 import FieldSelect from '../../common/FieldSelect';
+import { NumberInput } from '../../common/NumberInput';
 import { isGaugeVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../common/Config';
@@ -72,9 +71,7 @@ export const GaugeDisplayConfig: FC = memo(() => {
                         label="Minimum value"
                         description="Set the minimum value for the gauge scale"
                         value={min}
-                        onChange={handleNumberInputChange(setMin, () =>
-                            setMin(0),
-                        )}
+                        onNumberChange={(value) => setMin(value ?? 0)}
                         placeholder="0"
                         decimalScale={2}
                     />
@@ -85,9 +82,7 @@ export const GaugeDisplayConfig: FC = memo(() => {
                                 label="Maximum value"
                                 description="Set the maximum value for the gauge scale"
                                 value={max}
-                                onChange={handleNumberInputChange(setMax, () =>
-                                    setMax(0),
-                                )}
+                                onNumberChange={(value) => setMax(value ?? 0)}
                                 placeholder="100"
                                 decimalScale={2}
                                 style={{ flex: 1 }}

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeSection.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeSection.tsx
@@ -7,13 +7,13 @@ import {
     Accordion,
     Center,
     Group,
-    NumberInput,
     SegmentedControl,
     Stack,
     Tooltip,
 } from '@mantine-8/core';
 import { memo, type FC } from 'react';
 import FieldSelect from '../../common/FieldSelect';
+import { NumberInput } from '../../common/NumberInput';
 import { isGaugeVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import ColorSelector from '../ColorSelector';

--- a/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapDisplayConfig.tsx
@@ -1,7 +1,8 @@
-import { Group, NumberInput, Stack, Tooltip } from '@mantine-8/core';
+import { Group, Stack, Tooltip } from '@mantine-8/core';
 import { IconHelpCircle } from '@tabler/icons-react';
 import React from 'react';
 import MantineIcon from '../../common/MantineIcon';
+import { NumberInput } from '../../common/NumberInput';
 import { isTreemapVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../common/Config';

--- a/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapLayoutConfig.tsx
@@ -16,12 +16,11 @@ import {
     Switch,
     Text,
     Tooltip,
-    NumberInput,
 } from '@mantine-8/core';
 import { IconHelpCircle } from '@tabler/icons-react';
-import { optionalNumber } from '../../../utils/numberInputUtils';
 import FieldSelect from '../../common/FieldSelect';
 import MantineIcon from '../../common/MantineIcon';
+import { NumberInput } from '../../common/NumberInput';
 import { isTreemapVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import ColorSelector from '../ColorSelector';
@@ -255,10 +254,8 @@ export const Layout: React.FC = () => {
                                         <NumberInput
                                             size="xs"
                                             value={startColorThreshold}
-                                            onChange={(value) =>
-                                                setStartColorThreshold(
-                                                    optionalNumber(value),
-                                                )
+                                            onNumberChange={
+                                                setStartColorThreshold
                                             }
                                             hideControls={true}
                                             decimalScale={2}
@@ -289,10 +286,8 @@ export const Layout: React.FC = () => {
                                         <NumberInput
                                             size="xs"
                                             value={endColorThreshold}
-                                            onChange={(value) =>
-                                                setEndColorThreshold(
-                                                    optionalNumber(value),
-                                                )
+                                            onNumberChange={
+                                                setEndColorThreshold
                                             }
                                             hideControls={true}
                                             decimalScale={2}

--- a/packages/frontend/src/components/VisualizationConfigs/common/RowLimitControls.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/RowLimitControls.tsx
@@ -1,12 +1,7 @@
 import type { RowLimit } from '@lightdash/common';
-import {
-    Group,
-    NumberInput,
-    SegmentedControl,
-    Switch,
-    Text,
-} from '@mantine-8/core';
+import { Group, SegmentedControl, Switch, Text } from '@mantine-8/core';
 import { type FC } from 'react';
+import { NumberInput } from '../../common/NumberInput';
 import compactStyles from '../mantineTheme.module.css';
 
 const MODE_OPTIONS = [

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -10,10 +10,10 @@ import {
     type BaseFilterRule,
     type DateFilterRule,
 } from '@lightdash/common';
-import { Flex, Text, NumberInput } from '@mantine-8/core';
+import { Flex, Text } from '@mantine-8/core';
 import dayjs from 'dayjs';
 import { type FilterInputsProps } from '.';
-import { handleNumberInputChange } from '../../../../utils/numberInputUtils';
+import { NumberInput } from '../../NumberInput';
 import useFiltersContext from '../useFiltersContext';
 import { getFirstDayOfWeek } from '../utils/filterDateUtils';
 import { getPlaceholderByFilterTypeAndOperator } from '../utils/getPlaceholderByFilterTypeAndOperator';
@@ -266,7 +266,6 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
             return (
                 <Flex gap="xs" w="100%">
                     <NumberInput
-                        decimalScale={0}
                         size="xs"
                         flex="1 1 auto"
                         miw={50}
@@ -275,10 +274,12 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                         data-autofocus
                         value={isNaN(parsedValue) ? undefined : parsedValue}
                         min={0}
-                        onChange={handleNumberInputChange(
-                            (value) => onChange({ ...rule, values: [value] }),
-                            () => onChange({ ...rule, values: [] }),
-                        )}
+                        onNumberChange={(value) =>
+                            onChange({
+                                ...rule,
+                                values: value !== undefined ? [value] : [],
+                            })
+                        }
                     />
 
                     <FilterUnitOfTimeAutoComplete

--- a/packages/frontend/src/components/common/NumberInput.tsx
+++ b/packages/frontend/src/components/common/NumberInput.tsx
@@ -1,0 +1,47 @@
+import {
+    NumberInput as MantineNumberInput,
+    type NumberInputProps as MantineNumberInputProps,
+} from '@mantine-8/core';
+import { handleNumberInputChange } from '../../utils/numberInputUtils';
+
+export type NumberInputProps = Omit<
+    MantineNumberInputProps,
+    'onChange' | 'decimalScale'
+> & {
+    /**
+     * Fires with a number, or undefined when the field is cleared. Transient
+     * typing states ('', '-', '12.') never fire, so half-typed values cannot
+     * reach app state.
+     */
+    onNumberChange?: (value: number | undefined) => void;
+    /**
+     * Raw Mantine contract emitting `number | string`. Only for
+     * form.getInputProps() spreads, where the form library owns parsing.
+     */
+    onChange?: MantineNumberInputProps['onChange'];
+    /**
+     * Maximum decimal places. Integer-only by default; pass a number for
+     * decimal fields, or 'unlimited' to remove the cap entirely.
+     */
+    decimalScale?: number | 'unlimited';
+};
+
+/** Lightdash NumberInput. Prefer `onNumberChange` over `onChange`. */
+export const NumberInput = ({
+    onNumberChange,
+    onChange,
+    decimalScale = 0,
+    ...props
+}: NumberInputProps) => (
+    <MantineNumberInput
+        decimalScale={decimalScale === 'unlimited' ? undefined : decimalScale}
+        {...props}
+        onChange={
+            onChange ??
+            handleNumberInputChange(
+                (value) => onNumberChange?.(value),
+                () => onNumberChange?.(undefined),
+            )
+        }
+    />
+);

--- a/packages/frontend/src/features/funnelBuilder/components/FunnelStepsTab.tsx
+++ b/packages/frontend/src/features/funnelBuilder/components/FunnelStepsTab.tsx
@@ -3,13 +3,13 @@ import {
     Button,
     Group,
     Loader,
-    NumberInput,
     Select,
     Stack,
     Text,
 } from '@mantine-8/core';
 import { IconPlus, IconTrash } from '@tabler/icons-react';
 import { type FC } from 'react';
+import { NumberInput } from '../../../components/common/NumberInput';
 import { useAppDispatch, useAppSelector } from '../store';
 import {
     addStep,

--- a/packages/frontend/src/features/scheduler/components/CsvFormattingOptions.tsx
+++ b/packages/frontend/src/features/scheduler/components/CsvFormattingOptions.tsx
@@ -3,7 +3,6 @@ import {
     Button,
     Collapse,
     Group,
-    NumberInput,
     Radio,
     SimpleGrid,
     Stack,
@@ -17,6 +16,7 @@ import {
 } from '@tabler/icons-react';
 import { useState, type FC, type ReactNode } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { NumberInput } from '../../../components/common/NumberInput';
 import useHealth from '../../../hooks/health/useHealth';
 import { Limit, Values } from './types';
 

--- a/packages/frontend/src/features/tableCalculation/components/FormatRow/FormatRow.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/FormatRow/FormatRow.tsx
@@ -28,7 +28,6 @@ import {
     TextInput,
     Tooltip,
     type ComboboxItem,
-    NumberInput,
 } from '@mantine-8/core';
 import { type UseFormReturnType } from '@mantine/form';
 import {
@@ -44,6 +43,7 @@ import {
 import { useMemo, type FC } from 'react';
 import { type ValueOf } from 'type-fest';
 import MantineIcon from '../../../../components/common/MantineIcon';
+import { NumberInput } from '../../../../components/common/NumberInput';
 import { optionalNumber } from '../../../../utils/numberInputUtils';
 import classes from './FormatRow.module.css';
 
@@ -470,7 +470,6 @@ export const FormatRow: FC<Props> = ({
                     {isNumeric && format.type === CustomFormatType.NUMBER && (
                         <Group gap="md" wrap="wrap" align="flex-end">
                             <NumberInput
-                                decimalScale={0}
                                 className={classes.subFieldInputNarrow}
                                 size="xs"
                                 radius="md"
@@ -539,7 +538,6 @@ export const FormatRow: FC<Props> = ({
                                 {...formatInputProps('currency')}
                             />
                             <NumberInput
-                                decimalScale={0}
                                 className={classes.subFieldInput}
                                 size="xs"
                                 radius="md"
@@ -577,7 +575,6 @@ export const FormatRow: FC<Props> = ({
 
                     {isNumeric && format.type === CustomFormatType.PERCENT && (
                         <NumberInput
-                            decimalScale={0}
                             className={classes.subFieldInput}
                             size="xs"
                             radius="md"


### PR DESCRIPTION
### Description:

Adds a shared `NumberInput` wrapper (`components/common/NumberInput`) encapsulating Mantine 8's `number | string` onChange contract: `onNumberChange` fires a `number`, or `undefined` when cleared — transient typing states never reach app state. **Integer-only by default** (`decimalScale={0}`); decimal fields opt in with `decimalScale={n}` or `decimalScale="unlimited"`. Raw `onChange` remains only for `form.getInputProps()` spreads. Converts all NumberInput usages to the wrapper and adds the convention to the frontend style guide.

Stacked on #25953.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
