### PR TITLE
fix(frontend): inherit table font size in pivot table cells

### DIFF
--- a/packages/frontend/src/components/common/LightTable/index.tsx
+++ b/packages/frontend/src/components/common/LightTable/index.tsx
@@ -478,7 +478,9 @@ const BaseCell = (
                                 openDelay={500}
                                 variant="xs"
                             >
-                                <Text span>{children}</Text>
+                                <Text span inherit>
+                                    {children}
+                                </Text>
                             </Tooltip>
                         ) : (
                             <>{children}</>

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -577,7 +577,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                 }
 
                                 return (
-                                    <Text span fw={600}>
+                                    <Text span inherit fw={600}>
                                         {formatItemValue(
                                             item,
                                             subtotalValue,


### PR DESCRIPTION
## Summary

Fixes a font-size mismatch in pivot table tiles: header labels, tooltip-wrapped cells, and subtotal values rendered at 16px while the rest of the table renders at 13px.

## Root cause

`LightTable`'s `BaseCell` wraps tooltip-bearing cell content in `<Text span>`, and `PivotTable` renders subtotals as `<Text span fw={600}>`. Since the Mantine 8 `Text` migration, `Text` sets its own `font-size` (theme `md` = 16px) instead of inheriting the table's 13px like bare text nodes do. Cells without tooltips stayed at 13px, producing mixed sizes within one table.

## Fix

Add `inherit` to both `Text` sites so they inherit the surrounding table font size.

## Regression analysis

Only affects text inside `LightTable` tooltip-wrapped cells and `PivotTable` subtotal cells, which previously (pre-Mantine-8-Text) inherited the table font. No layout or behavior change beyond restoring the 13px size.

## Validation

- verified on the pivot table dashboard: all pivot cells/headers now render at a uniform 13px, matching regular result tables
- `pnpm -F frontend typecheck:fast`
- targeted oxlint (0 errors)