### PR TITLE
feat: forward upstream errors in the external connection test tool

### DIFF
--- a/packages/backend/src/controllers/geoJsonProxyController.test.ts
+++ b/packages/backend/src/controllers/geoJsonProxyController.test.ts
@@ -67,6 +67,21 @@ describe('GeoJsonProxyController parity', () => {
         ).rejects.toBeInstanceOf(ParameterError);
     });
 
+    it('rejects an upstream error status returned by secureFetch', async () => {
+        mockedSecureFetch.mockResolvedValue({
+            status: 404,
+            contentType: 'text/plain',
+            bodyText: 'not found',
+            truncated: false,
+        });
+        const controller = makeController();
+        await expect(
+            controller.get('https://example.com/data.json'),
+        ).rejects.toThrow(
+            'Failed to fetch GeoJSON: Request failed with status 404',
+        );
+    });
+
     it('returns parsed GeoJSON object on the happy path', async () => {
         mockedSecureFetch.mockResolvedValue({
             status: 200,

--- a/packages/backend/src/controllers/geoJsonProxyController.ts
+++ b/packages/backend/src/controllers/geoJsonProxyController.ts
@@ -103,6 +103,12 @@ export class GeoJsonProxyController extends BaseController {
                 // original controller, which accepted any content-type.
                 allowedContentTypes: [],
             });
+            // secureFetch forwards non-2xx responses; keep rejecting them here.
+            if (result.status >= 400) {
+                throw new ParameterError(
+                    `Failed to fetch GeoJSON: Request failed with status ${result.status}`,
+                );
+            }
             bodyText = result.bodyText;
         } catch (error) {
             if (error instanceof SecureFetchError) {

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
@@ -8,7 +8,15 @@ import { SecureFetchError } from '../../../utils/secureFetch/secureFetch';
 import * as secureFetchModule from '../../../utils/secureFetch/secureFetch';
 import { ExternalConnectionService } from './ExternalConnectionService';
 
-vi.mock('../../../utils/secureFetch/secureFetch');
+// Keep SecureFetchError real: auto-mocking the class would stub its
+// constructor and drop the reason/message the service forwards.
+vi.mock('../../../utils/secureFetch/secureFetch', async (importOriginal) => {
+    const actual =
+        await importOriginal<
+            typeof import('../../../utils/secureFetch/secureFetch')
+        >();
+    return { ...actual, secureFetch: vi.fn() };
+});
 
 const mockSecureFetch = vi.mocked(secureFetchModule.secureFetch);
 
@@ -515,9 +523,39 @@ describe('ExternalConnectionService.proxyFetch', () => {
             });
             await expect(promise).rejects.toBeInstanceOf(ParameterError);
             const err = await promise.catch((e) => e);
-            expect(err.message).not.toMatch(/10\.0\.0\.1/);
+            expect(err.message).toBe(
+                `Upstream request was blocked (${reason})`,
+            );
         },
     );
+
+    it('forwards an upstream error response (status + body) instead of throwing', async () => {
+        mockSecureFetch.mockResolvedValueOnce({
+            status: 400,
+            contentType: 'application/json',
+            bodyText: '{"error":"anthropic-version header is required"}',
+            truncated: false,
+        });
+        const { service, analytics } = buildService({
+            connection: baseConnection(),
+        });
+        const res = await service.proxyFetch(user, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            path: '/v1/x',
+        });
+        expect(res.status).toBe(400);
+        expect(res.body).toEqual({
+            error: 'anthropic-version header is required',
+        });
+        expect(analytics.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                properties: expect.objectContaining({
+                    status: 400,
+                    outcome: 'upstream_error',
+                }),
+            }),
+        );
+    });
 
     it('rate-limits the 2nd POST over the limit with a 429-class error', async () => {
         const { service } = buildService({

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -7,6 +7,7 @@ import {
     type ExternalFetchResponse,
     type RegisteredAccount,
 } from '@lightdash/common';
+import { SecureFetchError } from '../../../utils/secureFetch/secureFetch';
 import { ExternalConnectionService } from './ExternalConnectionService';
 
 // -------------------------------------------------------------------
@@ -436,6 +437,32 @@ describe('ExternalConnectionService.testConnection', () => {
 
         expect(executeExternalFetchSpy).not.toHaveBeenCalled();
         expect(model.getDecryptedSecret).not.toHaveBeenCalled();
+    });
+
+    it('forwards the blocked reason detail to the admin', async () => {
+        const { service } = buildService({});
+        mockAbility(service, true);
+
+        vi.spyOn(
+            service as unknown as {
+                executeExternalFetch: (...a: unknown[]) => Promise<unknown>;
+            },
+            'executeExternalFetch',
+        ).mockRejectedValue(
+            new SecureFetchError(
+                'disallowed_content_type',
+                'Disallowed content-type: text/html',
+            ),
+        );
+
+        await expect(
+            service.testConnection(adminAccount, projectUuid, connectionUuid, {
+                method: 'GET',
+                path: '/v1/current',
+            }),
+        ).rejects.toThrow(
+            'Upstream request was blocked (disallowed_content_type): Disallowed content-type: text/html',
+        );
     });
 
     it('throws NotFoundError for a connection in a different project', async () => {

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -632,6 +632,12 @@ export class ExternalConnectionService extends BaseService {
                 requestBytes: 0,
                 responseBytes: 0,
             });
+            if (error instanceof SecureFetchError) {
+                // Reason only — no raw internal detail reaches apps.
+                throw new ParameterError(
+                    `Upstream request was blocked (${error.reason})`,
+                );
+            }
             if (error instanceof ParameterError) {
                 throw error;
             }
@@ -641,7 +647,7 @@ export class ExternalConnectionService extends BaseService {
             throw new ParameterError('Proxy request failed');
         }
 
-        // 7. Audit success — never bodies, never the secret.
+        // 7. Audit the result — never bodies, never the secret.
         this.trackFetch({
             user,
             projectUuid,
@@ -651,7 +657,7 @@ export class ExternalConnectionService extends BaseService {
             method,
             path: req.path,
             status: result.response.status,
-            outcome: 'ok',
+            outcome: result.response.status >= 400 ? 'upstream_error' : 'ok',
             start,
             requestBytes: result.requestBytes,
             responseBytes: result.responseBytes,
@@ -809,11 +815,10 @@ export class ExternalConnectionService extends BaseService {
                 allowedContentTypes: connection.allowedContentTypes,
             });
         } catch (error) {
-            // Map SecureFetchError → ParameterError with NO raw upstream detail.
+            // SecureFetchError propagates: the caller decides how much detail
+            // to expose (runtime proxy: reason only; admin test tool: message).
             if (error instanceof SecureFetchError) {
-                throw new ParameterError(
-                    `Upstream request was blocked (${error.reason})`,
-                );
+                throw error;
             }
             throw new ParameterError('Upstream request failed');
         }
@@ -847,6 +852,38 @@ export class ExternalConnectionService extends BaseService {
             requestBytes,
             responseBytes: Buffer.byteLength(fetched.bodyText, 'utf8'),
         };
+    }
+
+    /**
+     * Runs the shared fetch core for the admin-only test endpoints, forwarding
+     * the blocked reason's detail the runtime proxy withholds — the caller
+     * manages the connection, so the detail helps them fix it.
+     */
+    private async executeTestFetch(
+        connection: ExternalConnection,
+        secret: string | null,
+        req: {
+            method: ExternalConnectionMethod;
+            path: string;
+            query?: Record<string, string>;
+            body?: unknown;
+        },
+    ): Promise<ExternalFetchResponse> {
+        try {
+            const result = await this.executeExternalFetch(
+                connection,
+                secret,
+                req,
+            );
+            return result.response;
+        } catch (error) {
+            if (error instanceof SecureFetchError) {
+                throw new ParameterError(
+                    `Upstream request was blocked (${error.reason}): ${error.message}`,
+                );
+            }
+            throw error;
+        }
     }
 
     private trackFetch(args: {
@@ -1094,13 +1131,12 @@ export class ExternalConnectionService extends BaseService {
                       connectionUuid,
                   );
 
-        const result = await this.executeExternalFetch(conn, secret, {
+        return this.executeTestFetch(conn, secret, {
             method,
             path: req.path,
             query: req.query,
             body: req.body,
         });
-        return result.response;
     }
 
     /**
@@ -1180,13 +1216,12 @@ export class ExternalConnectionService extends BaseService {
 
         const secret = data.type === 'none' ? null : (data.secret ?? null);
 
-        const result = await this.executeExternalFetch(connection, secret, {
+        return this.executeTestFetch(connection, secret, {
             method,
             path: req.path,
             query: req.query,
             body: req.body,
         });
-        return result.response;
     }
 
     /**

--- a/packages/backend/src/utils/secureFetch/secureFetch.test.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.test.ts
@@ -189,12 +189,18 @@ describe('secureFetch GET behavior', () => {
         );
     });
 
-    it('rejects a non-ok status (>=400) with reason request_failed', async () => {
+    it('returns the upstream response on a non-ok status (>=400)', async () => {
         mockedFetch.mockResolvedValue(jsonResponse('nope', { status: 503 }));
-        await expectReason(
-            secureFetch('https://example.com/x.json', BASE_OPTIONS),
-            'request_failed',
+        const result = await secureFetch(
+            'https://example.com/x.json',
+            BASE_OPTIONS,
         );
+        expect(result).toEqual({
+            status: 503,
+            contentType: 'application/json',
+            bodyText: 'nope',
+            truncated: false,
+        });
     });
 
     it('returns a SecureFetchResult on a happy-path GET', async () => {
@@ -418,6 +424,21 @@ describe('secureFetch size and content-type', () => {
             }),
             'disallowed_content_type',
         );
+    });
+
+    it('skips the content-type allowlist on error responses', async () => {
+        mockedFetch.mockResolvedValue(
+            jsonResponse('<html>Bad gateway</html>', {
+                status: 502,
+                contentType: 'text/html',
+            }),
+        );
+        const result = await secureFetch(
+            'https://example.com/x.json',
+            BASE_OPTIONS,
+        );
+        expect(result.status).toBe(502);
+        expect(result.bodyText).toBe('<html>Bad gateway</html>');
     });
 
     it('accepts an allowed content-type ignoring charset suffix', async () => {

--- a/packages/backend/src/utils/secureFetch/secureFetch.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.ts
@@ -34,6 +34,8 @@ export type SecureFetchOptions = {
     allowedContentTypes: string[];
 };
 
+// Non-2xx responses are returned, not thrown, so callers can forward upstream
+// errors; only security failures and network errors throw SecureFetchError.
 export type SecureFetchResult = {
     status: number;
     contentType: string;
@@ -202,13 +204,6 @@ export async function secureFetch(
             'Redirects are not allowed for security reasons',
         );
     }
-    if (!response.ok) {
-        throw new SecureFetchError(
-            'request_failed',
-            `Request failed with status ${response.status}`,
-        );
-    }
-
     const contentLength = response.headers.get('content-length');
     if (
         contentLength &&
@@ -224,8 +219,12 @@ export async function secureFetch(
         response.headers.get('content-type') ?? '',
     );
     // Empty allowlist = no content-type restriction (explicit opt-out; the proxy
-    // always passes a non-empty list). When non-empty, enforce a strict allowlist.
-    if (!isAllowedContentType(contentType, options.allowedContentTypes)) {
+    // always passes a non-empty list). Enforced only on success responses: error
+    // bodies are often text/html (gateway 502 pages) and must survive.
+    if (
+        response.ok &&
+        !isAllowedContentType(contentType, options.allowedContentTypes)
+    ) {
         throw new SecureFetchError(
             'disallowed_content_type',
             `Disallowed content-type: ${contentType || '(none)'}`,

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.tsx
@@ -388,28 +388,34 @@ export const ConnectionExamplesPanel: FC<Props> = ({
                 <Stack gap="xs">
                     <ConnectionTestResult response={testMutation.data} />
 
-                    <TextInput
-                        label="Sample label (optional)"
-                        placeholder="e.g. Current weather Berlin"
-                        size="xs"
-                        {...form.getInputProps('sampleLabel')}
-                    />
+                    {testMutation.data.status < 300 && (
+                        <>
+                            <TextInput
+                                label="Sample label (optional)"
+                                placeholder="e.g. Current weather Berlin"
+                                size="xs"
+                                {...form.getInputProps('sampleLabel')}
+                            />
 
-                    <Group>
-                        <Button
-                            type="button"
-                            size="xs"
-                            variant="outline"
-                            onClick={() => handleSaveSample(testMutation.data!)}
-                            loading={saveSampleMutation.isLoading}
-                        >
-                            Save as sample
-                        </Button>
-                        <Text fz="xs" c="ldGray.6">
-                            Saved samples ground Claude in the API&apos;s
-                            response shape.
-                        </Text>
-                    </Group>
+                            <Group>
+                                <Button
+                                    type="button"
+                                    size="xs"
+                                    variant="outline"
+                                    onClick={() =>
+                                        handleSaveSample(testMutation.data!)
+                                    }
+                                    loading={saveSampleMutation.isLoading}
+                                >
+                                    Save as sample
+                                </Button>
+                                <Text fz="xs" c="ldGray.6">
+                                    Saved samples ground Claude in the
+                                    API&apos;s response shape.
+                                </Text>
+                            </Group>
+                        </>
+                    )}
                 </Stack>
             )}
 

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/WizardTestStep.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/WizardTestStep.tsx
@@ -87,7 +87,8 @@ export const WizardTestStep: FC<Props> = ({
                 config,
                 ...request,
             });
-            onTestResult({ request, response });
+            // Only a 2xx result is worth saving as a sample.
+            onTestResult(response.status < 300 ? { request, response } : null);
         } catch {
             onTestResult(null);
         }
@@ -152,13 +153,15 @@ export const WizardTestStep: FC<Props> = ({
             {testMutation.data && (
                 <Stack gap="sm">
                     <ConnectionTestResult response={testMutation.data} />
-                    <Checkbox
-                        label="Save this response as an example to ground app generation"
-                        checked={saveSample}
-                        onChange={(e) =>
-                            onSaveSampleChange(e.currentTarget.checked)
-                        }
-                    />
+                    {testMutation.data.status < 300 && (
+                        <Checkbox
+                            label="Save this response as an example to ground app generation"
+                            checked={saveSample}
+                            onChange={(e) =>
+                                onSaveSampleChange(e.currentTarget.checked)
+                            }
+                        />
+                    )}
                 </Stack>
             )}
         </Stack>

--- a/packages/frontend/src/features/externalConnections/components/ConnectionTestResult.tsx
+++ b/packages/frontend/src/features/externalConnections/components/ConnectionTestResult.tsx
@@ -35,10 +35,10 @@ export const ConnectionTestResult: FC<Props> = ({ response }) => (
                 fz="xs"
                 style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
             >
-                {JSON.stringify(response.body, null, 2).slice(
-                    0,
-                    MAX_BODY_RENDER_CHARS,
-                )}
+                {(typeof response.body === 'string'
+                    ? response.body
+                    : JSON.stringify(response.body, null, 2)
+                ).slice(0, MAX_BODY_RENDER_CHARS)}
             </Code>
         </ScrollArea.Autosize>
     </Stack>


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-633/forward-errors-in-the-connection-testing-tool

### Description:
Upstream 4xx/5xx responses now flow back with status and body instead of a generic 'Upstream request was blocked (request_failed)' message, both in the admin test tool and the runtime proxy. Genuinely blocked requests (timeout, redirect, disallowed content type, ...) include the reason detail in the admin test paths only; the runtime proxy still exposes the reason alone.


Before:
<img width="462" height="78" alt="Screenshot 2026-07-23 at 10 31 52" src="https://github.com/user-attachments/assets/dcb01464-5f98-46b0-a4d5-96d487880966" />

After:
<img width="789" height="1014" alt="Screenshot 2026-07-23 at 10 24 56" src="https://github.com/user-attachments/assets/50b68d57-6cb1-48fc-ad9b-45e2526e6c25" />
