### PR TITLE
test: add agent_onboarding_run to the shipped page-name vocabulary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# [0.3454.0](https://github.com/lightdash/lightdash/compare/0.3453.0...0.3454.0) (2026-07-22)
+
+
+### Bug Fixes
+
+* show AI prompt greeting regardless of block position ([#25960](https://github.com/lightdash/lightdash/issues/25960)) ([bb5afdb](https://github.com/lightdash/lightdash/commit/bb5afdb730c56c0d913fd430444fbe7a203e32f0)), closes [/linear.app/lightdash/issue/ZAP-686/greeting-on-the-ai-prompt-doesnt-show-unless-its-at-the-top#agent-session-089dba31](https://github.com//linear.app/lightdash/issue/ZAP-686/greeting-on-the-ai-prompt-doesnt-show-unless-its-at-the-top/issues/agent-session-089dba31)
+
+
+### Features
+
+* **backend:** playground project provisioning service and endpoint ([#25945](https://github.com/lightdash/lightdash/issues/25945)) ([ad19a47](https://github.com/lightdash/lightdash/commit/ad19a47a2d79f4125a753f440bca32c0e34f312b))
+* **backend:** track playground provisioning through the project lifecycle ([#25942](https://github.com/lightdash/lightdash/issues/25942)) ([4dad6d9](https://github.com/lightdash/lightdash/commit/4dad6d9d8490e7be59ea363de4ee5d362e5c55f6))
+* **data-apps:** move auto-name off the build critical path ([#25962](https://github.com/lightdash/lightdash/issues/25962)) ([0ae4f51](https://github.com/lightdash/lightdash/commit/0ae4f51c2247f1f2aa10109f10ffc07df91e0dff))
+* **frontend:** ambient component stars on the no-warehouse homepage ([#25901](https://github.com/lightdash/lightdash/issues/25901)) ([f8b7cbb](https://github.com/lightdash/lightdash/commit/f8b7cbb80b3b02d4b10a9d5efd9341fdce70c7b5))
+* **frontend:** invite-an-expert page replacing the setup-invite modal ([#25946](https://github.com/lightdash/lightdash/issues/25946)) ([3be402e](https://github.com/lightdash/lightdash/commit/3be402e95e26a90a239deec8b6971049b293e443))
+* **frontend:** playground onboarding integration ([#25830](https://github.com/lightdash/lightdash/issues/25830)) ([b9a94a0](https://github.com/lightdash/lightdash/commit/b9a94a081c0141be57a57cba150cb3aa107e17bd))
+* playground sample-data bundle and build script ([#25944](https://github.com/lightdash/lightdash/issues/25944)) ([9660c65](https://github.com/lightdash/lightdash/commit/9660c65fa6063f6bf24569e77c85adfdc0561078))
+* **warehouses:** embedded DuckDB warehouse client, provisionable only internally ([#25943](https://github.com/lightdash/lightdash/issues/25943)) ([34f5364](https://github.com/lightdash/lightdash/commit/34f5364d5906190d3c9da782d29dc8c3c8d9306c))
+
 # [0.3453.0](https://github.com/lightdash/lightdash/compare/0.3452.0...0.3453.0) (2026-07-22)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lightdash",
-    "version": "0.3453.0",
+    "version": "0.3454.0",
     "main": "index.js",
     "license": "MIT",
     "private": true,

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "backend",
-    "version": "0.3453.0",
+    "version": "0.3454.0",
     "private": true,
     "license": "MIT",
     "main": "dist/index",

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -49221,7 +49221,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3453.0",
+        "version": "0.3454.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash/cli",
-  "version": "0.3453.0",
+  "version": "0.3454.0",
   "description": "Lightdash CLI tool",
   "license": "MIT",
   "repository": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash/common",
-  "version": "0.3453.0",
+  "version": "0.3454.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
     "name": "e2e",
-    "version": "0.3453.0",
+    "version": "0.3454.0",
     "private": true,
     "license": "MIT",
     "main": "index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightdash/frontend",
-    "version": "0.3453.0",
+    "version": "0.3454.0",
     "private": true,
     "scripts": {
         "typecheck": "tsc6 --project tsconfig.json --noEmit",

--- a/packages/frontend/sdk/package.json
+++ b/packages/frontend/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightdash/sdk",
-    "version": "0.3453.0",
+    "version": "0.3454.0",
     "private": false,
     "repository": {
         "type": "git",

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.module.css
@@ -1,0 +1,111 @@
+.sky {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 0;
+}
+
+/* Settled state: a plain rotated element, so text and borders are painted at
+   the tilted geometry instead of being resampled from a compositor layer. */
+.star {
+    /* The hero's own width and padding decide how much room is left beside it;
+       --star-slack picks a point in that band, so the scatter widens with the
+       window and follows the hero if its width ever changes. */
+    --star-hero-clearance: calc(
+        var(--homepage-hero-width) / 2 + var(--star-clearance)
+    );
+    --star-gutter: calc(
+        var(--star-hero-clearance) + var(--star-slack) *
+            max(
+                0px,
+                50vw - var(--homepage-page-padding-x) -
+                    var(--star-hero-clearance) - var(--star-width)
+            )
+    );
+    position: absolute;
+    width: var(--star-width);
+    top: var(--star-top);
+    opacity: var(--star-opacity);
+    transform: rotate(var(--star-tilt));
+}
+
+.starEntering {
+    animation: starEnter 500ms ease-out both;
+}
+
+.starLeaving {
+    /* Duration is mirrored by LEAVE_MS in HomepageStars.tsx. */
+    animation: starLeave 500ms ease-in both;
+}
+
+.starLeft {
+    right: calc(50% + var(--star-gutter));
+}
+
+.starRight {
+    left: calc(50% + var(--star-gutter));
+}
+
+.cardIcon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    border-radius: 6px;
+    background: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-dark-5)
+    );
+}
+
+.sparkline {
+    display: block;
+    width: 100%;
+    height: 32px;
+}
+
+.card {
+    background-color: light-dark(#fff, var(--mantine-color-dark-6));
+    border: 1px solid var(--mantine-color-ldGray-3);
+    border-radius: var(--mantine-radius-md);
+    box-shadow: var(--mantine-shadow-sm);
+    overflow: hidden;
+}
+
+/* Presentational copy of the homepage-builder's quick-action chip. */
+.chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 6px 12px;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    color: inherit;
+    background: light-dark(#fff, var(--mantine-color-dark-6));
+    border: 1px solid var(--mantine-color-ldGray-2);
+}
+
+@keyframes starEnter {
+    from {
+        opacity: 0;
+        transform: scale(0.5) translateY(10px) rotate(0deg);
+    }
+    to {
+        opacity: var(--star-opacity);
+        transform: scale(1) translateY(0) rotate(var(--star-tilt));
+    }
+}
+
+@keyframes starLeave {
+    from {
+        opacity: var(--star-opacity);
+        transform: scale(1) translateY(0) rotate(var(--star-tilt));
+    }
+    to {
+        opacity: 0;
+        transform: scale(0.55) translateY(-10px) rotate(var(--star-tilt));
+    }
+}

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.test.tsx
@@ -1,0 +1,254 @@
+import { MantineProvider } from '@mantine-8/core';
+import { act, fireEvent, render } from '@testing-library/react';
+import HomepageStars from './HomepageStars';
+
+// Nothing is mocked: the cards are purpose-built presentational markup, so
+// the focusability assertions below run against the real DOM.
+// Answers min-width/min-height queries against a pretend viewport, so the
+// tier the component picks is the one a real browser would pick.
+const stubMatchMedia = ({
+    reducedMotion = false,
+    width = 1600,
+    height = 1000,
+} = {}) => {
+    const fits = (query: string) => {
+        const minWidth = query.match(/min-width:\s*([\d.]+)px/);
+        const minHeight = query.match(/min-height:\s*([\d.]+)px/);
+        if (!minWidth || !minHeight) return false;
+        return width >= Number(minWidth[1]) && height >= Number(minHeight[1]);
+    };
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes('prefers-reduced-motion')
+            ? reducedMotion
+            : fits(query),
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia;
+};
+
+const renderStars = () =>
+    render(
+        <MantineProvider>
+            <HomepageStars />
+        </MantineProvider>,
+    );
+
+describe('HomepageStars', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        stubMatchMedia();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('spawns stars over time and caps how many are visible at once', () => {
+        const { container } = renderStars();
+        const sky = container.querySelector('[inert]');
+        expect(sky).not.toBeNull();
+        expect(sky!.childElementCount).toBe(0);
+
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+        expect(sky!.childElementCount).toBeGreaterThan(0);
+
+        act(() => {
+            vi.advanceTimersByTime(60000);
+        });
+        // MAX_STARS on screen; stars still fading out keep their slot on top
+        // of that, bounded by the 12 candidate slots.
+        const visible = sky!.querySelectorAll(
+            '[data-star-phase]:not([data-star-phase="leaving"])',
+        );
+        expect(visible.length).toBeLessThanOrEqual(7);
+        expect(sky!.childElementCount).toBeLessThanOrEqual(12);
+    });
+
+    it('never shows two stars with the same identity', () => {
+        const { container } = renderStars();
+        const sky = container.querySelector('[inert]')!;
+
+        for (let i = 0; i < 40; i++) {
+            act(() => {
+                vi.advanceTimersByTime(1000);
+            });
+            const defs = [...sky.children].map((star) =>
+                star.getAttribute('data-star-def'),
+            );
+            expect(new Set(defs).size).toBe(defs.length);
+        }
+        expect(sky.childElementCount).toBeGreaterThan(0);
+    });
+
+    it('never leaves one side empty while stars are visible', () => {
+        const { container } = renderStars();
+        const sky = container.querySelector('[inert]')!;
+
+        for (let i = 0; i < 40; i++) {
+            act(() => {
+                vi.advanceTimersByTime(1000);
+            });
+            const sides = [...sky.children].map((star) =>
+                star.getAttribute('data-side'),
+            );
+            if (sides.length > 0) {
+                expect(sides).toContain('left');
+                expect(sides).toContain('right');
+            }
+        }
+        // The loop must have actually exercised star activity.
+        expect(sky.childElementCount).toBeGreaterThan(0);
+    });
+
+    it('keeps stars on a side a full card apart', () => {
+        const { container } = renderStars();
+        const sky = container.querySelector('[inert]')!;
+
+        for (let i = 0; i < 40; i++) {
+            act(() => {
+                vi.advanceTimersByTime(1000);
+            });
+            const bySide = new Map<string, number[]>();
+            [...sky.children].forEach((star) => {
+                const side = star.getAttribute('data-side')!;
+                const top = Number.parseFloat(
+                    (star as HTMLElement).style.getPropertyValue('--star-top'),
+                );
+                bySide.set(side, [...(bySide.get(side) ?? []), top]);
+            });
+            bySide.forEach((tops) => {
+                const sorted = [...tops].sort((a, b) => a - b);
+                sorted.slice(1).forEach((top, index) => {
+                    // The wide tier needs 20.6% between slot centres; the
+                    // jitter is already included in these positions.
+                    expect(top - sorted[index]).toBeGreaterThanOrEqual(18.6);
+                });
+            });
+        }
+    });
+
+    it('expires stars even when animationend never fires', () => {
+        const { container } = renderStars();
+        const sky = container.querySelector('[inert]')!;
+
+        act(() => {
+            vi.advanceTimersByTime(3000);
+        });
+        expect(sky.childElementCount).toBeGreaterThan(0);
+        const earlyStar = sky.children[0];
+
+        // jsdom never fires animationend; the timeout fallback must still
+        // remove the star (max lifetime 8000ms + 300ms buffer).
+        act(() => {
+            vi.advanceTimersByTime(60000);
+        });
+        expect(earlyStar.isConnected).toBe(false);
+    });
+
+    it('settles a star out of its entry animation, then removes it once it leaves', () => {
+        const { container } = renderStars();
+        const sky = container.querySelector('[inert]')!;
+
+        act(() => {
+            vi.advanceTimersByTime(600);
+        });
+        const star = sky.children[0];
+        expect(star).toHaveAttribute('data-star-phase', 'entering');
+
+        act(() => {
+            fireEvent.animationEnd(star);
+        });
+        expect(star).toHaveAttribute('data-star-phase', 'settled');
+
+        // Its lifetime elapses: the star starts leaving, and only then does
+        // animationend remove it. Lifetimes are random, so step until it
+        // turns — well inside the 300ms slack before the removal fallback.
+        for (
+            let i = 0;
+            i < 60 && star.getAttribute('data-star-phase') !== 'leaving';
+            i++
+        ) {
+            act(() => {
+                vi.advanceTimersByTime(200);
+            });
+        }
+        expect(star).toHaveAttribute('data-star-phase', 'leaving');
+        expect(star.isConnected).toBe(true);
+
+        act(() => {
+            fireEvent.animationEnd(star);
+        });
+        expect(star.isConnected).toBe(false);
+    });
+
+    it('contains no focusable elements and is inert + aria-hidden', () => {
+        const { container } = renderStars();
+        const sky = container.querySelector('[inert]')!;
+        expect(sky).toHaveAttribute('aria-hidden');
+
+        act(() => {
+            vi.advanceTimersByTime(30000);
+        });
+        expect(sky.childElementCount).toBeGreaterThan(0);
+        expect(sky.querySelectorAll('a, button')).toHaveLength(0);
+    });
+
+    it('keeps one timer per star no matter how long the page stays open', () => {
+        const { container, unmount } = renderStars();
+        const sky = container.querySelector('[inert]')!;
+
+        act(() => {
+            vi.advanceTimersByTime(120000);
+        });
+        expect(sky.childElementCount).toBeGreaterThan(0);
+        // At most one timer per star (12 slots cap the total), plus the spawn
+        // timer — timers must not accumulate with time on the page.
+        expect(vi.getTimerCount()).toBeLessThanOrEqual(13);
+
+        unmount();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('still shows stars on a smaller viewport, at a narrower width', () => {
+        stubMatchMedia({ width: 1280, height: 820 });
+        const { container } = renderStars();
+        const sky = container.querySelector('[inert]')!;
+
+        act(() => {
+            vi.advanceTimersByTime(3000);
+        });
+        expect(sky.childElementCount).toBeGreaterThan(0);
+        const star = sky.children[0] as HTMLElement;
+        // 170px scaled by one of the three card sizes.
+        expect(['133px', '150px', '170px']).toContain(
+            star.style.getPropertyValue('--star-width'),
+        );
+    });
+
+    it('renders nothing when the viewport is too small for even the narrow tier', () => {
+        stubMatchMedia({ width: 1100, height: 820 });
+        const { container } = renderStars();
+
+        act(() => {
+            vi.advanceTimersByTime(10000);
+        });
+        expect(container.querySelector('[inert]')).toBeNull();
+    });
+
+    it('renders nothing and schedules no stars under prefers-reduced-motion', () => {
+        stubMatchMedia({ reducedMotion: true });
+        const { container } = renderStars();
+
+        act(() => {
+            vi.advanceTimersByTime(10000);
+        });
+        expect(container.querySelector('[inert]')).toBeNull();
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageStars.tsx
@@ -1,0 +1,719 @@
+import { assertUnreachable } from '@lightdash/common';
+import { Box, Group, Text } from '@mantine-8/core';
+import { useMediaQuery, useReducedMotion } from '@mantine-8/hooks';
+import {
+    IconChartArea,
+    IconChartBar,
+    IconChartLine,
+    IconChartPie,
+    IconFolder,
+    IconLayoutDashboard,
+    IconSparkles,
+    IconTable,
+    type Icon,
+} from '@tabler/icons-react';
+import {
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+    type CSSProperties,
+    type FC,
+    type ReactElement,
+} from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import classes from './HomepageStars.module.css';
+
+const randomBetween = (min: number, max: number) =>
+    min + Math.random() * (max - min);
+
+// Stars drop into candidate slots either side of the centered hero. The slots
+// are deliberately uneven and differ between the sides, so the sky reads as
+// scattered rather than as two columns; spacing is enforced at spawn time
+// instead of by a fixed pitch.
+const MAX_STARS = 7;
+const SLOT_TOP_JITTER_PCT = 1;
+// Cards come in three sizes, the smaller ones slightly faded, which reads as
+// depth and stops every card sharing an edge with its neighbours.
+const SIZE_SCALES = [0.78, 0.88, 1];
+// Only the mount gate needs these in JS — a media query cannot read the CSS
+// variables that own the layout (--homepage-hero-width, --homepage-page-padding-x).
+const CONTENT_HALF_WIDTH_PX = 360;
+const PAGE_PADDING_X_PX = 24;
+
+// Narrower viewports get narrower stars hugging the hero more closely, rather
+// than no stars at all. A tier is used from the width where a star at its
+// closest to the hero still clears the page padding, with breathing room:
+// 2 * (hero half + clearance + star + padding) + 40. How far past the hero a
+// star actually sits is spread across whatever space the viewport leaves,
+// which the stylesheet works out from --star-slack.
+type SkyTier = {
+    starWidthPx: number;
+    clearancePx: number;
+    minHeightPx: number;
+    cardHeightPx: number;
+};
+
+const tierMinWidth = (tier: SkyTier) =>
+    2 *
+        (CONTENT_HALF_WIDTH_PX +
+            tier.clearancePx +
+            tier.starWidthPx +
+            PAGE_PADDING_X_PX) +
+    40;
+
+// cardHeightPx is the measured height of the tallest card at that width, as a
+// rotated bounding box.
+const WIDE_TIER: SkyTier = {
+    starWidthPx: 220,
+    clearancePx: 40,
+    minHeightPx: 860,
+    cardHeightPx: 137,
+};
+const COMPACT_TIER: SkyTier = {
+    starWidthPx: 170,
+    clearancePx: 20,
+    minHeightPx: 800,
+    cardHeightPx: 132,
+};
+
+const STAGE_CHROME_PX = 122; // --navbar-height + the 72px homepageLayout keeps
+
+// Two stars on a side must be at least a card apart, measured against the
+// shortest stage the tier allows, with room for the jitter at both ends.
+const minSlotGapPct = (tier: SkyTier) =>
+    (tier.cardHeightPx / (tier.minHeightPx - STAGE_CHROME_PX)) * 100 +
+    2 * SLOT_TOP_JITTER_PCT;
+
+const tierMediaQuery = (tier: SkyTier) =>
+    `(min-width: ${tierMinWidth(tier)}px) and (min-height: ${
+        tier.minHeightPx
+    }px)`;
+
+type Slot = { side: 'left' | 'right'; topPct: number };
+
+const SLOTS: Slot[] = [
+    { side: 'left', topPct: 3 },
+    { side: 'left', topPct: 17 },
+    { side: 'left', topPct: 29 },
+    { side: 'left', topPct: 44 },
+    { side: 'left', topPct: 58 },
+    { side: 'left', topPct: 72 },
+    { side: 'right', topPct: 9 },
+    { side: 'right', topPct: 23 },
+    { side: 'right', topPct: 37 },
+    { side: 'right', topPct: 51 },
+    { side: 'right', topPct: 65 },
+    { side: 'right', topPct: 78 },
+];
+
+const PALETTE = [
+    'var(--mantine-color-blue-6)',
+    'var(--mantine-color-green-6)',
+    'var(--mantine-color-violet-6)',
+    'var(--mantine-color-teal-6)',
+    'var(--mantine-color-orange-6)',
+    'var(--mantine-color-red-6)',
+];
+
+// The cards are look-alikes, not the homepage's real content components: the
+// decoration has no content to show, and borrowing those would tie it to the
+// content domain model and mount a chart engine to draw scenery.
+const MOCK_CHARTS: { name: string; icon: Icon; tint: string }[] = [
+    {
+        name: 'Monthly recurring revenue',
+        icon: IconChartLine,
+        tint: PALETTE[0],
+    },
+    { name: 'Signups by channel', icon: IconChartBar, tint: PALETTE[1] },
+    { name: 'Orders per week', icon: IconChartBar, tint: PALETTE[3] },
+    { name: 'Active workspaces', icon: IconChartArea, tint: PALETTE[2] },
+    { name: 'Revenue by segment', icon: IconChartPie, tint: PALETTE[4] },
+    { name: 'Churn rate over time', icon: IconChartLine, tint: PALETTE[5] },
+];
+
+const MOCK_DASHBOARD_NAMES = ['Company KPIs', 'Growth overview'];
+
+const MOCK_KPIS: {
+    label: string;
+    value: string;
+    color: string;
+    variant: 'line' | 'bar';
+}[] = [
+    {
+        label: 'Total revenue',
+        value: '$128k',
+        color: PALETTE[0],
+        variant: 'line',
+    },
+    {
+        label: 'Weekly active users',
+        value: '4,209',
+        color: PALETTE[1],
+        variant: 'bar',
+    },
+    {
+        label: 'Conversion rate',
+        value: '3.8%',
+        color: PALETTE[2],
+        variant: 'line',
+    },
+    {
+        label: 'Avg. order value',
+        value: '$92',
+        color: PALETTE[3],
+        variant: 'bar',
+    },
+    { label: 'New signups', value: '312', color: PALETTE[4], variant: 'bar' },
+    { label: 'Churn rate', value: '1.2%', color: PALETTE[5], variant: 'line' },
+];
+
+// Presentational copies of the homepage quick-action chips — no links, no
+// hooks, no tracking, so the decoration never fires network requests or
+// pollutes homepage analytics.
+type ChipKey = 'ask-ai' | 'run-query' | 'browse-dashboards' | 'browse-spaces';
+
+const CHIP_DEFS: Record<ChipKey, { icon: Icon; title: string }> = {
+    'ask-ai': { icon: IconSparkles, title: 'Ask AI' },
+    'run-query': { icon: IconTable, title: 'Run a query' },
+    'browse-dashboards': {
+        icon: IconLayoutDashboard,
+        title: 'Browse dashboards',
+    },
+    'browse-spaces': { icon: IconFolder, title: 'Browse spaces' },
+};
+
+// Disjoint, so two chip stars on screen at once never repeat a label.
+const MOCK_CHIP_SETS: ChipKey[][] = [
+    ['ask-ai', 'run-query'],
+    ['browse-dashboards', 'browse-spaces'],
+];
+
+const StaticChips: FC<{ types: ChipKey[] }> = ({ types }) => (
+    <Group gap={8} justify="center">
+        {types.map((type) => (
+            <span key={type} className={classes.chip}>
+                <MantineIcon
+                    icon={CHIP_DEFS[type].icon}
+                    size={14}
+                    color="ldGray.6"
+                />
+                {CHIP_DEFS[type].title}
+            </span>
+        ))}
+    </Group>
+);
+
+const StarCard: FC<{
+    icon: Icon;
+    tint: string;
+    name: string;
+    meta: string;
+}> = ({ icon, tint, name, meta }) => (
+    <Box className={classes.card} p={14}>
+        <Box className={classes.cardIcon} mb={10}>
+            <MantineIcon icon={icon} size={16} style={{ color: tint }} />
+        </Box>
+        <Text size="sm" fw={600} truncate mb={2}>
+            {name}
+        </Text>
+        <Text size="xs" c="dimmed" truncate>
+            {meta}
+        </Text>
+    </Box>
+);
+
+const SPARKLINE_WIDTH = 100;
+const SPARKLINE_HEIGHT = 32;
+
+// Hand-drawn rather than charted: these are 14 meaningless numbers, and a real
+// chart engine would mount and dispose an instance per star.
+const StarSparkline: FC<{
+    values: number[];
+    color: string;
+    variant: 'line' | 'bar';
+}> = ({ values, color, variant }) => {
+    const max = Math.max(...values);
+    const min = Math.min(...values);
+    const span = max - min || 1;
+    const step = SPARKLINE_WIDTH / (values.length - 1 || 1);
+    const y = (value: number) =>
+        SPARKLINE_HEIGHT - ((value - min) / span) * (SPARKLINE_HEIGHT - 4) - 2;
+
+    return (
+        <svg
+            className={classes.sparkline}
+            viewBox={`0 0 ${SPARKLINE_WIDTH} ${SPARKLINE_HEIGHT}`}
+            preserveAspectRatio="none"
+            aria-hidden
+        >
+            {variant === 'bar' ? (
+                values.map((value, index) => (
+                    <rect
+                        key={index}
+                        x={index * step + step * 0.2}
+                        y={y(value)}
+                        width={step * 0.6}
+                        height={SPARKLINE_HEIGHT - y(value)}
+                        rx={1}
+                        fill={color}
+                    />
+                ))
+            ) : (
+                <>
+                    <path
+                        d={`M0,${SPARKLINE_HEIGHT} ${values
+                            .map(
+                                (value, index) =>
+                                    `L${index * step},${y(value)}`,
+                            )
+                            .join(
+                                ' ',
+                            )} L${SPARKLINE_WIDTH},${SPARKLINE_HEIGHT} Z`}
+                        fill={color}
+                        opacity={0.12}
+                    />
+                    <polyline
+                        points={values
+                            .map(
+                                (value, index) => `${index * step},${y(value)}`,
+                            )
+                            .join(' ')}
+                        fill="none"
+                        stroke={color}
+                        strokeWidth={2}
+                        strokeLinejoin="round"
+                    />
+                </>
+            )}
+        </svg>
+    );
+};
+
+// Everything random about a star's content is captured in its seed, drawn
+// before setState. Stars store descriptors (defKey + seed), not elements,
+// so state updates stay pure and content is stable across renders.
+type StarSeed = {
+    values: number[];
+    views: number;
+};
+
+const buildSparklineValues = (): number[] => {
+    let value = randomBetween(40, 60);
+    return Array.from({ length: 14 }, () => {
+        value = Math.max(5, value + randomBetween(-8, 10));
+        return Math.round(value);
+    });
+};
+
+// Catalog of distinct star identities. A def only spawns while no visible
+// star uses it, so the sky never shows duplicate cards, KPIs, or chips.
+type StarDef = { key: string; render: (seed: StarSeed) => ReactElement };
+
+const STAR_DEFS: StarDef[] = [
+    ...MOCK_CHARTS.map(
+        (chart): StarDef => ({
+            key: `chart-${chart.name}`,
+            render: (seed) => (
+                <StarCard
+                    icon={chart.icon}
+                    tint={chart.tint}
+                    name={chart.name}
+                    meta={`Chart · ${seed.views} views`}
+                />
+            ),
+        }),
+    ),
+    ...MOCK_DASHBOARD_NAMES.map(
+        (name): StarDef => ({
+            key: `dashboard-${name}`,
+            render: (seed) => (
+                <StarCard
+                    icon={IconLayoutDashboard}
+                    tint={PALETTE[2]}
+                    name={name}
+                    meta={`Dashboard · ${seed.views} views`}
+                />
+            ),
+        }),
+    ),
+    ...MOCK_KPIS.map(
+        (kpi): StarDef => ({
+            key: `kpi-${kpi.label}`,
+            render: (seed) => (
+                <Box className={classes.card} p="sm">
+                    <Text size="xs" c="dimmed" lineClamp={1}>
+                        {kpi.label}
+                    </Text>
+                    <Text fw={700} size="xl" mb={4}>
+                        {kpi.value}
+                    </Text>
+                    <StarSparkline
+                        values={seed.values}
+                        color={kpi.color}
+                        variant={kpi.variant}
+                    />
+                </Box>
+            ),
+        }),
+    ),
+    ...MOCK_CHIP_SETS.map(
+        (types, index): StarDef => ({
+            key: `chips-${index}`,
+            render: () => <StaticChips types={types} />,
+        }),
+    ),
+];
+
+const STAR_DEF_MAP = new Map(STAR_DEFS.map((def) => [def.key, def]));
+
+// A star animates only while entering and leaving. In between it sits in a
+// static transform so the browser paints it without a compositor layer —
+// a permanently animating layer is resampled through the tilt and goes soft.
+type StarPhase = 'entering' | 'settled' | 'leaving';
+
+// Must match the starLeave animation duration in the stylesheet.
+const LEAVE_MS = 500;
+
+const phaseClass = (phase: StarPhase) => {
+    switch (phase) {
+        case 'entering':
+            return classes.starEntering;
+        case 'leaving':
+            return classes.starLeaving;
+        case 'settled':
+            return '';
+        default:
+            return assertUnreachable(phase, 'Unknown star phase');
+    }
+};
+
+type Star = {
+    id: number;
+    defKey: string;
+    slot: Slot;
+    className: string;
+    style: CSSProperties;
+    seed: StarSeed;
+    phase: StarPhase;
+    lifetimeMs: number;
+};
+
+type StarDraws = {
+    lifetimeMs: number;
+    slotPick: number;
+    defPick: number;
+    sizePick: number;
+    gutterPick: number;
+    topJitter: number;
+    tilt: number;
+    seed: StarSeed;
+};
+
+// All randomness for a star is drawn before setState so the state updaters
+// below stay pure (StrictMode double-invokes them in dev).
+const drawStar = (): StarDraws => ({
+    lifetimeMs: randomBetween(5000, 9000),
+    slotPick: Math.random(),
+    defPick: Math.random(),
+    sizePick: Math.random(),
+    gutterPick: Math.random(),
+    topJitter: randomBetween(-SLOT_TOP_JITTER_PCT, SLOT_TOP_JITTER_PCT),
+    // Stars enter level and settle into a slight tilt, randomized
+    // counter-clockwise (negative) or clockwise (positive).
+    tilt: randomBetween(2, 5) * (Math.random() < 0.5 ? -1 : 1),
+    seed: {
+        values: buildSparklineValues(),
+        views: Math.floor(randomBetween(3, 900)),
+    },
+});
+
+// The side that has no star still on screen, ignoring stars already fading
+// out. null when both sides are covered — or when neither is, in which case
+// the caller is free to choose.
+const emptySideOf = (stars: Star[]): 'left' | 'right' | null => {
+    const visible = stars.filter((star) => star.phase !== 'leaving');
+    const hasLeft = visible.some((star) => star.slot.side === 'left');
+    const hasRight = visible.some((star) => star.slot.side === 'right');
+    if (hasLeft === hasRight) return null;
+    return hasLeft ? 'right' : 'left';
+};
+
+const appendStar = (
+    current: Star[],
+    id: number,
+    draws: StarDraws,
+    forcedSide: 'left' | 'right' | null,
+    tier: SkyTier,
+): Star[] => {
+    // Stars fading out still hold their slot and def, but they no longer
+    // count against the cap — otherwise a replacement can't take off while
+    // its predecessor is still on screen.
+    const visibleCount = current.filter(
+        (star) => star.phase !== 'leaving',
+    ).length;
+    if (visibleCount >= MAX_STARS) return current;
+    const minGapPct = minSlotGapPct(tier);
+    const freeSlots = SLOTS.filter(
+        (slot) =>
+            !current.some(
+                (star) =>
+                    star.slot.side === slot.side &&
+                    Math.abs(star.slot.topPct - slot.topPct) < minGapPct,
+            ),
+    );
+    const busyDefs = new Set(current.map((s) => s.defKey));
+    const freeDefs = STAR_DEFS.filter((def) => !busyDefs.has(def.key));
+    if (freeSlots.length === 0 || freeDefs.length === 0) return current;
+    const sideSlots = forcedSide
+        ? freeSlots.filter((slot) => slot.side === forcedSide)
+        : freeSlots;
+    const candidateSlots = sideSlots.length > 0 ? sideSlots : freeSlots;
+    const slot =
+        candidateSlots[Math.floor(draws.slotPick * candidateSlots.length)];
+    const def = freeDefs[Math.floor(draws.defPick * freeDefs.length)];
+    const sizeScale =
+        SIZE_SCALES[Math.floor(draws.sizePick * SIZE_SCALES.length)];
+    return [
+        ...current,
+        {
+            id,
+            defKey: def.key,
+            slot,
+            className:
+                slot.side === 'left' ? classes.starLeft : classes.starRight,
+            style: {
+                '--star-top': `${slot.topPct + draws.topJitter}%`,
+                '--star-clearance': `${tier.clearancePx}px`,
+                '--star-slack': `${draws.gutterPick.toFixed(3)}`,
+                '--star-width': `${Math.round(tier.starWidthPx * sizeScale)}px`,
+                '--star-opacity': `${(0.36 + 0.64 * sizeScale).toFixed(2)}`,
+                '--star-tilt': `${draws.tilt}deg`,
+            } as CSSProperties,
+            seed: draws.seed,
+            phase: 'entering',
+            lifetimeMs: draws.lifetimeMs,
+        },
+    ];
+};
+
+const HomepageStars: FC = () => {
+    const reducedMotion = useReducedMotion();
+    // JS is the single kill switch: CSS-hidden stars would never fire
+    // animationend, stranding their slots forever.
+    const wideFits = useMediaQuery(tierMediaQuery(WIDE_TIER), false);
+    const compactFits = useMediaQuery(tierMediaQuery(COMPACT_TIER), false);
+    const tier = wideFits ? WIDE_TIER : compactFits ? COMPACT_TIER : null;
+    const disabled = reducedMotion || tier === null;
+
+    const [stars, setStars] = useState<Star[]>([]);
+    const nextId = useRef(0);
+    const starTimers = useRef(new Map<number, number>());
+    const startLeavingRef = useRef<(id: number) => void>(() => {});
+    const removeStarRef = useRef<(id: number) => void>(() => {});
+
+    const setTimer = useCallback(
+        (id: number, delayMs: number, run: () => void) => {
+            const timers = starTimers.current;
+            const existing = timers.get(id);
+            if (existing !== undefined) window.clearTimeout(existing);
+            timers.set(
+                id,
+                window.setTimeout(() => {
+                    timers.delete(id);
+                    run();
+                }, delayMs),
+            );
+        },
+        [],
+    );
+
+    const clearTimer = useCallback((id: number) => {
+        const timers = starTimers.current;
+        const timer = timers.get(id);
+        if (timer !== undefined) {
+            window.clearTimeout(timer);
+            timers.delete(id);
+        }
+    }, []);
+
+    // Declines to plant a replacement once the sky is gated off mid-flight.
+    const appendIfFits = useCallback(
+        (
+            current: Star[],
+            id: number,
+            draws: StarDraws,
+            side: 'left' | 'right',
+        ) => (tier ? appendStar(current, id, draws, side, tier) : current),
+        [tier],
+    );
+
+    const removeStar = useCallback(
+        (id: number) => {
+            clearTimer(id);
+            // Backstop draw: startLeaving usually plants the replacement, but
+            // it can be declined when every slot or def is taken.
+            const draws = drawStar();
+            const replacementId = nextId.current++;
+            setStars((current) => {
+                if (!current.some((star) => star.id === id)) return current;
+                const next = current.filter((star) => star.id !== id);
+                if (next.length === 0) return next;
+                const emptySide = emptySideOf(next);
+                if (!emptySide) return next;
+                return appendIfFits(next, replacementId, draws, emptySide);
+            });
+        },
+        [clearTimer, appendIfFits],
+    );
+
+    const startLeaving = useCallback(
+        (id: number) => {
+            // Pre-draw a replacement in case this star's exit empties a side.
+            const draws = drawStar();
+            const replacementId = nextId.current++;
+            setStars((current) => {
+                if (
+                    !current.some(
+                        (star) => star.id === id && star.phase !== 'leaving',
+                    )
+                ) {
+                    return current;
+                }
+                const next = current.map((star) =>
+                    star.id === id
+                        ? { ...star, phase: 'leaving' as const }
+                        : star,
+                );
+                const emptySide = emptySideOf(next);
+                if (!emptySide) return next;
+                // The replacement fades in while this star fades out, so the
+                // side is never visually empty.
+                return appendIfFits(next, replacementId, draws, emptySide);
+            });
+            // Belt-and-braces: if animationend never fires (hidden tab, HMR)
+            // the star is removed anyway. No-op for an id already gone.
+            setTimer(id, LEAVE_MS + 300, () => removeStarRef.current(id));
+        },
+        [setTimer, appendIfFits],
+    );
+
+    // Lifetime timers are armed from state, so an id the updaters declined to
+    // add (cap reached, no free slot) never gets a timer — and never starts a
+    // timer chain of its own.
+    useEffect(() => {
+        stars.forEach((star) => {
+            if (star.phase === 'leaving') return;
+            if (starTimers.current.has(star.id)) return;
+            setTimer(star.id, star.lifetimeMs, () =>
+                startLeavingRef.current(star.id),
+            );
+        });
+    }, [stars, setTimer]);
+
+    useEffect(() => {
+        removeStarRef.current = removeStar;
+        startLeavingRef.current = startLeaving;
+    }, [removeStar, startLeaving]);
+
+    const settleStar = useCallback((id: number) => {
+        setStars((current) =>
+            current.some((star) => star.id === id && star.phase === 'entering')
+                ? current.map((star) =>
+                      star.id === id
+                          ? { ...star, phase: 'settled' as const }
+                          : star,
+                  )
+                : current,
+        );
+    }, []);
+
+    useEffect(() => {
+        // Also resets when the tier changes, so no star keeps a width and
+        // gutter drawn for a viewport that no longer applies.
+        setStars((current) => (current.length > 0 ? [] : current));
+        if (disabled || !tier) return undefined;
+
+        let cancelled = false;
+        let spawnTimer: number;
+        const pendingTimers = starTimers.current;
+
+        const spawn = () => {
+            if (cancelled) return;
+
+            const firstDraws = drawStar();
+            const firstId = nextId.current++;
+            const secondDraws = drawStar();
+            const secondId = nextId.current++;
+
+            setStars((current) => {
+                if (current.length === 0) {
+                    // Start balanced: one star on each side.
+                    const withLeft = appendStar(
+                        current,
+                        firstId,
+                        firstDraws,
+                        'left',
+                        tier,
+                    );
+                    return appendStar(
+                        withLeft,
+                        secondId,
+                        secondDraws,
+                        'right',
+                        tier,
+                    );
+                }
+                return appendStar(
+                    current,
+                    firstId,
+                    firstDraws,
+                    emptySideOf(current),
+                    tier,
+                );
+            });
+            spawnTimer = window.setTimeout(spawn, randomBetween(450, 1400));
+        };
+
+        spawnTimer = window.setTimeout(spawn, 500);
+        return () => {
+            cancelled = true;
+            window.clearTimeout(spawnTimer);
+            pendingTimers.forEach((timer) => window.clearTimeout(timer));
+            pendingTimers.clear();
+        };
+    }, [tier, disabled]);
+
+    if (disabled) return null;
+
+    return (
+        <Box className={classes.sky} inert aria-hidden>
+            {stars.map((star) => (
+                <Box
+                    key={star.id}
+                    className={`${classes.star} ${star.className} ${phaseClass(
+                        star.phase,
+                    )}`}
+                    style={star.style}
+                    data-side={star.slot.side}
+                    data-star-def={star.defKey}
+                    data-star-phase={star.phase}
+                    onAnimationEnd={(event) => {
+                        if (event.target !== event.currentTarget) return;
+                        if (star.phase === 'leaving') {
+                            removeStar(star.id);
+                        } else if (star.phase === 'entering') {
+                            // Drop the animation so the settled card is
+                            // painted, not resampled from a compositor layer.
+                            settleStar(star.id);
+                        }
+                    }}
+                >
+                    {STAR_DEF_MAP.get(star.defKey)?.render(star.seed) ?? null}
+                </Box>
+            ))}
+        </Box>
+    );
+};
+
+export default HomepageStars;

--- a/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.test.tsx
@@ -1,0 +1,76 @@
+import { MantineProvider } from '@mantine-8/core';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import NoProjectHomepage from './NoProjectHomepage';
+
+const state = vi.hoisted(() => ({ needsProject: true }));
+
+vi.mock('../../../providers/App/useApp', () => ({
+    default: () => ({ user: { data: { firstName: 'Ada' } } }),
+}));
+
+vi.mock('../../../hooks/organization/useOrganization', () => ({
+    useOrganization: () => ({
+        data: { needsProject: state.needsProject },
+        isInitialLoading: false,
+    }),
+}));
+
+vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: () => ({
+        data: { enabled: true },
+        isLoading: false,
+    }),
+}));
+
+vi.mock('./blocks/useRecommendedActions', () => ({
+    useRecommendedActions: () => ({ hasPendingActions: false }),
+}));
+
+vi.mock('./DayOneAskInput', () => ({
+    DayOneAskInput: () => <div data-testid="ask-input" />,
+}));
+
+vi.mock('./HomepageStars', () => ({
+    default: () => <div data-testid="homepage-stars" />,
+}));
+
+const renderHomepage = () =>
+    render(
+        <MantineProvider>
+            <MemoryRouter initialEntries={['/get-started']}>
+                <Routes>
+                    <Route
+                        path="/get-started"
+                        element={<NoProjectHomepage />}
+                    />
+                    <Route path="/" element={<div>redirected</div>} />
+                </Routes>
+            </MemoryRouter>
+        </MantineProvider>,
+    );
+
+describe('NoProjectHomepage', () => {
+    beforeEach(() => {
+        state.needsProject = true;
+    });
+
+    it('renders the decorative sky on the stage that holds the hero', () => {
+        renderHomepage();
+
+        const sky = screen.getByTestId('homepage-stars');
+        const stage = sky.parentElement!;
+        // The sky is absolutely positioned, so it and the hero must share a
+        // positioned stage — otherwise it paints over the greeting.
+        expect(stage.className).toContain('heroStage');
+        expect(stage).toContainElement(screen.getByTestId('ask-input'));
+    });
+
+    it('redirects away once the organization has a project', () => {
+        state.needsProject = false;
+        renderHomepage();
+
+        expect(screen.getByText('redirected')).toBeInTheDocument();
+        expect(screen.queryByTestId('homepage-stars')).toBeNull();
+    });
+});

--- a/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.tsx
@@ -11,6 +11,7 @@ import { useRecommendedActions } from './blocks/useRecommendedActions';
 import { DayOneAskInput } from './DayOneAskInput';
 import { getGreeting } from './greeting';
 import layout from './homepageLayout.module.css';
+import HomepageStars from './HomepageStars';
 
 const NoProjectHomepage: FC = () => {
     const { user } = useApp();
@@ -32,8 +33,9 @@ const NoProjectHomepage: FC = () => {
 
     return (
         <Box className={layout.page}>
-            <Box className={layout.heroSection}>
-                <Box className={layout.hero}>
+            <Box className={`${layout.heroSection} ${layout.heroStage}`}>
+                <HomepageStars />
+                <Box className={`${layout.hero} ${layout.heroStageContent}`}>
                     <Stack gap={16} align="center" w="100%">
                         <Text
                             component="h1"

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/RecommendedActionsChecklist.tsx
@@ -173,7 +173,10 @@ const ActionRow: FC<{
                         onClick={() =>
                             track({
                                 name: EventName.HOMEPAGE_RECOMMENDED_ACTION_CLICKED,
-                                properties: { actionKey },
+                                properties: {
+                                    actionKey,
+                                    destination: status.url,
+                                },
                             })
                         }
                     >

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
@@ -1,4 +1,8 @@
-import { ProjectType, type OrganizationProject } from '@lightdash/common';
+import {
+    FeatureFlags,
+    ProjectType,
+    type OrganizationProject,
+} from '@lightdash/common';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useGithubConfig } from '../../../../components/common/GithubIntegration/hooks/useGithubIntegration';
 import { useGitlabRepositories } from '../../../../components/common/GitlabIntegration/hooks/useGitlabIntegration';
@@ -6,6 +10,7 @@ import { useOrganization } from '../../../../hooks/organization/useOrganization'
 import { useGetSlack } from '../../../../hooks/slack/useSlack';
 import { useProject } from '../../../../hooks/useProject';
 import { useProjects } from '../../../../hooks/useProjects';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../providers/App/useApp';
 import { useRecommendedActions } from './useRecommendedActions';
 
@@ -20,6 +25,7 @@ vi.mock('../../../../hooks/slack/useSlack');
 vi.mock('../../../../hooks/useProject');
 vi.mock('../../../../hooks/useProjects');
 vi.mock('../../../../providers/App/useApp');
+vi.mock('../../../../hooks/useServerOrClientFeatureFlag');
 
 const organizationProject = (
     overrides: Partial<OrganizationProject>,
@@ -64,6 +70,9 @@ describe('useRecommendedActions', () => {
             data: undefined,
             isSuccess: false,
         } as ReturnType<typeof useGetSlack>);
+        vi.mocked(useServerFeatureFlag).mockReturnValue({
+            data: undefined,
+        } as ReturnType<typeof useServerFeatureFlag>);
         localStorage.clear();
     });
 
@@ -151,6 +160,66 @@ describe('useRecommendedActions', () => {
             expect(
                 result.current.statuses['connect-warehouse'].isComplete,
             ).toBe(true);
+        });
+    });
+
+    describe('add-semantic-layer destination', () => {
+        it('links to the agent setup flow when both flags are enabled', () => {
+            vi.mocked(useServerFeatureFlag).mockImplementation(
+                () =>
+                    ({
+                        data: { enabled: true },
+                    }) as ReturnType<typeof useServerFeatureFlag>,
+            );
+
+            const { result } = renderHook(() =>
+                useRecommendedActions('project-uuid'),
+            );
+
+            expect(
+                result.current.statuses['add-semantic-layer'].url,
+            ).toStrictEqual('/createProject/agent');
+        });
+
+        it('keeps the settings link when coding-agent onboarding is disabled', () => {
+            vi.mocked(useServerFeatureFlag).mockImplementation(
+                (flag) =>
+                    ({
+                        data: { enabled: flag === FeatureFlags.NewOnboarding },
+                    }) as ReturnType<typeof useServerFeatureFlag>,
+            );
+
+            const { result } = renderHook(() =>
+                useRecommendedActions('project-uuid'),
+            );
+
+            expect(
+                result.current.statuses['add-semantic-layer'].url,
+            ).toStrictEqual(
+                '/generalSettings/projectManagement/project-uuid/settings',
+            );
+        });
+
+        it('keeps the settings link when new-onboarding is disabled', () => {
+            vi.mocked(useServerFeatureFlag).mockImplementation(
+                (flag) =>
+                    ({
+                        data: {
+                            enabled:
+                                flag === FeatureFlags.CodingAgentOnboarding,
+                        },
+                    }) as ReturnType<typeof useServerFeatureFlag>,
+            );
+
+            const { result } = renderHook(() =>
+                useRecommendedActions('project-uuid'),
+            );
+
+            expect(
+                result.current.statuses['add-semantic-layer'].url,
+            ).toStrictEqual(
+                '/generalSettings/projectManagement/project-uuid/settings',
+            );
         });
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    FeatureFlags,
     DbtProjectType,
     DbtProjectTypeLabels,
     ProjectType,
@@ -16,6 +17,7 @@ import { useOrganization } from '../../../../hooks/organization/useOrganization'
 import { useGetSlack } from '../../../../hooks/slack/useSlack';
 import { useProject } from '../../../../hooks/useProject';
 import { useProjects } from '../../../../hooks/useProjects';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../providers/App/useApp';
 import { isPlaygroundProvisioningSource } from '../../../../utils/playgroundProject';
 import {
@@ -41,6 +43,13 @@ const useActionStatuses = (
     const { data: projects } = useProjects();
     const { data: githubConfig } = useGithubConfig();
     const { data: slack, isSuccess: isSlackSuccess } = useGetSlack();
+    const newOnboardingFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
+    const codingAgentOnboardingFlag = useServerFeatureFlag(
+        FeatureFlags.CodingAgentOnboarding,
+    );
+    const hasAgentSemanticLayerEntry =
+        newOnboardingFlag.data?.enabled === true &&
+        codingAgentOnboardingFlag.data?.enabled === true;
 
     const hasGithub = !!health.data?.hasGithub;
     const hasGitlab = !!health.data?.hasGitlab;
@@ -88,7 +97,9 @@ const useActionStatuses = (
                 ? DbtProjectTypeLabels[dbtConnection.type]
                 : null,
             doneIcon: null,
-            url: `/generalSettings/projectManagement/${projectUuid}/settings`,
+            url: hasAgentSemanticLayerEntry
+                ? '/createProject/agent'
+                : `/generalSettings/projectManagement/${projectUuid}/settings`,
         },
         'connect-source-control': {
             isVisible: hasGithub || hasGitlab,

--- a/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
+++ b/packages/frontend/src/ee/features/homepageBuilder/homepageLayout.module.css
@@ -5,10 +5,24 @@
 
 .page {
     --homepage-favbar-height: 48px;
+    /* Read by anything positioned relative to the hero — see HomepageStars. */
+    --homepage-hero-width: 720px;
+    --homepage-page-padding-x: 24px;
 
     display: flex;
     flex-direction: column;
-    padding: 24px 24px 48px;
+    padding: 24px var(--homepage-page-padding-x) 48px;
+}
+
+/* Anything absolutely positioned behind the hero (see HomepageStars) needs
+ * this pair: the section is its containing block, the hero sits above it. */
+.heroStage {
+    position: relative;
+}
+
+.heroStageContent {
+    position: relative;
+    z-index: 1;
 }
 
 .heroSection {
@@ -68,7 +82,7 @@
 
 .hero {
     width: 100%;
-    max-width: 720px;
+    max-width: var(--homepage-hero-width);
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -127,6 +127,7 @@ export type HomepageRecommendedActionClickedEvent = {
     name: EventName.HOMEPAGE_RECOMMENDED_ACTION_CLICKED;
     properties: {
         actionKey: HomepageRecommendedActionKey;
+        destination: string;
     };
 };
 

--- a/packages/frontend/src/types/Events.test.ts
+++ b/packages/frontend/src/types/Events.test.ts
@@ -1,0 +1,272 @@
+import { EventName, PageName } from './Events';
+
+// Analytics names are a contract with the warehouse, not just code: a wrong
+// value still typechecks, still ships, and only ever shows up as a missing or
+// misnamed event in the data. Adding a name means adding it here in the same
+// change, so the contract gets reviewed.
+const SHIPPED_EVENT_NAMES = [
+    'homepage_quick_action.clicked',
+    'homepage_recommended_action.clicked',
+    'homepage_recommended_action.skipped',
+    'revoke_invites_button.clicked',
+    'invite_users_to_organisation_button.clicked',
+    'run_query_button.clicked',
+    'add_column_button.click',
+    'create_table_calculation_button.click',
+    'format_metric_button.click',
+    'create_quick_table_calculation_button.click',
+    'edit_table_calculation_button.click',
+    'update_table_calculation_button.click',
+    'delete_table_calculation_button.click',
+    'confirm_delete_table_calculation_button.click',
+    'formula_table_calculation_ai_generate.clicked',
+    'update_project_button.click',
+    'create_project_button.click',
+    'create_project.failed',
+    'refresh_dbt_connection_button.click',
+    'update_project_tables_configuration.click',
+    'update_dashboard_name.click',
+    'documentation_button.click',
+    'try_demo.clicked',
+    'create_project_cli_button.click',
+    'create_project_manually_click.click',
+    'create_project_agent_button.click',
+    'create_project_warehouse_button.click',
+    'create_project_cli_sso_option.click',
+    'copy_create_project_code_click.click',
+    'onboarding_step.click',
+    'landing_run_query.click',
+    'setup_step.click',
+    'add_filter.click',
+    'dashboard_filter_lock.toggled',
+    'dashboard_filter_requirements.saved',
+    'go_to_link.click',
+    'add_custom_metric.click',
+    'remove_custom_metric.click',
+    'notifications.clicked',
+    'notifications_item.clicked',
+    'notifications_read_more.clicked',
+    'embed_download_csv.clicked',
+    'embed_download_image.clicked',
+    'ownload_image.clicked',
+    'custom_axis_range_toggle_clicked',
+    'create_project_access.clicked',
+    'search_result.clicked',
+    'global_search.open',
+    'global_search.closed',
+    'cross_filtering_apply.click',
+    'usage_analytics_clicked',
+    'view_underlying_data.clicked',
+    'drill_by.clicked',
+    'send_now_button.clicked',
+    'add_custom_dimension.clicked',
+    'date_zoom.clicked',
+    'comments.clicked',
+    'notifications_comments_item.clicked',
+    'dashboard_auto_refresh.updated',
+    'metrics_catalog.clicked',
+    'metrics_catalog_search.applied',
+    'metrics_catalog_chart_usage.clicked',
+    'metrics_catalog_chart_usage_chart.clicked',
+    'metrics_catalog_explore.clicked',
+    'metrics_catalog_category.clicked',
+    'metrics_catalog_category_filter.applied',
+    'metrics_catalog_icon.applied',
+    'metrics_catalog_explore_compare.last_period',
+    'metrics_catalog_explore_compare.another_metric',
+    'metrics_catalog_explore_date_filter.applied',
+    'metrics_catalog_explore_granularity.applied',
+    'metrics_catalog_explore_segment_by.applied',
+    'metrics_catalog_explore_time_dimension_override.applied',
+    'metrics_catalog_trees_edge.created',
+    'metrics_catalog_trees_edge.removed',
+    'metrics_catalog_trees_canvas_mode.clicked',
+    'write_back_from_custom_metric.clicked',
+    'write_back_from_custom_metric_header.clicked',
+    'write_back_from_custom_dimension.clicked',
+    'write_back_from_custom_dimension_header.clicked',
+    'custom_fields_replacement.applied',
+    'dashboard_chart.loaded',
+    'space_breadcrumb.clicked',
+    'ai_agent_chart_how_its_calculated.clicked',
+    'ai_agent_chart.created',
+    'ai_agent_chart.explored',
+    'ai_agent_ask.clicked',
+    'ai_agent_chat.minimized',
+    'ai_agent.suggestion_impression',
+    'ai_agent.suggestion_click',
+    'theme.toggled',
+    'dashboard_ui_version.toggled',
+    'signup_form.submitted',
+    'otp.resend_clicked',
+    'login_flow.method_selected',
+    'organization_setup_step.completed',
+    'organization_brand.detected',
+    'onboarding_warehouse.selected',
+    'bigquery_sso.signin_clicked',
+    'bigquery_sso.signin_completed',
+    'snowflake_cli_sso.command_copied',
+    'setup_invite.sent',
+    'playground_project.entered',
+    'onboarding_project_ready.start_exploring_clicked',
+    'homepage_ask.submitted',
+    'homepage_recommended_action.impression',
+    'homepage_recommended_action.restored',
+    'agent_setup_prompt.copied',
+    'create_project_columns_defined_button.click',
+];
+
+const SHIPPED_PAGE_NAMES = [
+    'welcome',
+    'register',
+    'login',
+    'password_recovery',
+    'password_reset',
+    'signup',
+    'explorer',
+    'home',
+    'explore_tables',
+    'saved_charts',
+    'saved_chart_explorer',
+    'chart_history',
+    'dashboard_history',
+    'project_settings',
+    'profile_settings',
+    'general_settings',
+    'password_settings',
+    'organization_settings',
+    'user_management_settings',
+    'project_management_settings',
+    'invite_management_settings',
+    'project_add_user',
+    'project_add_group_access',
+    'project_manage_group_access',
+    'project_update_group_access',
+    'about_lightdash',
+    'create_project',
+    'create_project_settings',
+    'saved_dashboards',
+    'DASHBOARD',
+    'SQL_RUNNER',
+    'SOURCE_CODE',
+    'SEMANTIC_VIEWER_VIEW',
+    'SEMANTIC_VIEWER_EDIT',
+    'social_login_settings',
+    'appearance_settings',
+    'access_tokens',
+    'agent_onboarding_run',
+    'no_access',
+    'no_project_access',
+    'space',
+    'spaces',
+    'share',
+    'user_activity',
+    'verify_email',
+    'join_organization',
+    'organization_setup',
+    'onboarding_data_source',
+    'onboarding_invite_expert',
+    'onboarding_project_ready',
+    'no_project_homepage',
+    'embed_dashboard',
+    'embed_saved_chart',
+    'embed_explore',
+    'embed_data_app',
+    'catalog',
+    'metrics_catalog',
+    'funnel_builder',
+];
+
+// Names that predate the convention below, including one misspelling that is
+// deliberately kept. Never add to these lists.
+const LEGACY_EVENT_NAMES = new Set([
+    'invite_users_to_organisation_button.clicked',
+    'add_column_button.click',
+    'create_table_calculation_button.click',
+    'format_metric_button.click',
+    'create_quick_table_calculation_button.click',
+    'edit_table_calculation_button.click',
+    'update_table_calculation_button.click',
+    'delete_table_calculation_button.click',
+    'confirm_delete_table_calculation_button.click',
+    'update_project_button.click',
+    'create_project_button.click',
+    'refresh_dbt_connection_button.click',
+    'update_project_tables_configuration.click',
+    'update_dashboard_name.click',
+    'documentation_button.click',
+    'create_project_cli_button.click',
+    'create_project_manually_click.click',
+    'create_project_agent_button.click',
+    'create_project_warehouse_button.click',
+    'create_project_cli_sso_option.click',
+    'copy_create_project_code_click.click',
+    'onboarding_step.click',
+    'landing_run_query.click',
+    'setup_step.click',
+    'add_filter.click',
+    'go_to_link.click',
+    'add_custom_metric.click',
+    'remove_custom_metric.click',
+    'ownload_image.clicked',
+    'create_project_access.clicked',
+    'cross_filtering_apply.click',
+    'send_now_button.clicked',
+    'create_project_columns_defined_button.click',
+]);
+
+const LEGACY_PAGE_NAMES = new Set([
+    'saved_charts',
+    'saved_chart_explorer',
+    'DASHBOARD',
+    'SQL_RUNNER',
+    'SOURCE_CODE',
+    'SEMANTIC_VIEWER_VIEW',
+    'SEMANTIC_VIEWER_EDIT',
+    'appearance_settings',
+]);
+
+const conventionalValue = (key: string) => key.toLowerCase();
+
+const asKeyValue = ([key, value]: [string, string]) => ({
+    key,
+    value: value.replace(/\./g, '_'),
+});
+
+describe('analytics names', () => {
+    it('emits only reviewed event names', () => {
+        expect(new Set(Object.values(EventName))).toEqual(
+            new Set(SHIPPED_EVENT_NAMES),
+        );
+    });
+
+    it('emits only reviewed page names', () => {
+        expect(new Set(Object.values(PageName))).toEqual(
+            new Set(SHIPPED_PAGE_NAMES),
+        );
+    });
+
+    it('derives new event names from their key', () => {
+        Object.entries(EventName)
+            .filter(([, value]) => !LEGACY_EVENT_NAMES.has(value))
+            .forEach((entry) => {
+                const { key, value } = asKeyValue(entry);
+                expect({ key, value }).toEqual({
+                    key,
+                    value: conventionalValue(key),
+                });
+            });
+    });
+
+    it('derives new page names from their key', () => {
+        Object.entries(PageName)
+            .filter(([, value]) => !LEGACY_PAGE_NAMES.has(value))
+            .forEach((entry) => {
+                const { key, value } = asKeyValue(entry);
+                expect({ key, value }).toEqual({
+                    key,
+                    value: conventionalValue(key),
+                });
+            });
+    });
+});

--- a/packages/frontend/src/types/Events.test.ts
+++ b/packages/frontend/src/types/Events.test.ts
@@ -167,6 +167,7 @@ const SHIPPED_PAGE_NAMES = [
     'onboarding_data_source',
     'onboarding_invite_expert',
     'onboarding_project_ready',
+    'agent_onboarding_run',
     'no_project_homepage',
     'embed_dashboard',
     'embed_saved_chart',

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -125,6 +125,7 @@ export enum EventName {
     EMBED_DOWNLOAD_CSV_CLICKED = 'embed_download_csv.clicked',
     EMBED_DOWNLOAD_IMAGE_CLICKED = 'embed_download_image.clicked',
 
+    // Misspelt since 2024; kept so the warehouse history stays in one piece.
     DOWNLOAD_IMAGE_CLICKED = 'ownload_image.clicked',
     CUSTOM_AXIS_RANGE_TOGGLE_CLICKED = 'custom_axis_range_toggle_clicked',
     CREATE_PROJECT_ACCESS_BUTTON_CLICKED = 'create_project_access.clicked',

--- a/packages/query-sdk/package.json
+++ b/packages/query-sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightdash/query-sdk",
-    "version": "0.3453.0",
+    "version": "0.3454.0",
     "private": false,
     "type": "module",
     "description": "SDK for building custom data apps against the Lightdash semantic layer",

--- a/packages/warehouses/package.json
+++ b/packages/warehouses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash/warehouses",
-  "version": "0.3453.0",
+  "version": "0.3454.0",
   "description": "Warehouse connectors for Lightdash",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Test-only fix. The analytics vocabulary-freeze test asserts every `PageName` member appears in the `SHIPPED_PAGE_NAMES` allowlist. #25902 added `PageName.agent_onboarding_run` without an allowlist entry, so the test fails on every branch containing both changes. This adds the missing entry.

Sits at the bottom of the capability-gating stack so the branches above it are independently green.

Linear: PROD-9153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKCp9N1DsA9jR8qiLg3wsa