### PR TITLE
feat(analytics): attribute ai writeback events to their workstream

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -36,6 +36,7 @@ import {
     type AiRouterDecisionConfidence,
     type AiRouterRouteNextAction,
     type AiWritebackFailureStage,
+    type AiWritebackWorkstream,
     type AppVersionDependencyEntry,
     type DataAppClaudeModel,
     type DataAppTemplate,
@@ -1729,6 +1730,7 @@ export type AiWritebackStartedEvent = BaseTrack & {
         projectId: string;
         owner: string;
         repo: string;
+        workstream: AiWritebackWorkstream;
         // Whether this turn resumed an existing conversation (and its sandbox)
         // rather than starting a fresh one.
         isResume: boolean;
@@ -1743,6 +1745,7 @@ export type AiWritebackCompletedEvent = BaseTrack & {
         projectId: string;
         owner: string;
         repo: string;
+        workstream: AiWritebackWorkstream;
         isResume: boolean;
         exitCode: number;
         // Whether the agent changed any files. When false no PR is opened.
@@ -1776,6 +1779,7 @@ export type AiWritebackFailedEvent = BaseTrack & {
         projectId: string;
         owner: string;
         repo: string;
+        workstream: AiWritebackWorkstream;
         isResume: boolean;
         failureStage: AiWritebackFailureStage;
         errorMessage: string;
@@ -1804,6 +1808,7 @@ export type AiWritebackMergedEvent = BaseTrack & {
         // Whether a dbt recompile was scheduled after the merge. Only
         // git-connected projects re-clone on compile, so others are skipped.
         compileScheduled: boolean;
+        workstream: AiWritebackWorkstream;
     };
 };
 

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -7,6 +7,7 @@ import {
     type AiThreadCreatedFrom,
     type AiWritebackRunStatus,
     type AiWritebackSource,
+    type AiWritebackWorkstream,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 
@@ -133,6 +134,7 @@ export type DbAiWritebackThread = {
      * NULL — deleting the source degrades a resume back to the primary.
      */
     project_dbt_source_uuid: string | null;
+    workstream: AiWritebackWorkstream;
     /** "owner/repo" this row's sandbox + PR target; null only on legacy rows. */
     target_repo: string | null;
     created_at: Date;
@@ -142,7 +144,11 @@ export type AiWritebackThreadTable = Knex.CompositeTableType<
     DbAiWritebackThread,
     Pick<
         DbAiWritebackThread,
-        'ai_thread_uuid' | 'sandbox_uuid' | 'pull_request_uuid' | 'target_repo'
+        | 'ai_thread_uuid'
+        | 'sandbox_uuid'
+        | 'pull_request_uuid'
+        | 'target_repo'
+        | 'workstream'
     > &
         Partial<Pick<DbAiWritebackThread, 'project_dbt_source_uuid'>>,
     Partial<Pick<DbAiWritebackThread, 'sandbox_uuid' | 'pull_request_uuid'>>

--- a/packages/backend/src/ee/database/migrations/20260722110000_add_workstream_to_ai_writeback_thread.ts
+++ b/packages/backend/src/ee/database/migrations/20260722110000_add_workstream_to_ai_writeback_thread.ts
@@ -1,0 +1,26 @@
+import { Knex } from 'knex';
+
+const TableName = 'ai_writeback_thread';
+const ColumnName = 'workstream';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasColumn(TableName, ColumnName))) {
+        await knex.schema.alterTable(TableName, (table) => {
+            table.text(ColumnName);
+        });
+    }
+    await knex(TableName).whereNull(ColumnName).update({
+        [ColumnName]: 'dbt-writeback',
+    });
+    await knex.schema.alterTable(TableName, (table) => {
+        table.text(ColumnName).notNullable().alter();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasColumn(TableName, ColumnName)) {
+        await knex.schema.alterTable(TableName, (table) => {
+            table.dropColumn(ColumnName);
+        });
+    }
+}

--- a/packages/backend/src/ee/database/migrations/20260722110000_add_workstream_to_ai_writeback_thread.ts
+++ b/packages/backend/src/ee/database/migrations/20260722110000_add_workstream_to_ai_writeback_thread.ts
@@ -13,7 +13,7 @@ export async function up(knex: Knex): Promise<void> {
         [ColumnName]: 'dbt-writeback',
     });
     await knex.schema.alterTable(TableName, (table) => {
-        table.text(ColumnName).notNullable().alter();
+        table.text(ColumnName).notNullable().defaultTo('dbt-writeback').alter();
     });
 }
 

--- a/packages/backend/src/ee/database/migrations/20260722110000_add_workstream_to_ai_writeback_thread.ts
+++ b/packages/backend/src/ee/database/migrations/20260722110000_add_workstream_to_ai_writeback_thread.ts
@@ -9,9 +9,12 @@ export async function up(knex: Knex): Promise<void> {
             table.text(ColumnName);
         });
     }
-    await knex(TableName).whereNull(ColumnName).update({
-        [ColumnName]: 'dbt-writeback',
-    });
+    await knex.raw(`UPDATE ?? SET ?? = ? WHERE ?? IS NULL`, [
+        TableName,
+        ColumnName,
+        'dbt-writeback',
+        ColumnName,
+    ]);
     await knex.schema.alterTable(TableName, (table) => {
         table.text(ColumnName).notNullable().defaultTo('dbt-writeback').alter();
     });

--- a/packages/backend/src/ee/models/AiWritebackThreadModel.ts
+++ b/packages/backend/src/ee/models/AiWritebackThreadModel.ts
@@ -1,3 +1,4 @@
+import { type AiWritebackWorkstream } from '@lightdash/common';
 import { Knex } from 'knex';
 import { PullRequestsTableName } from '../../database/entities/pullRequests';
 import {
@@ -107,6 +108,26 @@ export class AiWritebackThreadModel {
                 `${AiWritebackThreadTableName}.pull_request_uuid`,
             )
             .where(`${AiWritebackThreadTableName}.ai_thread_uuid`, aiThreadUuid)
+            .where(`${PullRequestsTableName}.pr_url`, prUrl)
+            .select<AiWritebackThreadWithPrUrl>(
+                `${AiWritebackThreadTableName}.*`,
+                `${PullRequestsTableName}.pr_url`,
+            )
+            .first();
+        return row ?? null;
+    }
+
+    async findByProjectUuidAndPrUrl(
+        projectUuid: string,
+        prUrl: string,
+    ): Promise<AiWritebackThreadWithPrUrl | null> {
+        const row = await this.database(AiWritebackThreadTableName)
+            .innerJoin(
+                PullRequestsTableName,
+                `${PullRequestsTableName}.pull_request_uuid`,
+                `${AiWritebackThreadTableName}.pull_request_uuid`,
+            )
+            .where(`${PullRequestsTableName}.project_uuid`, projectUuid)
             .where(`${PullRequestsTableName}.pr_url`, prUrl)
             .select<AiWritebackThreadWithPrUrl>(
                 `${AiWritebackThreadTableName}.*`,
@@ -231,6 +252,7 @@ export class AiWritebackThreadModel {
         // dbt connection. Binds the thread to one repo across resumes.
         projectDbtSourceUuid: string | null;
         targetRepo: string;
+        workstream: AiWritebackWorkstream;
     }): Promise<DbAiWritebackThread> {
         const [row] = await this.database<AiWritebackThreadTable>(
             AiWritebackThreadTableName,
@@ -241,6 +263,7 @@ export class AiWritebackThreadModel {
                 pull_request_uuid: data.pullRequestUuid,
                 project_dbt_source_uuid: data.projectDbtSourceUuid,
                 target_repo: data.targetRepo,
+                workstream: data.workstream,
             })
             .returning('*');
         return row;

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -1820,6 +1820,7 @@ describe('AiWritebackService.mergePullRequest', () => {
                 pullNumber: 7,
                 mergeCommitSha: 'sha-7',
                 compileScheduled: true,
+                workstream: 'dbt-writeback',
             },
         });
     });

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -2153,6 +2153,7 @@ export class AiWritebackService extends BaseService {
                 prTitle,
                 prDescription,
                 prSummary,
+                workstream: config.mode,
                 // The general agent must never commit CI/workflow files (R3);
                 // dbt writeback may (preview-deploy setup). Secrets are denied
                 // in both regardless.
@@ -4044,6 +4045,7 @@ export class AiWritebackService extends BaseService {
         prTitle,
         prDescription,
         prSummary,
+        workstream,
         denyCiPaths,
     }: {
         sandbox: SandboxHandle;
@@ -4059,6 +4061,7 @@ export class AiWritebackService extends BaseService {
         prTitle: string | null;
         prDescription: string | null;
         prSummary: string | null;
+        workstream: CodingAgentConfig['mode'];
         /** Reject the commit if it touches CI/workflow paths (general agent). */
         denyCiPaths: boolean;
     }): Promise<AppliedChanges> {
@@ -4117,6 +4120,7 @@ export class AiWritebackService extends BaseService {
                     sandboxUuid,
                     prUrl: targetPrUrl,
                     summary: prSummary,
+                    workstream,
                 });
             }
 
@@ -4159,6 +4163,7 @@ export class AiWritebackService extends BaseService {
             sandboxUuid,
             prUrl,
             summary: prSummary,
+            workstream,
         });
 
         return {
@@ -4215,6 +4220,7 @@ export class AiWritebackService extends BaseService {
         sandboxUuid,
         prUrl,
         summary,
+        workstream,
     }: {
         turn: TurnContext;
         projectUuid: string;
@@ -4223,6 +4229,7 @@ export class AiWritebackService extends BaseService {
         sandboxUuid: string;
         prUrl: string;
         summary: string | null;
+        workstream: CodingAgentConfig['mode'];
     }): Promise<void> {
         const pullRequest = await this.pullRequestsModel.findOrCreate({
             organizationUuid: turn.organizationUuid,
@@ -4247,7 +4254,7 @@ export class AiWritebackService extends BaseService {
                 projectDbtSourceUuid: turn.projectDbtSourceUuid,
                 // Record the repo so a thread can resume its latest PR per repo.
                 targetRepo: `${turn.gitConnection.owner}/${turn.gitConnection.repo}`,
-                workstream: config.mode,
+                workstream,
             });
         }
     }

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -595,7 +595,7 @@ export class AiWritebackService extends BaseService {
                 args.user,
                 args.projectUuid,
             );
-            this.trackMerged(args.user, args.projectUuid, {
+            await this.trackMerged(args.user, args.projectUuid, {
                 prUrl: args.prUrl,
                 mergeCommitSha: result.sha,
                 compileScheduled,
@@ -610,7 +610,7 @@ export class AiWritebackService extends BaseService {
      * throws back into the merge flow. Owner/repo/pullNumber are parsed from the
      * PR URL where possible (github.com links), and left null otherwise.
      */
-    private trackMerged(
+    private async trackMerged(
         user: SessionUser,
         projectUuid: string,
         properties: {
@@ -618,7 +618,7 @@ export class AiWritebackService extends BaseService {
             mergeCommitSha: string | null;
             compileScheduled: boolean;
         },
-    ): void {
+    ): Promise<void> {
         let parsed: {
             owner: string;
             repo: string;
@@ -628,6 +628,17 @@ export class AiWritebackService extends BaseService {
             parsed = parsePullRequestUrl(properties.prUrl);
         } catch {
             parsed = null;
+        }
+        let workstream: CodingAgentConfig['mode'] = 'dbt-writeback';
+        try {
+            const thread =
+                await this.aiWritebackThreadModel.findByProjectUuidAndPrUrl(
+                    projectUuid,
+                    properties.prUrl,
+                );
+            workstream = thread?.workstream ?? workstream;
+        } catch {
+            workstream = 'dbt-writeback';
         }
         this.analytics.track({
             event: 'ai_writeback.merged',
@@ -641,6 +652,7 @@ export class AiWritebackService extends BaseService {
                 pullNumber: parsed?.pullNumber ?? null,
                 mergeCommitSha: properties.mergeCommitSha,
                 compileScheduled: properties.compileScheduled,
+                workstream,
             },
         });
     }
@@ -1943,7 +1955,12 @@ export class AiWritebackService extends BaseService {
             throw error;
         }
 
-        const tracker = this.startTracking({ user, projectUuid, turn });
+        const tracker = this.startTracking({
+            user,
+            projectUuid,
+            turn,
+            workstream: config.mode,
+        });
 
         let failureStage: AiWritebackFailureStage = 'install';
         let stageStartedAt = Date.now();
@@ -3021,10 +3038,12 @@ export class AiWritebackService extends BaseService {
         user,
         projectUuid,
         turn,
+        workstream,
     }: {
         user: SessionUser;
         projectUuid: string;
         turn: TurnContext;
+        workstream: CodingAgentConfig['mode'];
     }) {
         const eventBase = {
             organizationId: turn.organizationUuid,
@@ -3032,6 +3051,7 @@ export class AiWritebackService extends BaseService {
             owner: turn.gitConnection.owner,
             repo: turn.gitConnection.repo,
             isResume: turn.isResume,
+            workstream,
         };
         const startedAt = Date.now();
 
@@ -4227,6 +4247,7 @@ export class AiWritebackService extends BaseService {
                 projectDbtSourceUuid: turn.projectDbtSourceUuid,
                 // Record the repo so a thread can resume its latest PR per repo.
                 targetRepo: `${turn.gitConnection.owner}/${turn.gitConnection.repo}`,
+                workstream: config.mode,
             });
         }
     }

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -1,6 +1,7 @@
 import { type FeatureFlags } from '@lightdash/common';
 import type {
     AiWritebackSource,
+    AiWritebackWorkstream,
     PullRequestProvider,
     SessionUser,
     SupportedDbtVersions,
@@ -140,7 +141,7 @@ export type CodingAgentSetup = {
  */
 export type CodingAgentConfig = {
     /** Tags logs/analytics and selects the few remaining mode branches. */
-    mode: 'dbt-writeback' | 'general';
+    mode: AiWritebackWorkstream;
     /**
      * The rollout feature flag this mode is gated behind (CodingAgent for the
      * general agent). Undefined for dbt writeback, which is always enabled.

--- a/packages/common/src/ee/aiWriteback/types.ts
+++ b/packages/common/src/ee/aiWriteback/types.ts
@@ -127,6 +127,8 @@ export type AiWritebackSource =
     | 'admin_review'
     | 'changeset';
 
+export type AiWritebackWorkstream = 'dbt-writeback' | 'general';
+
 export const AI_WRITEBACK_STAGES = [
     'install',
     'sandbox',


### PR DESCRIPTION
Add required workstream attribution to AI writeback analytics so dbt writeback and general coding-agent runs can be separated. Persist the workstream with PR threads so merge events retain attribution.

Events/properties added:
- ai_writeback.started: workstream
- ai_writeback.completed: workstream
- ai_writeback.failed: workstream
- ai_writeback.merged: workstream

Verified by CI (local checks intentionally skipped).

Linear: SPK-625

## Runtime verification

- EE migration applied cleanly. Database assertion: `workstream|NO|'dbt-writeback'::text`.
- The authenticated writeback API controller was exercised against the seeded project. Its source-control setup lacks local credentials, so the request failed during target preparation before the shared runner emitted analytics. Sink JSON: `[]` (no event was claimed).
- General-agent attribution is covered by the existing `runEditRepo` path, which passes `general` through `runCodingAgent` into `applyAgentChanges` and persisted PR workstreams; the existing service test covers the dbt merge fallback. A live general-agent run was impractical without the same local credentials.
- EE stack, PM2 instance processes, local sink, and the claimed port slot were powered down/released after verification.