### PR TITLE
feat(analytics): describe row/column limits, column customization and table-calc functions on chart save events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -613,7 +613,6 @@ type UpdateSavedChartEvent = BaseTrack & {
         hasColumnLimit: boolean;
         columnLimit: number | null;
         customColumnWidthsCount: number;
-        wrapColumnTitles: boolean;
         tableCalculationFunctions: string[];
         hasAverageDistinctAdditionalMetric: boolean;
         numCustomGroupBinCustomDimensions: number;
@@ -772,7 +771,6 @@ export type CreateSavedChartVersionEvent = BaseTrack & {
         hasColumnLimit: boolean;
         columnLimit: number | null;
         customColumnWidthsCount: number;
-        wrapColumnTitles: boolean;
         tableCalculationFunctions: string[];
         hasAverageDistinctAdditionalMetric: boolean;
     };

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -608,6 +608,15 @@ type UpdateSavedChartEvent = BaseTrack & {
         savedQueryId: string;
         dashboardId: string | undefined;
         virtualViewId: string | undefined;
+        hasRowLimit: boolean;
+        rowLimitCount: number | null;
+        hasColumnLimit: boolean;
+        columnLimit: number | null;
+        customColumnWidthsCount: number;
+        wrapColumnTitles: boolean;
+        tableCalculationFunctions: string[];
+        hasAverageDistinctAdditionalMetric: boolean;
+        numCustomGroupBinCustomDimensions: number;
     };
 };
 type DeleteSavedChartEvent = BaseTrack & {
@@ -755,8 +764,17 @@ export type CreateSavedChartVersionEvent = BaseTrack & {
         numFixedWidthBinCustomDimensions: number;
         numFixedBinsBinCustomDimensions: number;
         numCustomRangeBinCustomDimensions: number;
+        numCustomGroupBinCustomDimensions: number;
         numCustomSqlDimensions: number;
         parametersCount: number;
+        hasRowLimit: boolean;
+        rowLimitCount: number | null;
+        hasColumnLimit: boolean;
+        columnLimit: number | null;
+        customColumnWidthsCount: number;
+        wrapColumnTitles: boolean;
+        tableCalculationFunctions: string[];
+        hasAverageDistinctAdditionalMetric: boolean;
     };
 };
 

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -35,6 +35,7 @@ import {
     isValidTimezone,
     KnexPaginateArgs,
     KnexPaginatedData,
+    MetricType,
     MissingConfigError,
     NotFoundError,
     ParameterError,
@@ -118,6 +119,17 @@ type SavedChartServiceArguments = {
 type GoogleSheetValidationOptions = {
     validateGoogleSheet: boolean;
 };
+
+const TABLE_CALCULATION_FUNCTIONS = [
+    { name: 'total', pattern: /\btotal\b/i },
+    { name: 'row_total', pattern: /\brow_total\b/i },
+    { name: 'row', pattern: /\brow\b/i },
+    { name: 'offset', pattern: /\boffset\b/i },
+    { name: 'index', pattern: /\bindex\b/i },
+    { name: 'lookup', pattern: /\blookup\b/i },
+    { name: 'offset_list', pattern: /\boffset_list\b/i },
+    { name: 'list', pattern: /\blist\b/i },
+] as const;
 
 export class SavedChartService
     extends BaseService
@@ -389,6 +401,48 @@ export class SavedChartService
                     : undefined,
             parametersCount: Object.keys(savedChart.parameters || {}).length,
             ...countCustomDimensionsInMetricQuery(savedChart.metricQuery),
+            ...SavedChartService.getChartConfigEventProperties(savedChart),
+        };
+    }
+
+    static getChartConfigEventProperties(savedChart: SavedChartDAO) {
+        const tableConfig =
+            savedChart.chartConfig.type === ChartType.TABLE
+                ? savedChart.chartConfig.config
+                : undefined;
+        const cartesianConfig =
+            savedChart.chartConfig.type === ChartType.CARTESIAN
+                ? savedChart.chartConfig.config
+                : undefined;
+        const rowLimit = tableConfig?.rowLimit ?? cartesianConfig?.rowLimit;
+        const columnLimit = cartesianConfig?.columnLimit;
+
+        return {
+            hasRowLimit: rowLimit !== undefined,
+            rowLimitCount: rowLimit?.count ?? null,
+            hasColumnLimit: columnLimit !== undefined,
+            columnLimit: columnLimit ?? null,
+            customColumnWidthsCount: Object.values(
+                tableConfig?.columns ?? {},
+            ).filter((column) => column.width !== undefined).length,
+            wrapColumnTitles: tableConfig?.wrapColumnTitles === true,
+            tableCalculationFunctions: TABLE_CALCULATION_FUNCTIONS.filter(
+                ({ pattern }) =>
+                    savedChart.metricQuery.tableCalculations.some(
+                        (tableCalculation) =>
+                            (isSqlTableCalculation(tableCalculation) &&
+                                pattern.test(tableCalculation.sql)) ||
+                            (isFormulaTableCalculation(tableCalculation) &&
+                                pattern.test(tableCalculation.formula)),
+                    ),
+            ).map(({ name }) => name),
+            hasAverageDistinctAdditionalMetric:
+                savedChart.metricQuery.additionalMetrics?.some(
+                    (metric) => metric.type === MetricType.AVERAGE_DISTINCT,
+                ) ?? false,
+            numCustomGroupBinCustomDimensions:
+                countCustomDimensionsInMetricQuery(savedChart.metricQuery)
+                    .numCustomGroupBinCustomDimensions,
         };
     }
 
@@ -836,6 +890,7 @@ export class SavedChartService
                     cachedExplore?.type === ExploreType.VIRTUAL
                         ? cachedExplore.name
                         : undefined,
+                ...SavedChartService.getChartConfigEventProperties(savedChart),
             },
         });
         if (dashboardUuid && !savedChart.dashboardUuid) {

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -425,7 +425,6 @@ export class SavedChartService
             customColumnWidthsCount: Object.values(
                 tableConfig?.columns ?? {},
             ).filter((column) => column.width !== undefined).length,
-            wrapColumnTitles: tableConfig?.wrapColumnTitles === true,
             tableCalculationFunctions: TABLE_CALCULATION_FUNCTIONS.filter(
                 ({ pattern }) =>
                     savedChart.metricQuery.tableCalculations.some(

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -432,7 +432,6 @@ export type TableChart = {
     showTableNames?: boolean;
     /** Hide row number column */
     hideRowNumbers?: boolean;
-    wrapColumnTitles?: boolean;
     /** Show total results count */
     showResultsTotal?: boolean;
     /** Show subtotal rows */

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -432,6 +432,7 @@ export type TableChart = {
     showTableNames?: boolean;
     /** Hide row number column */
     hideRowNumbers?: boolean;
+    wrapColumnTitles?: boolean;
     /** Show total results count */
     showResultsTotal?: boolean;
     /** Show subtotal rows */


### PR DESCRIPTION
Adds derived configuration properties to `saved_chart.created` and `saved_chart.updated` for row and column limits, custom column widths, table-calculation functions, average-distinct additional metrics, and custom-group dimensions. Header wrapping is not tracked because it is not a current chart configuration feature.

Events/properties added: `saved_chart.created` and `saved_chart.updated` now include `hasRowLimit`, `rowLimitCount`, `hasColumnLimit`, `columnLimit`, `customColumnWidthsCount`, `tableCalculationFunctions`, `hasAverageDistinctAdditionalMetric`, and `numCustomGroupBinCustomDimensions`.

## Runtime verification

API chart saves were exercised with the custom-group-bins flag enabled; gzip sink captured `lightdash_server.saved_chart.updated` payloads:

```json
{"hasRowLimit":true,"rowLimitCount":2,"hasColumnLimit":true,"columnLimit":3,"customColumnWidthsCount":0,"tableCalculationFunctions":[],"hasAverageDistinctAdditionalMetric":false,"numCustomGroupBinCustomDimensions":0}
{"hasRowLimit":false,"rowLimitCount":null,"hasColumnLimit":false,"columnLimit":null,"customColumnWidthsCount":2,"tableCalculationFunctions":[],"hasAverageDistinctAdditionalMetric":false,"numCustomGroupBinCustomDimensions":0}
{"hasRowLimit":false,"rowLimitCount":null,"hasColumnLimit":false,"columnLimit":null,"customColumnWidthsCount":0,"tableCalculationFunctions":["total","offset"],"hasAverageDistinctAdditionalMetric":false,"numCustomGroupBinCustomDimensions":0}
{"hasRowLimit":false,"rowLimitCount":null,"hasColumnLimit":false,"columnLimit":null,"customColumnWidthsCount":0,"tableCalculationFunctions":[],"hasAverageDistinctAdditionalMetric":true,"numCustomGroupBinCustomDimensions":1}
{"hasRowLimit":false,"rowLimitCount":null,"hasColumnLimit":false,"columnLimit":null,"customColumnWidthsCount":0,"tableCalculationFunctions":[],"hasAverageDistinctAdditionalMetric":false,"numCustomGroupBinCustomDimensions":0}
```

Verified by runtime sink; local static checks intentionally skipped.

Linear: SPK-632
Linear: SPK-642
Linear: SPK-637