### PR TITLE
feat: bulk export all embedded dashboard tiles as CSV/XLSX

### DIFF
--- a/packages/backend/src/controllers/v2/DashboardController.ts
+++ b/packages/backend/src/controllers/v2/DashboardController.ts
@@ -54,18 +54,17 @@ export class DashboardControllerV2 extends BaseController {
         @Body() body: ExportContentRequest,
         @Request() req: express.Request,
     ): Promise<ApiJobScheduledResponse> {
-        assertRegisteredAccount(req.account);
+        // Intentionally not registered-only: embedded dashboards call this with
+        // a JWT account to bulk-export their tiles as a CSV/XLSX ZIP. The
+        // service enforces the required ability for both registered and JWT
+        // callers.
         this.setStatus(200);
 
         return {
             status: 'ok',
             results: await this.services
                 .getDashboardService()
-                .scheduleExportContent(
-                    toSessionUser(req.account),
-                    dashboardUuid,
-                    body,
-                ),
+                .scheduleExportContent(req.account!, dashboardUuid, body),
         };
     }
 

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -71,6 +71,7 @@ export type ApiEmbedDashboardResponse = {
         dashboardFiltersInteractivity?: CommonEmbedJwtContent['dashboardFiltersInteractivity'];
         parameterInteractivity?: CommonEmbedJwtContent['parameterInteractivity'];
         canExportCsv?: boolean;
+        canExportDashboardCsv?: boolean;
         canExportImages?: boolean;
         canExportPagePdf?: boolean;
         canDateZoom?: boolean;

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -757,6 +757,58 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     },
                 );
             },
+            [SCHEDULER_TASKS.EXPORT_CONTENT]: async (payload, helpers) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        SCHEDULER_TASKS.EXPORT_CONTENT,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            const { encodedJwt } = payload;
+                            if (encodedJwt) {
+                                // Embed export: rebuild the anonymous account
+                                // from the JWT so the tile queries run under the
+                                // token's access instead of a DB user.
+                                const account =
+                                    await this.embedService.getAccountFromJwt(
+                                        payload.projectUuid,
+                                        encodedJwt,
+                                    );
+                                await this.exportContent(
+                                    helpers.job.id,
+                                    helpers.job.run_at,
+                                    payload,
+                                    account,
+                                );
+                            } else {
+                                await this.exportContent(
+                                    helpers.job.id,
+                                    helpers.job.run_at,
+                                    payload,
+                                );
+                            }
+                        },
+                    ),
+                    helpers.job,
+                    this.lightdashConfig.scheduler.jobTimeout,
+                    async (job, e) => {
+                        await this.schedulerService.logSchedulerJob({
+                            task: SCHEDULER_TASKS.EXPORT_CONTENT,
+                            jobId: job.id,
+                            scheduledTime: job.run_at,
+                            status: SchedulerJobStatus.ERROR,
+                            details: {
+                                userUuid: payload.userUuid,
+                                projectUuid: payload.projectUuid,
+                                organizationUuid: payload.organizationUuid,
+                                error: getErrorMessage(e),
+                                createdByUserUuid: payload.userUuid,
+                            },
+                        });
+                    },
+                );
+            },
         };
     }
 }

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -1,10 +1,14 @@
+import { subject } from '@casl/ability';
 import {
     EE_SCHEDULER_TASKS,
+    ForbiddenError,
     getErrorMessage,
     getManagedAgentScheduleCron,
     isSchedulerTaskName,
     SCHEDULER_TASKS,
     SchedulerJobStatus,
+    type Account,
+    type ExportContentPayload,
 } from '@lightdash/common';
 import Logger from '../../logging/logger';
 import { type OpenIdIdentityModel } from '../../models/OpenIdIdentitiesModel';
@@ -767,12 +771,11 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                         async () => {
                             const { encodedJwt } = payload;
                             if (encodedJwt) {
-                                // Embed export: rebuild the anonymous account
-                                // from the JWT so the tile queries run under the
-                                // token's access instead of a DB user.
                                 const account =
-                                    await this.embedService.getAccountFromJwt(
-                                        payload.projectUuid,
+                                    await this.resolveEmbedExportAccount(
+                                        helpers.job.id,
+                                        helpers.job.run_at,
+                                        payload,
                                         encodedJwt,
                                     );
                                 await this.exportContent(
@@ -810,5 +813,55 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                 );
             },
         };
+    }
+
+    // Rebuilds the anonymous account from the embed JWT (re-verifying
+    // signature and expiry) and re-asserts the export ability against the
+    // payload, so the worker never trusts the queued job. Failures (e.g.
+    // expired token) are logged as job errors so the embed's status poller
+    // surfaces them instead of hanging on a SCHEDULED job forever.
+    private async resolveEmbedExportAccount(
+        jobId: string,
+        scheduledTime: Date,
+        payload: ExportContentPayload,
+        encodedJwt: string,
+    ): Promise<Account> {
+        try {
+            const account = await this.embedService.getAccountFromJwt(
+                payload.projectUuid,
+                encodedJwt,
+            );
+            if (
+                account.user.ability.cannot(
+                    'manage',
+                    subject('ExportCsv', {
+                        organizationUuid: payload.organizationUuid,
+                        projectUuid: payload.projectUuid,
+                        metadata: {
+                            dashboardUuid: payload.resourceUuid,
+                        },
+                    }),
+                )
+            ) {
+                throw new ForbiddenError(
+                    'Embed token is not authorized to export this dashboard',
+                );
+            }
+            return account;
+        } catch (e) {
+            await this.schedulerService.logSchedulerJob({
+                task: SCHEDULER_TASKS.EXPORT_CONTENT,
+                jobId,
+                scheduledTime,
+                status: SchedulerJobStatus.ERROR,
+                details: {
+                    createdByUserUuid: payload.userUuid,
+                    projectUuid: payload.projectUuid,
+                    organizationUuid: payload.organizationUuid,
+                    error: getErrorMessage(e),
+                },
+            });
+            throw e;
+        }
     }
 }

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -593,6 +593,7 @@ export class EmbedService extends BaseService {
         const {
             isPreview,
             canExportCsv,
+            canExportDashboardCsv,
             canExportImages,
             canExportPagePdf,
             canDateZoom,
@@ -667,6 +668,7 @@ export class EmbedService extends BaseService {
             dashboardFiltersInteractivity: account.access.filtering,
             parameterInteractivity: account.access.parameters,
             canExportCsv,
+            canExportDashboardCsv,
             canExportImages,
             canExportPagePdf: canExportPagePdf ?? true, // enabled by default for backwards compatibility
             canDateZoom,

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -51,6 +51,7 @@ import {
     isDashboardScheduler,
     isDashboardSqlChartTile,
     isDashboardValidationError,
+    isJwtUser,
     isSchedulerCsvOptions,
     isSchedulerGsheetsOptions,
     isSchedulerImageOptions,
@@ -582,6 +583,9 @@ export default class SchedulerTask {
             dashboardFilters?: ExportContentPayload['dashboardFilters'];
             dateZoomGranularity?: ExportContentPayload['dateZoomGranularity'];
         },
+        // Embed/JWT exports pass a pre-resolved anonymous account (no DB user),
+        // used for CSV/XLSX tile queries in place of getAccountByUserUuid.
+        overrideAccount?: AccountType,
     ): Promise<
         NotificationPayloadBase['page'] & {
             deliveryQueries?: SchedulerDeliveryQuery[];
@@ -846,7 +850,8 @@ export default class SchedulerTask {
             case SchedulerFormat.CSV:
             case SchedulerFormat.XLSX:
                 const account =
-                    await this.userService.getAccountByUserUuid(userUuid);
+                    overrideAccount ??
+                    (await this.userService.getAccountByUserUuid(userUuid));
                 const csvOptions = isSchedulerCsvOptions(options)
                     ? options
                     : undefined;
@@ -4806,7 +4811,7 @@ export default class SchedulerTask {
         zipNameBase: string;
         organizationUuid: string;
         projectUuid: string;
-        createdByUserUuid: string;
+        createdByUserUuid: string | null;
         logContext?: string;
     }) {
         if (!this.fileStorageClient.isEnabled()) {
@@ -5018,6 +5023,9 @@ export default class SchedulerTask {
         jobId: string,
         scheduledTime: Date,
         payload: ExportContentPayload,
+        // Embed/JWT exports pass a pre-resolved anonymous account so the tile
+        // queries run under the token's access instead of a DB user.
+        overrideAccount?: AccountType,
     ) {
         await this.logWrapper<string | number>(
             {
@@ -5072,6 +5080,7 @@ export default class SchedulerTask {
                         dashboardFilters: payload.dashboardFilters,
                         dateZoomGranularity: payload.dateZoomGranularity,
                     },
+                    overrideAccount,
                 );
 
                 if (payload.format === SchedulerFormat.IMAGE) {
@@ -5127,7 +5136,10 @@ export default class SchedulerTask {
                         zipNameBase: page.details.name,
                         organizationUuid: payload.organizationUuid,
                         projectUuid: payload.projectUuid,
-                        createdByUserUuid: payload.userUuid,
+                        // JWT/embed callers have no DB user row to reference.
+                        createdByUserUuid: overrideAccount
+                            ? null
+                            : payload.userUuid,
                     });
 
                     return {

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -3,6 +3,7 @@ import {
     Account,
     AnyType,
     ApiSqlQueryResults,
+    assertRegisteredAccount,
     DashboardFilters,
     DateGranularity,
     DownloadFileType,
@@ -614,6 +615,10 @@ export class CsvService extends BaseService {
         selectedTabs: string[] | null,
         dateZoomGranularity?: DateGranularity | string,
     ) {
+        // Registered-only: this legacy payload cannot carry an embed JWT, so a
+        // JWT-scheduled job would fail at the worker. Embeds use the v2
+        // dashboard exports endpoint instead.
+        assertRegisteredAccount(account);
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
         const auditedAbility = this.createAuditedAbility(account);

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     AbilityAction,
+    assertRegisteredAccount,
     BulkActionable,
     ContentType,
     CreateDashboard,
@@ -23,6 +24,7 @@ import {
     isDashboardScheduler,
     isDashboardUnversionedFields,
     isDashboardVersionedFields,
+    isJwtUser,
     isUserWithOrg,
     isValidFrequency,
     isValidTimezone,
@@ -162,7 +164,7 @@ export class DashboardService
     contentVerificationModel: ContentVerificationModel;
 
     async scheduleExportContent(
-        user: SessionUser,
+        account: Account,
         dashboardUuidOrSlug: UuidOrSlug,
         data: ExportContentRequest,
     ) {
@@ -179,11 +181,14 @@ export class DashboardService
             throw new ParameterError('Unsupported export format');
         }
 
-        const auditedAbility = this.createAuditedAbility(user);
+        const auditedAbility = this.createAuditedAbility(account);
         if (data.format === SchedulerFormat.IMAGE) {
+            // Image export renders the dashboard in a headless browser using a
+            // real session, so it is not available to embed/JWT callers.
+            assertRegisteredAccount(account);
             const { inheritsFromOrgOrProject, access } =
                 await this.spacePermissionService.getSpaceAccessContext(
-                    user.userUuid,
+                    account.user.userUuid,
                     dashboard.spaceUuid,
                 );
 
@@ -220,6 +225,13 @@ export class DashboardService
             throw new ForbiddenError();
         }
 
+        // Embed/JWT callers have no DB user; carry the encoded token so the
+        // scheduler worker can rebuild the anonymous account to run the tile
+        // queries under the same access it was granted.
+        const encodedJwt = isJwtUser(account)
+            ? account.authentication.source
+            : undefined;
+
         const payload: ExportContentPayload = {
             resourceType: SchedulerResourceType.DASHBOARD,
             resourceUuid: dashboard.uuid,
@@ -231,7 +243,8 @@ export class DashboardService
             selectedTabs: data.selectedTabs ?? null,
             organizationUuid: dashboard.organizationUuid,
             projectUuid: dashboard.projectUuid,
-            userUuid: user.userUuid,
+            userUuid: account.user.id,
+            encodedJwt,
             schedulerUuid: undefined,
         };
 

--- a/packages/common/src/authorization/jwtAbility.test.ts
+++ b/packages/common/src/authorization/jwtAbility.test.ts
@@ -236,6 +236,91 @@ describe('Embedded dashboard abilities', () => {
             });
         });
 
+        describe('Dashboard-level CSV/XLSX export (Export all)', () => {
+            it('should allow managing ExportCsv for the bound dashboard when canExportDashboardCsv is true', () => {
+                const embedUser = createEmbedJwt({
+                    content: { canExportDashboardCsv: true },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('ExportCsv', {
+                            organizationUuid: organization.organizationUuid,
+                            projectUuid: embed.projectUuid,
+                            metadata: {
+                                dashboardUuid,
+                                dashboardName: 'Dashboard 1',
+                            },
+                        }),
+                    ),
+                ).toBe(true);
+
+                expect(
+                    ability.can(
+                        'view',
+                        subject('JobStatus', {
+                            organizationUuid: organization.organizationUuid,
+                            projectUuid: embed.projectUuid,
+                            createdByUserUuid: 'external-id-1',
+                        }),
+                    ),
+                ).toBe(true);
+            });
+
+            it('should not allow managing ExportCsv for a different dashboard', () => {
+                const embedUser = createEmbedJwt({
+                    content: { canExportDashboardCsv: true },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('ExportCsv', {
+                            organizationUuid: organization.organizationUuid,
+                            projectUuid: embed.projectUuid,
+                            metadata: {
+                                dashboardUuid: 'some-other-dashboard',
+                                dashboardName: 'Other dashboard',
+                            },
+                        }),
+                    ),
+                ).toBe(false);
+            });
+
+            it('should not allow managing ExportCsv when canExportDashboardCsv is false', () => {
+                const embedUser = createEmbedJwt({
+                    content: { canExportDashboardCsv: false },
+                });
+                const ability = defineAbilityForEmbedUser(
+                    embedUser,
+                    dashboardUuid,
+                );
+
+                expect(
+                    ability.can(
+                        'manage',
+                        subject('ExportCsv', {
+                            organizationUuid: organization.organizationUuid,
+                            projectUuid: embed.projectUuid,
+                            metadata: {
+                                dashboardUuid,
+                                dashboardName: 'Dashboard 1',
+                            },
+                        }),
+                    ),
+                ).toBe(false);
+            });
+        });
+
         describe('PDF export', () => {
             it('should allow PDF export when canExportPagePdf is true', () => {
                 const embedUser = createEmbedJwt({

--- a/packages/common/src/authorization/jwtAbility.ts
+++ b/packages/common/src/authorization/jwtAbility.ts
@@ -289,6 +289,24 @@ const exportAbilities: EmbeddedAbilityBuilder = ({
                 type: 'pdf',
             });
         }
+
+        // Dashboard-level "Export all" (bundles every tile into a CSV/XLSX ZIP).
+        // Scoped to this dashboard via metadata.dashboardUuid so the shared
+        // `manage ExportCsv` check in DashboardService.scheduleExportContent
+        // passes only for the embedded dashboard. The accompanying JobStatus
+        // grant lets the embed poll the async export job it created.
+        if (embedUser.content.canExportDashboardCsv) {
+            can('manage', 'ExportCsv', {
+                organizationUuid: organization.organizationUuid,
+                projectUuid: embed.projectUuid,
+                'metadata.dashboardUuid': content.dashboardUuid,
+            });
+            can('view', 'JobStatus', {
+                organizationUuid: organization.organizationUuid,
+                projectUuid: embed.projectUuid,
+                createdByUserUuid: externalId,
+            });
+        }
     }
 
     return { embedUser, content, embed, externalId, builder };

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -73,6 +73,11 @@ export const InteractivityOptionsSchema = z.object({
         DashboardFilterInteractivityOptionsSchema.optional(),
     parameterInteractivity: ParameterInteractivityOptionsSchema.optional(),
     canExportCsv: z.boolean().optional(),
+    // Authorizes a dashboard-level "Export all" that bundles every chart tile
+    // into a single CSV/XLSX ZIP. Off by default — independent from the
+    // per-tile canExportCsv so operators can enable bulk export without the
+    // per-tile buttons, or vice versa.
+    canExportDashboardCsv: z.boolean().optional(),
     canExportImages: z.boolean().optional(),
     canExportPagePdf: z.boolean().optional(),
     canDateZoom: z.boolean().optional(),
@@ -219,6 +224,7 @@ export type CommonEmbedJwtContent = {
         enabled: boolean;
     };
     canExportCsv?: boolean;
+    canExportDashboardCsv?: boolean;
     canExportImages?: boolean;
     canDateZoom?: boolean;
     canExportPagePdf?: boolean;

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -826,6 +826,9 @@ export type ExportContentPayload = TraceTaskBase & {
     dateZoomGranularity?: DateGranularity | string;
     customViewportWidth?: number;
     selectedTabs?: string[] | null;
+    // Set for embed/JWT exports so the scheduler worker can rebuild the
+    // anonymous account (no DB user) and run each tile query under it.
+    encodedJwt?: string;
 };
 
 export type ExportContentRequest = {

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardExportAll.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardExportAll.tsx
@@ -34,14 +34,15 @@ const EmbedDashboardExportAll: FC<Props> = ({ dashboard, projectUuid }) => {
         return null;
     }
 
-    const handleExport = (format: SchedulerFormat.CSV | SchedulerFormat.XLSX) => {
+    const handleExport = (
+        format: SchedulerFormat.CSV | SchedulerFormat.XLSX,
+    ) => {
         const options: SchedulerCsvOptions = {
             formatted: true,
             limit: 'table',
             asAttachment: false,
             exportPivotedData: true,
-            xlsxFileLayout:
-                format === SchedulerFormat.XLSX ? 'zip' : undefined,
+            xlsxFileLayout: format === SchedulerFormat.XLSX ? 'zip' : undefined,
         };
 
         const event = {
@@ -67,9 +68,15 @@ const EmbedDashboardExportAll: FC<Props> = ({ dashboard, projectUuid }) => {
     return (
         <Menu position="bottom-end" withinPortal>
             <Menu.Target>
-                <Tooltip label="Export all tiles" withinPortal position="bottom">
+                <Tooltip
+                    label="Export all tiles"
+                    withinPortal
+                    position="bottom"
+                >
                     <ActionIcon
-                        className={embedContractClass('ld-dashboard-export-all')}
+                        className={embedContractClass(
+                            'ld-dashboard-export-all',
+                        )}
                         variant="default"
                         size="lg"
                         radius="md"

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardExportAll.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardExportAll.tsx
@@ -1,0 +1,100 @@
+import {
+    SchedulerFormat,
+    type Dashboard,
+    type InteractivityOptions,
+    type SchedulerCsvOptions,
+} from '@lightdash/common';
+import { ActionIcon, Menu, Tooltip } from '@mantine-8/core';
+import { IconCsv, IconFileTypeXls, IconTableExport } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useExportDashboardContent } from '../../../../../hooks/dashboard/useDashboard';
+import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
+import { type EventData } from '../../../../../providers/Tracking/types';
+import useTracking from '../../../../../providers/Tracking/useTracking';
+import { embedContractClass } from '../../styles/embedClassContract';
+
+type Props = {
+    dashboard: Dashboard & InteractivityOptions;
+    projectUuid: string;
+};
+
+// Bundles every chart tile into a single CSV/XLSX ZIP. Uses table row limits
+// and formatted values — the same defaults as the per-tile export — so embed
+// viewers get a one-click "download everything" without extra configuration.
+const EmbedDashboardExportAll: FC<Props> = ({ dashboard, projectUuid }) => {
+    const { track } = useTracking();
+    const exportDashboardContentMutation = useExportDashboardContent();
+    const dashboardFilters = useDashboardContext((c) => c.allFilters);
+    const dateZoomGranularity = useDashboardContext(
+        (c) => c.dateZoomGranularity,
+    );
+
+    if (!dashboard.canExportDashboardCsv) {
+        return null;
+    }
+
+    const handleExport = (format: SchedulerFormat.CSV | SchedulerFormat.XLSX) => {
+        const options: SchedulerCsvOptions = {
+            formatted: true,
+            limit: 'table',
+            asAttachment: false,
+            exportPivotedData: true,
+            xlsxFileLayout:
+                format === SchedulerFormat.XLSX ? 'zip' : undefined,
+        };
+
+        const event = {
+            name: 'embedding_export_all.clicked',
+            properties: {
+                projectUuid,
+                dashboardUuid: dashboard.uuid,
+                format,
+            },
+        };
+        track(event as EventData);
+
+        exportDashboardContentMutation.mutate({
+            dashboard,
+            format,
+            options,
+            dashboardFilters,
+            dateZoomGranularity,
+            selectedTabs: null,
+        });
+    };
+
+    return (
+        <Menu position="bottom-end" withinPortal>
+            <Menu.Target>
+                <Tooltip label="Export all tiles" withinPortal position="bottom">
+                    <ActionIcon
+                        className={embedContractClass('ld-dashboard-export-all')}
+                        variant="default"
+                        size="lg"
+                        radius="md"
+                        loading={exportDashboardContentMutation.isLoading}
+                    >
+                        <MantineIcon icon={IconTableExport} />
+                    </ActionIcon>
+                </Tooltip>
+            </Menu.Target>
+            <Menu.Dropdown>
+                <Menu.Item
+                    leftSection={<MantineIcon icon={IconCsv} />}
+                    onClick={() => handleExport(SchedulerFormat.CSV)}
+                >
+                    Export all as .csv (.zip)
+                </Menu.Item>
+                <Menu.Item
+                    leftSection={<MantineIcon icon={IconFileTypeXls} />}
+                    onClick={() => handleExport(SchedulerFormat.XLSX)}
+                >
+                    Export all as .xlsx (.zip)
+                </Menu.Item>
+            </Menu.Dropdown>
+        </Menu>
+    );
+};
+
+export default EmbedDashboardExportAll;

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.module.css
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.module.css
@@ -22,6 +22,7 @@
 .actions {
     display: flex;
     align-items: center;
+    gap: var(--mantine-spacing-xs);
     padding-right: var(--mantine-spacing-lg);
     padding-left: var(--mantine-spacing-sm);
 }

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx
@@ -7,6 +7,7 @@ import {
 import { Box } from '@mantine-8/core';
 import { type FC, type ReactNode } from 'react';
 import { embedContractClass } from '../../styles/embedClassContract';
+import EmbedDashboardExportAll from './EmbedDashboardExportAll';
 import EmbedDashboardExportPdf from './EmbedDashboardExportPdf';
 import EmbedDashboardFilterBar from './EmbedDashboardFilterBar';
 import styles from './EmbedDashboardHeader.module.css';
@@ -24,7 +25,11 @@ const EmbedDashboardHeader: FC<Props> = ({ dashboard, projectUuid, tabs }) => {
         isParameterInteractivityEnabled(dashboard.parameterInteractivity) ||
         isFilterInteractivityEnabled(dashboard.dashboardFiltersInteractivity);
 
-    if (!hasFilterBar && !tabs && !dashboard.canExportPagePdf) {
+    const hasHeaderActions = Boolean(
+        dashboard.canExportPagePdf || dashboard.canExportDashboardCsv,
+    );
+
+    if (!hasFilterBar && !tabs && !hasHeaderActions) {
         return null;
     }
 
@@ -53,12 +58,20 @@ const EmbedDashboardHeader: FC<Props> = ({ dashboard, projectUuid, tabs }) => {
             data-has-tabs={Boolean(tabs)}
         >
             <Box className={styles.primary}>{tabs ?? filterBar}</Box>
-            {dashboard.canExportPagePdf && (
+            {hasHeaderActions && (
                 <Box className={styles.actions}>
-                    <EmbedDashboardExportPdf
-                        dashboard={dashboard}
-                        projectUuid={projectUuid}
-                    />
+                    {dashboard.canExportDashboardCsv && (
+                        <EmbedDashboardExportAll
+                            dashboard={dashboard}
+                            projectUuid={projectUuid}
+                        />
+                    )}
+                    {dashboard.canExportPagePdf && (
+                        <EmbedDashboardExportPdf
+                            dashboard={dashboard}
+                            projectUuid={projectUuid}
+                        />
+                    )}
                 </Box>
             )}
             {tabs && filterBar && (

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
@@ -81,6 +81,7 @@ type FormValues = {
     dashboardFiltersInteractivity: DashboardFilterInteractivityOptions;
     parameterInteractivity: ParameterInteractivityOptions;
     canExportCsv?: boolean;
+    canExportDashboardCsv?: boolean;
     canExportImages?: boolean;
     externalId?: string;
     canExportPagePdf?: boolean;
@@ -131,6 +132,7 @@ const EmbedPreviewDashboardForm: FC<{
                 enabled: false,
             },
             canExportCsv: false,
+            canExportDashboardCsv: false,
             canExportImages: false,
             canDateZoom: false,
             canExportPagePdf: true,
@@ -176,6 +178,7 @@ const EmbedPreviewDashboardForm: FC<{
                     },
                     parameterInteractivity: values.parameterInteractivity,
                     canExportCsv: values.canExportCsv,
+                    canExportDashboardCsv: values.canExportDashboardCsv,
                     canExportImages: values.canExportImages,
                     isPreview,
                     canDateZoom: values.canDateZoom,
@@ -407,7 +410,16 @@ const EmbedPreviewDashboardForm: FC<{
                                     {...form.getInputProps('canExportCsv', {
                                         type: 'checkbox',
                                     })}
-                                    label="Export CSV"
+                                    label="Export CSV (per tile)"
+                                />
+                                <Switch
+                                    {...form.getInputProps(
+                                        'canExportDashboardCsv',
+                                        {
+                                            type: 'checkbox',
+                                        },
+                                    )}
+                                    label="Export all tiles (CSV/XLSX ZIP)"
                                 />
                                 <Switch
                                     {...form.getInputProps('canExportImages', {

--- a/packages/frontend/src/ee/features/embed/styles/embedClassContract.ts
+++ b/packages/frontend/src/ee/features/embed/styles/embedClassContract.ts
@@ -31,6 +31,7 @@ export const EMBED_CLASS_CONTRACT = [
     'ld-dashboard-date-zoom-dropdown', // portalled
     'ld-dashboard-parameter-dropdown', // portalled
     'ld-dashboard-guided-setup', // modal shown while filter rules are unmet (portalled)
+    'ld-dashboard-export-all', // dashboard-level "Export all" (CSV/XLSX ZIP) button
 ] as const satisfies readonly `ld-${EmbedSurface}-${string}`[];
 
 export type EmbedContractClassName = (typeof EMBED_CLASS_CONTRACT)[number];


### PR DESCRIPTION
## What & why

Embedded dashboards only support per-tile CSV export today, so end users have to download each tile one at a time. This adds a dashboard-level **"Export all"** to embedded dashboards that bundles every chart tile into a single CSV or XLSX ZIP — the equivalent of the non-embedded `DashboardExportModal`, gated behind a new embed-JWT flag `canExportDashboardCsv` so operators control availability.

## Approach

Following the embed guidance (no new `/embed` endpoint), the existing async export endpoint `POST /api/v2/dashboards/{uuid}/exports` is made JWT-compatible instead:

- **`canExportDashboardCsv`** added to the embed interactivity options. In `jwtAbility` it grants `manage:ExportCsv` scoped to the bound dashboard (`metadata.dashboardUuid`) plus `view:JobStatus`, so the *existing* `DashboardService.scheduleExportContent` permission check passes only for the embedded dashboard — no service-side auth branching.
- `scheduleExportContent` now takes an `Account` (was `SessionUser`) and threads the encoded JWT into the export job payload; image export remains registered-only (headless render needs a session).
- The scheduler `EXPORT_CONTENT` task accepts a pre-resolved account; the EE worker rebuilds the anonymous account from the JWT (mirroring the existing `DOWNLOAD_ASYNC_QUERY_RESULTS` pattern) so each tile query runs under the token's access with no DB user. Persistent-URL rows use a `null` creator for JWT callers.
- Frontend: the embedded dashboard header gains an **Export all** button (reusing `useExportDashboardContent`) offering CSV/XLSX ZIP, and the embed settings preview form exposes the new flag.

## Notes for reviewers

- Reuses `manage:ExportCsv` rather than introducing a new CASL subject/scope, so no `scoped_roles` migration is needed (embed JWT auth is separate from custom roles).
- The job-status polling and `createdByUserUuid` handling match the already-shipped per-tile embed export, so the end-to-end async flow is unchanged in shape.
- Generated OpenAPI artifacts (`routes.ts`/`swagger.json`) intentionally not committed per repo convention.

## Testing

- `pnpm -F common typecheck` / `pnpm -F backend typecheck:fast` / `pnpm -F frontend typecheck:fast` — clean
- Lint clean on all changed files (backend eslint, frontend oxlint, common eslint)
- Added `jwtAbility` unit tests covering the new grant (allow bound dashboard, deny other dashboard, deny when flag off) — 39 passing
- Not yet manually exercised end-to-end in a running embed; worth a functional pass before merge.


## Worker auth hardening (follow-up commits)

An audit of the embed auth surface against the shipped `DOWNLOAD_ASYNC_QUERY_RESULTS` pattern surfaced three gaps, fixed here:

- **Expired-token stuck jobs**: the EE worker resolved the JWT account *before* `exportContent`'s logWrapper, and `tryJobOrTimeout` only handles timeout errors — so an expired/invalid token permanently failed the job with no ERROR row, leaving the embed poller on `SCHEDULED` forever. The account is now resolved inside a logged section (mirroring the DOWNLOAD handler), so token errors surface in job status.
- **Worker-side re-check**: after rebuilding the account, the worker re-asserts `manage:ExportCsv` against the payload's dashboard — the worker no longer trusts anything from the queue beyond the re-verified token itself (parity with the DOWNLOAD flow's owner-scoped re-authorization).
- **v1 route coherence**: `CsvService.scheduleExportCsvDashboard` (legacy `POST /:dashboardUuid/exportCsv`) shares the same `manage:ExportCsv` check the new JWT grant satisfies, but its payload cannot carry `encodedJwt` — a JWT-scheduled job there would crash at the worker. It is now explicitly registered-only, making the v2 endpoint the single embed export path.
