### PR TITLE
feat: add skip space access upload flag

### DIFF
--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -1157,6 +1157,75 @@ version: 99
         logSpy.mockRestore();
     });
 
+    it('omits access and warns when skip-space-access is enabled', async () => {
+        const logSpy = vi
+            .spyOn(GlobalState, 'log')
+            .mockImplementation(() => undefined);
+        vi.mocked(lightdashApi).mockResolvedValueOnce({
+            action: SpaceAsCodeAction.CREATE,
+        } as never);
+
+        await upsertSpaces(
+            'project-uuid',
+            [{ filePath: 'space.space.yml', space: accessSpace('finance') }],
+            {},
+            false,
+            true,
+            true,
+        );
+
+        const [request] = vi.mocked(lightdashApi).mock.calls[0];
+        expect(JSON.parse(String(request.body))).toEqual({
+            contentType: 'space',
+            version: 1,
+            spaceName: 'finance',
+            slug: 'finance',
+        });
+        expect(request.url).toContain('publicSpaceCreate=true');
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'Existing destination access will be preserved',
+            ),
+        );
+        logSpy.mockRestore();
+    });
+
+    it.each([
+        'User example@lightdash.com is not a member of this organization',
+        'Group finance does not exist in this organization',
+    ])(
+        'suggests skip-space-access when a destination identity is missing: %s',
+        async (errorMessage) => {
+            const logSpy = vi
+                .spyOn(GlobalState, 'log')
+                .mockImplementation(() => undefined);
+            vi.mocked(lightdashApi).mockRejectedValueOnce(
+                new Error(errorMessage),
+            );
+
+            await expect(
+                upsertSpaces(
+                    'project-uuid',
+                    [
+                        {
+                            filePath: 'space.space.yml',
+                            space: accessSpace('finance'),
+                        },
+                    ],
+                    {},
+                    false,
+                    false,
+                ),
+            ).rejects.toThrow('content upload was not started');
+            expect(logSpy).toHaveBeenCalledWith(
+                expect.stringContaining(
+                    'Hint: use --skip-space-access to upload the space without applying its access policy.',
+                ),
+            );
+            logSpy.mockRestore();
+        },
+    );
+
     it('treats missing spaces and descendants as nonfatal with skip-space-create', async () => {
         vi.mocked(lightdashApi)
             .mockRejectedValueOnce(

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -163,6 +163,7 @@ export type DownloadHandlerOptions = {
     project?: string;
     languageMap: boolean;
     skipSpaceCreate: boolean;
+    skipSpaceAccess?: boolean; // Upload only: preserve destination access policies
     public: boolean;
     includeCharts: boolean;
     nested: boolean; // Use nested folder structure (projectName/spaceSlug/charts|dashboards)
@@ -2553,6 +2554,7 @@ export const uploadHandler = async (
                         changes,
                         options.skipSpaceCreate,
                         options.public,
+                        options.skipSpaceAccess,
                     ),
             });
         } else if (hasFilters) {

--- a/packages/cli/src/handlers/spacesAsCode.ts
+++ b/packages/cli/src/handlers/spacesAsCode.ts
@@ -835,8 +835,20 @@ export const upsertSpaces = async (
     changes: Record<string, number>,
     skipSpaceCreate: boolean,
     publicSpaceCreate: boolean,
+    skipSpaceAccess: boolean = false,
 ): Promise<Record<string, number>> => {
     if (files.length === 0) return changes;
+
+    if (
+        skipSpaceAccess &&
+        files.some(({ space }) => space.access !== undefined)
+    ) {
+        GlobalState.log(
+            styles.warning(
+                'Space access policies will be skipped. Existing destination access will be preserved; new spaces will use default access.',
+            ),
+        );
+    }
 
     const failedPaths = new Set<string>();
     const skippedPaths = new Set<string>();
@@ -867,10 +879,13 @@ export const upsertSpaces = async (
             );
         } else {
             try {
+                const spaceToUpload = skipSpaceAccess
+                    ? { ...space, access: undefined }
+                    : space;
                 const params = new URLSearchParams({
                     skipSpaceCreate: String(skipSpaceCreate),
                     publicSpaceCreate: String(
-                        publicSpaceCreate && space.access === undefined,
+                        publicSpaceCreate && spaceToUpload.access === undefined,
                     ),
                 });
                 const result = await lightdashApi<
@@ -878,7 +893,7 @@ export const upsertSpaces = async (
                 >({
                     method: 'POST',
                     url: `/api/v1/projects/${projectId}/code/spaces?${params.toString()}`,
-                    body: JSON.stringify(space),
+                    body: JSON.stringify(spaceToUpload),
                 });
                 const action = getSpacePromoteAction(result.action);
                 const key = `spaces ${action}`;
@@ -908,12 +923,29 @@ export const upsertSpaces = async (
                         ),
                     );
                 } else {
+                    const errorMessage = getErrorMessage(error);
+                    const accessIdentityError =
+                        errorMessage.includes(
+                            ' is not a member of this organization',
+                        ) ||
+                        errorMessage.includes(
+                            ' does not exist in this organization',
+                        ) ||
+                        errorMessage.includes(
+                            ' is ambiguous in this organization',
+                        ) ||
+                        errorMessage.includes(
+                            ' cannot be assigned through space access as code',
+                        );
+                    const skipAccessHint = accessIdentityError
+                        ? '\nHint: use --skip-space-access to upload the space without applying its access policy.'
+                        : '';
                     failedPaths.add(space.slug);
                     changes['spaces with errors'] =
                         (changes['spaces with errors'] ?? 0) + 1;
                     GlobalState.log(
                         styles.error(
-                            `Error upserting space "${space.slug}" (${filePath}): ${getErrorMessage(error)}`,
+                            `Error upserting space "${space.slug}" (${filePath}): ${errorMessage}${skipAccessHint}`,
                         ),
                     );
                 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -964,6 +964,11 @@ const uploadCommand = program
         false,
     )
     .option(
+        '--skip-space-access',
+        'upload spaces without applying their access policies',
+        false,
+    )
+    .option(
         '--skip-spaces',
         'skip uploading space definitions and access',
         false,


### PR DESCRIPTION
### Description

- add `--skip-space-access` to preserve destination access policies during project content uploads
- warn when access policies are skipped
- suggest the flag when destination users or groups are missing
- keep `--public` behavior for newly created spaces

### Verification

- `pnpm -F cli test`
- `pnpm -F cli typecheck:fast`
- `pnpm -F cli lint`
- `pnpm -F cli format`
- live CLI upload against a second organization, confirming existing access remained unchanged

Closes: PROD-9185



![CleanShot 2026-07-23 at 12.20.22.png](https://app.graphite.com/user-attachments/assets/64f04fa1-cc7f-49ec-88d9-62e34cdf86b6.png)

