### PR TITLE
feat(metricflow): carry format from config.meta into translated metrics

### DIFF
--- a/examples/metricflow-demo/assert-translation.cjs
+++ b/examples/metricflow-demo/assert-translation.cjs
@@ -37,8 +37,8 @@ const result = translateMetricFlowMetrics({
 
 // Expected Lightdash metrics on the `orders` model (same for both specs).
 const expected = {
-    // group_label carried over from config.meta
-    total_revenue: { type: 'sum', sql: '${TABLE}.amount', group_label: 'Order Metrics' },
+    // group_label and format carried over from config.meta
+    total_revenue: { type: 'sum', sql: '${TABLE}.amount', group_label: 'Order Metrics', format: '$,.2f' },
     order_count: { type: 'count', sql: '${TABLE}.order_id' },
     unique_customers: { type: 'count_distinct', sql: '${TABLE}.customer_id' },
     average_order_value: { type: 'average', sql: '${TABLE}.amount' },

--- a/examples/metricflow-demo/latest-spec/models/orders.yml
+++ b/examples/metricflow-demo/latest-spec/models/orders.yml
@@ -34,10 +34,11 @@ models:
         type: simple
         agg: sum
         expr: amount
-        # group_label from config.meta carries over to the Lightdash metric.
+        # group_label and format from config.meta carry over to the Lightdash metric.
         config:
           meta:
             group_label: Order Metrics
+            format: '$,.2f'
       - name: order_count
         label: Order count
         type: simple

--- a/examples/metricflow-demo/legacy-spec/models/schema.yml
+++ b/examples/metricflow-demo/legacy-spec/models/schema.yml
@@ -109,10 +109,11 @@ metrics:
     type: simple
     type_params:
       measure: total_revenue
-    # group_label from config.meta carries over to the Lightdash metric.
+    # group_label and format from config.meta carry over to the Lightdash metric.
     config:
       meta:
         group_label: Order Metrics
+        format: '$,.2f'
   - name: order_count
     label: Order count
     type: simple

--- a/packages/common/src/dbt/metricFlow.test.ts
+++ b/packages/common/src/dbt/metricFlow.test.ts
@@ -1122,6 +1122,67 @@ describe('translateMetricFlowMetrics', () => {
             );
         });
 
+        it('carries format from a measure config.meta', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: {
+                    sm: {
+                        ...ordersSemanticModel,
+                        measures: [
+                            {
+                                name: 'total_revenue',
+                                agg: MetricFlowAggregation.SUM,
+                                expr: 'order_total',
+                                create_metric: true,
+                                config: {
+                                    meta: {
+                                        format: '$,.2f',
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+                metrics: {},
+                modelNamesByUniqueId,
+            });
+            expect(result.metricsByModel.orders.total_revenue.format).toBe(
+                '$,.2f',
+            );
+        });
+
+        it('carries format from a simple metric config.meta, winning over the measure', () => {
+            const result = translateMetricFlowMetrics({
+                semanticModels: {
+                    sm: {
+                        ...ordersSemanticModel,
+                        measures: [
+                            {
+                                name: 'order_total_sum',
+                                agg: MetricFlowAggregation.SUM,
+                                expr: 'order_total',
+                                config: {
+                                    meta: {
+                                        format: ',.0f',
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+                metrics: {
+                    m: simpleMetric('revenue', 'order_total_sum', {
+                        config: {
+                            meta: {
+                                format: '$,.2f',
+                            },
+                        },
+                    }),
+                },
+                modelNamesByUniqueId,
+            });
+            expect(result.metricsByModel.orders.revenue.format).toBe('$,.2f');
+        });
+
         it('lets metric-level meta win over measure-level meta', () => {
             const result = translateMetricFlowMetrics({
                 semanticModels: {

--- a/packages/common/src/dbt/metricFlow.ts
+++ b/packages/common/src/dbt/metricFlow.ts
@@ -312,6 +312,7 @@ export const translateMetricFlowMetrics = ({
             description?: string | null;
             hidden?: boolean | null;
             groupLabel?: string | null;
+            format?: string | null;
         },
     ):
         | { modelName: string; definition: DbtModelLightdashMetric }
@@ -351,6 +352,8 @@ export const translateMetricFlowMetrics = ({
                 overrides.groupLabel ??
                 measure.config?.meta?.group_label ??
                 undefined,
+            format:
+                overrides.format ?? measure.config?.meta?.format ?? undefined,
         };
 
         if (metricType === MetricType.PERCENTILE) {
@@ -487,6 +490,7 @@ export const translateMetricFlowMetrics = ({
                 description: metric.description,
                 hidden: metric.config?.meta?.hidden,
                 groupLabel: metric.config?.meta?.group_label,
+                format: metric.config?.meta?.format,
             },
         );
         if ('error' in built) {
@@ -683,6 +687,7 @@ export const translateMetricFlowMetrics = ({
             description: metric.description ?? undefined,
             hidden: metric.config?.meta?.hidden ?? undefined,
             group_label: metric.config?.meta?.group_label ?? undefined,
+            format: metric.config?.meta?.format ?? undefined,
         });
         translatedCount += 1;
         return undefined;

--- a/packages/common/src/types/dbtSemanticLayer.ts
+++ b/packages/common/src/types/dbtSemanticLayer.ts
@@ -34,6 +34,7 @@ export type DbtSemanticConfig = {
     meta?: {
         hidden?: boolean | null;
         group_label?: string | null;
+        format?: string | null;
     } | null;
 };
 


### PR DESCRIPTION
Resolves #26009

## Description

Carries `format` from a metric's / measure's `config.meta` into the translated Lightdash metric, following the exact pattern #25607 established for `hidden` / `group_label` (metric-level wins over measure-level; also applied on the ratio/derived pass). With this, a MetricFlow-defined rate metric can render as `12.3%` instead of `0.1234` without keeping a parallel `meta.metrics` entry just for formatting.

**Scope note:** #26009 originally mentioned `round` and `compact` as well, but both are marked `@deprecated` in `DbtColumnLightdashMetric` in favour of format expressions, so this PR intentionally passes through `format` only — a format expression string covers rounding/compacting (e.g. `$,.2f`, `,.1%`).

## Changes

- `packages/common/src/types/dbtSemanticLayer.ts`: add `format` to `DbtSemanticConfig.meta`
- `packages/common/src/dbt/metricFlow.ts`: pass `format` through in the measure builder, the simple-metric pass, and the ratio/derived pass
- `packages/common/src/dbt/metricFlow.test.ts`: measure-level carry + metric-over-measure precedence tests
- `examples/metricflow-demo`: add `format` to `total_revenue` in both spec variants and assert it in `assert-translation.cjs`

## Verification

- `vitest run src/dbt/metricFlow.test.ts`: 41 passed (including the 2 new tests)

Process note: I know code contributions normally go through an `open-contribution` issue claimed in Slack — this one seemed small and pattern-following enough to propose directly, but happy to adjust if you'd rather route it through the usual process.