### PR TITLE
fix: derive homepage data app links from appUuid

### DIFF
--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/DataAppPickerModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/DataAppPickerModal.tsx
@@ -22,6 +22,7 @@ import MantineModal from '../../../../components/common/MantineModal';
 import { ResourceIcon } from '../../../../components/common/ResourceIcon';
 import { useInfiniteContent } from '../../../../hooks/useContent';
 import classes from './blockStyles.module.css';
+import { dataAppHref } from './resourceUrls';
 
 const PAGE_SIZE = 50;
 
@@ -33,7 +34,7 @@ const dataAppToResourceItem = (
 ): HomepageResourceItem => ({
     kind: 'data-app',
     appUuid: content.uuid,
-    url: `/projects/${projectUuid}/n${content.uuid}`,
+    url: dataAppHref(projectUuid, content.uuid),
     title: content.name,
     ...(content.description ? { description: content.description } : {}),
 });

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.test.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.test.tsx
@@ -9,6 +9,10 @@ vi.mock('../hooks/useHomepageLinkMetadata', () => ({
     fetchHomepageLinkMetadata: vi.fn(),
 }));
 
+vi.mock('../../../../features/apps/hooks/useAppThumbnail', () => ({
+    useAppThumbnailUrl: vi.fn(() => ({ data: null })),
+}));
+
 const mockFetch = vi.mocked(fetchHomepageLinkMetadata);
 
 const wrap = (ui: React.ReactNode) =>
@@ -59,6 +63,26 @@ describe('ResourcesBlockView', () => {
         expect(screen.getByRole('link')).toHaveAttribute(
             'href',
             claudeItem.url,
+        );
+    });
+
+    it('derives a data app href from appUuid, ignoring the stored url', () => {
+        const dataAppItem = {
+            url: '/projects/p1/nabc-123', // malformed url persisted by an old builder version
+            kind: 'data-app' as const,
+            title: 'My App',
+            appUuid: 'abc-123',
+        };
+        wrap(
+            <ResourcesBlockView
+                itemSpan={null}
+                projectUuid="p1"
+                block={block({ layout: 'list', items: [dataAppItem] })}
+            />,
+        );
+        expect(screen.getByRole('link')).toHaveAttribute(
+            'href',
+            '/projects/p1/apps/abc-123/view',
         );
     });
 

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/ResourcesBlock.tsx
@@ -42,6 +42,7 @@ import classes from './blockStyles.module.css';
 import { DataAppPickerModal } from './DataAppPickerModal';
 import { PageGrid, PageGridItem } from './PageGrid';
 import {
+    dataAppHref,
     faviconUrl,
     hostnameOf,
     looksLikeUrl,
@@ -270,6 +271,13 @@ const RowThumb: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
 // external-link chrome (new tab, hostname fallback) only applies to the latter.
 const isDataApp = (item: HomepageResourceItem) => item.kind === 'data-app';
 
+// Data app hrefs are derived from `appUuid` rather than trusting the stored
+// `url` — some already-persisted layouts contain malformed data app urls.
+const itemHref = (item: HomepageResourceItem, projectUuid: string): string =>
+    isDataApp(item) && item.appUuid
+        ? dataAppHref(projectUuid, item.appUuid)
+        : item.url;
+
 const ResourceCard: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
     item,
     projectUuid,
@@ -277,7 +285,7 @@ const ResourceCard: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
     const dataApp = isDataApp(item);
     return (
         <a
-            href={item.url}
+            href={itemHref(item, projectUuid)}
             target={dataApp ? undefined : '_blank'}
             rel={dataApp ? undefined : 'noopener noreferrer'}
             className={`${classes.mediaCard} ${classes.cardUnit1} ${classes.clickable} ${classes.plainLink}`}
@@ -313,7 +321,7 @@ const ResourceRow: FC<{ item: HomepageResourceItem; projectUuid: string }> = ({
     const dataApp = isDataApp(item);
     return (
         <a
-            href={item.url}
+            href={itemHref(item, projectUuid)}
             target={dataApp ? undefined : '_blank'}
             rel={dataApp ? undefined : 'noopener noreferrer'}
             className={`${classes.listRow} ${classes.clickable} ${classes.plainLink}`}

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/resourceUrls.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/resourceUrls.ts
@@ -1,6 +1,9 @@
 import { type HomepageResourceItem } from '@lightdash/common';
 import { fetchHomepageLinkMetadata } from '../hooks/useHomepageLinkMetadata';
 
+export const dataAppHref = (projectUuid: string, appUuid: string): string =>
+    `/projects/${projectUuid}/apps/${appUuid}/view`;
+
 export const hostnameOf = (url: string): string => {
     try {
         return new URL(url).hostname.replace(/^www\./, '');


### PR DESCRIPTION
## Problem

Data apps added to the homepage builder's Resources block linked to a malformed URL: the picker stored `/projects/{projectUuid}/n{appUuid}` — a stray `n` where the `apps/…/view` route segment should be. Clicking a data app card matched no route and bounced back to the homepage.

## Fix

- Added a shared `dataAppHref()` helper (`/projects/{projectUuid}/apps/{appUuid}/view` — the same canonical path used by BrowseMenu, omnibar, and schedulers) and use it in `DataAppPickerModal` so new items store the correct URL.
- `ResourcesBlockView` (card + list layouts) now derives the href from `item.appUuid` for `data-app` items instead of trusting the stored `url`. Already-published layouts contain the malformed URL, so this repairs them at render time — no data migration or re-save needed.

## Regression analysis

- Non-data-app resources are untouched: `itemHref()` falls through to `item.url` for every other kind, and external-link chrome (new tab, favicon, hostname fallback) is unchanged.
- Data-app items missing `appUuid` (shouldn't exist — the picker always sets it) also fall back to the stored `url`, i.e. previous behavior.
- Test added: a data-app item with a malformed persisted URL renders the canonical `/projects/p1/apps/{uuid}/view` href.

Relates: ZAP-647