### PR TITLE
fix: order dashboard excel export sheets by tab and chart position

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -8,8 +8,10 @@ import {
     CreateSchedulerAndTargets,
     CreateSchedulerLog,
     CreateSchedulerTarget,
+    DashboardChartTile,
     DashboardFilterRule,
     DashboardFilters,
+    DashboardSqlChartTile,
     DateZoom,
     derivePivotConfigurationFromPivotConfig,
     DimensionType,
@@ -90,6 +92,7 @@ import {
     SlackInstallationNotFoundError,
     SlackNotificationPayload,
     sleep,
+    sortTilesByDashboardOrder,
     SqlRunnerPayload,
     SqlRunnerPivotQueryPayload,
     SyncSlackChannelsPayload,
@@ -1004,204 +1007,221 @@ export default class SchedulerTask {
                             ...schedulerParameters,
                         };
 
-                        const chartTiles = dashboard.tiles
-                            .filter(isDashboardChartTileType)
-                            .filter((tile) => tile.properties.savedChartUuid)
-                            .filter((tile) =>
-                                isTileInSelectedTabs(tile, selectedTabs),
-                            )
-                            .map((tile) => ({
-                                tileUuid: tile.uuid,
-                                chartUuid: tile.properties.savedChartUuid!,
-                                // Use tile name as initial chart name, will be updated with actual chart name on success
-                                chartName:
-                                    tile.properties.title ||
-                                    tile.properties.chartName ||
-                                    'Unknown Chart',
-                                type: 'chart' as const,
-                            }));
-                        const sqlChartTiles = dashboard.tiles
-                            .filter(isDashboardSqlChartTile)
-                            .filter((tile) => !!tile.properties.savedSqlUuid)
-                            .filter((tile) =>
-                                isTileInSelectedTabs(tile, selectedTabs),
-                            )
-                            .map((tile) => ({
-                                tileUuid: tile.uuid,
-                                chartUuid: tile.properties.savedSqlUuid!,
-                                chartName:
-                                    tile.properties.title ||
-                                    tile.properties.chartName ||
-                                    'Unknown SQL Chart',
-                                type: 'sql_chart' as const,
-                            }));
+                        // Sheets are added to the workbook in promise order, so
+                        // sort tiles by dashboard layout (tab order, then
+                        // position) with SQL charts interleaved.
+                        const exportableTiles = sortTilesByDashboardOrder(
+                            dashboard.tiles.filter(
+                                (
+                                    tile,
+                                ): tile is
+                                    | DashboardChartTile
+                                    | DashboardSqlChartTile =>
+                                    (isDashboardChartTileType(tile) &&
+                                        !!tile.properties.savedChartUuid) ||
+                                    (isDashboardSqlChartTile(tile) &&
+                                        !!tile.properties.savedSqlUuid),
+                            ),
+                            dashboard.tabs,
+                        ).filter((tile) =>
+                            isTileInSelectedTabs(tile, selectedTabs),
+                        );
 
                         // Metadata for tracking failures - order matches the promises
-                        const chartMetadata = [...chartTiles, ...sqlChartTiles];
+                        const chartMetadata = exportableTiles.map((tile) =>
+                            isDashboardChartTileType(tile)
+                                ? {
+                                      tileUuid: tile.uuid,
+                                      chartUuid:
+                                          tile.properties.savedChartUuid!,
+                                      // Use tile name as initial chart name, will be updated with actual chart name on success
+                                      chartName:
+                                          tile.properties.title ||
+                                          tile.properties.chartName ||
+                                          'Unknown Chart',
+                                      type: 'chart' as const,
+                                  }
+                                : {
+                                      tileUuid: tile.uuid,
+                                      chartUuid: tile.properties.savedSqlUuid!,
+                                      chartName:
+                                          tile.properties.title ||
+                                          tile.properties.chartName ||
+                                          'Unknown SQL Chart',
+                                      type: 'sql_chart' as const,
+                                  },
+                        );
 
-                        const csvForChartPromises = chartTiles.map(
-                            async ({ chartUuid, tileUuid }) => {
-                                const chartLimit =
-                                    getSchedulerCsvLimit(csvOptions);
-                                const chart =
-                                    await this.schedulerService.savedChartModel.get(
-                                        chartUuid,
-                                    );
-                                const {
-                                    pivotConfig: downloadPivotConfig,
-                                    exportPivotedData:
-                                        effectiveExportPivotedData,
-                                } = getDownloadPivotOptions(
-                                    chart,
-                                    exportPivotedData,
+                        const downloadChartTileResults = async ({
+                            chartUuid,
+                            tileUuid,
+                        }: {
+                            chartUuid: string;
+                            tileUuid: string;
+                        }) => {
+                            const chartLimit = getSchedulerCsvLimit(csvOptions);
+                            const chart =
+                                await this.schedulerService.savedChartModel.get(
+                                    chartUuid,
                                 );
-                                const shouldPivotResults =
-                                    !!downloadPivotConfig;
-                                const query =
-                                    await this.asyncQueryService.executeAsyncDashboardChartQuery(
-                                        {
-                                            account,
-                                            projectUuid,
-                                            tileUuid,
-                                            chartUuid,
-                                            invalidateCache: true,
-                                            context:
-                                                QueryExecutionContext.SCHEDULED_DELIVERY,
-                                            dashboardUuid,
-                                            dashboardFilters,
-                                            dashboardSorts: [],
-                                            dateZoom,
-                                            parameters: finalParameters,
-                                            limit: chartLimit,
-                                            pivotResults: shouldPivotResults,
-                                        },
-                                    );
-                                const downloadResult =
-                                    await this.asyncQueryService.downloadSyncQueryResults(
-                                        {
-                                            account,
-                                            projectUuid,
-                                            queryUuid: query.queryUuid,
-                                            type: downloadFileType,
-                                            onlyRaw:
-                                                csvOptions?.formatted === false,
-                                            customLabels:
-                                                getCustomLabelsFromTableConfig(
-                                                    chart.chartConfig.config,
-                                                ),
-                                            hiddenFields: getHiddenTableFields(
-                                                chart.chartConfig,
-                                            ),
-                                            pivotConfig: downloadPivotConfig,
-                                            exportPivotedData:
-                                                effectiveExportPivotedData,
-                                            columnOrder:
-                                                chart.tableConfig.columnOrder,
-                                            conditionalFormattings:
-                                                getConditionalFormattingsFromChartConfig(
-                                                    chart.chartConfig.config,
-                                                ),
-                                            expirationSecondsOverride,
-                                        },
-                                        SCHEDULER_POLLING_OPTIONS,
-                                    );
-                                return {
-                                    chartName: chart.name,
-                                    filename: chart.name,
-                                    path: downloadResult.fileUrl,
-                                    localPath:
-                                        downloadResult.s3FileUrl ??
-                                        downloadResult.fileUrl,
-                                    truncated: false,
-                                    queryUuid: query.queryUuid,
-                                };
-                            },
-                        );
-                        const csvForSqlChartPromises = sqlChartTiles.map(
-                            async ({ chartUuid, tileUuid }) => {
-                                const sqlLimit =
-                                    getSchedulerCsvLimit(csvOptions);
-                                const query =
-                                    await this.asyncQueryService.executeAsyncDashboardSqlChartQuery(
-                                        {
-                                            account,
-                                            projectUuid,
-                                            savedSqlUuid: chartUuid,
-                                            invalidateCache: true,
-                                            context:
-                                                QueryExecutionContext.SCHEDULED_DELIVERY,
-                                            dashboardUuid,
-                                            tileUuid,
-                                            dashboardFilters,
-                                            dashboardSorts: [],
-                                            parameters: finalParameters,
-                                            limit:
-                                                sqlLimit === null
-                                                    ? MAX_SAFE_INTEGER
-                                                    : sqlLimit,
-                                        },
-                                    );
-                                const chart =
-                                    await this.asyncQueryService.savedSqlModel.getByUuid(
+                            const {
+                                pivotConfig: downloadPivotConfig,
+                                exportPivotedData: effectiveExportPivotedData,
+                            } = getDownloadPivotOptions(
+                                chart,
+                                exportPivotedData,
+                            );
+                            const shouldPivotResults = !!downloadPivotConfig;
+                            const query =
+                                await this.asyncQueryService.executeAsyncDashboardChartQuery(
+                                    {
+                                        account,
+                                        projectUuid,
+                                        tileUuid,
                                         chartUuid,
-                                        {
-                                            projectUuid,
-                                        },
-                                    );
-                                const downloadResult =
-                                    await this.asyncQueryService.downloadSyncQueryResults(
-                                        {
-                                            account,
-                                            projectUuid,
-                                            queryUuid: query.queryUuid,
-                                            type: downloadFileType,
-                                            onlyRaw:
-                                                csvOptions?.formatted === false,
-                                            customLabels:
-                                                getCustomLabelsFromVizTableConfig(
-                                                    isVizTableConfig(
-                                                        chart.config,
-                                                    )
-                                                        ? chart.config
-                                                        : undefined,
-                                                ),
-                                            hiddenFields:
-                                                getHiddenFieldsFromVizTableConfig(
-                                                    isVizTableConfig(
-                                                        chart.config,
-                                                    )
-                                                        ? chart.config
-                                                        : undefined,
-                                                ),
-                                            columnOrder:
-                                                getColumnOrderFromVizTableConfig(
-                                                    isVizTableConfig(
-                                                        chart.config,
-                                                    )
-                                                        ? chart.config
-                                                        : undefined,
-                                                ),
-                                            expirationSecondsOverride,
-                                        },
-                                        SCHEDULER_POLLING_OPTIONS,
-                                    );
-                                return {
-                                    chartName: chart.name,
-                                    filename: chart.name,
-                                    path: downloadResult.fileUrl,
-                                    localPath:
-                                        downloadResult.s3FileUrl ??
-                                        downloadResult.fileUrl,
-                                    truncated: false,
-                                    queryUuid: query.queryUuid,
-                                };
-                            },
-                        );
+                                        invalidateCache: true,
+                                        context:
+                                            QueryExecutionContext.SCHEDULED_DELIVERY,
+                                        dashboardUuid,
+                                        dashboardFilters,
+                                        dashboardSorts: [],
+                                        dateZoom,
+                                        parameters: finalParameters,
+                                        limit: chartLimit,
+                                        pivotResults: shouldPivotResults,
+                                    },
+                                );
+                            const downloadResult =
+                                await this.asyncQueryService.downloadSyncQueryResults(
+                                    {
+                                        account,
+                                        projectUuid,
+                                        queryUuid: query.queryUuid,
+                                        type: downloadFileType,
+                                        onlyRaw:
+                                            csvOptions?.formatted === false,
+                                        customLabels:
+                                            getCustomLabelsFromTableConfig(
+                                                chart.chartConfig.config,
+                                            ),
+                                        hiddenFields: getHiddenTableFields(
+                                            chart.chartConfig,
+                                        ),
+                                        pivotConfig: downloadPivotConfig,
+                                        exportPivotedData:
+                                            effectiveExportPivotedData,
+                                        columnOrder:
+                                            chart.tableConfig.columnOrder,
+                                        conditionalFormattings:
+                                            getConditionalFormattingsFromChartConfig(
+                                                chart.chartConfig.config,
+                                            ),
+                                        expirationSecondsOverride,
+                                    },
+                                    SCHEDULER_POLLING_OPTIONS,
+                                );
+                            return {
+                                chartName: chart.name,
+                                filename: chart.name,
+                                path: downloadResult.fileUrl,
+                                localPath:
+                                    downloadResult.s3FileUrl ??
+                                    downloadResult.fileUrl,
+                                truncated: false,
+                                queryUuid: query.queryUuid,
+                            };
+                        };
+                        const downloadSqlChartTileResults = async ({
+                            chartUuid,
+                            tileUuid,
+                        }: {
+                            chartUuid: string;
+                            tileUuid: string;
+                        }) => {
+                            const sqlLimit = getSchedulerCsvLimit(csvOptions);
+                            const query =
+                                await this.asyncQueryService.executeAsyncDashboardSqlChartQuery(
+                                    {
+                                        account,
+                                        projectUuid,
+                                        savedSqlUuid: chartUuid,
+                                        invalidateCache: true,
+                                        context:
+                                            QueryExecutionContext.SCHEDULED_DELIVERY,
+                                        dashboardUuid,
+                                        tileUuid,
+                                        dashboardFilters,
+                                        dashboardSorts: [],
+                                        parameters: finalParameters,
+                                        limit:
+                                            sqlLimit === null
+                                                ? MAX_SAFE_INTEGER
+                                                : sqlLimit,
+                                    },
+                                );
+                            const chart =
+                                await this.asyncQueryService.savedSqlModel.getByUuid(
+                                    chartUuid,
+                                    {
+                                        projectUuid,
+                                    },
+                                );
+                            const downloadResult =
+                                await this.asyncQueryService.downloadSyncQueryResults(
+                                    {
+                                        account,
+                                        projectUuid,
+                                        queryUuid: query.queryUuid,
+                                        type: downloadFileType,
+                                        onlyRaw:
+                                            csvOptions?.formatted === false,
+                                        customLabels:
+                                            getCustomLabelsFromVizTableConfig(
+                                                isVizTableConfig(chart.config)
+                                                    ? chart.config
+                                                    : undefined,
+                                            ),
+                                        hiddenFields:
+                                            getHiddenFieldsFromVizTableConfig(
+                                                isVizTableConfig(chart.config)
+                                                    ? chart.config
+                                                    : undefined,
+                                            ),
+                                        columnOrder:
+                                            getColumnOrderFromVizTableConfig(
+                                                isVizTableConfig(chart.config)
+                                                    ? chart.config
+                                                    : undefined,
+                                            ),
+                                        expirationSecondsOverride,
+                                    },
+                                    SCHEDULER_POLLING_OPTIONS,
+                                );
+                            return {
+                                chartName: chart.name,
+                                filename: chart.name,
+                                path: downloadResult.fileUrl,
+                                localPath:
+                                    downloadResult.s3FileUrl ??
+                                    downloadResult.fileUrl,
+                                truncated: false,
+                                queryUuid: query.queryUuid,
+                            };
+                        };
 
-                        const results = await Promise.allSettled([
-                            ...csvForChartPromises,
-                            ...csvForSqlChartPromises,
-                        ]);
+                        const results = await Promise.allSettled(
+                            chartMetadata.map(({ type, chartUuid, tileUuid }) =>
+                                type === 'chart'
+                                    ? downloadChartTileResults({
+                                          chartUuid,
+                                          tileUuid,
+                                      })
+                                    : downloadSqlChartTileResults({
+                                          chartUuid,
+                                          tileUuid,
+                                      }),
+                            ),
+                        );
 
                         // Separate successes and failures
                         const successfulResults = results.filter(

--- a/packages/common/src/utils/exportTabs.test.ts
+++ b/packages/common/src/utils/exportTabs.test.ts
@@ -3,6 +3,7 @@ import {
     getPagedExportOrphanHomeTabUuid,
     isTileInPagedExport,
     resolveExportTabs,
+    sortTilesByDashboardOrder,
 } from './exportTabs';
 
 const tab = (uuid: string, order: number, hidden?: boolean): DashboardTab => ({
@@ -44,6 +45,60 @@ describe('resolveExportTabs', () => {
         const snapshot = [...input];
         resolveExportTabs(input, null);
         expect(input).toEqual(snapshot);
+    });
+});
+
+describe('sortTilesByDashboardOrder', () => {
+    const tile = (
+        id: string,
+        tabUuid: string | null,
+        y: number,
+        x: number,
+    ) => ({ id, tabUuid, y, x });
+
+    it('sorts by tab order first, then y, then x', () => {
+        const tabs = [tab('second', 1), tab('first', 0)];
+        const tiles = [
+            tile('s1', 'second', 0, 0),
+            tile('f3', 'first', 1, 0),
+            tile('f2', 'first', 0, 5),
+            tile('f1', 'first', 0, 2),
+        ];
+        expect(sortTilesByDashboardOrder(tiles, tabs).map((t) => t.id)).toEqual(
+            ['f1', 'f2', 'f3', 's1'],
+        );
+    });
+
+    it('interleaves orphan tiles with the first tab by position', () => {
+        const tabs = [tab('a', 0), tab('b', 1)];
+        const tiles = [
+            tile('b1', 'b', 0, 0),
+            tile('orphan', null, 0, 0),
+            tile('a1', 'a', 1, 0),
+        ];
+        expect(sortTilesByDashboardOrder(tiles, tabs).map((t) => t.id)).toEqual(
+            ['orphan', 'a1', 'b1'],
+        );
+    });
+
+    it('sorts untabbed dashboards by y then x', () => {
+        const tiles = [
+            tile('c', null, 1, 0),
+            tile('a', null, 0, 0),
+            tile('b', null, 0, 3),
+        ];
+        expect(sortTilesByDashboardOrder(tiles, []).map((t) => t.id)).toEqual([
+            'a',
+            'b',
+            'c',
+        ]);
+    });
+
+    it('does not mutate the input array', () => {
+        const tiles = [tile('b', null, 1, 0), tile('a', null, 0, 0)];
+        const snapshot = [...tiles];
+        sortTilesByDashboardOrder(tiles, []);
+        expect(tiles).toEqual(snapshot);
     });
 });
 

--- a/packages/common/src/utils/exportTabs.ts
+++ b/packages/common/src/utils/exportTabs.ts
@@ -14,6 +14,29 @@ export const resolveExportTabs = (
 };
 
 /**
+ * Orders tiles the way the dashboard reads: tabs left to right (by `order`),
+ * then top-to-bottom / left-to-right within each tab. Orphan (no-tab) tiles
+ * sort with the first tab, matching where per-tab exports render them.
+ */
+export const sortTilesByDashboardOrder = <
+    T extends { tabUuid?: string | null; x: number; y: number },
+>(
+    tiles: T[],
+    tabs: DashboardTab[],
+): T[] => {
+    const tabPositions = new Map(
+        [...tabs]
+            .sort((a, b) => a.order - b.order)
+            .map((t, index) => [t.uuid, index]),
+    );
+    const position = (tile: T): number =>
+        (tile.tabUuid ? tabPositions.get(tile.tabUuid) : undefined) ?? 0;
+    return [...tiles].sort(
+        (a, b) => position(a) - position(b) || a.y - b.y || a.x - b.x,
+    );
+};
+
+/**
  * The tab that hosts orphan (legacy, no-tab) tiles in a per-tab export: the
  * first tab in resolved render order. Orphans render on this tab's page.
  * Null when nothing renders. Keying on the first RESOLVED tab (not the literal


### PR DESCRIPTION
## Problem

When exporting a dashboard with multiple tabs to Excel (workbook layout), the sheets did not follow the dashboard layout. `getNotificationPageData` built the tile list by filtering `dashboard.tiles` unsorted (the DB returns a global `y_offset, x_offset, tab_uuid` grid order, interleaving tabs), and always appended SQL chart tiles after all saved-chart tiles. `WorkbookExportHelper` adds sheets in the order the download promises are created, so the workbook order was effectively arbitrary.

## Solution

Reuse the same tab-ordering mechanism the per-tab image/PDF export uses (`exportTabs.ts` in common):

- Add a shared `sortTilesByDashboardOrder(tiles, tabs)` helper: sorts by tab `order` (left to right), then `y`, then `x` within each tab. Orphan (no-tab) tiles sort with the first tab, matching where per-tab exports render them.
- In the XLSX/CSV delivery branch of `getNotificationPageData`, build a single sorted list of exportable tiles (saved charts and SQL charts together) so SQL charts are interleaved by position instead of appended at the end. The per-tile download logic is extracted into `downloadChartTileResults` / `downloadSqlChartTileResults` and dispatched per tile in sorted order; failure metadata is derived from the same array so indexes still line up.

This also fixes attachment order for CSV-format deliveries, which share this branch.

## Testing

- New unit tests for `sortTilesByDashboardOrder` (tab order, y/x tiebreaks, orphan interleaving, input not mutated)
- `pnpm -F common build`, `pnpm -F backend typecheck:fast`, eslint on changed files

Closes: PROD-9167
Closes: #26013

🤖 Generated with [Claude Code](https://claude.com/claude-code)
