### PR TITLE
feat: homepage semantic-layer action lands on agent onboarding for the current project

### DIFF
--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -354,6 +354,26 @@ const APP_ROUTES: RouteObject[] = [
                 children: [
                     { index: true, element: <Navigate to="home" replace /> },
                     {
+                        path: 'onboarding/agent',
+                        lazy: async () => {
+                            const AgentOnboardingStartPage =
+                                await loadLazyRouteDefault(
+                                    './ee/features/agentOnboarding/AgentOnboardingStartPage',
+                                    () =>
+                                        import('./ee/features/agentOnboarding/AgentOnboardingStartPage'),
+                                );
+                            return {
+                                Component: () => (
+                                    <TrackPage
+                                        name={PageName.AGENT_ONBOARDING_START}
+                                    >
+                                        <AgentOnboardingStartPage />
+                                    </TrackPage>
+                                ),
+                            };
+                        },
+                    },
+                    {
                         path: 'onboarding/runs/:agentOnboardingRunUuid',
                         lazy: async () => {
                             const AgentOnboardingRunPage =

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -734,6 +734,32 @@ const APP_ROUTES: RouteObject[] = [
                 children: [
                     { index: true, element: <Navigate to="home" replace /> },
                     {
+                        path: 'onboarding/agent',
+                        handle: { hideAILauncher: true },
+                        lazy: async () => {
+                            const AgentOnboardingStartPage =
+                                await loadLazyRouteDefault(
+                                    './ee/features/agentOnboarding/AgentOnboardingStartPage',
+                                    () =>
+                                        import('./ee/features/agentOnboarding/AgentOnboardingStartPage'),
+                                );
+                            return {
+                                Component: () => (
+                                    <>
+                                        <NavBar />
+                                        <TrackPage
+                                            name={
+                                                PageName.AGENT_ONBOARDING_START
+                                            }
+                                        >
+                                            <AgentOnboardingStartPage />
+                                        </TrackPage>
+                                    </>
+                                ),
+                            };
+                        },
+                    },
+                    {
                         path: 'onboarding/runs/:agentOnboardingRunUuid',
                         handle: { hideAILauncher: true },
                         lazy: async () => {

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectUsingAgent.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectUsingAgent.tsx
@@ -1,46 +1,17 @@
 import {
-    assertUnreachable,
     DbtProjectType,
-    DuckdbConnectionType,
     ProjectType,
     WarehouseTypes,
     type CreateWarehouseCredentials,
     type Project,
-    type WarehouseCredentials,
 } from '@lightdash/common';
-import {
-    Button,
-    Code,
-    Collapse,
-    CopyButton,
-    Divider,
-    Group,
-    Stack,
-    Text,
-    ThemeIcon,
-    Title,
-} from '@mantine-8/core';
-import {
-    IconCheck,
-    IconChevronDown,
-    IconChevronLeft,
-    IconCopy,
-    IconSparkles,
-} from '@tabler/icons-react';
-import { useMemo, useRef, useState, type FC } from 'react';
-import { useNavigate } from 'react-router';
-import { AgentOnboardingProgress } from '../../../ee/features/agentOnboarding/AgentOnboardingProgress';
-import { useStartAgentOnboardingRun } from '../../../ee/features/agentOnboarding/hooks/useAgentOnboarding';
-import { getAgentOnboardingRunUrl } from '../../../ee/features/agentOnboarding/utils';
-import { useIsCopilotEnabled } from '../../../ee/features/aiCopilot/hooks/useIsCopilotEnabled';
+import { Button, Stack, Text, Title } from '@mantine-8/core';
+import { IconChevronLeft } from '@tabler/icons-react';
+import { useRef, useState, type FC } from 'react';
+import { AgentOnboardingLaunchPanel } from '../../../ee/features/agentOnboarding/AgentOnboardingLaunchPanel';
 import { useCreateProjectWithoutCompileMutation } from '../../../hooks/useProject';
-import useTracking from '../../../providers/Tracking/useTracking';
-import { EventName } from '../../../types/Events';
 import MantineIcon from '../../common/MantineIcon';
-import {
-    SettingsCard,
-    SettingsGridCard,
-} from '../../common/Settings/SettingsCard';
+import { SettingsGridCard } from '../../common/Settings/SettingsCard';
 import { dbtDefaults } from '../DbtForms/defaultValues';
 import { FormProvider, useForm } from '../formContext';
 import { ProjectFormProvider } from '../ProjectFormProvider';
@@ -53,15 +24,6 @@ import { OnboardingTitle } from './common/OnboardingTitle';
 import { getWarehouseIcon, getWarehouseLabel } from './utils';
 
 type PreparedProject = Pick<Project, 'projectUuid' | 'warehouseConnection'>;
-
-type ConnectionDefaults = {
-    database: string | undefined; // undefined when the warehouse has no database concept
-    schema: string | undefined;
-};
-
-// Treats empty strings as "not configured"
-const nonEmpty = (value: string | undefined): string | undefined =>
-    value || undefined;
 
 const getSchemaField = (
     warehouseType: WarehouseTypes,
@@ -82,64 +44,6 @@ const getAgentWarehouseValidators = (warehouseType: WarehouseTypes) => {
     return validators;
 };
 
-const getConnectionDefaults = (
-    credentials: WarehouseCredentials,
-): ConnectionDefaults => {
-    switch (credentials.type) {
-        case WarehouseTypes.POSTGRES:
-        case WarehouseTypes.REDSHIFT:
-        case WarehouseTypes.TRINO:
-            return {
-                database: nonEmpty(credentials.dbname),
-                schema: nonEmpty(credentials.schema),
-            };
-        case WarehouseTypes.SNOWFLAKE:
-        case WarehouseTypes.ATHENA:
-            return {
-                database: nonEmpty(credentials.database),
-                schema: nonEmpty(credentials.schema),
-            };
-        case WarehouseTypes.BIGQUERY:
-            return {
-                database: nonEmpty(credentials.project),
-                schema: nonEmpty(credentials.dataset),
-            };
-        case WarehouseTypes.DATABRICKS:
-            // `database` is semantically the schema for Databricks
-            return {
-                database: nonEmpty(credentials.catalog),
-                schema: nonEmpty(credentials.database),
-            };
-        case WarehouseTypes.CLICKHOUSE:
-            return {
-                database: undefined,
-                schema: nonEmpty(credentials.schema),
-            };
-        case WarehouseTypes.DUCKDB:
-            if (credentials.connectionType === DuckdbConnectionType.DUCKLAKE) {
-                return {
-                    database: nonEmpty(credentials.catalogAlias) ?? 'ducklake',
-                    schema: nonEmpty(credentials.schema),
-                };
-            }
-            if (credentials.connectionType === DuckdbConnectionType.EMBEDDED) {
-                return {
-                    database: credentials.dataset,
-                    schema: undefined,
-                };
-            }
-            return {
-                database: nonEmpty(credentials.database),
-                schema: nonEmpty(credentials.schema),
-            };
-        default:
-            return assertUnreachable(
-                credentials,
-                'Unknown warehouse type when getting connection defaults',
-            );
-    }
-};
-
 interface ConnectUsingAgentProps {
     selectedWarehouse: WarehouseTypes;
     siteUrl: string;
@@ -152,14 +56,9 @@ const ConnectUsingAgent: FC<ConnectUsingAgentProps> = ({
     onBack,
 }) => {
     const [preparedProject, setPreparedProject] = useState<PreparedProject>();
-    const [isLocalPromptOpen, setIsLocalPromptOpen] = useState(false);
     const isCreatingProjectRef = useRef(false);
-    const navigate = useNavigate();
     const createProjectMutation = useCreateProjectWithoutCompileMutation();
-    const startAgentOnboardingRun = useStartAgentOnboardingRun();
-    const { isCopilotEnabled } = useIsCopilotEnabled();
     const onProjectError = useOnProjectError();
-    const { track } = useTracking();
 
     const form = useForm({
         initialValues: {
@@ -208,181 +107,13 @@ const ConnectUsingAgent: FC<ConnectUsingAgentProps> = ({
         }
     };
 
-    const agentSetupPrompt = useMemo(() => {
-        if (!preparedProject) return undefined;
-
-        const normalizedSiteUrl = siteUrl.replace(/\/+$/, '');
-        const instructionsUrl = `${normalizedSiteUrl}/api/v1/prompts/project-onboarding`;
-
-        const connectionDefaults = preparedProject.warehouseConnection
-            ? getConnectionDefaults(preparedProject.warehouseConnection)
-            : undefined;
-
-        return [
-            '# Complete Lightdash project setup',
-            '',
-            '## Prepared setup',
-            '',
-            `- Warehouse type: ${selectedWarehouse}`,
-            `- Prepared project UUID: ${preparedProject.projectUuid}`,
-            ...(connectionDefaults?.database
-                ? [`- Configured database: ${connectionDefaults.database}`]
-                : []),
-            ...(connectionDefaults?.schema
-                ? [`- Configured schema: ${connectionDefaults.schema}`]
-                : []),
-            '',
-            '## Next step',
-            '',
-            `Fetch and follow the remaining instructions from: ${instructionsUrl}`,
-            'Use the prepared setup values above whenever those instructions refer to a setup value.',
-        ].join('\n');
-    }, [preparedProject, selectedWarehouse, siteUrl]);
-
-    const openProject = () => {
-        if (!preparedProject) return;
-        void navigate(`/projects/${preparedProject.projectUuid}`);
-    };
-
-    const startManagedSetup = async () => {
-        if (!preparedProject) return;
-        try {
-            const run = await startAgentOnboardingRun.mutateAsync(
-                preparedProject.projectUuid,
-            );
-            void navigate(
-                getAgentOnboardingRunUrl(
-                    run.agentOnboardingRunUuid,
-                    run.projectUuid,
-                ),
-            );
-        } catch {
-            return;
-        }
-    };
-
-    const localPrompt = (
-        <Stack gap="lg" className="sentry-block ph-no-capture">
-            <div>
-                <Title order={3}>Complete your project setup</Title>
-                <Text c="dimmed" mt="xs">
-                    Copy the prompt below and run it with your coding agent to
-                    finish setting up your Lightdash project.
-                </Text>
-            </div>
-
-            <Code
-                block
-                className="sentry-block ph-no-capture"
-                style={{
-                    whiteSpace: 'pre-wrap',
-                    overflowWrap: 'anywhere',
-                }}
-            >
-                {agentSetupPrompt}
-            </Code>
-
-            <CopyButton value={agentSetupPrompt ?? ''}>
-                {({ copied, copy }) => (
-                    <Button
-                        onClick={() => {
-                            copy();
-                            track({
-                                name: EventName.AGENT_SETUP_PROMPT_COPIED,
-                            });
-                        }}
-                        leftSection={
-                            <MantineIcon icon={copied ? IconCheck : IconCopy} />
-                        }
-                    >
-                        {copied ? 'Prompt copied' : 'Copy prompt'}
-                    </Button>
-                )}
-            </CopyButton>
-        </Stack>
-    );
-
     if (preparedProject) {
-        if (isCopilotEnabled) {
-            return (
-                <Stack w="100%" maw={960} mx="auto" mt="xl">
-                    <SettingsCard p="xl">
-                        <Stack gap="xl">
-                            <Group align="flex-start" wrap="nowrap" gap="md">
-                                <ThemeIcon
-                                    size={44}
-                                    radius="xl"
-                                    variant="light"
-                                    color="violet"
-                                >
-                                    <MantineIcon
-                                        icon={IconSparkles}
-                                        size="lg"
-                                    />
-                                </ThemeIcon>
-                                <Stack gap={6} style={{ flex: 1 }}>
-                                    <Title order={3}>
-                                        Let Lightdash build it for you
-                                    </Title>
-                                    <Text c="dimmed">
-                                        We’ll explore your warehouse, create a
-                                        semantic layer, and build a starter
-                                        dashboard. You can follow every step.
-                                    </Text>
-                                </Stack>
-                            </Group>
-
-                            <AgentOnboardingProgress />
-
-                            <Group justify="space-between">
-                                <Button
-                                    size="md"
-                                    leftSection={
-                                        <MantineIcon icon={IconSparkles} />
-                                    }
-                                    onClick={() => void startManagedSetup()}
-                                    loading={startAgentOnboardingRun.isLoading}
-                                >
-                                    Run it for me
-                                </Button>
-                                <Button
-                                    variant="subtle"
-                                    color="gray"
-                                    onClick={openProject}
-                                    disabled={startAgentOnboardingRun.isLoading}
-                                >
-                                    Skip to project
-                                </Button>
-                            </Group>
-
-                            <Divider />
-
-                            <Button
-                                variant="subtle"
-                                color="gray"
-                                w="fit-content"
-                                rightSection={
-                                    <MantineIcon icon={IconChevronDown} />
-                                }
-                                onClick={() =>
-                                    setIsLocalPromptOpen((value) => !value)
-                                }
-                            >
-                                Use my own coding agent instead
-                            </Button>
-                            <Collapse in={isLocalPromptOpen}>
-                                {localPrompt}
-                            </Collapse>
-                        </Stack>
-                    </SettingsCard>
-                </Stack>
-            );
-        }
-
         return (
-            <Stack w="100%" maw={960} mx="auto" mt="xl">
-                <SettingsCard p="xl">{localPrompt}</SettingsCard>
-            </Stack>
+            <AgentOnboardingLaunchPanel
+                project={preparedProject}
+                warehouseType={selectedWarehouse}
+                siteUrl={siteUrl}
+            />
         );
     }
 

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingLaunchPanel.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingLaunchPanel.tsx
@@ -1,0 +1,287 @@
+import {
+    assertUnreachable,
+    DuckdbConnectionType,
+    WarehouseTypes,
+    type Project,
+    type WarehouseCredentials,
+} from '@lightdash/common';
+import {
+    Button,
+    Code,
+    Collapse,
+    CopyButton,
+    Divider,
+    Group,
+    Stack,
+    Text,
+    ThemeIcon,
+    Title,
+} from '@mantine-8/core';
+import {
+    IconCheck,
+    IconChevronDown,
+    IconCopy,
+    IconSparkles,
+} from '@tabler/icons-react';
+import { useMemo, useState, type FC } from 'react';
+import { useNavigate } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { SettingsCard } from '../../../components/common/Settings/SettingsCard';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
+import { useIsCopilotEnabled } from '../aiCopilot/hooks/useIsCopilotEnabled';
+import { AgentOnboardingProgress } from './AgentOnboardingProgress';
+import { useStartAgentOnboardingRun } from './hooks/useAgentOnboarding';
+import { getAgentOnboardingRunUrl } from './utils';
+
+type ConnectionDefaults = {
+    database: string | undefined; // undefined when the warehouse has no database concept
+    schema: string | undefined;
+};
+
+// Treats empty strings as "not configured"
+const nonEmpty = (value: string | undefined): string | undefined =>
+    value || undefined;
+
+const getConnectionDefaults = (
+    credentials: WarehouseCredentials,
+): ConnectionDefaults => {
+    switch (credentials.type) {
+        case WarehouseTypes.POSTGRES:
+        case WarehouseTypes.REDSHIFT:
+        case WarehouseTypes.TRINO:
+            return {
+                database: nonEmpty(credentials.dbname),
+                schema: nonEmpty(credentials.schema),
+            };
+        case WarehouseTypes.SNOWFLAKE:
+        case WarehouseTypes.ATHENA:
+            return {
+                database: nonEmpty(credentials.database),
+                schema: nonEmpty(credentials.schema),
+            };
+        case WarehouseTypes.BIGQUERY:
+            return {
+                database: nonEmpty(credentials.project),
+                schema: nonEmpty(credentials.dataset),
+            };
+        case WarehouseTypes.DATABRICKS:
+            // `database` is semantically the schema for Databricks
+            return {
+                database: nonEmpty(credentials.catalog),
+                schema: nonEmpty(credentials.database),
+            };
+        case WarehouseTypes.CLICKHOUSE:
+            return {
+                database: undefined,
+                schema: nonEmpty(credentials.schema),
+            };
+        case WarehouseTypes.DUCKDB:
+            if (credentials.connectionType === DuckdbConnectionType.DUCKLAKE) {
+                return {
+                    database: nonEmpty(credentials.catalogAlias) ?? 'ducklake',
+                    schema: nonEmpty(credentials.schema),
+                };
+            }
+            if (credentials.connectionType === DuckdbConnectionType.EMBEDDED) {
+                return {
+                    database: credentials.dataset,
+                    schema: undefined,
+                };
+            }
+            return {
+                database: nonEmpty(credentials.database),
+                schema: nonEmpty(credentials.schema),
+            };
+        default:
+            return assertUnreachable(
+                credentials,
+                'Unknown warehouse type when getting connection defaults',
+            );
+    }
+};
+
+type AgentOnboardingLaunchPanelProps = {
+    project: Pick<Project, 'projectUuid' | 'warehouseConnection'>;
+    warehouseType: WarehouseTypes;
+    siteUrl: string;
+};
+
+export const AgentOnboardingLaunchPanel: FC<
+    AgentOnboardingLaunchPanelProps
+> = ({ project, warehouseType, siteUrl }) => {
+    const [isLocalPromptOpen, setIsLocalPromptOpen] = useState(false);
+    const navigate = useNavigate();
+    const startAgentOnboardingRun = useStartAgentOnboardingRun();
+    const { isCopilotEnabled } = useIsCopilotEnabled();
+    const { track } = useTracking();
+
+    const agentSetupPrompt = useMemo(() => {
+        const normalizedSiteUrl = siteUrl.replace(/\/+$/, '');
+        const instructionsUrl = `${normalizedSiteUrl}/api/v1/prompts/project-onboarding`;
+
+        const connectionDefaults = project.warehouseConnection
+            ? getConnectionDefaults(project.warehouseConnection)
+            : undefined;
+
+        return [
+            '# Complete Lightdash project setup',
+            '',
+            '## Prepared setup',
+            '',
+            `- Warehouse type: ${warehouseType}`,
+            `- Prepared project UUID: ${project.projectUuid}`,
+            ...(connectionDefaults?.database
+                ? [`- Configured database: ${connectionDefaults.database}`]
+                : []),
+            ...(connectionDefaults?.schema
+                ? [`- Configured schema: ${connectionDefaults.schema}`]
+                : []),
+            '',
+            '## Next step',
+            '',
+            `Fetch and follow the remaining instructions from: ${instructionsUrl}`,
+            'Use the prepared setup values above whenever those instructions refer to a setup value.',
+        ].join('\n');
+    }, [project, warehouseType, siteUrl]);
+
+    const openProject = () => {
+        void navigate(`/projects/${project.projectUuid}`);
+    };
+
+    const startManagedSetup = async () => {
+        try {
+            const run = await startAgentOnboardingRun.mutateAsync(
+                project.projectUuid,
+            );
+            void navigate(
+                getAgentOnboardingRunUrl(
+                    run.agentOnboardingRunUuid,
+                    run.projectUuid,
+                ),
+            );
+        } catch {
+            return;
+        }
+    };
+
+    const localPrompt = (
+        <Stack gap="lg" className="sentry-block ph-no-capture">
+            <div>
+                <Title order={3}>Complete your project setup</Title>
+                <Text c="dimmed" mt="xs">
+                    Copy the prompt below and run it with your coding agent to
+                    finish setting up your Lightdash project.
+                </Text>
+            </div>
+
+            <Code
+                block
+                className="sentry-block ph-no-capture"
+                style={{
+                    whiteSpace: 'pre-wrap',
+                    overflowWrap: 'anywhere',
+                }}
+            >
+                {agentSetupPrompt}
+            </Code>
+
+            <CopyButton value={agentSetupPrompt}>
+                {({ copied, copy }) => (
+                    <Button
+                        onClick={() => {
+                            copy();
+                            track({
+                                name: EventName.AGENT_SETUP_PROMPT_COPIED,
+                            });
+                        }}
+                        leftSection={
+                            <MantineIcon icon={copied ? IconCheck : IconCopy} />
+                        }
+                    >
+                        {copied ? 'Prompt copied' : 'Copy prompt'}
+                    </Button>
+                )}
+            </CopyButton>
+        </Stack>
+    );
+
+    if (isCopilotEnabled) {
+        return (
+            <Stack w="100%" maw={960} mx="auto" mt="xl">
+                <SettingsCard p="xl">
+                    <Stack gap="xl">
+                        <Group align="flex-start" wrap="nowrap" gap="md">
+                            <ThemeIcon
+                                size={44}
+                                radius="xl"
+                                variant="light"
+                                color="violet"
+                            >
+                                <MantineIcon icon={IconSparkles} size="lg" />
+                            </ThemeIcon>
+                            <Stack gap={6} style={{ flex: 1 }}>
+                                <Title order={3}>
+                                    Let Lightdash build it for you
+                                </Title>
+                                <Text c="dimmed">
+                                    We’ll explore your warehouse, create a
+                                    semantic layer, and build a starter
+                                    dashboard. You can follow every step.
+                                </Text>
+                            </Stack>
+                        </Group>
+
+                        <AgentOnboardingProgress />
+
+                        <Group justify="space-between">
+                            <Button
+                                size="md"
+                                leftSection={
+                                    <MantineIcon icon={IconSparkles} />
+                                }
+                                onClick={() => void startManagedSetup()}
+                                loading={startAgentOnboardingRun.isLoading}
+                            >
+                                Run it for me
+                            </Button>
+                            <Button
+                                variant="subtle"
+                                color="gray"
+                                onClick={openProject}
+                                disabled={startAgentOnboardingRun.isLoading}
+                            >
+                                Skip to project
+                            </Button>
+                        </Group>
+
+                        <Divider />
+
+                        <Button
+                            variant="subtle"
+                            color="gray"
+                            w="fit-content"
+                            rightSection={
+                                <MantineIcon icon={IconChevronDown} />
+                            }
+                            onClick={() =>
+                                setIsLocalPromptOpen((value) => !value)
+                            }
+                        >
+                            Use my own coding agent instead
+                        </Button>
+                        <Collapse in={isLocalPromptOpen}>
+                            {localPrompt}
+                        </Collapse>
+                    </Stack>
+                </SettingsCard>
+            </Stack>
+        );
+    }
+
+    return (
+        <Stack w="100%" maw={960} mx="auto" mt="xl">
+            <SettingsCard p="xl">{localPrompt}</SettingsCard>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingStartPage.test.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingStartPage.test.tsx
@@ -1,0 +1,107 @@
+import { MantineProvider } from '@mantine-8/core';
+import { render, screen } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import AgentOnboardingStartPage from './AgentOnboardingStartPage';
+
+const state = vi.hoisted(() => ({
+    isFlagEnabled: true,
+    project: {
+        projectUuid: 'project-uuid',
+        warehouseConnection: { type: 'postgres' },
+    } as unknown,
+}));
+
+vi.mock('../../../hooks/useProject', () => ({
+    useProject: () => ({ data: state.project, isInitialLoading: false }),
+}));
+
+vi.mock('../../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: () => ({
+        data: { enabled: state.isFlagEnabled },
+        isInitialLoading: false,
+    }),
+}));
+
+vi.mock('../../../providers/App/useApp', () => ({
+    default: () => ({
+        health: {
+            data: { siteUrl: 'https://app.lightdash.test' },
+            isInitialLoading: false,
+        },
+    }),
+}));
+
+vi.mock('../../../providers/Tracking/useTracking', () => ({
+    default: () => ({ track: vi.fn() }),
+}));
+
+vi.mock('../aiCopilot/hooks/useIsCopilotEnabled', () => ({
+    useIsCopilotEnabled: () => ({ isCopilotEnabled: true, isLoading: false }),
+}));
+
+vi.mock('./hooks/useAgentOnboarding', () => ({
+    useStartAgentOnboardingRun: () => ({
+        mutateAsync: vi.fn(),
+        isLoading: false,
+    }),
+}));
+
+vi.mock('../../../components/common/Page/Page', () => ({
+    default: ({ children }: PropsWithChildren) => <div>{children}</div>,
+}));
+
+const renderPage = () =>
+    render(
+        <MantineProvider>
+            <MemoryRouter
+                initialEntries={['/projects/project-uuid/onboarding/agent']}
+            >
+                <Routes>
+                    <Route
+                        path="/projects/:projectUuid/onboarding/agent"
+                        element={<AgentOnboardingStartPage />}
+                    />
+                    <Route
+                        path="/generalSettings/projectManagement/:projectUuid/settings"
+                        element={<div>project settings</div>}
+                    />
+                </Routes>
+            </MemoryRouter>
+        </MantineProvider>,
+    );
+
+describe('AgentOnboardingStartPage', () => {
+    beforeEach(() => {
+        state.isFlagEnabled = true;
+        state.project = {
+            projectUuid: 'project-uuid',
+            warehouseConnection: { type: 'postgres' },
+        };
+    });
+
+    it('renders the launch panel for a project with a warehouse connection', () => {
+        renderPage();
+
+        expect(
+            screen.getByText('Let Lightdash build it for you'),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Run it for me')).toBeInTheDocument();
+    });
+
+    it('redirects to project settings when the flag is disabled', () => {
+        state.isFlagEnabled = false;
+
+        renderPage();
+
+        expect(screen.getByText('project settings')).toBeInTheDocument();
+    });
+
+    it('redirects to project settings when the project has no warehouse connection', () => {
+        state.project = { projectUuid: 'project-uuid' };
+
+        renderPage();
+
+        expect(screen.getByText('project settings')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingStartPage.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingStartPage.tsx
@@ -1,5 +1,5 @@
 import { FeatureFlags } from '@lightdash/common';
-import { Stack, Text } from '@mantine-8/core';
+import { Box, Stack, Text } from '@mantine-8/core';
 import { type FC } from 'react';
 import { Navigate, useParams } from 'react-router';
 import Page from '../../../components/common/Page/Page';
@@ -44,7 +44,7 @@ const AgentOnboardingStartPage: FC = () => {
     return (
         <Page title="Project setup" withFixedContent withPaddedContent>
             <Stack w="100%" maw={960} mx="auto" mt="xl">
-                <div>
+                <Box>
                     <OnboardingTitle>
                         Set up your semantic layer
                     </OnboardingTitle>
@@ -52,7 +52,7 @@ const AgentOnboardingStartPage: FC = () => {
                         Turn your warehouse tables into metrics and dimensions
                         your team can explore.
                     </Text>
-                </div>
+                </Box>
             </Stack>
             <AgentOnboardingLaunchPanel
                 project={project}

--- a/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingStartPage.tsx
+++ b/packages/frontend/src/ee/features/agentOnboarding/AgentOnboardingStartPage.tsx
@@ -1,0 +1,66 @@
+import { FeatureFlags } from '@lightdash/common';
+import { Stack, Text } from '@mantine-8/core';
+import { type FC } from 'react';
+import { Navigate, useParams } from 'react-router';
+import Page from '../../../components/common/Page/Page';
+import PageSpinner from '../../../components/PageSpinner';
+import { OnboardingTitle } from '../../../components/ProjectConnection/ProjectConnectFlow/common/OnboardingTitle';
+import { useProject } from '../../../hooks/useProject';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../../providers/App/useApp';
+import { AgentOnboardingLaunchPanel } from './AgentOnboardingLaunchPanel';
+
+const AgentOnboardingStartPage: FC = () => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const { health } = useApp();
+    const { data: project, isInitialLoading: isLoadingProject } =
+        useProject(projectUuid);
+    const codingAgentOnboardingFlag = useServerFeatureFlag(
+        FeatureFlags.CodingAgentOnboarding,
+    );
+
+    if (
+        codingAgentOnboardingFlag.isInitialLoading ||
+        isLoadingProject ||
+        health.isInitialLoading
+    ) {
+        return <PageSpinner />;
+    }
+
+    if (
+        codingAgentOnboardingFlag.data?.enabled !== true ||
+        !project ||
+        !project.warehouseConnection ||
+        !health.data
+    ) {
+        return (
+            <Navigate
+                to={`/generalSettings/projectManagement/${projectUuid}/settings`}
+                replace
+            />
+        );
+    }
+
+    return (
+        <Page title="Project setup" withFixedContent withPaddedContent>
+            <Stack w="100%" maw={960} mx="auto" mt="xl">
+                <div>
+                    <OnboardingTitle>
+                        Set up your semantic layer
+                    </OnboardingTitle>
+                    <Text c="dimmed" mt="xs">
+                        Turn your warehouse tables into metrics and dimensions
+                        your team can explore.
+                    </Text>
+                </div>
+            </Stack>
+            <AgentOnboardingLaunchPanel
+                project={project}
+                warehouseType={project.warehouseConnection.type}
+                siteUrl={health.data.siteUrl}
+            />
+        </Page>
+    );
+};
+
+export default AgentOnboardingStartPage;

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
@@ -103,6 +103,31 @@ describe('useRecommendedActions', () => {
         });
     });
 
+    it('shows no source-control annotation when nothing is connected', () => {
+        vi.mocked(useApp).mockReturnValue({
+            health: { data: { hasGitlab: true } },
+            user: {
+                data: {
+                    ability: { can: () => true },
+                },
+            },
+        } as unknown as ReturnType<typeof useApp>);
+
+        const { result } = renderHook(() =>
+            useRecommendedActions('project-uuid'),
+        );
+
+        expect(
+            result.current.statuses['connect-source-control'].isVisible,
+        ).toBe(true);
+        expect(
+            result.current.statuses['connect-source-control'].isComplete,
+        ).toBe(false);
+        expect(
+            result.current.statuses['connect-source-control'].annotation,
+        ).toBeNull();
+    });
+
     describe('on a playground project', () => {
         beforeEach(() => {
             vi.mocked(useOrganization).mockReturnValue({

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.test.tsx
@@ -164,7 +164,7 @@ describe('useRecommendedActions', () => {
     });
 
     describe('add-semantic-layer destination', () => {
-        it('links to the agent setup flow when both flags are enabled', () => {
+        it('links to the current project agent setup flow when both flags are enabled', () => {
             vi.mocked(useServerFeatureFlag).mockImplementation(
                 () =>
                     ({
@@ -178,7 +178,7 @@ describe('useRecommendedActions', () => {
 
             expect(
                 result.current.statuses['add-semantic-layer'].url,
-            ).toStrictEqual('/createProject/agent');
+            ).toStrictEqual('/projects/project-uuid/onboarding/agent');
         });
 
         it('keeps the settings link when coding-agent onboarding is disabled', () => {

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
@@ -104,7 +104,11 @@ const useActionStatuses = (
         'connect-source-control': {
             isVisible: hasGithub || hasGitlab,
             isComplete: isGithubConnected || isGitlabConnected,
-            annotation: isGithubConnected ? 'GitHub' : 'GitLab',
+            annotation: isGithubConnected
+                ? 'GitHub'
+                : isGitlabConnected
+                  ? 'GitLab'
+                  : null,
             doneIcon: null,
             url: '/generalSettings/integrations',
         },

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/useRecommendedActions.tsx
@@ -98,7 +98,7 @@ const useActionStatuses = (
                 : null,
             doneIcon: null,
             url: hasAgentSemanticLayerEntry
-                ? '/createProject/agent'
+                ? `/projects/${projectUuid}/onboarding/agent`
                 : `/generalSettings/projectManagement/${projectUuid}/settings`,
         },
         'connect-source-control': {

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -53,6 +53,7 @@ export enum PageName {
     ONBOARDING_DATA_SOURCE = 'onboarding_data_source',
     ONBOARDING_INVITE_EXPERT = 'onboarding_invite_expert',
     ONBOARDING_PROJECT_READY = 'onboarding_project_ready',
+    AGENT_ONBOARDING_START = 'agent_onboarding_start',
     AGENT_ONBOARDING_RUN = 'agent_onboarding_run',
     NO_PROJECT_HOMEPAGE = 'no_project_homepage',
     EMBED_DASHBOARD = 'embed_dashboard',


### PR DESCRIPTION
## Summary

The homepage recommended action **Set up semantic layer** previously deep-linked to `/createProject/agent`, which dead-ended on the warehouse picker and would have provisioned a brand-new project. It now lands directly in the managed agent-onboarding experience (#25902) targeting the **current** project, with the warehouse type resolved from that project's existing connection — no re-asking for credentials, no new project.

This implements the "future note" on PROD-9156 (existing-project support for the coding-agent flow) and **supersedes #25975**, the conservative fix that routed the action back to project settings.

## Changes

- **New entry route** `/projects/:projectUuid/onboarding/agent` (`AgentOnboardingStartPage`), registered in `Routes.tsx`/`MobileRoutes.tsx` beside the run page with the same idioms (`hideAILauncher`, lazy load, `PageName.AGENT_ONBOARDING_START`). Guards: `coding-agent-onboarding` flag off, unknown project, or no `warehouseConnection` → redirect to project settings (the same fallback the homepage uses when flags are off).
- **Extracted `AgentOnboardingLaunchPanel`** out of `ConnectUsingAgent`: the prepared-project view ("Let Lightdash build it for you" / copy-prompt card) now takes `{ project, warehouseType, siteUrl }`, so the create-project flow and the existing-project entry share it unchanged. `/createProject/agent` behaviour is untouched.
- **`useRecommendedActions`**: the flags-on URL for `add-semantic-layer` is now `/projects/<uuid>/onboarding/agent`; the flags-off settings fallback is unchanged.

The managed-run backend (`POST /ee/projects/:projectUuid/agent-onboarding`) already accepts any project the user can manage, so no backend changes were needed.

## Verification

- Unit: updated `useRecommendedActions` cases + new `AgentOnboardingStartPage` tests (redirects + happy path); agentOnboarding + homepageBuilder suites pass (157 tests), `typecheck:fast` and touched-path lint clean.
- Browser (local dev, flags on): homepage action → entry page renders the launch panel for the current project's postgres warehouse → **Run it for me** started a managed run against that project, which completed end to end (explore → semantic layer → dashboard → handoff) and produced the starter dashboard. Copy-prompt path resolves the existing project's UUID/database.
- Browser (flag off, fresh API env): homepage action links to project settings; deep-linking the new route redirects to project settings.

Closes: PROD-9156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX3hqnkUYXoL6JMYaf6pin