### PR TITLE
feat(analytics): re-land persistent download file lifecycle events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -48,6 +48,7 @@ import { Request } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashConfig } from '../config/parseConfig';
 import { type ExternalConnectionEvent } from '../ee/analytics';
+import { type PersistentDownloadFileSource } from '../services/PersistentDownloadFileService/PersistentDownloadFileService';
 import { VERSION } from '../version';
 import type { AiUsageEvent } from './aiUsage';
 import type { EventStreamSink } from './eventStream/EventStreamSink';
@@ -1931,6 +1932,63 @@ export type DownloadCsv = BaseTrack & {
     };
 };
 
+export type PersistentFileGenerationRequestedEvent = BaseTrack & {
+    event: 'persistent_file.generation_requested';
+    userId?: string;
+    properties: {
+        fileUuid: string;
+        organizationId: string;
+        projectId: string | null;
+        createdByUserUuid: string | null;
+        fileType: string;
+        source: PersistentDownloadFileSource;
+        expirationSeconds: number;
+    };
+};
+
+export type PersistentFileGenerationCompletedEvent = BaseTrack & {
+    event: 'persistent_file.generation_completed';
+    userId?: string;
+    properties: {
+        fileUuid: string;
+        organizationId: string;
+        projectId: string | null;
+        createdByUserUuid: string | null;
+        fileType: string;
+        source: PersistentDownloadFileSource;
+        expirationSeconds: number;
+        durationMs: number;
+    };
+};
+
+export type PersistentFileUrlRequestedEvent = BaseTrack & {
+    event: 'persistent_file.url_requested';
+    userId?: string;
+    properties: {
+        fileUuid: string;
+        organizationId: string;
+        projectId: string | null;
+        createdByUserUuid: string | null;
+        requestedByUserUuid: string | null;
+        source: 'api';
+    };
+};
+
+export type PersistentFileUrlRespondedEvent = BaseTrack & {
+    event: 'persistent_file.url_responded';
+    userId?: string;
+    properties: {
+        fileUuid: string;
+        organizationId: string;
+        projectId: string | null;
+        createdByUserUuid: string | null;
+        requestedByUserUuid: string | null;
+        source: 'api';
+        statusCode: number;
+        responseMs: number;
+    };
+};
+
 export type Validation = BaseTrack & {
     event:
         | 'validation.page_viewed'
@@ -2813,6 +2871,10 @@ type TypedEvent =
     | SchedulerOwnershipReassignedEvent
     | ImpersonationEvent
     | PromptFetchedEvent
+    | PersistentFileGenerationRequestedEvent
+    | PersistentFileGenerationCompletedEvent
+    | PersistentFileUrlRequestedEvent
+    | PersistentFileUrlRespondedEvent
     | AiUsageEvent;
 
 type UntypedEvent<T extends BaseTrack> = Omit<BaseTrack, 'event'> &

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -64,8 +64,7 @@ type Identify = {
     };
 };
 export type BaseTrack = Omit<AnalyticsTrack, 'context'>;
-export const ANONYMOUS_TRACKING_UUID =
-    '00000000-0000-0000-0000-000000000000';
+export const ANONYMOUS_TRACKING_UUID = '00000000-0000-0000-0000-000000000000';
 export type OnboardingFlow = 'new' | 'legacy';
 export type OneTimePasscodePurpose =
     | 'signup_verification'

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -64,6 +64,8 @@ type Identify = {
     };
 };
 export type BaseTrack = Omit<AnalyticsTrack, 'context'>;
+export const ANONYMOUS_TRACKING_UUID =
+    '00000000-0000-0000-0000-000000000000';
 export type OnboardingFlow = 'new' | 'legacy';
 export type OneTimePasscodePurpose =
     | 'signup_verification'

--- a/packages/backend/src/controllers/fileController.ts
+++ b/packages/backend/src/controllers/fileController.ts
@@ -55,6 +55,7 @@ export class FileController extends BaseController {
             .getFileStream(fileId, {
                 ip: req.ip,
                 userAgent: req.headers['user-agent'],
+                requestedByUserUuid: req.user?.userUuid ?? null,
             });
 
         const res = req.res!;

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -743,6 +743,7 @@ export default class SchedulerTask {
                                     createdByUserUuid: userUuid,
                                     expirationSeconds:
                                         expirationSecondsOverride,
+                                    source: 'scheduler',
                                 },
                             );
                     }
@@ -4937,6 +4938,7 @@ export default class SchedulerTask {
             organizationUuid,
             projectUuid,
             createdByUserUuid,
+            source: 'scheduler',
         });
     }
 
@@ -5009,6 +5011,7 @@ export default class SchedulerTask {
                 projectUuid,
                 createdByUserUuid,
                 expirationSeconds: expirationSecondsOverride,
+                source: 'scheduler',
             }),
             numFileFailures: workbookResult.failedFileCount,
         };

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1746,6 +1746,7 @@ export class AsyncQueryService extends ProjectService {
                                 ? null
                                 : account.user.userUuid,
                             expirationSeconds: expirationSecondsOverride,
+                            source: 'async_query',
                         },
                     );
                 return {
@@ -1879,6 +1880,7 @@ export class AsyncQueryService extends ProjectService {
                     createdByUserUuid: persistentUrlContext.createdByUserUuid,
                     expirationSeconds:
                         persistentUrlContext.expirationSecondsOverride,
+                    source: 'async_query',
                 });
             return {
                 fileUrl: persistentUrl,

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -574,6 +574,7 @@ export class CsvService extends BaseService {
                     organizationUuid,
                     projectUuid,
                     createdByUserUuid,
+                    source: 'analytics',
                 });
             return {
                 filename: fileName,

--- a/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.test.ts
+++ b/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.test.ts
@@ -1,11 +1,11 @@
 import { NotFoundError } from '@lightdash/common';
 import { Readable } from 'stream';
+import type { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import type { LightdashConfig } from '../../config/parseConfig';
 import type { DbPersistentDownloadFile } from '../../database/entities/persistentDownloadFile';
 import { PersistentDownloadFileModel } from '../../models/PersistentDownloadFileModel';
-import type { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { PersistentDownloadFileService } from './PersistentDownloadFileService';
 
 const mockS3GetFileUrl = vi.fn();

--- a/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.test.ts
+++ b/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.test.ts
@@ -5,6 +5,7 @@ import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import type { LightdashConfig } from '../../config/parseConfig';
 import type { DbPersistentDownloadFile } from '../../database/entities/persistentDownloadFile';
 import { PersistentDownloadFileModel } from '../../models/PersistentDownloadFileModel';
+import type { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { PersistentDownloadFileService } from './PersistentDownloadFileService';
 
 const mockS3GetFileUrl = vi.fn();
@@ -24,6 +25,9 @@ const createService = (
     configOverrides: Partial<LightdashConfig['persistentDownloadUrls']> = {},
 ) =>
     new PersistentDownloadFileService({
+        analytics: {
+            track: vi.fn(),
+        } as unknown as LightdashAnalytics,
         lightdashConfig: {
             ...lightdashConfigMock,
             persistentDownloadUrls: {

--- a/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
+++ b/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
@@ -5,10 +5,13 @@ import {
 } from '@lightdash/common';
 import { nanoid } from 'nanoid';
 import { type Readable } from 'stream';
+import {
+    ANONYMOUS_TRACKING_UUID,
+    type LightdashAnalytics,
+} from '../../analytics/LightdashAnalytics';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
 import { LightdashConfig } from '../../config/parseConfig';
 import { PersistentDownloadFileModel } from '../../models/PersistentDownloadFileModel';
-import { type LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { BaseService } from '../BaseService';
 
 export type PersistentDownloadFileSource =
@@ -51,6 +54,16 @@ export class PersistentDownloadFileService extends BaseService {
         this.fileStorageClient = fileStorageClient;
     }
 
+    private safelyTrack(track: () => void): void {
+        try {
+            track();
+        } catch {
+            this.logger.warn(
+                'Unable to track persistent download file lifecycle event',
+            );
+        }
+    }
+
     async createPersistentUrl(data: {
         s3Key: string;
         fileType: string;
@@ -90,18 +103,20 @@ export class PersistentDownloadFileService extends BaseService {
         const expiresAt = new Date(Date.now() + expirationSeconds * 1000);
         const source = data.source ?? 'other';
         const createStartedAt = Date.now();
-        this.analytics?.track({
-            event: 'persistent_file.generation_requested',
-            userId: data.createdByUserUuid ?? undefined,
-            properties: {
-                fileUuid: fileNanoid,
-                organizationId: data.organizationUuid,
-                projectId: data.projectUuid,
-                createdByUserUuid: data.createdByUserUuid,
-                fileType: data.fileType,
-                source,
-                expirationSeconds,
-            },
+        this.safelyTrack(() => {
+            this.analytics?.track({
+                event: 'persistent_file.generation_requested',
+                userId: data.createdByUserUuid ?? ANONYMOUS_TRACKING_UUID,
+                properties: {
+                    fileUuid: fileNanoid,
+                    organizationId: data.organizationUuid,
+                    projectId: data.projectUuid,
+                    createdByUserUuid: data.createdByUserUuid,
+                    fileType: data.fileType,
+                    source,
+                    expirationSeconds,
+                },
+            });
         });
         await this.persistentDownloadFileModel.create({
             nanoid: fileNanoid,
@@ -112,19 +127,21 @@ export class PersistentDownloadFileService extends BaseService {
             createdByUserUuid: data.createdByUserUuid,
             expiresAt,
         });
-        this.analytics?.track({
-            event: 'persistent_file.generation_completed',
-            userId: data.createdByUserUuid ?? undefined,
-            properties: {
-                fileUuid: fileNanoid,
-                organizationId: data.organizationUuid,
-                projectId: data.projectUuid,
-                createdByUserUuid: data.createdByUserUuid,
-                fileType: data.fileType,
-                source,
-                expirationSeconds,
-                durationMs: Date.now() - createStartedAt,
-            },
+        this.safelyTrack(() => {
+            this.analytics?.track({
+                event: 'persistent_file.generation_completed',
+                userId: data.createdByUserUuid ?? ANONYMOUS_TRACKING_UUID,
+                properties: {
+                    fileUuid: fileNanoid,
+                    organizationId: data.organizationUuid,
+                    projectId: data.projectUuid,
+                    createdByUserUuid: data.createdByUserUuid,
+                    fileType: data.fileType,
+                    source,
+                    expirationSeconds,
+                    durationMs: Date.now() - createStartedAt,
+                },
+            });
         });
 
         const url = new URL(
@@ -201,6 +218,7 @@ export class PersistentDownloadFileService extends BaseService {
         requestContext?: {
             ip: string | undefined;
             userAgent: string | undefined;
+            requestedByUserUuid: string | null;
         },
     ): Promise<{
         stream: Readable;
@@ -209,36 +227,40 @@ export class PersistentDownloadFileService extends BaseService {
     }> {
         const file = await this.getValidFile(fileNanoid);
         const requestStartedAt = Date.now();
-        this.analytics?.track({
-            event: 'persistent_file.url_requested',
-            userId: requestContext?.requestedByUserUuid ?? undefined,
-            properties: {
-                fileUuid: fileNanoid,
-                organizationId: file.organization_uuid,
-                projectId: file.project_uuid,
-                createdByUserUuid: file.created_by_user_uuid,
-                requestedByUserUuid:
-                    requestContext?.requestedByUserUuid ?? null,
-                source: 'api',
-            },
+        const requestedByUserUuid =
+            requestContext?.requestedByUserUuid ?? null;
+        this.safelyTrack(() => {
+            this.analytics?.track({
+                event: 'persistent_file.url_requested',
+                userId: requestedByUserUuid ?? ANONYMOUS_TRACKING_UUID,
+                properties: {
+                    fileUuid: fileNanoid,
+                    organizationId: file.organization_uuid,
+                    projectId: file.project_uuid,
+                    createdByUserUuid: file.created_by_user_uuid,
+                    requestedByUserUuid,
+                    source: 'api',
+                },
+            });
         });
 
         const stream = await this.fileStorageClient.getFileStream(file.s3_key);
 
-        this.analytics?.track({
-            event: 'persistent_file.url_responded',
-            userId: requestContext?.requestedByUserUuid ?? undefined,
-            properties: {
-                fileUuid: fileNanoid,
-                organizationId: file.organization_uuid,
-                projectId: file.project_uuid,
-                createdByUserUuid: file.created_by_user_uuid,
-                requestedByUserUuid:
-                    requestContext?.requestedByUserUuid ?? null,
-                source: 'api',
-                statusCode: 200,
-                responseMs: Date.now() - requestStartedAt,
-            },
+        this.safelyTrack(() => {
+            this.analytics?.track({
+                event: 'persistent_file.url_responded',
+                userId: requestedByUserUuid ?? ANONYMOUS_TRACKING_UUID,
+                properties: {
+                    fileUuid: fileNanoid,
+                    organizationId: file.organization_uuid,
+                    projectId: file.project_uuid,
+                    createdByUserUuid: file.created_by_user_uuid,
+                    requestedByUserUuid,
+                    source: 'api',
+                    statusCode: 200,
+                    responseMs: Date.now() - requestStartedAt,
+                },
+            });
         });
 
         this.logger.info(

--- a/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
+++ b/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
@@ -8,9 +8,21 @@ import { type Readable } from 'stream';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
 import { LightdashConfig } from '../../config/parseConfig';
 import { PersistentDownloadFileModel } from '../../models/PersistentDownloadFileModel';
+import { type LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { BaseService } from '../BaseService';
 
+export type PersistentDownloadFileSource =
+    | 'chart'
+    | 'dashboard'
+    | 'sql_chart'
+    | 'pivot'
+    | 'analytics'
+    | 'async_query'
+    | 'scheduler'
+    | 'other';
+
 type PersistentDownloadFileServiceArguments = {
+    analytics?: LightdashAnalytics;
     lightdashConfig: LightdashConfig;
     persistentDownloadFileModel: PersistentDownloadFileModel;
     fileStorageClient: FileStorageClient;
@@ -19,6 +31,7 @@ type PersistentDownloadFileServiceArguments = {
 const PERSISTENT_URL_S3_EXPIRY_SECONDS = 300; // 5 minutes
 
 export class PersistentDownloadFileService extends BaseService {
+    private readonly analytics: LightdashAnalytics | undefined;
     private readonly lightdashConfig: LightdashConfig;
 
     private readonly persistentDownloadFileModel: PersistentDownloadFileModel;
@@ -26,11 +39,13 @@ export class PersistentDownloadFileService extends BaseService {
     private readonly fileStorageClient: FileStorageClient;
 
     constructor({
+        analytics,
         lightdashConfig,
         persistentDownloadFileModel,
         fileStorageClient,
     }: PersistentDownloadFileServiceArguments) {
         super();
+        this.analytics = analytics;
         this.lightdashConfig = lightdashConfig;
         this.persistentDownloadFileModel = persistentDownloadFileModel;
         this.fileStorageClient = fileStorageClient;
@@ -43,6 +58,7 @@ export class PersistentDownloadFileService extends BaseService {
         projectUuid: string | null;
         createdByUserUuid: string | null;
         expirationSeconds?: number;
+        source?: PersistentDownloadFileSource;
     }): Promise<string> {
         // Use the persistent-URL system when the instance enables it
         // (PERSISTENT_DOWNLOAD_URLS_ENABLED, off by default), or transparently
@@ -72,6 +88,21 @@ export class PersistentDownloadFileService extends BaseService {
             data.expirationSeconds ??
             this.lightdashConfig.persistentDownloadUrls.expirationSeconds;
         const expiresAt = new Date(Date.now() + expirationSeconds * 1000);
+        const source = data.source ?? 'other';
+        const createStartedAt = Date.now();
+        this.analytics?.track({
+            event: 'persistent_file.generation_requested',
+            userId: data.createdByUserUuid ?? undefined,
+            properties: {
+                fileUuid: fileNanoid,
+                organizationId: data.organizationUuid,
+                projectId: data.projectUuid,
+                createdByUserUuid: data.createdByUserUuid,
+                fileType: data.fileType,
+                source,
+                expirationSeconds,
+            },
+        });
         await this.persistentDownloadFileModel.create({
             nanoid: fileNanoid,
             s3Key: data.s3Key,
@@ -80,6 +111,20 @@ export class PersistentDownloadFileService extends BaseService {
             projectUuid: data.projectUuid,
             createdByUserUuid: data.createdByUserUuid,
             expiresAt,
+        });
+        this.analytics?.track({
+            event: 'persistent_file.generation_completed',
+            userId: data.createdByUserUuid ?? undefined,
+            properties: {
+                fileUuid: fileNanoid,
+                organizationId: data.organizationUuid,
+                projectId: data.projectUuid,
+                createdByUserUuid: data.createdByUserUuid,
+                fileType: data.fileType,
+                source,
+                expirationSeconds,
+                durationMs: Date.now() - createStartedAt,
+            },
         });
 
         const url = new URL(
@@ -135,6 +180,7 @@ export class PersistentDownloadFileService extends BaseService {
         requestContext?: {
             ip: string | undefined;
             userAgent: string | undefined;
+            requestedByUserUuid: string | null;
         },
     ): Promise<string> {
         const file = await this.getValidFile(fileNanoid);
@@ -162,8 +208,38 @@ export class PersistentDownloadFileService extends BaseService {
         s3Key: string;
     }> {
         const file = await this.getValidFile(fileNanoid);
+        const requestStartedAt = Date.now();
+        this.analytics?.track({
+            event: 'persistent_file.url_requested',
+            userId: requestContext?.requestedByUserUuid ?? undefined,
+            properties: {
+                fileUuid: fileNanoid,
+                organizationId: file.organization_uuid,
+                projectId: file.project_uuid,
+                createdByUserUuid: file.created_by_user_uuid,
+                requestedByUserUuid:
+                    requestContext?.requestedByUserUuid ?? null,
+                source: 'api',
+            },
+        });
 
         const stream = await this.fileStorageClient.getFileStream(file.s3_key);
+
+        this.analytics?.track({
+            event: 'persistent_file.url_responded',
+            userId: requestContext?.requestedByUserUuid ?? undefined,
+            properties: {
+                fileUuid: fileNanoid,
+                organizationId: file.organization_uuid,
+                projectId: file.project_uuid,
+                createdByUserUuid: file.created_by_user_uuid,
+                requestedByUserUuid:
+                    requestContext?.requestedByUserUuid ?? null,
+                source: 'api',
+                statusCode: 200,
+                responseMs: Date.now() - requestStartedAt,
+            },
+        });
 
         this.logger.info(
             `Serving persistent download (stream): nanoid=${fileNanoid}, ip=${requestContext?.ip}, userAgent=${requestContext?.userAgent}`,

--- a/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
+++ b/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
@@ -35,6 +35,7 @@ const PERSISTENT_URL_S3_EXPIRY_SECONDS = 300; // 5 minutes
 
 export class PersistentDownloadFileService extends BaseService {
     private readonly analytics: LightdashAnalytics;
+
     private readonly lightdashConfig: LightdashConfig;
 
     private readonly persistentDownloadFileModel: PersistentDownloadFileModel;

--- a/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
+++ b/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
@@ -213,8 +213,7 @@ export class PersistentDownloadFileService extends BaseService {
     }> {
         const file = await this.getValidFile(fileNanoid);
         const requestStartedAt = Date.now();
-        const requestedByUserUuid =
-            requestContext?.requestedByUserUuid ?? null;
+        const requestedByUserUuid = requestContext?.requestedByUserUuid ?? null;
         this.analytics.track({
             event: 'persistent_file.url_requested',
             userId: requestedByUserUuid ?? ANONYMOUS_TRACKING_UUID,

--- a/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
+++ b/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
@@ -25,7 +25,7 @@ export type PersistentDownloadFileSource =
     | 'other';
 
 type PersistentDownloadFileServiceArguments = {
-    analytics?: LightdashAnalytics;
+    analytics: LightdashAnalytics;
     lightdashConfig: LightdashConfig;
     persistentDownloadFileModel: PersistentDownloadFileModel;
     fileStorageClient: FileStorageClient;
@@ -34,7 +34,7 @@ type PersistentDownloadFileServiceArguments = {
 const PERSISTENT_URL_S3_EXPIRY_SECONDS = 300; // 5 minutes
 
 export class PersistentDownloadFileService extends BaseService {
-    private readonly analytics: LightdashAnalytics | undefined;
+    private readonly analytics: LightdashAnalytics;
     private readonly lightdashConfig: LightdashConfig;
 
     private readonly persistentDownloadFileModel: PersistentDownloadFileModel;
@@ -52,16 +52,6 @@ export class PersistentDownloadFileService extends BaseService {
         this.lightdashConfig = lightdashConfig;
         this.persistentDownloadFileModel = persistentDownloadFileModel;
         this.fileStorageClient = fileStorageClient;
-    }
-
-    private safelyTrack(track: () => void): void {
-        try {
-            track();
-        } catch {
-            this.logger.warn(
-                'Unable to track persistent download file lifecycle event',
-            );
-        }
     }
 
     async createPersistentUrl(data: {
@@ -103,20 +93,18 @@ export class PersistentDownloadFileService extends BaseService {
         const expiresAt = new Date(Date.now() + expirationSeconds * 1000);
         const source = data.source ?? 'other';
         const createStartedAt = Date.now();
-        this.safelyTrack(() => {
-            this.analytics?.track({
-                event: 'persistent_file.generation_requested',
-                userId: data.createdByUserUuid ?? ANONYMOUS_TRACKING_UUID,
-                properties: {
-                    fileUuid: fileNanoid,
-                    organizationId: data.organizationUuid,
-                    projectId: data.projectUuid,
-                    createdByUserUuid: data.createdByUserUuid,
-                    fileType: data.fileType,
-                    source,
-                    expirationSeconds,
-                },
-            });
+        this.analytics.track({
+            event: 'persistent_file.generation_requested',
+            userId: data.createdByUserUuid ?? ANONYMOUS_TRACKING_UUID,
+            properties: {
+                fileUuid: fileNanoid,
+                organizationId: data.organizationUuid,
+                projectId: data.projectUuid,
+                createdByUserUuid: data.createdByUserUuid,
+                fileType: data.fileType,
+                source,
+                expirationSeconds,
+            },
         });
         await this.persistentDownloadFileModel.create({
             nanoid: fileNanoid,
@@ -127,21 +115,19 @@ export class PersistentDownloadFileService extends BaseService {
             createdByUserUuid: data.createdByUserUuid,
             expiresAt,
         });
-        this.safelyTrack(() => {
-            this.analytics?.track({
-                event: 'persistent_file.generation_completed',
-                userId: data.createdByUserUuid ?? ANONYMOUS_TRACKING_UUID,
-                properties: {
-                    fileUuid: fileNanoid,
-                    organizationId: data.organizationUuid,
-                    projectId: data.projectUuid,
-                    createdByUserUuid: data.createdByUserUuid,
-                    fileType: data.fileType,
-                    source,
-                    expirationSeconds,
-                    durationMs: Date.now() - createStartedAt,
-                },
-            });
+        this.analytics.track({
+            event: 'persistent_file.generation_completed',
+            userId: data.createdByUserUuid ?? ANONYMOUS_TRACKING_UUID,
+            properties: {
+                fileUuid: fileNanoid,
+                organizationId: data.organizationUuid,
+                projectId: data.projectUuid,
+                createdByUserUuid: data.createdByUserUuid,
+                fileType: data.fileType,
+                source,
+                expirationSeconds,
+                durationMs: Date.now() - createStartedAt,
+            },
         });
 
         const url = new URL(
@@ -229,38 +215,34 @@ export class PersistentDownloadFileService extends BaseService {
         const requestStartedAt = Date.now();
         const requestedByUserUuid =
             requestContext?.requestedByUserUuid ?? null;
-        this.safelyTrack(() => {
-            this.analytics?.track({
-                event: 'persistent_file.url_requested',
-                userId: requestedByUserUuid ?? ANONYMOUS_TRACKING_UUID,
-                properties: {
-                    fileUuid: fileNanoid,
-                    organizationId: file.organization_uuid,
-                    projectId: file.project_uuid,
-                    createdByUserUuid: file.created_by_user_uuid,
-                    requestedByUserUuid,
-                    source: 'api',
-                },
-            });
+        this.analytics.track({
+            event: 'persistent_file.url_requested',
+            userId: requestedByUserUuid ?? ANONYMOUS_TRACKING_UUID,
+            properties: {
+                fileUuid: fileNanoid,
+                organizationId: file.organization_uuid,
+                projectId: file.project_uuid,
+                createdByUserUuid: file.created_by_user_uuid,
+                requestedByUserUuid,
+                source: 'api',
+            },
         });
 
         const stream = await this.fileStorageClient.getFileStream(file.s3_key);
 
-        this.safelyTrack(() => {
-            this.analytics?.track({
-                event: 'persistent_file.url_responded',
-                userId: requestedByUserUuid ?? ANONYMOUS_TRACKING_UUID,
-                properties: {
-                    fileUuid: fileNanoid,
-                    organizationId: file.organization_uuid,
-                    projectId: file.project_uuid,
-                    createdByUserUuid: file.created_by_user_uuid,
-                    requestedByUserUuid,
-                    source: 'api',
-                    statusCode: 200,
-                    responseMs: Date.now() - requestStartedAt,
-                },
-            });
+        this.analytics.track({
+            event: 'persistent_file.url_responded',
+            userId: requestedByUserUuid ?? ANONYMOUS_TRACKING_UUID,
+            properties: {
+                fileUuid: fileNanoid,
+                organizationId: file.organization_uuid,
+                projectId: file.project_uuid,
+                createdByUserUuid: file.created_by_user_uuid,
+                requestedByUserUuid,
+                source: 'api',
+                statusCode: 200,
+                responseMs: Date.now() - requestStartedAt,
+            },
         });
 
         this.logger.info(

--- a/packages/backend/src/services/PivotTableService/PivotTableService.ts
+++ b/packages/backend/src/services/PivotTableService/PivotTableService.ts
@@ -368,6 +368,7 @@ export class PivotTableService extends BaseService {
                     projectUuid,
                     createdByUserUuid,
                     expirationSeconds: expirationSecondsOverride,
+                    source: 'pivot',
                 });
             return {
                 filename: fileName,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -712,6 +712,7 @@ export class ServiceRepository
             'persistentDownloadFileService',
             () =>
                 new PersistentDownloadFileService({
+                    analytics: this.context.lightdashAnalytics,
                     lightdashConfig: this.context.lightdashConfig,
                     persistentDownloadFileModel:
                         this.models.getPersistentDownloadFileModel(),


### PR DESCRIPTION
## Summary
- Re-land persistent download file lifecycle analytics for persistent file creation and public file access.
- Preserve the existing event names and emit stored file organization/project context plus file type and source.
- Public anonymous requests use the all-zeros tracking UUID as the analytics identity while retaining `requestedByUserUuid: null`.
- Generation events use the same fallback identity for scheduler and worker contexts with no user.
- The original instrumentation was reverted because anonymous public download requests had no user identity and the tracking call threw.

## Runtime verification
- Started this worktree with persistent download URLs enabled and sent analytics to a local gzip-capable sink.
- Created a CSV through the async query download API, then fetched its persistent URL with no cookies: HTTP 200 with an 89-byte CSV response.
- The sink received generation events with the real user UUID and the two anonymous URL events below; backend logs contained no tracking exception.

~~~json
{"event":"lightdash_server.persistent_file.url_requested","userId":"00000000-0000-0000-0000-000000000000","properties":{"fileUuid":"7vGmKLAxRuZgRImDm9CqA","organizationId":"172a2270-000f-42be-9c68-c4752c23ae51","projectId":"3675b69e-8324-4110-bdca-059031aa8da3","createdByUserUuid":"b264d83a-9000-426a-85ec-3f9c20f368ce","requestedByUserUuid":null,"source":"api"},"context":{"app":{"namespace":"lightdash","name":"lightdash_server","version":"0.3457.2","mode":"development","siteUrl":null,"installId":"6a17c977-67e1-457c-acc2-558429a74cf9","installType":"unknown"},"library":{"name":"analytics-node","version":"2.1.1"}},"type":"track","channel":"server","_metadata":{"nodeVersion":"20.19.6"},"originalTimestamp":"2026-07-22T20:45:04.899Z","messageId":"23d340bb-94b9-4289-8ddd-dd9bf2b240e6","sentAt":"2026-07-22T20:45:14.761Z"}
{"event":"lightdash_server.persistent_file.url_responded","userId":"00000000-0000-0000-0000-000000000000","properties":{"fileUuid":"7vGmKLAxRuZgRImDm9CqA","organizationId":"172a2270-000f-42be-9c68-c4752c23ae51","projectId":"3675b69e-8324-4110-bdca-059031aa8da3","createdByUserUuid":"b264d83a-9000-426a-85ec-3f9c20f368ce","requestedByUserUuid":null,"source":"api","statusCode":200,"responseMs":10},"context":{"app":{"namespace":"lightdash","name":"lightdash_server","version":"0.3457.2","mode":"development","siteUrl":null,"installId":"6a17c977-67e1-457c-acc2-558429a74cf9","installType":"unknown"},"library":{"name":"analytics-node","version":"2.1.1"}},"type":"track","channel":"server","_metadata":{"nodeVersion":"20.19.6"},"originalTimestamp":"2026-07-22T20:45:04.909Z","messageId":"34f3ba84-4d48-4f09-b24e-d89456cf0f8a","sentAt":"2026-07-22T20:45:14.761Z"}
~~~

## Events
- `persistent_file.generation_requested`: `fileUuid`, `organizationId`, `projectId`, `createdByUserUuid`, `fileType`, `source`, `expirationSeconds`
- `persistent_file.generation_completed`: same properties plus `durationMs`
- `persistent_file.url_requested`: `fileUuid`, `organizationId`, `projectId`, `createdByUserUuid`, `requestedByUserUuid`, `source`
- `persistent_file.url_responded`: same properties plus `statusCode`, `responseMs`

Verified by runtime test above; CI will run repository checks.

Linear: SPK-631