### PR TITLE
fix(analytics): make onboarding funnel events fire before the tracking SDK is ready

### DIFF
--- a/packages/frontend/src/providers/Tracking/TrackingProvider.tsx
+++ b/packages/frontend/src/providers/Tracking/TrackingProvider.tsx
@@ -21,6 +21,10 @@ import {
 } from './types';
 import useTracking from './useTracking';
 
+type PendingTrack = (analytics: typeof rudderSDK) => void;
+
+const pendingTracks: PendingTrack[] = [];
+
 const TrackingProviderMain: FC<React.PropsWithChildren<TrackingData>> = ({
     rudder,
     page: pageContext,
@@ -84,6 +88,13 @@ const TrackingProviderMain: FC<React.PropsWithChildren<TrackingData>> = ({
         }
     }, [rudder, writeKey, dataPlaneUrl]);
 
+    useEffect(() => {
+        if (!rudderAnalytics) return;
+        pendingTracks
+            .splice(0)
+            .forEach((pendingTrack) => pendingTrack(rudderAnalytics));
+    }, [rudderAnalytics]);
+
     const page = useCallback(
         (rudderPageEvent: PageData): void => {
             const newPageContext = getLightdashPageProperties(rudderPageEvent);
@@ -102,16 +113,26 @@ const TrackingProviderMain: FC<React.PropsWithChildren<TrackingData>> = ({
 
     const track = useCallback(
         ({ name, properties = {} }: EventData): void => {
-            rudderAnalytics?.track(
-                `${LIGHTDASH_APP_NAME}.${name}`,
-                properties,
-                {
+            const sendTrack: PendingTrack = (analytics) =>
+                analytics.track(`${LIGHTDASH_APP_NAME}.${name}`, properties, {
                     ...lightdashContext,
                     section: sectionContext,
-                } as rudderSDK.apiOptions,
-            );
+                } as rudderSDK.apiOptions);
+
+            if (rudderAnalytics) {
+                sendTrack(rudderAnalytics);
+            } else if (rudder || (writeKey && dataPlaneUrl)) {
+                pendingTracks.push(sendTrack);
+            }
         },
-        [rudderAnalytics, sectionContext, lightdashContext],
+        [
+            rudderAnalytics,
+            rudder,
+            writeKey,
+            dataPlaneUrl,
+            sectionContext,
+            lightdashContext,
+        ],
     );
     const identify = useCallback(
         ({ id, traits }: IdentifyData) => {


### PR DESCRIPTION
## What / why

The onboarding call sites are wired and the tracking provider is mounted on unauthenticated routes, but `track()` silently discarded calls made before the asynchronously loaded SDK became ready. Once-only onboarding effects marked themselves as fired after those dropped calls, so they never retried.

Configured tracking calls are now queued centrally with their event properties and page/section context, then flushed when the SDK becomes ready. This guarantees delivery without adding readiness handling to each onboarding call site; tracking-disabled deployments keep the existing no-op behavior.

## Events covered

- `signup_form.submitted` — `variant`
- `otp.resend_clicked` — `purpose`
- `login_flow.method_selected` — `method`
- `organization_setup_step.completed` — `step`
- `organization_brand.detected` — `found`, `autoApplied`
- `onboarding_warehouse.selected` — `warehouse`, `tier`
- `setup_invite.sent` — no properties
- `playground_project.entered` — no properties
- `onboarding_project_ready.start_exploring_clicked` — `projectId`
- `agent_setup_prompt.copied` — no properties

## Runtime verification

Verified with the real browserless Chrome over CDP and `new-onboarding` forced on. The tracking SDK control-plane response was delayed by 10 seconds so each action fired before readiness. All three events arrived once after queue flush and remained at count 1 after readiness; the sink also decoded backend gzip batches.

```json
{"event":"lightdash_webapp.signup_form.submitted","properties":{"variant":"email_only"},"type":"track","context":{"page":{"path":"/register","name":"register"}}}
{"event":"lightdash_webapp.otp.resend_clicked","properties":{"purpose":"signup_verification"},"type":"track","context":{"page":{"path":"/verify-email","name":"verify_email"}}}
{"event":"lightdash_webapp.login_flow.method_selected","properties":{"method":"email_otp"},"type":"track","context":{"page":{"path":"/login","name":"login"}}}
```

verified by CI (local checks intentionally skipped)

Linear: SPK-626