### PR TITLE
feat(analytics): track chart explore remaps, org leaves, admin notification sends + Redshift auth type

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1,6 +1,7 @@
 /// <reference path="../@types/rudder-sdk-node.d.ts" />
 import {
     Account,
+    AdminNotificationType,
     AI_WRITEBACK_STAGES,
     AnyType,
     CacheMetadata,
@@ -284,6 +285,15 @@ type UserJoinOrganizationEvent = BaseTrack & {
         organizationId: string;
         role: OrganizationMemberRole;
         projectIds: string[];
+    };
+};
+
+type UserLeftOrganizationEvent = BaseTrack & {
+    event: 'user.left_organization';
+    userId: string;
+    properties: {
+        organizationId: string;
+        wasOrganizationAdmin: boolean;
     };
 };
 
@@ -608,6 +618,16 @@ type UpdateSavedChartEvent = BaseTrack & {
         savedQueryId: string;
         dashboardId: string | undefined;
         virtualViewId: string | undefined;
+    };
+};
+
+type SavedChartExploreChangedEvent = BaseTrack & {
+    event: 'saved_chart.explore_changed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        savedChartId: string;
     };
 };
 type DeleteSavedChartEvent = BaseTrack & {
@@ -2421,6 +2441,16 @@ export type RenameResourceEvent = BaseTrack & {
     };
 };
 
+type AdminNotificationSentEvent = BaseTrack & {
+    event: 'admin_notification.sent';
+    userId?: string;
+    properties: {
+        organizationId: string;
+        projectId: string | undefined;
+        notificationType: AdminNotificationType;
+    };
+};
+
 export type SupportShareEvent = BaseTrack & {
     event: 'support.share';
     userId: string;
@@ -2737,6 +2767,7 @@ type TypedEvent =
     | OnboardingStepCompletedEvent
     | SetupInviteAcceptedEvent
     | UserJoinOrganizationEvent
+    | UserLeftOrganizationEvent
     | QueryExecutionEvent
     | QueryReadyEvent
     | QueryErrorEvent
@@ -2750,6 +2781,7 @@ type TypedEvent =
     | ResultsCacheDeleteEvent
     | ModeDashboardChartEvent
     | UpdateSavedChartEvent
+    | SavedChartExploreChangedEvent
     | DeleteSavedChartEvent
     | RestoredSavedChartEvent
     | FormulaTableCalculationSavedEvent
@@ -2824,6 +2856,7 @@ type TypedEvent =
     | GroupCreateAndUpdateEvent
     | GroupDeleteEvent
     | ConditionalFormattingRuleSavedEvent
+    | AdminNotificationSentEvent
     | ViewSqlChart
     | CreateSqlChartEvent
     | UpdateSqlChartEvent

--- a/packages/backend/src/services/AdminNotificationService/AdminNotificationService.test.ts
+++ b/packages/backend/src/services/AdminNotificationService/AdminNotificationService.test.ts
@@ -5,6 +5,7 @@ import {
     ProjectMemberRole,
 } from '@lightdash/common';
 import EmailClient from '../../clients/EmailClient/EmailClient';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
@@ -57,6 +58,7 @@ const userModel = {
 describe('AdminNotificationService', () => {
     const service = new AdminNotificationService({
         lightdashConfig: lightdashConfigMock,
+        analytics: analyticsMock,
         emailClient: emailClient as unknown as EmailClient,
         organizationMemberProfileModel:
             organizationMemberProfileModel as unknown as OrganizationMemberProfileModel,

--- a/packages/backend/src/services/AdminNotificationService/AdminNotificationService.test.ts
+++ b/packages/backend/src/services/AdminNotificationService/AdminNotificationService.test.ts
@@ -4,8 +4,8 @@ import {
     OrganizationMemberRole,
     ProjectMemberRole,
 } from '@lightdash/common';
-import EmailClient from '../../clients/EmailClient/EmailClient';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import EmailClient from '../../clients/EmailClient/EmailClient';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
 import { OrganizationModel } from '../../models/OrganizationModel';

--- a/packages/backend/src/services/AdminNotificationService/AdminNotificationService.ts
+++ b/packages/backend/src/services/AdminNotificationService/AdminNotificationService.ts
@@ -5,6 +5,7 @@ import {
     OrganizationMemberRole,
     ProjectMemberRole,
 } from '@lightdash/common';
+import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import EmailClient from '../../clients/EmailClient/EmailClient';
 import { LightdashConfig } from '../../config/parseConfig';
 import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
@@ -15,6 +16,7 @@ import { BaseService } from '../BaseService';
 
 type AdminNotificationServiceArguments = {
     lightdashConfig: LightdashConfig;
+    analytics: LightdashAnalytics;
     emailClient: EmailClient;
     organizationMemberProfileModel: OrganizationMemberProfileModel;
     organizationModel: OrganizationModel;
@@ -24,6 +26,8 @@ type AdminNotificationServiceArguments = {
 
 export class AdminNotificationService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
+
+    private readonly analytics: LightdashAnalytics;
 
     private readonly emailClient: EmailClient;
 
@@ -37,6 +41,7 @@ export class AdminNotificationService extends BaseService {
 
     constructor({
         lightdashConfig,
+        analytics,
         emailClient,
         organizationMemberProfileModel,
         organizationModel,
@@ -45,6 +50,7 @@ export class AdminNotificationService extends BaseService {
     }: AdminNotificationServiceArguments) {
         super({ serviceName: 'AdminNotificationService' });
         this.lightdashConfig = lightdashConfig;
+        this.analytics = analytics;
         this.emailClient = emailClient;
         this.organizationMemberProfileModel = organizationMemberProfileModel;
         this.organizationModel = organizationModel;
@@ -192,6 +198,15 @@ export class AdminNotificationService extends BaseService {
                 recipientEmails,
                 payload,
             );
+            this.analytics.track({
+                event: 'admin_notification.sent',
+                userId: payload.changedBy.userUuid,
+                properties: {
+                    organizationId: payload.organizationUuid,
+                    projectId: payload.projectUuid,
+                    notificationType: payload.type,
+                },
+            });
 
             this.logger.info(
                 `Sent org admin ${
@@ -281,6 +296,15 @@ export class AdminNotificationService extends BaseService {
                 recipientEmails,
                 payload,
             );
+            this.analytics.track({
+                event: 'admin_notification.sent',
+                userId: payload.changedBy.userUuid,
+                properties: {
+                    organizationId: payload.organizationUuid,
+                    projectId: payload.projectUuid,
+                    notificationType: payload.type,
+                },
+            });
 
             this.logger.info(
                 `Sent project admin ${
@@ -355,6 +379,15 @@ export class AdminNotificationService extends BaseService {
                 recipients,
                 payload,
             );
+            this.analytics.track({
+                event: 'admin_notification.sent',
+                userId: payload.changedBy.userUuid,
+                properties: {
+                    organizationId: payload.organizationUuid,
+                    projectId: payload.projectUuid,
+                    notificationType: payload.type,
+                },
+            });
         } catch (error) {
             this.logger.error(
                 'Failed to send connection settings change notification',

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -426,6 +426,40 @@ describe('ProjectService', () => {
         ).toMatchObject({ onboardingFlow: 'new' });
     });
 
+    test.each([
+        [RedshiftAuthenticationType.IAM, RedshiftAuthenticationType.IAM],
+        [undefined, RedshiftAuthenticationType.PASSWORD],
+    ])(
+        'includes Redshift authentication type %s in project analytics properties',
+        (authenticationType, expectedAuthenticationType) => {
+            expect(
+                ProjectService.getAnalyticProperties(
+                    {
+                        name: projectWithSensitiveFields.name,
+                        type: projectWithSensitiveFields.type,
+                        dbtConnection: projectWithSensitiveFields.dbtConnection,
+                        warehouseConnection: {
+                            type: WarehouseTypes.REDSHIFT,
+                            host: 'localhost',
+                            user: 'analytics',
+                            password: 'password',
+                            port: 5439,
+                            dbname: 'analytics',
+                            schema: 'public',
+                            authenticationType,
+                        },
+                    },
+                    projectUuid,
+                    user,
+                    RequestMethod.WEB_APP,
+                    'new',
+                ),
+            ).toMatchObject({
+                authenticationType: expectedAuthenticationType,
+            });
+        },
+    );
+
     test('does not compile and removes a preview when copying fails', async () => {
         const previewProjectUuid = 'failed-preview-project-uuid';
         (

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -145,8 +145,8 @@ import {
     ProjectSummary,
     ProjectType,
     QueryExecutionContext,
-    RegisteredAccount,
     RedshiftAuthenticationType,
+    RegisteredAccount,
     ReplaceableCustomFields,
     ReplaceCustomFields,
     ReplaceCustomFieldsPayload,
@@ -2759,10 +2759,10 @@ export class ProjectService extends BaseService {
             warehouseType === WarehouseTypes.BIGQUERY ||
             warehouseType === WarehouseTypes.SNOWFLAKE ||
             warehouseType === WarehouseTypes.REDSHIFT
-                ? createProject.warehouseConnection?.authenticationType ??
+                ? (createProject.warehouseConnection?.authenticationType ??
                   (warehouseType === WarehouseTypes.REDSHIFT
                       ? RedshiftAuthenticationType.PASSWORD
-                      : undefined)
+                      : undefined))
                 : undefined;
         return {
             projectName: createProject.name,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -146,6 +146,7 @@ import {
     ProjectType,
     QueryExecutionContext,
     RegisteredAccount,
+    RedshiftAuthenticationType,
     ReplaceableCustomFields,
     ReplaceCustomFields,
     ReplaceCustomFieldsPayload,
@@ -2756,8 +2757,12 @@ export class ProjectService extends BaseService {
         const warehouseType = createProject.warehouseConnection?.type;
         const authenticationType =
             warehouseType === WarehouseTypes.BIGQUERY ||
-            warehouseType === WarehouseTypes.SNOWFLAKE
-                ? createProject.warehouseConnection?.authenticationType
+            warehouseType === WarehouseTypes.SNOWFLAKE ||
+            warehouseType === WarehouseTypes.REDSHIFT
+                ? createProject.warehouseConnection?.authenticationType ??
+                  (warehouseType === WarehouseTypes.REDSHIFT
+                      ? RedshiftAuthenticationType.PASSWORD
+                      : undefined)
                 : undefined;
         return {
             projectName: createProject.name,

--- a/packages/backend/src/services/RenameService/RenameService.ts
+++ b/packages/backend/src/services/RenameService/RenameService.ts
@@ -305,6 +305,18 @@ export class RenameService extends BaseService {
                 updatedChart,
                 undefined,
             );
+
+            if (type === RenameType.MODEL) {
+                this.analytics.track({
+                    event: 'saved_chart.explore_changed',
+                    userId: user.userUuid,
+                    properties: {
+                        organizationId: organizationUuid,
+                        projectId: chartProjectUuid,
+                        savedChartId: chart.uuid,
+                    },
+                });
+            }
         }
 
         this.analytics.track({

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -329,6 +329,7 @@ export class ServiceRepository
             () =>
                 new AdminNotificationService({
                     lightdashConfig: this.context.lightdashConfig,
+                    analytics: this.context.lightdashAnalytics,
                     emailClient: this.clients.getEmailClient(),
                     organizationMemberProfileModel:
                         this.models.getOrganizationMemberProfileModel(),

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -2511,6 +2511,15 @@ export class UserService extends BaseService {
             userToDelete,
             context: 'leave_organization',
         });
+        this.analytics.track({
+            event: 'user.left_organization',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                wasOrganizationAdmin:
+                    member.role === OrganizationMemberRole.ADMIN,
+            },
+        });
 
         this.logger.info('User left organization', {
             userUuid: user.userUuid,


### PR DESCRIPTION
Tracks backend feature-usage analytics for chart explore remaps, organization leaves, and admin notification sends; also includes Redshift authentication type in project events.

Events/properties added:
- `saved_chart.explore_changed`: `organizationId`, `projectId`, `savedChartId`
- `user.left_organization`: `organizationId`, `wasOrganizationAdmin`
- `admin_notification.sent`: `organizationId`, `projectId`, `notificationType` (all 5 admin notification types)
- `project.created` / `project.updated`: Redshift `authenticationType` with password fallback

Verified by CI (local checks intentionally skipped).

Runtime verification
- `saved_chart.explore_changed`: `{ "organizationId": "172a2270-000f-42be-9c68-c4752c23ae51", "projectId": "3675b69e-8324-4110-bdca-059031aa8da3", "savedChartId": "68cd434d-5bf9-4134-a734-422522472ec8" }`
- `user.left_organization`: `{ "organizationId": "172a2270-000f-42be-9c68-c4752c23ae51", "wasOrganizationAdmin": true }`
- `admin_notification.sent`: `{ "organizationId": "172a2270-000f-42be-9c68-c4752c23ae51", "notificationType": "org_admin_added" }`
- Redshift: no local Redshift connection is available. The project analytics branch reads the Redshift credential authentication type and defaults an absent value to `password`; unit coverage exercises both IAM and password-fallback cases.

Linear: SPK-634
Linear: SPK-636
Linear: SPK-639
Linear: SPK-640