### PR TITLE
fix(frontend): close metrics catalog category popover on outside click

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -82,6 +82,8 @@ const EditPopover: FC<EditPopoverProps> = ({
             opened={opened}
             closeOnClickOutside
             width={200}
+            // Controlled v8 Popovers signal outside-click/Escape via onDismiss, not onClose
+            onDismiss={handleClose}
             onClose={handleClose}
             trapFocus={opened}
             shadow="sm"

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
@@ -247,6 +247,12 @@ export const MetricsCatalogCategoryForm: FC<Props> = memo(
         return (
             <Popover
                 opened={opened}
+                // Controlled v8 Popovers signal outside-click/Escape via onDismiss, not onClose
+                onDismiss={() => {
+                    if (!hasOpenSubPopover) {
+                        onClose?.();
+                    }
+                }}
                 onClose={() => {
                     // Only close the main popover if no sub-popovers are open
                     if (!hasOpenSubPopover) {


### PR DESCRIPTION
## Summary

Fixes the metrics catalog category popover (and its color-edit sub-popover) not closing on outside click or Escape.

## Root cause

Regression from the Mantine 8 Popover migration (#25748). In Mantine 8, a **controlled** Popover (`opened` prop set) no longer invokes the `onClose` prop on outside click — the internal click-outside handler calls `setOpened(false)`, which for controlled state only fires `onChange`. The v8 contract for controlled popovers is `onDismiss`, which fires on outside click and Escape. Both popovers here are controlled and only passed `onClose`, so dismiss interactions became no-ops. This also kept the `hasOpenSubPopover` guard stuck when the sub-popover was open.

## Fix

Add `onDismiss` handlers mirroring the existing `onClose` logic (including the `hasOpenSubPopover` guard on the main popover).

## Regression analysis

Additive only — `onClose` props are untouched, so any path that closes via parent state change behaves as before. Other controlled v8 Popovers in the codebase may have the same latent issue; this PR scopes to the reported surface.

## Validation

- verified live: popover closes on outside click, closes on Escape, reopens correctly afterward, and the select-category-then-click-outside flow works
- frontend fast typecheck + oxlint