### PR TITLE
feat(cli): extend warehouse column validation

### DIFF
--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -58,6 +58,35 @@ export type CompileHandlerOptions = DbtCompileOptions & {
     validateWarehouseColumns?: boolean;
 };
 
+export const hasBlockingCompileError = (
+    explore: Explore | ExploreError,
+): boolean =>
+    isExploreError(explore) ||
+    explore.warnings?.some(
+        (warning) => warning.type === InlineErrorType.WAREHOUSE_COLUMN_ERROR,
+    ) === true;
+
+export const stripWarehouseColumnErrors = (
+    explore: Explore | ExploreError,
+): Explore | ExploreError => {
+    if (isExploreError(explore) || explore.warnings === undefined) {
+        return explore;
+    }
+
+    const { warnings: currentWarnings, ...exploreWithoutWarnings } = explore;
+    const warnings = currentWarnings.filter(
+        (warning) => warning.type !== InlineErrorType.WAREHOUSE_COLUMN_ERROR,
+    );
+
+    if (warnings.length === currentWarnings.length) {
+        return explore;
+    }
+
+    return warnings.length > 0
+        ? { ...exploreWithoutWarnings, warnings }
+        : exploreWithoutWarnings;
+};
+
 const getDisplayableDiagnostics = (explore: Explore) => {
     const diagnostics = explore.warnings ?? [];
     const errors = diagnostics.filter(
@@ -616,7 +645,7 @@ export const compileHandler = async (
 
     GlobalState.setVerbose(options.verbose);
     const explores = await compile(options);
-    const errorsCount = explores.filter((e) => isExploreError(e)).length;
+    const errorsCount = explores.filter(hasBlockingCompileError).length;
     console.error('');
     if (errorsCount > 0) {
         console.error(

--- a/packages/cli/src/handlers/compileWarehouseColumnValidation.test.ts
+++ b/packages/cli/src/handlers/compileWarehouseColumnValidation.test.ts
@@ -22,10 +22,17 @@ import { getDbtContext } from '../dbt/context';
 import { loadManifest } from '../dbt/manifest';
 import { validateDbtModel } from '../dbt/validation';
 import { loadLightdashModels } from '../lightdash/loader';
-import { compile, type CompileHandlerOptions } from './compile';
+import {
+    compile,
+    hasBlockingCompileError,
+    stripWarehouseColumnErrors,
+    type CompileHandlerOptions,
+} from './compile';
+import { lightdashApi } from './dbt/apiClient';
 import { maybeCompileModelsAndJoins } from './dbt/compile';
 import { tryGetDbtVersion } from './dbt/getDbtVersion';
 import getWarehouseClient from './dbt/getWarehouseClient';
+import { deploy } from './deploy';
 
 vi.mock('../analytics/analytics');
 vi.mock('../config', () => ({
@@ -36,6 +43,10 @@ vi.mock('../dbt/manifest');
 vi.mock('../dbt/validation');
 vi.mock('../lightdash/loader');
 vi.mock('./dbt/compile');
+vi.mock('./dbt/apiClient', async (importOriginal) => {
+    const original = await importOriginal<typeof import('./dbt/apiClient')>();
+    return { ...original, lightdashApi: vi.fn() };
+});
 vi.mock('./dbt/getDbtVersion');
 vi.mock('./dbt/getWarehouseClient');
 vi.mock('@lightdash/warehouses', async (importOriginal) => {
@@ -346,6 +357,65 @@ describe('compile warehouse column validation', () => {
             expect(warningTypes).toEqual([
                 InlineErrorType.WAREHOUSE_COLUMN_ERROR,
             ]);
+            expect(result.filter(hasBlockingCompileError)).toHaveLength(1);
+            expect(
+                result
+                    .map(stripWarehouseColumnErrors)
+                    .flatMap((explore) =>
+                        isExploreError(explore) ? [] : (explore.warnings ?? []),
+                    ),
+            ).toEqual([]);
+        });
+
+        test('blocks deploy when the warehouse rejects a column', async () => {
+            setupWarehouseClient();
+            mockProberToAppendWarning(WAREHOUSE_WARNING);
+            const explores = await compile({
+                ...baseOptions(tempDir),
+                validateWarehouseColumns: true,
+            });
+            vi.spyOn(process, 'exit').mockImplementation(() => {
+                throw new Error('process.exit');
+            });
+
+            await expect(
+                deploy(explores, {
+                    ...baseOptions(tempDir),
+                    projectUuid: 'projectUuid',
+                    ignoreErrors: false,
+                    validateWarehouseColumns: true,
+                }),
+            ).rejects.toThrow('process.exit');
+            expect(process.exit).toHaveBeenCalledWith(1);
+        });
+
+        test('does not persist warehouse diagnostics when deploy errors are ignored', async () => {
+            setupWarehouseClient();
+            mockProberToAppendWarning(WAREHOUSE_WARNING);
+            const explores = await compile({
+                ...baseOptions(tempDir),
+                validateWarehouseColumns: true,
+            });
+
+            await deploy(explores, {
+                ...baseOptions(tempDir),
+                projectUuid: 'projectUuid',
+                ignoreErrors: true,
+                validateWarehouseColumns: true,
+            });
+
+            const deployRequest = vi
+                .mocked(lightdashApi)
+                .mock.calls.find(
+                    ([request]) =>
+                        request.url === '/api/v1/projects/projectUuid/explores',
+                );
+            if (deployRequest === undefined) {
+                throw new Error('Expected explores deploy request');
+            }
+            expect(deployRequest[0].body).not.toContain(
+                InlineErrorType.WAREHOUSE_COLUMN_ERROR,
+            );
         });
 
         test('keeps generic warnings hidden when partial compilation is disabled', async () => {
@@ -415,7 +485,7 @@ describe('compile warehouse column validation', () => {
             setupWarehouseClient();
             mockProberToAppendWarning(WAREHOUSE_WARNING);
 
-            await compile({
+            const result = await compile({
                 ...baseOptions(tempDir),
                 validateWarehouseColumns: true,
             });
@@ -431,6 +501,17 @@ describe('compile warehouse column validation', () => {
                     ),
                 ]),
             );
+            expect(
+                result
+                    .map(stripWarehouseColumnErrors)
+                    .flatMap((explore) =>
+                        isExploreError(explore)
+                            ? []
+                            : (explore.warnings ?? []).map(
+                                  (warning) => warning.type,
+                              ),
+                    ),
+            ).toEqual([InlineErrorType.DUPLICATE_FIELD_NAME]);
         });
 
         test('renders only the warehouse error when partial compilation is disabled and generic warnings exist', async () => {

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -6,7 +6,6 @@ import {
     ExploreError,
     friendlyName,
     getErrorMessage,
-    isExploreError,
     LightdashError,
     ParseError,
     Project,
@@ -26,7 +25,11 @@ import GlobalState from '../globalState';
 import { readAndLoadLightdashProjectConfig } from '../lightdash-config';
 import { CliProjectType, detectProjectType } from '../lightdash/projectType';
 import * as styles from '../styles';
-import { compile } from './compile';
+import {
+    compile,
+    hasBlockingCompileError,
+    stripWarehouseColumnErrors,
+} from './compile';
 import {
     createProject,
     resolveOrganizationCredentialsName,
@@ -63,6 +66,7 @@ type DeployHandlerOptions = DbtCompileOptions & {
     parallelBatches?: string;
     gzip?: boolean;
     disableTimestampConversion?: boolean;
+    validateWarehouseColumns: boolean;
 };
 
 type DeployArgs = DeployHandlerOptions & {
@@ -346,7 +350,7 @@ export const deploy = async (
         process.exit(1);
     }
 
-    const errors = explores.filter((e) => isExploreError(e)).length;
+    const errors = explores.filter(hasBlockingCompileError).length;
     if (errors > 0) {
         if (options.ignoreErrors) {
             console.error(
@@ -363,6 +367,8 @@ export const deploy = async (
             process.exit(1);
         }
     }
+
+    const deployableExplores = explores.map(stripWarehouseColumnErrors);
 
     const lightdashProjectConfig = await readAndLoadLightdashProjectConfig(
         path.resolve(options.projectDir),
@@ -426,10 +432,10 @@ export const deploy = async (
 
     // Use batched deploy if enabled
     if (options.useBatchedDeploy) {
-        await deployBatched(explores, options);
+        await deployBatched(deployableExplores, options);
     } else {
         const deployStartTime = Date.now();
-        const deployPayload = JSON.stringify(explores);
+        const deployPayload = JSON.stringify(deployableExplores);
         try {
             const deployResponse = await lightdashApi<ApiDeployExploresResults>(
                 {

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -47,6 +47,7 @@ type PreviewHandlerOptions = DbtCompileOptions & {
     parallelBatches?: string;
     expiresIn?: string;
     disableTimestampConversion?: boolean;
+    validateWarehouseColumns: boolean;
 };
 
 type StopPreviewHandlerOptions = {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -87,6 +87,8 @@ function parseDisableTimestampConversionOption(
     return value.toLowerCase() === 'true';
 }
 
+const validateWarehouseColumnsDescription = `Check physical \${TABLE}.column references in dimensions and metrics by executing zero-row queries against the warehouse. Requires warehouse credentials.`;
+
 function parseProjectArgument(value: string | undefined): string | undefined {
     if (value === undefined) {
         throw new InvalidArgumentError('No project argument provided.');
@@ -469,6 +471,11 @@ program
         'Disable timestamp conversion to UTC for Snowflake warehouses. Only use this if your timestamp values are already in UTC.',
         parseDisableTimestampConversionOption,
     )
+    .option(
+        '--validate-warehouse-columns',
+        validateWarehouseColumnsDescription,
+        false,
+    )
     .action(compileHandler);
 
 program
@@ -598,6 +605,11 @@ program
         '--expires-in <hours>',
         'Number of hours until the preview project auto-expires (default: 720, i.e. 30 days)',
     )
+    .option(
+        '--validate-warehouse-columns',
+        validateWarehouseColumnsDescription,
+        false,
+    )
     .action(previewHandler);
 
 program
@@ -723,6 +735,11 @@ program
     .option(
         '--expires-in <hours>',
         'Number of hours until the preview project auto-expires (default: 720, i.e. 30 days)',
+    )
+    .option(
+        '--validate-warehouse-columns',
+        validateWarehouseColumnsDescription,
+        false,
     )
     .action(startPreviewHandler);
 
@@ -1139,6 +1156,11 @@ program
         '1',
     )
     .option('--gzip', 'Enable gzip compression for request bodies', false)
+    .option(
+        '--validate-warehouse-columns',
+        validateWarehouseColumnsDescription,
+        false,
+    )
     .action(deployHandler);
 
 program
@@ -1231,7 +1253,7 @@ program
     )
     .option(
         '--validate-warehouse-columns',
-        `Check physical \${TABLE}.column references in dimensions and metrics by executing zero-row queries against the warehouse. Requires warehouse credentials and only applies when tables are validated.`,
+        validateWarehouseColumnsDescription,
         false,
     )
     .option(


### PR DESCRIPTION
## What changed

- Expose `--validate-warehouse-columns` on `compile`, `deploy`, `preview`, and `start-preview`, alongside the existing `validate` support.
- Treat warehouse column diagnostics as blocking compile/deploy errors.
- Preserve `--ignore-errors` while stripping CLI-only warehouse diagnostics before upload, so findings are never cached in deployed explores.
- Keep every command probe-free by default.

## Verification

- CLI: 303 tests passed.
- CLI typecheck, lint, and formatting passed.
- Confirmed all five commands advertise the flag.
- Completed a 12-case PostgreSQL matrix across compile, deploy, and start-preview: valid references passed with the flag off and on; a stale reference passed with the flag off and failed with the flag on.
- Ran deploy cases against a disposable preview project and deleted it afterward.

