### PR TITLE
fix: preserve project context v1 compatibility

### DIFF
--- a/packages/common/src/ee/AiAgent/projectContext.test.ts
+++ b/packages/common/src/ee/AiAgent/projectContext.test.ts
@@ -129,12 +129,110 @@ describe('loadProjectContextFile', () => {
 
     test('rejects legacy string object refs in v2 files', () => {
         const yaml = `
+version: 2
+entries:
+  - id: routing
+    kind: context
+    content: Use payments.
+    objects: [payments]
+`;
+        expect(() => loadProjectContextFile(yaml)).toThrow(ParseError);
+    });
+
+    test('drops invalid object refs from quoted v1 documents', () => {
+        const yaml = `
+version: "1"
+entries:
+  - id: routing
+    kind: context
+    content: Use payments.
+    objects: [payments]
+`;
+        expect(loadProjectContextFile(yaml)).toEqual([
+            {
+                id: 'routing',
+                kind: 'context',
+                content: 'Use payments.',
+                terms: [],
+                objects: [],
+            },
+        ]);
+    });
+
+    test('drops the whole legacy objects array when any ref is invalid', () => {
+        const yaml = `
+version: 1
+entries:
+  - id: routing
+    kind: context
+    content: Use payments.
+    objects:
+      - type: explore
+        name: payments
+      - orders
+`;
+        expect(loadProjectContextFile(yaml)[0].objects).toEqual([]);
+    });
+
+    test('preserves valid typed object refs in v1 documents', () => {
+        const yaml = `
+version: 1
+entries:
+  - id: routing
+    kind: context
+    content: Use payments.
+    objects:
+      - type: explore
+        name: payments
+`;
+        expect(loadProjectContextFile(yaml)[0].objects).toEqual([
+            { type: 'explore', name: 'payments' },
+        ]);
+    });
+
+    test('still rejects invalid non-object fields in v1 documents', () => {
+        const yaml = `
+version: 1
+entries:
+  - id: routing
+    kind: unknown
+    content: Use payments.
+    objects: [payments]
+`;
+        expect(() => loadProjectContextFile(yaml)).toThrow(ParseError);
+    });
+
+    test('drops invalid object refs from legacy bare arrays', () => {
+        const yaml = `
 - id: routing
   kind: context
   content: Use payments.
   objects: [payments]
 `;
-        expect(() => loadProjectContextFile(yaml)).toThrow(ParseError);
+        expect(loadProjectContextFile(yaml)[0].objects).toEqual([]);
+    });
+
+    test.each([
+        [
+            'v1 documents',
+            `version: 1
+entries:
+  - id: routing
+    kind: context
+    content: Use payments.
+    objects:
+`,
+        ],
+        [
+            'legacy bare arrays',
+            `- id: routing
+  kind: context
+  content: Use payments.
+  objects:
+`,
+        ],
+    ])('drops null objects from %s', (_, yaml) => {
+        expect(loadProjectContextFile(yaml)[0].objects).toEqual([]);
     });
 
     test('derives an id from the first term when absent', () => {
@@ -343,9 +441,9 @@ entries:
         ]);
     });
 
-    test('rejects v1 documents', () => {
+    test('rejects unsupported document versions', () => {
         const yaml = `
-version: 1
+version: 3
 entries:
   - id: hr
     kind: definition
@@ -356,6 +454,42 @@ entries:
 });
 
 describe('applyProjectContextWriteback', () => {
+    test('upgrades v1 files and drops invalid object refs', () => {
+        const existing = `version: "1"
+entries:
+  - id: legacy
+    kind: context
+    content: Use orders.
+    objects: [orders]
+`;
+        const { content } = applyProjectContextWriteback(existing, {
+            op: 'create',
+            id: 'payments',
+            kind: 'context',
+            content: 'Use payments.',
+            terms: [],
+            objects: [{ type: 'explore', name: 'payments' }],
+        });
+
+        expect(content).toContain('version: 2');
+        expect(loadProjectContextFile(content)).toEqual([
+            {
+                id: 'legacy',
+                kind: 'context',
+                content: 'Use orders.',
+                terms: [],
+                objects: [],
+            },
+            {
+                id: 'payments',
+                kind: 'context',
+                content: 'Use payments.',
+                terms: [],
+                objects: [{ type: 'explore', name: 'payments' }],
+            },
+        ]);
+    });
+
     test('creates a canonical file from empty content', () => {
         const { content, entryId, op } = applyProjectContextWriteback('', {
             op: 'create',

--- a/packages/common/src/ee/AiAgent/projectContext.ts
+++ b/packages/common/src/ee/AiAgent/projectContext.ts
@@ -44,6 +44,47 @@ export const aiProjectContextTypedObjectRefSchema: z.ZodType<AiProjectContextTyp
 export const aiProjectContextObjectRefSchema: z.ZodType<AiProjectContextObjectRef> =
     z.union([z.string().min(1), aiProjectContextTypedObjectRefSchema]);
 
+const typedProjectContextObjectRefsSchema = z.array(
+    aiProjectContextTypedObjectRefSchema,
+);
+
+const sanitizeLegacyProjectContextEntry = (entry: unknown): unknown => {
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+        return entry;
+    }
+
+    const sanitized = { ...entry } as Record<string, unknown>;
+    if (
+        !typedProjectContextObjectRefsSchema.safeParse(sanitized.objects)
+            .success
+    ) {
+        sanitized.objects = [];
+    }
+    return sanitized;
+};
+
+const normalizeLegacyProjectContext = (loaded: unknown): unknown => {
+    if (Array.isArray(loaded)) {
+        return loaded.map(sanitizeLegacyProjectContextEntry);
+    }
+    if (typeof loaded !== 'object' || loaded === null) {
+        return loaded;
+    }
+
+    const document = loaded as Record<string, unknown>;
+    if (document.version !== 1 && document.version !== '1') {
+        return loaded;
+    }
+
+    return {
+        ...document,
+        version: PROJECT_CONTEXT_FILE_VERSION,
+        entries: Array.isArray(document.entries)
+            ? document.entries.map(sanitizeLegacyProjectContextEntry)
+            : document.entries,
+    };
+};
+
 export const serializeAiProjectContextObjectRef = (
     ref: AiProjectContextObjectRef,
 ): string => {
@@ -242,6 +283,7 @@ export const loadProjectContextFile = (
         );
     }
 
+    const normalized = normalizeLegacyProjectContext(loaded);
     const ajv = new Ajv({
         coerceTypes: true,
         allErrors: true,
@@ -250,7 +292,7 @@ export const loadProjectContextFile = (
     AjvErrors(ajv);
     const validate = ajv.compile(lightdashProjectContextSchema);
 
-    if (!validate(loaded)) {
+    if (!validate(normalized)) {
         const errors = betterAjvErrors(
             lightdashProjectContextSchema,
             loaded,
@@ -263,9 +305,9 @@ export const loadProjectContextFile = (
     }
 
     const rawEntries = (
-        Array.isArray(loaded)
-            ? loaded
-            : (loaded as { entries: unknown[] }).entries
+        Array.isArray(normalized)
+            ? normalized
+            : (normalized as { entries: unknown[] }).entries
     ) as ProjectContextFileEntry[];
     const entries: ProjectContextEntry[] = [];
     const usedIds = new Set<string>();
@@ -308,10 +350,11 @@ export const applyProjectContextWriteback = (
     if (existingContent.trim() !== '') {
         const doc = parseDocument(existingContent);
         const entriesNode = doc.get('entries');
-        if (doc.errors.length === 0 && isSeq(entriesNode)) {
-            if (doc.get('version') === undefined) {
-                doc.set('version', PROJECT_CONTEXT_FILE_VERSION);
-            }
+        if (
+            doc.errors.length === 0 &&
+            isSeq(entriesNode) &&
+            doc.get('version') === PROJECT_CONTEXT_FILE_VERSION
+        ) {
             const node = doc.createNode({
                 id: entryId,
                 kind: judgeEntry.kind,


### PR DESCRIPTION
## Summary

- load version 1 and legacy bare-array project context files
- drop an entry's entire `objects` array when it is not a valid typed-ref array
- preserve valid typed refs and keep version 2 validation strict
- upgrade version 1 files to version 2 during writeback

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/ee/AiAgent/projectContext.test.ts` — 37 passed
- `pnpm -F common typecheck:fast`
- focused common lint and formatting checks
- full 35-entry version 1 reproduction loaded successfully with invalid object refs removed

Relates: ZAP-671
Closes: #26035