### PR TITLE
feat: divert preview envs from a pre-seeded database snapshot

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -6,6 +6,13 @@ preview:
   - "docker/**/*"
   - "okteto.preview.yaml"
 
+# Previews divert their database from a pre-seeded snapshot of main; PRs that
+# change the seed data itself must migrate and seed from scratch instead
+preview_db_full:
+  - "examples/full-jaffle-shop-demo/**"
+  - "packages/backend/src/database/seeds/**"
+  - "packages/backend/src/ee/database/seeds/**"
+
 cli:
   - "packages/cli/**/*"
   - "packages/e2e/cypress/cli/**/*"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -163,6 +163,7 @@ jobs:
       api_schema: ${{ steps.changes.outputs.api_schema == 'true' }}
       timezone: ${{ steps.changes.outputs.timezone == 'true' || contains(github.event.pull_request.body, 'test-timezone') || contains(github.event.pull_request.body, 'test-all') }}
       cli: ${{ steps.changes.outputs.cli == 'true' || contains(github.event.pull_request.body, 'test-cli') || contains(github.event.pull_request.body, 'test-all') }}
+      db_divert: ${{ steps.changes.outputs.preview_db_full != 'true' }}
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -350,7 +351,7 @@ jobs:
           name: pr-${{ github.event.number }}
           timeout: 15m
           file: okteto.preview.yaml
-          variables: SITE_URL=https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev
+          variables: SITE_URL=https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev,DB_DIVERT=${{ needs.files-changed.outputs.db_divert }}
 
       - name: Set preview URL output
         run: echo "url=https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/preview-db-snapshot.yml
+++ b/.github/workflows/preview-db-snapshot.yml
@@ -1,0 +1,63 @@
+name: Preview DB Snapshot
+
+# Rebuilds the pre-seeded database snapshot that preview environments divert
+# from (see okteto.preview.yaml) whenever the data it contains would change.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/backend/src/database/migrations/**"
+      - "packages/backend/src/ee/database/migrations/**"
+      - "packages/backend/src/database/seeds/**"
+      - "packages/backend/src/ee/database/seeds/**"
+      - "examples/full-jaffle-shop-demo/**"
+      # A Postgres image change makes existing snapshots' PGDATA incompatible
+      - "docker/docker-compose.preview.yml"
+      - "docker/docker-compose.db-snapshot.yml"
+      - "scripts/preview-db-snapshot.sh"
+      - ".github/workflows/preview-db-snapshot.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-db-snapshot
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    name: Build and snapshot the preview database
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 45
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Okteto context
+        uses: okteto/context@5212ce5ebf9d3584bafd33f4a295a8521fc5abe7 # latest
+        with:
+          url: ${{ secrets.OKTETO_CONTEXT }}
+          token: ${{ secrets.OKTETO_TOKEN }}
+
+      - name: Create namespace if missing
+        run: okteto namespace create db-snapshot || true
+
+      - name: Reset builder state
+        run: |
+          okteto kubeconfig
+          # Start from a blank volume so changed seeds and migrations are
+          # fully re-applied instead of hitting the entrypoint's seed guard
+          kubectl -n db-snapshot delete deployment db-snapshot-seeder --ignore-not-found --wait
+          kubectl -n db-snapshot delete statefulset db-snapshot --ignore-not-found --wait
+          kubectl -n db-snapshot delete pvc db-data --ignore-not-found --wait
+
+      - name: Deploy database and seeder
+        run: okteto deploy -f docker/docker-compose.db-snapshot.yml --namespace db-snapshot --name db-snapshot --timeout 30m
+
+      - name: Snapshot the seeded volume
+        run: ./scripts/preview-db-snapshot.sh "${GITHUB_SHA::7}"

--- a/docker/CLAUDE.md
+++ b/docker/CLAUDE.md
@@ -68,6 +68,7 @@ services:
 -   `docker-compose.dev.yml`: Full development environment
 -   `docker-compose.dev.mini.yml`: Minimal setup
 -   `docker-compose.preview.yml`: Preview deployments
+-   `docker-compose.db-snapshot.yml`: Builds the pre-seeded database snapshot that previews divert from
 
 </importantToKnow>
 

--- a/docker/docker-compose.db-snapshot.yml
+++ b/docker/docker-compose.db-snapshot.yml
@@ -1,0 +1,57 @@
+# Builds the pre-seeded database that preview environments divert from.
+# Deployed by .github/workflows/preview-db-snapshot.yml into the persistent
+# db-snapshot namespace: the seeder runs the same entrypoint as previews
+# (dbt + migrate + seed) against a blank volume, then the workflow snapshots
+# the volume with scripts/preview-db-snapshot.sh.
+volumes:
+    db-data:
+        driver_opts:
+            # csi-okteto is required: the default storage class can't snapshot
+            class: csi-okteto
+            size: 2Gi
+
+services:
+    db-snapshot:
+        image: pgvector/pgvector:pg18
+        restart: always
+        environment:
+            # Must match the preview PGPASSWORD in okteto.preview.yaml: a
+            # database diverted from this snapshot keeps this password
+            - POSTGRES_PASSWORD=not-very-secret-preview-db
+        ports:
+            - '5432'
+        volumes:
+            - db-data:/var/lib/postgresql
+
+    db-snapshot-seeder:
+        build:
+            target: pr-runner
+            context: ..
+            dockerfile: dockerfile-prs
+        restart: always
+        depends_on:
+            - db-snapshot
+        environment:
+            NODE_ENV: production
+            DBT_DEMO_DIR: /usr/app
+            # Must match the preview LIGHTDASH_SECRET in
+            # docker-compose.preview.yml: the seed encrypts warehouse
+            # credentials with it, and a diverted preview must decrypt them
+            LIGHTDASH_SECRET: not very secret
+            PGHOST: db-snapshot
+            PGPORT: 5432
+            PGDATABASE: postgres
+            PGPASSWORD: not-very-secret-preview-db
+            PGUSER: postgres
+            PGMAXCONNECTIONS: 10
+            # Set in the okteto admin UI. EE migrations and seeds only run
+            # with a license key; without it diverted previews would be
+            # missing the enterprise seed data
+            LIGHTDASH_LICENSE_KEY: ${LIGHTDASH_LICENSE_KEY}
+            # Never used by migrate/seed, but loading the knexfile parses the
+            # full Lightdash config, which requires S3 settings to be present
+            S3_ENDPOINT: http://unused:9000
+            S3_BUCKET: unused
+            S3_REGION: unused
+        entrypoint: ['/usr/bin/renderDeployHook.sh']
+        command: ['sleep', 'infinity']

--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -1,5 +1,16 @@
 volumes:
     node_modules:
+    # When DB_SNAPSHOT_NAME is set (see okteto.preview.yaml), Okteto's webhook
+    # diverts this volume to a copy-on-write clone of a pre-seeded snapshot
+    # instead of a blank disk. Empty values deploy a normal blank volume.
+    # csi-okteto is required: the default storage class can't restore snapshots.
+    db-data:
+        driver_opts:
+            class: csi-okteto
+            size: 2Gi
+        labels:
+            dev.okteto.com/from-snapshot-name: ${DB_SNAPSHOT_NAME:-}
+            dev.okteto.com/from-snapshot-namespace: ${DB_SNAPSHOT_NAMESPACE:-}
 
 # Okteto specific
 endpoints:
@@ -15,6 +26,8 @@ services:
             - POSTGRES_PASSWORD=${PGPASSWORD}
         ports:
             - '5432'
+        volumes:
+            - db-data:/var/lib/postgresql
 
     headless-browser:
         build:

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -412,6 +412,12 @@ CMD ["node", "dist/index.js"]
 
 FROM prod AS pr-runner
 
+# psql is used by renderDeployHook.sh to detect a pre-seeded database
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    postgresql-client \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy demo dbt project for E2E testing
 COPY ./examples/full-jaffle-shop-demo/renderDeployHook.sh /usr/bin/renderDeployHook.sh
 COPY ./examples/full-jaffle-shop-demo/dbt /usr/app/dbt

--- a/examples/full-jaffle-shop-demo/renderDeployHook.sh
+++ b/examples/full-jaffle-shop-demo/renderDeployHook.sh
@@ -1,14 +1,36 @@
 #!/bin/bash
 set -e
 
-# Idempotent dbt commands
-dbt1.7 deps --project-dir /usr/app/dbt --profiles-dir /usr/app/profiles
-dbt1.7 seed --project-dir /usr/app/dbt --profiles-dir /usr/app/profiles --full-refresh
-dbt1.7 run --project-dir /usr/app/dbt --profiles-dir /usr/app/profiles --full-refresh
+# A database diverted from a pre-seeded snapshot (see okteto.preview.yaml)
+# already contains the dbt demo data and the Lightdash seed; it only needs
+# the branch's unapplied migrations. Any error in the check (blank database,
+# database not up yet) falls through to the full path.
+is_seeded() {
+    [ "$(psql -tAc "SELECT to_regclass('jaffle.orders') IS NOT NULL AND EXISTS (SELECT 1 FROM emails WHERE email = 'demo@lightdash.com')" 2>/dev/null)" = "t" ]
+}
 
-# Rollback all migrations and seed
-pnpm -F backend rollback-all-production
-pnpm -F backend migrate-production
-pnpm -F backend seed-production
+# Wait for the database before deciding which path to take, otherwise a
+# diverted database that is still starting up would be mistaken for blank
+for _ in $(seq 1 60); do
+    psql -tAc "SELECT 1" >/dev/null 2>&1 && break
+    sleep 2
+done
+
+if is_seeded; then
+    echo "Database diverted from snapshot: applying delta migrations only"
+    pnpm -F backend migrate-production
+else
+    echo "Database not pre-seeded: running full dbt + migrate + seed"
+
+    # Idempotent dbt commands
+    dbt1.7 deps --project-dir /usr/app/dbt --profiles-dir /usr/app/profiles
+    dbt1.7 seed --project-dir /usr/app/dbt --profiles-dir /usr/app/profiles --full-refresh
+    dbt1.7 run --project-dir /usr/app/dbt --profiles-dir /usr/app/profiles --full-refresh
+
+    # Rollback all migrations and seed
+    pnpm -F backend rollback-all-production
+    pnpm -F backend migrate-production
+    pnpm -F backend seed-production
+fi
 
 exec "$@"

--- a/okteto.preview.yaml
+++ b/okteto.preview.yaml
@@ -1,6 +1,49 @@
 deploy:
   commands:
-    - name: Generating postgres password...
-      command: echo "PGPASSWORD=$(openssl rand -hex 16)" >> "$OKTETO_ENV"
+    - name: Configuring database...
+      command: |
+        set -e
+        # Stable password shared with the snapshot builder
+        # (docker/docker-compose.db-snapshot.yml): a database diverted from a
+        # snapshot keeps the password it was initialised with, because
+        # Postgres ignores POSTGRES_PASSWORD when PGDATA already exists. The
+        # database is only reachable inside the cluster.
+        echo "PGPASSWORD=not-very-secret-preview-db" >> "$OKTETO_ENV"
+
+        # Divert: boot the preview database from the newest pre-seeded
+        # snapshot (built by .github/workflows/preview-db-snapshot.yml on
+        # main) so the entrypoint only runs the branch's delta migrations.
+        # Fall back to a blank volume and the full migrate + seed path when no
+        # snapshot is ready, or when the PR changes the seed data itself
+        # (DB_DIVERT=false, computed from changed files in pr.yml).
+        SNAPSHOT=""
+        if [ "${DB_DIVERT:-true}" = "true" ]; then
+          SNAPSHOT=$(kubectl get volumesnapshots -n db-snapshot \
+            -l app.kubernetes.io/part-of=lightdash-preview-db \
+            --sort-by=.metadata.creationTimestamp \
+            -o jsonpath='{range .items[?(@.status.readyToUse==true)]}{.metadata.name}{"\n"}{end}' \
+            2>/dev/null | tail -n 1 || true)
+        fi
+        if [ -n "$SNAPSHOT" ]; then
+          echo "Diverting preview database to snapshot db-snapshot/$SNAPSHOT"
+          echo "DB_SNAPSHOT_NAME=$SNAPSHOT" >> "$OKTETO_ENV"
+          echo "DB_SNAPSHOT_NAMESPACE=db-snapshot" >> "$OKTETO_ENV"
+        else
+          echo "No preview database snapshot available: migrating and seeding from scratch"
+        fi
+
+        # Recreate the database volume on every deploy (a fresh clone when
+        # diverting, blank otherwise) so each push to the PR still resets the
+        # database: e2e tests start from pristine seed data and edited
+        # migrations are re-applied.
+        kubectl delete statefulset db-preview --ignore-not-found --wait
+        # Previews deployed before db-preview had a volume ran it as a
+        # Deployment; remove it so Okteto can recreate it as a StatefulSet
+        kubectl delete deployment db-preview --ignore-not-found --wait
+        kubectl delete pvc db-data --ignore-not-found --wait
+        # Okteto does not restart a deployment whose spec is unchanged (e.g.
+        # re-running the deploy on the same commit); delete the app so its
+        # entrypoint always re-runs against the recreated database
+        kubectl delete deployment lightdash-preview --ignore-not-found --wait
     - name: Deploying compose...
       command: okteto deploy -f docker/docker-compose.preview.yml

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -2,6 +2,13 @@
 
 ## Okteto Preview Environment
 
+### `preview-db-snapshot.sh <suffix>`
+
+Snapshots the seeded preview database volume in the `db-snapshot` namespace so
+preview environments can divert from it instead of migrating + seeding from
+scratch. Run by `.github/workflows/preview-db-snapshot.yml` on merges to main
+that change migrations, seeds, or the jaffle demo project.
+
 ### `okteto-ssh.sh <pr_number>`
 
 SSH into a preview environment pod.

--- a/scripts/preview-db-snapshot.sh
+++ b/scripts/preview-db-snapshot.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -euo pipefail
+
+# Snapshots the seeded preview database volume in the db-snapshot namespace so
+# preview environments can divert from it (see okteto.preview.yaml). Expects
+# docker/docker-compose.db-snapshot.yml to be deployed in that namespace and
+# kubectl to be authenticated (okteto kubeconfig). Runs from
+# .github/workflows/preview-db-snapshot.yml.
+
+NAMESPACE="${DB_SNAPSHOT_NAMESPACE:-db-snapshot}"
+SNAPSHOT_NAME="preview-db-${1:?usage: preview-db-snapshot.sh <suffix, e.g. short sha>}"
+KEEP=3
+
+is_seeded() {
+    [ "$(kubectl -n "$NAMESPACE" exec statefulset/db-snapshot -- psql -U postgres -tAc \
+        "SELECT to_regclass('jaffle.orders') IS NOT NULL AND EXISTS (SELECT 1 FROM emails WHERE email = 'demo@lightdash.com')" \
+        2>/dev/null)" = "t" ]
+}
+
+echo "Waiting for the seeder to finish (dbt + migrate + seed)..."
+seeded=""
+for _ in $(seq 1 120); do
+    if is_seeded; then
+        seeded=true
+        break
+    fi
+    sleep 10
+done
+[ -n "$seeded" ] || {
+    echo "Timed out waiting for the seed to complete"
+    exit 1
+}
+
+# Flush to disk so the snapshot restores without WAL replay
+kubectl -n "$NAMESPACE" exec statefulset/db-snapshot -- psql -U postgres -c "CHECKPOINT;"
+
+kubectl -n "$NAMESPACE" apply -f - <<EOF
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: ${SNAPSHOT_NAME}
+  labels:
+    app.kubernetes.io/part-of: lightdash-preview-db
+spec:
+  volumeSnapshotClassName: okteto-snapshot-class
+  source:
+    persistentVolumeClaimName: db-data
+EOF
+
+echo "Waiting for ${SNAPSHOT_NAME} to be ready..."
+ready=""
+for _ in $(seq 1 60); do
+    if [ "$(kubectl -n "$NAMESPACE" get volumesnapshot "$SNAPSHOT_NAME" -o jsonpath='{.status.readyToUse}' 2>/dev/null)" = "true" ]; then
+        ready=true
+        break
+    fi
+    sleep 10
+done
+[ -n "$ready" ] || {
+    echo "Timed out waiting for the snapshot to be ready"
+    kubectl -n "$NAMESPACE" get volumesnapshot "$SNAPSHOT_NAME" -o yaml || true
+    exit 1
+}
+echo "Snapshot ${NAMESPACE}/${SNAPSHOT_NAME} is ready"
+
+# Previews always divert from the newest ready snapshot; keep a few for safety
+snapshots=$(kubectl -n "$NAMESPACE" get volumesnapshots \
+    -l app.kubernetes.io/part-of=lightdash-preview-db \
+    --sort-by=.metadata.creationTimestamp -o name)
+count=$(echo "$snapshots" | grep -c . || true)
+if [ "$count" -gt "$KEEP" ]; then
+    echo "$snapshots" | head -n $((count - KEEP)) | xargs kubectl -n "$NAMESPACE" delete
+fi


### PR DESCRIPTION
## Summary

Preview environments spend ~20 minutes running dbt + migrations + seed against a blank Postgres on every boot. This PR builds that database once on merges to `main`, snapshots the volume ([Okteto volume snapshots](https://www.okteto.com/docs/core/use-volume-snapshots/)), and **diverts** new previews to boot from a copy-on-write clone. The entrypoint then only applies the branch's unapplied migrations — usually none. Each preview still gets its own writable database; isolation is unchanged.

## How it works

- **Volume**: `db-preview` now stores PGDATA on a `csi-okteto` volume (the default storage class can't restore snapshots). When `okteto.preview.yaml` finds a ready snapshot in the `db-snapshot` namespace it sets the `dev.okteto.com/from-snapshot-*` labels so the PVC clones it; empty labels deploy a blank volume (current behaviour).
- **Entrypoint**: `renderDeployHook.sh` skips dbt + seed when the database is already seeded and runs `migrate-production` only. Blank databases take the existing full path — divert can never break preview creation.
- **Reset per push**: the db statefulset, app deployment, and volume are recreated on every deploy, so each push still starts from pristine data (e2e determinism) and edited migrations re-run.
- **Snapshot refresh**: a new `Preview DB Snapshot` workflow rebuilds the snapshot when migrations, seeds, or the jaffle demo project change on main (keeps the newest 3).
- **Safety valve**: PRs that change the seed data itself (`examples/full-jaffle-shop-demo/**`, backend seeds) deploy with `DB_DIVERT=false` and build from scratch — including this PR's own preview.
- **Stable credentials**: a cloned database keeps the `PGPASSWORD` and credential-encrypting `LIGHTDASH_SECRET` it was built with, so the builder and previews share fixed values (cluster-internal only).

## Validated end-to-end on the live cluster

Built the snapshot with the real builder compose + script in a test namespace, then deployed the real preview compose diverted from it in a second namespace:

- Entrypoint logged `Database diverted from snapshot: applying delta migrations only` → knex `Already up to date` (0 delta migrations)
- All 527 migrations (incl. EE) present in one batch; EE seed data (`embedding`) present — the builder gets `LIGHTDASH_LICENSE_KEY` from okteto admin variables since EE migrations *and seeds* are gated on it
- `/api/v1/health` ok; **~2–3 min to healthy vs ~20 min** on the full path
- Fallback verified: empty snapshot labels produce a plain blank volume and the full seed path

## Rollout

1. Merge — previews keep working via the fallback path (no snapshot exists yet).
2. Run the **Preview DB Snapshot** workflow once (`workflow_dispatch`) to create the `db-snapshot` namespace and first snapshot.
3. Subsequent preview deploys divert automatically; refreshes run on main when data-affecting files change.

Closes: SPK-297

https://claude.ai/code/session_01RmebrVJwigL6JnggGwpzQR