### PR TITLE
fix(ai): preserve deep research runs after refresh errors

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.test.tsx
@@ -1,0 +1,103 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { deepResearchRunFixture } from '../../deepResearch/fixtures';
+import { DeepResearchThreadRuns } from './DeepResearchThreadRuns';
+
+const { useDeepResearchRunMock } = vi.hoisted(() => ({
+    useDeepResearchRunMock: vi.fn(),
+}));
+
+vi.mock('../../../../../hooks/user/useUser', () => ({
+    default: () => ({ data: { userUuid: 'user-1' } }),
+}));
+
+vi.mock('../../deepResearch/deepResearchRegistry', () => ({
+    useDeepResearchRunsForThread: () => [
+        {
+            runUuid: 'run-1',
+            projectUuid: 'project-1',
+            threadUuid: 'thread-1',
+            userUuid: 'user-1',
+            question: 'Why did enterprise retention fall in Q2?',
+            depth: 'standard',
+            createdAt: '2026-07-15T09:00:00.000Z',
+            state: 'started',
+        },
+    ],
+}));
+
+vi.mock('../../hooks/useDeepResearch', () => ({
+    useContinueDeepResearchMutation: () => ({
+        mutate: vi.fn(),
+        isLoading: false,
+    }),
+    useDeepResearchRun: useDeepResearchRunMock,
+    useDeepResearchThreadRuns: () => ({ data: [] }),
+}));
+
+vi.mock('./DeepResearchRunCard', () => ({
+    DeepResearchRunCard: () => <div>Saved deep research result</div>,
+}));
+
+describe('DeepResearchThreadRuns', () => {
+    const renderThreadRuns = () =>
+        renderWithProviders(
+            <DeepResearchThreadRuns
+                projectUuid="project-1"
+                threadUuid="thread-1"
+            />,
+        );
+
+    const setRunQuery = ({
+        data,
+        isError = false,
+        isEventsError = false,
+    }: {
+        data: typeof deepResearchRunFixture | undefined;
+        isError?: boolean;
+        isEventsError?: boolean;
+    }) => {
+        useDeepResearchRunMock.mockReturnValue({
+            data,
+            isLoading: false,
+            isError,
+            refetch: vi.fn(),
+            eventsQuery: {
+                data: { events: [], nextCursor: null },
+                isError: isEventsError,
+                refetch: vi.fn(),
+            },
+        });
+    };
+
+    it.each([
+        ['run', { data: deepResearchRunFixture, isError: true }],
+        ['events', { data: deepResearchRunFixture, isEventsError: true }],
+    ])(
+        'keeps the saved run visible when a background %s refresh fails',
+        (_query, state) => {
+            setRunQuery(state);
+            renderThreadRuns();
+
+            expect(
+                screen.getByText('Saved deep research result'),
+            ).toBeInTheDocument();
+            expect(
+                screen.queryByText('Could not refresh this run'),
+            ).not.toBeInTheDocument();
+        },
+    );
+
+    it('shows the refresh error when the run fails without saved data', () => {
+        setRunQuery({ data: undefined, isError: true });
+        renderThreadRuns();
+
+        expect(
+            screen.getByText('Could not refresh this run'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText('Saved deep research result'),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchThreadRuns.tsx
@@ -64,7 +64,7 @@ const DeepResearchThreadRun = ({
     if (runQuery.isLoading) {
         return <Skeleton h={190} radius="md" />;
     }
-    if (runQuery.isError || runQuery.eventsQuery.isError) {
+    if (runQuery.isError && !runQuery.data) {
         return (
             <Paper p="lg" radius="md" withBorder aria-label="Deep research run">
                 <Stack gap="sm">


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9162/deep-research-intermittently-says-it-could-not-refresh-data

## Summary

Deep Research intermittently replaced a saved run card with “Could not refresh this run” when a background polling request failed. Cached run content now remains visible during transient run or event refresh failures.

## Root cause

TanStack Query retains successful data when a background refetch fails, but the component checked either query's error flag before rendering that retained data.

```ts
if (runQuery.isError || runQuery.eventsQuery.isError) {
```

This turned an auxiliary polling failure into a blocking state even though the durable run remained available.

## Fix

The blocking warning now requires a primary run failure with no cached run data. Event failures and primary background refresh failures continue rendering the saved run.

- `DeepResearchThreadRuns.tsx` — distinguishes initial run-load failure from background refresh failure.
- `DeepResearchThreadRuns.test.tsx` — covers cached run and event failures plus the genuine no-data error state.

## Before

```text
Saved run + transient poll failure
              │
              ▼
“Could not refresh this run”
```

## After

```text
Saved run + transient poll failure
              │
              ▼
Saved run remains visible
```

## Test plan

- [x] `pnpm -F frontend exec vitest run <DeepResearch suites>` — 16 tests pass.
- [x] Full frontend Vitest suite — 1,405 tests pass.
- [x] `pnpm -F frontend typecheck:fast`.
- [x] Changed-file oxlint — 0 warnings and 0 errors.
- [x] Regression covers primary refresh error, events refresh error, and initial no-data error.