### PR TITLE
ci: publish sandbox templates through a reusable workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -477,431 +477,70 @@ jobs:
           git push origin main
 
   # ============================================================================
-  # Job 4: Data App E2B template — publish a tag matching this release
+  # Job 4: Publish versioned E2B templates
   # ============================================================================
-  # Two paths:
-  #   build  — full E2B template rebuild when sandboxes/data-apps/** or
-  #            packages/query-sdk/** changed since the previous release.
-  #   retag  — fast path that re-tags the existing :latest build with the new
-  #            release version, so every released version still has a pinned
-  #            tag without burning E2B build minutes on a no-op rebuild.
-  data-app-template-resolve:
-    name: Resolve E2B template build action
-    runs-on: depot-ubuntu-24.04-4
-    outputs:
-      action: ${{ steps.plan.outputs.action }}
-      primary_tag: ${{ steps.plan.outputs.primary_tag }}
-      source_tag: ${{ steps.plan.outputs.source_tag }}
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.release.tag_name }}
-
-      - name: Plan build
-        id: plan
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          set -euo pipefail
-          PRIMARY_TAG="$RELEASE_TAG"
-          PREVIOUS_TAG=$(git tag --sort=-version:refname | grep -A1 "^${RELEASE_TAG}$" | tail -1 || true)
-          if [ -z "$PREVIOUS_TAG" ] || [ "$PREVIOUS_TAG" = "$RELEASE_TAG" ]; then
-            echo "No previous tag found — performing full build"
-            ACTION="build"
-            SOURCE_TAG=""
-          else
-            CHANGED=$(git diff --name-only "$PREVIOUS_TAG" "$RELEASE_TAG" -- 'sandboxes/data-apps/' 'packages/query-sdk/' || true)
-            if [ -n "$CHANGED" ]; then
-              echo "Template/SDK changed since $PREVIOUS_TAG — performing full build"
-              echo "$CHANGED"
-              ACTION="build"
-              SOURCE_TAG=""
-            else
-              echo "No template/SDK changes since $PREVIOUS_TAG — re-tagging :latest"
-              ACTION="retag"
-              SOURCE_TAG="latest"
-            fi
-          fi
-          echo "action=$ACTION" >> "$GITHUB_OUTPUT"
-          echo "primary_tag=$PRIMARY_TAG" >> "$GITHUB_OUTPUT"
-          echo "source_tag=$SOURCE_TAG" >> "$GITHUB_OUTPUT"
-
-  data-app-template-build:
-    name: Build E2B template (${{ matrix.region }})
-    needs: data-app-template-resolve
-    if: needs.data-app-template-resolve.outputs.action == 'build'
-    runs-on: depot-ubuntu-24.04-4
+  e2b-templates:
+    name: Publish ${{ matrix.template.display_name }} (${{ matrix.region }})
     strategy:
       fail-fast: false
       matrix:
         region: [us, eu]
-    env:
-      E2B_API_KEY: ${{ matrix.region == 'eu' && secrets.E2B_API_KEY_EU || secrets.E2B_API_KEY }}
-      E2B_DOMAIN: ${{ matrix.region == 'eu' && 'e2b-juliett.dev' || '' }}
-      E2B_TEMPLATE_NAME: lightdash-data-app
-      E2B_TEMPLATE_TAG: ${{ needs.data-app-template-resolve.outputs.primary_tag }}
-      E2B_TEMPLATE_EXTRA_TAGS: latest
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.event.release.tag_name }}
-
-      - name: Setup Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        with:
-          mode: firewall-free
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
-
-      - name: Install root deps
-        run: sfw pnpm install --frozen-lockfile --prefer-offline
-
-      - name: Install sandbox deps
-        working-directory: sandboxes/data-apps
-        run: sfw pnpm install --frozen-lockfile --prefer-offline
-
-      - name: Build & publish E2B template
-        working-directory: sandboxes/data-apps
-        run: pnpm run build
-
-  data-app-template-retag:
-    name: Re-tag existing E2B build (${{ matrix.region }})
-    needs: data-app-template-resolve
-    if: needs.data-app-template-resolve.outputs.action == 'retag'
-    runs-on: depot-ubuntu-24.04-4
-    strategy:
-      fail-fast: false
-      matrix:
-        region: [us, eu]
-    env:
-      E2B_API_KEY: ${{ matrix.region == 'eu' && secrets.E2B_API_KEY_EU || secrets.E2B_API_KEY }}
-      E2B_DOMAIN: ${{ matrix.region == 'eu' && 'e2b-juliett.dev' || '' }}
-      E2B_TEMPLATE_NAME: lightdash-data-app
-      E2B_TEMPLATE_TAG: ${{ needs.data-app-template-resolve.outputs.primary_tag }}
-      E2B_TEMPLATE_SOURCE_TAG: ${{ needs.data-app-template-resolve.outputs.source_tag }}
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.event.release.tag_name }}
-
-      - name: Setup Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        with:
-          mode: firewall-free
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Install sandbox deps
-        working-directory: sandboxes/data-apps
-        run: sfw pnpm install --frozen-lockfile --prefer-offline
-
-      - name: Re-tag :latest build with release version
-        working-directory: sandboxes/data-apps
-        run: pnpm exec tsx assign-tag.ts
-
-  # ============================================================================
-  # Job 5: AI Writeback E2B template — publish a tag matching this release
-  # ============================================================================
-  # Mirrors the data-app template jobs above. Two paths:
-  #   build  — full E2B template rebuild when sandboxes/ai-writeback/**
-  #            changed since the previous release.
-  #   retag  — fast path that re-tags the existing :latest build with the new
-  #            release version, so every released version still has a pinned
-  #            tag without burning E2B build minutes on a no-op rebuild.
-  # The build is self-contained (no root workspace deps), so there is no
-  # "Install root deps" step.
-  ai-writeback-template-resolve:
-    name: Resolve AI writeback E2B template build action
-    runs-on: depot-ubuntu-24.04-4
-    outputs:
-      action: ${{ steps.plan.outputs.action }}
-      primary_tag: ${{ steps.plan.outputs.primary_tag }}
-      source_tag: ${{ steps.plan.outputs.source_tag }}
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.release.tag_name }}
-
-      - name: Plan build
-        id: plan
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          set -euo pipefail
-          PRIMARY_TAG="$RELEASE_TAG"
-          PREVIOUS_TAG=$(git tag --sort=-version:refname | grep -A1 "^${RELEASE_TAG}$" | tail -1 || true)
-          if [ -z "$PREVIOUS_TAG" ] || [ "$PREVIOUS_TAG" = "$RELEASE_TAG" ]; then
-            echo "No previous tag found — performing full build"
-            ACTION="build"
-            SOURCE_TAG=""
-          else
-            CHANGED=$(git diff --name-only "$PREVIOUS_TAG" "$RELEASE_TAG" -- 'sandboxes/ai-writeback/' || true)
-            if [ -n "$CHANGED" ]; then
-              echo "Template changed since $PREVIOUS_TAG — performing full build"
-              echo "$CHANGED"
-              ACTION="build"
-              SOURCE_TAG=""
-            else
-              echo "No template changes since $PREVIOUS_TAG — re-tagging :latest"
-              ACTION="retag"
-              SOURCE_TAG="latest"
-            fi
-          fi
-          echo "action=$ACTION" >> "$GITHUB_OUTPUT"
-          echo "primary_tag=$PRIMARY_TAG" >> "$GITHUB_OUTPUT"
-          echo "source_tag=$SOURCE_TAG" >> "$GITHUB_OUTPUT"
-
-  ai-writeback-template-build:
-    name: Build AI writeback E2B template (${{ matrix.region }})
-    needs: ai-writeback-template-resolve
-    if: needs.ai-writeback-template-resolve.outputs.action == 'build'
-    runs-on: depot-ubuntu-24.04-4
-    strategy:
-      fail-fast: false
-      matrix:
-        region: [us, eu]
-    env:
-      E2B_API_KEY: ${{ matrix.region == 'eu' && secrets.E2B_API_KEY_EU || secrets.E2B_API_KEY }}
-      E2B_DOMAIN: ${{ matrix.region == 'eu' && 'e2b-juliett.dev' || '' }}
-      E2B_AI_WRITEBACK_TEMPLATE_NAME: lightdash-ai-writeback
-      E2B_AI_WRITEBACK_TEMPLATE_TAG: ${{ needs.ai-writeback-template-resolve.outputs.primary_tag }}
-      E2B_AI_WRITEBACK_TEMPLATE_EXTRA_TAGS: latest
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.event.release.tag_name }}
-
-      - name: Setup Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        with:
-          mode: firewall-free
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Install sandbox deps
-        working-directory: sandboxes/ai-writeback
-        run: sfw pnpm install --frozen-lockfile --prefer-offline
-
-      - name: Build & publish E2B template
-        working-directory: sandboxes/ai-writeback
-        run: pnpm run build
-
-  ai-writeback-template-retag:
-    name: Re-tag existing AI writeback E2B build (${{ matrix.region }})
-    needs: ai-writeback-template-resolve
-    if: needs.ai-writeback-template-resolve.outputs.action == 'retag'
-    runs-on: depot-ubuntu-24.04-4
-    strategy:
-      fail-fast: false
-      matrix:
-        region: [us, eu]
-    env:
-      E2B_API_KEY: ${{ matrix.region == 'eu' && secrets.E2B_API_KEY_EU || secrets.E2B_API_KEY }}
-      E2B_DOMAIN: ${{ matrix.region == 'eu' && 'e2b-juliett.dev' || '' }}
-      E2B_AI_WRITEBACK_TEMPLATE_NAME: lightdash-ai-writeback
-      E2B_AI_WRITEBACK_TEMPLATE_TAG: ${{ needs.ai-writeback-template-resolve.outputs.primary_tag }}
-      E2B_AI_WRITEBACK_TEMPLATE_SOURCE_TAG: ${{ needs.ai-writeback-template-resolve.outputs.source_tag }}
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.event.release.tag_name }}
-
-      - name: Setup Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        with:
-          mode: firewall-free
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Install sandbox deps
-        working-directory: sandboxes/ai-writeback
-        run: sfw pnpm install --frozen-lockfile --prefer-offline
-
-      - name: Re-tag :latest build with release version
-        working-directory: sandboxes/ai-writeback
-        run: pnpm exec tsx assign-tag.ts
-
-  # ============================================================================
-  # Job 6: Coding agent E2B template — publish a tag matching this release
-  # ============================================================================
-  # Mirrors the AI writeback template jobs above for the lean general coding
-  # agent image (sandboxes/ai-coding-agent/). Two paths:
-  #   build  — full E2B template rebuild when sandboxes/ai-coding-agent/**
-  #            changed since the previous release.
-  #   retag  — fast path that re-tags the existing :latest build with the new
-  #            release version, avoiding a no-op rebuild.
-  coding-agent-template-resolve:
-    name: Resolve coding agent E2B template build action
-    runs-on: depot-ubuntu-24.04-4
-    outputs:
-      action: ${{ steps.plan.outputs.action }}
-      primary_tag: ${{ steps.plan.outputs.primary_tag }}
-      source_tag: ${{ steps.plan.outputs.source_tag }}
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.release.tag_name }}
-
-      - name: Plan build
-        id: plan
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          set -euo pipefail
-          PRIMARY_TAG="$RELEASE_TAG"
-          PREVIOUS_TAG=$(git tag --sort=-version:refname | grep -A1 "^${RELEASE_TAG}$" | tail -1 || true)
-          if [ -z "$PREVIOUS_TAG" ] || [ "$PREVIOUS_TAG" = "$RELEASE_TAG" ]; then
-            echo "No previous tag found — performing full build"
-            ACTION="build"
-            SOURCE_TAG=""
-          else
-            CHANGED=$(git diff --name-only "$PREVIOUS_TAG" "$RELEASE_TAG" -- 'sandboxes/ai-coding-agent/' || true)
-            if [ -n "$CHANGED" ]; then
-              echo "Template changed since $PREVIOUS_TAG — performing full build"
-              echo "$CHANGED"
-              ACTION="build"
-              SOURCE_TAG=""
-            else
-              echo "No template changes since $PREVIOUS_TAG — re-tagging :latest"
-              ACTION="retag"
-              SOURCE_TAG="latest"
-            fi
-          fi
-          echo "action=$ACTION" >> "$GITHUB_OUTPUT"
-          echo "primary_tag=$PRIMARY_TAG" >> "$GITHUB_OUTPUT"
-          echo "source_tag=$SOURCE_TAG" >> "$GITHUB_OUTPUT"
-
-  coding-agent-template-build:
-    name: Build coding agent E2B template (${{ matrix.region }})
-    needs: coding-agent-template-resolve
-    if: needs.coding-agent-template-resolve.outputs.action == 'build'
-    runs-on: depot-ubuntu-24.04-4
-    strategy:
-      fail-fast: false
-      matrix:
-        region: [us, eu]
-    env:
-      E2B_API_KEY: ${{ matrix.region == 'eu' && secrets.E2B_API_KEY_EU || secrets.E2B_API_KEY }}
-      E2B_DOMAIN: ${{ matrix.region == 'eu' && 'e2b-juliett.dev' || '' }}
-      E2B_CODING_AGENT_TEMPLATE_NAME: lightdash-ai-coding-agent
-      E2B_CODING_AGENT_TEMPLATE_TAG: ${{ needs.coding-agent-template-resolve.outputs.primary_tag }}
-      E2B_CODING_AGENT_TEMPLATE_EXTRA_TAGS: latest
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.event.release.tag_name }}
-
-      - name: Setup Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        with:
-          mode: firewall-free
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Install sandbox deps
-        working-directory: sandboxes/ai-coding-agent
-        run: sfw pnpm install --frozen-lockfile --prefer-offline
-
-      - name: Build & publish E2B template
-        working-directory: sandboxes/ai-coding-agent
-        run: pnpm run build
-
-  coding-agent-template-retag:
-    name: Re-tag existing coding agent E2B build (${{ matrix.region }})
-    needs: coding-agent-template-resolve
-    if: needs.coding-agent-template-resolve.outputs.action == 'retag'
-    runs-on: depot-ubuntu-24.04-4
-    strategy:
-      fail-fast: false
-      matrix:
-        region: [us, eu]
-    env:
-      E2B_API_KEY: ${{ matrix.region == 'eu' && secrets.E2B_API_KEY_EU || secrets.E2B_API_KEY }}
-      E2B_DOMAIN: ${{ matrix.region == 'eu' && 'e2b-juliett.dev' || '' }}
-      E2B_CODING_AGENT_TEMPLATE_NAME: lightdash-ai-coding-agent
-      E2B_CODING_AGENT_TEMPLATE_TAG: ${{ needs.coding-agent-template-resolve.outputs.primary_tag }}
-      E2B_CODING_AGENT_TEMPLATE_SOURCE_TAG: ${{ needs.coding-agent-template-resolve.outputs.source_tag }}
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.event.release.tag_name }}
-
-      - name: Setup Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
-        with:
-          mode: firewall-free
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Install sandbox deps
-        working-directory: sandboxes/ai-coding-agent
-        run: sfw pnpm install --frozen-lockfile --prefer-offline
-
-      - name: Re-tag :latest build with release version
-        working-directory: sandboxes/ai-coding-agent
-        run: pnpm exec tsx assign-tag.ts
+        template:
+          - display_name: data app E2B template
+            directory: sandboxes/data-apps
+            name: lightdash-data-app
+            name_env: E2B_TEMPLATE_NAME
+            tag_env: E2B_TEMPLATE_TAG
+            extra_tags_env: E2B_TEMPLATE_EXTRA_TAGS
+            source_tag_env: E2B_TEMPLATE_SOURCE_TAG
+            additional_watch_paths: packages/query-sdk
+            install_root_deps: true
+          - display_name: AI writeback E2B template
+            directory: sandboxes/ai-writeback
+            name: lightdash-ai-writeback
+            name_env: E2B_AI_WRITEBACK_TEMPLATE_NAME
+            tag_env: E2B_AI_WRITEBACK_TEMPLATE_TAG
+            extra_tags_env: E2B_AI_WRITEBACK_TEMPLATE_EXTRA_TAGS
+            source_tag_env: E2B_AI_WRITEBACK_TEMPLATE_SOURCE_TAG
+            additional_watch_paths: |
+              packages/cli
+              packages/common
+              packages/warehouses
+              skills
+            install_root_deps: false
+          - display_name: coding agent E2B template
+            directory: sandboxes/ai-coding-agent
+            name: lightdash-ai-coding-agent
+            name_env: E2B_CODING_AGENT_TEMPLATE_NAME
+            tag_env: E2B_CODING_AGENT_TEMPLATE_TAG
+            extra_tags_env: E2B_CODING_AGENT_TEMPLATE_EXTRA_TAGS
+            source_tag_env: E2B_CODING_AGENT_TEMPLATE_SOURCE_TAG
+            additional_watch_paths: ''
+            install_root_deps: false
+          - display_name: agent onboarding E2B template
+            directory: sandboxes/agent-onboarding
+            name: lightdash-agent-onboarding
+            name_env: E2B_AGENT_ONBOARDING_TEMPLATE_NAME
+            tag_env: E2B_AGENT_ONBOARDING_TEMPLATE_TAG
+            extra_tags_env: E2B_AGENT_ONBOARDING_TEMPLATE_EXTRA_TAGS
+            source_tag_env: E2B_AGENT_ONBOARDING_TEMPLATE_SOURCE_TAG
+            additional_watch_paths: |
+              packages/cli
+              packages/common
+              packages/warehouses
+              skills
+            install_root_deps: false
+    uses: ./.github/workflows/publish-e2b-template.yml
+    with:
+      release_tag: ${{ github.event.release.tag_name }}
+      template_directory: ${{ matrix.template.directory }}
+      template_name: ${{ matrix.template.name }}
+      template_name_env: ${{ matrix.template.name_env }}
+      template_tag_env: ${{ matrix.template.tag_env }}
+      template_extra_tags_env: ${{ matrix.template.extra_tags_env }}
+      template_source_tag_env: ${{ matrix.template.source_tag_env }}
+      additional_watch_paths: ${{ matrix.template.additional_watch_paths }}
+      install_root_deps: ${{ matrix.template.install_root_deps }}
+      e2b_domain: ${{ matrix.region == 'eu' && 'e2b-juliett.dev' || '' }}
+    secrets:
+      e2b_api_key: ${{ matrix.region == 'eu' && secrets.E2B_API_KEY_EU || secrets.E2B_API_KEY }}

--- a/.github/workflows/publish-e2b-template.yml
+++ b/.github/workflows/publish-e2b-template.yml
@@ -1,0 +1,138 @@
+name: Publish E2B template
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+      template_directory:
+        required: true
+        type: string
+      template_name:
+        required: true
+        type: string
+      template_name_env:
+        required: true
+        type: string
+      template_tag_env:
+        required: true
+        type: string
+      template_extra_tags_env:
+        required: true
+        type: string
+      template_source_tag_env:
+        required: true
+        type: string
+      additional_watch_paths:
+        default: ''
+        type: string
+      install_root_deps:
+        default: false
+        type: boolean
+      e2b_domain:
+        default: ''
+        type: string
+    secrets:
+      e2b_api_key:
+        required: true
+
+jobs:
+  publish:
+    runs-on: depot-ubuntu-24.04-4
+    env:
+      E2B_API_KEY: ${{ secrets.e2b_api_key }}
+      E2B_DOMAIN: ${{ inputs.e2b_domain }}
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.release_tag }}
+
+      - name: Plan build
+        id: plan
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          TEMPLATE_DIRECTORY: ${{ inputs.template_directory }}
+          ADDITIONAL_WATCH_PATHS: ${{ inputs.additional_watch_paths }}
+        run: |
+          set -euo pipefail
+          PREVIOUS_TAG=$(git tag --sort=-version:refname | grep -A1 "^${RELEASE_TAG}$" | tail -1 || true)
+          if [ -z "$PREVIOUS_TAG" ] || [ "$PREVIOUS_TAG" = "$RELEASE_TAG" ]; then
+            echo "No previous tag found — performing full build"
+            ACTION="build"
+          else
+            WATCH_PATHS=("$TEMPLATE_DIRECTORY")
+            while IFS= read -r watch_path; do
+              [ -n "$watch_path" ] && WATCH_PATHS+=("$watch_path")
+            done <<< "$ADDITIONAL_WATCH_PATHS"
+            CHANGED=$(git diff --name-only "$PREVIOUS_TAG" "$RELEASE_TAG" -- "${WATCH_PATHS[@]}" || true)
+            if [ -n "$CHANGED" ]; then
+              echo "Template changed since $PREVIOUS_TAG — performing full build"
+              echo "$CHANGED"
+              ACTION="build"
+            else
+              echo "No template changes since $PREVIOUS_TAG — re-tagging :latest"
+              ACTION="retag"
+            fi
+          fi
+          echo "action=$ACTION" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            ${{ inputs.template_directory }}/pnpm-lock.yaml
+
+      - name: Install root deps
+        if: steps.plan.outputs.action == 'build' && inputs.install_root_deps
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Install sandbox deps
+        working-directory: ${{ inputs.template_directory }}
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Build and publish template
+        if: steps.plan.outputs.action == 'build'
+        working-directory: ${{ inputs.template_directory }}
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          TEMPLATE_NAME: ${{ inputs.template_name }}
+          TEMPLATE_NAME_ENV: ${{ inputs.template_name_env }}
+          TEMPLATE_TAG_ENV: ${{ inputs.template_tag_env }}
+          TEMPLATE_EXTRA_TAGS_ENV: ${{ inputs.template_extra_tags_env }}
+        run: |
+          env \
+            "$TEMPLATE_NAME_ENV=$TEMPLATE_NAME" \
+            "$TEMPLATE_TAG_ENV=$RELEASE_TAG" \
+            "$TEMPLATE_EXTRA_TAGS_ENV=latest" \
+            pnpm run build
+
+      - name: Re-tag latest build with release version
+        if: steps.plan.outputs.action == 'retag'
+        working-directory: ${{ inputs.template_directory }}
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          TEMPLATE_NAME: ${{ inputs.template_name }}
+          TEMPLATE_NAME_ENV: ${{ inputs.template_name_env }}
+          TEMPLATE_TAG_ENV: ${{ inputs.template_tag_env }}
+          TEMPLATE_SOURCE_TAG_ENV: ${{ inputs.template_source_tag_env }}
+        run: |
+          env \
+            "$TEMPLATE_NAME_ENV=$TEMPLATE_NAME" \
+            "$TEMPLATE_TAG_ENV=$RELEASE_TAG" \
+            "$TEMPLATE_SOURCE_TAG_ENV=latest" \
+            pnpm exec tsx assign-tag.ts

--- a/sandboxes/CLAUDE.md
+++ b/sandboxes/CLAUDE.md
@@ -1,0 +1,101 @@
+# Sandbox Development
+
+Each production sandbox under this directory is a standalone image consumed by
+one or more `SandboxProvider` implementations. Keep the image, backend runtime
+configuration, local development path, and release publishing workflow aligned.
+
+## Required template files
+
+An E2B template should contain:
+
+- `e2b.Dockerfile` as the production image definition.
+- `build-sandbox.ts` using the E2B SDK to build the Dockerfile, apply the
+  configured primary and extra tags, stream build logs, and exit nonzero on
+  failure.
+- `assign-tag.ts` to apply a release tag to an existing build without rebuilding.
+- A private standalone `package.json`, `pnpm-lock.yaml`, and
+  `pnpm-workspace.yaml`. Sandboxes are not part of the root pnpm workspace.
+- A `build-local-image.sh` when the feature supports
+  `SANDBOX_PROVIDER=docker`. Derive any local-only Dockerfile changes from
+  `e2b.Dockerfile`; do not maintain two independent image definitions.
+- A `.gitignore` covering `.env`, `node_modules`, generated Dockerfiles, packed
+  tarballs, and other build output.
+
+Complex templates should also have a README describing their inputs, outputs,
+runtime restrictions, local workflow, template name, and environment variables.
+
+## Image rules
+
+- Install only the tools the agent is allowed to use. Keep restricted-agent
+  images deliberately minimal.
+- Route package installation through `sfw`, except for installing `sfw` itself.
+  Pin tool versions when reproducibility matters.
+- Never bake credentials or local `.env` files into an image.
+- Make the runtime workdir, user, home directory, installed skills, and writable
+  paths match the constants and paths used by the backend service.
+- E2B supplies its runtime user. If plain Docker needs extra user setup, add it
+  in the generated `Dockerfile.local`.
+- Preinstall runtime dependencies. Agents should not install packages unless the
+  feature explicitly permits it.
+
+## Names and runtime configuration
+
+- Give each template a stable production name and environment-variable family
+  for its name, primary tag, extra tags, and source tag.
+- Keep the defaults in `build-sandbox.ts`, `assign-tag.ts`, and
+  `packages/backend/src/config/parseConfig.ts` identical.
+- Backend template tags should default to the running Lightdash `VERSION`, so a
+  release always launches its matching sandbox image.
+- Add local Docker image configuration and bootstrap wiring when Docker is a
+  supported provider. Add provider-specific image configuration only for
+  providers the owning service supports.
+
+## Release publishing
+
+Every E2B template must be included in the template matrix in
+`.github/workflows/post-release.yml`, which calls the reusable
+`publish-e2b-template.yml` workflow. Do not copy its build and retag steps into
+the release workflow.
+
+- Publish in both US and EU E2B regions.
+- Build `<template>:<release-version>` and update `:latest` when the template or
+  one of its baked dependencies changed since the previous release.
+- Otherwise, retag the existing `:latest` build with the release version.
+- Watch every repository path baked into the image, including shared packages,
+  SDKs, or skills; do not limit change detection to the sandbox directory when
+  external sources affect the image.
+- Add or rename the workflow entry in the same change as the template.
+
+## Local workflow
+
+From the sandbox directory:
+
+```bash
+sfw pnpm install --frozen-lockfile
+E2B_API_KEY=... pnpm run build
+```
+
+Use the template-specific name, tag, and extra-tag variables for a release-style
+build. Pass `--no-cache` when verifying Dockerfile changes that must bypass the
+E2B cache.
+
+For Docker-backed local development:
+
+```bash
+./build-local-image.sh
+```
+
+Keep its default tag aligned with `parseConfig.ts` and the local bootstrap
+script.
+
+## Validation
+
+- Run the standalone frozen install and verify the TypeScript scripts start
+  without module or configuration errors.
+- Parse the changed workflow YAML and confirm every `build-sandbox.ts` template
+  has release-workflow coverage.
+- Build the local image when Docker support or the Dockerfile changes.
+- Run a real E2B build only when external publishing and build costs are
+  intended; verify both the versioned tag and `latest`.
+- Smoke-test sandbox creation through each provider supported by the owning
+  backend service.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates: PROD-9045

### Description:
Consolidates all E2B sandbox publishing into one reusable workflow called from a template-by-region matrix.
Preserves template-specific dependencies, build triggers, release tags, and US/EU publishing while adding the missing agent-onboarding template.
Adds shared sandbox build and validation guidance in `sandboxes/CLAUDE.md`.