### PR TITLE
feat(frontend): add Mantine 8 TagPill

### DIFF
--- a/packages/frontend/src/components/common/TagsInput/TagPill.module.css
+++ b/packages/frontend/src/components/common/TagsInput/TagPill.module.css
@@ -1,0 +1,84 @@
+.root {
+    display: flex;
+    align-items: center;
+    background-color: light-dark(
+        var(--mantine-color-ldGray-1),
+        var(--mantine-color-ldDark-7)
+    );
+    color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldDark-0)
+    );
+    font-weight: 500;
+    border-radius: var(--tag-pill-radius, var(--mantine-radius-sm));
+    cursor: default;
+    user-select: none;
+    max-width: calc(100% - 20px);
+}
+
+.root[data-disabled] {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-3),
+        var(--mantine-color-ldDark-5)
+    );
+    color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldDark-1)
+    );
+    cursor: not-allowed;
+}
+
+.root[data-size='xs'] {
+    height: 16px;
+    font-size: 10px;
+    padding-left: calc(var(--mantine-spacing-xs) / 1.5);
+}
+
+.root[data-size='sm'] {
+    height: 22px;
+    font-size: 12px;
+    padding-left: calc(var(--mantine-spacing-sm) / 1.5);
+}
+
+.root[data-size='md'] {
+    height: 26px;
+    font-size: 14px;
+    padding-left: calc(var(--mantine-spacing-md) / 1.5);
+}
+
+.root[data-static][data-size='xs'] {
+    padding-right: var(--mantine-spacing-xs);
+}
+
+.root[data-static][data-size='sm'] {
+    padding-right: var(--mantine-spacing-sm);
+}
+
+.root[data-static][data-size='md'] {
+    padding-right: var(--mantine-spacing-md);
+}
+
+.label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.remove {
+    color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldDark-0)
+    );
+}
+
+.root[data-size='xs'] .remove {
+    margin-left: calc(var(--mantine-spacing-xs) / 6);
+}
+
+.root[data-size='sm'] .remove {
+    margin-left: calc(var(--mantine-spacing-sm) / 6);
+}
+
+.root[data-size='md'] .remove {
+    margin-left: calc(var(--mantine-spacing-md) / 6);
+}

--- a/packages/frontend/src/components/common/TagsInput/TagPill.test.tsx
+++ b/packages/frontend/src/components/common/TagsInput/TagPill.test.tsx
@@ -1,0 +1,37 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { TagPill } from './TagPill';
+
+describe('TagPill', () => {
+    it('renders the label', () => {
+        renderWithProviders(<TagPill label="my tag" />);
+        expect(screen.getByText('my tag')).toBeInTheDocument();
+    });
+
+    it('calls onRemove when the remove button is pressed', async () => {
+        const onRemove = vi.fn();
+        renderWithProviders(<TagPill label="my tag" onRemove={onRemove} />);
+        await userEvent.click(screen.getByRole('button', { hidden: true }));
+        expect(onRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders no remove button when readOnly', () => {
+        renderWithProviders(
+            <TagPill label="my tag" readOnly onRemove={() => {}} />,
+        );
+        expect(
+            screen.queryByRole('button', { hidden: true }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('renders no remove button when disabled', () => {
+        renderWithProviders(
+            <TagPill label="my tag" disabled onRemove={() => {}} />,
+        );
+        expect(
+            screen.queryByRole('button', { hidden: true }),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/common/TagsInput/TagPill.tsx
+++ b/packages/frontend/src/components/common/TagsInput/TagPill.tsx
@@ -1,0 +1,58 @@
+import { CloseButton } from '@mantine-8/core';
+import { type ComponentPropsWithoutRef, type FC } from 'react';
+import classes from './TagPill.module.css';
+
+export type TagPillSize = 'xs' | 'sm' | 'md';
+
+const closeButtonSizes: Record<TagPillSize, number> = {
+    xs: 16,
+    sm: 22,
+    md: 24,
+};
+
+export type TagPillProps = {
+    label: string;
+    onRemove?: () => void;
+    disabled?: boolean;
+    readOnly?: boolean;
+    size?: TagPillSize;
+} & Omit<ComponentPropsWithoutRef<'div'>, 'children'>;
+
+export const TagPill: FC<TagPillProps> = ({
+    label,
+    onRemove,
+    disabled = false,
+    readOnly = false,
+    size = 'sm',
+    className,
+    ...others
+}) => {
+    const isStatic = disabled || readOnly || !onRemove;
+
+    return (
+        <div
+            className={
+                className ? `${classes.root} ${className}` : classes.root
+            }
+            data-size={size}
+            data-disabled={disabled || undefined}
+            data-static={isStatic || undefined}
+            {...others}
+        >
+            <span className={classes.label}>{label}</span>
+
+            {!isStatic && (
+                <CloseButton
+                    aria-hidden
+                    onMouseDown={onRemove}
+                    size={closeButtonSizes[size]}
+                    radius={2}
+                    variant="transparent"
+                    iconSize="70%"
+                    className={classes.remove}
+                    tabIndex={-1}
+                />
+            )}
+        </div>
+    );
+};


### PR DESCRIPTION
## Summary

First of a 2-PR stack replacing the custom Mantine 6 `TagInput` with Mantine 8.

Adds `TagPill` — a Mantine 8 port of the old `TagInput/DefaultValue` pill (CSS module with `light-dark()` tokens, same sizes/colors/close-button behavior). No consumers change in this PR; #25999 migrates them and deletes the v6 component.

## Validation

- unit tests: render, remove-on-mousedown, readOnly/disabled hide the remove button
- frontend fast typecheck + oxlint