### PR TITLE
fix: show AI prompt greeting regardless of block position

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
@@ -41,11 +41,25 @@ describe('AskAiHeroBlockView', () => {
         expect(screen.getByTestId('ask-input')).toBeInTheDocument();
     });
 
-    it('renders inline mid-page without the greeting, even when toggled on', () => {
+    it('greets inline mid-page when toggled on', () => {
         wrap(
             <AskAiHeroBlockView
                 itemSpan={null}
                 block={block}
+                projectUuid="p1"
+            />,
+        );
+        expect(
+            screen.getByText(/What do you want to know/),
+        ).toBeInTheDocument();
+        expect(screen.getByTestId('ask-input')).toBeInTheDocument();
+    });
+
+    it('does not greet when the toggle is off', () => {
+        wrap(
+            <AskAiHeroBlockView
+                itemSpan={null}
+                block={{ ...block, config: { showGreeting: false } }}
                 projectUuid="p1"
             />,
         );

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
@@ -60,16 +60,15 @@ export const AskAiHero: FC<{
 export const AskAiHeroBlockView: FC<BlockComponentProps> = ({
     block,
     projectUuid,
-    presentation = 'inline',
 }) => {
     const isAiEnabled = useAiAgentButtonVisibility();
     if (block.type !== 'ask-ai-hero' || !isAiEnabled) return null;
-    // Mid-page the composer renders inline: the greeting is hero-context only,
-    // even when the homepage has it toggled on.
+    // The greeting follows its toggle regardless of the block's position; it
+    // still renders inline mid-page rather than only in the hero slot.
     return (
         <AskAiHero
             projectUuid={projectUuid}
-            showGreeting={presentation === 'hero' && block.config.showGreeting}
+            showGreeting={block.config.showGreeting}
             showRecommendedActions={
                 block.config.showRecommendedActions === true
             }


### PR DESCRIPTION
The AI prompt block's greeting was gated on the block resolving to the hero (top) slot **in addition to** its `showGreeting` toggle. So a mid-page AI prompt block never rendered the greeting, even with the toggle on.

The greeting now follows its toggle regardless of position — it still renders inline mid-page rather than only in the hero slot.

Changed the condition in `AskAiHeroBlockView` from `presentation === 'hero' && block.config.showGreeting` to just `block.config.showGreeting`, and updated the tests accordingly.