### PR TITLE
refactor(frontend): migrate Header and Tooltip to Mantine 8

### DIFF
--- a/packages/frontend/src/MobileRoutes.module.css
+++ b/packages/frontend/src/MobileRoutes.module.css
@@ -1,0 +1,7 @@
+.header {
+    align-items: center;
+    box-sizing: border-box;
+    background-color: var(--mantine-color-dark-7);
+    border-bottom: 1px solid var(--mantine-color-dark-5);
+    box-shadow: var(--mantine-shadow-lg);
+}

--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -4,11 +4,11 @@ import {
     Burger,
     Divider,
     Drawer,
+    getDefaultZIndex,
     Group,
     Stack,
     Title,
 } from '@mantine-8/core';
-import { getDefaultZIndex, Header, MantineProvider } from '@mantine/core';
 import {
     IconChartAreaLine,
     IconFolders,
@@ -16,7 +16,7 @@ import {
     IconLayoutDashboard,
     IconLogout,
 } from '@tabler/icons-react';
-import { lazy, Suspense, useCallback, useMemo, useState, type FC } from 'react';
+import { lazy, Suspense, useCallback, useState, type FC } from 'react';
 import {
     Link,
     Navigate,
@@ -37,7 +37,7 @@ import LegacyAppPreviewRedirect from './features/apps/LegacyAppPreviewRedirect';
 import { loadLazyRouteDefault } from './features/chunkErrorHandler';
 import { useActiveProjectUuid } from './hooks/useActiveProject';
 import useLogoutMutation from './hooks/user/useUserLogoutMutation';
-import { getMantineThemeOverride } from './mantineTheme';
+import classes from './MobileRoutes.module.css';
 import Mantine8Provider from './providers/Mantine8Provider';
 import { TrackPage } from './providers/Tracking/TrackingProvider';
 import Logo from './svgs/logo-icon.svg?react';
@@ -86,13 +86,6 @@ export const MobileNavBar: FC = () => {
         },
     });
 
-    // Force dark theme for navbar (excluding global styles)
-    const darkTheme = useMemo(() => {
-        const fullDarkTheme = getMantineThemeOverride('dark');
-        const { globalStyles, ...themeWithoutGlobalStyles } = fullDarkTheme;
-        return themeWithoutGlobalStyles;
-    }, []);
-
     return (
         <Box id="mobile-navbar" data-mantine-color-scheme="dark">
             <Mantine8Provider
@@ -100,107 +93,100 @@ export const MobileNavBar: FC = () => {
                 cssVariablesSelector="#mobile-navbar"
                 getRootElement={getMobileNavBarRootElement}
             >
-                <MantineProvider theme={darkTheme}>
-                    <Header
-                        height={50}
-                        display="flex"
-                        px="md"
-                        zIndex={getDefaultZIndex('app')}
-                        sx={{
-                            alignItems: 'center',
-                            boxShadow: 'lg',
-                        }}
-                    >
-                        <Group align="center" justify="space-between" flex={1}>
-                            <ActionIcon
-                                variant="subtle"
-                                color="gray"
-                                component={Link}
-                                to={'/'}
-                                title="Home"
-                                size="lg"
-                            >
-                                <Logo />
-                            </ActionIcon>
-                            <Burger
-                                opened={isMenuOpen}
+                <Box
+                    component="header"
+                    className={classes.header}
+                    h={50}
+                    mah={50}
+                    display="flex"
+                    px="md"
+                    style={{ zIndex: getDefaultZIndex('app') }}
+                >
+                    <Group align="center" justify="space-between" flex={1}>
+                        <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            component={Link}
+                            to={'/'}
+                            title="Home"
+                            size="lg"
+                        >
+                            <Logo />
+                        </ActionIcon>
+                        <Burger
+                            opened={isMenuOpen}
+                            onClick={toggleMenu}
+                            color="white"
+                            aria-label={
+                                isMenuOpen
+                                    ? 'Close navigation menu'
+                                    : 'Open navigation menu'
+                            }
+                            aria-expanded={isMenuOpen}
+                            aria-controls="mobile-navigation"
+                        />
+                    </Group>
+                </Box>
+
+                <Drawer
+                    id="mobile-navigation"
+                    title={<ThemeSwitcher />}
+                    opened={isMenuOpen}
+                    onClose={toggleMenu}
+                    size="75%"
+                    portalProps={{ target: '#mobile-navbar' }}
+                >
+                    <Title order={6} fw={600} mb="xs">
+                        Project
+                    </Title>
+                    <ProjectSwitcher />
+                    <Divider my="lg" />
+                    <RouterNavLink
+                        exact
+                        label="Home"
+                        to={`/`}
+                        leftSection={<MantineIcon icon={IconHome} />}
+                        onClick={toggleMenu}
+                    />
+                    <RouterNavLink
+                        exact
+                        label="Spaces"
+                        to={`/projects/${activeProjectUuid}/spaces`}
+                        leftSection={<MantineIcon icon={IconFolders} />}
+                        onClick={toggleMenu}
+                    />
+                    <RouterNavLink
+                        exact
+                        label="Dashboards"
+                        to={`/projects/${activeProjectUuid}/dashboards`}
+                        leftSection={<MantineIcon icon={IconLayoutDashboard} />}
+                        onClick={toggleMenu}
+                    />
+                    <RouterNavLink
+                        exact
+                        label="Charts"
+                        to={`/projects/${activeProjectUuid}/saved`}
+                        leftSection={<MantineIcon icon={IconChartAreaLine} />}
+                        onClick={toggleMenu}
+                    />
+                    {isMenuOpen && (
+                        <Suspense fallback={null}>
+                            <MobileAiAgentsNavLink
+                                activeProjectUuid={activeProjectUuid}
                                 onClick={toggleMenu}
-                                color="white"
-                                aria-label={
-                                    isMenuOpen
-                                        ? 'Close navigation menu'
-                                        : 'Open navigation menu'
-                                }
-                                aria-expanded={isMenuOpen}
-                                aria-controls="mobile-navigation"
                             />
-                        </Group>
-                    </Header>
+                        </Suspense>
+                    )}
+                    <Divider my="lg" />
 
-                    <Drawer
-                        id="mobile-navigation"
-                        title={<ThemeSwitcher />}
-                        opened={isMenuOpen}
-                        onClose={toggleMenu}
-                        size="75%"
-                        portalProps={{ target: '#mobile-navbar' }}
-                    >
-                        <Title order={6} fw={600} mb="xs">
-                            Project
-                        </Title>
-                        <ProjectSwitcher />
-                        <Divider my="lg" />
-                        <RouterNavLink
-                            exact
-                            label="Home"
-                            to={`/`}
-                            leftSection={<MantineIcon icon={IconHome} />}
-                            onClick={toggleMenu}
-                        />
-                        <RouterNavLink
-                            exact
-                            label="Spaces"
-                            to={`/projects/${activeProjectUuid}/spaces`}
-                            leftSection={<MantineIcon icon={IconFolders} />}
-                            onClick={toggleMenu}
-                        />
-                        <RouterNavLink
-                            exact
-                            label="Dashboards"
-                            to={`/projects/${activeProjectUuid}/dashboards`}
-                            leftSection={
-                                <MantineIcon icon={IconLayoutDashboard} />
-                            }
-                            onClick={toggleMenu}
-                        />
-                        <RouterNavLink
-                            exact
-                            label="Charts"
-                            to={`/projects/${activeProjectUuid}/saved`}
-                            leftSection={
-                                <MantineIcon icon={IconChartAreaLine} />
-                            }
-                            onClick={toggleMenu}
-                        />
-                        {isMenuOpen && (
-                            <Suspense fallback={null}>
-                                <MobileAiAgentsNavLink
-                                    activeProjectUuid={activeProjectUuid}
-                                    onClick={toggleMenu}
-                                />
-                            </Suspense>
-                        )}
-                        <Divider my="lg" />
-
-                        <RouterNavLink
-                            exact
-                            label="Logout"
-                            to={`/`}
-                            leftSection={<MantineIcon icon={IconLogout} />}
-                            onClick={() => logout()}
-                        />
-                    </Drawer>
-                </MantineProvider>
+                    <RouterNavLink
+                        exact
+                        label="Logout"
+                        to={`/`}
+                        leftSection={<MantineIcon icon={IconLogout} />}
+                        onClick={() => logout()}
+                    />
+                </Drawer>
             </Mantine8Provider>
         </Box>
     );

--- a/packages/frontend/src/components/CompilationHistory/CompilationLogDrawer.tsx
+++ b/packages/frontend/src/components/CompilationHistory/CompilationLogDrawer.tsx
@@ -48,7 +48,6 @@ export const CompilationLogDrawer: FC<CompilationLogDrawerProps> = ({
                                 <Tooltip
                                     label={copied ? 'Copied' : 'Copy JSON'}
                                     withinPortal
-                                    variant="xs"
                                 >
                                     <ActionIcon
                                         color={copied ? 'teal' : 'gray'}

--- a/packages/frontend/src/components/CompilationHistory/SourceFilter.tsx
+++ b/packages/frontend/src/components/CompilationHistory/SourceFilter.tsx
@@ -38,11 +38,7 @@ const CompilationSourceFilter: FC<CompilationSourceFilterProps> = ({
         <Group gap={2} wrap="nowrap">
             <Popover width={250} position="bottom-start">
                 <Popover.Target>
-                    <Tooltip
-                        withinPortal
-                        variant="xs"
-                        label="Filter logs by source"
-                    >
+                    <Tooltip withinPortal label="Filter logs by source">
                         <Button
                             h={32}
                             c="foreground"

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -44,8 +44,9 @@ import {
     Badge,
     HoverCard,
     Portal,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip, useMantineColorScheme } from '@mantine/core';
+import { useMantineColorScheme } from '@mantine/core';
 import { useClipboard, useElementSize } from '@mantine/hooks';
 import {
     IconAlertCircle,
@@ -1516,7 +1517,6 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                                 <Tooltip
                                     disabled={!isEditMode}
                                     label="Finish editing dashboard to use these actions"
-                                    variant="xs"
                                 >
                                     <Box>
                                         <Tooltip
@@ -1525,7 +1525,6 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                                             }
                                             label={editButtonTooltipLabel}
                                             position="top-start"
-                                            variant="xs"
                                         >
                                             <Box>
                                                 <EditChartMenuItem
@@ -1545,7 +1544,6 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                                                         'This chart contains custom dimensions, you will not be able to run custom SQL on explore.'
                                                     }
                                                     position="top-start"
-                                                    variant="xs"
                                                     disabled={
                                                         !cannotUseCustomDimensions
                                                     }

--- a/packages/frontend/src/components/DataViz/VisualizationSwitcher.tsx
+++ b/packages/frontend/src/components/DataViz/VisualizationSwitcher.tsx
@@ -32,7 +32,7 @@ const VisualizationActionIcon: FC<VisualizationActionIconProps> = memo(
         const ICON_UNSELECTED_COLOR = colors.ldGray[9];
 
         return (
-            <Tooltip variant="xs" label={label} withinPortal>
+            <Tooltip label={label} withinPortal>
                 <Box>
                     <ActionIcon
                         onClick={onClick}

--- a/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartFieldConfiguration.tsx
@@ -7,8 +7,7 @@ import {
     type VizIndexLayoutOptions,
     type VizPivotLayoutOptions,
 } from '@lightdash/common';
-import { Box, Group, Stack, ActionIcon } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
+import { Box, Group, Stack, ActionIcon, Tooltip } from '@mantine-8/core';
 import { IconMinus, IconPlus, IconX } from '@tabler/icons-react';
 import { type FC } from 'react';
 import {
@@ -104,7 +103,7 @@ const YFieldsAxisConfig: FC<{
                                     )
                                 }
                             />
-                            <Tooltip variant="xs" label="Remove Y axis">
+                            <Tooltip label="Remove Y axis">
                                 <ActionIcon
                                     color="ldGray.6"
                                     variant="subtle"
@@ -180,7 +179,7 @@ const XFieldAxisConfig = ({
                     )
                 }
             />
-            <Tooltip variant="xs" label="Remove X axis">
+            <Tooltip label="Remove X axis">
                 <ActionIcon
                     color="ldGray.6"
                     variant="subtle"
@@ -318,7 +317,7 @@ export const CartesianChartFieldConfiguration = ({
                 <Config.Section>
                     <Config.Group>
                         <Config.Heading>{`Y-axis`}</Config.Heading>
-                        <Tooltip variant="xs" label="Add Y axis">
+                        <Tooltip label="Add Y axis">
                             <ActionIcon
                                 color="ldGray.6"
                                 variant="subtle"

--- a/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizAggregationConfig.tsx
@@ -3,8 +3,7 @@ import {
     VizAggregationOptions,
     type VizValuesLayoutOptions,
 } from '@lightdash/common';
-import { Box, Group, Text, Select } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
+import { Box, Group, Text, Select, Tooltip } from '@mantine-8/core';
 import {
     IconAsterisk,
     IconMathFunction,
@@ -87,7 +86,7 @@ export const DataVizAggregationConfig: FC<Props> = ({
     }));
 
     return (
-        <Tooltip label="Aggregation type" variant="xs" withinPortal>
+        <Tooltip label="Aggregation type" withinPortal>
             <Select
                 allowDeselect={false}
                 comboboxProps={{ withinPortal: true }}

--- a/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/DataVizSortConfig.tsx
@@ -1,6 +1,5 @@
 import { SortByDirection, type VizSortBy } from '@lightdash/common';
-import { Box, Text, Select } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
+import { Box, Text, Select, Tooltip } from '@mantine-8/core';
 import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react';
 import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
@@ -68,7 +67,7 @@ export const DataVizSortConfig: FC<Props> = ({ sortBy, onChangeSortBy }) => {
     ];
 
     return (
-        <Tooltip label="Sort by" variant="xs" withinPortal>
+        <Tooltip label="Sort by" withinPortal>
             <Select
                 allowDeselect={false}
                 comboboxProps={{ withinPortal: true }}

--- a/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.tsx
+++ b/packages/frontend/src/components/DataViz/visualizations/ChartDataTable.tsx
@@ -4,8 +4,8 @@ import {
     type VizColumnsConfig,
     type VizTableHeaderSortConfig,
 } from '@lightdash/common';
-import { Flex, Group, type FlexProps, Badge } from '@mantine-8/core';
-import { Tooltip, useMantineTheme } from '@mantine/core';
+import { Flex, Group, type FlexProps, Badge, Tooltip } from '@mantine-8/core';
+import { useMantineTheme } from '@mantine/core';
 import { IconArrowDown, IconArrowUp } from '@tabler/icons-react';
 import { flexRender } from '@tanstack/react-table';
 import { useMemo } from 'react';

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -7,8 +7,7 @@ import {
     isMetric,
     type FilterableField,
 } from '@lightdash/common';
-import { UnstyledButton, ActionIcon } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
+import { UnstyledButton, ActionIcon, Tooltip } from '@mantine-8/core';
 import { IconFilter } from '@tabler/icons-react';
 import {
     Fragment,

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
@@ -193,7 +193,6 @@ export const ItemDetailPreview: FC<{
                                 SQL
                             </Text>
                             <Tooltip
-                                variant="xs"
                                 position="right"
                                 label={
                                     showCompiled

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -24,8 +24,8 @@ import {
     NavLink,
     Text,
     HoverCard,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import {
     IconAlertTriangle,
     IconCalendarPin,

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNodeActions.tsx
@@ -16,8 +16,13 @@ import {
     type Dimension,
     type Metric,
 } from '@lightdash/common';
-import { Box, Menu, type MenuProps, ActionIcon } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
+import {
+    Box,
+    Menu,
+    type MenuProps,
+    ActionIcon,
+    Tooltip,
+} from '@mantine-8/core';
 import {
     IconCode,
     IconCopy,

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -1,7 +1,6 @@
 import { subject } from '@casl/ability';
 import { FeatureFlags, isCustomSqlDimension } from '@lightdash/common';
-import { Button, Group, Text, ActionIcon } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
+import { Button, Group, Text, ActionIcon, Tooltip } from '@mantine-8/core';
 import { IconCode, IconPlus } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
 import {
@@ -166,7 +165,6 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
                 {showAddButton && (
                     <Tooltip
                         label="Add a custom dimension with SQL"
-                        variant="xs"
                         position="left"
                     >
                         <Button

--- a/packages/frontend/src/components/Explorer/ExplorerHeader/QueryWarnings.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorerHeader/QueryWarnings.tsx
@@ -6,8 +6,8 @@ import {
     Title,
     ActionIcon,
     Popover,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import { Fragment, useState, type FC } from 'react';

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -272,7 +272,6 @@ const FiltersCard: FC = memo(() => {
                 <>
                     {totalActiveFilters > 0 && !filterIsOpen ? (
                         <Tooltip
-                            variant="xs"
                             arrowOffset={12}
                             label={
                                 <div

--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -11,8 +11,8 @@ import {
     Skeleton,
     ActionIcon,
     SegmentedControl,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconCheck, IconClipboard } from '@tabler/icons-react';
 import {
@@ -113,7 +113,6 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
                     <CopyButton value={formattedSql} timeout={2000}>
                         {({ copied, copy }) => (
                             <Tooltip
-                                variant="xs"
                                 label={
                                     copied ? 'Copied to clipboard' : 'Copy SQL'
                                 }

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationConfig.tsx
@@ -6,8 +6,8 @@ import {
     Loader,
     ScrollArea,
     Text,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { IconX } from '@tabler/icons-react';
 import { lazy, Suspense, useMemo, type FC } from 'react';
 import scrollAreaClasses from '../../../styles/ScrollArea.module.css';

--- a/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
+++ b/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
@@ -104,7 +104,7 @@ const StatusFilter: FC<{
     return (
         <Popover width={250} position="bottom-start">
             <Popover.Target>
-                <Tooltip withinPortal variant="xs" label="Filter by status">
+                <Tooltip withinPortal label="Filter by status">
                     <Button
                         h={32}
                         c="foreground"

--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -664,7 +664,6 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
                 <Group gap="xs" wrap="nowrap">
                     <Tooltip
                         withinPortal
-                        variant="xs"
                         label="Search by name, email, or role"
                     >
                         <TextInput

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
@@ -9,8 +9,8 @@ import {
     Stack,
     PasswordInput,
     Text,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import {
     IconCheck,
     IconCopy,

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
@@ -10,8 +10,8 @@ import {
     Select,
     PasswordInput,
     Avatar,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { IconCheck, IconRefresh } from '@tabler/icons-react';
 import React, { useEffect, type FC } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
@@ -86,7 +86,7 @@ const GithubLoginForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                                 <Tooltip
                                     withinPortal
                                     position="left"
-                                    width={300}
+                                    w={300}
                                     multiline
                                     label="Click here to open your Github installation page to add more repositories."
                                 >

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectManually/ConnectManuallyStep1.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectManually/ConnectManuallyStep1.tsx
@@ -1,6 +1,5 @@
 import { type WarehouseTypes } from '@lightdash/common';
-import { Button, Stack, Text } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
+import { Button, Stack, Text, Tooltip } from '@mantine-8/core';
 import { Prism } from '@mantine/prism';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import { type FC } from 'react';

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -19,8 +19,9 @@ import {
     Text,
     Select,
     Switch,
+    Tooltip,
 } from '@mantine-8/core';
-import { NumberInput, Tooltip } from '@mantine/core';
+import { NumberInput } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconCheck, IconExclamationCircle } from '@tabler/icons-react';
 import {

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
@@ -12,8 +12,8 @@ import {
     Anchor,
     Select,
     PasswordInput,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { IconCheck, IconPlus, IconTrash } from '@tabler/icons-react';
 import { type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/PostgresForm.tsx
@@ -8,8 +8,9 @@ import {
     Anchor,
     Select,
     PasswordInput,
+    Tooltip,
 } from '@mantine-8/core';
-import { NumberInput, Tooltip } from '@mantine/core';
+import { NumberInput } from '@mantine/core';
 import { IconCheck, IconCopy } from '@tabler/icons-react';
 import React, { type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/RedshiftForm.tsx
@@ -8,8 +8,9 @@ import {
     Anchor,
     Select,
     PasswordInput,
+    Tooltip,
 } from '@mantine-8/core';
-import { NumberInput, Tooltip } from '@mantine/core';
+import { NumberInput } from '@mantine/core';
 import { IconCheck, IconCopy } from '@tabler/icons-react';
 import { useEffect, type FC, type ReactNode } from 'react';
 import { useToggle } from 'react-use';

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -15,8 +15,9 @@ import {
     Text,
     Select,
     PasswordInput,
+    Tooltip,
 } from '@mantine-8/core';
-import { NumberInput, Tooltip } from '@mantine/core';
+import { NumberInput } from '@mantine/core';
 import { IconCheck } from '@tabler/icons-react';
 import {
     useCallback,

--- a/packages/frontend/src/components/SchedulersView/filters/ResourceTypeFilter.tsx
+++ b/packages/frontend/src/components/SchedulersView/filters/ResourceTypeFilter.tsx
@@ -36,7 +36,6 @@ export const ResourceTypeFilter = ({
             value: 'chart',
             label: (
                 <Tooltip
-                    variant="xs"
                     label="Show only chart schedulers"
                     withinPortal
                     maw={200}
@@ -51,7 +50,6 @@ export const ResourceTypeFilter = ({
             value: 'dashboard',
             label: (
                 <Tooltip
-                    variant="xs"
                     label="Show only dashboard schedulers"
                     withinPortal
                     maw={200}

--- a/packages/frontend/src/components/SchedulersView/filters/SearchFilter.tsx
+++ b/packages/frontend/src/components/SchedulersView/filters/SearchFilter.tsx
@@ -11,7 +11,7 @@ type SearchFilterProps =
 
 export const SearchFilter = ({ search, setSearch }: SearchFilterProps) => {
     return (
-        <Tooltip withinPortal variant="xs" label="Search by scheduler name">
+        <Tooltip withinPortal label="Search by scheduler name">
             <TextInput
                 size="xs"
                 radius="md"

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/ValidatorTableTopToolbar.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/ValidatorTableTopToolbar.tsx
@@ -97,11 +97,7 @@ export const ValidatorTableTopToolbar: FC<ValidatorTableTopToolbarProps> = ({
 
                 <Popover width={250} position="bottom-start">
                     <Popover.Target>
-                        <Tooltip
-                            withinPortal
-                            variant="xs"
-                            label="Filter by source type"
-                        >
+                        <Tooltip withinPortal label="Filter by source type">
                             <Button
                                 h={30}
                                 c="foreground"

--- a/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AllowedDomainsPanel/index.tsx
@@ -15,8 +15,8 @@ import {
     ActionIcon,
     Group,
     Select,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
 import { IconHelpCircle, IconPlus, IconTrash } from '@tabler/icons-react';
 import { useEffect, useMemo, useState, type FC } from 'react';

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
@@ -9,8 +9,8 @@ import {
     Badge,
     ColorSwatch,
     Menu,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
     IconDotsVertical,
@@ -132,7 +132,6 @@ export const PaletteItem: FC<PaletteItemProps> = ({
                                 position="bottom-end"
                                 multiline
                                 maw={200}
-                                variant="xs"
                             >
                                 <Badge color="gray" variant="light">
                                     <Group gap={2}>

--- a/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
@@ -9,8 +9,8 @@ import {
     Title,
     Button,
     Avatar,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import {
     IconAlertCircle,
     IconClock,

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
@@ -653,11 +653,7 @@ const ProjectManagementPanel: FC = () => {
                 wrap="nowrap"
             >
                 <Group gap="xs" wrap="nowrap" style={{ flex: 1, minWidth: 0 }}>
-                    <Tooltip
-                        withinPortal
-                        variant="xs"
-                        label="Search by project name"
-                    >
+                    <Tooltip withinPortal label="Search by project name">
                         <ContentTableSearchInput
                             placeholder="Search projects..."
                             value={search}
@@ -741,11 +737,7 @@ const ProjectManagementPanel: FC = () => {
                     {/* Warehouse filter */}
                     <Popover width={220} position="bottom-start">
                         <Popover.Target>
-                            <Tooltip
-                                withinPortal
-                                variant="xs"
-                                label="Filter by warehouse"
-                            >
+                            <Tooltip withinPortal label="Filter by warehouse">
                                 <Button
                                     h={32}
                                     c="foreground"
@@ -842,11 +834,7 @@ const ProjectManagementPanel: FC = () => {
                     {availableCreators.length > 0 && (
                         <Popover width={250} position="bottom-start">
                             <Popover.Target>
-                                <Tooltip
-                                    withinPortal
-                                    variant="xs"
-                                    label="Filter by creator"
-                                >
+                                <Tooltip withinPortal label="Filter by creator">
                                     <Button
                                         h={32}
                                         c="foreground"

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsTopToolbar.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsTopToolbar.tsx
@@ -42,7 +42,6 @@ export const GroupsTopToolbar: FC<GroupsTopToolbarProps> = memo(
                 <Group gap="xs" wrap="nowrap" style={{ flex: 1, minWidth: 0 }}>
                     <Tooltip
                         withinPortal
-                        variant="xs"
                         label="Search by name, members or member email"
                     >
                         <TextInput

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTopToolbar.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTopToolbar.tsx
@@ -42,7 +42,6 @@ export const UsersTopToolbar: FC<UsersTopToolbarProps> = memo(
                 <Group gap="xs" wrap="nowrap" style={{ flex: 1, minWidth: 0 }}>
                     <Tooltip
                         withinPortal
-                        variant="xs"
                         label="Search by name, email, or role"
                     >
                         <TextInput

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -18,8 +18,8 @@ import {
     NumberInput,
     SegmentedControl,
     Stack,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { IconRotate360 } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { EMPTY_X_AXIS } from '../../../../hooks/cartesianChartConfig/useCartesianChartConfig';
@@ -217,7 +217,7 @@ export const Layout: FC<Props> = ({ items }) => {
                             validConfig?.layout.flipAxes ? 'Y' : 'X'
                         }-axis`}</Config.Heading>
                         <Group gap="two">
-                            <Tooltip variant="xs" label="Flip Axes">
+                            <Tooltip label="Flip Axes">
                                 <ActionIcon
                                     variant="subtle"
                                     onClick={() =>
@@ -454,7 +454,6 @@ export const Layout: FC<Props> = ({ items }) => {
                     </Stack>
                     {canBeStacked && (
                         <Tooltip
-                            variant="xs"
                             label="x-axis must be non-numeric to enable stacking"
                             withinPortal
                             position="top-start"

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipConfig.tsx
@@ -265,7 +265,6 @@ export const TooltipConfig: FC<Props> = ({ fields }) => {
                 <Tooltip
                     withinPortal={true}
                     maw={350}
-                    variant="xs"
                     multiline
                     label="Use this input to enhance chart tooltips with additional content. You can incorporate HTML code and include dynamic values using the format ${variable_name}.
                                 Click here to read more about this on our docs."

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormattingRule.tsx
@@ -14,8 +14,8 @@ import {
     Text,
     ActionIcon,
     Select,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp, IconTrash } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';

--- a/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/FunnelChartConfigTabs.tsx
@@ -18,8 +18,9 @@ import {
     Tabs,
     SegmentedControl,
     Switch,
+    Tooltip,
 } from '@mantine-8/core';
-import { MantineProvider, Tooltip, useMantineColorScheme } from '@mantine/core';
+import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { memo, useMemo, type FC } from 'react';
 import FieldSelect from '../../common/FieldSelect';
 import { isFunnelVisualizationConfig } from '../../LightdashVisualization/types';
@@ -121,7 +122,6 @@ export const ConfigTabs: FC = memo(() => {
                                     <Config.Heading>Data field</Config.Heading>
 
                                     <Tooltip
-                                        variant="xs"
                                         disabled={
                                             numericFields &&
                                             numericFields.length > 0

--- a/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/GaugeConfig/GaugeDisplayConfig.tsx
@@ -9,8 +9,9 @@ import {
     Group,
     SegmentedControl,
     Stack,
+    Tooltip,
 } from '@mantine-8/core';
-import { NumberInput, Tooltip } from '@mantine/core';
+import { NumberInput } from '@mantine/core';
 import { memo, type FC } from 'react';
 import FieldSelect from '../../common/FieldSelect';
 import { isGaugeVisualizationConfig } from '../../LightdashVisualization/types';
@@ -125,7 +126,6 @@ export const GaugeDisplayConfig: FC = memo(() => {
                                         <Tooltip
                                             label="Set the maximum value"
                                             withinPortal
-                                            variant="xs"
                                         >
                                             <Center>Value</Center>
                                         </Tooltip>
@@ -137,7 +137,6 @@ export const GaugeDisplayConfig: FC = memo(() => {
                                         <Tooltip
                                             label="Select a field to use as the maximum value"
                                             withinPortal
-                                            variant="xs"
                                         >
                                             <Center>Field</Center>
                                         </Tooltip>

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapFieldConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapFieldConfiguration.tsx
@@ -1,6 +1,5 @@
 import { getItemLabelWithoutTableName } from '@lightdash/common';
-import { TextInput, Box, Group, ActionIcon } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
+import { TextInput, Box, Group, ActionIcon, Tooltip } from '@mantine-8/core';
 import { useDebouncedState } from '@mantine/hooks';
 import { IconEye, IconEyeOff } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/GroupItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/GroupItem.tsx
@@ -12,8 +12,8 @@ import {
     Stack,
     type StackProps,
     ActionIcon,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
 import { forwardRef } from 'react';
@@ -113,11 +113,7 @@ export const GroupItem = forwardRef<
                         />
                     </Box>
 
-                    <Tooltip
-                        variant="xs"
-                        label="Override value label options"
-                        withinPortal
-                    >
+                    <Tooltip label="Override value label options" withinPortal>
                         <ActionIcon
                             variant="subtle"
                             color="gray"

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/PieChartLayoutConfig.tsx
@@ -9,8 +9,7 @@ import {
     type Metric,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, Group, Stack, SegmentedControl } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
+import { Box, Group, Stack, SegmentedControl, Tooltip } from '@mantine-8/core';
 import FieldSelect from '../../common/FieldSelect';
 import { isPieVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
@@ -45,7 +44,6 @@ export const Layout: React.FC = () => {
                     <Config.Group>
                         <Config.Heading>Groups</Config.Heading>
                         <Tooltip
-                            variant="xs"
                             disabled={
                                 !(
                                     dimensions.length === 0 ||
@@ -119,7 +117,6 @@ export const Layout: React.FC = () => {
                     <Config.Heading>Metric</Config.Heading>
 
                     <Tooltip
-                        variant="xs"
                         disabled={numericMetrics && numericMetrics.length > 0}
                         label="You must select at least one numeric metric to create a pie chart"
                     >

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnCellDisplay.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnCellDisplay.tsx
@@ -62,7 +62,6 @@ export const ColumnCellDisplay: FC = () => {
                         label="Display numeric values as bars in cells"
                         withinPortal
                         position="right"
-                        variant="xs"
                     >
                         <MantineIcon icon={IconInfoCircle} color="ldGray.6" />
                     </Tooltip>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -19,8 +19,8 @@ import {
     Text,
     SegmentedControl,
     Select,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import differenceBy from 'lodash/differenceBy';
 import { useCallback, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
@@ -237,7 +237,6 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
                                         <Tooltip
                                             label="Compare selected field to values"
                                             withinPortal
-                                            variant="xs"
                                         >
                                             <Center>Values</Center>
                                         </Tooltip>
@@ -249,7 +248,6 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
                                         <Tooltip
                                             label="Compare selected field to another field"
                                             withinPortal
-                                            variant="xs"
                                         >
                                             <Center>Field</Center>
                                         </Tooltip>
@@ -261,7 +259,6 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
                                         <Tooltip
                                             label="Compare another field to values"
                                             withinPortal
-                                            variant="xs"
                                         >
                                             <Center>Field values</Center>
                                         </Tooltip>

--- a/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapDisplayConfig.tsx
@@ -23,7 +23,6 @@ export const Display: React.FC = () => {
                         <Tooltip
                             withinPortal={true}
                             maw={350}
-                            variant="xs"
                             multiline
                             label="Any sections smaller than this will not be displayed. You can zoom in to see smaller sections."
                         >
@@ -50,7 +49,6 @@ export const Display: React.FC = () => {
                         <Tooltip
                             withinPortal={true}
                             maw={350}
-                            variant="xs"
                             multiline
                             label="The maximum depth of the treemap. If set, deeper levels can be viewed by clicking on nodes."
                         >

--- a/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapLayoutConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapLayoutConfig.tsx
@@ -8,8 +8,16 @@ import {
     type Metric,
     type TableCalculation,
 } from '@lightdash/common';
-import { Box, Grid, Group, Stack, Switch, Text } from '@mantine-8/core';
-import { NumberInput, Tooltip } from '@mantine/core';
+import {
+    Box,
+    Grid,
+    Group,
+    Stack,
+    Switch,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import { NumberInput } from '@mantine/core';
 import { IconHelpCircle } from '@tabler/icons-react';
 import FieldSelect from '../../common/FieldSelect';
 import MantineIcon from '../../common/MantineIcon';
@@ -108,7 +116,6 @@ export const Layout: React.FC = () => {
                         <Tooltip
                             withinPortal={true}
                             maw={350}
-                            variant="xs"
                             multiline
                             label="Drag and drop your dimensions to order them hierarchically."
                         >
@@ -151,7 +158,6 @@ export const Layout: React.FC = () => {
                         <Tooltip
                             withinPortal={true}
                             maw={350}
-                            variant="xs"
                             multiline
                             label="Determines how large each block is."
                         >
@@ -192,7 +198,6 @@ export const Layout: React.FC = () => {
                         <Tooltip
                             withinPortal={true}
                             maw={350}
-                            variant="xs"
                             multiline
                             label="Dynamically set the color of the nodes based on a metric. If not set, the treemap will use a default color scheme."
                         >

--- a/packages/frontend/src/components/VisualizationConfigs/common/AddButton.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/AddButton.tsx
@@ -1,10 +1,18 @@
 import { Button, type ButtonProps } from '@mantine-8/core';
-import { type ButtonHTMLAttributes, type FC } from 'react';
+import { forwardRef, type ButtonHTMLAttributes } from 'react';
 
 type Props = ButtonProps & ButtonHTMLAttributes<HTMLButtonElement>;
 
-export const AddButton: FC<Props> = ({ ...props }) => (
-    <Button size="compact-sm" variant="subtle" leftSection="+" {...props}>
+export const AddButton = forwardRef<HTMLButtonElement, Props>((props, ref) => (
+    <Button
+        ref={ref}
+        size="compact-sm"
+        variant="subtle"
+        leftSection="+"
+        {...props}
+    >
         Add
     </Button>
-);
+));
+
+AddButton.displayName = 'AddButton';

--- a/packages/frontend/src/components/common/ContentTable/ContentTableSearchInput.tsx
+++ b/packages/frontend/src/components/common/ContentTable/ContentTableSearchInput.tsx
@@ -90,7 +90,7 @@ const ContentTableSearchInputComponent = ({
     }
 
     return (
-        <Tooltip withinPortal variant="xs" label={tooltipLabel}>
+        <Tooltip withinPortal label={tooltipLabel}>
             {input}
         </Tooltip>
     );

--- a/packages/frontend/src/components/common/FilterFacet/FilterFacet.tsx
+++ b/packages/frontend/src/components/common/FilterFacet/FilterFacet.tsx
@@ -234,7 +234,7 @@ const FilterFacet = ({
         <Popover position="bottom-start" withArrow shadow="md" radius="md">
             <Popover.Target>
                 {tooltipLabel ? (
-                    <Tooltip withinPortal variant="xs" label={tooltipLabel}>
+                    <Tooltip withinPortal label={tooltipLabel}>
                         {trigger}
                     </Tooltip>
                 ) : (

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -8,10 +8,10 @@ import {
     Pill,
     Text,
     TextInput,
+    Tooltip,
     type ComboboxProps,
     type PillsInputProps,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { useDisclosure, useHover } from '@mantine/hooks';
 import {
     IconAlertCircle,

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -132,7 +132,6 @@ const FilterRuleForm: FC<Props> = memo(
                     label={isRequiredLabel}
                     disabled={!isFieldSelectDisabled}
                     withinPortal
-                    variant="xs"
                     multiline
                 >
                     <Box>
@@ -215,7 +214,6 @@ const FilterRuleForm: FC<Props> = memo(
                             label={isRequiredLabel}
                             disabled={!isRequired}
                             withinPortal
-                            variant="xs"
                             multiline
                         >
                             <span>
@@ -231,12 +229,7 @@ const FilterRuleForm: FC<Props> = memo(
                             </span>
                         </Tooltip>
                     ) : isRequired ? (
-                        <Tooltip
-                            label={isRequiredLabel}
-                            withinPortal
-                            variant="xs"
-                            multiline
-                        >
+                        <Tooltip label={isRequiredLabel} withinPortal multiline>
                             <span>
                                 <ActionIcon variant="subtle" disabled>
                                     <IconDots size="20" />

--- a/packages/frontend/src/components/common/JsonViewer/JsonCellViewer.tsx
+++ b/packages/frontend/src/components/common/JsonViewer/JsonCellViewer.tsx
@@ -100,7 +100,6 @@ export const JsonCellModal: FC<ModalProps> = ({ value, opened, onClose }) => {
                         <Tooltip
                             label={copied ? 'Copied JSON' : 'Copy JSON'}
                             withinPortal
-                            variant="xs"
                         >
                             <ActionIcon
                                 color={copied ? 'teal' : 'gray'}

--- a/packages/frontend/src/components/common/LightTable/index.tsx
+++ b/packages/frontend/src/components/common/LightTable/index.tsx
@@ -2,8 +2,13 @@ import {
     assertUnreachable,
     type ConditionalFormattingTextStyle,
 } from '@lightdash/common';
-import { Box, type BoxProps as BoxPropsBase, Text } from '@mantine-8/core';
-import { Tooltip, useMantineTheme } from '@mantine/core';
+import {
+    Box,
+    type BoxProps as BoxPropsBase,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import { useMantineTheme } from '@mantine/core';
 import { getHotkeyHandler, useClipboard, useId } from '@mantine/hooks';
 import { type PolymorphicComponentProps } from '@mantine/utils';
 import debounce from 'lodash/debounce';
@@ -476,7 +481,6 @@ const BaseCell = (
                                 multiline
                                 label={withTooltip}
                                 openDelay={500}
-                                variant="xs"
                             >
                                 <Text span inherit>
                                     {children}

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -22,9 +22,10 @@ import {
     Button,
     ActionIcon,
     Anchor,
+    Tooltip,
 } from '@mantine-8/core';
 import { useDebouncedCallback } from '@mantine-8/hooks';
-import { Tooltip, useMantineTheme } from '@mantine/core';
+import { useMantineTheme } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconAppWindow,
@@ -124,7 +125,7 @@ const DebouncedSearchInput = memo(
         );
 
         return (
-            <Tooltip withinPortal variant="xs" label="Search by name">
+            <Tooltip withinPortal label="Search by name">
                 <TextInput
                     size="xs"
                     radius="md"

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
@@ -78,7 +78,6 @@ const ResourceViewGridChartItem: FC<ResourceViewGridChartItemProps> = ({
                 <Tooltip
                     label={item.data.description}
                     position="top"
-                    variant="xs"
                     maw={400}
                     multiline
                     disabled={!item.data.description}

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
@@ -78,7 +78,6 @@ const ResourceViewGridDashboardItem: FC<ResourceViewGridDashboardItemProps> = ({
                     position="top"
                     maw={400}
                     multiline
-                    variant="xs"
                     label={item.data.description}
                     disabled={!item.data.description}
                 >

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDataAppItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDataAppItem.tsx
@@ -89,7 +89,6 @@ const ResourceViewGridDataAppItem: FC<ResourceViewGridDataAppItemProps> = ({
                         <Tooltip
                             label={item.data.description}
                             position="top"
-                            variant="xs"
                             maw={400}
                             multiline
                             disabled={

--- a/packages/frontend/src/components/common/Table/ScrollableTable/CellTooltip.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/CellTooltip.tsx
@@ -7,7 +7,7 @@ type CellTooltipProps = Omit<TooltipProps, 'children'> & {
 
 const CellTooltip: FC<CellTooltipProps> = ({ elementBounds, ...rest }) => (
     <Portal>
-        <Tooltip {...rest} opened variant="xs">
+        <Tooltip {...rest} opened>
             <div
                 style={{
                     pointerEvents: 'none',

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -14,8 +14,15 @@ import {
     type ConditionalFormattingRowFields,
     type ResultRow,
 } from '@lightdash/common';
-import { Center, Group, Loader, Skeleton, Button } from '@mantine-8/core';
-import { Tooltip, useMantineColorScheme } from '@mantine/core';
+import {
+    Center,
+    Group,
+    Loader,
+    Skeleton,
+    Button,
+    Tooltip,
+} from '@mantine-8/core';
+import { useMantineColorScheme } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { flexRender, type Row } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
@@ -1,6 +1,7 @@
 import { Draggable } from '@hello-pangea/dnd';
 import { isField } from '@lightdash/common';
-import { Tooltip, useMantineTheme } from '@mantine/core';
+import { Tooltip } from '@mantine-8/core';
+import { useMantineTheme } from '@mantine/core';
 import { flexRender } from '@tanstack/react-table';
 import isEqual from 'lodash/isEqual';
 import React, { useEffect, type FC } from 'react';
@@ -132,7 +133,6 @@ const TableHeader: FC<TableHeaderProps> = ({
                                                 >
                                                     <Tooltip
                                                         withinPortal
-                                                        variant="xs"
                                                         openDelay={500}
                                                         maw={400}
                                                         multiline

--- a/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardExportModal.tsx
@@ -308,7 +308,6 @@ export const DashboardExportModal: FC<DashboardExportModalProps> = ({
                                 <Tooltip
                                     withinPortal
                                     maw={400}
-                                    variant="xs"
                                     multiline
                                     label="When unchecked, choose specific tabs to include in the export."
                                 >

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
@@ -315,7 +315,6 @@ const AiAgentAdminAgentsTable = () => {
                                         <Box key={idx}>
                                             <Tooltip
                                                 withinPortal
-                                                variant="xs"
                                                 label={
                                                     isResolved
                                                         ? channelName

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
@@ -243,7 +243,6 @@ const AiAgentAdminThreadsTable = ({
                 return (
                     <Tooltip
                         withinPortal
-                        variant="xs"
                         label={thread.title || 'Untitled Thread'}
                         disabled={!isTruncated.isTruncated}
                         multiline
@@ -313,11 +312,7 @@ const AiAgentAdminThreadsTable = ({
             Cell: ({ row }) => {
                 const thread = row.original;
                 return (
-                    <Tooltip
-                        withinPortal
-                        variant="xs"
-                        label={thread.user.email}
-                    >
+                    <Tooltip withinPortal label={thread.user.email}>
                         <Text c="ldGray.9" fz="sm" fw={400}>
                             {thread.user.name}
                         </Text>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/FeedbackFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/FeedbackFilter.tsx
@@ -34,7 +34,6 @@ export const FeedbackFilter = ({
             value: 'thumbs_up',
             label: (
                 <Tooltip
-                    variant="xs"
                     label="Show only threads with positive feedback"
                     withinPortal
                     maw={200}
@@ -49,7 +48,6 @@ export const FeedbackFilter = ({
             value: 'thumbs_down',
             label: (
                 <Tooltip
-                    variant="xs"
                     label="Show only threads with negative feedback"
                     withinPortal
                     maw={200}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityDetail.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityDetail.tsx
@@ -48,7 +48,6 @@ export const McpActivityDetail: FC<{ toolCall: McpActivityItem }> = ({
             value: (
                 <Tooltip
                     withinPortal
-                    variant="xs"
                     label={formatToolCallTimeFull(toolCall.createdAt)}
                 >
                     <Text fz="sm" display="inline-block">

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityOverview.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityOverview.tsx
@@ -248,7 +248,6 @@ const RecentErrorsCard: FC<{
                             </Group>
                             <Tooltip
                                 withinPortal
-                                variant="xs"
                                 label={formatToolCallTimeFull(item.createdAt)}
                             >
                                 <Text

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityTable.tsx
@@ -75,7 +75,7 @@ const SessionHeaderLabel: FC<{
             color="ldGray.6"
         />
         {session.sessionId ? (
-            <Tooltip withinPortal variant="xs" label={session.sessionId}>
+            <Tooltip withinPortal label={session.sessionId}>
                 <Text fz="xs" ff="monospace" fw={600} c="ldGray.9">
                     {session.sessionId.slice(0, 8)}
                 </Text>
@@ -99,7 +99,6 @@ const ClientCellContent: FC<{ call: McpActivityItem }> = ({ call }) => {
     return (
         <Tooltip
             withinPortal
-            variant="xs"
             label={userAgent ?? label}
             disabled={!isTruncated.isTruncated && !userAgent}
             multiline
@@ -266,7 +265,6 @@ const McpActivityTable = ({
                 ) : (
                     <Tooltip
                         withinPortal
-                        variant="xs"
                         label={formatToolCallTimeFull(
                             row.original.call.createdAt,
                         )}
@@ -321,11 +319,7 @@ const McpActivityTable = ({
             ),
             Cell: ({ row }) =>
                 row.original.type === 'session' ? null : (
-                    <Tooltip
-                        withinPortal
-                        variant="xs"
-                        label={row.original.call.user.email}
-                    >
+                    <Tooltip withinPortal label={row.original.call.user.email}>
                         <Text c="ldGray.9" fz="sm" fw={400}>
                             {row.original.call.user.name}
                         </Text>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
@@ -146,7 +146,6 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                         </Stack>
                         <Group gap={8} wrap="nowrap" align="center">
                             <Tooltip
-                                variant="xs"
                                 position="top"
                                 label={`First seen ${formatReviewDate(
                                     item.firstSeenAt,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/SourceFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/SourceFilter.tsx
@@ -20,7 +20,7 @@ export const SourceFilter = ({
     const data = [
         {
             label: (
-                <Tooltip withinPortal variant="xs" label="All sources">
+                <Tooltip withinPortal label="All sources">
                     <Box>
                         <Text fz="xs" fw={500}>
                             All
@@ -32,7 +32,7 @@ export const SourceFilter = ({
         },
         {
             label: (
-                <Tooltip withinPortal variant="xs" label="Web app threads">
+                <Tooltip withinPortal label="Web app threads">
                     <Box>
                         <MantineIcon
                             icon={IconMessageCircleStar}
@@ -45,7 +45,7 @@ export const SourceFilter = ({
         },
         {
             label: (
-                <Tooltip withinPortal variant="xs" label="Slack threads">
+                <Tooltip withinPortal label="Slack threads">
                     <Box>
                         <MantineIcon icon={IconBrandSlack} {...iconProps} />
                     </Box>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -235,7 +235,7 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                             ? 'Review details'
                             : 'Thread preview'}
                     </Title>
-                    <Tooltip label="Open Thread" variant="xs" position="right">
+                    <Tooltip label="Open Thread" position="right">
                         <ActionIcon
                             variant="subtle"
                             color="gray"
@@ -256,11 +256,7 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                             variant="pill"
                         />
                     )}
-                    <Tooltip
-                        label="Open Agent Settings"
-                        variant="xs"
-                        position="right"
-                    >
+                    <Tooltip label="Open Agent Settings" position="right">
                         <ActionIcon
                             variant="subtle"
                             color="gray"

--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentButton.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentButton.tsx
@@ -40,7 +40,7 @@ export const AskAiAgentButton: FC<Props> = ({
     if (!canAsk) return null;
 
     return (
-        <Tooltip label="Ask AI Agent" variant="xs" withinPortal>
+        <Tooltip label="Ask AI Agent" withinPortal>
             <ActionIcon
                 variant={variant}
                 size={size}

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
@@ -739,11 +739,7 @@ export const ServiceAccountsTable: FC<Props> = ({
                 className={classes.toolbar}
             >
                 <Group gap="xs" wrap="nowrap" flex={1} miw={0}>
-                    <Tooltip
-                        withinPortal
-                        variant="xs"
-                        label="Search by description"
-                    >
+                    <Tooltip withinPortal label="Search by description">
                         <TextInput
                             size="xs"
                             radius="md"
@@ -822,7 +818,6 @@ export const ServiceAccountsTable: FC<Props> = ({
                                 <Popover.Target>
                                     <Tooltip
                                         withinPortal
-                                        variant="xs"
                                         label="Filter by creator"
                                     >
                                         <Button

--- a/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.tsx
+++ b/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.tsx
@@ -1,5 +1,4 @@
-import { Button, Card, List } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
+import { Button, Card, List, Tooltip } from '@mantine-8/core';
 import { type SuggestionProps } from '@tiptap/suggestion';
 import { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 import { type SuggestionsItem } from '../../types';

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
@@ -18,8 +18,9 @@ import {
     Text,
     Select,
     Switch,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip, type PopoverProps } from '@mantine/core';
+import { type PopoverProps } from '@mantine/core';
 import { IconHelpCircle, IconX } from '@tabler/icons-react';
 import { useEffect, useMemo, useState, type FC } from 'react';
 import FilterInputComponent from '../../../components/common/Filters/FilterInputs';
@@ -226,7 +227,6 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                                 variant={'light'}
                                 rightSection={
                                     <Tooltip
-                                        variant="xs"
                                         label={
                                             filterRule.singleValue
                                                 ? 'Prevent selection of multiple values'

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
@@ -23,8 +23,9 @@ import {
     ActionIcon,
     Checkbox,
     Select,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip, type PopoverProps } from '@mantine/core';
+import { type PopoverProps } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import FieldSelect from '../../../components/common/FieldSelect';

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -28,8 +28,9 @@ import {
     Tabs,
     Text,
     Select,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip, type PopoverProps } from '@mantine/core';
+import { type PopoverProps } from '@mantine/core';
 import { IconRotate2, IconSql } from '@tabler/icons-react';
 import { produce } from 'immer';
 import { useCallback, useMemo, useRef, useState, type FC } from 'react';

--- a/packages/frontend/src/features/dashboardTabs/Tab.tsx
+++ b/packages/frontend/src/features/dashboardTabs/Tab.tsx
@@ -56,7 +56,6 @@ const DraggableTab: FC<DraggableTabProps> = ({
                         withArrow
                         openDelay={500}
                         color="dark"
-                        variant="xs"
                         disabled={!isTruncated}
                         maw={300}
                         multiline

--- a/packages/frontend/src/features/metricsCatalog/components/CatalogCategory.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/CatalogCategory.tsx
@@ -1,6 +1,5 @@
 import type { CatalogItem } from '@lightdash/common';
-import { Group, ActionIcon, Badge } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
+import { Group, ActionIcon, Badge, Tooltip } from '@mantine-8/core';
 import { IconCode, IconX } from '@tabler/icons-react';
 import type { CSSProperties, FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -47,7 +46,6 @@ export const CatalogCategory: FC<Props> = ({
             rightSection={
                 showYamlIcon && (
                     <Tooltip
-                        variant="xs"
                         maw={200}
                         position="top"
                         withinPortal

--- a/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/ExploreMetricButton.tsx
@@ -1,6 +1,5 @@
 import { type CatalogField } from '@lightdash/common';
-import { Button } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
+import { Button, Tooltip } from '@mantine-8/core';
 import { useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { type ContentTableRow } from '../../../components/common/ContentTable';
@@ -57,7 +56,6 @@ export const ExploreMetricButton = ({ row }: Props) => {
     return (
         <Tooltip
             withinPortal
-            variant="xs"
             label="Click to view this in the Metrics Explorer"
             openDelay={200}
             maw={250}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -11,8 +11,8 @@ import {
     ActionIcon,
     SimpleGrid,
     Popover,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { useDisclosure, useHover } from '@mantine/hooks';
 import { IconCode, IconDots, IconTrash } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
@@ -144,7 +144,6 @@ const EditPopover: FC<EditPopoverProps> = ({
 
                     <Group justify="space-between">
                         <Tooltip
-                            variant="xs"
                             label="Delete this tag permanently"
                             openDelay={200}
                             maw={250}
@@ -234,7 +233,6 @@ export const MetricCatalogCategoryFormItem: FC<Props> = ({
 
             {!canEdit && (
                 <Tooltip
-                    variant="xs"
                     maw={200}
                     position="top"
                     withinPortal

--- a/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricChartUsageButton.tsx
@@ -49,7 +49,6 @@ export const MetricChartUsageButton = ({
     return (
         <Tooltip
             withinPortal
-            variant="xs"
             disabled={!canViewChartUsage}
             openDelay={200}
             maw={250}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -34,8 +34,8 @@ import {
     SegmentedControl,
     Badge,
     Popover,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import {
     IconEye,
     IconEyeOff,
@@ -113,7 +113,6 @@ const SortableColumn: FC<{
         <Group ref={setNodeRef} style={style} justify="space-between" h={28}>
             <Group gap={4}>
                 <Tooltip
-                    variant="xs"
                     disabled={!column.frozen}
                     label={`The ${column.name} column is pinned for usability`}
                     position="top"
@@ -439,7 +438,6 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                         <Popover.Target>
                             <Tooltip
                                 withinPortal
-                                variant="xs"
                                 multiline
                                 maw={150}
                                 label="Manage column visibility"
@@ -505,7 +503,6 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                         <>
                                             <Tooltip
                                                 position="bottom"
-                                                variant="xs"
                                                 withinPortal
                                                 label={
                                                     hasConfigChanges
@@ -551,7 +548,6 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                     ) : (
                                         <Tooltip
                                             position="bottom"
-                                            variant="xs"
                                             withinPortal
                                             label={'Discard unsaved changes'}
                                         >
@@ -609,7 +605,6 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                 label: (
                                     <Tooltip
                                         withinPortal
-                                        variant="xs"
                                         label="List view"
                                         position="bottom-end"
                                     >
@@ -627,7 +622,6 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                 label: (
                                     <Tooltip
                                         withinPortal
-                                        variant="xs"
                                         label="Canvas"
                                         position="bottom-end"
                                     >

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreComparison.tsx
@@ -14,8 +14,8 @@ import {
     Stack,
     Text,
     Select,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { IconCalendar, IconStack } from '@tabler/icons-react';
 import { type UseQueryResult } from '@tanstack/react-query';
 import { useCallback, type FC } from 'react';
@@ -137,7 +137,6 @@ export const MetricExploreComparison: FC<Props> = ({
                         <Tooltip
                             key={comparison.type}
                             label={comparison.tooltipLabel}
-                            variant="xs"
                             position="right"
                             withinPortal
                         >

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
@@ -15,8 +15,8 @@ import {
     Button,
     SegmentedControl,
     Popover,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { DatePicker, MonthPicker, YearPicker } from '@mantine/dates';
 import { useCallback, useEffect, useRef, type FC } from 'react';
 import useTracking from '../../../../providers/Tracking/useTracking';
@@ -131,7 +131,6 @@ export const MetricExploreDatePicker: FC<Props> = ({
         ...presets.map((preset) => ({
             label: (
                 <Tooltip
-                    variant="xs"
                     label={`${formatDate(preset.getValue()[0])} to ${formatDate(
                         preset.getValue()[1],
                     )}`}
@@ -203,7 +202,6 @@ export const MetricExploreDatePicker: FC<Props> = ({
                     {showTimeDimensionIntervalPicker &&
                         timeDimensionBaseField && (
                             <Tooltip
-                                variant="xs"
                                 label="Change granularity"
                                 position="top"
                                 withinPortal

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilterAutoComplete.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreFilterAutoComplete.tsx
@@ -4,10 +4,10 @@ import {
     Highlight,
     Loader,
     Text,
+    Tooltip,
     type ComboboxProps,
     type PillsInputProps,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import uniq from 'lodash/uniq';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreSegmentationPicker.tsx
@@ -14,8 +14,8 @@ import {
     Stack,
     Text,
     Select,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { IconInfoCircle, IconX } from '@tabler/icons-react';
 import { type UseQueryResult } from '@tanstack/react-query';
 import { useMemo, type FC } from 'react';

--- a/packages/frontend/src/features/notifications/components/AiReviewNotifications.tsx
+++ b/packages/frontend/src/features/notifications/components/AiReviewNotifications.tsx
@@ -1,6 +1,6 @@
 import { type NotificationAiReview } from '@lightdash/common';
-import { Group, Menu, Text } from '@mantine-8/core';
-import { Tooltip, useMantineTheme } from '@mantine/core';
+import { Group, Menu, Text, Tooltip } from '@mantine-8/core';
+import { useMantineTheme } from '@mantine/core';
 import { IconCircleFilled } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { useCallback, type FC } from 'react';

--- a/packages/frontend/src/features/notifications/components/DashboardCommentsNotifications.tsx
+++ b/packages/frontend/src/features/notifications/components/DashboardCommentsNotifications.tsx
@@ -1,6 +1,6 @@
 import { type NotificationDashboardComment } from '@lightdash/common';
-import { Menu, Text } from '@mantine-8/core';
-import { Tooltip, useMantineTheme } from '@mantine/core';
+import { Menu, Text, Tooltip } from '@mantine-8/core';
+import { useMantineTheme } from '@mantine/core';
 import { IconCircleFilled } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { useCallback, type FC } from 'react';

--- a/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.tsx
@@ -53,7 +53,6 @@ export const ContentTypeFilter: FC<ContentTypeFilterProps> = ({
             value: ContentType.CHART,
             label: (
                 <Tooltip
-                    variant="xs"
                     label="Show only deleted charts"
                     withinPortal
                     maw={200}

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -19,8 +19,8 @@ import {
     LoadingOverlay,
     SegmentedControl,
     Transition,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { useElementSize, useHotkeys } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import {
@@ -472,7 +472,6 @@ export const ContentPanel: FC = () => {
                                             label: (
                                                 <Tooltip
                                                     disabled={!hasUnrunChanges}
-                                                    variant="xs"
                                                     withinPortal
                                                     label="You haven't run this query yet."
                                                 >
@@ -495,7 +494,6 @@ export const ContentPanel: FC = () => {
                                                     disabled={
                                                         !!queryResults?.results
                                                     }
-                                                    variant="xs"
                                                     withinPortal
                                                     label="Run a query to see the chart"
                                                 >
@@ -565,7 +563,6 @@ export const ContentPanel: FC = () => {
                             />
                             {activeEditorTab === EditorTabs.SQL && (
                                 <Tooltip
-                                    variant="xs"
                                     label="Format SQL"
                                     withArrow
                                     position="bottom"

--- a/packages/frontend/src/features/sqlRunner/components/Download/ResultsDownloadButton.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Download/ResultsDownloadButton.tsx
@@ -3,8 +3,7 @@ import {
     getHiddenFieldsFromVizTableConfig,
     type VizTableConfig,
 } from '@lightdash/common';
-import { ActionIcon, Popover } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
+import { ActionIcon, Popover, Tooltip } from '@mantine-8/core';
 import { IconDownload } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
@@ -43,7 +42,7 @@ const ResultsDownloadButton: FC<Props> = ({
     return (
         <Popover withArrow disabled={disabled}>
             <Popover.Target>
-                <Tooltip variant="xs" label="Download results">
+                <Tooltip label="Download results">
                     <ActionIcon variant="default" disabled={disabled}>
                         <MantineIcon icon={IconDownload} />
                     </ActionIcon>

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -8,8 +8,8 @@ import {
     Button,
     ActionIcon,
     Menu,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
     IconBrandGithub,

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderEdit.tsx
@@ -8,8 +8,8 @@ import {
     ActionIcon,
     HoverCard,
     Menu,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import {
     IconArrowBack,
     IconDots,
@@ -236,7 +236,6 @@ export const HeaderEdit: FC = () => {
                             </Button>
                         ) : (
                             <Tooltip
-                                variant="xs"
                                 label="Back to view page"
                                 position="bottom"
                             >

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -8,8 +8,8 @@ import {
     Button,
     ActionIcon,
     Menu,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
     IconCirclesRelation,

--- a/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Sidebar.tsx
@@ -1,6 +1,12 @@
 import { ChartKind } from '@lightdash/common';
-import { ActionIcon, Group, ScrollArea, Stack, Title } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
+import {
+    ActionIcon,
+    Group,
+    ScrollArea,
+    Stack,
+    Title,
+    Tooltip,
+} from '@mantine-8/core';
 import { IconLayoutSidebarLeftCollapse, IconReload } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -43,11 +49,7 @@ export const Sidebar: FC<Props> = ({ setSidebarOpen }) => {
                             : 'VISUALIZATION'}
                     </Title>
                     {activeSidebarTab === SidebarTabs.TABLES && (
-                        <Tooltip
-                            variant="xs"
-                            label="Refresh tables"
-                            position="right"
-                        >
+                        <Tooltip label="Refresh tables" position="right">
                             <ActionIcon
                                 variant="subtle"
                                 color="gray"
@@ -59,7 +61,7 @@ export const Sidebar: FC<Props> = ({ setSidebarOpen }) => {
                         </Tooltip>
                     )}
                 </Group>
-                <Tooltip variant="xs" label="Close sidebar" position="left">
+                <Tooltip label="Close sidebar" position="left">
                     <ActionIcon variant="subtle" color="gray" size="xs">
                         <MantineIcon
                             icon={IconLayoutSidebarLeftCollapse}

--- a/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.tsx
@@ -6,8 +6,9 @@ import {
     UnstyledButton,
     HoverCard,
     Popover,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip, useMantineTheme } from '@mantine/core';
+import { useMantineTheme } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { Editor } from '@monaco-editor/react';
 import {
@@ -133,7 +134,7 @@ export const SqlQueryHistory: FC = () => {
     return (
         <Popover withinPortal>
             <Popover.Target>
-                <Tooltip variant="xs" label="SQL Query history">
+                <Tooltip label="SQL Query history">
                     <ActionIcon
                         variant="default"
                         size={32}

--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -10,8 +10,8 @@ import {
     ActionIcon,
     Highlight,
     ScrollArea,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { useDebouncedValue, useHover } from '@mantine/hooks';
 import { IconCopy, IconSearch, IconX } from '@tabler/icons-react';
 import { memo, useState, type FC } from 'react';
@@ -39,7 +39,6 @@ const TableField: FC<{
                     <CopyButton value={`${activeTable}.${field.name}`}>
                         {({ copied, copy }) => (
                             <Tooltip
-                                variant="xs"
                                 label={copied ? 'Copied to clipboard' : 'Copy'}
                                 withArrow
                                 position="right"
@@ -65,12 +64,7 @@ const TableField: FC<{
                 <TableFieldIcon fieldType={field.type} />
             )}
 
-            <Tooltip
-                withinPortal
-                variant="xs"
-                label={field.name}
-                disabled={!isTruncated}
-            >
+            <Tooltip withinPortal label={field.name} disabled={!isTruncated}>
                 <Text
                     ref={truncatedRef}
                     fw={500}

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -13,8 +13,8 @@ import {
     ActionIcon,
     Highlight,
     ScrollArea,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { useDebouncedValue, useHover } from '@mantine/hooks';
 import {
     IconChevronDown,
@@ -108,12 +108,11 @@ const TableItem: FC<TableItemProps> = memo(
                 >
                     <Tooltip
                         withinPortal
-                        variant="xs"
                         label={table}
                         disabled={!isTruncated}
                         multiline
                         maw={300}
-                        sx={{
+                        style={{
                             wordBreak: 'break-word',
                         }}
                     >
@@ -147,7 +146,6 @@ const TableItem: FC<TableItemProps> = memo(
                     <CopyButton value={`${quotedTable}`}>
                         {({ copied, copy }) => (
                             <Tooltip
-                                variant="xs"
                                 label={copied ? 'Copied to clipboard' : 'Copy'}
                                 withArrow
                                 position="right"

--- a/packages/frontend/src/features/sync/components/SyncModalView.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalView.tsx
@@ -48,7 +48,6 @@ const ToggleSyncEnabled: FC<{ scheduler: Scheduler }> = ({ scheduler }) => {
         <>
             <Tooltip
                 withinPortal
-                variant="xs"
                 maw={130}
                 label={
                     scheduler.enabled

--- a/packages/frontend/src/features/virtualView/components/CreateVirtualViewModal.tsx
+++ b/packages/frontend/src/features/virtualView/components/CreateVirtualViewModal.tsx
@@ -98,7 +98,6 @@ export const CreateVirtualViewModal: FC<Props> = ({ opened, onClose }) => {
             cancelDisabled={isLoadingVirtual}
             headerActions={
                 <Tooltip
-                    variant="xs"
                     withinPortal
                     multiline
                     maw={300}

--- a/packages/frontend/src/features/virtualView/components/HeaderVirtualView.tsx
+++ b/packages/frontend/src/features/virtualView/components/HeaderVirtualView.tsx
@@ -100,7 +100,6 @@ const ChartErrorListItem: FC<{
         <Group gap="xs" wrap="nowrap">
             <MantineIcon icon={IconAlertHexagon} color="orange" size={16} />
             <Tooltip
-                variant="xs"
                 withinPortal
                 label={
                     <Stack gap={2}>
@@ -554,11 +553,7 @@ export const HeaderVirtualView: FC<{
             </Group>
 
             <Group gap="sm">
-                <Tooltip
-                    variant="xs"
-                    label="No changes to save"
-                    disabled={hasChanges}
-                >
+                <Tooltip label="No changes to save" disabled={hasChanges}>
                     <Box>
                         <Button
                             size="xs"

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -8,8 +8,9 @@ import {
     ActionIcon,
     Anchor,
     Modal,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip, useMantineTheme } from '@mantine/core';
+import { useMantineTheme } from '@mantine/core';
 import { modals } from '@mantine/modals';
 import { IconCheck, IconCopy, IconSpeakerphone } from '@tabler/icons-react';
 import { defaultContext } from '@tanstack/react-query';

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -27,8 +27,7 @@ import {
     type ResultValue,
     type TableCalculation,
 } from '@lightdash/common';
-import { Group, Skeleton } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
+import { Group, Skeleton, Tooltip } from '@mantine-8/core';
 import { IconExclamationCircle } from '@tabler/icons-react';
 import { type CellContext } from '@tanstack/react-table';
 import omit from 'lodash/omit';

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -854,7 +854,7 @@ const Settings: FC = () => {
             isSidebarCollapsed={isSidebarCollapsed}
             isSidebarCollapsible
             collapsedSidebarContent={
-                <Tooltip label="Pin sidebar" position="right" variant="xs">
+                <Tooltip label="Pin sidebar" position="right">
                     <ActionIcon
                         variant="subtle"
                         color="gray"
@@ -882,7 +882,6 @@ const Settings: FC = () => {
                                     ? 'Pin sidebar'
                                     : 'Unpin sidebar'
                             }
-                            variant="xs"
                         >
                             <ActionIcon
                                 variant="subtle"

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -1,6 +1,5 @@
 import { getFieldQuoteChar } from '@lightdash/common';
-import { Group, Paper, Stack, ActionIcon } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
+import { Group, Paper, Stack, ActionIcon, Tooltip } from '@mantine-8/core';
 import { IconLayoutSidebarLeftExpand } from '@tabler/icons-react';
 import { useEffect } from 'react';
 import { Provider } from 'react-redux';
@@ -204,11 +203,7 @@ const SqlRunner = ({
                         style={{ flexGrow: 0 }}
                     >
                         <Stack gap="xs">
-                            <Tooltip
-                                variant="xs"
-                                label={'Open sidebar'}
-                                position="right"
-                            >
+                            <Tooltip label={'Open sidebar'} position="right">
                                 <ActionIcon
                                     variant="subtle"
                                     color="gray"

--- a/packages/frontend/src/pages/UserActivity.tsx
+++ b/packages/frontend/src/pages/UserActivity.tsx
@@ -13,8 +13,8 @@ import {
     Anchor,
     Card,
     Table,
+    Tooltip,
 } from '@mantine-8/core';
-import { Tooltip } from '@mantine/core';
 import { IconUsers } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link, useParams } from 'react-router';


### PR DESCRIPTION
## Summary

Stacked on #25978, which contains the Drawer + Modal migration.

- replace the removed v6 `Header` with a semantic v8 `Box component="header"`
- preserve the mobile navbar's 50px static flow, dark surface, app z-index, and scoped Drawer portal
- migrate 64 legacy Tooltip owners (117 roots + 2 groups) to Mantine 8
- remove obsolete `variant="xs"` from migrated and existing v8 Tooltip owners
- convert Tooltip `width`/`sx` props and forward the local AddButton ref

## Validation

- AST inventory: 64/64 owners, 117/117 roots, 2/2 groups; zero legacy Tooltip/Header imports
- behavioral Tooltip props retained: position, disabled, opened, delays, offsets, portal, arrows, multiline, max width
- frontend fast typecheck
- frontend lint (0 errors; 4 pre-existing warnings)
- frontend format check
- full frontend Vitest suite

## Manual QA

- mobile routes: dark 50px header stays in document flow; Drawer overlays and portals inside the scoped dark provider
- dashboard/Explorer/SQL Runner/toolbars: Tooltip delay, wrapping, arrow, collision, and portal layering
- Tooltip.Group warm-open behavior in chart data table and SQL Runner
- disabled/truncation tooltips and both conditional targets