### PR TITLE
feat(cli): add partial compilation opt-out

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -337,9 +337,6 @@ export const lightdashConfigMock: LightdashConfig = {
     editYamlInUi: {
         enabled: false,
     },
-    partialCompilation: {
-        enabled: true,
-    },
     funnelBuilder: {
         enabled: false,
     },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1574,14 +1574,6 @@ export type LightdashConfig = {
     editYamlInUi: {
         enabled: boolean;
     };
-    /**
-     * When enabled, fields that fail to compile will be marked with a
-     * compilationError instead of causing the entire explore to fail.
-     * This allows users to still access other fields in the explore.
-     */
-    partialCompilation: {
-        enabled: boolean;
-    };
     funnelBuilder: {
         enabled: boolean;
     };
@@ -3094,9 +3086,6 @@ export const parseConfig = (): LightdashConfig => {
         analyticsEmbedSecret: process.env.ANALYTICS_EMBED_SECRET,
         editYamlInUi: {
             enabled: process.env.EDIT_YAML_IN_UI_ENABLED === 'true',
-        },
-        partialCompilation: {
-            enabled: process.env.PARTIAL_COMPILATION_ENABLED !== 'false',
         },
         funnelBuilder: {
             enabled:

--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -192,7 +192,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
     public async compileAllExplores(
         trackingParams?: TrackingParams,
         loadSources: boolean = false,
-        allowPartialCompilation: boolean = false,
+        allowPartialCompilation: boolean = true,
     ): Promise<(Explore | ExploreError)[]> {
         Logger.debug('Install dependencies');
         // Install dependencies for dbt and fetch the manifest - may raise error meaning no explores compile

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2840,8 +2840,7 @@ export class ProjectService extends BaseService {
                                       await adapter.compileAllExplores(
                                           trackingParams,
                                           false, // loadSources
-                                          this.lightdashConfig
-                                              .partialCompilation.enabled,
+                                          true, // allowPartialCompilation
                                       );
                                   const compiledProjectConfig =
                                       await adapter.getLightdashProjectConfig(
@@ -3511,8 +3510,7 @@ export class ProjectService extends BaseService {
                                 await compileAdapter.compileAllExplores(
                                     trackingParams,
                                     false, // loadSources
-                                    this.lightdashConfig.partialCompilation
-                                        .enabled,
+                                    true, // allowPartialCompilation
                                 );
                             timings.compileExplores.end = performance.now();
                             timings.getConfig.start = performance.now();
@@ -6467,7 +6465,7 @@ export class ProjectService extends BaseService {
             const explores = await adapter.compileAllExplores(
                 trackingParams,
                 false, // loadSources
-                this.lightdashConfig.partialCompilation.enabled,
+                true, // allowPartialCompilation
             );
             this.analytics.track({
                 event: 'project.compiled',

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -19,7 +19,7 @@ export interface ProjectAdapter {
      * Compile all explores
      * @param trackingParams - Optional tracking parameters to track the compilation and lightdash project config (lightdash.config.yml) overrides
      * @param loadSources - Whether to load source information for each explore
-     * @param allowPartialCompilation - When true, fields that fail to compile will be marked with errors instead of failing the entire explore
+     * @param allowPartialCompilation - When false, a field compilation failure fails the entire explore. Defaults to true.
      * @returns A promise that resolves to an array of explores or explore errors
      */
     compileAllExplores(

--- a/packages/cli/src/handlers/compile.test.ts
+++ b/packages/cli/src/handlers/compile.test.ts
@@ -1,8 +1,14 @@
-import { isExploreError } from '@lightdash/common';
+import {
+    DimensionType,
+    isExploreError,
+    MetricType,
+    type LightdashModel,
+} from '@lightdash/common';
 import fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import type { Mock } from 'vitest';
+import * as lightdashLoader from '../lightdash/loader';
 import { compile, type CompileHandlerOptions } from './compile';
 
 vi.mock('execa');
@@ -10,6 +16,27 @@ vi.mock('../analytics/analytics');
 vi.mock('../config', () => ({
     getConfig: vi.fn().mockResolvedValue({ user: null, context: null }),
 }));
+
+const modelWithBrokenMetric = {
+    type: 'model',
+    name: 'test_model',
+    description: 'Test model',
+    sql_from: 'SELECT * FROM test_table',
+    dimensions: [
+        {
+            name: 'id',
+            description: 'ID column',
+            type: DimensionType.NUMBER,
+            sql: 'id',
+        },
+    ],
+    metrics: {
+        broken_metric: {
+            type: MetricType.SUM,
+            sql: `\${missing_dimension}`,
+        },
+    },
+} satisfies LightdashModel;
 
 const getCompileOptions = (projectDir: string): CompileHandlerOptions => ({
     projectDir,
@@ -121,25 +148,9 @@ dimensions:
     });
 
     test('should allow partial compilation by default and allow it to be disabled explicitly', async () => {
-        await fs.writeFile(
-            path.join(tempDir, 'lightdash', 'models', 'test_model.yml'),
-            `
-version: 1
-type: model
-name: test_model
-description: Test model
-sql_from: "SELECT * FROM test_table"
-dimensions:
-  - name: id
-    description: ID column
-    type: number
-    sql: id
-metrics:
-  broken_metric:
-    type: sum
-    sql: \${missing_dimension}
-            `,
-        );
+        vi.spyOn(lightdashLoader, 'loadLightdashModels').mockResolvedValue([
+            modelWithBrokenMetric,
+        ]);
 
         const errorOutput: string[] = [];
         vi.spyOn(console, 'error').mockImplementation((...args) => {

--- a/packages/cli/src/handlers/compile.test.ts
+++ b/packages/cli/src/handlers/compile.test.ts
@@ -1,15 +1,42 @@
+import { isExploreError } from '@lightdash/common';
 import fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import type { Mock } from 'vitest';
-import * as styles from '../styles';
-import { compile } from './compile';
+import { compile, type CompileHandlerOptions } from './compile';
 
 vi.mock('execa');
 vi.mock('../analytics/analytics');
 vi.mock('../config', () => ({
     getConfig: vi.fn().mockResolvedValue({ user: null, context: null }),
 }));
+
+const getCompileOptions = (projectDir: string): CompileHandlerOptions => ({
+    projectDir,
+    profilesDir: '',
+    target: undefined,
+    profile: undefined,
+    vars: undefined,
+    verbose: false,
+    startOfWeek: 0,
+    skipWarehouseCatalog: true,
+    skipDbtCompile: true,
+    useDbtList: false,
+    select: undefined,
+    models: undefined,
+    threads: undefined,
+    noVersionCheck: false,
+    exclude: undefined,
+    selector: undefined,
+    state: undefined,
+    fullRefresh: false,
+    defer: false,
+    targetPath: undefined,
+    favorState: false,
+    combineManifest: undefined,
+    warehouseCredentials: false,
+    disableTimestampConversion: false,
+});
 
 describe('compile', () => {
     let tempDir: string;
@@ -50,6 +77,7 @@ dimensions:
     });
 
     afterEach(async () => {
+        vi.restoreAllMocks();
         await fs.rm(tempDir, { recursive: true, force: true });
     });
 
@@ -58,32 +86,7 @@ dimensions:
         const { LightdashAnalytics } = await import('../analytics/analytics');
         (LightdashAnalytics.track as Mock).mockResolvedValue(undefined);
 
-        const result = await compile({
-            projectDir: tempDir,
-            profilesDir: '',
-            target: undefined,
-            profile: undefined,
-            vars: undefined,
-            verbose: false,
-            startOfWeek: 0,
-            skipWarehouseCatalog: true,
-            skipDbtCompile: true,
-            useDbtList: false,
-            select: undefined,
-            models: undefined,
-            threads: undefined,
-            noVersionCheck: false,
-            exclude: undefined,
-            selector: undefined,
-            state: undefined,
-            fullRefresh: false,
-            defer: false,
-            targetPath: undefined,
-            favorState: false,
-            combineManifest: undefined,
-            warehouseCredentials: false,
-            disableTimestampConversion: false,
-        });
+        const result = await compile(getCompileOptions(tempDir));
 
         // Should succeed even though dbt is not installed
         expect(result).toBeDefined();
@@ -111,158 +114,73 @@ dimensions:
         const startedCall = trackCalls.find(
             (call) => call[0].event === 'compile.started',
         );
-        expect(startedCall).toBeDefined();
-        expect(startedCall![0].properties.dbtVersion).toBeUndefined();
+        if (startedCall === undefined) {
+            throw new Error('Expected compile.started analytics event');
+        }
+        expect(startedCall[0].properties.dbtVersion).toBeUndefined();
     });
 
-    test('should display PARTIAL_SUCCESS with warning messages', () => {
-        // Mock console.error to capture output
-        const consoleSpy = vi
-            .spyOn(console, 'error')
-            .mockImplementation(() => {});
+    test('should allow partial compilation by default and allow it to be disabled explicitly', async () => {
+        await fs.writeFile(
+            path.join(tempDir, 'lightdash', 'models', 'test_model.yml'),
+            `
+version: 1
+type: model
+name: test_model
+description: Test model
+sql_from: "SELECT * FROM test_table"
+dimensions:
+  - name: id
+    description: ID column
+    type: number
+    sql: id
+metrics:
+  broken_metric:
+    type: sum
+    sql: \${missing_dimension}
+            `,
+        );
 
-        // Partial compilation is now enabled by default
-        const originalEnv = process.env.PARTIAL_COMPILATION_ENABLED;
-        // No need to set to 'true' as it's enabled by default
+        const errorOutput: string[] = [];
+        vi.spyOn(console, 'error').mockImplementation((...args) => {
+            errorOutput.push(args.map(String).join(' '));
+        });
 
-        try {
-            // Create mock explores array with different statuses
-            const mockExplores = [
-                {
-                    name: 'successful_explore',
-                    label: 'Successful Explore',
-                    tags: [],
-                    baseTable: 'table1',
-                    // No warnings or errors - should be SUCCESS
-                },
-                {
-                    name: 'explore_with_warnings',
-                    label: 'Explore with Warnings',
-                    tags: [],
-                    baseTable: 'table2',
-                    warnings: [
-                        {
-                            type: 'MISSING_TABLE',
-                            message:
-                                'Join to table "missing_table" was skipped',
-                        },
-                        {
-                            type: 'FIELD_ERROR',
-                            message: 'Field compilation warning',
-                        },
-                    ],
-                },
-                {
-                    name: 'failed_explore',
-                    label: 'Failed Explore',
-                    tags: [],
-                    errors: [
-                        {
-                            type: 'NO_DIMENSIONS_FOUND',
-                            message: 'No dimensions found in model',
-                        },
-                    ],
-                },
-            ];
+        const partialResult = await compile(getCompileOptions(tempDir));
+        expect(partialResult.filter(isExploreError)).toHaveLength(0);
+        expect(
+            partialResult.flatMap((explore) =>
+                isExploreError(explore) ? [] : (explore.warnings ?? []),
+            ),
+        ).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    message: expect.stringContaining('broken_metric'),
+                }),
+            ]),
+        );
+        expect(errorOutput).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining('- PARTIAL_SUCCESS> test_model'),
+                expect.stringContaining(
+                    'Compiled 1 explores, SUCCESS=0 PARTIAL_SUCCESS=1 ERRORS=0',
+                ),
+            ]),
+        );
 
-            // Simulate the explore display logic from compile.ts
-            let errors = 0;
-            let partialSuccess = 0;
-            let success = 0;
-
-            mockExplores.forEach((e) => {
-                let status: string;
-                let messages = '';
-
-                if ('errors' in e && e.errors) {
-                    status = styles.error('ERROR');
-                    messages = `: ${styles.error(e.errors.map((err: { message: string }) => err.message).join(', '))}`;
-                    errors += 1;
-                } else if (
-                    process.env.PARTIAL_COMPILATION_ENABLED !== 'false' &&
-                    'warnings' in e &&
-                    e.warnings &&
-                    e.warnings.length > 0
-                ) {
-                    status = styles.warning('PARTIAL_SUCCESS');
-                    messages = `: ${styles.warning(
-                        e.warnings
-                            .map(
-                                (warning: { message: string }) =>
-                                    warning.message,
-                            )
-                            .join(', '),
-                    )}`;
-                    partialSuccess += 1;
-                } else {
-                    status = styles.success('SUCCESS');
-                    success += 1;
-                }
-
-                console.error(`- ${status}> ${e.name} ${messages}`);
-            });
-            console.error('');
-
-            // Display summary
-            if (
-                process.env.PARTIAL_COMPILATION_ENABLED !== 'false' &&
-                partialSuccess > 0
-            ) {
-                console.error(
-                    `Compiled ${mockExplores.length} explores, SUCCESS=${success} PARTIAL_SUCCESS=${partialSuccess} ERRORS=${errors}`,
-                );
-            } else {
-                console.error(
-                    `Compiled ${mockExplores.length} explores, SUCCESS=${success} ERRORS=${errors}`,
-                );
-            }
-
-            // Verify the output
-            const calls = consoleSpy.mock.calls.map((call) => call[0]);
-
-            // Check that PARTIAL_SUCCESS status is displayed
-            const partialSuccessCall = calls.find(
-                (call) =>
-                    typeof call === 'string' &&
-                    call.includes('PARTIAL_SUCCESS> explore_with_warnings'),
-            );
-            expect(partialSuccessCall).toBeDefined();
-            expect(partialSuccessCall).toContain(
-                'Join to table "missing_table" was skipped',
-            );
-            expect(partialSuccessCall).toContain('Field compilation warning');
-
-            // Check that SUCCESS status is displayed
-            const successCall = calls.find(
-                (call) =>
-                    typeof call === 'string' &&
-                    call.includes('SUCCESS> successful_explore'),
-            );
-            expect(successCall).toBeDefined();
-
-            // Check that ERROR status is displayed
-            const errorCall = calls.find(
-                (call) =>
-                    typeof call === 'string' &&
-                    call.includes('ERROR> failed_explore'),
-            );
-            expect(errorCall).toBeDefined();
-
-            // Check the summary includes PARTIAL_SUCCESS count
-            const summaryCall = calls.find(
-                (call) =>
-                    typeof call === 'string' &&
-                    call.includes('Compiled') &&
-                    call.includes('PARTIAL_SUCCESS='),
-            );
-            expect(summaryCall).toBeDefined();
-            expect(summaryCall).toContain(
-                'SUCCESS=1 PARTIAL_SUCCESS=1 ERRORS=1',
-            );
-        } finally {
-            // Clean up
-            consoleSpy.mockRestore();
-            process.env.PARTIAL_COMPILATION_ENABLED = originalEnv;
-        }
+        errorOutput.length = 0;
+        const strictResult = await compile({
+            ...getCompileOptions(tempDir),
+            partialCompilation: false,
+        });
+        expect(strictResult.filter(isExploreError)).toHaveLength(1);
+        expect(errorOutput).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining('- ERROR> test_model'),
+                expect.stringContaining(
+                    'Compiled 1 explores, SUCCESS=0 ERRORS=1',
+                ),
+            ]),
+        );
     });
 });

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -88,16 +88,21 @@ export const stripWarehouseColumnErrors = (
         : exploreWithoutWarnings;
 };
 
-const getDisplayableDiagnostics = (explore: Explore) => {
+const getDisplayableDiagnostics = (
+    explore: Explore,
+    allowPartialCompilation: boolean,
+) => {
     const diagnostics = explore.warnings ?? [];
     const errors = diagnostics.filter(
         (diagnostic) =>
             diagnostic.type === InlineErrorType.WAREHOUSE_COLUMN_ERROR,
     );
-    const warnings = diagnostics.filter(
-        (diagnostic) =>
-            diagnostic.type !== InlineErrorType.WAREHOUSE_COLUMN_ERROR,
-    );
+    const warnings = allowPartialCompilation
+        ? diagnostics.filter(
+              (diagnostic) =>
+                  diagnostic.type !== InlineErrorType.WAREHOUSE_COLUMN_ERROR,
+          )
+        : [];
     return { errors, warnings };
 };
 
@@ -566,7 +571,7 @@ export const compile = async (options: CompileHandlerOptions) => {
             errors += 1;
         } else {
             const { errors: warehouseErrors, warnings } =
-                getDisplayableDiagnostics(e);
+                getDisplayableDiagnostics(e, allowPartialCompilation);
             if (warehouseErrors.length > 0) {
                 status = styles.error('ERROR');
                 messages = `: ${styles.error(

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -56,6 +56,7 @@ export type CompileHandlerOptions = DbtCompileOptions & {
     warehouseCredentials?: boolean;
     disableTimestampConversion?: boolean;
     validateWarehouseColumns?: boolean;
+    partialCompilation?: boolean;
 };
 
 export const hasBlockingCompileError = (
@@ -93,23 +94,26 @@ const getDisplayableDiagnostics = (explore: Explore) => {
         (diagnostic) =>
             diagnostic.type === InlineErrorType.WAREHOUSE_COLUMN_ERROR,
     );
-    const warnings =
-        process.env.PARTIAL_COMPILATION_ENABLED !== 'false'
-            ? diagnostics.filter(
-                  (diagnostic) =>
-                      diagnostic.type !==
-                      InlineErrorType.WAREHOUSE_COLUMN_ERROR,
-              )
-            : [];
+    const warnings = diagnostics.filter(
+        (diagnostic) =>
+            diagnostic.type !== InlineErrorType.WAREHOUSE_COLUMN_ERROR,
+    );
     return { errors, warnings };
 };
 
-const getExploresFromLightdashYmlProject = async (
-    projectDir: string,
-    lightdashProjectConfig: LightdashProjectConfig,
-    startOfWeek?: number,
-    disableTimestampConversion?: boolean,
-): Promise<(Explore | ExploreError)[] | null> => {
+const getExploresFromLightdashYmlProject = async ({
+    projectDir,
+    lightdashProjectConfig,
+    startOfWeek,
+    disableTimestampConversion,
+    allowPartialCompilation,
+}: {
+    projectDir: string;
+    lightdashProjectConfig: LightdashProjectConfig;
+    startOfWeek: number | undefined;
+    disableTimestampConversion: boolean | undefined;
+    allowPartialCompilation: boolean;
+}): Promise<(Explore | ExploreError)[] | null> => {
     // Try to load Lightdash YAML models
     const lightdashModels = await loadLightdashModels(projectDir);
 
@@ -156,8 +160,7 @@ const getExploresFromLightdashYmlProject = async (
         lightdashProjectConfig,
         {
             disableTimestampConversion,
-            allowPartialCompilation:
-                process.env.PARTIAL_COMPILATION_ENABLED !== 'false',
+            allowPartialCompilation,
             postProcessors: [preAggregatePostProcessor],
         },
     );
@@ -305,6 +308,7 @@ export const compile = async (options: CompileHandlerOptions) => {
     const dbtVersionResult = await tryGetDbtVersion();
     const executionId = uuidv4();
     const startTime = Date.now();
+    const allowPartialCompilation = options.partialCompilation !== false;
 
     await LightdashAnalytics.track({
         event: 'compile.started',
@@ -331,12 +335,13 @@ export const compile = async (options: CompileHandlerOptions) => {
     let explores: (Explore | ExploreError)[] | null = null;
     let dbtMetrics: DbtManifest['metrics'] | null = null;
 
-    explores = await getExploresFromLightdashYmlProject(
-        absoluteProjectPath,
+    explores = await getExploresFromLightdashYmlProject({
+        projectDir: absoluteProjectPath,
         lightdashProjectConfig,
-        options.startOfWeek,
-        options.disableTimestampConversion,
-    );
+        startOfWeek: options.startOfWeek,
+        disableTimestampConversion: options.disableTimestampConversion,
+        allowPartialCompilation,
+    });
 
     if (explores !== null && options.validateWarehouseColumns === true) {
         console.error(
@@ -526,8 +531,7 @@ export const compile = async (options: CompileHandlerOptions) => {
             lightdashProjectConfig,
             {
                 disableTimestampConversion: options.disableTimestampConversion,
-                allowPartialCompilation:
-                    process.env.PARTIAL_COMPILATION_ENABLED !== 'false',
+                allowPartialCompilation,
                 postProcessors: [preAggregatePostProcessor],
             },
         );

--- a/packages/cli/src/handlers/compileWarehouseColumnValidation.test.ts
+++ b/packages/cli/src/handlers/compileWarehouseColumnValidation.test.ts
@@ -242,7 +242,6 @@ describe('compile warehouse column validation', () => {
     });
 
     afterEach(async () => {
-        vi.unstubAllEnvs();
         vi.restoreAllMocks();
         await fs.rm(tempDir, { recursive: true, force: true });
     });
@@ -305,8 +304,7 @@ describe('compile warehouse column validation', () => {
         const WAREHOUSE_WARNING =
             'Warehouse rejected column reference TABLE.rolling_30d_avg_sales in model "my_model"';
 
-        test('renders ERROR for a warehouse rejection when partial compilation is enabled', async () => {
-            vi.stubEnv('PARTIAL_COMPILATION_ENABLED', 'true');
+        test('renders ERROR for a warehouse rejection by default', async () => {
             setupWarehouseClient();
             mockProberToAppendWarning(WAREHOUSE_WARNING);
 
@@ -328,13 +326,13 @@ describe('compile warehouse column validation', () => {
         });
 
         test('renders ERROR for a warehouse rejection when partial compilation is disabled', async () => {
-            vi.stubEnv('PARTIAL_COMPILATION_ENABLED', 'false');
             setupWarehouseClient();
             mockProberToAppendWarning(WAREHOUSE_WARNING);
 
             const result = await compile({
                 ...baseOptions(tempDir),
                 validateWarehouseColumns: true,
+                partialCompilation: false,
             });
 
             expect(errorOutput).toEqual(
@@ -418,8 +416,7 @@ describe('compile warehouse column validation', () => {
             );
         });
 
-        test('keeps generic warnings hidden when partial compilation is disabled', async () => {
-            vi.stubEnv('PARTIAL_COMPILATION_ENABLED', 'false');
+        test('renders non-fatal warnings when partial compilation is disabled', async () => {
             vi.mocked(validateDbtModel).mockResolvedValue({
                 valid: [modelWithDuplicateMetricName],
                 invalid: [],
@@ -429,30 +426,21 @@ describe('compile warehouse column validation', () => {
             await compile({
                 ...baseOptions(tempDir),
                 skipWarehouseCatalog: true,
+                partialCompilation: false,
             });
 
             expect(errorOutput).toEqual(
                 expect.arrayContaining([
-                    expect.stringContaining('- SUCCESS> my_model'),
-                    expect.stringContaining(
-                        'Compiled 1 explores, SUCCESS=1 ERRORS=0',
-                    ),
-                ]),
-            );
-            expect(errorOutput).not.toEqual(
-                expect.arrayContaining([
-                    expect.stringContaining('PARTIAL_SUCCESS'),
-                ]),
-            );
-            expect(errorOutput).not.toEqual(
-                expect.arrayContaining([
+                    expect.stringContaining('- PARTIAL_SUCCESS> my_model'),
                     expect.stringContaining('Skipped metric "id"'),
+                    expect.stringContaining(
+                        'Compiled 1 explores, SUCCESS=0 PARTIAL_SUCCESS=1 ERRORS=0',
+                    ),
                 ]),
             );
         });
 
-        test('renders generic warnings when partial compilation is enabled', async () => {
-            vi.stubEnv('PARTIAL_COMPILATION_ENABLED', 'true');
+        test('renders generic warnings by default', async () => {
             vi.mocked(validateDbtModel).mockResolvedValue({
                 valid: [modelWithDuplicateMetricName],
                 invalid: [],
@@ -475,8 +463,7 @@ describe('compile warehouse column validation', () => {
             );
         });
 
-        test('renders the warehouse error and generic warnings when partial compilation is enabled', async () => {
-            vi.stubEnv('PARTIAL_COMPILATION_ENABLED', 'true');
+        test('renders the warehouse error and generic warnings by default', async () => {
             vi.mocked(validateDbtModel).mockResolvedValue({
                 valid: [modelWithDuplicateMetricName],
                 invalid: [],
@@ -514,8 +501,7 @@ describe('compile warehouse column validation', () => {
             ).toEqual([InlineErrorType.DUPLICATE_FIELD_NAME]);
         });
 
-        test('renders only the warehouse error when partial compilation is disabled and generic warnings exist', async () => {
-            vi.stubEnv('PARTIAL_COMPILATION_ENABLED', 'false');
+        test('renders the warehouse error and non-fatal warnings when partial compilation is disabled', async () => {
             vi.mocked(validateDbtModel).mockResolvedValue({
                 valid: [modelWithDuplicateMetricName],
                 invalid: [],
@@ -527,6 +513,7 @@ describe('compile warehouse column validation', () => {
             await compile({
                 ...baseOptions(tempDir),
                 validateWarehouseColumns: true,
+                partialCompilation: false,
             });
 
             expect(errorOutput).toEqual(
@@ -534,14 +521,10 @@ describe('compile warehouse column validation', () => {
                     expect.stringContaining(
                         `- ERROR> my_model : ${WAREHOUSE_WARNING}`,
                     ),
+                    expect.stringContaining('Skipped metric "id"'),
                     expect.stringContaining(
                         'Compiled 1 explores, SUCCESS=0 ERRORS=1',
                     ),
-                ]),
-            );
-            expect(errorOutput).not.toEqual(
-                expect.arrayContaining([
-                    expect.stringContaining('Skipped metric "id"'),
                 ]),
             );
         });

--- a/packages/cli/src/handlers/compileWarehouseColumnValidation.test.ts
+++ b/packages/cli/src/handlers/compileWarehouseColumnValidation.test.ts
@@ -416,7 +416,7 @@ describe('compile warehouse column validation', () => {
             );
         });
 
-        test('renders non-fatal warnings when partial compilation is disabled', async () => {
+        test('keeps generic warnings hidden when partial compilation is disabled', async () => {
             vi.mocked(validateDbtModel).mockResolvedValue({
                 valid: [modelWithDuplicateMetricName],
                 invalid: [],
@@ -431,11 +431,20 @@ describe('compile warehouse column validation', () => {
 
             expect(errorOutput).toEqual(
                 expect.arrayContaining([
-                    expect.stringContaining('- PARTIAL_SUCCESS> my_model'),
-                    expect.stringContaining('Skipped metric "id"'),
+                    expect.stringContaining('- SUCCESS> my_model'),
                     expect.stringContaining(
-                        'Compiled 1 explores, SUCCESS=0 PARTIAL_SUCCESS=1 ERRORS=0',
+                        'Compiled 1 explores, SUCCESS=1 ERRORS=0',
                     ),
+                ]),
+            );
+            expect(errorOutput).not.toEqual(
+                expect.arrayContaining([
+                    expect.stringContaining('PARTIAL_SUCCESS'),
+                ]),
+            );
+            expect(errorOutput).not.toEqual(
+                expect.arrayContaining([
+                    expect.stringContaining('Skipped metric "id"'),
                 ]),
             );
         });
@@ -501,7 +510,7 @@ describe('compile warehouse column validation', () => {
             ).toEqual([InlineErrorType.DUPLICATE_FIELD_NAME]);
         });
 
-        test('renders the warehouse error and non-fatal warnings when partial compilation is disabled', async () => {
+        test('renders only the warehouse error when partial compilation is disabled', async () => {
             vi.mocked(validateDbtModel).mockResolvedValue({
                 valid: [modelWithDuplicateMetricName],
                 invalid: [],
@@ -521,10 +530,14 @@ describe('compile warehouse column validation', () => {
                     expect.stringContaining(
                         `- ERROR> my_model : ${WAREHOUSE_WARNING}`,
                     ),
-                    expect.stringContaining('Skipped metric "id"'),
                     expect.stringContaining(
                         'Compiled 1 explores, SUCCESS=0 ERRORS=1',
                     ),
+                ]),
+            );
+            expect(errorOutput).not.toEqual(
+                expect.arrayContaining([
+                    expect.stringContaining('Skipped metric "id"'),
                 ]),
             );
         });

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -67,6 +67,7 @@ type DeployHandlerOptions = DbtCompileOptions & {
     gzip?: boolean;
     disableTimestampConversion?: boolean;
     validateWarehouseColumns: boolean;
+    partialCompilation?: boolean;
 };
 
 type DeployArgs = DeployHandlerOptions & {

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -48,6 +48,7 @@ type PreviewHandlerOptions = DbtCompileOptions & {
     expiresIn?: string;
     disableTimestampConversion?: boolean;
     validateWarehouseColumns: boolean;
+    partialCompilation?: boolean;
 };
 
 type StopPreviewHandlerOptions = {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -476,6 +476,10 @@ program
         validateWarehouseColumnsDescription,
         false,
     )
+    .option(
+        '--no-partial-compilation',
+        'Fail when a field or join cannot be compiled instead of returning a partial explore',
+    )
     .action(compileHandler);
 
 program
@@ -610,6 +614,10 @@ program
         validateWarehouseColumnsDescription,
         false,
     )
+    .option(
+        '--no-partial-compilation',
+        'Fail when a field or join cannot be compiled instead of returning a partial explore',
+    )
     .action(previewHandler);
 
 program
@@ -740,6 +748,10 @@ program
         '--validate-warehouse-columns',
         validateWarehouseColumnsDescription,
         false,
+    )
+    .option(
+        '--no-partial-compilation',
+        'Fail when a field or join cannot be compiled instead of returning a partial explore',
     )
     .action(startPreviewHandler);
 
@@ -1166,6 +1178,10 @@ program
         validateWarehouseColumnsDescription,
         false,
     )
+    .option(
+        '--no-partial-compilation',
+        'Fail when a field or join cannot be compiled instead of returning a partial explore',
+    )
     .action(deployHandler);
 
 program
@@ -1268,6 +1284,10 @@ program
     .option(
         '--exclude-spaces <spaceSlugs...>',
         'Skip validation errors for charts and dashboards in these spaces (and their sub-spaces). Spaces must be visible to your credentials',
+    )
+    .option(
+        '--no-partial-compilation',
+        'Fail when a field or join cannot be compiled instead of returning a partial explore',
     )
     .action(validateHandler);
 

--- a/packages/e2e/cypress/cli/dbt/cli.cy.ts
+++ b/packages/e2e/cypress/cli/dbt/cli.cy.ts
@@ -243,13 +243,12 @@ describe('CLI', () => {
 
     it('Should throw error on lightdash compile', () => {
         cy.exec(
-            `${cliCommand} compile --project-dir ${projectDir} --profiles-dir ${profilesDir} -m orders`,
+            `${cliCommand} compile --project-dir ${projectDir} --profiles-dir ${profilesDir} -m orders --no-partial-compilation`,
             {
                 failOnNonZeroExit: false,
                 env: {
                     CI: true,
                     NODE_ENV: 'development',
-                    PARTIAL_COMPILATION_ENABLED: 'false',
                     ...databaseEnvVars,
                 },
                 log: true,


### PR DESCRIPTION
## What changed

- Remove `PARTIAL_COMPILATION_ENABLED` from backend and CLI configuration.
- Keep partial compilation enabled by default for every backend compilation path.
- Add `--no-partial-compilation` to `compile`, `validate`, `deploy`, `preview`, and `start-preview` for strict CI/CD checks.
- Replace the Cypress CLI fixture's environment opt-out with the explicit flag.

## Verification

- CLI: 320 tests passed.
- Backend adapter and ProjectService: 85 tests passed.
- CLI and backend typechecks passed.
- CLI, backend, and Cypress lint/format passed.
- Confirmed the removed environment variable no longer changes compilation behavior.
- Confirmed strict compile and validate report the broken model and exit non-zero.

test-all
