### PR TITLE
fix: mark credential-bearing API requests as sensitive for network history redaction

### DIFF
--- a/packages/frontend/src/api.test.ts
+++ b/packages/frontend/src/api.test.ts
@@ -1,7 +1,12 @@
 import { JWT_HEADER_NAME } from '@lightdash/common';
 import nock from 'nock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { BASE_API_URL, lightdashApi, lightdashApiStream } from './api';
+import {
+    BASE_API_URL,
+    lightdashApi,
+    lightdashApiStream,
+    networkHistory,
+} from './api';
 import { EMBED_KEY } from './ee/providers/Embed/types';
 import {
     clearInMemoryStorage,
@@ -118,6 +123,104 @@ describe('api', () => {
         expect(scope.isDone()).toBe(true);
 
         clearInMemoryStorage();
+    });
+});
+
+describe('networkHistory redaction', () => {
+    beforeEach(() => {
+        networkHistory.length = 0;
+    });
+
+    it('redacts body and response of sensitive requests on success', async () => {
+        const scope = nock(BASE_API_URL)
+            .post('/api/v1/login')
+            .reply(200, {
+                status: 'ok',
+                results: { token: 'secret-response' },
+            });
+
+        await lightdashApi({
+            method: 'POST',
+            url: '/login',
+            body: JSON.stringify({ email: 'a@b.com', password: 'hunter2' }),
+            sensitive: true,
+        });
+
+        scope.done();
+
+        expect(networkHistory).toHaveLength(1);
+        expect(JSON.stringify(networkHistory)).not.toContain('hunter2');
+        expect(JSON.stringify(networkHistory)).not.toContain('secret-response');
+        expect(networkHistory[0]).toMatchObject({
+            method: 'POST',
+            url: '/login',
+            status: 200,
+            body: '[REDACTED: sensitive request]',
+            json: '[REDACTED: sensitive request]',
+        });
+    });
+
+    it('redacts body and error of sensitive requests on failure', async () => {
+        const scope = nock(BASE_API_URL)
+            .post('/api/v1/login')
+            .reply(401, {
+                status: 'error',
+                error: {
+                    name: 'AuthorizationError',
+                    statusCode: 401,
+                    message: 'Invalid credentials for hunter2',
+                    data: {},
+                },
+            });
+
+        await expect(
+            lightdashApi({
+                method: 'POST',
+                url: '/login',
+                body: JSON.stringify({
+                    email: 'a@b.com',
+                    password: 'hunter2',
+                }),
+                sensitive: true,
+            }),
+        ).rejects.toMatchObject({
+            error: { name: 'AuthorizationError' },
+        });
+
+        scope.done();
+
+        expect(networkHistory).toHaveLength(1);
+        expect(JSON.stringify(networkHistory)).not.toContain('hunter2');
+        expect(networkHistory[0]).toMatchObject({
+            method: 'POST',
+            url: '/login',
+            body: '[REDACTED: sensitive request]',
+            error: '[REDACTED: sensitive request]',
+        });
+    });
+
+    it('retains body and response of non-sensitive requests', async () => {
+        const scope = nock(BASE_API_URL).post('/api/v1/test').reply(200, {
+            status: 'ok',
+            results: 'visible',
+        });
+
+        await lightdashApi({
+            method: 'POST',
+            url: '/test',
+            body: JSON.stringify({ foo: 'bar' }),
+        });
+
+        scope.done();
+
+        expect(networkHistory).toHaveLength(1);
+        expect(networkHistory[0]).toMatchObject({
+            body: JSON.stringify({ foo: 'bar' }),
+            json: JSON.stringify({
+                status: 'ok',
+                results: 'visible',
+            }),
+        });
     });
 });
 

--- a/packages/frontend/src/ee/features/serviceAccounts/useServiceAccounts.ts
+++ b/packages/frontend/src/ee/features/serviceAccounts/useServiceAccounts.ts
@@ -36,6 +36,7 @@ export const useServiceAccounts = () => {
                 method: 'POST',
                 url: '/service-accounts',
                 body: JSON.stringify(newAccount),
+                sensitive: true,
             });
         },
         onSuccess: async () => {
@@ -114,6 +115,7 @@ export const useServiceAccounts = () => {
                 method: 'PATCH',
                 url: `/service-accounts/${uuid}/rotate`,
                 body: JSON.stringify({ expiresAt }),
+                sensitive: true,
             }),
         onSuccess: async () => {
             await queryClient.invalidateQueries([CACHE_KEY]);

--- a/packages/frontend/src/features/externalConnections/hooks/useTestConnectionConfig.ts
+++ b/packages/frontend/src/features/externalConnections/hooks/useTestConnectionConfig.ts
@@ -27,6 +27,7 @@ const testConnectionConfig = async ({
         method: 'POST',
         url: `/ee/projects/${projectUuid}/external-connections/test-config`,
         body: JSON.stringify(body),
+        sensitive: true,
     });
 
 export const useTestConnectionConfig = () => {

--- a/packages/frontend/src/features/users/hooks/useLogin.ts
+++ b/packages/frontend/src/features/users/hooks/useLogin.ts
@@ -59,6 +59,7 @@ const loginQuery = async (data: LoginParams) =>
         url: `/login`,
         method: 'POST',
         body: JSON.stringify(data),
+        sensitive: true,
     });
 
 export const useLoginWithEmailMutation = ({

--- a/packages/frontend/src/hooks/gdrive/useGdrive.ts
+++ b/packages/frontend/src/hooks/gdrive/useGdrive.ts
@@ -16,6 +16,7 @@ export const getGdriveAccessToken = async () =>
         url: `/gdrive/get-access-token`,
         method: 'GET',
         body: undefined,
+        sensitive: true,
     });
 
 export const triggerGdriveLogin = async (

--- a/packages/frontend/src/hooks/organization/useOrganizationWarehouseCredentials.ts
+++ b/packages/frontend/src/hooks/organization/useOrganizationWarehouseCredentials.ts
@@ -27,6 +27,7 @@ const createOrganizationWarehouseCredentials = async (
         url: `/org/warehouse-credentials`,
         method: 'POST',
         body: JSON.stringify(data),
+        sensitive: true,
     });
 
 const updateOrganizationWarehouseCredentials = async ({
@@ -40,6 +41,7 @@ const updateOrganizationWarehouseCredentials = async ({
         url: `/org/warehouse-credentials/${uuid}`,
         method: 'PATCH',
         body: JSON.stringify(data),
+        sensitive: true,
     });
 
 const deleteOrganizationWarehouseCredentials = async (uuid: string) =>

--- a/packages/frontend/src/hooks/sensitiveApiRequests.test.tsx
+++ b/packages/frontend/src/hooks/sensitiveApiRequests.test.tsx
@@ -1,0 +1,291 @@
+import { type AnyType } from '@lightdash/common';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+vi.mock('../api', () => ({
+    lightdashApi: vi.fn(),
+}));
+
+vi.mock('./toaster/useToaster', () => ({
+    default: () => ({
+        showToastSuccess: vi.fn(),
+        showToastApiError: vi.fn(),
+        showToastError: vi.fn(),
+    }),
+}));
+
+vi.mock('./useQueryError', () => ({
+    default: () => vi.fn(),
+}));
+
+vi.mock('../providers/ActiveJob/useActiveJob', () => ({
+    default: () => ({ activeJob: undefined }),
+}));
+
+vi.mock('../providers/Tracking/useTracking', () => ({
+    default: () => ({ track: vi.fn() }),
+}));
+
+import { lightdashApi } from '../api';
+import { useServiceAccounts } from '../ee/features/serviceAccounts/useServiceAccounts';
+import { useTestConnectionConfig } from '../features/externalConnections/hooks/useTestConnectionConfig';
+import { useLoginWithEmailMutation } from '../features/users/hooks/useLogin';
+import { getGdriveAccessToken } from './gdrive/useGdrive';
+import {
+    useCreateOrganizationWarehouseCredentials,
+    useUpdateOrganizationWarehouseCredentials,
+} from './organization/useOrganizationWarehouseCredentials';
+import { useRotateAccessToken } from './useAccessToken';
+import { usePasswordResetMutation } from './usePasswordReset';
+import { useUpdateWarehouseCredentialsMutation } from './useProject';
+import { useUserUpdatePasswordMutation } from './user/usePassword';
+import {
+    useUserWarehouseCredentialsCreateMutation,
+    useUserWarehouseCredentialsUpdateMutation,
+} from './userWarehouseCredentials/useUserWarehouseCredentials';
+
+const mockApi = lightdashApi as unknown as Mock;
+
+function createWrapper() {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    });
+    return ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+}
+
+describe('credential-bearing requests are marked sensitive', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockApi.mockResolvedValue(undefined);
+    });
+
+    it('login', async () => {
+        const { result } = renderHook(
+            () =>
+                useLoginWithEmailMutation({
+                    onSuccess: vi.fn(),
+                    onError: vi.fn(),
+                }),
+            { wrapper: createWrapper() },
+        );
+
+        await result.current.mutateAsync({
+            email: 'a@b.com',
+            password: 'hunter2',
+        });
+
+        expect(mockApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/login',
+                method: 'POST',
+                sensitive: true,
+            }),
+        );
+    });
+
+    it('password update', async () => {
+        const { result } = renderHook(() => useUserUpdatePasswordMutation(), {
+            wrapper: createWrapper(),
+        });
+
+        await result.current.mutateAsync({
+            password: 'old',
+            newPassword: 'new',
+        });
+
+        expect(mockApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/user/password',
+                method: 'POST',
+                sensitive: true,
+            }),
+        );
+    });
+
+    it('password reset', async () => {
+        const { result } = renderHook(() => usePasswordResetMutation(), {
+            wrapper: createWrapper(),
+        });
+
+        await result.current.mutateAsync({
+            code: 'code',
+            newPassword: 'new',
+        });
+
+        expect(mockApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/user/password/reset',
+                method: 'POST',
+                sensitive: true,
+            }),
+        );
+    });
+
+    it('personal access token rotation', async () => {
+        const { result } = renderHook(() => useRotateAccessToken(), {
+            wrapper: createWrapper(),
+        });
+
+        await result.current.mutateAsync({
+            tokenUuid: 'token-uuid',
+            expiresAt: '2030-01-01',
+        });
+
+        expect(mockApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/user/me/personal-access-tokens/token-uuid/rotate',
+                method: 'PATCH',
+                sensitive: true,
+            }),
+        );
+    });
+
+    it('project warehouse credentials update', async () => {
+        const { result } = renderHook(
+            () => useUpdateWarehouseCredentialsMutation('project-uuid'),
+            { wrapper: createWrapper() },
+        );
+
+        await result.current.mutateAsync({} as AnyType);
+
+        expect(mockApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/projects/project-uuid/warehouse-credentials',
+                method: 'PUT',
+                sensitive: true,
+            }),
+        );
+    });
+
+    it('user warehouse credentials create and update', async () => {
+        const created = renderHook(
+            () => useUserWarehouseCredentialsCreateMutation(),
+            { wrapper: createWrapper() },
+        );
+        await created.result.current.mutateAsync({} as AnyType);
+
+        expect(mockApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/user/warehouseCredentials',
+                method: 'POST',
+                sensitive: true,
+            }),
+        );
+
+        const updated = renderHook(
+            () => useUserWarehouseCredentialsUpdateMutation('cred-uuid'),
+            { wrapper: createWrapper() },
+        );
+        await updated.result.current.mutateAsync({} as AnyType);
+
+        expect(mockApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/user/warehouseCredentials/cred-uuid',
+                method: 'PATCH',
+                sensitive: true,
+            }),
+        );
+    });
+
+    it('organization warehouse credentials create and update', async () => {
+        const created = renderHook(
+            () => useCreateOrganizationWarehouseCredentials(),
+            { wrapper: createWrapper() },
+        );
+        await created.result.current.mutateAsync({} as AnyType);
+
+        expect(mockApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/org/warehouse-credentials',
+                method: 'POST',
+                sensitive: true,
+            }),
+        );
+
+        const updated = renderHook(
+            () => useUpdateOrganizationWarehouseCredentials(),
+            { wrapper: createWrapper() },
+        );
+        await updated.result.current.mutateAsync({
+            uuid: 'cred-uuid',
+            data: {},
+        } as AnyType);
+
+        expect(mockApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/org/warehouse-credentials/cred-uuid',
+                method: 'PATCH',
+                sensitive: true,
+            }),
+        );
+    });
+
+    it('service account create and token rotation', async () => {
+        const { result } = renderHook(() => useServiceAccounts(), {
+            wrapper: createWrapper(),
+        });
+
+        await result.current.createAccount.mutateAsync({} as AnyType);
+
+        expect(mockApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/service-accounts',
+                method: 'POST',
+                sensitive: true,
+            }),
+        );
+
+        await result.current.rotateAccount.mutateAsync({
+            uuid: 'sa-uuid',
+            expiresAt: '2030-01-01',
+        });
+
+        expect(mockApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/service-accounts/sa-uuid/rotate',
+                method: 'PATCH',
+                sensitive: true,
+            }),
+        );
+    });
+
+    it('external connection config test', async () => {
+        const { result } = renderHook(() => useTestConnectionConfig(), {
+            wrapper: createWrapper(),
+        });
+
+        await result.current.mutateAsync({
+            projectUuid: 'project-uuid',
+            config: {},
+            path: '/',
+        } as AnyType);
+
+        expect(mockApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/ee/projects/project-uuid/external-connections/test-config',
+                method: 'POST',
+                sensitive: true,
+            }),
+        );
+    });
+
+    it('gdrive access token', async () => {
+        await getGdriveAccessToken();
+
+        expect(mockApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/gdrive/get-access-token',
+                sensitive: true,
+            }),
+        );
+    });
+});

--- a/packages/frontend/src/hooks/useAccessToken.ts
+++ b/packages/frontend/src/hooks/useAccessToken.ts
@@ -42,6 +42,7 @@ const rotateAccessToken = async (tokenUuid: string, expiresAt: string) =>
         url: `/user/me/personal-access-tokens/${tokenUuid}/rotate`,
         method: 'PATCH',
         body: JSON.stringify({ expiresAt }),
+        sensitive: true,
     });
 
 export const useAccessToken = (

--- a/packages/frontend/src/hooks/usePasswordReset.ts
+++ b/packages/frontend/src/hooks/usePasswordReset.ts
@@ -28,6 +28,7 @@ const resetPasswordQuery = async (data: PasswordReset): Promise<null> =>
         url: `/user/password/reset`,
         method: 'POST',
         body: JSON.stringify(data),
+        sensitive: true,
     });
 
 export const usePasswordResetLink = (code: string | undefined) =>

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -31,6 +31,7 @@ const createProject = async (data: CreateProject) =>
         url: `/org/projects/precompiled`,
         method: 'POST',
         body: JSON.stringify(data),
+        sensitive: true,
     });
 
 const createProjectWithoutCompile = async (data: CreateProject) =>
@@ -46,6 +47,7 @@ const updateProject = async (uuid: string, data: UpdateProject) =>
         url: `/projects/${uuid}`,
         method: 'PATCH',
         body: JSON.stringify(data),
+        sensitive: true,
     });
 
 const getProject = async (uuid: string) =>
@@ -193,6 +195,7 @@ const updateWarehouseCredentials = async (
         body: JSON.stringify({
             warehouseConnection: warehouseCredentials,
         }),
+        sensitive: true,
     });
 
 export const useUpdateWarehouseCredentialsMutation = (uuid: string) => {

--- a/packages/frontend/src/hooks/user/usePassword.ts
+++ b/packages/frontend/src/hooks/user/usePassword.ts
@@ -29,6 +29,7 @@ const updateUserPasswordQuery = (data: UserPasswordUpdate) =>
         url: `/user/password`,
         method: 'POST',
         body: JSON.stringify(data),
+        sensitive: true,
     });
 
 export const useUserUpdatePasswordMutation = (

--- a/packages/frontend/src/hooks/userWarehouseCredentials/useUserWarehouseCredentials.ts
+++ b/packages/frontend/src/hooks/userWarehouseCredentials/useUserWarehouseCredentials.ts
@@ -56,6 +56,7 @@ const createUserWarehouseCredentials = async (
         url: `/user/warehouseCredentials`,
         method: 'POST',
         body: JSON.stringify(data),
+        sensitive: true,
     });
 
 export const useUserWarehouseCredentialsCreateMutation = (
@@ -101,6 +102,7 @@ const updateUserWarehouseCredentials = async (
         url: `/user/warehouseCredentials/${uuid}`,
         method: 'PATCH',
         body: JSON.stringify(data),
+        sensitive: true,
     });
 
 export const useUserWarehouseCredentialsUpdateMutation = (uuid: string) => {

--- a/packages/frontend/src/pages/Invite.tsx
+++ b/packages/frontend/src/pages/Invite.tsx
@@ -155,6 +155,7 @@ const createUserQuery = async (data: ActivateUserWithInviteCode) =>
         url: `/user`,
         method: 'POST',
         body: JSON.stringify(data),
+        sensitive: true,
     });
 
 const Invite: FC = () => {

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -37,6 +37,7 @@ const registerQuery = async (data: CreateUserArgs | CreateEmailOnlyUserArgs) =>
         url: `/user`,
         method: 'POST',
         body: JSON.stringify(data),
+        sensitive: true,
     });
 
 const Register: FC = () => {


### PR DESCRIPTION
Marks login, registration, password, project/warehouse-credential, service-account, token-rotation, and external-connection test requests as sensitive so their bodies and responses are redacted from the frontend network history used in support-share diagnostics. Verified via unit tests and end-to-end browser verification of the redaction behaviour in a running instance: sensitive request bodies are redacted in the support-share network history while ordinary requests remain unaffected.

Linear: SPK-578
