### PR TITLE
refactor(homepage): remove personal homepage overrides

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -496,8 +496,6 @@ import {
     AnnouncementsTableName,
     HomepageAssignmentsTable,
     HomepageAssignmentsTableName,
-    HomepagePersonalOverridesTable,
-    HomepagePersonalOverridesTableName,
     HomepagesTableName,
     ProjectHomepagesTable,
 } from '../ee/database/entities/projectHomepages';
@@ -638,7 +636,6 @@ declare module 'knex/types/tables' {
         [AiAgentUserPreferencesTableName]: AiAgentUserPreferencesTable;
         [HomepagesTableName]: ProjectHomepagesTable;
         [HomepageAssignmentsTableName]: HomepageAssignmentsTable;
-        [HomepagePersonalOverridesTableName]: HomepagePersonalOverridesTable;
         [AnnouncementsTableName]: AnnouncementsTable;
         [AiAgentReasoningTableName]: AiAgentReasoningTable;
         [AiAgentToolCallTableName]: AiAgentToolCallTable;

--- a/packages/backend/src/ee/controllers/projectHomepageController.ts
+++ b/packages/backend/src/ee/controllers/projectHomepageController.ts
@@ -10,13 +10,11 @@ import {
     type ApiProjectHomepagesResponse,
     type ApiRecentlyViewedResponse,
     type ApiResolvedHomepageResponse,
-    type ApiSuccess,
     type ApiSuccessEmpty,
     type CreateProjectHomepageRequest,
     type HomepageViewAsTarget,
     type ProjectMemberRole,
     type PublishProjectHomepageRequest,
-    type SetPersonalHomepageRequest,
     type UpdateHomepageGroupPrioritiesRequest,
     type UpdateProjectHomepageDraftRequest,
     type UUID,
@@ -72,69 +70,6 @@ export class ProjectHomepageController extends BaseController {
                 projectUuid,
             ),
         };
-    }
-
-    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
-    @SuccessResponse('200', 'Success')
-    @Get('/personal-override')
-    @OperationId('getPersonalHomepage')
-    async getPersonalOverride(
-        @Request() req: express.Request,
-        @Path() projectUuid: UUID,
-    ): Promise<ApiSuccess<string | null>> {
-        assertRegisteredAccount(req.account);
-        this.setStatus(200);
-        return {
-            status: 'ok',
-            results: await this.getHomepageService().getPersonalHomepage(
-                toSessionUser(req.account),
-                projectUuid,
-            ),
-        };
-    }
-
-    @Middlewares([
-        allowApiKeyAuthentication,
-        isAuthenticated,
-        unauthorisedInDemo,
-    ])
-    @SuccessResponse('200', 'Success')
-    @Patch('/personal-override')
-    @OperationId('setPersonalHomepage')
-    async setPersonalOverride(
-        @Request() req: express.Request,
-        @Path() projectUuid: UUID,
-        @Body() body: SetPersonalHomepageRequest,
-    ): Promise<ApiSuccessEmpty> {
-        assertRegisteredAccount(req.account);
-        await this.getHomepageService().setPersonalHomepage(
-            toSessionUser(req.account),
-            projectUuid,
-            body.dashboardUuid,
-        );
-        this.setStatus(200);
-        return { status: 'ok', results: undefined };
-    }
-
-    @Middlewares([
-        allowApiKeyAuthentication,
-        isAuthenticated,
-        unauthorisedInDemo,
-    ])
-    @SuccessResponse('200', 'Success')
-    @Delete('/personal-override')
-    @OperationId('clearPersonalHomepage')
-    async clearPersonalOverride(
-        @Request() req: express.Request,
-        @Path() projectUuid: UUID,
-    ): Promise<ApiSuccessEmpty> {
-        assertRegisteredAccount(req.account);
-        await this.getHomepageService().clearPersonalHomepage(
-            toSessionUser(req.account),
-            projectUuid,
-        );
-        this.setStatus(200);
-        return { status: 'ok', results: undefined };
     }
 
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
@@ -425,7 +360,6 @@ export class ProjectHomepageController extends BaseController {
                 projectUuid,
                 homepageUuid,
                 body.audience,
-                body.allowPersonal,
             ),
         };
     }

--- a/packages/backend/src/ee/database/entities/projectHomepages.ts
+++ b/packages/backend/src/ee/database/entities/projectHomepages.ts
@@ -10,7 +10,6 @@ export type DbProjectHomepage = {
     draft_config: HomepageConfig;
     published_config: HomepageConfig | null;
     is_default: boolean;
-    allow_personal: boolean;
     created_by_user_uuid: string | null;
     created_at: Date;
     updated_at: Date;
@@ -32,7 +31,6 @@ export type DbProjectHomepageUpdate = Partial<
         | 'draft_config'
         | 'published_config'
         | 'is_default'
-        | 'allow_personal'
         | 'updated_at'
     >
 >;
@@ -41,24 +39,6 @@ export type ProjectHomepagesTable = Knex.CompositeTableType<
     DbProjectHomepage,
     DbProjectHomepageIn,
     DbProjectHomepageUpdate
->;
-
-export const HomepagePersonalOverridesTableName = 'homepage_personal_overrides';
-
-export type DbHomepagePersonalOverride = {
-    user_uuid: string;
-    project_uuid: string;
-    dashboard_uuid: string;
-    created_at: Date;
-};
-
-export type HomepagePersonalOverridesTable = Knex.CompositeTableType<
-    DbHomepagePersonalOverride,
-    Pick<
-        DbHomepagePersonalOverride,
-        'user_uuid' | 'project_uuid' | 'dashboard_uuid'
-    >,
-    Pick<DbHomepagePersonalOverride, 'dashboard_uuid'>
 >;
 
 export const HomepageAssignmentsTableName = 'homepage_assignments';

--- a/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
@@ -31,7 +31,6 @@ const draftConfig: HomepageConfig = {
 
 const makeDbHomepage = (overrides: Partial<Record<string, unknown>> = {}) => ({
     homepage_uuid: HOMEPAGE_UUID,
-    allow_personal: true,
     project_uuid: PROJECT_UUID,
     name: 'Team homepage',
     draft_config: draftConfig,
@@ -108,7 +107,7 @@ describe('ProjectHomepageModel', () => {
             tracker.on.select(HomepagesTableName).responseOnce([]);
 
             await expect(
-                model.publish(HOMEPAGE_UUID, { type: 'everyone' }, true),
+                model.publish(HOMEPAGE_UUID, { type: 'everyone' }),
             ).rejects.toThrow(NotFoundError);
         });
 
@@ -124,11 +123,9 @@ describe('ProjectHomepageModel', () => {
                     makeDbHomepage({ published_config: draftConfig }),
                 ]);
 
-            const result = await model.publish(
-                HOMEPAGE_UUID,
-                { type: 'everyone' },
-                true,
-            );
+            const result = await model.publish(HOMEPAGE_UUID, {
+                type: 'everyone',
+            });
 
             expect(tracker.history.update).toHaveLength(2);
             const unsetQuery = tracker.history.update[0];
@@ -154,11 +151,10 @@ describe('ProjectHomepageModel', () => {
                 .responseOnce([{ max: 1 }]);
             tracker.on.insert('homepage_assignments').responseOnce([]);
 
-            const result = await model.publish(
-                HOMEPAGE_UUID,
-                { type: 'groups', groupUuids: ['group-a', 'group-b'] },
-                true,
-            );
+            const result = await model.publish(HOMEPAGE_UUID, {
+                type: 'groups',
+                groupUuids: ['group-a', 'group-b'],
+            });
 
             // publish update must not set is_default for group audiences
             const publishQuery = tracker.history.update[0];

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -19,7 +19,6 @@ import { type Knex } from 'knex';
 import {
     AnnouncementsTableName,
     HomepageAssignmentsTableName,
-    HomepagePersonalOverridesTableName,
     HomepagesTableName,
     type DbAnnouncement,
     type DbProjectHomepage,
@@ -40,7 +39,6 @@ export class ProjectHomepageModel {
             draftConfig: row.draft_config,
             publishedConfig: row.published_config,
             isDefault: row.is_default,
-            allowPersonal: row.allow_personal,
             createdByUserUuid: row.created_by_user_uuid,
             createdAt: row.created_at,
             updatedAt: row.updated_at,
@@ -93,7 +91,6 @@ export class ProjectHomepageModel {
             homepageUuid: row.homepage_uuid,
             name: row.name,
             config: row.published_config,
-            allowPersonal: row.allow_personal,
         };
     }
 
@@ -230,66 +227,10 @@ export class ProjectHomepageModel {
         }));
     }
 
-    async getPersonalOverride(
-        userUuid: string,
-        projectUuid: string,
-    ): Promise<string | undefined> {
-        const row = await this.database(HomepagePersonalOverridesTableName)
-            .join(
-                'dashboards',
-                'dashboards.dashboard_uuid',
-                `${HomepagePersonalOverridesTableName}.dashboard_uuid`,
-            )
-            .where(`${HomepagePersonalOverridesTableName}.user_uuid`, userUuid)
-            .andWhere(
-                `${HomepagePersonalOverridesTableName}.project_uuid`,
-                projectUuid,
-            )
-            .whereNull('dashboards.deleted_at')
-            .select(`${HomepagePersonalOverridesTableName}.dashboard_uuid`)
-            .first();
-        return row?.dashboard_uuid;
-    }
-
-    async setPersonalOverride(
-        userUuid: string,
-        projectUuid: string,
-        dashboardUuid: string,
-    ): Promise<void> {
-        const dashboardInProject = await this.database('dashboards')
-            .join('spaces', 'spaces.space_id', 'dashboards.space_id')
-            .join('projects', 'projects.project_id', 'spaces.project_id')
-            .where('dashboards.dashboard_uuid', dashboardUuid)
-            .where('projects.project_uuid', projectUuid)
-            .whereNull('dashboards.deleted_at')
-            .first();
-        if (!dashboardInProject) {
-            throw new NotFoundError('Dashboard not found in this project');
-        }
-        await this.database(HomepagePersonalOverridesTableName)
-            .insert({
-                user_uuid: userUuid,
-                project_uuid: projectUuid,
-                dashboard_uuid: dashboardUuid,
-            })
-            .onConflict(['user_uuid', 'project_uuid'])
-            .merge({ dashboard_uuid: dashboardUuid });
-    }
-
-    async deletePersonalOverride(
-        userUuid: string,
-        projectUuid: string,
-    ): Promise<void> {
-        await this.database(HomepagePersonalOverridesTableName)
-            .where({ user_uuid: userUuid, project_uuid: projectUuid })
-            .delete();
-    }
-
     // Publishing to "everyone" promotes the homepage to the project default
     async publish(
         homepageUuid: string,
         audience: HomepageAudience,
-        allowPersonal: boolean,
     ): Promise<ProjectHomepage> {
         return this.database.transaction(async (trx) => {
             const existing = await trx(HomepagesTableName)
@@ -312,7 +253,6 @@ export class ProjectHomepageModel {
                 .where({ homepage_uuid: homepageUuid })
                 .update({
                     published_config: existing.draft_config,
-                    allow_personal: allowPersonal,
                     ...(makeDefault ? { is_default: true } : {}),
                     updated_at: new Date(),
                 })
@@ -477,7 +417,6 @@ export class ProjectHomepageModel {
                         homepageUuid: byGroup.homepage_uuid,
                         name: byGroup.name,
                         config: byGroup.published_config,
-                        allowPersonal: byGroup.allow_personal,
                     },
                     source: {
                         type: 'group',
@@ -499,7 +438,6 @@ export class ProjectHomepageModel {
                         homepageUuid: byRole.homepage_uuid,
                         name: byRole.name,
                         config: byRole.published_config,
-                        allowPersonal: byRole.allow_personal,
                     },
                     source: { type: 'role', role: viewer.role },
                 };

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -44,7 +44,6 @@ const makeHomepage = (
     draftConfig: validConfig,
     publishedConfig: null,
     isDefault: true,
-    allowPersonal: true,
     createdByUserUuid: USER_UUID,
     createdAt: NOW,
     updatedAt: NOW,
@@ -139,9 +138,6 @@ const makeService = ({
             getPublishedDefault: vi.fn().mockResolvedValue(undefined),
             getRecentlyViewed: vi.fn().mockResolvedValue([]),
             getAssignments: vi.fn().mockResolvedValue([]),
-            getPersonalOverride: vi.fn().mockResolvedValue(undefined),
-            setPersonalOverride: vi.fn().mockResolvedValue(undefined),
-            deletePersonalOverride: vi.fn().mockResolvedValue(undefined),
             updateGroupPriorities: vi.fn().mockResolvedValue(undefined),
             resolvePublished: vi.fn().mockResolvedValue(undefined),
             list: vi.fn().mockResolvedValue([]),
@@ -335,14 +331,11 @@ describe('ProjectHomepageService', () => {
             PROJECT_UUID,
             HOMEPAGE_UUID,
             { type: 'everyone' },
-            true,
         );
 
-        expect(publish).toHaveBeenCalledWith(
-            HOMEPAGE_UUID,
-            { type: 'everyone' },
-            true,
-        );
+        expect(publish).toHaveBeenCalledWith(HOMEPAGE_UUID, {
+            type: 'everyone',
+        });
         expect(result.publishedConfig).toEqual(validConfig);
     });
 
@@ -385,7 +378,6 @@ describe('ProjectHomepageService', () => {
             PROJECT_UUID,
             HOMEPAGE_UUID,
             { type: 'everyone' },
-            true,
         );
 
         expect(publishProjectDraftAnnouncements).toHaveBeenCalledWith(
@@ -441,7 +433,6 @@ describe('ProjectHomepageService', () => {
             PROJECT_UUID,
             HOMEPAGE_UUID,
             { type: 'everyone' },
-            true,
         );
 
         expect(postMessage).toHaveBeenCalledTimes(2);
@@ -502,7 +493,6 @@ describe('ProjectHomepageService', () => {
                 homepageUuid: HOMEPAGE_UUID,
                 name: 'Sales homepage',
                 config: validConfig,
-                allowPersonal: true,
             },
             source: { type: 'group', groupUuid: 'group-1', priority: 1 },
         });
@@ -559,13 +549,11 @@ describe('ProjectHomepageService', () => {
                 homepageUuid: HOMEPAGE_UUID,
                 name: 'Editors homepage',
                 config: validConfig,
-                allowPersonal: true,
             },
             source: { type: 'role', role: 'editor' },
         });
-        const getPersonalOverride = vi.fn();
         const service = makeService({
-            projectHomepageModel: { resolvePublished, getPersonalOverride },
+            projectHomepageModel: { resolvePublished },
         });
 
         const result = await service.viewAsHomepage(
@@ -578,34 +566,10 @@ describe('ProjectHomepageService', () => {
             groupUuids: [],
             role: 'editor',
         });
-        // group/role targets never consult the target's personal override
-        expect(getPersonalOverride).not.toHaveBeenCalled();
         expect(result.reason).toEqual({ type: 'role', role: 'editor' });
         expect(result.resolved).toEqual(
             expect.objectContaining({ type: 'homepage' }),
         );
-    });
-
-    it("viewAsHomepage for a user target applies the target's personal override", async () => {
-        const service = makeService({
-            projectHomepageModel: {
-                getPersonalOverride: vi
-                    .fn()
-                    .mockResolvedValue('dashboard-uuid-1'),
-                resolvePublished: vi.fn().mockResolvedValue(undefined),
-            },
-        });
-
-        const result = await service.viewAsHomepage(
-            makeAdminUser(),
-            PROJECT_UUID,
-            { type: 'user', userUuid: USER_UUID },
-        );
-
-        expect(result).toEqual({
-            resolved: { type: 'dashboard', dashboardUuid: 'dashboard-uuid-1' },
-            reason: { type: 'personal', dashboardUuid: 'dashboard-uuid-1' },
-        });
     });
 
     describe('announcements', () => {

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -167,9 +167,6 @@ export type ProjectHomepageServiceArguments = {
         | 'getPublishedDefault'
         | 'getRecentlyViewed'
         | 'getAssignments'
-        | 'getPersonalOverride'
-        | 'setPersonalOverride'
-        | 'deletePersonalOverride'
         | 'updateGroupPriorities'
         | 'resolvePublished'
         | 'list'
@@ -304,35 +301,18 @@ export class ProjectHomepageService extends BaseService {
         return homepage;
     }
 
-    // Resolution: personal → group priority → role → project default
+    // Resolution: group priority → role → project default
     private async resolveForViewer(
         projectUuid: string,
         viewer: {
             groupUuids: string[];
             role: ProjectMemberRole | undefined;
-            personalOverride: string | undefined;
         },
     ): Promise<HomepageViewAsResult> {
         const published = await this.projectHomepageModel.resolvePublished(
             projectUuid,
             { groupUuids: viewer.groupUuids, role: viewer.role },
         );
-        // Personal choice wins unless the audience homepage disallows it
-        if (
-            viewer.personalOverride &&
-            (published?.homepage.allowPersonal ?? true)
-        ) {
-            return {
-                resolved: {
-                    type: 'dashboard',
-                    dashboardUuid: viewer.personalOverride,
-                },
-                reason: {
-                    type: 'personal',
-                    dashboardUuid: viewer.personalOverride,
-                },
-            };
-        }
         if (published) {
             return {
                 resolved: { type: 'homepage', homepage: published.homepage },
@@ -349,13 +329,8 @@ export class ProjectHomepageService extends BaseService {
     ): Promise<{
         groupUuids: string[];
         role: ProjectMemberRole | undefined;
-        personalOverride: string | undefined;
     }> {
-        const [override, groups, membership] = await Promise.all([
-            this.projectHomepageModel.getPersonalOverride(
-                userUuid,
-                projectUuid,
-            ),
+        const [groups, membership] = await Promise.all([
             organizationUuid
                 ? this.groupsModel.findUserGroups({
                       userUuid,
@@ -367,7 +342,6 @@ export class ProjectHomepageService extends BaseService {
         return {
             groupUuids: groups.map((group) => group.uuid),
             role: membership?.role,
-            personalOverride: override,
         };
     }
 
@@ -406,56 +380,15 @@ export class ProjectHomepageService extends BaseService {
                 return this.resolveForViewer(projectUuid, {
                     groupUuids: [target.groupUuid],
                     role: undefined,
-                    personalOverride: undefined,
                 });
             case 'role':
                 return this.resolveForViewer(projectUuid, {
                     groupUuids: [],
                     role: target.role,
-                    personalOverride: undefined,
                 });
             default:
                 return assertUnreachable(target, 'Unknown view-as target type');
         }
-    }
-
-    async setPersonalHomepage(
-        user: SessionUser,
-        projectUuid: string,
-        dashboardUuid: string,
-    ): Promise<void> {
-        await this.assertFlagEnabled(user);
-        this.assertCanView(user, projectUuid);
-        await this.projectHomepageModel.setPersonalOverride(
-            user.userUuid,
-            projectUuid,
-            dashboardUuid,
-        );
-    }
-
-    async clearPersonalHomepage(
-        user: SessionUser,
-        projectUuid: string,
-    ): Promise<void> {
-        await this.assertFlagEnabled(user);
-        this.assertCanView(user, projectUuid);
-        await this.projectHomepageModel.deletePersonalOverride(
-            user.userUuid,
-            projectUuid,
-        );
-    }
-
-    async getPersonalHomepage(
-        user: SessionUser,
-        projectUuid: string,
-    ): Promise<string | null> {
-        await this.assertFlagEnabled(user);
-        this.assertCanView(user, projectUuid);
-        const override = await this.projectHomepageModel.getPersonalOverride(
-            user.userUuid,
-            projectUuid,
-        );
-        return override ?? null;
     }
 
     async getAssignments(
@@ -581,7 +514,6 @@ export class ProjectHomepageService extends BaseService {
         projectUuid: string,
         homepageUuid: string,
         audience: HomepageAudience,
-        allowPersonal: boolean,
     ): Promise<ProjectHomepage> {
         await this.assertFlagEnabled(user);
         this.assertCanManage(user, projectUuid);
@@ -589,7 +521,6 @@ export class ProjectHomepageService extends BaseService {
         const published = await this.projectHomepageModel.publish(
             homepageUuid,
             audience,
-            allowPersonal,
         );
         const { organizationUuid } = user;
         if (organizationUuid) {

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.test.ts
@@ -66,7 +66,6 @@ const makeHomepage = (
     draftConfig,
     publishedConfig: null,
     isDefault: true,
-    allowPersonal: false,
     createdByUserUuid: USER_UUID,
     createdAt: NOW,
     updatedAt: NOW,
@@ -213,11 +212,9 @@ describe('provisionOnboardingHomepage', () => {
             draftConfig: buildOnboardingHomepageConfig(),
             createdByUserUuid: USER_UUID,
         });
-        expect(mocks.publishHomepage).toHaveBeenCalledWith(
-            HOMEPAGE_UUID,
-            { type: 'everyone' },
-            true,
-        );
+        expect(mocks.publishHomepage).toHaveBeenCalledWith(HOMEPAGE_UUID, {
+            type: 'everyone',
+        });
         expect(mocks.track).toHaveBeenCalledWith({
             event: 'onboarding_homepage.provisioned',
             userId: USER_UUID,

--- a/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
+++ b/packages/backend/src/ee/services/ProjectService/provisionOnboardingHomepage.ts
@@ -71,11 +71,9 @@ export const provisionOnboardingHomepage = async ({
         draftConfig: buildOnboardingHomepageConfig(),
         createdByUserUuid: user.userUuid,
     });
-    await projectHomepageModel.publish(
-        homepage.homepageUuid,
-        { type: 'everyone' },
-        true,
-    );
+    await projectHomepageModel.publish(homepage.homepageUuid, {
+        type: 'everyone',
+    });
     analytics.track({
         event: 'onboarding_homepage.provisioned',
         userId: user.userUuid,

--- a/packages/common/src/ee/homepage/types.ts
+++ b/packages/common/src/ee/homepage/types.ts
@@ -139,7 +139,6 @@ export type HomepageAudience =
 
 export type PublishProjectHomepageRequest = {
     audience: HomepageAudience;
-    allowPersonal: boolean;
 };
 
 export type HomepageAssignment = {
@@ -232,7 +231,6 @@ export type ProjectHomepage = {
     draftConfig: HomepageConfig;
     publishedConfig: HomepageConfig | null;
     isDefault: boolean;
-    allowPersonal: boolean;
     createdByUserUuid: string | null;
     createdAt: Date;
     updatedAt: Date;
@@ -242,12 +240,12 @@ export type PublishedProjectHomepage = {
     homepageUuid: string;
     name: string;
     config: HomepageConfig;
-    allowPersonal: boolean;
 };
 
-export type ResolvedHomepage =
-    | { type: 'homepage'; homepage: PublishedProjectHomepage }
-    | { type: 'dashboard'; dashboardUuid: string };
+export type ResolvedHomepage = {
+    type: 'homepage';
+    homepage: PublishedProjectHomepage;
+};
 
 export type HomepageResolutionSource =
     | { type: 'group'; groupUuid: string; priority: number }
@@ -264,9 +262,7 @@ export type HomepageViewAsTarget =
     | { type: 'group'; groupUuid: string }
     | { type: 'role'; role: ProjectMemberRole };
 
-export type HomepageViewAsReason =
-    | { type: 'personal'; dashboardUuid: string }
-    | HomepageResolutionSource;
+export type HomepageViewAsReason = HomepageResolutionSource;
 
 export type HomepageViewAsResult = {
     resolved: ResolvedHomepage | null;
@@ -274,10 +270,6 @@ export type HomepageViewAsResult = {
 };
 
 export type ApiHomepageViewAsResponse = ApiSuccess<HomepageViewAsResult>;
-
-export type SetPersonalHomepageRequest = {
-    dashboardUuid: string;
-};
 
 export type ApiResolvedHomepageResponse = ApiSuccess<ResolvedHomepage | null>;
 

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -32,8 +32,6 @@ import {
     IconFolderPlus,
     IconFolderSymlink,
     IconHistory,
-    IconHome,
-    IconHomeOff,
     IconInfoCircle,
     IconMaximize,
     IconMinimize,
@@ -52,15 +50,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { useToggle } from 'react-use';
 import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
-import { useIsCopilotEnabled } from '../../../ee/features/aiCopilot/hooks/useIsCopilotEnabled';
 import AIDashboardSummary from '../../../ee/features/ambientAi/components/aiDashboardSummary';
-import {
-    useClearPersonalHomepage,
-    useHomepageBuilderFlag,
-    usePersonalHomepage,
-    useResolvedHomepage,
-    useSetPersonalHomepage,
-} from '../../../ee/features/homepageBuilder/hooks/useProjectHomepage';
 import DashboardAsCodeModal from '../../../features/contentAsCode/components/DashboardAsCodeModal';
 import { PromotionConfirmDialog } from '../../../features/promotion/components/PromotionConfirmDialog';
 import {
@@ -269,34 +259,6 @@ const DashboardHeader = memo(
             if (!dashboardUuid) return;
             toggleDashboardPinning({ uuid: dashboardUuid });
         }, [dashboardUuid, toggleDashboardPinning]);
-
-        const { isEnabled: isHomepageBuilderFlagEnabled } =
-            useHomepageBuilderFlag();
-        const { isCopilotEnabled } = useIsCopilotEnabled();
-        // Without copilot the homepage builder falls back to the classic
-        // homepage (see Home.tsx), so its personal-homepage controls are hidden.
-        const isHomepageBuilderEnabled =
-            isHomepageBuilderFlagEnabled && isCopilotEnabled;
-        const { data: resolvedHomepage } = useResolvedHomepage(projectUuid, {
-            enabled: isHomepageBuilderEnabled,
-        });
-        const { data: personalHomepage } = usePersonalHomepage(projectUuid, {
-            enabled: isHomepageBuilderEnabled,
-        });
-        const { mutate: setPersonalHomepage } = useSetPersonalHomepage(
-            projectUuid ?? '',
-        );
-        const { mutate: clearPersonalHomepage } = useClearPersonalHomepage(
-            projectUuid ?? '',
-        );
-        const isPersonalHomepage =
-            !!personalHomepage && personalHomepage === dashboardUuid;
-        const canSetPersonalHomepage =
-            isHomepageBuilderEnabled &&
-            !(
-                resolvedHomepage?.type === 'homepage' &&
-                !resolvedHomepage.homepage.allowPersonal
-            );
 
         const { data: favorites } = useFavorites(projectUuid);
         const { mutate: toggleFavorite } = useFavoriteMutation(projectUuid);
@@ -885,33 +847,6 @@ const DashboardHeader = memo(
                                             {isPinned
                                                 ? 'Unpin from homepage'
                                                 : 'Pin to homepage'}
-                                        </Menu.Item>
-                                    )}
-
-                                    {canSetPersonalHomepage && (
-                                        <Menu.Item
-                                            leftSection={
-                                                <MantineIcon
-                                                    icon={
-                                                        isPersonalHomepage
-                                                            ? IconHomeOff
-                                                            : IconHome
-                                                    }
-                                                />
-                                            }
-                                            onClick={() => {
-                                                if (isPersonalHomepage) {
-                                                    clearPersonalHomepage();
-                                                } else if (dashboardUuid) {
-                                                    setPersonalHomepage(
-                                                        dashboardUuid,
-                                                    );
-                                                }
-                                            }}
-                                        >
-                                            {isPersonalHomepage
-                                                ? 'Remove as my homepage'
-                                                : 'Make this my homepage'}
                                         </Menu.Item>
                                     )}
 

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -1228,10 +1228,9 @@ export const HomepageEditor: FC<Props> = ({
                 homepageUuid={homepage.homepageUuid}
                 homepageName={homepage.name}
                 isPublishing={publishMutation.isLoading}
-                initialAllowPersonal={homepage.allowPersonal}
-                onPublish={(audience, allowPersonal) =>
+                onPublish={(audience) =>
                     publishMutation.mutate(
-                        { audience, allowPersonal },
+                        { audience },
                         {
                             onSuccess: () => setIsPublishModalOpen(false),
                         },

--- a/packages/frontend/src/ee/features/homepageBuilder/PreviewPane.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PreviewPane.tsx
@@ -6,9 +6,7 @@ import {
     type HomepageViewAsTarget,
 } from '@lightdash/common';
 import {
-    Anchor,
     Badge,
-    Card,
     Group,
     Loader,
     SegmentedControl,
@@ -16,10 +14,7 @@ import {
     Stack,
     Text,
 } from '@mantine-8/core';
-import { IconExternalLink } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { Link } from 'react-router';
-import MantineIcon from '../../../components/common/MantineIcon';
 import { useOrganizationGroups } from '../../../hooks/useOrganizationGroups';
 import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import classes from './HomepageEditor.module.css';
@@ -33,8 +28,6 @@ const reasonLabel = (
     groupNames: Map<string, string>,
 ): string => {
     switch (reason.type) {
-        case 'personal':
-            return 'their personal pick';
         case 'group':
             return `via group ${groupNames.get(reason.groupUuid) ?? 'unknown'} (priority ${reason.priority})`;
         case 'role':
@@ -194,29 +187,6 @@ export const PreviewPane: FC<{
                     day-one default.
                 </Text>
             </Stack>
-        );
-    }
-    if (result.data.resolved.type === 'dashboard') {
-        const { dashboardUuid } = result.data.resolved;
-        return (
-            <Card withBorder p="md" maw={640} mx="auto" mt="xl">
-                <Group gap="xs">
-                    <Text size="sm">
-                        This viewer lands directly on a dashboard.
-                    </Text>
-                    <Anchor
-                        component={Link}
-                        to={`/projects/${projectUuid}/dashboards/${dashboardUuid}/view`}
-                        target="_blank"
-                        size="sm"
-                    >
-                        <Group gap={4} wrap="nowrap">
-                            Open dashboard
-                            <MantineIcon icon={IconExternalLink} size="sm" />
-                        </Group>
-                    </Anchor>
-                </Group>
-            </Card>
         );
     }
     return (

--- a/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/PublishModal.tsx
@@ -12,7 +12,6 @@ import {
     Group,
     SegmentedControl,
     Stack,
-    Switch,
     Text,
 } from '@mantine-8/core';
 import {
@@ -39,7 +38,7 @@ import {
 } from './hooks/useProjectHomepage';
 import classes from './PublishModal.module.css';
 
-const RESOLUTION_STEPS = ['Personal', 'Group priority', 'Role', 'Org default'];
+const RESOLUTION_STEPS = ['Group priority', 'Role', 'Org default'];
 
 const ROLE_DESCRIPTIONS: Record<ProjectMemberRole, string> = {
     [ProjectMemberRole.VIEWER]: 'Read-only consumers of dashboards',
@@ -64,8 +63,7 @@ type Props = {
     homepageUuid: string;
     homepageName: string;
     isPublishing: boolean;
-    initialAllowPersonal: boolean;
-    onPublish: (audience: HomepageAudience, allowPersonal: boolean) => void;
+    onPublish: (audience: HomepageAudience) => void;
 };
 
 // Thin loader: PublishModal itself stays mounted for the lifetime of the
@@ -123,7 +121,6 @@ const PublishModalBody: FC<BodyProps> = ({
     homepageUuid,
     homepageName,
     isPublishing,
-    initialAllowPersonal,
     onPublish,
     groups,
     assignments,
@@ -152,7 +149,6 @@ const PublishModalBody: FC<BodyProps> = ({
           : 'everyone';
 
     const [mode, setMode] = useState<string>(initialMode);
-    const [allowPersonal, setAllowPersonal] = useState(initialAllowPersonal);
     const [selectedGroups, setSelectedGroups] = useState<string[]>(() =>
         ownAssignments
             .filter((a) => a.targetType === 'group')
@@ -198,14 +194,11 @@ const PublishModalBody: FC<BodyProps> = ({
 
     const handlePublish = () => {
         if (mode === 'groups') {
-            onPublish(
-                { type: 'groups', groupUuids: selectedGroups },
-                allowPersonal,
-            );
+            onPublish({ type: 'groups', groupUuids: selectedGroups });
         } else if (mode === 'roles') {
-            onPublish({ type: 'roles', roles: selectedRoles }, allowPersonal);
+            onPublish({ type: 'roles', roles: selectedRoles });
         } else {
-            onPublish({ type: 'everyone' }, allowPersonal);
+            onPublish({ type: 'everyone' });
         }
     };
 
@@ -282,8 +275,7 @@ const PublishModalBody: FC<BodyProps> = ({
                                     starting point
                                 </Text>{' '}
                                 everyone lands on — unless a group they’re in
-                                has its own homepage, or they’ve set a personal
-                                one.
+                                has its own homepage.
                             </Text>
                         </Group>
                     </Box>
@@ -467,8 +459,7 @@ const PublishModalBody: FC<BodyProps> = ({
                             ))}
                         </div>
                         <Text fz={12} c="dimmed" lh={1.45}>
-                            A group assignment always wins over a role, and a
-                            personal choice wins over both.
+                            A group assignment always wins over a role.
                         </Text>
                     </>
                 )}
@@ -504,17 +495,6 @@ const PublishModalBody: FC<BodyProps> = ({
                         </Group>
                     ))}
                 </Group>
-
-                <Box p="11px 13px" className={classes.borderedPanel}>
-                    <Switch
-                        label="Allow personal customization"
-                        description="Viewers can favorite items or set a dashboard as their own homepage."
-                        checked={allowPersonal}
-                        onChange={(e) =>
-                            setAllowPersonal(e.currentTarget.checked)
-                        }
-                    />
-                </Box>
             </Stack>
         </MantineModal>
     );

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useProjectHomepage.ts
@@ -27,30 +27,6 @@ const getResolvedHomepage = async (projectUuid: string) =>
         body: undefined,
     });
 
-const getPersonalHomepageApi = async (projectUuid: string) =>
-    lightdashApi<string | null>({
-        url: `/projects/${projectUuid}/homepage/personal-override`,
-        method: 'GET',
-        body: undefined,
-    });
-
-const setPersonalHomepageApi = async (
-    projectUuid: string,
-    dashboardUuid: string,
-) =>
-    lightdashApi<undefined>({
-        url: `/projects/${projectUuid}/homepage/personal-override`,
-        method: 'PATCH',
-        body: JSON.stringify({ dashboardUuid }),
-    });
-
-const clearPersonalHomepageApi = async (projectUuid: string) =>
-    lightdashApi<undefined>({
-        url: `/projects/${projectUuid}/homepage/personal-override`,
-        method: 'DELETE',
-        body: undefined,
-    });
-
 const getHomepageForBuilder = async (
     projectUuid: string,
     homepageUuid?: string,
@@ -102,12 +78,11 @@ const publishHomepageApi = async (
     projectUuid: string,
     homepageUuid: string,
     audience: HomepageAudience,
-    allowPersonal: boolean,
 ) =>
     lightdashApi<ProjectHomepage>({
         url: `/projects/${projectUuid}/homepage/${homepageUuid}/publish`,
         method: 'POST',
-        body: JSON.stringify({ audience, allowPersonal }),
+        body: JSON.stringify({ audience }),
     });
 
 const discardHomepageDraftApi = async (
@@ -167,66 +142,6 @@ export const useResolvedHomepage = (
         queryKey: [PROJECT_HOMEPAGE_QUERY_KEY, projectUuid, 'resolved'],
         queryFn: () => getResolvedHomepage(projectUuid!),
     });
-
-export const usePersonalHomepage = (
-    projectUuid: string | undefined,
-    { enabled = true }: { enabled?: boolean } = {},
-) =>
-    useQuery<string | null, ApiError>({
-        enabled: !!projectUuid && enabled,
-        queryKey: [PROJECT_HOMEPAGE_QUERY_KEY, projectUuid, 'personal'],
-        queryFn: () => getPersonalHomepageApi(projectUuid!),
-    });
-
-export const useSetPersonalHomepage = (projectUuid: string) => {
-    const { showToastSuccess, showToastApiError } = useToaster();
-    const queryClient = useQueryClient();
-    return useMutation<undefined, ApiError, string>(
-        (dashboardUuid) => setPersonalHomepageApi(projectUuid, dashboardUuid),
-        {
-            mutationKey: ['set_personal_homepage'],
-            onSuccess: async () => {
-                await queryClient.invalidateQueries([
-                    PROJECT_HOMEPAGE_QUERY_KEY,
-                    projectUuid,
-                ]);
-                showToastSuccess({
-                    title: 'This dashboard is now your homepage',
-                });
-            },
-            onError: ({ error }) => {
-                showToastApiError({
-                    title: 'Failed to set your homepage',
-                    apiError: error,
-                });
-            },
-        },
-    );
-};
-
-export const useClearPersonalHomepage = (projectUuid: string) => {
-    const { showToastSuccess, showToastApiError } = useToaster();
-    const queryClient = useQueryClient();
-    return useMutation<undefined, ApiError, void>(
-        () => clearPersonalHomepageApi(projectUuid),
-        {
-            mutationKey: ['clear_personal_homepage'],
-            onSuccess: async () => {
-                await queryClient.invalidateQueries([
-                    PROJECT_HOMEPAGE_QUERY_KEY,
-                    projectUuid,
-                ]);
-                showToastSuccess({ title: 'Homepage reset to default' });
-            },
-            onError: ({ error }) => {
-                showToastApiError({
-                    title: 'Failed to reset your homepage',
-                    apiError: error,
-                });
-            },
-        },
-    );
-};
 
 export const useHomepageForBuilder = (
     projectUuid: string | undefined,
@@ -451,15 +366,10 @@ export const usePublishHomepage = (
     return useMutation<
         ProjectHomepage,
         ApiError,
-        { audience: HomepageAudience; allowPersonal: boolean }
+        { audience: HomepageAudience }
     >(
-        ({ audience, allowPersonal }) =>
-            publishHomepageApi(
-                projectUuid,
-                homepageUuid!,
-                audience,
-                allowPersonal,
-            ),
+        ({ audience }) =>
+            publishHomepageApi(projectUuid, homepageUuid!, audience),
         {
             mutationKey: ['publish_project_homepage'],
             onSuccess: async () => {

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -2,7 +2,7 @@ import { subject } from '@casl/ability';
 import { DbtProjectType, ProjectType } from '@lightdash/common';
 import { Stack } from '@mantine-8/core';
 import { type FC } from 'react';
-import { Navigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
 import { useUnmount } from 'react-use';
 import ErrorState from '../components/common/ErrorState';
 import Page from '../components/common/Page/Page';
@@ -103,18 +103,6 @@ const Home: FC = () => {
 
     if (
         isHomepageBuilderEnabled &&
-        resolvedHomepage.data?.type === 'dashboard'
-    ) {
-        return (
-            <Navigate
-                to={`/projects/${project.data.projectUuid}/dashboards/${resolvedHomepage.data.dashboardUuid}/view`}
-                replace
-            />
-        );
-    }
-
-    if (
-        isHomepageBuilderEnabled &&
         resolvedHomepage.data?.type === 'homepage'
     ) {
         const { homepage } = resolvedHomepage.data;
@@ -132,7 +120,7 @@ const Home: FC = () => {
                     config={homepage.config}
                     projectUuid={project.data.projectUuid}
                     topBar={
-                        homepage.allowPersonal && !hasFavoritesBlock ? (
+                        !hasFavoritesBlock ? (
                             <PersonalFavoritesBar
                                 projectUuid={project.data.projectUuid}
                             />


### PR DESCRIPTION
## Summary

Removes the per-user "Make this my homepage" feature (personal homepage overrides) end to end. This partially reverts the personal layer shipped in #25568 — the personal favorites strip from that PR stays; only the personal dashboard override and its allow-personal publish toggle are removed.

### What's removed

**Frontend**
- "Make this my homepage" / "Remove as my homepage" menu item in the dashboard header
- `usePersonalHomepage` / `useSetPersonalHomepage` / `useClearPersonalHomepage` hooks
- "Allow personal customization" switch and the "Personal" resolution pill in the publish modal
- Dashboard-redirect branch in `Home.tsx` and the personal-pick preview card in the builder's view-as pane

**Backend (EE)**
- `GET/PATCH/DELETE /api/v1/projects/{uuid}/homepage/personal-override` endpoints
- Personal-override step in homepage resolution (now: group priority → role → project default)
- Override CRUD in `ProjectHomepageModel`; `publish()` no longer takes `allowPersonal`
- **No schema drop in this PR** — `homepage_personal_overrides` and `homepages.allow_personal` are still read/written by already-released code (old pods query them on every homepage resolution), so the guarded drop migration is split into stacked PR #25989, to merge only after this PR is in a published release

**Common**
- `SetPersonalHomepageRequest`, `allowPersonal` fields, the `{ type: 'dashboard' }` variant of `ResolvedHomepage`, and the `'personal'` view-as reason

### Behavior changes / regression analysis

- Existing per-user overrides stop taking effect (rows linger until #25989 drops the table); affected users land on their resolved audience homepage instead of their picked dashboard. This is the intended outcome of removing the feature.
- The personal favorites bar on published homepages was previously gated on the homepage's `allowPersonal` flag (default `true`); it now always shows when the homepage has no favorites block. Homepages published with the toggle off (opt-out) will newly show the favorites bar.
- The `personal-override` endpoints return 404 after this; they were only called by the removed frontend code.

### Testing

- Common/backend/frontend typechecks pass; homepage model/service/onboarding test suites pass (51 tests)
- `generate-api` run; generated artifacts left for the release workflow per repo convention

allow-api-breaking-change — the removed `/personal-override` endpoints and `allowPersonal` response fields were only consumed by the frontend code deleted in this PR.

Relates: ZAP-628
