### PR TITLE
feat(analytics): track dbt source count on compiles and source add/remove events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -896,6 +896,17 @@ type ProjectCompiledEvent = BaseTrack & {
         modelsWithSqlFiltersCount: number;
         columnAccessFiltersCount: number;
         additionalDimensionsCount: number;
+        dbtSourceCount: number;
+    };
+};
+
+type DbtSourceEvent = BaseTrack & {
+    event: 'dbt_source_added' | 'dbt_source_removed';
+    userId?: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        dbtSourceCount: number;
     };
 };
 
@@ -2785,6 +2796,7 @@ type TypedEvent =
     | PlaygroundProjectProvisionedEvent
     | ProjectDeletedEvent
     | ProjectCompiledEvent
+    | DbtSourceEvent
     | UpdatedDashboardEvent
     | DeletedDashboardEvent
     | RestoredDashboardEvent

--- a/packages/backend/src/services/ProjectDbtSourcesService.ts
+++ b/packages/backend/src/services/ProjectDbtSourcesService.ts
@@ -110,7 +110,7 @@ export class ProjectDbtSourcesService extends BaseService {
         account: Account,
         projectUuid: string,
         action: 'view' | 'manage',
-    ): Promise<void> {
+    ): Promise<string> {
         const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
         const auditedAbility = this.createAuditedAbility(account);
@@ -126,6 +126,7 @@ export class ProjectDbtSourcesService extends BaseService {
         ) {
             throw new ForbiddenError();
         }
+        return organizationUuid;
     }
 
     async getProjectDbtSources(
@@ -155,7 +156,11 @@ export class ProjectDbtSourcesService extends BaseService {
         projectUuid: string,
         data: ApiCreateProjectDbtSource,
     ): Promise<ProjectDbtSourceSummary> {
-        await this.checkProjectAccess(account, projectUuid, 'manage');
+        const organizationUuid = await this.checkProjectAccess(
+            account,
+            projectUuid,
+            'manage',
+        );
         // GitHub-only for now: additional sources are restricted to GitHub
         // connections until the other git providers are validated end-to-end.
         if (data.dbtConnection.type !== DbtProjectType.GITHUB) {
@@ -180,6 +185,15 @@ export class ProjectDbtSourcesService extends BaseService {
                 dbtConnection: data.dbtConnection,
             },
         );
+        this.analytics.track({
+            event: 'dbt_source_added',
+            userId: account.user?.id,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                dbtSourceCount: existing.length + 2,
+            },
+        });
         return ProjectDbtSourcesService.toSummary(created);
     }
 
@@ -260,7 +274,11 @@ export class ProjectDbtSourcesService extends BaseService {
         projectUuid: string,
         projectDbtSourceUuid: string,
     ): Promise<void> {
-        await this.checkProjectAccess(account, projectUuid, 'manage');
+        const organizationUuid = await this.checkProjectAccess(
+            account,
+            projectUuid,
+            'manage',
+        );
         const source =
             await this.projectDbtSourcesModel.getSource(projectDbtSourceUuid);
         if (source.projectUuid !== projectUuid) {
@@ -268,6 +286,17 @@ export class ProjectDbtSourcesService extends BaseService {
                 'This dbt source does not belong to the project',
             );
         }
+        const sources =
+            await this.projectDbtSourcesModel.getSources(projectUuid);
         await this.projectDbtSourcesModel.deleteSource(projectDbtSourceUuid);
+        this.analytics.track({
+            event: 'dbt_source_removed',
+            userId: account.user?.id,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                dbtSourceCount: sources.length,
+            },
+        });
     }
 }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3484,20 +3484,18 @@ export class ProjectService extends BaseService {
                         // combined explore set as "Refresh dbt".
                         let compileAdapter = primaryAdapter;
                         try {
-                            const resolvedCompileAdapter =
-                                await this.resolveCompileAdapter({
-                                    projectUuid,
-                                    organizationUuid: user.organizationUuid,
-                                    userUuid: user.userUuid,
-                                    primary: {
-                                        adapter: primaryAdapter,
-                                        warehouseCredentials,
-                                        cachedWarehouse,
-                                        dbtVersionOption,
-                                    },
-                                    manifestFetchAdapters,
-                                });
-                            compileAdapter = resolvedCompileAdapter.adapter;
+                            compileAdapter = await this.resolveCompileAdapter({
+                                projectUuid,
+                                organizationUuid: user.organizationUuid,
+                                userUuid: user.userUuid,
+                                primary: {
+                                    adapter: primaryAdapter,
+                                    warehouseCredentials,
+                                    cachedWarehouse,
+                                    dbtVersionOption,
+                                },
+                                manifestFetchAdapters,
+                            });
                             const trackingParams = {
                                 projectUuid,
                                 organizationUuid: user.organizationUuid,
@@ -4391,6 +4389,7 @@ export class ProjectService extends BaseService {
         userUuid,
         primary,
         manifestFetchAdapters,
+        onDbtSourceCount,
     }: {
         projectUuid: string;
         organizationUuid: string | undefined;
@@ -4402,30 +4401,31 @@ export class ProjectService extends BaseService {
             dbtVersionOption: DbtVersionOption;
         };
         manifestFetchAdapters: ProjectAdapter[];
-    }): Promise<{ adapter: ProjectAdapter; dbtSourceCount: number }> {
+        onDbtSourceCount?: (dbtSourceCount: number) => void;
+    }): Promise<ProjectAdapter> {
         const { enabled: multiDbtSourcesEnabled } =
             await this.featureFlagModel.get({
                 featureFlagId: FeatureFlags.MultiDbtSources,
                 user: { userUuid, organizationUuid },
             });
         if (!multiDbtSourcesEnabled) {
-            return { adapter: primary.adapter, dbtSourceCount: 1 };
+            onDbtSourceCount?.(1);
+            return primary.adapter;
         }
         const sources =
             await this.projectDbtSourcesModel.getSources(projectUuid);
         if (sources.length === 0) {
-            return { adapter: primary.adapter, dbtSourceCount: 1 };
+            onDbtSourceCount?.(1);
+            return primary.adapter;
         }
-        return {
-            adapter: await this.buildMergedManifestAdapter({
-                projectUuid,
-                organizationUuid,
-                primary,
-                sources,
-                manifestFetchAdapters,
-            }),
-            dbtSourceCount: sources.length + 1,
-        };
+        onDbtSourceCount?.(sources.length + 1);
+        return this.buildMergedManifestAdapter({
+            projectUuid,
+            organizationUuid,
+            primary,
+            sources,
+            manifestFetchAdapters,
+        });
     }
 
     /**
@@ -6442,14 +6442,17 @@ export class ProjectService extends BaseService {
             // compiling, so cross-source ref()/joins resolve and the explore set is
             // the union of all sources. A project with zero registered sources runs
             // the unchanged single-source path (N=0 short-circuit / regression firewall).
-            const resolvedCompileAdapter = await this.resolveCompileAdapter({
+            let dbtSourceCount = 1;
+            adapter = await this.resolveCompileAdapter({
                 projectUuid,
                 organizationUuid: project.organizationUuid,
                 userUuid: user.userUuid,
                 primary: buildResult,
                 manifestFetchAdapters,
+                onDbtSourceCount: (count) => {
+                    dbtSourceCount = count;
+                },
             });
-            adapter = resolvedCompileAdapter.adapter;
             const packages = await adapter.getDbtPackages();
             const trackingParams = {
                 projectUuid,
@@ -6586,7 +6589,7 @@ export class ProjectService extends BaseService {
                         },
                         0,
                     ),
-                    dbtSourceCount: resolvedCompileAdapter.dbtSourceCount,
+                    dbtSourceCount,
                 },
             });
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3484,18 +3484,20 @@ export class ProjectService extends BaseService {
                         // combined explore set as "Refresh dbt".
                         let compileAdapter = primaryAdapter;
                         try {
-                            compileAdapter = await this.resolveCompileAdapter({
-                                projectUuid,
-                                organizationUuid: user.organizationUuid,
-                                userUuid: user.userUuid,
-                                primary: {
-                                    adapter: primaryAdapter,
-                                    warehouseCredentials,
-                                    cachedWarehouse,
-                                    dbtVersionOption,
-                                },
-                                manifestFetchAdapters,
-                            });
+                            const resolvedCompileAdapter =
+                                await this.resolveCompileAdapter({
+                                    projectUuid,
+                                    organizationUuid: user.organizationUuid,
+                                    userUuid: user.userUuid,
+                                    primary: {
+                                        adapter: primaryAdapter,
+                                        warehouseCredentials,
+                                        cachedWarehouse,
+                                        dbtVersionOption,
+                                    },
+                                    manifestFetchAdapters,
+                                });
+                            compileAdapter = resolvedCompileAdapter.adapter;
                             const trackingParams = {
                                 projectUuid,
                                 organizationUuid: user.organizationUuid,
@@ -4400,27 +4402,30 @@ export class ProjectService extends BaseService {
             dbtVersionOption: DbtVersionOption;
         };
         manifestFetchAdapters: ProjectAdapter[];
-    }): Promise<ProjectAdapter> {
+    }): Promise<{ adapter: ProjectAdapter; dbtSourceCount: number }> {
         const { enabled: multiDbtSourcesEnabled } =
             await this.featureFlagModel.get({
                 featureFlagId: FeatureFlags.MultiDbtSources,
                 user: { userUuid, organizationUuid },
             });
         if (!multiDbtSourcesEnabled) {
-            return primary.adapter;
+            return { adapter: primary.adapter, dbtSourceCount: 1 };
         }
         const sources =
             await this.projectDbtSourcesModel.getSources(projectUuid);
         if (sources.length === 0) {
-            return primary.adapter;
+            return { adapter: primary.adapter, dbtSourceCount: 1 };
         }
-        return this.buildMergedManifestAdapter({
-            projectUuid,
-            organizationUuid,
-            primary,
-            sources,
-            manifestFetchAdapters,
-        });
+        return {
+            adapter: await this.buildMergedManifestAdapter({
+                projectUuid,
+                organizationUuid,
+                primary,
+                sources,
+                manifestFetchAdapters,
+            }),
+            dbtSourceCount: sources.length + 1,
+        };
     }
 
     /**
@@ -6437,13 +6442,14 @@ export class ProjectService extends BaseService {
             // compiling, so cross-source ref()/joins resolve and the explore set is
             // the union of all sources. A project with zero registered sources runs
             // the unchanged single-source path (N=0 short-circuit / regression firewall).
-            adapter = await this.resolveCompileAdapter({
+            const resolvedCompileAdapter = await this.resolveCompileAdapter({
                 projectUuid,
                 organizationUuid: project.organizationUuid,
                 userUuid: user.userUuid,
                 primary: buildResult,
                 manifestFetchAdapters,
             });
+            adapter = resolvedCompileAdapter.adapter;
             const packages = await adapter.getDbtPackages();
             const trackingParams = {
                 projectUuid,
@@ -6580,6 +6586,7 @@ export class ProjectService extends BaseService {
                         },
                         0,
                     ),
+                    dbtSourceCount: resolvedCompileAdapter.dbtSourceCount,
                 },
             });
 


### PR DESCRIPTION
## What and why

Tracks multi-source dbt adoption on compiles and source-management actions.

Added project.compiled property: dbtSourceCount.

Added events:
- dbt_source_added: organizationId, projectId, dbtSourceCount
- dbt_source_removed: organizationId, projectId, dbtSourceCount

Verified by CI (local checks intentionally skipped).

Linear: SPK-627

## Runtime verification

Verified against a local gzip Rudder sink with the multi-dbt-sources feature flag enabled.

- dbt_source_added returned dbtSourceCount 2.
- dbt_source_removed returned dbtSourceCount 1.
- A seeded single-source refresh returned project.compiled with dbtSourceCount 1.
- A two-source refresh was attempted with a public git-backed source but ended in ParameterError, so no count-2 compiled event was emitted locally.

Sink JSON excerpts:
```json
{"event":"lightdash_server.dbt_source_added","properties":{"organizationId":"172a2270-000f-42be-9c68-c4752c23ae51","projectId":"3675b69e-8324-4110-bdca-059031aa8da3","dbtSourceCount":2}}
{"event":"lightdash_server.dbt_source_removed","properties":{"organizationId":"172a2270-000f-42be-9c68-c4752c23ae51","projectId":"3675b69e-8324-4110-bdca-059031aa8da3","dbtSourceCount":1}}
{"event":"lightdash_server.project.compiled","properties":{"projectId":"3675b69e-8324-4110-bdca-059031aa8da3","dbtSourceCount":1}}
```