### PR TITLE
fix(scheduler): make scheduled job max attempts configurable

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -1148,6 +1148,30 @@ describe('scheduler poll interval', () => {
     });
 });
 
+describe('scheduler max attempts', () => {
+    test('should default max attempts to 1', () => {
+        const config = parseConfig();
+
+        expect(config.scheduler.maxAttempts).toBe(1);
+    });
+
+    test('should parse max attempts from environment variable', () => {
+        process.env.SCHEDULER_MAX_ATTEMPTS = '3';
+
+        const config = parseConfig();
+
+        expect(config.scheduler.maxAttempts).toBe(3);
+    });
+
+    test('should clamp invalid max attempts to 1', () => {
+        process.env.SCHEDULER_MAX_ATTEMPTS = '0';
+
+        const config = parseConfig();
+
+        expect(config.scheduler.maxAttempts).toBe(1);
+    });
+});
+
 test('should set groups.enabled only when the environment variable is set', () => {
     const undefinedConfig = parseConfig();
     expect(undefinedConfig.groups.enabled).toBeUndefined();

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1398,6 +1398,7 @@ export type LightdashConfig = {
         pollInterval: number;
         jobTimeout: number;
         screenshotTimeout?: number;
+        maxAttempts: number;
         tasks: Array<SchedulerTaskName>;
         queryHistory: {
             cleanup: {
@@ -2874,6 +2875,11 @@ export const parseConfig = (): LightdashConfig => {
             screenshotTimeout: process.env.SCHEDULER_SCREENSHOT_TIMEOUT
                 ? parseInt(process.env.SCHEDULER_SCREENSHOT_TIMEOUT, 10)
                 : undefined,
+            maxAttempts: Math.max(
+                1,
+                getIntegerFromEnvironmentVariable('SCHEDULER_MAX_ATTEMPTS') ||
+                    1,
+            ),
             tasks: parseAndSanitizeSchedulerTasks(),
             queryHistory: {
                 cleanup: {

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -75,7 +75,18 @@ type SchedulerClientArguments = {
     featureFlagModel: FeatureFlagModel;
 };
 
-const SCHEDULED_JOB_MAX_ATTEMPTS = 1;
+// Base max attempts for scheduled jobs. Configurable via the
+// SCHEDULER_MAX_ATTEMPTS env var (parsed in parseConfig into
+// lightdashConfig.scheduler.maxAttempts), defaulting to 1 to preserve
+// existing behavior. Mutated once from lightdashConfig when the
+// SchedulerClient is constructed so the static addJob default below picks up
+// the operator-configured value.
+const DEFAULT_SCHEDULER_MAX_ATTEMPTS = 1;
+let scheduledJobMaxAttempts = DEFAULT_SCHEDULER_MAX_ATTEMPTS;
+
+export const setScheduledJobMaxAttempts = (maxAttempts: number) => {
+    scheduledJobMaxAttempts = Math.max(1, Math.floor(maxAttempts));
+};
 
 // Name of the per-org graphile named queue that serializes an organization's
 // recurring scheduled deliveries. One queue per org → at most one delivery
@@ -141,6 +152,7 @@ export class SchedulerClient {
         this.analytics = analytics;
         this.schedulerModel = schedulerModel;
         this.featureFlagModel = featureFlagModel;
+        setScheduledJobMaxAttempts(lightdashConfig.scheduler.maxAttempts);
         this.graphileUtils = makeWorkerUtils({
             connectionString: lightdashConfig.database.connectionUri,
         })
@@ -233,7 +245,7 @@ export class SchedulerClient {
         payload: TaskPayloadMap[T],
         scheduledAt: Date,
         priority: JobPriority,
-        maxAttempts: number = SCHEDULED_JOB_MAX_ATTEMPTS,
+        maxAttempts: number = scheduledJobMaxAttempts,
         explicitJobKey?: string,
         queueName?: string,
     ) {
@@ -461,13 +473,13 @@ export class SchedulerClient {
               }
             : scheduler;
 
-        let maxAttempts = SCHEDULED_JOB_MAX_ATTEMPTS;
+        let maxAttempts = scheduledJobMaxAttempts;
         if (
             isCreateScheduler(scheduler) &&
             scheduler.format === SchedulerFormat.IMAGE &&
             !!scheduler.dashboardUuid
         ) {
-            maxAttempts = SCHEDULED_JOB_MAX_ATTEMPTS + 1;
+            maxAttempts = scheduledJobMaxAttempts + 1;
         }
 
         const id = await SchedulerClient.addJob(


### PR DESCRIPTION
Closes: N/A (no existing issue; motivation below)

### Description:

Makes the per-job max attempts for scheduled jobs configurable via the `SCHEDULER_MAX_ATTEMPTS` env var (surfaced as `lightdashConfig.scheduler.maxAttempts`), defaulting to `1` to preserve existing behavior.

#### Motivation

The below is written specific to what my company is experiencing, but I'm sure it generalizes.

Scheduled delivery jobs (Slack deliveries, CSV exports) intermittently fail with transient warehouse **connection timeouts** (e.g. `Connection terminated due to connection timeout` after ~30s), while healthy reruns of the same charts complete in a couple of seconds. Because the per-job max attempts is hardcoded to `1`, these transient connection failures are never retried — the delivery just fails and an owner has to manually re-run it.

Sidebar: I'm guessing these timeouts are due to Redshift serverless cold starts.

Retrying once is safe for this failure mode: the connection timeout occurs before any delivery side-effect (the worker cannot reach the warehouse), so a retry does not double-deliver. This is consistent with the existing behavior where image-format dashboard deliveries already retry once (`maxAttempts + 1`).

I remember reading that retrying can have some potentially undesired side effects, such that this scenario:
1. Attempt 1 fails, so a failure notification is sent.
2. Attempt 2 succeeds.

(vs waiting until retries are exhausted before sending failure notification).

However, I think this and any other potential downsides could be documented, then this PR would be a net win.

#### Changes

- `parseConfig.ts`: add `scheduler.maxAttempts`, parsed from `SCHEDULER_MAX_ATTEMPTS`, clamped to `>= 1`, default `1`.
- `SchedulerClient.ts`: replace the hardcoded `SCHEDULED_JOB_MAX_ATTEMPTS = 1` constant with a configurable module-level value (`scheduledJobMaxAttempts`) initialized from `lightdashConfig.scheduler.maxAttempts` in the constructor via `setScheduledJobMaxAttempts`. The static `addJob` default and the image-delivery `+1` logic now use this value.
- `parseConfig.test.ts`: cover default, override, and clamp-to-1 cases.

#### Scope / blast radius

This knob applies to **all** jobs that use the default max attempts (e.g. `SQL_RUNNER`, `VALIDATE_PROJECT`, `INDEX_CATALOG`, and the batch-notification senders). Jobs that intentionally run a single attempt to avoid re-running slow warehouse queries (e.g. `UPLOAD_GSHEET_FROM_QUERY`, `COMPILE_PROJECT`, `MATERIALIZE_PRE_AGGREGATE`) already pass an explicit `maxAttempts` and are unaffected. The default stays `1`, so existing deployments see no behavior change unless they opt in.

Operators hitting transient warehouse connection timeouts can set `SCHEDULER_MAX_ATTEMPTS=2` to enable a single retry.

---

This PR is distinct from #20663 (TCP keepalive + `makeWorkerUtils` init retry for Lightdash's metadata DB);this PR addresses per-job delivery retries against the warehouse.

_This PR was prepared with AI assistance on behalf of the author._
