### PR TITLE
fix: dev-fast-start ensures local sandbox images exist

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -290,17 +290,22 @@ template, so Docker is the working local path anyway. Public docs:
 
 ### Setup (one-time per machine)
 
-1. **Build the two local images** (heavy — `lightdash-sandbox:local` ~2.3GB for data apps,
-   `lightdash-ai-writeback:local` ~5GB for writeback; rebuild only when the toolchain changes):
+1. **Build the three local images** (heavy — `lightdash-sandbox:local` ~2.3GB for data apps,
+   `lightdash-ai-writeback:local` ~5GB for writeback, `lightdash-agent-onboarding:local`
+   ~2.2GB for managed onboarding runs; rebuild only when the toolchain changes).
+   `dev-fast-start.sh` builds any that are missing whenever the env file has
+   `SANDBOX_PROVIDER=docker`, so normally there is nothing to do by hand:
    ```bash
    ./sandboxes/data-apps/build-local-image.sh        # -> lightdash-sandbox:local
    ./sandboxes/ai-writeback/build-local-image.sh     # -> lightdash-ai-writeback:local
+   ./sandboxes/agent-onboarding/build-local-image.sh # -> lightdash-agent-onboarding:local
    ```
 2. **Env** (the `ee` profile writes `SANDBOX_PROVIDER=docker`; the image vars default, set only to override):
    ```bash
    SANDBOX_PROVIDER=docker
    # SANDBOX_DOCKER_IMAGE=lightdash-sandbox:local
    # SANDBOX_AI_WRITEBACK_DOCKER_IMAGE=lightdash-ai-writeback:local
+   # SANDBOX_AGENT_ONBOARDING_DOCKER_IMAGE=lightdash-agent-onboarding:local
    ```
    Requires `ANTHROPIC_API_KEY` (agent) and MinIO up (snapshots tar to object storage).
 
@@ -313,6 +318,12 @@ template, so Docker is the working local path anyway. Public docs:
   show `SANDBOX_PROVIDER=docker`.
 - **After an OrbStack/Docker restart**, MinIO + NATS may not come back (gen needs MinIO) and
   the graphile worker can zombie — re-run shared compose up and restart the scheduler.
+- **A sandbox feature failing with `(HTTP code 404) ... No such image: lightdash-<name>:local`**
+  means that local image was never built on this machine (each new sandbox type ships its own
+  image — agent-onboarding arrived with #25902). Run the matching
+  `./sandboxes/<dir>/build-local-image.sh`, or re-run `./scripts/dev-fast-start.sh`, which
+  builds missing sandbox images automatically. No PM2 restart needed — the image is resolved
+  at container launch.
 
 ### Verify
 

--- a/sandboxes/data-apps/build-local-image.sh
+++ b/sandboxes/data-apps/build-local-image.sh
@@ -12,9 +12,17 @@ cd "$(dirname "$0")"
 
 IMAGE="${1:-lightdash-sandbox:local}"
 
+# Same prereq recipe as build-sandbox.ts, so this script works standalone.
 if [ ! -f lightdash-query-sdk.tgz ]; then
-    echo "lightdash-query-sdk.tgz missing — run build-sandbox.ts first or pack the SDK." >&2
-    exit 1
+    echo "lightdash-query-sdk.tgz missing — building and packing @lightdash/query-sdk ..."
+    pnpm -C ../../packages/query-sdk build
+    pnpm -C ../../packages/query-sdk pack --pack-destination "$(pwd)"
+    TARBALL="$(find . -maxdepth 1 -name 'lightdash-query-sdk-*.tgz' | head -1)"
+    if [ -z "$TARBALL" ]; then
+        echo "query-sdk pack produced no tarball" >&2
+        exit 1
+    fi
+    mv "$TARBALL" lightdash-query-sdk.tgz
 fi
 
 # Derive a local Dockerfile that creates the `user` account before the chown.

--- a/scripts/dev-fast-start.sh
+++ b/scripts/dev-fast-start.sh
@@ -328,6 +328,33 @@ fi
 docker compose -p "$LD_COMPOSE_PROJECT" -f "$INSTANCE_COMPOSE" --env-file .env.development up -d \
     || fail "docker-instance" "could not start per-instance PostgreSQL"
 
+# ---------------------------------------------------------------------------
+# The Docker sandbox provider launches agent containers from local images that
+# are built once per machine, never pulled. A missing image only surfaces later
+# as a runtime 404 ("No such image: lightdash-agent-onboarding:local") when a
+# sandbox-backed feature first runs, so build any that are absent now. Env
+# overrides mean the operator points at their own image — leave those alone.
+if grep -q "^SANDBOX_PROVIDER=docker" .env.development.local 2>/dev/null; then
+    step "Ensure local sandbox images"
+    ensure_sandbox_image() {
+        SANDBOX_IMAGE="$1"; SANDBOX_BUILD_SCRIPT="$2"; SANDBOX_OVERRIDE_VAR="$3"
+        if grep -q "^${SANDBOX_OVERRIDE_VAR}=" .env.development.local 2>/dev/null; then
+            echo "OK: ${SANDBOX_OVERRIDE_VAR} is overridden; skipping ${SANDBOX_IMAGE}"
+            return 0
+        fi
+        if docker image inspect "$SANDBOX_IMAGE" >/dev/null 2>&1; then
+            echo "OK: ${SANDBOX_IMAGE} present"
+            return 0
+        fi
+        echo "Building ${SANDBOX_IMAGE} (one-time per machine; several minutes)"
+        "$SANDBOX_BUILD_SCRIPT" \
+            || fail "sandbox-images" "failed to build ${SANDBOX_IMAGE} via ${SANDBOX_BUILD_SCRIPT}"
+    }
+    ensure_sandbox_image lightdash-sandbox:local ./sandboxes/data-apps/build-local-image.sh SANDBOX_DOCKER_IMAGE
+    ensure_sandbox_image lightdash-ai-writeback:local ./sandboxes/ai-writeback/build-local-image.sh SANDBOX_AI_WRITEBACK_DOCKER_IMAGE
+    ensure_sandbox_image lightdash-agent-onboarding:local ./sandboxes/agent-onboarding/build-local-image.sh SANDBOX_AGENT_ONBOARDING_DOCKER_IMAGE
+fi
+
 step "Wait for PostgreSQL"
 PG_READY=false
 for _ in $(seq 1 30); do


### PR DESCRIPTION
## Summary

With the Docker sandbox provider (`SANDBOX_PROVIDER=docker`, the local EE dev default), sandbox-backed features launch containers from machine-local images that are built once per machine and never pulled. Nothing in the dev-env start path checked they exist, so a feature whose image was never built failed only at runtime — most recently the managed onboarding run (#25902) with `(HTTP code 404) ... No such image: lightdash-agent-onboarding:local`.

## Changes

- `scripts/dev-fast-start.sh`: new idempotent **Ensure local sandbox images** step (only when the env file sets `SANDBOX_PROVIDER=docker`). Checks `lightdash-sandbox:local`, `lightdash-ai-writeback:local`, and `lightdash-agent-onboarding:local`; builds any that are missing via the sandbox's `build-local-image.sh`; skips images whose env override is set.
- `sandboxes/data-apps/build-local-image.sh`: now self-sufficient — builds and packs `@lightdash/query-sdk` itself when `lightdash-query-sdk.tgz` is absent (same recipe as `build-sandbox.ts`) instead of exiting with an error, matching the other sandboxes' standalone build scripts.
- `.claude/commands/docker-dev.md`: sandbox section lists all three images (agent-onboarding was missing), notes the auto-build, and adds a gotcha entry for the runtime `No such image` symptom.

## Verification

- `bash -n` + shellcheck clean on the patched script.
- Ensure-step exercised locally: present images short-circuit with `OK`, env-overridden images are skipped, and a genuinely missing `lightdash-sandbox:local` was built end to end by the patched data-apps script (SDK pack → docker build → image present).

Closes: SPK-623

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX3hqnkUYXoL6JMYaf6pin