### PR TITLE
refactor(frontend): migrate layout and overlay components to Mantine 8

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -42,13 +42,9 @@ import {
     Stack,
     Text,
     Badge,
-} from '@mantine-8/core';
-import {
     HoverCard,
-    Portal,
-    Tooltip,
-    useMantineColorScheme,
-} from '@mantine/core';
+} from '@mantine-8/core';
+import { Portal, Tooltip, useMantineColorScheme } from '@mantine/core';
 import { useClipboard, useElementSize } from '@mantine/hooks';
 import {
     IconAlertCircle,

--- a/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapLayoutConfig.tsx
@@ -8,8 +8,8 @@ import {
     type Metric,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, Group, Stack, Switch, Text } from '@mantine-8/core';
-import { Grid, NumberInput, Tooltip } from '@mantine/core';
+import { Box, Grid, Group, Stack, Switch, Text } from '@mantine-8/core';
+import { NumberInput, Tooltip } from '@mantine/core';
 import { IconHelpCircle } from '@tabler/icons-react';
 import FieldSelect from '../../common/FieldSelect';
 import MantineIcon from '../../common/MantineIcon';

--- a/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.module.css
+++ b/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.module.css
@@ -1,0 +1,11 @@
+.root {
+    overflow-y: auto;
+}
+
+.itemWrapper {
+    width: 100%;
+
+    &:hover {
+        background-color: var(--mantine-color-blue-1);
+    }
+}

--- a/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.tsx
+++ b/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.tsx
@@ -1,8 +1,9 @@
-import { Button, Card } from '@mantine-8/core';
-import { List, Tooltip } from '@mantine/core';
+import { Button, Card, List } from '@mantine-8/core';
+import { Tooltip } from '@mantine/core';
 import { type SuggestionProps } from '@tiptap/suggestion';
 import { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 import { type SuggestionsItem } from '../../types';
+import classes from './SuggestionList.module.css';
 
 export type SuggestionListRef = {
     onKeyDown: (props: { event: KeyboardEvent }) => boolean;
@@ -68,17 +69,10 @@ export const SuggestionList = forwardRef<
                 withPadding={false}
                 listStyleType="none"
                 mah={120}
-                styles={(theme) => ({
-                    root: {
-                        overflowY: 'auto',
-                    },
-                    itemWrapper: {
-                        width: '100%',
-                        '&:hover': {
-                            backgroundColor: theme.colors.blue['1'],
-                        },
-                    },
-                })}
+                classNames={{
+                    root: classes.root,
+                    itemWrapper: classes.itemWrapper,
+                }}
             >
                 {props.items.map((item, index) => (
                     <List.Item key={index} fz="xs">

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -18,8 +18,9 @@ import {
     Indicator,
     LoadingOverlay,
     SegmentedControl,
+    Transition,
 } from '@mantine-8/core';
-import { Tooltip, Transition } from '@mantine/core';
+import { Tooltip } from '@mantine/core';
 import { useElementSize, useHotkeys } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import {

--- a/packages/frontend/src/pages/PasswordRecoveryForm.tsx
+++ b/packages/frontend/src/pages/PasswordRecoveryForm.tsx
@@ -7,8 +7,8 @@ import {
     Title,
     Button,
     Anchor,
+    List,
 } from '@mantine-8/core';
-import { List } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { type FC } from 'react';
 import { Link } from 'react-router';


### PR DESCRIPTION
## Summary

- migrate `Transition`, `Grid`, `List`, and `HoverCard` from Mantine 6 to Mantine 8
- move `SuggestionList` nested hover styling to a CSS Module compatible with Mantine 8
- preserve existing component props, layout, transitions, and overlay behavior

## Why

Reduces the remaining Mantine 6 surface while keeping each call site's behavior unchanged.

## Validation

- `pnpm -F frontend typecheck:fast`
- targeted `oxfmt` and `oxlint`
- AST check confirms zero legacy imports for all four components
- frontend suite: 1,350/1,351 passed; the only failure came from separate MultiSelect work not included in this branch