### PR TITLE
fix(frontend): remove recommended actions homepage toggle

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx
@@ -1,7 +1,7 @@
 import { type HomepageAskAiHeroBlock } from '@lightdash/common';
 import { MantineProvider } from '@mantine-8/core';
 import { render, screen } from '@testing-library/react';
-import { AskAiHeroBlockView } from './AskAiHeroBlock';
+import { AskAiHeroBlockBuild, AskAiHeroBlockView } from './AskAiHeroBlock';
 
 vi.mock('../DayOneAskInput', () => ({
     DayOneAskInput: () => <div data-testid="ask-input" />,
@@ -65,5 +65,27 @@ describe('AskAiHeroBlockView', () => {
         );
         expect(screen.queryByText(/What do you want to know/)).toBeNull();
         expect(screen.getByTestId('ask-input')).toBeInTheDocument();
+    });
+});
+
+describe('AskAiHeroBlockBuild', () => {
+    it('does not offer recommended actions configuration', () => {
+        wrap(
+            <AskAiHeroBlockBuild
+                itemSpan={null}
+                block={block}
+                projectUuid="p1"
+                onChange={vi.fn()}
+            />,
+        );
+
+        expect(
+            screen.getByRole('switch', { name: 'Show greeting' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('switch', {
+                name: 'Show recommended actions',
+            }),
+        ).not.toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx
@@ -105,19 +105,6 @@ export const AskAiHeroBlockBuild: FC<BuildComponentProps> = ({
                     })
                 }
             />
-            <Switch
-                label="Show recommended actions"
-                checked={block.config.showRecommendedActions === true}
-                onChange={(e) =>
-                    onChange({
-                        ...block,
-                        config: {
-                            ...block.config,
-                            showRecommendedActions: e.currentTarget.checked,
-                        },
-                    })
-                }
-            />
         </Stack>
     );
 };


### PR DESCRIPTION
## What changed

- Remove the **Show recommended actions** switch from the homepage builder v2 Ask AI hero settings.
- Keep existing saved homepage rendering behavior unchanged.
- Add regression coverage for the remaining builder controls.

## Why

Recommended actions should no longer be configurable from the homepage builder UI.

## Validation

- `pnpm -F frontend exec vitest run src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx`
- `pnpm -F frontend run linter ./src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.tsx ./src/ee/features/homepageBuilder/blocks/AskAiHeroBlock.test.tsx`
- `pnpm -F frontend typecheck:fast`