### PR TITLE
fix: route the semantic-layer setup action back to project settings

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
@@ -1,8 +1,4 @@
-import {
-    FeatureFlags,
-    ProjectType,
-    type OrganizationProject,
-} from '@lightdash/common';
+import { ProjectType, type OrganizationProject } from '@lightdash/common';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useGithubConfig } from '../../../../components/common/GithubIntegration/hooks/useGithubIntegration';
 import { useGitlabRepositories } from '../../../../components/common/GitlabIntegration/hooks/useGitlabIntegration';
@@ -164,28 +160,11 @@ describe('useRecommendedActions', () => {
     });
 
     describe('add-semantic-layer destination', () => {
-        it('links to the agent setup flow when both flags are enabled', () => {
+        it('links to the project settings page even with all flags enabled', () => {
             vi.mocked(useServerFeatureFlag).mockImplementation(
                 () =>
                     ({
                         data: { enabled: true },
-                    }) as ReturnType<typeof useServerFeatureFlag>,
-            );
-
-            const { result } = renderHook(() =>
-                useRecommendedActions('project-uuid'),
-            );
-
-            expect(
-                result.current.statuses['add-semantic-layer'].url,
-            ).toStrictEqual('/createProject/agent');
-        });
-
-        it('keeps the settings link when coding-agent onboarding is disabled', () => {
-            vi.mocked(useServerFeatureFlag).mockImplementation(
-                (flag) =>
-                    ({
-                        data: { enabled: flag === FeatureFlags.NewOnboarding },
                     }) as ReturnType<typeof useServerFeatureFlag>,
             );
 
@@ -200,14 +179,11 @@ describe('useRecommendedActions', () => {
             );
         });
 
-        it('keeps the settings link when new-onboarding is disabled', () => {
+        it('links to the project settings page with flags disabled', () => {
             vi.mocked(useServerFeatureFlag).mockImplementation(
-                (flag) =>
+                () =>
                     ({
-                        data: {
-                            enabled:
-                                flag === FeatureFlags.CodingAgentOnboarding,
-                        },
+                        data: { enabled: false },
                     }) as ReturnType<typeof useServerFeatureFlag>,
             );
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
@@ -1,6 +1,5 @@
 import { subject } from '@casl/ability';
 import {
-    FeatureFlags,
     DbtProjectType,
     DbtProjectTypeLabels,
     ProjectType,
@@ -17,7 +16,6 @@ import { useOrganization } from '../../../../hooks/organization/useOrganization'
 import { useGetSlack } from '../../../../hooks/slack/useSlack';
 import { useProject } from '../../../../hooks/useProject';
 import { useProjects } from '../../../../hooks/useProjects';
-import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../providers/App/useApp';
 import { isPlaygroundProvisioningSource } from '../../../../utils/playgroundProject';
 import {
@@ -43,13 +41,6 @@ const useActionStatuses = (
     const { data: projects } = useProjects();
     const { data: githubConfig } = useGithubConfig();
     const { data: slack, isSuccess: isSlackSuccess } = useGetSlack();
-    const newOnboardingFlag = useServerFeatureFlag(FeatureFlags.NewOnboarding);
-    const codingAgentOnboardingFlag = useServerFeatureFlag(
-        FeatureFlags.CodingAgentOnboarding,
-    );
-    const hasAgentSemanticLayerEntry =
-        newOnboardingFlag.data?.enabled === true &&
-        codingAgentOnboardingFlag.data?.enabled === true;
 
     const hasGithub = !!health.data?.hasGithub;
     const hasGitlab = !!health.data?.hasGitlab;
@@ -97,9 +88,10 @@ const useActionStatuses = (
                 ? DbtProjectTypeLabels[dbtConnection.type]
                 : null,
             doneIcon: null,
-            url: hasAgentSemanticLayerEntry
-                ? '/createProject/agent'
-                : `/generalSettings/projectManagement/${projectUuid}/settings`,
+            // Always the settings page: /createProject/agent cannot serve an
+            // existing project — it re-asks for a warehouse and provisions a
+            // new project instead of attaching the semantic layer (PROD-9156).
+            url: `/generalSettings/projectManagement/${projectUuid}/settings`,
         },
         'connect-source-control': {
             isVisible: hasGithub || hasGitlab,


### PR DESCRIPTION
The homepage recommended action "Set up semantic layer" deep-linked into `/createProject/agent` (since #25952). That entry cannot serve the action's only audience — users with an existing project: the deep link dead-ends on the legacy warehouse picker (`method=agent` is invisible until a warehouse is clicked), and `ConnectUsingAgent` then provisions a **new** project instead of attaching a semantic layer to the one the user is on.

This routes the action back to the project settings page. If the coding-agent flow later gains existing-project support, the deep link can be re-enabled at the single `url:` site — see the ticket for details.

Tests updated: the destination suite now pins the settings URL in both flag states.

Linear: PROD-9156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKCp9N1DsA9jR8qiLg3wsa