### PR TITLE
chore(frontend): remove direct Mantine utils dependency

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -47,7 +47,6 @@
         "@mantine/modals": "6.0.22",
         "@mantine/prism": "6.0.21",
         "@mantine/tiptap": "6.0.21",
-        "@mantine/utils": "6.0.21",
         "@monaco-editor/react": "4.6.0",
         "@pierre/diffs": "1.2.5",
         "@popsql/monaco-sql-languages": "0.2.0",

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -1,5 +1,4 @@
 import { Box, Flex, Text, Button } from '@mantine-8/core';
-import { noop } from '@mantine/utils';
 import { IconAlertCircle, IconRefresh, IconTable } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useRef, type FC } from 'react';
 import {
@@ -24,6 +23,8 @@ import DashboardHeaderContextMenu from './DashboardHeaderContextMenu';
 import ExplorerPivotTable from './ExplorerPivotTable';
 import MinimalCellContextMenu from './MinimalCellContextMenu';
 import PivotRerunState from './PivotRerunState';
+
+const noop = () => undefined;
 
 type SimpleTableProps = {
     isDashboard: boolean;

--- a/packages/frontend/src/components/common/LightTable/index.tsx
+++ b/packages/frontend/src/components/common/LightTable/index.tsx
@@ -5,12 +5,12 @@ import {
 import {
     Box,
     type BoxProps as BoxPropsBase,
+    type PolymorphicComponentProps,
     Text,
     Tooltip,
 } from '@mantine-8/core';
 import { useMantineTheme } from '@mantine/core';
 import { getHotkeyHandler, useClipboard, useId } from '@mantine/hooks';
-import { type PolymorphicComponentProps } from '@mantine/utils';
 import debounce from 'lodash/debounce';
 import {
     createContext,
@@ -54,7 +54,7 @@ type TableRowProps = PolymorphicComponentProps<'tr', BoxProps> & {
     index: number;
 };
 type TableCellProps = PolymorphicComponentProps<'th' | 'td', BoxProps> & {
-    isMinimal: boolean;
+    isMinimal?: boolean;
     withMinimalWidth?: boolean;
     withAlignRight?: boolean;
     withBoldFont?: boolean;
@@ -172,7 +172,9 @@ const TableComponent = forwardRef<HTMLTableElement, TableProps>(
 
         const [isContainerInitialized, setIsContainerInitialized] =
             useState(false);
-        const containerScroll = useScroll(containerRef);
+        const containerScroll = useScroll(
+            containerRef as React.RefObject<HTMLElement>,
+        );
 
         useEffect(() => {
             if (!containerRef.current) return;

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -2076,7 +2076,8 @@ const PivotTable: FC<PivotTableProps> = ({
                                         withTextStyle={textStyle ?? false}
                                         withBoldFont={meta?.type === 'label'}
                                         withBackground={
-                                            conditionalFormatting?.backgroundColor
+                                            conditionalFormatting?.backgroundColor ??
+                                            false
                                         }
                                         withTooltip={
                                             labelFieldDescription ||

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1125,9 +1125,6 @@ importers:
       '@mantine/tiptap':
         specifier: 6.0.21
         version: 6.0.21(@mantine/core@6.0.22(@emotion/react@11.10.6(@types/react@19.2.2)(react@19.2.0))(@mantine/hooks@6.0.22(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mantine/hooks@6.0.22(react@19.2.0))(@tabler/icons-react@2.47.0(react@19.2.0))(@tiptap/extension-link@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2))(@tiptap/react@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      '@mantine/utils':
-        specifier: 6.0.21
-        version: 6.0.21(react@19.2.0)
       '@monaco-editor/react':
         specifier: 4.6.0
         version: 4.6.0(monaco-editor@0.44.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)


### PR DESCRIPTION
## Summary

- remove the frontend's direct `@mantine/utils` dependency
- import `PolymorphicComponentProps` from the existing Mantine 8 core package
- replace `noop` with a local stable function
- align LightTable/PivotTable types exposed by the stricter Mantine 8 type

## Why

The two direct utility imports already have equivalent local or existing-package alternatives, so the explicit dependency is unnecessary. Mantine 6 packages still retain `@mantine/utils` transitively.

## Impact

No intended runtime behavior change. This reduces the frontend's direct dependency surface.

## Validation

- `pnpm -F frontend typecheck:fast`
- targeted frontend lint
- targeted formatting check
- frozen lockfile install
- pre-commit hooks, including unused-exports check