### PR TITLE
fix: org-setup redirect gates on health loaded, not telemetry enabled

### DIFF
--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.test.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.test.tsx
@@ -341,4 +341,37 @@ describe('UserCompletionModal', () => {
         ).toBeInTheDocument();
         expect(screen.queryByText('Nearly there...')).not.toBeInTheDocument();
     });
+
+    it('still redirects to organization setup when telemetry is disabled', async () => {
+        mockFeatureFlag(true);
+
+        renderWithProviders(
+            <MemoryRouter initialEntries={['/']}>
+                <Routes>
+                    <Route path="/" element={<UserCompletionModal />} />
+                    <Route
+                        path="/organization-setup"
+                        element={<div>Organization setup page</div>}
+                    />
+                </Routes>
+            </MemoryRouter>,
+            {
+                user: {
+                    isSetupComplete: false,
+                    organizationName: '',
+                },
+                health: {
+                    rudder: {
+                        writeKey: undefined,
+                        dataPlaneUrl: undefined,
+                    },
+                },
+            },
+        );
+
+        expect(
+            await screen.findByText('Organization setup page'),
+        ).toBeInTheDocument();
+        expect(screen.queryByText('Nearly there...')).not.toBeInTheDocument();
+    });
 });

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
@@ -187,9 +187,7 @@ const UserCompletionModalWithUser = () => {
 
     if (orgSetupPageFlag.data?.enabled) {
         const shouldSetup =
-            user.data &&
-            !user.data.isSetupComplete &&
-            health.data?.rudder.writeKey !== undefined;
+            user.data && !user.data.isSetupComplete && health.isSuccess;
         // Keyed by pathname so the redirect re-fires if a competing route
         // redirect (e.g. AppRoute's needsProject -> /createProject) wins the
         // same render commit.


### PR DESCRIPTION
The redirect into `/organization-setup` was conditioned on `health.data?.rudder.writeKey !== undefined`, which is really "telemetry is not disabled" — `rudder.writeKey` is only ever `undefined` when `RUDDERSTACK_ANALYTICS_DISABLED=true`, a common self-hosting privacy setting. On such instances the org-setup page never triggered, `isSetupComplete` stayed false forever, and the organization was never named.

The condition now tests what it always meant to test: that health has loaded (`health.isSuccess`).

The legacy `UserCompletionModal`'s own `rudder.writeKey` check is deliberately left as-is — it was an explicit product choice in #15618 and only affects the flag-off path.

Tests: new case asserting the redirect fires with telemetry disabled.

Linear: PROD-9117

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKCp9N1DsA9jR8qiLg3wsa