### PR TITLE
fix: BigQuery auth default and picker copy consult Google OAuth capability

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -34,7 +34,6 @@ import {
 } from 'react';
 import { useToggle } from 'react-use';
 import { useGoogleLoginPopup } from '../../../hooks/gdrive/useGdrive';
-import useHealth from '../../../hooks/health/useHealth';
 import {
     useBigqueryDatasets,
     useBigqueryProjectRecommendation,
@@ -42,6 +41,7 @@ import {
     useIsBigQueryAuthenticated,
 } from '../../../hooks/useBigquerySSO';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../../providers/App/useApp';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import MantineIcon from '../../common/MantineIcon';
@@ -52,7 +52,10 @@ import FormSection from '../Inputs/FormSection';
 import StartOfWeekSelect from '../Inputs/StartOfWeekSelect';
 import { useProjectFormContext } from '../useProjectFormContext';
 import classes from './BigQueryForm.module.css';
-import { largestDatasetName } from './bigQuerySso';
+import {
+    getBigqueryDefaultAuthenticationType,
+    largestDatasetName,
+} from './bigQuerySso';
 import DataTimezoneField from './DataTimezoneField';
 import { BigQueryDefaultValues } from './defaultValues';
 
@@ -264,8 +267,9 @@ const BigQueryForm: FC<{
     const hasAppliedProjectRecommendation = useRef(false);
     const [debouncedProject] = useDebouncedValue(project.value, 300);
     const { savedProject } = useProjectFormContext();
-    const health = useHealth();
+    const { health } = useApp();
     const isAdcEnabled = health.data?.auth.google?.enableGCloudADC;
+    const isGoogleSsoAvailable = health.data?.auth.google?.enabled ?? false;
     // Fetching databases can only happen if user is authenticated
     // if user authenticates, and change to private_key
     // We will not make any queries, in case private_key is different
@@ -318,13 +322,16 @@ const BigQueryForm: FC<{
         !isSso || isAuthenticated || isSavedBigquerySsoProject;
 
     // savedProject might not be loaded when the form is rendered, so we need to set the defaultValue also on a hook
-    const defaultAuthenticationType = BigqueryAuthenticationType.SSO;
+    const defaultAuthenticationType =
+        getBigqueryDefaultAuthenticationType(isGoogleSsoAvailable);
 
     const warehouseConnectFlag = useServerFeatureFlag(
         FeatureFlags.NewOnboarding,
     );
     const shouldDefaultToSso =
-        !savedProject && (warehouseConnectFlag.data?.enabled ?? false);
+        !savedProject &&
+        (warehouseConnectFlag.data?.enabled ?? false) &&
+        isGoogleSsoAvailable;
     useEffect(() => {
         if (shouldDefaultToSso && !form.isTouched()) {
             form.setFieldValue(
@@ -427,7 +434,7 @@ const BigQueryForm: FC<{
             value: BigqueryAuthenticationType.PRIVATE_KEY,
             label: 'Service Account (JSON key file)',
         },
-        {
+        (isGoogleSsoAvailable || isSavedBigquerySsoProject) && {
             value: BigqueryAuthenticationType.SSO,
             label: 'User Account (Sign in with Google)',
         },

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/bigQuerySso.test.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/bigQuerySso.test.ts
@@ -1,4 +1,22 @@
-import { largestDatasetName } from './bigQuerySso';
+import { BigqueryAuthenticationType } from '@lightdash/common';
+import {
+    getBigqueryDefaultAuthenticationType,
+    largestDatasetName,
+} from './bigQuerySso';
+
+describe('getBigqueryDefaultAuthenticationType', () => {
+    it('defaults to SSO when the instance has google oauth configured', () => {
+        expect(getBigqueryDefaultAuthenticationType(true)).toBe(
+            BigqueryAuthenticationType.SSO,
+        );
+    });
+
+    it('defaults to a service account key when google oauth is missing', () => {
+        expect(getBigqueryDefaultAuthenticationType(false)).toBe(
+            BigqueryAuthenticationType.PRIVATE_KEY,
+        );
+    });
+});
 
 describe('largestDatasetName', () => {
     it('returns the largest dataset with a positive known size', () => {

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/bigQuerySso.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/bigQuerySso.ts
@@ -1,4 +1,14 @@
-import { type BigqueryDataset } from '@lightdash/common';
+import {
+    BigqueryAuthenticationType,
+    type BigqueryDataset,
+} from '@lightdash/common';
+
+export const getBigqueryDefaultAuthenticationType = (
+    isGoogleSsoAvailable: boolean,
+): BigqueryAuthenticationType =>
+    isGoogleSsoAvailable
+        ? BigqueryAuthenticationType.SSO
+        : BigqueryAuthenticationType.PRIVATE_KEY;
 
 export const largestDatasetName = (
     datasets: BigqueryDataset[],

--- a/packages/frontend/src/pages/OnboardingDataSource.test.tsx
+++ b/packages/frontend/src/pages/OnboardingDataSource.test.tsx
@@ -1,0 +1,72 @@
+import { FeatureFlags, type HealthState } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+import { renderWithProviders } from '../testing/testUtils';
+import OnboardingDataSource from './OnboardingDataSource';
+
+vi.mock('../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: vi.fn(),
+}));
+
+const healthWithGoogleAuth = (enabled: boolean): Partial<HealthState> => ({
+    auth: {
+        disablePasswordAuthentication: false,
+        google: {
+            oauth2ClientId: enabled ? 'client-id' : undefined,
+            loginPath: '/login/google',
+            googleDriveApiKey: undefined,
+            enabled,
+            enableGCloudADC: false,
+        },
+        okta: { enabled: false, loginPath: '/login/okta' },
+        oneLogin: { enabled: false, loginPath: '/login/oneLogin' },
+        azuread: { enabled: false, loginPath: '/login/azuread' },
+        oidc: { enabled: false, loginPath: '/login/oidc' },
+        pat: { maxExpirationTimeInDays: undefined },
+        snowflake: { enabled: false },
+        databricks: { enabled: false },
+    },
+});
+
+const renderDataSourcePicker = (isGoogleAuthEnabled: boolean) =>
+    renderWithProviders(
+        <MemoryRouter>
+            <OnboardingDataSource />
+        </MemoryRouter>,
+        { health: healthWithGoogleAuth(isGoogleAuthEnabled) },
+    );
+
+describe('OnboardingDataSource', () => {
+    beforeEach(() => {
+        vi.mocked(useServerFeatureFlag).mockReturnValue({
+            data: { id: FeatureFlags.NewOnboarding, enabled: true },
+            isLoading: false,
+        } as ReturnType<typeof useServerFeatureFlag>);
+    });
+
+    it('advertises google sign-in for BigQuery when google auth is configured', async () => {
+        renderDataSourcePicker(true);
+
+        expect(
+            await screen.findByText('Sign in with Google to connect'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText('Connect with a service account'),
+        ).not.toBeInTheDocument();
+        expect(screen.getByText('Connect with SSO')).toBeInTheDocument();
+    });
+
+    it('advertises a service account for BigQuery when google auth is not configured', async () => {
+        renderDataSourcePicker(false);
+
+        expect(
+            await screen.findByText('Connect with a service account'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText('Sign in with Google to connect'),
+        ).not.toBeInTheDocument();
+        expect(screen.getByText('Connect with SSO')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/pages/OnboardingDataSource.tsx
+++ b/packages/frontend/src/pages/OnboardingDataSource.tsx
@@ -29,6 +29,7 @@ import {
 import { ProjectFormProvider } from '../components/ProjectConnection/ProjectFormProvider';
 import { useOrganization } from '../hooks/organization/useOrganization';
 import { useOnboardingPageGuard } from '../hooks/useOnboardingPageGuard';
+import useApp from '../providers/App/useApp';
 import useTracking from '../providers/Tracking/useTracking';
 import { EventName } from '../types/Events';
 import classes from './OnboardingDataSource.module.css';
@@ -65,12 +66,25 @@ const popularKeys: SelectedWarehouse[] = POPULAR_WAREHOUSES.map(
     (warehouse) => warehouse.key,
 );
 
-const popularWarehouses = POPULAR_WAREHOUSES.map(({ key, subtitle }) => {
-    const label = WarehouseTypeLabels.find(
-        (warehouse) => warehouse.key === key,
-    )?.label;
-    return label ? { key, subtitle, label } : undefined;
-}).filter((warehouse) => warehouse !== undefined);
+const BIGQUERY_SERVICE_ACCOUNT_SUBTITLE = 'Connect with a service account';
+
+const getPopularWarehouses = (isGoogleSsoAvailable: boolean) =>
+    POPULAR_WAREHOUSES.map(({ key, subtitle }) => {
+        const label = WarehouseTypeLabels.find(
+            (warehouse) => warehouse.key === key,
+        )?.label;
+        if (!label) {
+            return undefined;
+        }
+        return {
+            key,
+            label,
+            subtitle:
+                key === WarehouseTypes.BIGQUERY && !isGoogleSsoAvailable
+                    ? BIGQUERY_SERVICE_ACCOUNT_SUBTITLE
+                    : subtitle,
+        };
+    }).filter((warehouse) => warehouse !== undefined);
 
 const allWarehouses = orderedWarehouses.filter(
     (warehouse) => !popularKeys.includes(warehouse.key),
@@ -105,6 +119,10 @@ const SectionHeader: FC<{ title: string; hint?: string }> = ({
 const DataSourcePicker: FC = () => {
     const navigate = useNavigate();
     const { track } = useTracking();
+    const { health } = useApp();
+    const popularWarehouses = getPopularWarehouses(
+        health.data?.auth.google.enabled ?? false,
+    );
 
     const handleSelect = (
         key: SelectedWarehouse,


### PR DESCRIPTION
Under `new-onboarding`, the data-source picker advertised "BigQuery — Sign in with Google to connect" and the BigQuery form defaulted new projects to SSO auth, with no check that the instance has Google OAuth configured. On instances without it (most self-hosted), the flagship path dead-ends at a sign-in that cannot complete.

Both surfaces now consult `health.auth.google.enabled`:

- `BigQueryForm` defaults to Service Account (JSON key file) when Google OAuth is unavailable, and only offers the SSO option when it can work (or when editing an existing SSO-connected project).
- The picker's BigQuery subtitle becomes "Connect with a service account" when SSO can't work. Snowflake's "Connect with SSO" is unchanged — its CLI-SSO path is core and needs no instance OAuth.

Tests: pure-helper coverage for the default-auth decision plus a picker test asserting the subtitle follows the capability.

Linear: PROD-9118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKCp9N1DsA9jR8qiLg3wsa