### PR TITLE
feat(ai): AI_COPILOT_SELF_MANAGED_PROVIDERS marks instance-level customer keys in usage analytics

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -23,11 +23,25 @@ const customHeadersSchema = z.record(z.string()).default({});
 // toggle — some LLM gateways don't support streaming (SSE) completions.
 const supportsStreamingSchema = z.boolean().default(true);
 
+export const AI_PROVIDER_KEYS = [
+    'openai',
+    'azure',
+    'anthropic',
+    'openrouter',
+    'bedrock',
+] as const;
+
 export const aiCopilotConfigSchema = z
     .object({
         defaultProvider: z
-            .enum(['openai', 'azure', 'anthropic', 'openrouter', 'bedrock'])
+            .enum(AI_PROVIDER_KEYS)
             .default(DEFAULT_DEFAULT_AI_PROVIDER),
+        // Providers whose instance-level API key belongs to the customer
+        // rather than Lightdash (e.g. a dedicated cloud deployment configured
+        // with the customer's own key). Only affects the `keyManagement`
+        // dimension on AI usage analytics; org BYO keys are tracked separately
+        // at config resolution.
+        selfManagedProviders: z.array(z.enum(AI_PROVIDER_KEYS)).default([]),
         defaultEmbeddingModelProvider: z
             .enum(['openai', 'bedrock', 'azure'])
             .default(DEFAULT_DEFAULT_AI_PROVIDER),

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -240,6 +240,7 @@ export const lightdashConfigMock: LightdashConfig = {
             askAiButtonEnabled: false,
             embeddingEnabled: true,
             defaultProvider: 'openai',
+            selfManagedProviders: [],
             providers: {
                 openai: {
                     apiKey: 'mock_api_key',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -36,6 +36,7 @@ import { type ClientAuthMethod } from 'openid-client';
 import { z } from 'zod';
 import { VERSION } from '../version';
 import {
+    AI_PROVIDER_KEYS,
     aiCopilotConfigSchema,
     AiCopilotConfigSchemaType,
     DEFAULT_AI_TOOL_DESCRIPTION_MAX_CHARS,
@@ -1156,6 +1157,19 @@ export const getAiConfig = () => ({
     defaultEmbeddingModelProvider:
         process.env.AI_DEFAULT_EMBEDDING_PROVIDER ||
         DEFAULT_DEFAULT_AI_PROVIDER,
+    // Unknown names are dropped (with a log) rather than passed through so a
+    // typo can't fail schema validation and discard the whole parsed config.
+    selfManagedProviders: getArrayFromCommaSeparatedList(
+        'AI_COPILOT_SELF_MANAGED_PROVIDERS',
+    ).filter((provider): provider is (typeof AI_PROVIDER_KEYS)[number] => {
+        if ((AI_PROVIDER_KEYS as readonly string[]).includes(provider)) {
+            return true;
+        }
+        console.error(
+            `Ignoring unknown provider "${provider}" in AI_COPILOT_SELF_MANAGED_PROVIDERS`,
+        );
+        return false;
+    }),
     providers: {
         azure: process.env.AZURE_AI_API_KEY
             ? {

--- a/packages/backend/src/ee/services/ai/models/index.test.ts
+++ b/packages/backend/src/ee/services/ai/models/index.test.ts
@@ -130,6 +130,22 @@ describe('getModel', () => {
         expect(keyManagement).toBe('lightdash-managed');
     });
 
+    it('stamps self-managed when the resolved provider is instance self-managed', () => {
+        const { keyManagement } = getModel({
+            ...copilotConfigWithStreaming(true),
+            selfManagedProviders: ['openai'],
+        });
+        expect(keyManagement).toBe('self-managed');
+    });
+
+    it('stamps lightdash-managed when a different provider is instance self-managed', () => {
+        const { keyManagement } = getModel({
+            ...copilotConfigWithStreaming(true),
+            selfManagedProviders: ['anthropic'],
+        });
+        expect(keyManagement).toBe('lightdash-managed');
+    });
+
     it('wraps the model with simulateStreamingMiddleware when the provider does not support streaming', () => {
         const { model } = getModel(copilotConfigWithStreaming(false));
 

--- a/packages/backend/src/ee/services/ai/models/index.ts
+++ b/packages/backend/src/ee/services/ai/models/index.ts
@@ -31,7 +31,10 @@ export { MODEL_PRESETS };
  * by the resolver (OrgAiCopilotConfigResolver) listing the providers whose
  * apiKey came from the org's own self-managed key; absent/empty for the
  * instance (Lightdash-managed) config. Optional so the raw instance config is
- * still a valid input (it resolves to Lightdash-managed).
+ * still a valid input (it resolves to Lightdash-managed). Instance-level
+ * customer-owned keys are declared separately via
+ * `selfManagedProviders` (AI_COPILOT_SELF_MANAGED_PROVIDERS) on the config
+ * itself.
  */
 export type CopilotConfigForModel = LightdashConfig['ai']['copilot'] & {
     byoProviders?: ByoAiProvider[];
@@ -41,7 +44,9 @@ export const resolveKeyManagement = (
     config: CopilotConfigForModel,
     provider: AiProvider,
 ): AiKeyManagement =>
-    isByoAiProvider(provider) && (config.byoProviders ?? []).includes(provider)
+    (isByoAiProvider(provider) &&
+        (config.byoProviders ?? []).includes(provider)) ||
+    (config.selfManagedProviders ?? []).includes(provider)
         ? 'self-managed'
         : 'lightdash-managed';
 


### PR DESCRIPTION
### Description

Follow-up to #25980 / [PROD-9155](https://linear.app/lightdash/issue/PROD-9155/include-whether-customers-use-a-lightdash-managed-or-self-managed-key).

#25980 stamps `keyManagement` as `self-managed` only when the org's own BYO key (from in-app org settings) serves the call. Dedicated cloud deployments where the **customer's own key is injected at the instance level** (env vars in their deployment config) were indistinguishable from the shared Lightdash key, so their usage reported `lightdash-managed`.

This adds `AI_COPILOT_SELF_MANAGED_PROVIDERS` — a comma-separated list of providers (`openai,azure,anthropic,openrouter,bedrock`) whose instance-level API key belongs to the customer. `resolveKeyManagement` now stamps `self-managed` when the resolved provider is either org-BYO **or** in that list. Per-provider (not a single boolean) so mixed setups stay accurate — e.g. a customer with their own OpenAI key but the shared Anthropic key reports each provider correctly.

Unknown provider names in the env var are dropped with a log instead of failing schema validation (a typo would otherwise discard the whole parsed copilot config via the safeParse fallback).

Default is empty (current behavior unchanged). lightdash-cloud will derive and set this env var per customer deployment (separate PR in that repo).

### Validation
- `typecheck:fast` clean, `oxfmt --check` clean
- 76 tests passing across `models/index`, `OrgAiCopilotConfigResolver`, `aiUsage` (2 new cases)