### PR TITLE
fix: preserve files on filtered agent and virtual view downloads

### DIFF
--- a/packages/cli/src/handlers/contentAsCode/resource.test.ts
+++ b/packages/cli/src/handlers/contentAsCode/resource.test.ts
@@ -1,11 +1,32 @@
+import { ContentAsCodeType, type AgentAsCode } from '@lightdash/common';
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { ALERT_CODE_RESOURCE } from './projectResources';
-import { readCodeResourceFiles } from './resource';
+import {
+    AI_AGENT_CODE_RESOURCE,
+    ALERT_CODE_RESOURCE,
+} from './projectResources';
+import { readCodeResourceFiles, writeCodeResourceDocuments } from './resource';
 
 const temporaryDirectories: string[] = [];
+
+const agent = (slug: string): AgentAsCode => ({
+    contentType: ContentAsCodeType.AI_AGENT,
+    version: 1,
+    agentVersion: 2,
+    slug,
+    name: slug,
+    description: null,
+    imageUrl: null,
+    instruction: null,
+    tags: null,
+    enableDataAccess: true,
+    enableSelfImprovement: false,
+    enableContentTools: false,
+    enableUserContext: false,
+    modelConfig: null,
+});
 
 afterEach(async () => {
     await Promise.all(
@@ -19,6 +40,54 @@ afterEach(async () => {
 });
 
 describe('content-as-code resource files', () => {
+    it('preserves other documents when writing a filtered download', async () => {
+        const basePath = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'lightdash-content-as-code-'),
+        );
+        temporaryDirectories.push(basePath);
+        await writeCodeResourceDocuments({
+            definition: AI_AGENT_CODE_RESOURCE,
+            basePath,
+            documents: [agent('alpha'), agent('beta')],
+            pruneOtherDocuments: true,
+        });
+
+        await writeCodeResourceDocuments({
+            definition: AI_AGENT_CODE_RESOURCE,
+            basePath,
+            documents: [agent('alpha')],
+            pruneOtherDocuments: false,
+        });
+
+        await expect(
+            fs.readdir(path.join(basePath, 'ai-agents')),
+        ).resolves.toEqual(['alpha.yml', 'beta.yml']);
+    });
+
+    it('prunes other documents when writing a complete download', async () => {
+        const basePath = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'lightdash-content-as-code-'),
+        );
+        temporaryDirectories.push(basePath);
+        await writeCodeResourceDocuments({
+            definition: AI_AGENT_CODE_RESOURCE,
+            basePath,
+            documents: [agent('alpha'), agent('beta')],
+            pruneOtherDocuments: true,
+        });
+
+        await writeCodeResourceDocuments({
+            definition: AI_AGENT_CODE_RESOURCE,
+            basePath,
+            documents: [agent('alpha')],
+            pruneOtherDocuments: true,
+        });
+
+        await expect(
+            fs.readdir(path.join(basePath, 'ai-agents')),
+        ).resolves.toEqual(['alpha.yml']);
+    });
+
     it('ignores other scheduled content types in a shared legacy folder', async () => {
         const basePath = await fs.mkdtemp(
             path.join(os.tmpdir(), 'lightdash-content-as-code-'),

--- a/packages/cli/src/handlers/contentAsCode/resource.ts
+++ b/packages/cli/src/handlers/contentAsCode/resource.ts
@@ -161,10 +161,12 @@ export const writeCodeResourceDocuments = async <Document>({
     definition,
     basePath,
     documents,
+    pruneOtherDocuments,
 }: {
     definition: CodeResourceDefinition<Document>;
     basePath: string;
     documents: Document[];
+    pruneOtherDocuments: boolean;
 }): Promise<void> => {
     const sortedDocuments = definition.sort
         ? [...documents].sort(definition.sort)
@@ -218,24 +220,26 @@ export const writeCodeResourceDocuments = async <Document>({
         ),
     );
 
-    const downloadedIdentities = new Set(
-        sortedDocuments.map((document) =>
-            normalizeIdentity(definition, definition.identity(document)),
-        ),
-    );
-    await Promise.all(
-        current.files
-            .filter(
-                ({ document }) =>
-                    !downloadedIdentities.has(
-                        normalizeIdentity(
-                            definition,
-                            definition.identity(document),
+    if (pruneOtherDocuments) {
+        const downloadedIdentities = new Set(
+            sortedDocuments.map((document) =>
+                normalizeIdentity(definition, definition.identity(document)),
+            ),
+        );
+        await Promise.all(
+            current.files
+                .filter(
+                    ({ document }) =>
+                        !downloadedIdentities.has(
+                            normalizeIdentity(
+                                definition,
+                                definition.identity(document),
+                            ),
                         ),
-                    ),
-            )
-            .map(({ filePath }) => fs.unlink(filePath)),
-    );
+                )
+                .map(({ filePath }) => fs.unlink(filePath)),
+        );
+    }
 };
 
 export const downloadCodeResource = async <Document>({
@@ -248,7 +252,12 @@ export const downloadCodeResource = async <Document>({
     list: () => Promise<Document[]>;
 }): Promise<number> => {
     const documents = await list();
-    await writeCodeResourceDocuments({ definition, basePath, documents });
+    await writeCodeResourceDocuments({
+        definition,
+        basePath,
+        documents,
+        pruneOtherDocuments: true,
+    });
     return documents.length;
 };
 

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -901,6 +901,7 @@ const downloadVirtualViews = async (
         definition: VIRTUAL_VIEW_CODE_RESOURCE,
         basePath: getDownloadFolder(customPath),
         documents: results.virtualViews,
+        pruneOtherDocuments: slugs.length === 0,
     });
     results.skipped.forEach(({ slug, reason }) =>
         GlobalState.log(
@@ -1078,6 +1079,7 @@ const downloadAiAgents = async (
         definition: AI_AGENT_CODE_RESOURCE,
         basePath: getDownloadFolder(customPath),
         documents: agents,
+        pruneOtherDocuments: ids.length === 0,
     });
 
     return downloaded;


### PR DESCRIPTION
## Summary

- preserve unrelated YAML files when downloading a filtered set of AI agents or virtual views
- make local-file pruning explicit so it only runs for complete, unfiltered snapshots
- add regression coverage for filtered preservation and full-snapshot pruning

## Root cause

`writeCodeResourceDocuments` treated every API response as a complete resource snapshot. Filtered agent and virtual-view responses omit resources that were not requested, so the writer incorrectly unlinked their existing local YAML files.

## Verification

- `pnpm -F @lightdash/cli test` — 303 tests passed
- focused content-as-code resource tests — 3 tests passed
- `pnpm -F @lightdash/cli lint`
- `pnpm -F @lightdash/cli typecheck`
- `pnpm -F @lightdash/cli format`
- real CLI agent download: full download followed by a single-agent download preserved the complete local file set
- real CLI missing-agent filter: zero downloaded without removing existing files
- real CLI virtual-view download: full download followed by a single-view download preserved the complete local file set

Closes: SPK-648
Closes: #26012