### PR TITLE
fix: gate email-only signup enrollment on SMTP capability

### DIFF
--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -416,9 +416,31 @@ describe('UserService', () => {
 
         test('registers an email-only user when the feature is enabled', async () => {
             const featureFlagModel = createFeatureFlagModel(true);
-            const service = createUserService(lightdashConfigMock, {
-                featureFlagModel,
-            });
+            const service = createUserService(
+                {
+                    ...lightdashConfigMock,
+                    smtp: {
+                        host: 'localhost',
+                        port: 587,
+                        secure: false,
+                        allowInvalidCertificate: false,
+                        useAuth: false,
+                        auth: {
+                            user: '',
+                            pass: undefined,
+                            accessToken: undefined,
+                        },
+                        sender: {
+                            name: 'Lightdash',
+                            email: 'lightdash@example.com',
+                        },
+                        inlineImageCid: false,
+                    },
+                },
+                {
+                    featureFlagModel,
+                },
+            );
             const loginMethodAllowedSpy = vi
                 .spyOn(service, 'isLoginMethodAllowed')
                 .mockResolvedValue(true);
@@ -462,6 +484,28 @@ describe('UserService', () => {
                     isOrganizationCreator: true,
                 },
             });
+        });
+
+        test('rejects an email-only user without an email server', async () => {
+            const featureFlagModel = createFeatureFlagModel(true);
+            const service = createUserService(
+                { ...lightdashConfigMock, smtp: undefined },
+                {
+                    featureFlagModel,
+                },
+            );
+
+            await expect(
+                service.registerOrActivateUser({
+                    email: 'email-only@example.com',
+                }),
+            ).rejects.toThrow(
+                new ForbiddenError(
+                    'Email-only signup requires an email server to be configured',
+                ),
+            );
+
+            expect(userModel.createUser).not.toHaveBeenCalled();
         });
 
         test('rejects an email-only user when the feature is disabled', async () => {

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1764,6 +1764,11 @@ export class UserService extends BaseService {
             if (onboardingFlow !== 'new') {
                 throw new ForbiddenError('Email-only signup is not enabled');
             }
+            if (!this.lightdashConfig.smtp) {
+                throw new ForbiddenError(
+                    'Email-only signup requires an email server to be configured',
+                );
+            }
 
             await this.checkNewUserRegistrationAllowed(undefined, user.email);
 

--- a/packages/frontend/src/pages/Register.test.tsx
+++ b/packages/frontend/src/pages/Register.test.tsx
@@ -1,0 +1,47 @@
+import { FeatureFlags } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+import { renderWithProviders } from '../testing/testUtils';
+import Register from './Register';
+
+vi.mock('../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: vi.fn(),
+}));
+
+const renderRegister = (hasEmailClient: boolean) =>
+    renderWithProviders(
+        <MemoryRouter>
+            <Register />
+        </MemoryRouter>,
+        { health: { hasEmailClient } },
+    );
+
+describe('Register', () => {
+    beforeEach(() => {
+        vi.mocked(useServerFeatureFlag).mockReturnValue({
+            data: { id: FeatureFlags.NewOnboarding, enabled: true },
+            isLoading: false,
+        } as ReturnType<typeof useServerFeatureFlag>);
+    });
+
+    it('renders the classic signup form without an email client', async () => {
+        renderRegister(false);
+
+        expect(await screen.findByLabelText(/First name/)).toBeInTheDocument();
+        expect(screen.getByLabelText(/Last name/)).toBeInTheDocument();
+        expect(screen.getByLabelText(/Password/)).toBeInTheDocument();
+    });
+
+    it('renders the email-only signup form with an email client', async () => {
+        renderRegister(true);
+
+        expect(
+            await screen.findByLabelText(/Email address/),
+        ).toBeInTheDocument();
+        expect(screen.queryByLabelText(/First name/)).not.toBeInTheDocument();
+        expect(screen.queryByLabelText(/Last name/)).not.toBeInTheDocument();
+        expect(screen.queryByLabelText(/Password/)).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -85,7 +85,9 @@ const Register: FC = () => {
         return <PageSpinner />;
     }
 
-    const isEmailOnlySignup = emailOnlySignupFlag.data?.enabled ?? false;
+    const isEmailOnlySignup =
+        (emailOnlySignupFlag.data?.enabled ?? false) &&
+        !!health.data?.hasEmailClient;
 
     const ssoAvailable =
         health.data?.auth.google.enabled ||


### PR DESCRIPTION
With `new-onboarding` enabled, the register page always offered email-only signup, even on instances with no SMTP configured. An account created that way has no password and no SSO identity; its only login path is an email OTP that silently never sends (`EmailClient.sendEmail` is a no-op without a transporter), so once the session ends the account is permanently locked out.

This gates email-only **enrollment** on the instance's email capability, on both sides:

- `UserService.registerOrActivateUser` now rejects email-only registration with a `ForbiddenError` when no SMTP is configured (mirrors how health computes `hasEmailClient`).
- The register page requires `health.hasEmailClient` before offering the email-only form, falling back to the classic password form otherwise.

OTP **login** for existing passwordless users is deliberately untouched — the flag's enrollment-vs-login distinction is preserved.

Tests: backend rejection + success paths updated for the SMTP dimension; new frontend test asserting the form fallback.

Linear: PROD-9116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKCp9N1DsA9jR8qiLg3wsa