### PR TITLE
fix: day-0 get-started surfaces require copilot to match the homepage renderer

### DIFF
--- a/packages/frontend/src/components/AppRoute.test.tsx
+++ b/packages/frontend/src/components/AppRoute.test.tsx
@@ -1,0 +1,112 @@
+import { MantineProvider } from '@mantine-8/core';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import AppRoute from './AppRoute';
+
+const state = vi.hoisted(() => ({
+    needsProject: true,
+    isCopilotEnabled: true,
+    isCopilotLoading: false,
+    isHomepageBuilderEnabled: true,
+    isNewOnboardingEnabled: true,
+}));
+
+vi.mock('../providers/App/useApp', () => ({
+    default: () => ({
+        health: { isInitialLoading: false, error: null, data: {} },
+    }),
+}));
+
+vi.mock('../hooks/organization/useOrganization', () => ({
+    useOrganization: () => ({
+        data: { needsProject: state.needsProject },
+        isInitialLoading: false,
+        error: null,
+    }),
+}));
+
+vi.mock('../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: () => ({
+        data: { enabled: state.isNewOnboardingEnabled },
+        isLoading: false,
+    }),
+}));
+
+vi.mock('../ee/features/aiCopilot/hooks/useIsCopilotEnabled', () => ({
+    useIsCopilotEnabled: () => ({
+        isCopilotEnabled: state.isCopilotEnabled,
+        isLoading: state.isCopilotLoading,
+    }),
+}));
+
+vi.mock('../ee/features/homepageBuilder/hooks/useProjectHomepage', () => ({
+    useHomepageBuilderFlag: () => ({
+        isEnabled: state.isHomepageBuilderEnabled,
+        isLoading: false,
+    }),
+}));
+
+const renderAppRoute = () =>
+    render(
+        <MantineProvider>
+            <MemoryRouter initialEntries={['/']}>
+                <Routes>
+                    <Route
+                        path="/"
+                        element={
+                            <AppRoute>
+                                <div>app</div>
+                            </AppRoute>
+                        }
+                    />
+                    <Route
+                        path="/get-started"
+                        element={<div>get started</div>}
+                    />
+                    <Route
+                        path="/createProject"
+                        element={<div>create project</div>}
+                    />
+                </Routes>
+            </MemoryRouter>
+        </MantineProvider>,
+    );
+
+describe('AppRoute', () => {
+    beforeEach(() => {
+        state.needsProject = true;
+        state.isCopilotEnabled = true;
+        state.isCopilotLoading = false;
+        state.isHomepageBuilderEnabled = true;
+        state.isNewOnboardingEnabled = true;
+    });
+
+    it('sends a copilot-enabled organization to the day one homepage', () => {
+        renderAppRoute();
+
+        expect(screen.getByText('get started')).toBeInTheDocument();
+    });
+
+    it('sends a copilot-less organization straight to project creation', () => {
+        state.isCopilotEnabled = false;
+        renderAppRoute();
+
+        expect(screen.getByText('create project')).toBeInTheDocument();
+    });
+
+    it('waits for the copilot signal before routing', () => {
+        state.isCopilotEnabled = false;
+        state.isCopilotLoading = true;
+        renderAppRoute();
+
+        expect(screen.queryByText('create project')).toBeNull();
+        expect(screen.queryByText('get started')).toBeNull();
+    });
+
+    it('renders its children once the organization has a project', () => {
+        state.needsProject = false;
+        renderAppRoute();
+
+        expect(screen.getByText('app')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/AppRoute.tsx
+++ b/packages/frontend/src/components/AppRoute.tsx
@@ -1,6 +1,7 @@
 import { FeatureFlags } from '@lightdash/common';
 import { type FC } from 'react';
 import { Navigate, useLocation } from 'react-router';
+import { useIsCopilotEnabled } from '../ee/features/aiCopilot/hooks/useIsCopilotEnabled';
 import { useHomepageBuilderFlag } from '../ee/features/homepageBuilder/hooks/useProjectHomepage';
 import { useOrganization } from '../hooks/organization/useOrganization';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
@@ -14,6 +15,8 @@ const AppRoute: FC<React.PropsWithChildren> = ({ children }) => {
     const orgRequest = useOrganization();
     const homepageBuilderFlag = useHomepageBuilderFlag();
     const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
+    const { isCopilotEnabled, isLoading: isCopilotLoading } =
+        useIsCopilotEnabled();
 
     if (health.isInitialLoading || orgRequest.isInitialLoading) {
         return <PageSpinner />;
@@ -28,11 +31,16 @@ const AppRoute: FC<React.PropsWithChildren> = ({ children }) => {
     }
 
     if (orgRequest?.data?.needsProject) {
-        if (homepageBuilderFlag.isLoading || orgSetupPageFlag.isLoading) {
+        if (
+            homepageBuilderFlag.isLoading ||
+            orgSetupPageFlag.isLoading ||
+            isCopilotLoading
+        ) {
             return <PageSpinner />;
         }
         const showGetStarted =
             homepageBuilderFlag.isEnabled &&
+            isCopilotEnabled &&
             (orgSetupPageFlag.data?.enabled ?? false);
         return (
             <Navigate

--- a/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.test.tsx
@@ -3,7 +3,12 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import NoProjectHomepage from './NoProjectHomepage';
 
-const state = vi.hoisted(() => ({ needsProject: true }));
+const state = vi.hoisted(() => ({
+    needsProject: true,
+    isCopilotEnabled: true,
+    isCopilotLoading: false,
+    isHomepageBuilderEnabled: true,
+}));
 
 vi.mock('../../../providers/App/useApp', () => ({
     default: () => ({ user: { data: { firstName: 'Ada' } } }),
@@ -19,6 +24,20 @@ vi.mock('../../../hooks/organization/useOrganization', () => ({
 vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
     useServerFeatureFlag: () => ({
         data: { enabled: true },
+        isLoading: false,
+    }),
+}));
+
+vi.mock('../aiCopilot/hooks/useIsCopilotEnabled', () => ({
+    useIsCopilotEnabled: () => ({
+        isCopilotEnabled: state.isCopilotEnabled,
+        isLoading: state.isCopilotLoading,
+    }),
+}));
+
+vi.mock('./hooks/useProjectHomepage', () => ({
+    useHomepageBuilderFlag: () => ({
+        isEnabled: state.isHomepageBuilderEnabled,
         isLoading: false,
     }),
 }));
@@ -53,6 +72,9 @@ const renderHomepage = () =>
 describe('NoProjectHomepage', () => {
     beforeEach(() => {
         state.needsProject = true;
+        state.isCopilotEnabled = true;
+        state.isCopilotLoading = false;
+        state.isHomepageBuilderEnabled = true;
     });
 
     it('renders the decorative sky on the stage that holds the hero', () => {
@@ -72,5 +94,30 @@ describe('NoProjectHomepage', () => {
 
         expect(screen.getByText('redirected')).toBeInTheDocument();
         expect(screen.queryByTestId('homepage-stars')).toBeNull();
+    });
+
+    it('redirects away when the organization has no copilot', () => {
+        state.isCopilotEnabled = false;
+        renderHomepage();
+
+        expect(screen.getByText('redirected')).toBeInTheDocument();
+        expect(screen.queryByTestId('ask-input')).toBeNull();
+    });
+
+    it('redirects away when the homepage builder is disabled', () => {
+        state.isHomepageBuilderEnabled = false;
+        renderHomepage();
+
+        expect(screen.getByText('redirected')).toBeInTheDocument();
+        expect(screen.queryByTestId('ask-input')).toBeNull();
+    });
+
+    it('waits for the copilot signal before deciding', () => {
+        state.isCopilotEnabled = false;
+        state.isCopilotLoading = true;
+        renderHomepage();
+
+        expect(screen.queryByText('redirected')).toBeNull();
+        expect(screen.queryByTestId('ask-input')).toBeNull();
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/NoProjectHomepage.tsx
@@ -6,24 +6,38 @@ import PageSpinner from '../../../components/PageSpinner';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
+import { useIsCopilotEnabled } from '../aiCopilot/hooks/useIsCopilotEnabled';
 import { RecommendedActionsChecklist } from './blocks/RecommendedActionsChecklist';
 import { useRecommendedActions } from './blocks/useRecommendedActions';
 import { DayOneAskInput } from './DayOneAskInput';
 import { getGreeting } from './greeting';
 import layout from './homepageLayout.module.css';
 import HomepageStars from './HomepageStars';
+import { useHomepageBuilderFlag } from './hooks/useProjectHomepage';
 
 const NoProjectHomepage: FC = () => {
     const { user } = useApp();
     const { data: organization, isInitialLoading } = useOrganization();
     const orgSetupPageFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
+    const homepageBuilderFlag = useHomepageBuilderFlag();
+    const { isCopilotEnabled, isLoading: isCopilotLoading } =
+        useIsCopilotEnabled();
     const actions = useRecommendedActions(null);
 
-    if (isInitialLoading || orgSetupPageFlag.isLoading) {
+    if (
+        isInitialLoading ||
+        orgSetupPageFlag.isLoading ||
+        homepageBuilderFlag.isLoading ||
+        isCopilotLoading
+    ) {
         return <PageSpinner />;
     }
 
     if (!orgSetupPageFlag.data?.enabled) {
+        return <Navigate to="/" replace />;
+    }
+
+    if (!homepageBuilderFlag.isEnabled || !isCopilotEnabled) {
         return <Navigate to="/" replace />;
     }
 


### PR DESCRIPTION
The day-0 `/get-started` homepage rendered the AI ask composer with no copilot check, while the post-connect homepage (`Home.tsx`) requires `homepage-builder` **and** copilot for the builder experience. A copilot-less org was promised "Ask anything about your data…" on day 0 and then landed on the classic homepage with no AI surface.

The day-0 surfaces now agree with the renderer:

- `AppRoute` only routes no-project users to `/get-started` when the builder flag, `new-onboarding`, and copilot are all enabled (same `useIsCopilotEnabled` hook `Home.tsx` uses, so trial orgs keep working).
- `NoProjectHomepage` applies the same gates itself, so direct URLs behave like routed ones.

`provisionOnboardingHomepage` is deliberately left ungated: the provisioned homepage is invisible without copilot, the backend flag can't see trial state, and pre-provisioning means the homepage is ready if copilot is enabled later.

Tests: new AppRoute and NoProjectHomepage suites covering the copilot-less redirect and the fully-enabled render (mutation-checked against the reverted guards).

Linear: PROD-9120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKCp9N1DsA9jR8qiLg3wsa