### PR TITLE
feat(pivot-table): calculate row subtotals

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/CLAUDE.md
+++ b/packages/backend/src/utils/QueryBuilder/CLAUDE.md
@@ -53,7 +53,7 @@ const sql = composer.getSql({ columnLimit }); // PivotQueryBuilder-wrapped when 
 definition to build a totals query. The composer just forwards it —
 **totals are entirely `MetricQueryBuilder`'s job**: in its constructor the
 builder collapses the (compiled) source query + pivot config into the requested
-grain (`grandTotal`/`columnTotal`/`rowTotal`/`columnSubtotal`) via
+grain (`grandTotal`/`columnTotal`/`rowTotal`/`columnSubtotal`/`rowSubtotal`) via
 `TotalQueryBuilder`, compiles the collapsed query internally, and keeps the
 original around as the embedded source where needed. The effective (collapsed)
 query/pivot are exposed via the builder's `getEffectiveMetricQuery()` /
@@ -196,7 +196,7 @@ const builder = new SqlQueryBuilder(
 const { sql, parameterReferences } = builder.getSqlAndReferences();
 ```
 
-**TotalQueryBuilder** — transforms a source query (`metricQuery` + `pivotConfiguration`) into the totals query that reproduces a requested grain (`grandTotal` / `columnTotal` / `rowTotal` / `columnSubtotal`). It does NOT emit SQL — it returns a transformed `MetricQuery` + `PivotConfiguration` that is then executed through the normal path (`MetricQueryBuilder` / `PivotQueryBuilder`). Mirrors `MetricQueryBuilder`'s surface: configure via the constructor, then call `compileQuery()`. Used by `AsyncQueryService` to compute table-calc/metric totals for a previously-executed query.
+**TotalQueryBuilder** — transforms a source query (`metricQuery` + `pivotConfiguration`) into the totals query that reproduces a requested grain (`grandTotal` / `columnTotal` / `rowTotal` / `columnSubtotal` / `rowSubtotal`). It does NOT emit SQL — it returns a transformed `MetricQuery` + `PivotConfiguration` that is then executed through the normal path (`MetricQueryBuilder` / `PivotQueryBuilder`). Mirrors `MetricQueryBuilder`'s surface: configure via the constructor, then call `compileQuery()`. Used by `AsyncQueryService` to compute table-calc/metric totals for a previously-executed query.
 
 ```typescript
 import { TotalQueryBuilder } from './TotalQueryBuilder';
@@ -205,7 +205,7 @@ const { metricQuery, pivotConfiguration } = new TotalQueryBuilder({
     metricQuery: source.metricQuery,
     pivotConfiguration: source.pivotConfiguration, // or null
     kind: 'columnTotal',
-    subtotalDimensions, // only for kind: 'columnSubtotal'
+    subtotalDimensions, // required for subtotal kinds
 }).compileQuery();
 ```
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -4835,7 +4835,10 @@ export class MetricQueryBuilder {
                 scope: 'results',
             });
         }
-        if (this.args.totalConfiguration?.kind === 'columnSubtotal') {
+        if (
+            this.args.totalConfiguration?.kind === 'columnSubtotal' ||
+            this.args.totalConfiguration?.kind === 'rowSubtotal'
+        ) {
             groupRestrictions.push({
                 joinDimensions: grainDimensions,
                 scope: 'visiblePage',

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.test.ts
@@ -167,6 +167,7 @@ describe('QueryComposer', () => {
             { kind: 'columnTotal', subtotalDimensions: undefined },
             { kind: 'rowTotal', subtotalDimensions: undefined },
             { kind: 'columnSubtotal', subtotalDimensions: ['table1_dim1'] },
+            { kind: 'rowSubtotal', subtotalDimensions: ['table1_dim1'] },
         ];
 
         it.each(CASES)(

--- a/packages/backend/src/utils/QueryBuilder/TotalQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/TotalQueryBuilder.test.ts
@@ -1013,6 +1013,37 @@ describe('TotalQueryBuilder: columnSubtotal', () => {
     });
 });
 
+describe('TotalQueryBuilder: rowSubtotal', () => {
+    const multiIndexPivotConfiguration: PivotConfiguration = {
+        ...pivotConfiguration,
+        indexColumn: [
+            {
+                reference: 'orders_created_at',
+                type: VizIndexType.TIME,
+            },
+            {
+                reference: 'orders_status',
+                type: VizIndexType.CATEGORY,
+            },
+        ],
+        groupByColumns: [{ reference: 'orders_payment_method' }],
+    };
+
+    it('groups by the subtotal dimensions and collapses the pivot', () => {
+        const result = new TotalQueryBuilder({
+            metricQuery: baseMetricQuery,
+            pivotConfiguration: multiIndexPivotConfiguration,
+            subtotalDimensions: ['orders_created_at'],
+            kind: 'rowSubtotal',
+        }).compileQuery();
+
+        expect(result.metricQuery.dimensions).toEqual(['orders_created_at']);
+        expect(result.metricQuery.sorts).toEqual([]);
+        expect(result.metricQuery.metrics).toEqual(baseMetricQuery.metrics);
+        expect(result.pivotConfiguration).toBeUndefined();
+    });
+});
+
 describe('TotalQueryBuilder: visible groups (PROD-7570)', () => {
     it('columnSubtotal always restricts to the grain groups on the visible page', () => {
         const result = new TotalQueryBuilder({

--- a/packages/backend/src/utils/QueryBuilder/TotalQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/TotalQueryBuilder.ts
@@ -152,7 +152,7 @@ export type TotalQueryBuilderArgs = {
     metricQuery: MetricQuery;
     pivotConfiguration: PivotConfiguration | null;
     kind: TotalQueryKind;
-    // Required only for `columnSubtotal`.
+    // Required for subtotal kinds.
     subtotalDimensions?: string[];
 };
 
@@ -208,6 +208,8 @@ export class TotalQueryBuilder {
                 return { ...this.buildRowTotalQuery(), sourceQuery };
             case 'columnSubtotal':
                 return { ...this.buildColumnSubtotalQuery(), sourceQuery };
+            case 'rowSubtotal':
+                return { ...this.buildRowSubtotalQuery(), sourceQuery };
             default:
                 return assertUnreachable(
                     kind,
@@ -224,6 +226,7 @@ export class TotalQueryBuilder {
             hasBlockingTotalFilters(metricQuery) ||
             // Subtotals pin to the grain groups on the visible page.
             kind === 'columnSubtotal' ||
+            kind === 'rowSubtotal' ||
             // Sum-of-rows calcs aggregate over the source rows.
             getSumOfRowsTableCalculations(metricQuery).length > 0;
         if (!needsSourceQuery) {
@@ -390,6 +393,60 @@ export class TotalQueryBuilder {
 
         return {
             metricQuery: subtotalMetricQuery,
+            pivotConfiguration: undefined,
+        };
+    }
+
+    private buildRowSubtotalQuery(): TotalQueryResult {
+        const { metricQuery, pivotConfiguration } = this.args;
+        const subtotalDimensions = this.args.subtotalDimensions ?? [];
+        const groupByColumns = pivotConfiguration?.groupByColumns ?? [];
+        if (!pivotConfiguration || groupByColumns.length === 0) {
+            throw new NotSupportedError(
+                'Row subtotals are only supported for pivoted queries',
+            );
+        }
+        if (subtotalDimensions.length === 0) {
+            throw new NotSupportedError(
+                'Row subtotals require at least one subtotal dimension',
+            );
+        }
+
+        const indexFieldIds = new Set(
+            getIndexColumnFieldIds(pivotConfiguration.indexColumn),
+        );
+        const sourceDimensionIds = new Set(metricQuery.dimensions);
+        const missing = subtotalDimensions.filter(
+            (id) => !indexFieldIds.has(id) || !sourceDimensionIds.has(id),
+        );
+        if (missing.length > 0) {
+            throw new NotSupportedError(
+                `Row subtotal query references dimensions that were not row indexes in the source query: ${missing.join(', ')}`,
+            );
+        }
+
+        const popMetricIds = getPopMetricIds(metricQuery);
+        const keptMetrics = metricQuery.metrics.filter(
+            (id) => !popMetricIds.has(id),
+        );
+
+        return {
+            metricQuery: {
+                ...metricQuery,
+                dimensions: subtotalDimensions,
+                sorts: [],
+                tableCalculations: getTotalableTableCalculations(
+                    metricQuery,
+                    new Set(keptMetrics),
+                ),
+                metrics: keptMetrics,
+                additionalMetrics: (metricQuery.additionalMetrics ?? []).filter(
+                    (am) => !isPeriodOverPeriodAdditionalMetric(am),
+                ),
+                filters: hasBlockingTotalFilters(metricQuery)
+                    ? stripBlockingFilters(metricQuery.filters)
+                    : metricQuery.filters,
+            },
             pivotConfiguration: undefined,
         };
     }

--- a/packages/backend/src/utils/QueryBuilder/__snapshots__/QueryComposer.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/__snapshots__/QueryComposer.test.ts.snap
@@ -69,6 +69,39 @@ FROM "db"."schema"."table1" AS "table1"
 LIMIT 1"
 `;
 
+exports[`QueryComposer > totalConfiguration > collapses the source query into the totals grain for kind "'rowSubtotal'" 1`] = `
+"WITH source_rows AS (
+SELECT
+  "table1".dim1 AS "table1_dim1",
+  "table1".shared AS "table1_shared",
+  MAX("table1".number_column) AS "table1_metric1"
+FROM "db"."schema"."table1" AS "table1"
+
+GROUP BY 1,2
+),
+visible_page_rows AS (
+SELECT
+  *
+FROM source_rows
+ORDER BY "table1_dim1"
+LIMIT 500
+),
+visible_dimension_groups AS (
+SELECT DISTINCT
+  "table1_dim1"
+FROM visible_page_rows
+)
+SELECT
+  "table1".dim1 AS "table1_dim1",
+  MAX("table1".number_column) AS "table1_metric1"
+FROM "db"."schema"."table1" AS "table1"
+
+INNER JOIN visible_dimension_groups ON (("table1".dim1) = visible_dimension_groups."table1_dim1" OR (("table1".dim1) IS NULL AND visible_dimension_groups."table1_dim1" IS NULL))
+GROUP BY 1
+ORDER BY "table1_metric1" DESC
+LIMIT 500"
+`;
+
 exports[`QueryComposer > totalConfiguration > collapses the source query into the totals grain for kind "'rowTotal'" 1`] = `
 "WITH original_query AS (SELECT "table1".dim1 AS "table1_dim1", MAX("table1".number_column) AS "table1_metric1" FROM "db"."schema"."table1" AS "table1" GROUP BY 1 ORDER BY "table1_metric1" DESC),
 group_by_query AS (SELECT "table1_dim1", sum("table1_metric1") AS "table1_metric1_sum" FROM original_query group by "table1_dim1")

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -52,7 +52,8 @@ export type TotalQueryKind =
     | 'grandTotal'
     | 'columnTotal'
     | 'rowTotal'
-    | 'columnSubtotal';
+    | 'columnSubtotal'
+    | 'rowSubtotal';
 
 /**
  * Turns a source query into a totals query for the given grain. Consumed by
@@ -61,7 +62,7 @@ export type TotalQueryKind =
  */
 export type TotalConfiguration = {
     kind: TotalQueryKind;
-    // Required only for `columnSubtotal`; undefined for every other kind.
+    // Required for subtotal kinds; undefined for every other kind.
     subtotalDimensions: string[] | undefined;
 };
 

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -1208,7 +1208,7 @@ export const convertSqlPivotedRowsToPivotData = ({
             pivotColumnInfo,
         },
         groupedSubtotals,
-        groupedRowSubtotals,
+        ...(groupedRowSubtotals ? { groupedRowSubtotals } : {}),
     };
 
     const retrofitted = combinedRetrofit(

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -13,6 +13,7 @@ import {
     type PivotColumn,
     type PivotConfig,
     type PivotData,
+    type PivotRowTotalsByIndex,
     type TotalField,
 } from '../types/pivot';
 import { type ResultRow, type ResultValue } from '../types/results';
@@ -30,16 +31,6 @@ import { type PivotValuesColumn } from '../visualizations/types';
 type FieldFunction = (fieldId: string) => ItemsMap[string] | undefined;
 
 type FieldLabelFunction = (fieldId: string) => string | undefined;
-
-/**
- * Warehouse-computed row totals, keyed by a stable index-value key (built with
- * `buildPivotRowTotalKey`) → metric fieldId → numeric total. Produced by the
- * `calculate-total` endpoint (`kind: 'rowTotal'`) and fed into the pivot worker
- * so the displayed row totals are correct for every metric type — count
- * distinct, average, ratios — instead of the client-side sum that only holds
- * for additive metrics.
- */
-export type PivotRowTotalsByIndex = Record<string, Record<string, number>>;
 
 // ISO 8601 datetime with an explicit timezone (e.g. 2026-01-01T00:00:00Z).
 const ISO_DATETIME_RE =
@@ -506,6 +497,7 @@ export const convertSqlPivotedRowsToPivotData = ({
     getField,
     getFieldLabel,
     groupedSubtotals,
+    groupedRowSubtotals,
     warehouseRowTotals,
     warehouseColumnTotals,
     warehouseGrandTotals,
@@ -527,6 +519,7 @@ export const convertSqlPivotedRowsToPivotData = ({
     getField: FieldFunction;
     getFieldLabel: FieldLabelFunction;
     groupedSubtotals: Record<string, Record<string, number>[]> | undefined;
+    groupedRowSubtotals?: PivotData['groupedRowSubtotals'];
     /**
      * Warehouse-computed row totals from `calculate-total` (`kind: 'rowTotal'`).
      * Row totals are exclusively warehouse-computed — there is no client-side
@@ -1215,6 +1208,7 @@ export const convertSqlPivotedRowsToPivotData = ({
             pivotColumnInfo,
         },
         groupedSubtotals,
+        groupedRowSubtotals,
     };
 
     const retrofitted = combinedRetrofit(

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -168,13 +168,13 @@ export type CalculateTotalKind =
     | 'grandTotal'
     | 'columnTotal'
     | 'rowTotal'
-    | 'columnSubtotal';
-// | 'rowSubtotal'
+    | 'columnSubtotal'
+    | 'rowSubtotal';
 
 export type ExecuteAsyncCalculateTotalRequestParams = {
     kind: CalculateTotalKind;
-    // Required for `columnSubtotal`: the dimensions this subtotal level groups
-    // by (the pivot groupBy columns are added from the source query).
+    // Required for subtotal kinds: the dimensions this subtotal level groups
+    // by. Column subtotals also add the pivot groupBy columns.
     subtotalDimensions?: string[];
     invalidateCache?: boolean;
 };

--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -91,6 +91,11 @@ export type TotalField = null | {
 
 type TotalValue = null | number;
 
+/** Warehouse-computed metric totals keyed by pivot row values. */
+export type PivotRowTotalsByIndex = Record<string, Record<string, number>>;
+
+export type GroupedPivotRowSubtotals = Record<string, PivotRowTotalsByIndex>;
+
 type DataValue = null | ResultValue;
 
 export type PivotColumn = {
@@ -142,4 +147,5 @@ export type PivotData = {
      */
     hiddenIndexValues?: FieldValue[][];
     groupedSubtotals?: Record<string, Record<string, number>[]>;
+    groupedRowSubtotals?: GroupedPivotRowSubtotals;
 };

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -233,6 +233,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
         updateColumnProperty,
         isCalculatingColumnTotals,
         isCalculatingRowTotals,
+        isCalculatingRowSubtotals,
         isCalculatingGrandTotals,
         isCalculatingSubtotals,
     } = visualizationConfig.chartConfig;
@@ -332,6 +333,9 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                     isCalculatingColumnTotals
                                 }
                                 isRowTotalsLoading={isCalculatingRowTotals}
+                                isRowSubtotalsLoading={
+                                    isCalculatingRowSubtotals
+                                }
                                 isGrandTotalsLoading={isCalculatingGrandTotals}
                                 isSubtotalsLoading={isCalculatingSubtotals}
                                 {...rest}
@@ -360,6 +364,9 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                     isCalculatingColumnTotals
                                 }
                                 isRowTotalsLoading={isCalculatingRowTotals}
+                                isRowSubtotalsLoading={
+                                    isCalculatingRowSubtotals
+                                }
                                 isGrandTotalsLoading={isCalculatingGrandTotals}
                                 isSubtotalsLoading={isCalculatingSubtotals}
                                 {...rest}

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -62,6 +62,7 @@ import React, {
 import {
     findMatchingSubtotal,
     getGroupingValuesAndSubtotalKey,
+    getRowSubtotalValue,
     getSubtotalValueFromGroup,
 } from '../../../hooks/tableVisualization/getDataAndColumns';
 import {
@@ -187,6 +188,8 @@ type PivotTableProps = BoxProps & // TODO: remove this
         isColumnTotalsLoading?: boolean;
         /** Row-total cells render a loading skeleton while their async query is in flight. */
         isRowTotalsLoading?: boolean;
+        /** Grouped row-total cells render a loading skeleton while row subtotals are in flight. */
+        isRowSubtotalsLoading?: boolean;
         /** Grand-total intersection cells render a loading skeleton while their async query is in flight. */
         isGrandTotalsLoading?: boolean;
         /** Subtotal cells render a loading skeleton while their async query is in flight. */
@@ -224,6 +227,7 @@ const PivotTable: FC<PivotTableProps> = ({
     showRowGrouping = false,
     isColumnTotalsLoading = false,
     isRowTotalsLoading = false,
+    isRowSubtotalsLoading = false,
     isGrandTotalsLoading = false,
     isSubtotalsLoading = false,
     columnProperties = {},
@@ -549,21 +553,27 @@ const PivotTable: FC<PivotTableProps> = ({
                                 const { groupingValues, subtotalGroupKey } =
                                     groupingValuesAndSubtotalKey;
 
-                                // Get the pivoted header values for the column
-                                const pivotedHeaderValues =
-                                    finalHeaderInfoForColumns[colIndex];
-
-                                // Find the subtotal for the row, this is used to find the subtotal in the groupedSubtotals object
-                                const subtotal = findMatchingSubtotal(
-                                    data.groupedSubtotals?.[subtotalGroupKey],
-                                    groupingValues,
-                                    pivotedHeaderValues,
-                                );
-
-                                const subtotalValue = getSubtotalValueFromGroup(
-                                    subtotal,
-                                    col.baseId ?? col.fieldId,
-                                );
+                                const isRowTotal =
+                                    col.columnType === 'rowTotal';
+                                const subtotalValue = isRowTotal
+                                    ? getRowSubtotalValue(
+                                          data.groupedRowSubtotals,
+                                          subtotalGroupKey,
+                                          groupingValues,
+                                          col.underlyingId,
+                                      )
+                                    : getSubtotalValueFromGroup(
+                                          findMatchingSubtotal(
+                                              data.groupedSubtotals?.[
+                                                  subtotalGroupKey
+                                              ],
+                                              groupingValues,
+                                              finalHeaderInfoForColumns[
+                                                  colIndex
+                                              ],
+                                          ),
+                                          col.baseId ?? col.fieldId,
+                                      );
 
                                 if (subtotalValue === null) {
                                     return null;
@@ -571,7 +581,9 @@ const PivotTable: FC<PivotTableProps> = ({
 
                                 if (
                                     subtotalValue === undefined &&
-                                    isSubtotalsLoading &&
+                                    (isRowTotal
+                                        ? isRowSubtotalsLoading
+                                        : isSubtotalsLoading) &&
                                     isNumericItem(item)
                                 ) {
                                     return (
@@ -619,6 +631,7 @@ const PivotTable: FC<PivotTableProps> = ({
         rowNumberWidth,
         parameters,
         isSubtotalsLoading,
+        isRowSubtotalsLoading,
     ]);
 
     // Minimum table width so auto columns don't get squeezed to zero
@@ -1774,7 +1787,7 @@ const PivotTable: FC<PivotTableProps> = ({
 
                                 if (
                                     data.pivotConfig.metricsAsRows &&
-                                    isDataColumn &&
+                                    (isDataColumn || isRowTotal) &&
                                     metricFieldId
                                 ) {
                                     item = getField(metricFieldId);
@@ -1791,13 +1804,23 @@ const PivotTable: FC<PivotTableProps> = ({
                                 const fullValue =
                                     cell.getValue() as ResultRow[0];
                                 const metricSubtotalValue =
-                                    isMetricSubtotal && isDataColumn
+                                    isMetricSubtotal &&
+                                    (isDataColumn || isRowTotal)
                                         ? (() => {
                                               const groupingMatch =
                                                   getGroupingValuesAndSubtotalKey(
                                                       cell.getContext(),
                                                   );
                                               if (!groupingMatch) return null;
+
+                                              if (isRowTotal) {
+                                                  return getRowSubtotalValue(
+                                                      data.groupedRowSubtotals,
+                                                      groupingMatch.subtotalGroupKey,
+                                                      groupingMatch.groupingValues,
+                                                      renderRow.metricFieldId,
+                                                  );
+                                              }
 
                                               const subtotal =
                                                   findMatchingSubtotal(
@@ -1818,7 +1841,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                     | ResultValue
                                     | undefined =
                                     isMetricSubtotal &&
-                                    isDataColumn &&
+                                    (isDataColumn || isRowTotal) &&
                                     metricSubtotalValue !== null
                                         ? {
                                               raw: metricSubtotalValue,
@@ -1843,7 +1866,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                           }
                                         : undefined;
                                 const value = isMetricSubtotal
-                                    ? isDataColumn
+                                    ? isDataColumn || isRowTotal
                                         ? metricSubtotalResultValue
                                         : meta?.type === 'label'
                                           ? metricSubtotalLabelValue
@@ -2129,9 +2152,12 @@ const PivotTable: FC<PivotTableProps> = ({
                                                     renderRow.metricFieldId,
                                                 ) ?? renderRow.metricFieldId}
                                             </Text>
-                                        ) : isMetricSubtotal && isDataColumn ? (
+                                        ) : isMetricSubtotal &&
+                                          (isDataColumn || isRowTotal) ? (
                                             metricSubtotalValue === undefined &&
-                                            isSubtotalsLoading &&
+                                            (isRowTotal
+                                                ? isRowSubtotalsLoading
+                                                : isSubtotalsLoading) &&
                                             isNumericItem(item) ? (
                                                 <Skeleton
                                                     height={16}
@@ -2145,9 +2171,8 @@ const PivotTable: FC<PivotTableProps> = ({
                                                 </Text>
                                             )
                                         ) : isMetricSubtotal &&
-                                          (isRowTotal ||
-                                              (meta?.type === 'indexValue' &&
-                                                  !cell.getIsGrouped())) ? null : cell.getIsGrouped() ? (
+                                          meta?.type === 'indexValue' &&
+                                          !cell.getIsGrouped() ? null : cell.getIsGrouped() ? (
                                             // Grouping-only mode (row dedup
                                             // without subtotals): suppress the
                                             // carat + group count chrome and

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -1,4 +1,5 @@
 import {
+    buildPivotRowTotalKey,
     formatItemValue,
     getSubtotalKey,
     isCustomDimension,
@@ -7,6 +8,7 @@ import {
     isNumericItem,
     normalizePivotMatchRaw,
     type ItemsMap,
+    type GroupedPivotRowSubtotals,
     type ParametersValuesMap,
     type ResultRow,
     type ResultValue,
@@ -118,6 +120,30 @@ export function getSubtotalValueFromGroup(
     // Convert null to undefined so formatItemValue shows '-' instead of '∅'
     // SQL returns null when all aggregated values are null (no data)
     return subtotal[columnId] ?? undefined;
+}
+
+export function getRowSubtotalValue(
+    groupedRowSubtotals: GroupedPivotRowSubtotals | undefined,
+    subtotalGroupKey: string,
+    groupingValues: Record<string, { value: ResultValue } | undefined>,
+    metricFieldId: string | undefined,
+): number | null | undefined {
+    if (!groupedRowSubtotals || !metricFieldId) return undefined;
+
+    const subtotalRow =
+        groupedRowSubtotals[subtotalGroupKey]?.[
+            buildPivotRowTotalKey(
+                Object.entries(groupingValues).map(([fieldId, value]) => [
+                    fieldId,
+                    value?.value.raw,
+                ]),
+            )
+        ];
+    if (!subtotalRow) return undefined;
+
+    const total =
+        subtotalRow[`${metricFieldId}_any`] ?? subtotalRow[metricFieldId];
+    return typeof total === 'number' ? total : null;
 }
 
 const getImageSize = (item: ItemsMap[string] | undefined) => {

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -26,6 +26,7 @@ import uniq from 'lodash/uniq';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
     useAsyncCalculateGrandTotal,
+    useAsyncCalculateRowSubtotals,
     useAsyncCalculateRowTotal,
     useAsyncCalculateSubtotals,
     useAsyncCalculateTotal,
@@ -290,6 +291,21 @@ const useTableConfig = (
             enabled: isInitialQueryReady && showSubtotals && canUseSubtotals,
             invalidateCache,
         });
+    const { data: groupedRowSubtotals, isFetching: isCalculatingRowSubtotals } =
+        useAsyncCalculateRowSubtotals({
+            projectUuid,
+            sourceQueryUuid: resultsData?.queryUuid,
+            dimensions: resultsData?.metricQuery?.dimensions,
+            columnOrder,
+            pivotDimensions,
+            enabled:
+                isInitialQueryReady &&
+                showSubtotals &&
+                canUseSubtotals &&
+                !!tableChartConfig?.showRowCalculation &&
+                (pivotDimensions?.length ?? 0) > 0,
+            invalidateCache,
+        });
 
     const columns = useMemo(() => {
         if (!selectedItemIds || !itemsMap) {
@@ -396,6 +412,7 @@ const useTableConfig = (
             getField,
             getFieldLabel,
             groupedSubtotals,
+            groupedRowSubtotals,
             warehouseRowTotals: asyncRowTotals,
             warehouseColumnTotals: asyncTotals,
             warehouseGrandTotals: asyncGrandTotals,
@@ -415,6 +432,7 @@ const useTableConfig = (
         tableChartConfig?.showColumnCalculation,
         tableChartConfig?.showRowCalculation,
         groupedSubtotals,
+        groupedRowSubtotals,
         asyncRowTotals,
         asyncTotals,
         asyncGrandTotals,
@@ -729,6 +747,7 @@ const useTableConfig = (
             groupedSubtotals,
             isCalculatingColumnTotals,
             isCalculatingRowTotals,
+            isCalculatingRowSubtotals,
             isCalculatingGrandTotals,
             isCalculatingSubtotals,
             rowLimit,
@@ -777,6 +796,7 @@ const useTableConfig = (
             groupedSubtotals,
             isCalculatingColumnTotals,
             isCalculatingRowTotals,
+            isCalculatingRowSubtotals,
             isCalculatingGrandTotals,
             isCalculatingSubtotals,
             rowLimit,

--- a/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
+++ b/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
@@ -7,6 +7,7 @@ import {
     type ApiExecuteAsyncMetricQueryResults,
     type ApiGetAsyncQueryResults,
     type CalculateTotalKind,
+    type GroupedPivotRowSubtotals,
     type PivotRowTotalsByIndex,
     type RawResultRow,
     type ResultRow,
@@ -263,6 +264,117 @@ const getSubtotalDimensionGroups = (
     const withoutPivot = ordered.filter((d) => !pivotDimensions.includes(d));
     const toSubtotal = withoutPivot.slice(0, -1);
     return toSubtotal.map((_, index) => toSubtotal.slice(0, index + 1));
+};
+
+const buildGroupedRowSubtotals = (
+    entries: Array<[dimensions: string[], rows: ResultRow[]]>,
+): GroupedPivotRowSubtotals =>
+    Object.fromEntries(
+        entries.map(([dimensions, rows]) => [
+            getSubtotalKey(dimensions),
+            buildWarehouseRowTotals(rows, dimensions),
+        ]),
+    );
+
+const fetchRowSubtotals = async (args: {
+    projectUuid: string;
+    sourceQueryUuid: string;
+    dimensionGroups: string[][];
+    invalidateCache?: boolean;
+}): Promise<GroupedPivotRowSubtotals> => {
+    const entries = await Promise.all(
+        args.dimensionGroups.map(
+            async (
+                group,
+            ): Promise<[dimensions: string[], rows: ResultRow[]]> => {
+                const { queryUuid } = await startCalculateTotalQuery({
+                    projectUuid: args.projectUuid,
+                    sourceQueryUuid: args.sourceQueryUuid,
+                    kind: 'rowSubtotal',
+                    subtotalDimensions: group,
+                    invalidateCache: args.invalidateCache,
+                });
+
+                const query = await pollForResults(args.projectUuid, queryUuid);
+                if (
+                    query.status === QueryHistoryStatus.ERROR ||
+                    query.status === QueryHistoryStatus.EXPIRED
+                ) {
+                    throw new Error(
+                        query.error || 'Error computing row subtotals',
+                    );
+                }
+                if (query.status !== QueryHistoryStatus.READY) {
+                    throw new Error(
+                        'Unexpected query status while polling row subtotals',
+                    );
+                }
+
+                const rows = await fetchAllResultRows(
+                    args.projectUuid,
+                    queryUuid,
+                );
+                return [group, rows];
+            },
+        ),
+    );
+
+    return buildGroupedRowSubtotals(entries);
+};
+
+export const useAsyncCalculateRowSubtotals = ({
+    projectUuid,
+    sourceQueryUuid,
+    dimensions,
+    columnOrder,
+    pivotDimensions,
+    enabled,
+    invalidateCache,
+}: {
+    projectUuid: string | undefined;
+    sourceQueryUuid: string | undefined;
+    dimensions: string[] | undefined;
+    columnOrder: string[];
+    pivotDimensions: string[] | undefined;
+    enabled: boolean;
+    invalidateCache?: boolean;
+}) => {
+    const dimensionGroups = getSubtotalDimensionGroups(
+        dimensions ?? [],
+        columnOrder,
+        pivotDimensions ?? [],
+    );
+
+    return useQuery<GroupedPivotRowSubtotals, ApiError>({
+        queryKey: [
+            'calculate_async_row_subtotals',
+            projectUuid,
+            sourceQueryUuid,
+            dimensionGroups,
+            invalidateCache,
+        ],
+        queryFn: () => {
+            if (!projectUuid || !sourceQueryUuid) {
+                return Promise.reject(
+                    new Error(
+                        'Missing projectUuid or sourceQueryUuid for async row subtotals',
+                    ),
+                );
+            }
+            return fetchRowSubtotals({
+                projectUuid,
+                sourceQueryUuid,
+                dimensionGroups,
+                invalidateCache,
+            });
+        },
+        enabled:
+            enabled &&
+            !!projectUuid &&
+            !!sourceQueryUuid &&
+            dimensionGroups.length > 0,
+        retry: false,
+    });
 };
 
 // One async calculate-total call per nesting level (kind 'columnSubtotal'),


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-5900/row-totals-should-sum-subtotals-in-pivot-tables
Closes: https://github.com/lightdash/lightdash/issues/21068

## Summary

- calculate row totals for each pivot subtotal grain in the warehouse
- preserve aggregate semantics for averages, distinct counts, ratios, and other non-additive metrics
- render grouped row subtotals in both metric layouts with an independent loading state

Linear: https://linear.app/lightdash/issue/PROD-5900/row-totals-should-sum-subtotals-in-pivot-tables

## Screenshots

### Before

<img width="1876" height="1148" alt="Before: subtotal row totals are unavailable" src="https://github.com/user-attachments/assets/57f845fd-deca-4c98-93e7-aad2ee89f237" />

### After

<img width="1876" height="1148" alt="After: warehouse-computed subtotal row totals" src="https://github.com/user-attachments/assets/f927ab2f-7d8a-4fd4-9f78-a2df3b6e142b" />

<img width="3252" height="1732" alt="CleanShot 2026-07-23 at 11 54 21@2x" src="https://github.com/user-attachments/assets/c6c73bcd-b5cd-4371-a3b8-960b0068c3cc" />


## Testing

- `pnpm -F backend test TotalQueryBuilder.test.ts QueryComposer.test.ts` (59 tests)
- `pnpm -F common typecheck:fast`
- `pnpm -F backend typecheck:fast`
- `pnpm -F frontend typecheck:fast`
- pre-commit backend/frontend/common lint and formatting
- local API generation/compatibility validation
- local before/after visual verification