### PR TITLE
feat(backend): GCP Cloud Run sandbox provider (gcp-cloud-run)

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -439,6 +439,10 @@ export const lightdashConfigMock: LightdashConfig = {
         azureSandboxesDataAppDiskImage: null,
         azureSandboxesAiWritebackGroup: null,
         azureSandboxesAiWritebackDiskImage: null,
+        gcpCloudRun: {
+            sandboxUrl: null,
+            sandboxSecret: null,
+        },
         e2bAgentOnboardingTemplateName: 'lightdash-agent-onboarding',
         e2bAgentOnboardingTemplateTag: 'test',
         e2bCodingAgentTemplateName: 'lightdash-ai-coding-agent',

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -1644,3 +1644,19 @@ describe('pgWire TLS configuration', () => {
         expect(() => parseConfig()).toThrowError(ParseError);
     });
 });
+
+describe('SANDBOX_PROVIDER', () => {
+    test('defaults to e2b when unset', () => {
+        expect(parseConfig().appRuntime.sandboxProvider).toBe('e2b');
+    });
+
+    test('parses gcp-cloud-run', () => {
+        process.env.SANDBOX_PROVIDER = 'gcp-cloud-run';
+        expect(parseConfig().appRuntime.sandboxProvider).toBe('gcp-cloud-run');
+    });
+
+    test('throws on an unknown provider instead of falling back to e2b', () => {
+        process.env.SANDBOX_PROVIDER = 'gcp-cloudrun';
+        expect(() => parseConfig()).toThrowError(ParseError);
+    });
+});

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -1659,4 +1659,9 @@ describe('SANDBOX_PROVIDER', () => {
         process.env.SANDBOX_PROVIDER = 'gcp-cloudrun';
         expect(() => parseConfig()).toThrowError(ParseError);
     });
+
+    test('normalizes case and whitespace instead of crashing boot', () => {
+        process.env.SANDBOX_PROVIDER = ' E2B ';
+        expect(parseConfig().appRuntime.sandboxProvider).toBe('e2b');
+    });
 });

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2130,11 +2130,15 @@ const DEFAULT_JOB_TIMEOUT = 1000 * 60 * 10; // 10 minutes
 const parseSandboxProvider = (
     value: string | undefined,
 ): AppRuntimeConfig['sandboxProvider'] => {
+    if (value === undefined || value === '') return 'e2b';
+    if (value === 'e2b') return 'e2b';
     if (value === 'docker') return 'docker';
     if (value === 'lambda-microvm') return 'lambda-microvm';
     if (value === 'azure-sandboxes') return 'azure-sandboxes';
     if (value === 'gcp-cloud-run') return 'gcp-cloud-run';
-    return 'e2b';
+    throw new ParseError(
+        `Cannot parse environment variable "SANDBOX_PROVIDER". Value must be one of e2b, docker, lambda-microvm, azure-sandboxes, gcp-cloud-run but SANDBOX_PROVIDER=${value}`,
+    );
 };
 
 const parseDataAppOtelConfig = (): DataAppOtelConfig => {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1742,10 +1742,17 @@ export type AppRuntimeConfig = {
      * (dev / self-host testbed — see docs/sandbox-runtime.md);
      * `lambda-microvm` runs AWS Lambda MicroVMs (native suspend/resume);
      * `azure-sandboxes` runs Azure Container Apps Sandboxes (native
-     * suspend/resume — the Azure analog of E2B / Lambda MicroVMs).
+     * suspend/resume — the Azure analog of E2B / Lambda MicroVMs);
+     * `gcp-cloud-run` runs Google Cloud Run Sandboxes behind a gateway service
+     * deployed with `--sandbox-launcher` (object-store snapshots, like Docker).
      * Later: kubernetes | ecs | microsandbox.
      */
-    sandboxProvider: 'e2b' | 'docker' | 'lambda-microvm' | 'azure-sandboxes';
+    sandboxProvider:
+        | 'e2b'
+        | 'docker'
+        | 'lambda-microvm'
+        | 'azure-sandboxes'
+        | 'gcp-cloud-run';
     /**
      * OCI image the `docker` sandbox provider launches data-app containers
      * from. Built locally from sandboxes/data-apps (e.g. `lightdash-sandbox:local`).
@@ -1836,6 +1843,16 @@ export type AppRuntimeConfig = {
     /** Disk image the AI writeback pipeline launches (decoupled from the data-app
      * image). Required only when `azure-sandboxes`. */
     azureSandboxesAiWritebackDiskImage: string | null;
+    /**
+     * Config for the `gcp-cloud-run` provider: URL + shared secret of the
+     * sandbox gateway Cloud Run service (deployed with `--sandbox-launcher`,
+     * data-app toolchain image baked in). Required only when
+     * `sandboxProvider === 'gcp-cloud-run'`.
+     */
+    gcpCloudRun: {
+        sandboxUrl: string | null;
+        sandboxSecret: string | null;
+    };
     /** E2B template used by managed project onboarding. */
     e2bAgentOnboardingTemplateName: string;
     e2bAgentOnboardingTemplateTag: string;
@@ -2116,6 +2133,7 @@ const parseSandboxProvider = (
     if (value === 'docker') return 'docker';
     if (value === 'lambda-microvm') return 'lambda-microvm';
     if (value === 'azure-sandboxes') return 'azure-sandboxes';
+    if (value === 'gcp-cloud-run') return 'gcp-cloud-run';
     return 'e2b';
 };
 
@@ -2261,6 +2279,10 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
             process.env.AZURE_SANDBOXES_DATA_APP_GROUP || null,
         azureSandboxesDataAppDiskImage:
             process.env.AZURE_SANDBOXES_DATA_APP_DISK_IMAGE || null,
+        gcpCloudRun: {
+            sandboxUrl: process.env.GCP_CLOUD_RUN_SANDBOX_URL || null,
+            sandboxSecret: process.env.GCP_CLOUD_RUN_SANDBOX_SECRET || null,
+        },
         azureSandboxesAiWritebackGroup:
             process.env.AZURE_SANDBOXES_AI_WRITEBACK_GROUP || null,
         azureSandboxesAiWritebackDiskImage:

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2130,12 +2130,15 @@ const DEFAULT_JOB_TIMEOUT = 1000 * 60 * 10; // 10 minutes
 const parseSandboxProvider = (
     value: string | undefined,
 ): AppRuntimeConfig['sandboxProvider'] => {
-    if (value === undefined || value === '') return 'e2b';
-    if (value === 'e2b') return 'e2b';
-    if (value === 'docker') return 'docker';
-    if (value === 'lambda-microvm') return 'lambda-microvm';
-    if (value === 'azure-sandboxes') return 'azure-sandboxes';
-    if (value === 'gcp-cloud-run') return 'gcp-cloud-run';
+    // Normalized so deploy-tooling artifacts (case, stray whitespace) don't
+    // crash boot; real typos still throw rather than silently running on e2b.
+    const normalized = value?.trim().toLowerCase();
+    if (!normalized) return 'e2b';
+    if (normalized === 'e2b') return 'e2b';
+    if (normalized === 'docker') return 'docker';
+    if (normalized === 'lambda-microvm') return 'lambda-microvm';
+    if (normalized === 'azure-sandboxes') return 'azure-sandboxes';
+    if (normalized === 'gcp-cloud-run') return 'gcp-cloud-run';
     throw new ParseError(
         `Cannot parse environment variable "SANDBOX_PROVIDER". Value must be one of e2b, docker, lambda-microvm, azure-sandboxes, gcp-cloud-run but SANDBOX_PROVIDER=${value}`,
     );

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -1334,6 +1334,11 @@ export class AiWritebackService extends BaseService {
     private getSandboxManager(): SandboxManager {
         if (!this.sandboxManager) {
             const { sandboxProvider } = this.lightdashConfig.appRuntime;
+            if (sandboxProvider === 'gcp-cloud-run') {
+                throw new MissingConfigError(
+                    'AI writeback is not supported on the gcp-cloud-run sandbox provider yet (it needs its own gateway image)',
+                );
+            }
             this.sandboxManager = createSandboxManager({
                 provider: sandboxProvider,
                 e2bApiKey: this.lightdashConfig.appRuntime.e2bApiKey,

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -1345,9 +1345,15 @@ export class AiWritebackService extends BaseService {
                     sandboxProvider === 'azure-sandboxes'
                         ? this.getAzureSandboxesConfig()
                         : null,
-                // Object-store snapshots are only for the Docker backend (no
-                // native pause); native-pause providers (E2B, Lambda, Azure
-                // Sandboxes) never touch S3, so don't construct a client.
+                // AI writeback on Cloud Run needs its own gateway service (the
+                // writeback toolchain image is baked into the gateway
+                // deployment); unsupported until one exists — the factory
+                // throws a clear config error if selected.
+                gcpCloudRun: null,
+                // Object-store snapshots are only for the backends with no
+                // native pause (Docker, GCP Cloud Run); native-pause providers
+                // (E2B, Lambda, Azure Sandboxes) never touch S3, so don't
+                // construct a client.
                 snapshotStore:
                     sandboxProvider === 'docker'
                         ? new S3SnapshotStore({

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -174,6 +174,7 @@ import {
     SandboxCommandError,
     SandboxManager,
     type AzureSandboxesConfig,
+    type CloudRunSandboxesConfig,
     type PersistentWorkspace,
     type SandboxHandle,
     type SandboxSpec,
@@ -739,11 +740,17 @@ export class AppGenerateService extends BaseService {
                     sandboxProvider === 'azure-sandboxes'
                         ? this.getAzureSandboxesConfig()
                         : null,
-                // Object-store snapshots are only for the Docker backend (no
-                // native pause); native-pause providers (E2B, Lambda, Azure
-                // Sandboxes) never touch S3, so don't construct a client.
+                gcpCloudRun:
+                    sandboxProvider === 'gcp-cloud-run'
+                        ? this.getCloudRunSandboxesConfig()
+                        : null,
+                // Object-store snapshots are only for the backends with no
+                // native pause (Docker, GCP Cloud Run); native-pause providers
+                // (E2B, Lambda, Azure Sandboxes) never touch S3, so don't
+                // construct a client.
                 snapshotStore:
-                    sandboxProvider === 'docker'
+                    sandboxProvider === 'docker' ||
+                    sandboxProvider === 'gcp-cloud-run'
                         ? new S3SnapshotStore({
                               lightdashConfig: this.lightdashConfig,
                           })
@@ -785,6 +792,12 @@ export class AppGenerateService extends BaseService {
             }
             return diskImage;
         }
+        if (sandboxProvider === 'gcp-cloud-run') {
+            // The toolchain image is baked into the gateway service deployment
+            // — per-sandbox image selection is not possible, so the gateway URL
+            // stands in as the template ref for logs/telemetry.
+            return this.getCloudRunSandboxesConfig().sandboxUrl;
+        }
         // E2B treats `name` and `name:default` interchangeably, so an empty
         // tag is fine — it just resolves to the implicit `default` build.
         return e2bTemplateTag
@@ -818,6 +831,20 @@ export class AppGenerateService extends BaseService {
             tokenScope: azureSandboxes.tokenScope,
             resourceTier: azureSandboxes.resourceTier,
             autoSuspendIdleSeconds: Math.floor(sandboxIdleTimeoutMs / 1000),
+        };
+    }
+
+    /** Assemble the `gcp-cloud-run` provider config (gateway URL + secret). */
+    private getCloudRunSandboxesConfig(): CloudRunSandboxesConfig {
+        const { gcpCloudRun } = this.lightdashConfig.appRuntime;
+        if (!gcpCloudRun.sandboxUrl || !gcpCloudRun.sandboxSecret) {
+            throw new MissingConfigError(
+                'GCP Cloud Run sandboxes are not configured (GCP_CLOUD_RUN_SANDBOX_URL / GCP_CLOUD_RUN_SANDBOX_SECRET)',
+            );
+        }
+        return {
+            sandboxUrl: gcpCloudRun.sandboxUrl,
+            sandboxSecret: gcpCloudRun.sandboxSecret,
         };
     }
 

--- a/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
@@ -374,6 +374,11 @@ export class OnboardingAgentService extends BaseService {
     private getSandboxManager(): SandboxManager {
         if (!this.sandboxManager) {
             const { sandboxProvider } = this.lightdashConfig.appRuntime;
+            if (sandboxProvider === 'gcp-cloud-run') {
+                throw new MissingConfigError(
+                    'The onboarding agent is not supported on the gcp-cloud-run sandbox provider yet (it needs its own gateway image)',
+                );
+            }
             this.sandboxManager = createSandboxManager({
                 provider: sandboxProvider,
                 e2bApiKey: this.lightdashConfig.appRuntime.e2bApiKey,

--- a/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
+++ b/packages/backend/src/ee/services/OnboardingAgentService/OnboardingAgentService.ts
@@ -382,6 +382,9 @@ export class OnboardingAgentService extends BaseService {
                         .sandboxAgentOnboardingDockerImage,
                 lambdaMicroVm: null,
                 azureSandboxes: null,
+                // Onboarding on Cloud Run would need its own gateway service
+                // (toolchain baked into the gateway image); unsupported for now.
+                gcpCloudRun: null,
                 snapshotStore:
                     sandboxProvider === 'docker'
                         ? new S3SnapshotStore({

--- a/packages/backend/src/ee/services/SandboxRuntime/CloudRunExecChannel.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/CloudRunExecChannel.ts
@@ -1,0 +1,545 @@
+import { randomUUID } from 'node:crypto';
+import { StringDecoder } from 'node:string_decoder';
+import { Agent, type Dispatcher } from 'undici';
+import { SandboxCommandError, SandboxTimeoutError } from './errors';
+import { shQuote } from './gitOverCommands';
+import {
+    type CommandResult,
+    type RunOptions,
+    type SandboxCommands,
+    type SandboxFiles,
+} from './types';
+
+/**
+ * Fold `cwd`/`envs` into a single `/bin/sh -c` command line. The gateway exec
+ * takes only a command (its own `--workdir`/`-e` flags exist but folding keeps
+ * one wire shape for buffered and detached runs alike).
+ *
+ * `export PATH;` first: the sandbox exec shell has a PATH *variable* (with
+ * /usr/local/bin) but does not export it, so child processes fall back to
+ * glibc's `/bin:/usr/bin` default and `#!/usr/bin/env node` shebangs (pnpm,
+ * npx) fail with ENOENT. Exporting the shell's own PATH fixes every descendant.
+ *
+ * The Claude Code kill-switches guard against a sandbox-launcher fault
+ * (reproduced Jul 2026, preview): a process that starts `node` as a setsid
+ * session leader kills the whole sandbox (its control server dies; every
+ * subsequent exec fails with "connection refused"). Claude Code is a bundled
+ * node binary whose auto-updater / background tasks spawn exactly that shape
+ * ~90s into a run, so they are disabled for every command in the sandbox —
+ * they only affect the `claude` CLI and are harmless to other commands.
+ */
+const buildCommandLine = (command: string, options?: RunOptions): string => {
+    const parts: string[] = [
+        'export PATH DISABLE_AUTOUPDATER=1 CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1;',
+    ];
+    if (options?.cwd) parts.push(`cd ${shQuote(options.cwd)} &&`);
+    if (options?.envs) {
+        const exports = Object.entries(options.envs)
+            .map(([key, value]) => `${key}=${shQuote(value)}`)
+            .join(' ');
+        if (exports) parts.push(`export ${exports};`);
+    }
+    parts.push(command);
+    return parts.join(' ');
+};
+
+/**
+ * The gateway exec endpoint is buffered: response headers arrive only when the
+ * shell command completes, so undici's default 300s headersTimeout would kill
+ * longer runs with `fetch failed`. This dispatcher disables undici's clocks and
+ * is used ONLY for exec calls already bounded by the caller's AbortController.
+ */
+const bufferedExecDispatcher = new Agent({
+    headersTimeout: 0,
+    bodyTimeout: 0,
+});
+
+/**
+ * Runs bounded above this threshold switch to detached mode (start under
+ * nohup, poll output files with short requests) — the Azure channel's pattern.
+ *
+ * Set just under the gateway's 3600s Cloud Run request timeout, so in practice
+ * every run is one buffered exec: with the sandbox launcher in preview,
+ * long-lived processes started detached (no live exec session) have repeatedly
+ * taken the whole sandbox down mid-run ("connecting to control server …
+ * connection refused" on every later exec), while identical foreground
+ * workloads survive. Detached mode remains as the fallback for runs bounded
+ * beyond the request cap.
+ */
+const DETACHED_EXEC_THRESHOLD_MS = 58 * 60 * 1000;
+const DETACHED_POLL_INTERVAL_MS = 2_000;
+/** Poll/start/kill requests are short; bound them individually. */
+const INTERNAL_EXEC_TIMEOUT_MS = 60 * 1000;
+/**
+ * A failed poll leaves the detached process running, so transient gateway
+ * hiccups are survivable — only this many consecutive failures abort the run.
+ */
+const MAX_CONSECUTIVE_POLL_FAILURES = 5;
+
+/**
+ * Every command reaches the sandbox as one `/bin/sh -c <string>` argv entry and
+ * Linux caps a single argv string at 128KiB (MAX_ARG_STRLEN), so file writes
+ * are chunked base64 appends sized to stay well under that cap after base64
+ * expansion (64KiB binary → ~86KiB base64 + command scaffolding).
+ */
+const WRITE_CHUNK_BYTES = 64 * 1024;
+/**
+ * Reads stream through a pipe (no argv limit); the bound is the gateway's
+ * buffered JSON response, so chunks can be much larger.
+ */
+const READ_CHUNK_BYTES = 4 * 1024 * 1024;
+
+const sleep = (ms: number): Promise<void> =>
+    new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+
+/** The gateway exec wire result (`{stdout, stderr, exitCode}` JSON). */
+interface ExecResponse {
+    stdout: string;
+    stderr: string;
+    exitCode: number;
+}
+
+/** One parsed detached poll tick: new output bytes + exit code when done. */
+interface DetachedTick {
+    exitCode: number | null;
+    out: Buffer;
+    err: Buffer;
+}
+
+/**
+ * Parse the S/O/E wire protocol emitted by the detached poll command: an
+ * `S<exit-code-or-empty>` line, then `O<base64>` / `E<base64>` lines carrying
+ * the new stdout/stderr bytes since the last poll. Throws on malformed output —
+ * the caller treats that as a transient poll failure.
+ */
+const parseDetachedTick = (stdout: string): DetachedTick => {
+    const lines = stdout.split('\n');
+    const sLine = lines.find((line) => line.startsWith('S'));
+    const oLine = lines.find((line) => line.startsWith('O'));
+    const eLine = lines.find((line) => line.startsWith('E'));
+    if (sLine === undefined || oLine === undefined || eLine === undefined) {
+        throw new Error(
+            `malformed detached poll output: ${stdout.slice(0, 200)}`,
+        );
+    }
+    const status = sLine.slice(1).trim();
+    let exitCode: number | null = null;
+    if (status !== '') {
+        exitCode = Number(status);
+        if (!Number.isInteger(exitCode)) {
+            throw new Error(`malformed detached exit status: "${status}"`);
+        }
+    }
+    return {
+        exitCode,
+        out: Buffer.from(oLine.slice(1), 'base64'),
+        err: Buffer.from(eLine.slice(1), 'base64'),
+    };
+};
+
+/** Validate/narrow the gateway exec JSON to {@link ExecResponse}. */
+const decodeExecResponse = (value: unknown): ExecResponse => {
+    if (typeof value !== 'object' || value === null) {
+        throw new SandboxCommandError(
+            -1,
+            'exec response was not an object',
+            '',
+        );
+    }
+    const record = value as Record<string, unknown>;
+    if (typeof record.exitCode !== 'number') {
+        throw new SandboxCommandError(
+            -1,
+            `exec response missing a numeric exitCode: ${JSON.stringify(
+                value,
+            ).slice(0, 200)}`,
+            '',
+        );
+    }
+    return {
+        stdout: typeof record.stdout === 'string' ? record.stdout : '',
+        stderr: typeof record.stderr === 'string' ? record.stderr : '',
+        exitCode: record.exitCode,
+    };
+};
+
+/**
+ * HTTP client for the ComputeSDK Cloud Run sandbox gateway — a Cloud Run
+ * service deployed with `--sandbox-launcher` that fronts the in-instance
+ * `sandbox` CLI with a small JSON API (`/v1/sandbox/create|exec|destroy`),
+ * authenticated with a static shared secret header. Sandbox ids must match the
+ * gateway's `[A-Za-z0-9_-]+` rule.
+ */
+export class CloudRunGatewayClient {
+    private readonly baseUrl: string;
+
+    constructor(
+        sandboxUrl: string,
+        private readonly sandboxSecret: string,
+    ) {
+        this.baseUrl = sandboxUrl.replace(/\/+$/, '');
+    }
+
+    async post(
+        path: string,
+        body: Record<string, unknown>,
+        options?: { signal?: AbortSignal; dispatcher?: Dispatcher },
+    ): Promise<unknown> {
+        const requestInit: RequestInit & { dispatcher?: Dispatcher } = {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+                'x-computesdk-cloud-run-secret': this.sandboxSecret,
+            },
+            body: JSON.stringify(body),
+            signal: options?.signal ?? null,
+            dispatcher: options?.dispatcher,
+        };
+        const response = await fetch(
+            `${this.baseUrl}/v1/sandbox/${path}`,
+            requestInit,
+        );
+        if (!response.ok) {
+            // Gateway error bodies are untrusted — truncate rather than
+            // echoing them verbatim into logs/Sentry.
+            const text = await response.text().catch(() => '');
+            throw new SandboxCommandError(
+                response.status,
+                `Cloud Run sandbox gateway ${path} failed: ${text.slice(0, 200)}`,
+                '',
+            );
+        }
+        return response.json();
+    }
+
+    /** `sandbox run <id> --detach` behind the gateway. */
+    async createSandbox(input: {
+        sandboxId: string;
+        allowEgress: boolean;
+        envs: Record<string, string> | null;
+    }): Promise<void> {
+        await this.post('create', {
+            sandboxId: input.sandboxId,
+            write: true,
+            allowEgress: input.allowEgress,
+            env: input.envs ?? {},
+        });
+    }
+
+    /** `sandbox delete <id>` behind the gateway. Fire-and-forget on the server. */
+    async destroySandbox(sandboxId: string): Promise<void> {
+        await this.post('destroy', { sandboxId });
+    }
+}
+
+/**
+ * Data plane for one Cloud Run sandbox, built entirely on the gateway's
+ * stateful exec endpoint (`sandbox exec <id>`): commands are buffered
+ * round-trips (or detached-and-polled beyond the threshold), and files are
+ * implemented over exec with base64 chunking sized to the argv limit — the
+ * gateway's own read/write endpoints embed whole payloads in a single command
+ * string, which breaks on anything large.
+ */
+export class CloudRunExecChannel {
+    private readonly detachedThresholdMs: number;
+
+    private readonly pollIntervalMs: number;
+
+    constructor(
+        private readonly client: CloudRunGatewayClient,
+        private readonly sandboxId: string,
+        tuning?: { detachedThresholdMs?: number; pollIntervalMs?: number },
+    ) {
+        this.detachedThresholdMs =
+            tuning?.detachedThresholdMs ?? DETACHED_EXEC_THRESHOLD_MS;
+        this.pollIntervalMs =
+            tuning?.pollIntervalMs ?? DETACHED_POLL_INTERVAL_MS;
+    }
+
+    readonly commands: SandboxCommands = {
+        run: async (
+            command: string,
+            options?: RunOptions,
+        ): Promise<CommandResult> => {
+            // A run allowed to outlive the gateway's per-request exec cap
+            // cannot be one buffered call — detach it and poll instead.
+            if (
+                options?.timeoutMs !== undefined &&
+                options.timeoutMs > this.detachedThresholdMs
+            ) {
+                return this.runDetached(command, {
+                    ...options,
+                    timeoutMs: options.timeoutMs,
+                });
+            }
+            return this.runBuffered(command, options);
+        },
+    };
+
+    /** One buffered exec round-trip: the response arrives when the command completes. */
+    private async runBuffered(
+        command: string,
+        options?: RunOptions,
+    ): Promise<CommandResult> {
+        const controller = new AbortController();
+        const timeoutMs = options?.timeoutMs;
+        const timer =
+            timeoutMs && timeoutMs > 0
+                ? setTimeout(() => controller.abort(), timeoutMs)
+                : null;
+        try {
+            const raw = await this.client.post(
+                'exec',
+                {
+                    sandboxId: this.sandboxId,
+                    command: buildCommandLine(command, options),
+                    // Server-side backstop 10s past the client abort so the
+                    // spawn is reaped even if this client goes away. Unbounded
+                    // runs get the internal cap — callers wanting longer must
+                    // pass a timeout (and thereby detach past the threshold).
+                    timeout: (timeoutMs ?? INTERNAL_EXEC_TIMEOUT_MS) + 10_000,
+                },
+                {
+                    signal: controller.signal,
+                    dispatcher: timer ? bufferedExecDispatcher : undefined,
+                },
+            );
+            const result = decodeExecResponse(raw);
+            // The gateway reports its own spawn timeout as exit 124.
+            if (result.exitCode === 124 && /timed out/i.test(result.stderr)) {
+                throw new SandboxTimeoutError(
+                    `Command timed out on the gateway (configured ${timeoutMs}ms)`,
+                );
+            }
+            // Buffered exec — replay the captured output through the streaming
+            // callbacks once so downstream line-parsers still see it.
+            if (result.stdout) options?.onStdout?.(result.stdout);
+            if (result.stderr) options?.onStderr?.(result.stderr);
+            if (result.exitCode !== 0) {
+                throw new SandboxCommandError(
+                    result.exitCode,
+                    result.stderr,
+                    result.stdout,
+                );
+            }
+            return result;
+        } catch (error) {
+            if (error instanceof DOMException && error.name === 'AbortError') {
+                throw new SandboxTimeoutError(
+                    `Command timed out after ${timeoutMs}ms`,
+                );
+            }
+            throw error;
+        } finally {
+            if (timer) clearTimeout(timer);
+        }
+    }
+
+    /**
+     * Best-effort stop of a detached run's entire process group: TERM for a
+     * graceful window, then KILL. Targets the negative PGID recorded at start
+     * (see the setsid note in {@link runDetached}). Never throws: this runs on
+     * paths that are already reporting a failure.
+     */
+    private async killDetachedProcessGroup(runDir: string): Promise<void> {
+        const pidFile = shQuote(`${runDir}/pid`);
+        await this.runBuffered(
+            `if [ -f ${pidFile} ]; then PGID="$(cat ${pidFile})"; ` +
+                `kill -TERM -- "-$PGID" 2>/dev/null; sleep 2; ` +
+                `kill -KILL -- "-$PGID" 2>/dev/null; fi; true`,
+            { timeoutMs: INTERNAL_EXEC_TIMEOUT_MS },
+        ).catch(() => {});
+    }
+
+    /**
+     * Run a long command without ever holding a gateway request open for its
+     * duration: start it detached under nohup with its streams and exit code
+     * captured to files (a ~1s request), then poll those files with short
+     * requests, replaying new bytes through `onStdout`/`onStderr` as they land.
+     * The process keeps running in the sandbox across transient poll failures.
+     */
+    private async runDetached(
+        command: string,
+        options: RunOptions & { timeoutMs: number },
+    ): Promise<CommandResult> {
+        const runDir = `/tmp/.lightdash-exec/${randomUUID()}`;
+        // cwd/envs are folded into the inner command line; the subshell keeps
+        // compound inner commands (a && b) under one redirect.
+        const inner = buildCommandLine(command, options);
+        const wrapped = `( ${inner} ) > ${runDir}/out.log 2> ${runDir}/err.log; echo $? > ${runDir}/exit`;
+        // setsid makes the wrapper the leader of a fresh process group whose
+        // PGID equals the recorded PID, so a kill can target the whole command
+        // tree (`kill -- -PID`) — signalling only the wrapper shell would
+        // orphan its children (claude, pnpm, …).
+        await this.runBuffered(
+            `mkdir -p ${shQuote(runDir)}; nohup setsid /bin/sh -c ${shQuote(wrapped)} < /dev/null > /dev/null 2>&1 & echo $! > ${shQuote(`${runDir}/pid`)}`,
+            { timeoutMs: INTERNAL_EXEC_TIMEOUT_MS },
+        );
+
+        const startedAt = Date.now();
+        // StringDecoder holds back a multi-byte UTF-8 sequence split across
+        // poll boundaries instead of emitting a corrupt character.
+        const outDecoder = new StringDecoder('utf8');
+        const errDecoder = new StringDecoder('utf8');
+        let outOffset = 0;
+        let errOffset = 0;
+        let stdout = '';
+        let stderr = '';
+        let consecutiveFailures = 0;
+
+        for (;;) {
+            const elapsedMs = Date.now() - startedAt;
+            if (elapsedMs >= options.timeoutMs) {
+                // eslint-disable-next-line no-await-in-loop
+                await this.killDetachedProcessGroup(runDir);
+                throw new SandboxTimeoutError(
+                    `Command timed out after ${elapsedMs}ms (configured ${options.timeoutMs}ms)`,
+                );
+            }
+
+            // eslint-disable-next-line no-await-in-loop
+            await sleep(this.pollIntervalMs);
+
+            let tick: DetachedTick;
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                const response = await this.runBuffered(
+                    `printf S; cat ${shQuote(`${runDir}/exit`)} 2>/dev/null; echo; ` +
+                        `printf O; tail -c +${outOffset + 1} ${shQuote(`${runDir}/out.log`)} 2>/dev/null | base64 | tr -d '\\n'; echo; ` +
+                        `printf E; tail -c +${errOffset + 1} ${shQuote(`${runDir}/err.log`)} 2>/dev/null | base64 | tr -d '\\n'; echo`,
+                    { timeoutMs: INTERNAL_EXEC_TIMEOUT_MS },
+                );
+                tick = parseDetachedTick(response.stdout);
+                consecutiveFailures = 0;
+            } catch (error) {
+                consecutiveFailures += 1;
+                if (consecutiveFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+                    // Abandoning the run must not orphan the command tree — a
+                    // caller's retry could otherwise run alongside it.
+                    // eslint-disable-next-line no-await-in-loop
+                    await this.killDetachedProcessGroup(runDir);
+                    throw new SandboxCommandError(
+                        -1,
+                        `Detached exec polling failed ${consecutiveFailures} times in a row: ${
+                            error instanceof Error
+                                ? error.message
+                                : String(error)
+                        }`,
+                        stdout,
+                    );
+                }
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
+            outOffset += tick.out.length;
+            errOffset += tick.err.length;
+            const outText = outDecoder.write(tick.out);
+            if (outText) {
+                stdout += outText;
+                options.onStdout?.(outText);
+            }
+            const errText = errDecoder.write(tick.err);
+            if (errText) {
+                stderr += errText;
+                options.onStderr?.(errText);
+            }
+
+            if (tick.exitCode !== null) {
+                // Flush bytes the decoders held back waiting for the rest of a
+                // multi-byte sequence that never came.
+                const outTail = outDecoder.end();
+                if (outTail) {
+                    stdout += outTail;
+                    options.onStdout?.(outTail);
+                }
+                const errTail = errDecoder.end();
+                if (errTail) {
+                    stderr += errTail;
+                    options.onStderr?.(errTail);
+                }
+                if (tick.exitCode !== 0) {
+                    // Keep runDir on failure so the logs survive for post-mortem.
+                    throw new SandboxCommandError(
+                        tick.exitCode,
+                        stderr,
+                        stdout,
+                    );
+                }
+                // eslint-disable-next-line no-await-in-loop
+                await this.files.remove(runDir).catch(() => {});
+                return { stdout, stderr, exitCode: 0 };
+            }
+        }
+    }
+
+    readonly files: SandboxFiles = {
+        read: async (path: string): Promise<string> => {
+            const bytes = await this.files.readBytes(path);
+            return bytes.toString('utf8');
+        },
+        readBytes: async (path: string): Promise<Buffer> => {
+            const quoted = shQuote(path);
+            const sizeResult = await this.runBuffered(`wc -c < ${quoted}`, {
+                timeoutMs: INTERNAL_EXEC_TIMEOUT_MS,
+            });
+            const size = Number(sizeResult.stdout.trim());
+            if (!Number.isInteger(size)) {
+                throw new SandboxCommandError(
+                    -1,
+                    `could not size ${path}: ${sizeResult.stdout.slice(0, 100)}`,
+                    '',
+                );
+            }
+            const chunks: Buffer[] = [];
+            for (let offset = 0; offset < size; offset += READ_CHUNK_BYTES) {
+                // eslint-disable-next-line no-await-in-loop
+                const result = await this.runBuffered(
+                    `tail -c +${offset + 1} ${quoted} | head -c ${READ_CHUNK_BYTES} | base64 | tr -d '\\n'`,
+                    { timeoutMs: INTERNAL_EXEC_TIMEOUT_MS },
+                );
+                chunks.push(Buffer.from(result.stdout, 'base64'));
+            }
+            return Buffer.concat(chunks);
+        },
+        write: async (
+            path: string,
+            contents: string | Uint8Array,
+        ): Promise<void> => {
+            const buffer =
+                typeof contents === 'string'
+                    ? Buffer.from(contents, 'utf8')
+                    : Buffer.from(contents);
+            const quoted = shQuote(path);
+            const dir = shQuote(
+                path.includes('/')
+                    ? path.slice(0, path.lastIndexOf('/')) || '/'
+                    : '.',
+            );
+            await this.runBuffered(`mkdir -p ${dir} && : > ${quoted}`, {
+                timeoutMs: INTERNAL_EXEC_TIMEOUT_MS,
+            });
+            for (
+                let offset = 0;
+                offset < buffer.length;
+                offset += WRITE_CHUNK_BYTES
+            ) {
+                const chunk = buffer
+                    .subarray(offset, offset + WRITE_CHUNK_BYTES)
+                    .toString('base64');
+                // eslint-disable-next-line no-await-in-loop
+                await this.runBuffered(
+                    `printf '%s' '${chunk}' | base64 -d >> ${quoted}`,
+                    { timeoutMs: INTERNAL_EXEC_TIMEOUT_MS },
+                );
+            }
+        },
+        remove: async (path: string): Promise<void> => {
+            await this.runBuffered(`rm -rf ${shQuote(path)}`, {
+                timeoutMs: INTERNAL_EXEC_TIMEOUT_MS,
+            }).catch(() => {});
+        },
+    };
+}

--- a/packages/backend/src/ee/services/SandboxRuntime/CloudRunExecChannel.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/CloudRunExecChannel.ts
@@ -35,7 +35,16 @@ const buildCommandLine = (command: string, options?: RunOptions): string => {
     if (options?.cwd) parts.push(`cd ${shQuote(options.cwd)} &&`);
     if (options?.envs) {
         const exports = Object.entries(options.envs)
-            .map(([key, value]) => `${key}=${shQuote(value)}`)
+            .map(([key, value]) => {
+                // Keys are interpolated unquoted into the sh -c string — only
+                // POSIX identifiers are safe.
+                if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+                    throw new Error(
+                        `Invalid sandbox env var name: ${JSON.stringify(key)}`,
+                    );
+                }
+                return `${key}=${shQuote(value)}`;
+            })
             .join(' ');
         if (exports) parts.push(`export ${exports};`);
     }
@@ -215,7 +224,15 @@ export class CloudRunGatewayClient {
                 '',
             );
         }
-        return response.json();
+        try {
+            return await response.json();
+        } catch (error) {
+            throw new SandboxCommandError(
+                -1,
+                `Cloud Run sandbox gateway ${path} returned a non-JSON response`,
+                '',
+            );
+        }
     }
 
     /** `sandbox run <id> --detach` behind the gateway. */
@@ -288,22 +305,26 @@ export class CloudRunExecChannel {
         options?: RunOptions,
     ): Promise<CommandResult> {
         const controller = new AbortController();
-        const timeoutMs = options?.timeoutMs;
-        const timer =
-            timeoutMs && timeoutMs > 0
-                ? setTimeout(() => controller.abort(), timeoutMs)
-                : null;
+        const timeoutMs =
+            options?.timeoutMs && options.timeoutMs > 0
+                ? options.timeoutMs
+                : undefined;
+        const timer = timeoutMs
+            ? setTimeout(() => controller.abort(), timeoutMs)
+            : null;
+        // Server-side backstop 10s past the client abort so the spawn is
+        // reaped even if this client goes away. Unbounded runs get the
+        // internal cap — callers wanting longer must pass a timeout (and
+        // thereby detach past the threshold).
+        const serverTimeoutMs =
+            (timeoutMs ?? INTERNAL_EXEC_TIMEOUT_MS) + 10_000;
         try {
             const raw = await this.client.post(
                 'exec',
                 {
                     sandboxId: this.sandboxId,
                     command: buildCommandLine(command, options),
-                    // Server-side backstop 10s past the client abort so the
-                    // spawn is reaped even if this client goes away. Unbounded
-                    // runs get the internal cap — callers wanting longer must
-                    // pass a timeout (and thereby detach past the threshold).
-                    timeout: (timeoutMs ?? INTERNAL_EXEC_TIMEOUT_MS) + 10_000,
+                    timeout: serverTimeoutMs,
                 },
                 {
                     signal: controller.signal,
@@ -314,7 +335,7 @@ export class CloudRunExecChannel {
             // The gateway reports its own spawn timeout as exit 124.
             if (result.exitCode === 124 && /timed out/i.test(result.stderr)) {
                 throw new SandboxTimeoutError(
-                    `Command timed out on the gateway (configured ${timeoutMs}ms)`,
+                    `Command timed out on the gateway (server cap ${serverTimeoutMs}ms)`,
                 );
             }
             // Buffered exec — replay the captured output through the streaming

--- a/packages/backend/src/ee/services/SandboxRuntime/CloudRunExecChannel.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/CloudRunExecChannel.ts
@@ -202,12 +202,16 @@ export class CloudRunGatewayClient {
             requestInit,
         );
         if (!response.ok) {
-            // Gateway error bodies are untrusted — truncate rather than
-            // echoing them verbatim into logs/Sentry.
+            // Gateway error bodies are untrusted — truncate and redact the
+            // shared secret rather than echoing them verbatim into logs/Sentry.
             const text = await response.text().catch(() => '');
+            const sanitized = text
+                .split(this.sandboxSecret)
+                .join('[redacted]')
+                .slice(0, 200);
             throw new SandboxCommandError(
                 response.status,
-                `Cloud Run sandbox gateway ${path} failed: ${text.slice(0, 200)}`,
+                `Cloud Run sandbox gateway ${path} failed: ${sanitized}`,
                 '',
             );
         }

--- a/packages/backend/src/ee/services/SandboxRuntime/CloudRunSandboxProvider.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/CloudRunSandboxProvider.ts
@@ -1,0 +1,208 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+import {
+    CloudRunExecChannel,
+    CloudRunGatewayClient,
+} from './CloudRunExecChannel';
+import { createGitOverCommands, shQuote } from './gitOverCommands';
+import { type SnapshotStore } from './SnapshotStore';
+import {
+    type PersistOptions,
+    type SandboxCapabilities,
+    type SandboxGit,
+    type SandboxHandle,
+    type SandboxLogger,
+    type SandboxProvider,
+    type SandboxSpec,
+    type SnapshotRef,
+} from './types';
+
+/**
+ * Strip the leading slash so a `tar -C / <path>` archives `home/user/repo`
+ * rather than `/home/user/repo`, letting `tar -x -C /` restore it to the exact
+ * same absolute location on resume (same convention as the Docker provider).
+ */
+const toArchiveRelative = (absolutePath: string): string =>
+    absolutePath.replace(/^\/+/, '');
+
+/** Static config the `gcp-cloud-run` provider needs. */
+export interface CloudRunSandboxesConfig {
+    /** Base URL of the sandbox gateway Cloud Run service. */
+    sandboxUrl: string;
+    /** Shared secret the gateway authenticates callers with. */
+    sandboxSecret: string;
+}
+
+class CloudRunSandboxHandle implements SandboxHandle {
+    readonly commands;
+
+    readonly files;
+
+    readonly git: SandboxGit;
+
+    constructor(
+        readonly sandboxId: string,
+        channel: CloudRunExecChannel,
+    ) {
+        this.commands = channel.commands;
+        this.files = channel.files;
+        this.git = createGitOverCommands(channel.commands, channel.files);
+    }
+}
+
+/**
+ * Google **Cloud Run Sandboxes** provider (public preview, Jul 2026). Sandboxes
+ * are gVisor-isolated execution boundaries spawned *inside* a Cloud Run service
+ * instance deployed with `--sandbox-launcher`; a small gateway service (the
+ * ComputeSDK Cloud Run gateway) fronts the in-instance `sandbox` CLI with an
+ * HTTP API, which is what this provider drives — the backend itself runs
+ * anywhere (locally in dev) and reaches sandboxes over HTTPS.
+ *
+ * Sandboxes see the *gateway container's filesystem* read-only with a writable
+ * memory overlay, so the toolchain image is baked into the gateway deployment —
+ * `spec.templateRef` cannot select a per-sandbox image and is ignored.
+ *
+ * No native suspend: like Docker this is a `pauseResume: false` backend —
+ * `persist` tars the declared workspace to the {@link SnapshotStore} and
+ * `resume` restores it into a fresh sandbox (`s3-tar` refs).
+ *
+ * Egress is binary on this backend (`--allow-egress` per sandbox, deny by
+ * default): a non-empty spec allowlist coarsens to full egress, mirroring the
+ * Lambda provider's INTERNET_EGRESS MVP posture.
+ */
+export class CloudRunSandboxProvider implements SandboxProvider {
+    readonly capabilities: SandboxCapabilities = { pauseResume: false };
+
+    private readonly client: CloudRunGatewayClient;
+
+    constructor(
+        config: CloudRunSandboxesConfig,
+        private readonly logger: SandboxLogger,
+        private readonly snapshotStore: SnapshotStore,
+    ) {
+        this.client = new CloudRunGatewayClient(
+            config.sandboxUrl,
+            config.sandboxSecret,
+        );
+    }
+
+    async create(spec: SandboxSpec): Promise<SandboxHandle> {
+        // Gateway sandbox ids must match [A-Za-z0-9_-]+.
+        const sandboxId = `ld-${randomUUID()}`;
+        const allowEgress = spec.egress.allow.length > 0;
+        if (allowEgress) {
+            this.logger.warn(
+                `Cloud Run sandboxes enforce egress as all-or-nothing; coarsening the ${spec.egress.allow.length}-host allowlist to full egress (id=${sandboxId})`,
+            );
+        }
+        await this.client.createSandbox({
+            sandboxId,
+            allowEgress,
+            envs: spec.envs ?? null,
+        });
+        this.logger.info(`Cloud Run sandbox created (id=${sandboxId})`);
+        return this.buildHandle(sandboxId);
+    }
+
+    async connect(sandboxId: string): Promise<SandboxHandle> {
+        const handle = this.buildHandle(sandboxId);
+        // The gateway has no real liveness endpoint — a trivial exec verifies
+        // the sandbox still exists. Throws if it is gone; callers fall back to
+        // create/resume.
+        await handle.commands.run('true', { timeoutMs: 30_000 });
+        return handle;
+    }
+
+    async destroy(sandboxId: string): Promise<void> {
+        try {
+            await this.client.destroySandbox(sandboxId);
+            this.logger.info(`Cloud Run sandbox destroyed (id=${sandboxId})`);
+        } catch (error) {
+            // Cleanup path — already-gone sandboxes and transient gateway
+            // errors are logged, not fatal.
+            this.logger.warn(
+                `Cloud Run sandbox destroy failed (id=${sandboxId}): ${String(
+                    error,
+                )}`,
+            );
+        }
+    }
+
+    /**
+     * Tar the declared workspace inside the sandbox and push it to the snapshot
+     * store — the same `s3-tar` shape the Docker provider writes, staged to a
+     * file and read back as raw bytes. Does not delete the sandbox — the
+     * Manager does that after persisting.
+     */
+    async persist(
+        handle: SandboxHandle,
+        options: PersistOptions,
+    ): Promise<SnapshotRef> {
+        const { workspace } = options;
+        const snapshotKey = `sandboxes/${randomUUID()}/snapshot.tar.gz`;
+        const archivePath = `/tmp/.ld-snapshot-${randomBytes(4).toString(
+            'hex',
+        )}.tar.gz`;
+        const excludeFlags = workspace.exclude
+            .map((pattern) => `--exclude=${shQuote(pattern)}`)
+            .join(' ');
+        const includeArgs = workspace.include
+            .map((path) => shQuote(toArchiveRelative(path)))
+            .join(' ');
+        await handle.commands.run(
+            `tar czf ${shQuote(archivePath)} --ignore-failed-read ${excludeFlags} -C / ${includeArgs}`,
+            { timeoutMs: 120_000 },
+        );
+        try {
+            const archive = await handle.files.readBytes(archivePath);
+            await this.snapshotStore.put(snapshotKey, archive);
+        } finally {
+            await handle.files.remove(archivePath);
+        }
+        this.logger.info(
+            `Cloud Run sandbox ${handle.sandboxId} persisted to ${snapshotKey} (${workspace.include.length} path(s))`,
+        );
+        return { kind: 's3-tar', key: snapshotKey };
+    }
+
+    /**
+     * Create a fresh sandbox from `spec`, then download the snapshot tarball
+     * and extract it `-C /` so the workspace lands back at its original paths.
+     */
+    async resume(ref: SnapshotRef, spec: SandboxSpec): Promise<SandboxHandle> {
+        if (ref.kind !== 's3-tar') {
+            throw new Error(
+                `CloudRunSandboxProvider cannot resume a snapshot of kind '${ref.kind}'`,
+            );
+        }
+        const handle = await this.create(spec);
+        const archivePath = `/tmp/.ld-restore-${randomBytes(4).toString(
+            'hex',
+        )}.tar.gz`;
+        const archive = await this.snapshotStore.get(ref.key);
+        await handle.files.write(archivePath, archive);
+        try {
+            await handle.commands.run(`tar xzf ${shQuote(archivePath)} -C /`, {
+                timeoutMs: 120_000,
+            });
+        } finally {
+            await handle.files.remove(archivePath);
+        }
+        this.logger.info(
+            `Cloud Run sandbox ${handle.sandboxId} resumed from ${ref.key}`,
+        );
+        return handle;
+    }
+
+    /** Delete the snapshot blob backing an s3-tar ref. */
+    async deleteSnapshot(ref: SnapshotRef): Promise<void> {
+        if (ref.kind !== 's3-tar') {
+            return;
+        }
+        await this.snapshotStore.delete(ref.key);
+    }
+
+    private buildHandle(sandboxId: string): SandboxHandle {
+        const channel = new CloudRunExecChannel(this.client, sandboxId);
+        return new CloudRunSandboxHandle(sandboxId, channel);
+    }
+}

--- a/packages/backend/src/ee/services/SandboxRuntime/index.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/index.ts
@@ -6,6 +6,10 @@ import {
     AzureSandboxGroupControlPlane,
     type AzureSandboxesConfig,
 } from './AzureContainerAppsSandboxProvider';
+import {
+    CloudRunSandboxProvider,
+    type CloudRunSandboxesConfig,
+} from './CloudRunSandboxProvider';
 import { DockerSandboxProvider } from './DockerSandboxProvider';
 import { E2bSandboxProvider } from './E2bSandboxProvider';
 import {
@@ -18,6 +22,7 @@ import { type SnapshotStore } from './SnapshotStore';
 import { type SandboxLogger, type SandboxProvider } from './types';
 
 export * from './AzureContainerAppsSandboxProvider';
+export * from './CloudRunSandboxProvider';
 export * from './errors';
 export * from './SandboxManager';
 export * from './SnapshotStore';
@@ -27,7 +32,8 @@ export type SandboxProviderKind =
     | 'e2b'
     | 'docker'
     | 'lambda-microvm'
-    | 'azure-sandboxes';
+    | 'azure-sandboxes'
+    | 'gcp-cloud-run';
 
 /** Static, non-per-sandbox config the Lambda MicroVMs provider needs. */
 export interface LambdaMicroVmProviderConfig extends LambdaMicroVmConfig {
@@ -47,10 +53,16 @@ export interface CreateSandboxProviderOptions {
      */
     azureSandboxes: AzureSandboxesConfig | null;
     /**
-     * Backing store for object-store snapshots. Required only by the Docker
-     * provider (no native memory snapshot); native-pause providers (E2B, Lambda,
-     * Azure Sandboxes) keep the snapshot in the provider and pass `null` so no S3
-     * client is constructed on those paths.
+     * Required when `provider === 'gcp-cloud-run'`; ignored otherwise. The
+     * gateway URL + secret of the Cloud Run service deployed with
+     * `--sandbox-launcher` (toolchain image baked into that deployment).
+     */
+    gcpCloudRun: CloudRunSandboxesConfig | null;
+    /**
+     * Backing store for object-store snapshots. Required by the providers with
+     * no native memory snapshot (Docker, GCP Cloud Run); native-pause providers
+     * (E2B, Lambda, Azure Sandboxes) keep the snapshot in the provider and pass
+     * `null` so no S3 client is constructed on those paths.
      */
     snapshotStore: SnapshotStore | null;
     logger: SandboxLogger;
@@ -103,6 +115,24 @@ export const createSandboxProvider = (
                 options.logger,
             );
         }
+        case 'gcp-cloud-run': {
+            const config = options.gcpCloudRun;
+            if (!config) {
+                throw new MissingConfigError(
+                    'GCP Cloud Run sandboxes are not configured (GCP_CLOUD_RUN_SANDBOX_URL / GCP_CLOUD_RUN_SANDBOX_SECRET)',
+                );
+            }
+            if (!options.snapshotStore) {
+                throw new MissingConfigError(
+                    'GCP Cloud Run sandbox provider requires an object store for snapshots',
+                );
+            }
+            return new CloudRunSandboxProvider(
+                config,
+                options.logger,
+                options.snapshotStore,
+            );
+        }
         case 'azure-sandboxes': {
             const config = options.azureSandboxes;
             if (!config || !config.sandboxGroup) {
@@ -137,7 +167,9 @@ export interface CreateSandboxManagerOptions {
     lambdaMicroVm: LambdaMicroVmProviderConfig | null;
     /** Required when `provider === 'azure-sandboxes'`. */
     azureSandboxes: AzureSandboxesConfig | null;
-    /** Forwarded to the provider; the Docker backend only (null otherwise). */
+    /** Required when `provider === 'gcp-cloud-run'`. */
+    gcpCloudRun: CloudRunSandboxesConfig | null;
+    /** Forwarded to the provider; object-store backends only (null otherwise). */
     snapshotStore: SnapshotStore | null;
     registryModel: SandboxRegistryStore;
     logger: SandboxLogger;
@@ -156,6 +188,7 @@ export const createSandboxManager = (
         dockerImage: options.dockerImage,
         lambdaMicroVm: options.lambdaMicroVm,
         azureSandboxes: options.azureSandboxes,
+        gcpCloudRun: options.gcpCloudRun,
         snapshotStore: options.snapshotStore,
         logger: options.logger,
     });


### PR DESCRIPTION
## Summary

Adds a sandbox provider for **Google Cloud Run Sandboxes** (public preview, Jul 2026): gVisor-isolated sandboxes spawned inside a Cloud Run service deployed with `--sandbox-launcher`, fronted by the ComputeSDK gateway's HTTP API. The backend runs anywhere (locally in dev) and reaches sandboxes over HTTPS.

- `CloudRunExecChannel` — gateway client + data plane over the stateful exec endpoint: buffered exec for everything within the gateway's 1h request cap (long-lived *detached* processes have repeatedly taken down preview sandboxes, so detached+poll is only a fallback beyond that), files over exec with base64 chunking sized to the 128KiB argv cap, `export PATH` + Claude Code background-spawn kill-switches on every command (sandbox exec sessions don't export PATH; detached node children can kill the sandbox).
- `CloudRunSandboxProvider` — `pauseResume: false` backend reusing the existing `s3-tar` snapshot path and `SnapshotStore` (like Docker). Egress coarsens the per-host allowlist to Cloud Run's binary `--allow-egress` (same MVP posture as Lambda's INTERNET_EGRESS).
- Config: `SANDBOX_PROVIDER=gcp-cloud-run` + `GCP_CLOUD_RUN_SANDBOX_URL` / `GCP_CLOUD_RUN_SANDBOX_SECRET`.
- Wired for the data-app pipeline; AI writeback / onboarding pass `gcpCloudRun: null` (they need their own gateway image) and fail with a clear config error if selected.

The gateway image is the data-app toolchain image + the ComputeSDK gateway server (`node gateway.mjs`), deployed with `--sandbox-launcher`; sandboxes see that filesystem read-only with a writable overlay, so the toolchain is baked into the gateway deployment and `templateRef` is ignored.

## Test plan

- [x] Backend typecheck + lint
- [x] E2E on a local dev deployment against a gateway in GCP staging: data-app generation (Claude Code in-sandbox, buffered exec), Vite build incl. one Claude auto-fix round, packaging via chunked reads, S3 upload, snapshot suspend
- [x] Iteration (v2): s3-tar snapshot resume into a fresh sandbox, `claude --continue`, rebuild, re-suspend
- [x] Egress deny-by-default vs `--allow-egress` verified per sandbox

Relates: PROD-8590