### PR TITLE
refactor(frontend): migrate tables and overlays to Mantine 8

### DIFF
--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -1,17 +1,14 @@
 import {
     ActionIcon,
+    Box,
     Burger,
     Divider,
+    Drawer,
     Group,
     Stack,
     Title,
 } from '@mantine-8/core';
-import {
-    Drawer,
-    getDefaultZIndex,
-    Header,
-    MantineProvider,
-} from '@mantine/core';
+import { getDefaultZIndex, Header, MantineProvider } from '@mantine/core';
 import {
     IconChartAreaLine,
     IconFolders,
@@ -41,6 +38,7 @@ import { loadLazyRouteDefault } from './features/chunkErrorHandler';
 import { useActiveProjectUuid } from './hooks/useActiveProject';
 import useLogoutMutation from './hooks/user/useUserLogoutMutation';
 import { getMantineThemeOverride } from './mantineTheme';
+import Mantine8Provider from './providers/Mantine8Provider';
 import { TrackPage } from './providers/Tracking/TrackingProvider';
 import Logo from './svgs/logo-icon.svg?react';
 import { PageName } from './types/Events';
@@ -48,6 +46,9 @@ import { PageName } from './types/Events';
 const MobileAiAgentsNavLink = lazy(
     () => import('./components/Mobile/MobileAiAgentsNavLink'),
 );
+
+const getMobileNavBarRootElement = () =>
+    document.getElementById('mobile-navbar') ?? undefined;
 
 const RedirectToResource: FC = () => {
     const { projectUuid, savedQueryUuid, dashboardUuid } = useParams();
@@ -93,102 +94,115 @@ export const MobileNavBar: FC = () => {
     }, []);
 
     return (
-        <MantineProvider theme={darkTheme}>
-            <Header
-                height={50}
-                display="flex"
-                px="md"
-                zIndex={getDefaultZIndex('app')}
-                sx={{
-                    alignItems: 'center',
-                    boxShadow: 'lg',
-                }}
+        <Box id="mobile-navbar" data-mantine-color-scheme="dark">
+            <Mantine8Provider
+                forceColorScheme="dark"
+                cssVariablesSelector="#mobile-navbar"
+                getRootElement={getMobileNavBarRootElement}
             >
-                <Group align="center" justify="space-between" flex={1}>
-                    <ActionIcon
-                        variant="subtle"
-                        color="gray"
-                        component={Link}
-                        to={'/'}
-                        title="Home"
-                        size="lg"
+                <MantineProvider theme={darkTheme}>
+                    <Header
+                        height={50}
+                        display="flex"
+                        px="md"
+                        zIndex={getDefaultZIndex('app')}
+                        sx={{
+                            alignItems: 'center',
+                            boxShadow: 'lg',
+                        }}
                     >
-                        <Logo />
-                    </ActionIcon>
-                    <Burger
-                        opened={isMenuOpen}
-                        onClick={toggleMenu}
-                        color="white"
-                        aria-label={
-                            isMenuOpen
-                                ? 'Close navigation menu'
-                                : 'Open navigation menu'
-                        }
-                        aria-expanded={isMenuOpen}
-                        aria-controls="mobile-navigation"
-                    />
-                </Group>
-            </Header>
+                        <Group align="center" justify="space-between" flex={1}>
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                                component={Link}
+                                to={'/'}
+                                title="Home"
+                                size="lg"
+                            >
+                                <Logo />
+                            </ActionIcon>
+                            <Burger
+                                opened={isMenuOpen}
+                                onClick={toggleMenu}
+                                color="white"
+                                aria-label={
+                                    isMenuOpen
+                                        ? 'Close navigation menu'
+                                        : 'Open navigation menu'
+                                }
+                                aria-expanded={isMenuOpen}
+                                aria-controls="mobile-navigation"
+                            />
+                        </Group>
+                    </Header>
 
-            <Drawer
-                id="mobile-navigation"
-                title={<ThemeSwitcher />}
-                opened={isMenuOpen}
-                onClose={toggleMenu}
-                size="75%"
-            >
-                <Title order={6} fw={600} mb="xs">
-                    Project
-                </Title>
-                <ProjectSwitcher />
-                <Divider my="lg" />
-                <RouterNavLink
-                    exact
-                    label="Home"
-                    to={`/`}
-                    leftSection={<MantineIcon icon={IconHome} />}
-                    onClick={toggleMenu}
-                />
-                <RouterNavLink
-                    exact
-                    label="Spaces"
-                    to={`/projects/${activeProjectUuid}/spaces`}
-                    leftSection={<MantineIcon icon={IconFolders} />}
-                    onClick={toggleMenu}
-                />
-                <RouterNavLink
-                    exact
-                    label="Dashboards"
-                    to={`/projects/${activeProjectUuid}/dashboards`}
-                    leftSection={<MantineIcon icon={IconLayoutDashboard} />}
-                    onClick={toggleMenu}
-                />
-                <RouterNavLink
-                    exact
-                    label="Charts"
-                    to={`/projects/${activeProjectUuid}/saved`}
-                    leftSection={<MantineIcon icon={IconChartAreaLine} />}
-                    onClick={toggleMenu}
-                />
-                {isMenuOpen && (
-                    <Suspense fallback={null}>
-                        <MobileAiAgentsNavLink
-                            activeProjectUuid={activeProjectUuid}
+                    <Drawer
+                        id="mobile-navigation"
+                        title={<ThemeSwitcher />}
+                        opened={isMenuOpen}
+                        onClose={toggleMenu}
+                        size="75%"
+                        portalProps={{ target: '#mobile-navbar' }}
+                    >
+                        <Title order={6} fw={600} mb="xs">
+                            Project
+                        </Title>
+                        <ProjectSwitcher />
+                        <Divider my="lg" />
+                        <RouterNavLink
+                            exact
+                            label="Home"
+                            to={`/`}
+                            leftSection={<MantineIcon icon={IconHome} />}
                             onClick={toggleMenu}
                         />
-                    </Suspense>
-                )}
-                <Divider my="lg" />
+                        <RouterNavLink
+                            exact
+                            label="Spaces"
+                            to={`/projects/${activeProjectUuid}/spaces`}
+                            leftSection={<MantineIcon icon={IconFolders} />}
+                            onClick={toggleMenu}
+                        />
+                        <RouterNavLink
+                            exact
+                            label="Dashboards"
+                            to={`/projects/${activeProjectUuid}/dashboards`}
+                            leftSection={
+                                <MantineIcon icon={IconLayoutDashboard} />
+                            }
+                            onClick={toggleMenu}
+                        />
+                        <RouterNavLink
+                            exact
+                            label="Charts"
+                            to={`/projects/${activeProjectUuid}/saved`}
+                            leftSection={
+                                <MantineIcon icon={IconChartAreaLine} />
+                            }
+                            onClick={toggleMenu}
+                        />
+                        {isMenuOpen && (
+                            <Suspense fallback={null}>
+                                <MobileAiAgentsNavLink
+                                    activeProjectUuid={activeProjectUuid}
+                                    onClick={toggleMenu}
+                                />
+                            </Suspense>
+                        )}
+                        <Divider my="lg" />
 
-                <RouterNavLink
-                    exact
-                    label="Logout"
-                    to={`/`}
-                    leftSection={<MantineIcon icon={IconLogout} />}
-                    onClick={() => logout()}
-                />
-            </Drawer>
-        </MantineProvider>
+                        <RouterNavLink
+                            exact
+                            label="Logout"
+                            to={`/`}
+                            leftSection={<MantineIcon icon={IconLogout} />}
+                            onClick={() => logout()}
+                        />
+                    </Drawer>
+                </MantineProvider>
+            </Mantine8Provider>
+        </Box>
     );
 };
 

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -43,8 +43,9 @@ import {
     Text,
     Badge,
     HoverCard,
+    Portal,
 } from '@mantine-8/core';
-import { Portal, Tooltip, useMantineColorScheme } from '@mantine/core';
+import { Tooltip, useMantineColorScheme } from '@mantine/core';
 import { useClipboard, useElementSize } from '@mantine/hooks';
 import {
     IconAlertCircle,

--- a/packages/frontend/src/components/JobDetailsDrawer/index.tsx
+++ b/packages/frontend/src/components/JobDetailsDrawer/index.tsx
@@ -14,8 +14,9 @@ import {
     Text,
     Title,
     ActionIcon,
+    Drawer,
+    type DefaultMantineColor,
 } from '@mantine-8/core';
-import { Drawer, type DefaultMantineColor } from '@mantine/core';
 import { useInterval } from '@mantine/hooks';
 import {
     IconAlertTriangle,

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CredentialsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CredentialsTable.tsx
@@ -1,6 +1,5 @@
 import { type OrganizationWarehouseCredentials } from '@lightdash/common';
-import { Group, Paper, Text, ActionIcon } from '@mantine-8/core';
-import { Table } from '@mantine/core';
+import { ActionIcon, Group, Paper, Table } from '@mantine-8/core';
 import { IconEdit, IconTrash } from '@tabler/icons-react';
 import { type Dispatch, type FC, type SetStateAction } from 'react';
 import { useTableStyles } from '../../../hooks/styles/useTableStyles';
@@ -30,13 +29,11 @@ const CredentialsItem: FC<
     setWarehouseCredentialsToBeDeleted,
     setWarehouseCredentialsToBeEdited,
 }) => (
-    <tr>
-        <Text component="td" fw={500}>
-            {credentials.name}
-        </Text>
-        <td>{credentials.description || '-'}</td>
-        <td>{getWarehouseLabel(credentials.warehouseType)}</td>
-        <td
+    <Table.Tr>
+        <Table.Td fw={500}>{credentials.name}</Table.Td>
+        <Table.Td>{credentials.description || '-'}</Table.Td>
+        <Table.Td>{getWarehouseLabel(credentials.warehouseType)}</Table.Td>
+        <Table.Td
             style={{
                 display: 'flex',
                 justifyContent: 'flex-end',
@@ -64,8 +61,8 @@ const CredentialsItem: FC<
                     <MantineIcon icon={IconTrash} />
                 </ActionIcon>
             </Group>
-        </td>
-    </tr>
+        </Table.Td>
+    </Table.Tr>
 );
 
 export const CredentialsTable: FC<CredentialsTableProps> = ({
@@ -81,15 +78,15 @@ export const CredentialsTable: FC<CredentialsTableProps> = ({
                 className={cx(classes.root, classes.alignLastTdRight)}
                 ta="left"
             >
-                <thead>
-                    <tr>
-                        <th>Name</th>
-                        <th>Description</th>
-                        <th>Warehouse</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
+                <Table.Thead>
+                    <Table.Tr>
+                        <Table.Th>Name</Table.Th>
+                        <Table.Th>Description</Table.Th>
+                        <Table.Th>Warehouse</Table.Th>
+                        <Table.Th />
+                    </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
                     {credentials?.map((c) => (
                         <CredentialsItem
                             key={c.organizationWarehouseCredentialsUuid}
@@ -102,7 +99,7 @@ export const CredentialsTable: FC<CredentialsTableProps> = ({
                             }
                         />
                     ))}
-                </tbody>
+                </Table.Tbody>
             </Table>
         </Paper>
     );

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCellOverlay.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCellOverlay.tsx
@@ -1,6 +1,6 @@
 import { type CatalogField } from '@lightdash/common';
-import { Box } from '@mantine-8/core';
-import { getDefaultZIndex, Portal, px, useMantineTheme } from '@mantine/core';
+import { Box, Portal } from '@mantine-8/core';
+import { getDefaultZIndex, px, useMantineTheme } from '@mantine/core';
 import MarkdownPreview, {
     type MarkdownPreviewProps,
 } from '@uiw/react-markdown-preview';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -6,8 +6,9 @@ import {
     Button,
     ActionIcon,
     Highlight,
+    Portal,
 } from '@mantine-8/core';
-import { getDefaultZIndex, Portal } from '@mantine/core';
+import { getDefaultZIndex } from '@mantine/core';
 import { useClickOutside } from '@mantine/hooks';
 import { IconTrash } from '@tabler/icons-react';
 import EmojiPicker, {

--- a/packages/frontend/src/features/tableCalculation/components/CreateTableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/CreateTableCalculationModal.tsx
@@ -3,7 +3,6 @@ import {
     TableCalculationType,
     type TableCalculation,
 } from '@lightdash/common';
-import { type ModalProps } from '@mantine/core';
 import { useCallback, type FC } from 'react';
 import {
     explorerActions,
@@ -15,7 +14,7 @@ import TableCalculationModal, {
     type TableCalculationSaveMeta,
 } from './TableCalculationModal';
 
-type Props = ModalProps & {
+type Props = {
     opened: boolean;
     onClose: () => void;
 };

--- a/packages/frontend/src/features/tableCalculation/components/UpdateTableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/UpdateTableCalculationModal.tsx
@@ -3,7 +3,6 @@ import {
     TableCalculationType,
     type TableCalculation,
 } from '@lightdash/common';
-import { type ModalProps } from '@mantine/core';
 import { useCallback, type FC } from 'react';
 import {
     explorerActions,
@@ -15,7 +14,9 @@ import TableCalculationModal, {
     type TableCalculationSaveMeta,
 } from './TableCalculationModal';
 
-type Props = ModalProps & {
+type Props = {
+    opened: boolean;
+    onClose: () => void;
     tableCalculation: TableCalculation;
 };
 

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -7,8 +7,9 @@ import {
     Button,
     ActionIcon,
     Anchor,
+    Modal,
 } from '@mantine-8/core';
-import { Modal, Tooltip, useMantineTheme } from '@mantine/core';
+import { Tooltip, useMantineTheme } from '@mantine/core';
 import { modals } from '@mantine/modals';
 import { IconCheck, IconCopy, IconSpeakerphone } from '@tabler/icons-react';
 import { defaultContext } from '@tanstack/react-query';
@@ -134,7 +135,6 @@ const ApiErrorDisplayWithHealth = ({
         case 'SnowflakeTokenError':
             return (
                 <>
-                    {/* FIXME: Replace with MantineModal when we migrate fully to Mantine 8 */}
                     <Modal
                         opened={true}
                         onClose={() => onClose?.()}

--- a/packages/frontend/src/pages/UserActivity.tsx
+++ b/packages/frontend/src/pages/UserActivity.tsx
@@ -12,8 +12,9 @@ import {
     Button,
     Anchor,
     Card,
+    Table,
 } from '@mantine-8/core';
-import { Table, Tooltip } from '@mantine/core';
+import { Tooltip } from '@mantine/core';
 import { IconUsers } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link, useParams } from 'react-router';
@@ -89,40 +90,40 @@ const showTableViews = ({
     views: ActivityViews[];
 }) => {
     return (
-        <tbody>
+        <Table.Tbody>
             {views.map((view) => {
                 const to =
                     type === 'dashboard'
                         ? getDashboardLink(projectUuid, view.uuid)
                         : getChartLink(projectUuid, view.uuid);
                 return (
-                    <tr key={`${key}-${view.uuid}`}>
-                        <td>
+                    <Table.Tr key={`${key}-${view.uuid}`}>
+                        <Table.Td>
                             <Anchor inherit component={Link} to={to}>
                                 {view.name}
                             </Anchor>
-                        </td>
-                        <td>{view.count}</td>
-                    </tr>
+                        </Table.Td>
+                        <Table.Td>{view.count}</Table.Td>
+                    </Table.Tr>
                 );
             })}
-        </tbody>
+        </Table.Tbody>
     );
 };
 
 const showTableBodyWithUsers = (key: string, userList: UserWithCount[]) => {
     return (
-        <tbody>
+        <Table.Tbody>
             {userList.map((user) => {
                 return (
-                    <tr key={`${key}-${user.userUuid}`}>
-                        <td>{user.firstName} </td>
-                        <td>{user.lastName}</td>
-                        <td>{user.count}</td>
-                    </tr>
+                    <Table.Tr key={`${key}-${user.userUuid}`}>
+                        <Table.Td>{user.firstName} </Table.Td>
+                        <Table.Td>{user.lastName}</Table.Td>
+                        <Table.Td>{user.count}</Table.Td>
+                    </Table.Tr>
                 );
             })}
-        </tbody>
+        </Table.Tbody>
     );
 };
 
@@ -372,13 +373,13 @@ const UserActivity: FC = () => {
                         days?"
                 >
                     <Table withColumnBorders ta="left">
-                        <thead>
-                            <tr>
-                                <th>First Name</th>
-                                <th>Last Name</th>
-                                <th>Number of Queries</th>
-                            </tr>
-                        </thead>
+                        <Table.Thead>
+                            <Table.Tr>
+                                <Table.Th>First Name</Table.Th>
+                                <Table.Th>Last Name</Table.Th>
+                                <Table.Th>Number of Queries</Table.Th>
+                            </Table.Tr>
+                        </Table.Thead>
                         {showTableBodyWithUsers(
                             'users-most-queries',
                             data.tableMostQueries,
@@ -392,13 +393,13 @@ const UserActivity: FC = () => {
                         last 7 days? (top 10)"
                 >
                     <Table withColumnBorders ta="left">
-                        <thead>
-                            <tr>
-                                <th>First Name</th>
-                                <th>Last Name</th>
-                                <th>Number of chart updates</th>
-                            </tr>
-                        </thead>
+                        <Table.Thead>
+                            <Table.Tr>
+                                <Table.Th>First Name</Table.Th>
+                                <Table.Th>Last Name</Table.Th>
+                                <Table.Th>Number of chart updates</Table.Th>
+                            </Table.Tr>
+                        </Table.Thead>
                         {showTableBodyWithUsers(
                             'users-created-most-charts',
                             data.tableMostCreatedCharts,
@@ -410,13 +411,13 @@ const UserActivity: FC = () => {
                     description="Which users have not run queries in the last 90 days?"
                 >
                     <Table withColumnBorders ta="left">
-                        <thead>
-                            <tr>
-                                <th>First Name</th>
-                                <th>Last Name</th>
-                                <th>Days since last query</th>
-                            </tr>
-                        </thead>
+                        <Table.Thead>
+                            <Table.Tr>
+                                <Table.Th>First Name</Table.Th>
+                                <Table.Th>Last Name</Table.Th>
+                                <Table.Th>Days since last query</Table.Th>
+                            </Table.Tr>
+                        </Table.Thead>
                         {showTableBodyWithUsers(
                             'users-not-logged-in',
                             data.tableNoQueries,
@@ -429,23 +430,23 @@ const UserActivity: FC = () => {
                     description="User's most viewed dashboard"
                 >
                     <Table withColumnBorders ta="left">
-                        <thead>
-                            <tr>
-                                <th>First Name</th>
-                                <th>Last Name</th>
-                                <th>Dashboard name</th>
-                                <th>Number of views</th>
-                            </tr>
-                        </thead>
-                        <tbody>
+                        <Table.Thead>
+                            <Table.Tr>
+                                <Table.Th>First Name</Table.Th>
+                                <Table.Th>Last Name</Table.Th>
+                                <Table.Th>Dashboard name</Table.Th>
+                                <Table.Th>Number of views</Table.Th>
+                            </Table.Tr>
+                        </Table.Thead>
+                        <Table.Tbody>
                             {data.userMostViewedDashboards.map((user) => {
                                 return (
-                                    <tr
+                                    <Table.Tr
                                         key={`user-most-viewed-${user.userUuid}`}
                                     >
-                                        <td>{user.firstName} </td>
-                                        <td>{user.lastName}</td>
-                                        <td>
+                                        <Table.Td>{user.firstName} </Table.Td>
+                                        <Table.Td>{user.lastName}</Table.Td>
+                                        <Table.Td>
                                             <Anchor
                                                 inherit
                                                 component={Link}
@@ -456,13 +457,13 @@ const UserActivity: FC = () => {
                                             >
                                                 {user.dashboardName}
                                             </Anchor>
-                                        </td>
+                                        </Table.Td>
 
-                                        <td>{user.count}</td>
-                                    </tr>
+                                        <Table.Td>{user.count}</Table.Td>
+                                    </Table.Tr>
                                 );
                             })}
-                        </tbody>
+                        </Table.Tbody>
                     </Table>
                 </VisualizationCard>
                 {health?.hasExtendedUsageAnalytics ? (
@@ -472,12 +473,12 @@ const UserActivity: FC = () => {
                             description="Dashboard views (top 20)"
                         >
                             <Table withColumnBorders ta="left">
-                                <thead>
-                                    <tr>
-                                        <th>Dashboard name</th>
-                                        <th>Views</th>
-                                    </tr>
-                                </thead>
+                                <Table.Thead>
+                                    <Table.Tr>
+                                        <Table.Th>Dashboard name</Table.Th>
+                                        <Table.Th>Views</Table.Th>
+                                    </Table.Tr>
+                                </Table.Thead>
                                 {showTableViews({
                                     key: 'dashboard-views',
                                     projectUuid,
@@ -491,12 +492,12 @@ const UserActivity: FC = () => {
                             description="Chart views (top 20)"
                         >
                             <Table withColumnBorders ta="left">
-                                <thead>
-                                    <tr>
-                                        <th>Chart name</th>
-                                        <th>Views</th>
-                                    </tr>
-                                </thead>
+                                <Table.Thead>
+                                    <Table.Tr>
+                                        <Table.Th>Chart name</Table.Th>
+                                        <Table.Th>Views</Table.Th>
+                                    </Table.Tr>
+                                </Table.Thead>
                                 {showTableViews({
                                     key: 'chart-views',
                                     projectUuid,


### PR DESCRIPTION
## Stack

- Base: #25977
- This PR should merge after the base PR.

## Summary

- migrate all remaining legacy `Table` roots and native descendants to Mantine 8 compound components
- migrate all remaining legacy `Portal` usages and adopt Mantine 8 shared portal targets
- migrate `Drawer`, `Modal`, and `DefaultMantineColor` to Mantine 8
- preserve the mobile navigation's forced-dark theme by scoping Mantine 8 variables and its Drawer portal to the mobile navbar root
- replace misleading broad `ModalProps` inheritance with the actual `opened`/`onClose` contracts

## Why

Reduces the remaining Mantine 6 runtime surface while preserving table styling, overlay behavior, focus management, and mobile dark-mode presentation.

## Validation

- `pnpm -F common build`
- `pnpm -F formula build`
- `pnpm -F frontend typecheck:fast`
- targeted `oxfmt` and `oxlint`
- AST checks confirm zero legacy imports for all migrated surfaces and zero native table descendants in migrated owners
- `pnpm -F frontend test` (166 files, 1,338 tests passed)