### PR TITLE
fix: keep email one-time passcode attempt counter across re-issue and throttle resend

### DIFF
--- a/packages/backend/src/models/EmailModel.test.ts
+++ b/packages/backend/src/models/EmailModel.test.ts
@@ -1,0 +1,50 @@
+import knex from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { EmailModel } from './EmailModel';
+
+describe('EmailModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new EmailModel({ database });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('preserves the attempt counter when re-issuing an OTP before the reset cutoff', async () => {
+        tracker.on
+            .any(({ method }) => method === 'select')
+            .response([
+                {
+                    email: 'email',
+                    is_verified: true,
+                    created_at: new Date(),
+                    number_of_attempts: 0,
+                },
+            ]);
+        tracker.on.any(() => true).response({ rows: [] });
+
+        const resetAttemptsIfOtpCreatedBefore = new Date(
+            Date.now() - 15 * 60 * 1000,
+        );
+        await model.createPrimaryEmailOtp({
+            passcode: '123456',
+            userUuid: 'user-uuid',
+            resetAttemptsIfOtpCreatedBefore,
+        });
+
+        const [upsert] = tracker.history.all;
+        expect(upsert.sql).toContain('number_of_attempts = CASE');
+        expect(upsert.sql).toContain(
+            'WHEN email_one_time_passcodes.created_at < $3 THEN 0',
+        );
+        expect(upsert.sql).toContain(
+            'ELSE email_one_time_passcodes.number_of_attempts',
+        );
+        expect(upsert.bindings).toContain(resetAttemptsIfOtpCreatedBefore);
+    });
+});

--- a/packages/backend/src/models/EmailModel.ts
+++ b/packages/backend/src/models/EmailModel.ts
@@ -81,9 +81,11 @@ export class EmailModel {
     async createPrimaryEmailOtp({
         passcode,
         userUuid,
+        resetAttemptsIfOtpCreatedBefore,
     }: {
         passcode: string;
         userUuid: string;
+        resetAttemptsIfOtpCreatedBefore: Date;
     }): Promise<EmailStatus> {
         const hashedPasscode = await bcrypt.hash(
             passcode,
@@ -103,7 +105,10 @@ export class EmailModel {
                 UPDATE
                     SET passcode = EXCLUDED.passcode,
                     created_at = DEFAULT,
-                    number_of_attempts = DEFAULT
+                    number_of_attempts = CASE
+                        WHEN email_one_time_passcodes.created_at < ? THEN 0
+                        ELSE email_one_time_passcodes.number_of_attempts
+                    END
                 RETURNING email_id
             )
             SELECT emails.email, emails.is_verified, email_one_time_passcodes.created_at, email_one_time_passcodes.number_of_attempts
@@ -113,7 +118,7 @@ export class EmailModel {
             INNER JOIN inserted 
                 ON inserted.email_id = emails.email_id
         `,
-            [hashedPasscode, userUuid],
+            [hashedPasscode, userUuid, resetAttemptsIfOtpCreatedBefore],
         );
         return this.getPrimaryEmailStatus(userUuid);
     }

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -907,9 +907,10 @@ describe('UserService', () => {
                 userModel.findUserByEmail.mockResolvedValueOnce(sessionUser);
                 userModel.hasPassword.mockResolvedValueOnce(false);
                 userModel.hasOpenIdIdentity.mockResolvedValueOnce(false);
-                emailModel.getPrimaryEmailStatus.mockResolvedValueOnce(
-                    activeOtp(),
-                );
+                const twoMinutesAgo = new Date(Date.now() - 2 * 60 * 1000);
+                emailModel.getPrimaryEmailStatus
+                    .mockResolvedValueOnce(activeOtp(0, twoMinutesAgo))
+                    .mockResolvedValueOnce(activeOtp(0, twoMinutesAgo));
 
                 await service.requestEmailOtpLogin('email');
 
@@ -922,6 +923,27 @@ describe('UserService', () => {
                         onboardingFlow: 'new',
                     },
                 });
+            });
+
+            test('does not re-issue an OTP within the resend interval', async () => {
+                const service = createUserService(lightdashConfigMock, {
+                    featureFlagModel: createFeatureFlagModel(true),
+                });
+                userModel.findUserByEmail.mockResolvedValueOnce(sessionUser);
+                userModel.hasPassword.mockResolvedValueOnce(false);
+                userModel.hasOpenIdIdentity.mockResolvedValueOnce(false);
+                emailModel.getPrimaryEmailStatus.mockResolvedValueOnce(
+                    activeOtp(),
+                );
+
+                await expect(
+                    service.requestEmailOtpLogin('email'),
+                ).resolves.toBeUndefined();
+
+                expect(emailModel.createPrimaryEmailOtp).not.toHaveBeenCalled();
+                expect(
+                    emailClient.sendOneTimePasscodeEmail,
+                ).not.toHaveBeenCalled();
             });
         });
 

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -281,6 +281,8 @@ export class UserService extends BaseService {
 
     private readonly emailOneTimePasscodeMaxAttempts = 5;
 
+    private readonly emailOneTimePasscodeResendIntervalSeconds = 60;
+
     constructor({
         lightdashConfig,
         analytics,
@@ -2080,6 +2082,9 @@ export class UserService extends BaseService {
         const emailStatus = await this.emailModel.createPrimaryEmailOtp({
             passcode,
             userUuid: user.userUuid,
+            resetAttemptsIfOtpCreatedBefore: new Date(
+                Date.now() - this.emailOneTimePasscodeExpirySeconds * 1000,
+            ),
         });
         await this.emailClient.sendOneTimePasscodeEmail({
             recipient: emailStatus.email,
@@ -2148,6 +2153,16 @@ export class UserService extends BaseService {
             !user ||
             !user.isActive ||
             !(await this.isStrictlyPasswordlessUser(user, normalizedEmail))
+        ) {
+            return;
+        }
+        const emailStatus = await this.emailModel.getPrimaryEmailStatus(
+            user.userUuid,
+        );
+        if (
+            emailStatus.otp &&
+            Date.now() - emailStatus.otp.createdAt.getTime() <
+                this.emailOneTimePasscodeResendIntervalSeconds * 1000
         ) {
             return;
         }


### PR DESCRIPTION
Re-issuing a primary-email one-time passcode now preserves the existing attempt counter unless the previous code has expired, and repeat requests within 60s of the last issue no longer generate a new code or email.

Linear: SPK-579