### PR TITLE
feat: advertise playground capability in health; invite page skips unavailable provisioning

### DIFF
--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -17,6 +17,7 @@ export const BaseResponse: HealthState = {
     signupUrl: undefined,
     helpMenuUrl: undefined,
     hasEmailClient: false,
+    hasPlaygroundProjects: false,
     hasEmailWhitelabel: false,
     hasExtendedUsageAnalytics: false,
     hasMicrosoftTeams: false,

--- a/packages/backend/src/services/HealthService/HealthService.test.ts
+++ b/packages/backend/src/services/HealthService/HealthService.test.ts
@@ -72,6 +72,29 @@ describe('health', () => {
             isAuthenticated: true,
         });
     });
+
+    it('advertises playground projects only when a license key is configured', async () => {
+        expect(
+            (await healthService.getHealthState(undefined))
+                .hasPlaygroundProjects,
+        ).toBe(false);
+
+        const licensedService = new HealthService({
+            organizationModel:
+                organizationModel as unknown as OrganizationModel,
+            lightdashConfig: {
+                ...lightdashConfigMock,
+                license: { licenseKey: 'test-license-key' },
+            },
+            migrationModel: migrationModel as unknown as MigrationModel,
+            organizationSettingsModel:
+                organizationSettingsModel as unknown as OrganizationSettingsModel,
+        });
+        expect(
+            (await licensedService.getHealthState(undefined))
+                .hasPlaygroundProjects,
+        ).toBe(true);
+    });
     it('Should return localDbtEnabled false when in cloud beta mode', async () => {
         const service = new HealthService({
             organizationModel:

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -221,6 +221,11 @@ export class HealthService extends BaseService {
                 },
             },
             hasEmailClient: !!this.lightdashConfig.smtp,
+            // Deliberately not isEnterpriseEnabled(): that check is `!==
+            // undefined` against a string|null config value, so it is true
+            // even without a license. Existing consumers rely on that
+            // behaviour; this new field must not (see PROD-9154).
+            hasPlaygroundProjects: !!this.lightdashConfig.license.licenseKey,
             hasEmailWhitelabel: !!this.lightdashConfig.postmark.accountToken,
             hasHeadlessBrowser:
                 this.lightdashConfig.headlessBrowser?.host !== undefined,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -501,6 +501,11 @@ export type HealthState = {
     requiresOrgRegistration: boolean;
     hasEmailClient: boolean;
     /**
+     * Instance can provision the sample-data playground project (enterprise
+     * builds only).
+     */
+    hasPlaygroundProjects: boolean;
+    /**
      * Instance has a Postmark account token, so email whitelabelling can be
      * offered (the org still needs the EmailWhitelabel feature flag).
      */

--- a/packages/frontend/src/pages/OnboardingInviteExpert.test.tsx
+++ b/packages/frontend/src/pages/OnboardingInviteExpert.test.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
     canInvite: true,
     hasUser: true,
     needsProject: true,
+    hasPlaygroundProjects: true,
     inviteLink: undefined as InviteLink | undefined,
     createInvite: vi.fn(),
     updateUser: vi.fn(),
@@ -27,7 +28,12 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../providers/App/useApp', () => ({
     default: () => ({
-        health: { data: { hasEmailClient: true } },
+        health: {
+            data: {
+                hasEmailClient: true,
+                hasPlaygroundProjects: mocks.hasPlaygroundProjects,
+            },
+        },
         user: {
             data: mocks.hasUser
                 ? {
@@ -134,6 +140,7 @@ describe('OnboardingInviteExpert', () => {
         mocks.canInvite = true;
         mocks.hasUser = true;
         mocks.needsProject = true;
+        mocks.hasPlaygroundProjects = true;
         mocks.inviteLink = undefined;
         mocks.createInvite.mockResolvedValue({});
         mocks.updateUser.mockResolvedValue({});
@@ -302,6 +309,30 @@ describe('OnboardingInviteExpert', () => {
             expect(mocks.createInvite).toHaveBeenCalled();
         });
         expect(mocks.ensurePlayground).not.toHaveBeenCalled();
+        expect(currentPath).toBe('/onboarding/invite-expert');
+    });
+
+    it('skips provisioning when the instance has no playground projects', async () => {
+        mocks.hasPlaygroundProjects = false;
+        const { rerenderPage } = renderPage();
+        await submitInvite();
+
+        await waitFor(() => {
+            expect(mocks.createInvite).toHaveBeenCalled();
+        });
+        expect(mocks.ensurePlayground).not.toHaveBeenCalled();
+        expect(screen.queryByText(/Preparing your playground/)).toBeNull();
+
+        mocks.inviteLink = {
+            email: 'expert@example.com',
+            inviteUrl: 'https://lightdash.test/invite/abc',
+        };
+        rerenderPage();
+
+        expect(await screen.findByText('Invite ready')).toBeInTheDocument();
+        expect(
+            screen.queryByText(/couldn't set up a sample project/i),
+        ).toBeNull();
         expect(currentPath).toBe('/onboarding/invite-expert');
     });
 

--- a/packages/frontend/src/pages/OnboardingInviteExpert.tsx
+++ b/packages/frontend/src/pages/OnboardingInviteExpert.tsx
@@ -111,9 +111,11 @@ const OnboardingInviteExpert: FC = () => {
     } = useEnsurePlaygroundProject();
 
     // The flag says the flow exists, not that a playground can be provisioned:
-    // an org that already has a project would be sent into that project instead
+    // the instance must support it and the org must not already have a project
     const canOfferPlayground =
-        isNewOnboarding && organization?.needsProject === true;
+        isNewOnboarding &&
+        health.data?.hasPlaygroundProjects === true &&
+        organization?.needsProject === true;
 
     const titleRef = useRef<HTMLHeadingElement>(null);
     const hasFocusedTitleRef = useRef(false);

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -94,6 +94,7 @@ export default function mockHealthResponse(
             },
         },
         hasEmailClient: false,
+        hasPlaygroundProjects: false,
         hasEmailWhitelabel: false,
         hasHeadlessBrowser: false,
         hasExtendedUsageAnalytics: false,


### PR DESCRIPTION
The invite-an-expert page fires `POST /org/playground-projects/ensure` after sending the invite and infers playground availability from the caught error — on instances that can't provision playgrounds the user watches "Preparing your playground…" resolve into a failure callout, and Sentry captures an exception for what is really "capability absent".

This advertises the capability instead of probing for it:

- `health` gains `hasPlaygroundProjects`, computed from the enterprise license key. It deliberately does **not** reuse `isEnterpriseEnabled()`: that helper's check is permissive in a way existing consumers may rely on, so this new field computes its own strict check inline and the wider question is tracked separately (PROD-9154). No existing health field changes behaviour.
- The invite page folds the capability into `canOfferPlayground`, skipping the provisioning attempt and its promise copy entirely when the instance can't fulfil it. The check fails closed (`=== true`), so older backends without the field simply don't promise a playground. The existing failure classification stays as defense-in-depth for unexpected errors.

Tests: HealthService licensed/unlicensed coverage for the new field; invite-page test asserting the invite succeeds without any provisioning call when the capability is absent.

Linear: PROD-9119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKCp9N1DsA9jR8qiLg3wsa