### PR TITLE
feat(data-apps): upgrade app to the latest template as a special iteration

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1473,6 +1473,20 @@ export type DataAppIteratedEvent = BaseTrack & {
     };
 };
 
+export type DataAppUpgradeRequestedEvent = BaseTrack & {
+    event: 'data_app.upgrade_requested';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        appUuid: string;
+        version: number;
+        /** What the app's bundle self-reported; null for legacy bundles. */
+        reportedSdkVersion: string | null;
+        reportedFeatureCount: number | null;
+    };
+};
+
 export type DataAppVersionCancelledEvent = BaseTrack & {
     event: 'data_app.version.cancelled';
     userId: string;
@@ -1710,6 +1724,7 @@ export type DataAppUploadRejectedEvent = BaseTrack & {
 export type DataAppEvent =
     | DataAppCreatedEvent
     | DataAppIteratedEvent
+    | DataAppUpgradeRequestedEvent
     | DataAppVersionCancelledEvent
     | DataAppVersionCompletedEvent
     | DataAppVersionFailedEvent

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -28,8 +28,10 @@ import {
     type ApiTogglePinnedItem,
     type ApiUpdateAppRequest,
     type ApiUpdateAppResponse,
+    type ApiUpgradeAppResponse,
     type GenerateAppRequestBody,
     type ImportAppCodeRequestBody,
+    type UpgradeAppRequestBody,
 } from '@lightdash/common';
 import {
     Body,
@@ -397,6 +399,36 @@ export class AppGenerateController extends BaseController {
             toSessionUser(req.account),
             projectUuid,
             appUuid,
+        );
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: result,
+        };
+    }
+
+    /**
+     * Rebuild this app on the current template image (fresh sandbox, latest
+     * SDK and skills). The body carries what the running bundle self-reported
+     * so the upgrade agent can offer the newly available features.
+     * @summary Upgrade app to the latest template
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{appUuid}/upgrade')
+    @OperationId('upgradeApp')
+    async upgradeApp(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() appUuid: string,
+        @Body() body: UpgradeAppRequestBody,
+    ): Promise<ApiUpgradeAppResponse> {
+        assertRegisteredAccount(req.account);
+        const result = await this.getAppGenerateService().upgradeApp(
+            toSessionUser(req.account),
+            projectUuid,
+            appUuid,
+            body,
         );
         this.setStatus(200);
         return {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -83,6 +83,7 @@ import {
     type SavedChart,
     type SessionUser,
     type TogglePinnedItemInfo,
+    type UpgradeAppRequestBody,
 } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { Knex } from 'knex';
@@ -1958,6 +1959,84 @@ export class AppGenerateService extends BaseService {
         };
     }
 
+    private static readonly CLAUDE_SESSION_PATHS =
+        'root/.claude root/.claude.json home/user/.claude home/user/.claude.json';
+
+    /**
+     * Upgrade pre-step: best-effort extract the Claude session state from the
+     * old sandbox, then destroy it and clear `sandbox_id` so `acquireSandbox`
+     * takes its cold-create path — a fresh box from the CURRENT template
+     * image with the latest ready source restored from S3. Session carry and
+     * destroy failures are logged, never fatal.
+     */
+    private async prepareUpgradeColdStart(
+        appUuid: string,
+        projectUuid: string,
+        copilot: CopilotConfig,
+        extraEgressHosts: string[],
+    ): Promise<Buffer | null> {
+        const app = await this.appModel.getApp(appUuid, projectUuid);
+        if (!app.sandbox_id) return null;
+        let sessionTar: Buffer | null = null;
+        try {
+            const { sandbox: oldSandbox } = await this.resumeSandbox(
+                app.sandbox_id,
+                appUuid,
+                copilot,
+                extraEgressHosts,
+            );
+            const result = await oldSandbox.commands.run(
+                `tar -cf /tmp/claude-session.tar --ignore-failed-read -C / ${AppGenerateService.CLAUDE_SESSION_PATHS}`,
+                { timeoutMs: 60_000 },
+            );
+            if (result.exitCode === 0) {
+                sessionTar = Buffer.from(
+                    await oldSandbox.files.readBytes('/tmp/claude-session.tar'),
+                );
+            }
+        } catch (error) {
+            this.logger.warn(
+                `App ${appUuid}: could not carry the Claude session over the upgrade: ${getErrorMessage(error)}`,
+            );
+        }
+        try {
+            await this.getSandboxManager().destroy({
+                sandboxUuid: app.sandbox_id,
+            });
+        } catch (error) {
+            this.logger.warn(
+                `App ${appUuid}: failed to destroy the old sandbox on upgrade: ${getErrorMessage(error)}`,
+            );
+        }
+        await this.appModel.updateSandboxUuid(appUuid, null);
+        this.logger.info(
+            `App ${appUuid}: upgrade cold-start prepared (sessionCarried=${sessionTar !== null})`,
+        );
+        return sessionTar;
+    }
+
+    /** Best-effort restore of a carried Claude session into the new box. */
+    private async restoreClaudeSession(
+        sandbox: SandboxHandle,
+        appUuid: string,
+        sessionTar: Buffer,
+    ): Promise<void> {
+        try {
+            await sandbox.files.write('/tmp/claude-session.tar', sessionTar);
+            await sandbox.commands.run(
+                'tar -xf /tmp/claude-session.tar -C / && rm -f /tmp/claude-session.tar',
+                { timeoutMs: 60_000 },
+            );
+            this.logger.info(
+                `App ${appUuid}: Claude session restored into the upgraded sandbox`,
+            );
+        } catch (error) {
+            this.logger.warn(
+                `App ${appUuid}: failed to restore the Claude session into the new sandbox: ${getErrorMessage(error)}`,
+            );
+        }
+    }
+
     /**
      * Write resolved chart references as individual JSON files in the sandbox.
      * Returns a summary string to prepend to the prompt, or empty string if
@@ -3442,6 +3521,18 @@ export class AppGenerateService extends BaseService {
                 return;
             }
             try {
+                // Upgrade: drop the old sandbox first (carrying the Claude
+                // session best-effort) so the iteration path below cold-starts
+                // on the current template image.
+                let upgradeSessionTar: Buffer | null = null;
+                if (payload.isUpgrade) {
+                    upgradeSessionTar = await this.prepareUpgradeColdStart(
+                        appUuid,
+                        projectUuid,
+                        copilot,
+                        registryHosts,
+                    );
+                }
                 if (isIteration) {
                     const app = await this.appModel.getApp(
                         appUuid,
@@ -3473,6 +3564,13 @@ export class AppGenerateService extends BaseService {
                     sandboxUuid = result.sandboxUuid;
                     durations.sandboxMs = result.durationMs;
                     await this.appModel.updateSandboxUuid(appUuid, sandboxUuid);
+                }
+                if (upgradeSessionTar) {
+                    await this.restoreClaudeSession(
+                        sandbox,
+                        appUuid,
+                        upgradeSessionTar,
+                    );
                 }
             } catch (error) {
                 const marked = await this.markError(
@@ -5194,56 +5292,11 @@ export class AppGenerateService extends BaseService {
             design: designSnapshot,
         };
 
-        // Carry the latest version's custom dependency set forward. The dep
-        // FILES must be copied under the new version's S3 prefix BEFORE the
-        // row is created so a copy failure can't orphan a pending version.
-        // An errored version can hold a summary without files, so walk back
-        // to the newest version whose files actually exist.
-        let carriedDependencies: AppVersionDependencies | undefined;
-        if (latestVersion?.dependencies) {
-            // Kill-switch: iterations restore the stored dep set, so they must
-            // stop too when custom dependencies are disabled instance-wide.
-            if (!this.lightdashConfig.appRuntime.customDependenciesEnabled) {
-                throw new ParameterError(
-                    'Custom app dependencies are disabled on this instance (LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED). This app declares custom packages, so it cannot be iterated until they are re-enabled.',
-                );
-            }
-            carriedDependencies = latestVersion.dependencies;
-            const { client, bucket } = this.getS3Client();
-            const toPrefix = versionPrefix(appUuid, newVersion);
-            const candidates =
-                await this.appModel.getVersionsWithDependencies(appUuid);
-            let copied = false;
-            for (const candidate of candidates) {
-                const fromPrefix = versionPrefix(appUuid, candidate.version);
-                try {
-                    // eslint-disable-next-line no-await-in-loop
-                    await Promise.all(
-                        ['deps/package.json', 'deps/pnpm-lock.yaml'].map(
-                            (key) =>
-                                client.send(
-                                    new CopyObjectCommand({
-                                        Bucket: bucket,
-                                        CopySource: `${bucket}/${fromPrefix}${key}`,
-                                        Key: `${toPrefix}${key}`,
-                                    }),
-                                ),
-                        ),
-                    );
-                    copied = true;
-                    break;
-                } catch (err) {
-                    this.logger.warn(
-                        `App ${appUuid}: dependency files missing for version ${candidate.version}, trying an earlier version (${getErrorMessage(err)})`,
-                    );
-                }
-            }
-            if (!copied) {
-                throw new ParameterError(
-                    "Could not carry this app's custom dependencies forward: no stored dependency files found. Re-upload the app with 'lightdash upload --apps' to restore them.",
-                );
-            }
-        }
+        const carriedDependencies = await this.carryDependenciesForward(
+            appUuid,
+            newVersion,
+            latestVersion?.dependencies,
+        );
 
         await this.appModel.createVersion(
             appUuid,
@@ -5301,6 +5354,200 @@ export class AppGenerateService extends BaseService {
             dashboardBlueprint: dashboardBlueprint ?? undefined,
             claudeModel,
             designUuid: effectiveDesignUuid,
+        });
+
+        return { appUuid, version: newVersion };
+    }
+
+    /**
+     * Carry the latest version's custom dependency set forward. The dep
+     * FILES must be copied under the new version's S3 prefix BEFORE the
+     * row is created so a copy failure can't orphan a pending version.
+     * An errored version can hold a summary without files, so walk back
+     * to the newest version whose files actually exist.
+     */
+    private async carryDependenciesForward(
+        appUuid: string,
+        newVersion: number,
+        latestDependencies: AppVersionDependencies | null | undefined,
+    ): Promise<AppVersionDependencies | undefined> {
+        if (!latestDependencies) return undefined;
+        // Kill-switch: iterations restore the stored dep set, so they must
+        // stop too when custom dependencies are disabled instance-wide.
+        if (!this.lightdashConfig.appRuntime.customDependenciesEnabled) {
+            throw new ParameterError(
+                'Custom app dependencies are disabled on this instance (LIGHTDASH_APP_CUSTOM_DEPENDENCIES_ENABLED). This app declares custom packages, so it cannot be iterated until they are re-enabled.',
+            );
+        }
+        const { client, bucket } = this.getS3Client();
+        const toPrefix = versionPrefix(appUuid, newVersion);
+        const candidates =
+            await this.appModel.getVersionsWithDependencies(appUuid);
+        let copied = false;
+        for (const candidate of candidates) {
+            const fromPrefix = versionPrefix(appUuid, candidate.version);
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                await Promise.all(
+                    ['deps/package.json', 'deps/pnpm-lock.yaml'].map((key) =>
+                        client.send(
+                            new CopyObjectCommand({
+                                Bucket: bucket,
+                                CopySource: `${bucket}/${fromPrefix}${key}`,
+                                Key: `${toPrefix}${key}`,
+                            }),
+                        ),
+                    ),
+                );
+                copied = true;
+                break;
+            } catch (err) {
+                this.logger.warn(
+                    `App ${appUuid}: dependency files missing for version ${candidate.version}, trying an earlier version (${getErrorMessage(err)})`,
+                );
+            }
+        }
+        if (!copied) {
+            throw new ParameterError(
+                "Could not carry this app's custom dependencies forward: no stored dependency files found. Re-upload the app with 'lightdash upload --apps' to restore them.",
+            );
+        }
+        return latestDependencies;
+    }
+
+    static readonly UPGRADE_PROMPT_LABEL = 'Upgrade to the latest app template';
+
+    /**
+     * The stored row prompt stays the short label (what chat history shows);
+     * this composed instruction is what the pipeline actually sends —
+     * mirrors the theme-change prompt pattern.
+     */
+    private static buildUpgradePrompt(body: UpgradeAppRequestBody): string {
+        const candidates = (body.candidateFeatures ?? []).slice(0, 20);
+        const featureStep =
+            candidates.length > 0
+                ? [
+                      '2. These SDK features may be new to this app:',
+                      ...candidates.map(
+                          (f) =>
+                              `   - ${f.key}: ${f.label} — ${f.description}${
+                                  f.wiring
+                                      ? ` [wiring needed: ${f.wiring}]`
+                                      : ''
+                              }`,
+                      ),
+                      '   Keep only the ones that BOTH exist in the SDK installed in this workspace (verify in node_modules/@lightdash/query-sdk, e.g. dist/features.js) AND would be genuinely useful for what this app does. Silently discard the rest.',
+                      '   A feature marked [wiring needed] still counts as available — if it fits the app, OFFER it (the wiring happens later, only if the user asks). Remember its wiring note: it is how you implement the feature when they do.',
+                      '   A candidate that is ALREADY working after this rebuild (it activates automatically on the new SDK, or the app already contains its wiring) belongs on the "Now active" line of your final message, not the ask-list.',
+                  ].join('\n')
+                : '2. Read SDK_FEATURES from node_modules/@lightdash/query-sdk/dist/features.js to see what is available. If that file does not exist, the installed SDK predates feature reporting — there is nothing to offer; skip the feature list entirely.';
+        return [
+            'This app has just been moved to the latest app template (new SDK, components, and skills).',
+            'Do the following, in order:',
+            '1. You cannot run shell commands — the pipeline builds the app after your turn and returns any build errors to you. Check compatibility by reading the app source against the installed SDK, and fix any breakage minimally in the source. Do not change features, content, or visual design.',
+            featureStep,
+            'Never infer or invent "new features" from export lists, type definitions, or guesswork — if a feature is not declared in the installed SDK feature registry, do not mention it.',
+            '3. Your ENTIRE final message must be this template and nothing else — no text before it, between its parts, or after it:',
+            '',
+            '   The app was upgraded to the latest template successfully. [or, on failure, one plain sentence saying what broke]',
+            '',
+            '   Now active: **<feature label>** — one short phrase on what it does. [only for candidates you VERIFIED are already working after the rebuild; omit the line when there are none]',
+            '',
+            '   Newly available — ask me to add any of these:',
+            '   - **<feature label>** — one short sentence on what it would do for this app.',
+            '',
+            '   Omit the "Now active" line and/or the "Newly available" section when empty.',
+            '   It is for a non-technical app owner: never describe what you checked or how, never mention files, code, or APIs, and do not discuss features outside the bullet list.',
+            '   Do not implement any of the features now.',
+        ].join('\n');
+    }
+
+    /**
+     * Upgrade-as-iteration: rebuilds the app on the current template image.
+     * The `isUpgrade` flag makes the pipeline destroy the app's sandbox
+     * (carrying the Claude session best-effort) so the run cold-starts on the
+     * current image with the latest source restored. Nothing is persisted
+     * about freshness — the running bundle self-reports via the SDK manifest.
+     */
+    async upgradeApp(
+        user: SessionUser,
+        projectUuid: string,
+        appUuid: string,
+        body: UpgradeAppRequestBody = {},
+    ): Promise<GenerateAppResult> {
+        await this.assertDataAppsEnabled(user);
+
+        const app = await this.appModel.getApp(appUuid, projectUuid);
+        await this.assertCanManageApp(
+            user,
+            app,
+            'Insufficient permissions to upgrade this data app',
+        );
+
+        const latestVersion = await this.appModel.getLatestVersion(appUuid);
+        if (
+            latestVersion?.status &&
+            isAppVersionInProgress(latestVersion.status)
+        ) {
+            throw new ParameterError(
+                'A version is already building for this app',
+            );
+        }
+        const latestReady = await this.appModel.getLatestReadyVersion(appUuid);
+        if (!latestReady) {
+            throw new ParameterError(
+                'This app has no ready version to upgrade',
+            );
+        }
+
+        const newVersion = (latestVersion?.version ?? 0) + 1;
+        this.logger.info(
+            `App ${appUuid}: upgrade started (version=${newVersion}, reportedSdkVersion=${
+                body.reportedSdkVersion ?? 'unknown'
+            })`,
+        );
+
+        const carriedDependencies = await this.carryDependenciesForward(
+            appUuid,
+            newVersion,
+            latestVersion?.dependencies,
+        );
+
+        await this.appModel.createVersion(
+            appUuid,
+            {
+                version: newVersion,
+                prompt: AppGenerateService.UPGRADE_PROMPT_LABEL,
+            },
+            'pending',
+            user.userUuid,
+            undefined,
+            carriedDependencies,
+        );
+
+        this.analytics.track({
+            event: 'data_app.upgrade_requested',
+            userId: user.userUuid,
+            properties: {
+                organizationId: user.organizationUuid!,
+                projectId: projectUuid,
+                appUuid,
+                version: newVersion,
+                reportedSdkVersion: body.reportedSdkVersion ?? null,
+                reportedFeatureCount: body.reportedFeatures?.length ?? null,
+            },
+        });
+
+        await this.schedulerClient.appGeneratePipeline({
+            appUuid,
+            version: newVersion,
+            projectUuid,
+            organizationUuid: user.organizationUuid!,
+            userUuid: user.userUuid,
+            prompt: AppGenerateService.buildUpgradePrompt(body),
+            isIteration: true,
+            isUpgrade: true,
+            designUuid: app.design_uuid,
         });
 
         return { appUuid, version: newVersion };

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
@@ -1,0 +1,311 @@
+import { ForbiddenError, ParameterError } from '@lightdash/common';
+import { AppGenerateService } from './AppGenerateService';
+
+vi.mock('e2b', () => ({
+    Sandbox: class {},
+    CommandExitError: class extends Error {},
+    ALL_TRAFFIC: '*',
+}));
+vi.mock('ai', () => ({
+    generateObject: vi.fn(),
+}));
+
+const PROJECT_UUID = 'proj-uuid-1';
+const APP_UUID = 'app-uuid-1';
+const USER_UUID = 'user-uuid-1';
+const USER_ORG_UUID = 'org-uuid-user';
+
+const makeUser = () =>
+    ({
+        userUuid: USER_UUID,
+        organizationUuid: USER_ORG_UUID,
+    }) as never;
+
+const makeApp = (overrides: Record<string, unknown> = {}) => ({
+    app_id: APP_UUID,
+    project_uuid: PROJECT_UUID,
+    organization_uuid: USER_ORG_UUID,
+    space_uuid: null,
+    created_by_user_uuid: USER_UUID,
+    sandbox_id: 'sandbox-registry-uuid',
+    design_uuid: null,
+    ...overrides,
+});
+
+function buildService(opts: { canManage?: boolean } = {}) {
+    const appModel = {
+        getApp: vi.fn().mockResolvedValue(makeApp()),
+        getLatestVersion: vi.fn().mockResolvedValue({
+            version: 4,
+            status: 'ready',
+            dependencies: null,
+            created_at: new Date(),
+        }),
+        getLatestReadyVersion: vi.fn().mockResolvedValue({ version: 4 }),
+        getVersionsWithDependencies: vi.fn().mockResolvedValue([]),
+        createVersion: vi.fn().mockResolvedValue({ version: 5 }),
+        updateSandboxUuid: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const schedulerClient = {
+        appGeneratePipeline: vi.fn().mockResolvedValue({ jobId: 'job-1' }),
+    };
+
+    const featureFlagModel = {
+        get: vi.fn().mockResolvedValue({ enabled: true }),
+    };
+
+    const spacePermissionService = {
+        getSpaceAccessContext: vi.fn().mockResolvedValue({}),
+    };
+
+    const analytics = { track: vi.fn() };
+
+    const lightdashConfig = {
+        appRuntime: {
+            customDependenciesEnabled: true,
+            dependencyRegistryHosts: ['registry.npmjs.org'],
+        },
+    };
+
+    const service = new AppGenerateService({
+        lightdashConfig: lightdashConfig as never,
+        analytics: analytics as never,
+        analyticsModel: {} as never,
+        catalogModel: {} as never,
+        appModel: appModel as never,
+        featureFlagModel: featureFlagModel as never,
+        organizationDesignModel: {} as never,
+        pinnedListModel: {} as never,
+        projectModel: {} as never,
+        projectParametersModel: {} as never,
+        spaceModel: {} as never,
+        schedulerClient: schedulerClient as never,
+        savedChartService: {} as never,
+        spacePermissionService: spacePermissionService as never,
+        dashboardService: {} as never,
+        projectService: {} as never,
+        promoteService: {} as never,
+        externalConnectionModel: {} as never,
+        sandboxRegistryModel: {} as never,
+        orgAiCopilotConfigResolver: {} as never,
+    });
+
+    const canManage = opts.canManage ?? true;
+    vi.spyOn(
+        service as unknown as { createAuditedAbility: () => unknown },
+        'createAuditedAbility',
+    ).mockReturnValue({
+        can: () => canManage,
+        cannot: () => !canManage,
+    });
+
+    return { service, appModel, schedulerClient, analytics };
+}
+
+describe('upgradeApp', () => {
+    it('stores the short label and enqueues a composed prompt with the candidate features', async () => {
+        const { service, appModel, schedulerClient, analytics } =
+            buildService();
+
+        const result = await service.upgradeApp(
+            makeUser(),
+            PROJECT_UUID,
+            APP_UUID,
+            {
+                reportedSdkVersion: '0.3400.0',
+                reportedFeatures: ['query', 'inspect'],
+                candidateFeatures: [
+                    {
+                        key: 'drill-down',
+                        label: 'Drill down',
+                        description: 'Explore a metric by another dimension',
+                    },
+                    {
+                        key: 'lineage',
+                        label: 'Inspect data',
+                        description: 'Trace charts back to their queries',
+                        wiring: 'Spread lineage props onto chart roots',
+                    },
+                ],
+            },
+        );
+
+        expect(result).toEqual({ appUuid: APP_UUID, version: 5 });
+        expect(appModel.createVersion).toHaveBeenCalledWith(
+            APP_UUID,
+            { version: 5, prompt: 'Upgrade to the latest app template' },
+            'pending',
+            USER_UUID,
+            undefined,
+            undefined,
+        );
+
+        const payload = schedulerClient.appGeneratePipeline.mock.calls[0][0];
+        expect(payload.isUpgrade).toBe(true);
+        expect(payload.isIteration).toBe(true);
+        expect(payload.version).toBe(5);
+        expect(payload.prompt).toContain(
+            'drill-down: Drill down — Explore a metric by another dimension',
+        );
+        expect(payload.prompt).toContain(
+            'lineage: Inspect data — Trace charts back to their queries [wiring needed: Spread lineage props onto chart roots]',
+        );
+        expect(payload.prompt).toContain('still counts as available');
+        expect(payload.prompt).toContain('@lightdash/query-sdk');
+        expect(payload.prompt).toContain('Never infer or invent');
+        expect(payload.prompt).toContain('non-technical app owner');
+        expect(payload.prompt).toContain('ENTIRE final message');
+        expect(payload.prompt).toContain('cannot run shell commands');
+        expect(payload.prompt).toContain('Now active');
+        expect(payload.prompt).not.toBe('Upgrade to the latest app template');
+
+        expect(analytics.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'data_app.upgrade_requested',
+                properties: expect.objectContaining({
+                    appUuid: APP_UUID,
+                    version: 5,
+                    reportedSdkVersion: '0.3400.0',
+                    reportedFeatureCount: 2,
+                }),
+            }),
+        );
+    });
+
+    it('falls back to reading the installed registry when no candidates are sent', async () => {
+        const { service, schedulerClient } = buildService();
+
+        await service.upgradeApp(makeUser(), PROJECT_UUID, APP_UUID, {});
+
+        const payload = schedulerClient.appGeneratePipeline.mock.calls[0][0];
+        expect(payload.prompt).toContain('dist/features.js');
+        expect(payload.prompt).toContain('skip the feature list entirely');
+        expect(payload.prompt).toContain('Never infer or invent');
+    });
+
+    it('rejects when the app has no ready version', async () => {
+        const { service, appModel } = buildService();
+        appModel.getLatestVersion.mockResolvedValue({
+            version: 1,
+            status: 'error',
+            dependencies: null,
+        });
+        appModel.getLatestReadyVersion.mockResolvedValue(null);
+
+        await expect(
+            service.upgradeApp(makeUser(), PROJECT_UUID, APP_UUID, {}),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    it('rejects when a version is already building', async () => {
+        const { service, appModel } = buildService();
+        appModel.getLatestVersion.mockResolvedValue({
+            version: 4,
+            status: 'generating',
+            dependencies: null,
+        });
+
+        await expect(
+            service.upgradeApp(makeUser(), PROJECT_UUID, APP_UUID, {}),
+        ).rejects.toThrow('A version is already building for this app');
+    });
+
+    it('rejects a user without manage permission', async () => {
+        const { service } = buildService({ canManage: false });
+
+        await expect(
+            service.upgradeApp(makeUser(), PROJECT_UUID, APP_UUID, {}),
+        ).rejects.toThrow(ForbiddenError);
+    });
+});
+
+describe('prepareUpgradeColdStart', () => {
+    type PrepareFn = (
+        appUuid: string,
+        projectUuid: string,
+        copilot: unknown,
+        extraEgressHosts: string[],
+    ) => Promise<Buffer | null>;
+
+    const setup = (
+        opts: { resumeFails?: boolean; sandboxId?: string | null } = {},
+    ) => {
+        const { service, appModel } = buildService();
+        appModel.getApp.mockResolvedValue(
+            makeApp({
+                sandbox_id:
+                    opts.sandboxId !== undefined
+                        ? opts.sandboxId
+                        : 'sandbox-registry-uuid',
+            }),
+        );
+        const oldSandbox = {
+            sandboxId: 'provider-sandbox-id',
+            commands: {
+                run: vi
+                    .fn()
+                    .mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }),
+            },
+            files: {
+                readBytes: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+            },
+        };
+        const resumeSpy = vi.spyOn(
+            service as unknown as { resumeSandbox: () => unknown },
+            'resumeSandbox',
+        );
+        if (opts.resumeFails) {
+            resumeSpy.mockRejectedValue(new Error('sandbox expired'));
+        } else {
+            resumeSpy.mockResolvedValue({ sandbox: oldSandbox, durationMs: 5 });
+        }
+        const manager = { destroy: vi.fn().mockResolvedValue(undefined) };
+        vi.spyOn(
+            service as unknown as { getSandboxManager: () => unknown },
+            'getSandboxManager',
+        ).mockReturnValue(manager);
+        const prepare = (
+            service as unknown as { prepareUpgradeColdStart: PrepareFn }
+        ).prepareUpgradeColdStart.bind(service);
+        return { prepare, appModel, manager, oldSandbox };
+    };
+
+    it('tars the Claude session, destroys the sandbox, and clears sandbox_id', async () => {
+        const { prepare, appModel, manager, oldSandbox } = setup();
+
+        const tar = await prepare(APP_UUID, PROJECT_UUID, {}, []);
+
+        expect(tar).not.toBeNull();
+        expect(oldSandbox.commands.run).toHaveBeenCalledWith(
+            expect.stringContaining('--ignore-failed-read'),
+            expect.anything(),
+        );
+        expect(manager.destroy).toHaveBeenCalledWith({
+            sandboxUuid: 'sandbox-registry-uuid',
+        });
+        expect(appModel.updateSandboxUuid).toHaveBeenCalledWith(APP_UUID, null);
+    });
+
+    it('still destroys and clears when the old sandbox cannot be resumed', async () => {
+        const { prepare, appModel, manager } = setup({ resumeFails: true });
+
+        const tar = await prepare(APP_UUID, PROJECT_UUID, {}, []);
+
+        expect(tar).toBeNull();
+        expect(manager.destroy).toHaveBeenCalledWith({
+            sandboxUuid: 'sandbox-registry-uuid',
+        });
+        expect(appModel.updateSandboxUuid).toHaveBeenCalledWith(APP_UUID, null);
+    });
+
+    it('is a no-op when the app has no sandbox', async () => {
+        const { prepare, appModel, manager } = setup({ sandboxId: null });
+
+        const tar = await prepare(APP_UUID, PROJECT_UUID, {}, []);
+
+        expect(tar).toBeNull();
+        expect(manager.destroy).not.toHaveBeenCalled();
+        expect(appModel.updateSandboxUuid).not.toHaveBeenCalled();
+    });
+});

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -429,6 +429,40 @@ export type ApiDuplicateAppResponse = ApiSuccess<{
     version: number;
 }>;
 
+/**
+ * A feature the frontend's SDK registry says may be new to this app.
+ * Mirrors the SdkFeature shape from @lightdash/query-sdk/features.
+ */
+export type UpgradeCandidateFeature = {
+    key: string;
+    label: string;
+    description: string;
+    /** Agent-facing app-code wiring the feature needs before it works;
+     *  absent = activates automatically on the new SDK. */
+    wiring?: string;
+};
+
+/**
+ * What the app's running bundle reported about itself via the SDK's
+ * `lightdash:sdk:manifest` message. Both fields absent for legacy bundles
+ * whose SDK predates feature reporting. Forwarded into the upgrade prompt —
+ * the backend does not validate against any registry.
+ *
+ * candidateFeatures is the authoritative "possibly new" list computed by the
+ * frontend from its own SDK registry — the in-sandbox agent only verifies and
+ * filters it, never discovers features on its own.
+ */
+export type UpgradeAppRequestBody = {
+    reportedSdkVersion?: string;
+    reportedFeatures?: string[];
+    candidateFeatures?: UpgradeCandidateFeature[];
+};
+
+export type ApiUpgradeAppResponse = ApiSuccess<{
+    appUuid: string;
+    version: number;
+}>;
+
 export type PromoteAppAction = 'create' | 'update';
 
 /**

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -57,6 +57,10 @@ export type AppGeneratePipelineJobPayload = TraceTaskBase & {
     template?: DataAppTemplate; // starter template selected on creation; absent on iteration
     imageIds?: string[];
     isIteration: boolean;
+    // Upgrade-as-iteration: the worker destroys the app's sandbox (carrying
+    // the Claude session best-effort) so this run cold-starts on the current
+    // template image. Absent on ordinary jobs.
+    isUpgrade?: boolean;
     chartReferences?: ChartReference[];
     // Structural snapshot of the attached dashboard (tabs, tile layout,
     // filters). Written into the sandbox as a layout blueprint alongside the

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -3,7 +3,7 @@ import {
     isApiError,
     type AppVersionStatus,
 } from '@lightdash/common';
-import { ActionIcon, Menu, Tooltip } from '@mantine-8/core';
+import { ActionIcon, Menu, Text, Tooltip } from '@mantine-8/core';
 import {
     IconArrowsUpDown,
     IconCamera,
@@ -16,12 +16,14 @@ import {
     IconPhotoX,
     IconRefresh,
     IconSend,
+    IconSparkles,
     IconTrash,
 } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState, type FC, type ReactNode } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
 import AppDeleteModal from '../../../components/common/modal/AppDeleteModal';
 import AppUpdateModal from '../../../components/common/modal/AppUpdateModal';
 import useToaster from '../../../hooks/toaster/useToaster';
@@ -34,6 +36,7 @@ import {
 import { useCanCreateDataApp } from '../hooks/useCanCreateDataApp';
 import { useCanEditDataApp } from '../hooks/useCanEditDataApp';
 import { useDuplicateApp } from '../hooks/useDuplicateApp';
+import { useUpgradeApp } from '../hooks/useUpgradeApp';
 import {
     DataAppFavoriteMenuItem,
     FavoritePersonalDataAppModal,
@@ -73,6 +76,9 @@ type Props = {
      *  looking at. Null when the iframe hasn't announced screenshot
      *  capability — the modal then falls back to a default-state render. */
     capturePreviewScreenshot: (() => Promise<File>) | null;
+    /** Upgrade action for the builder surface; null on surfaces without an
+     *  upgrade flow (the viewer). `disabled` while a build is in flight. */
+    upgrade: { disabled: boolean } | null;
 };
 
 /**
@@ -101,6 +107,7 @@ const AppHeaderActions: FC<Props> = ({
     navItem,
     captureThumbnail,
     capturePreviewScreenshot,
+    upgrade,
 }) => {
     const navigate = useNavigate();
 
@@ -163,6 +170,7 @@ const AppHeaderActions: FC<Props> = ({
     ]);
 
     const [schedulerModalOpen, setSchedulerModalOpen] = useState(false);
+    const [isUpgradeModalOpen, setIsUpgradeModalOpen] = useState(false);
     const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
     const [isMoveToSpaceOpen, setIsMoveToSpaceOpen] = useState(false);
     const [isPromoteModalOpen, setIsPromoteModalOpen] = useState(false);
@@ -181,6 +189,14 @@ const AppHeaderActions: FC<Props> = ({
             },
         );
     }, [duplicateMutate, navigate, projectUuid, appUuid]);
+
+    const { mutate: upgradeMutate, isLoading: isUpgrading } = useUpgradeApp();
+    const handleUpgrade = useCallback(() => {
+        upgradeMutate(
+            { projectUuid, appUuid, body: {} },
+            { onSuccess: () => setIsUpgradeModalOpen(false) },
+        );
+    }, [upgradeMutate, projectUuid, appUuid]);
 
     return (
         <>
@@ -247,6 +263,17 @@ const AppHeaderActions: FC<Props> = ({
                         </Menu.Item>
                     )}
                     {(canEdit || canDuplicate) && <Menu.Divider />}
+                    {canEdit && upgrade && (
+                        <Menu.Item
+                            leftSection={
+                                <MantineIcon icon={IconSparkles} size={14} />
+                            }
+                            disabled={upgrade.disabled || isUpgrading}
+                            onClick={() => setIsUpgradeModalOpen(true)}
+                        >
+                            Upgrade app
+                        </Menu.Item>
+                    )}
                     {canEdit && (
                         <Menu.Item
                             leftSection={
@@ -337,6 +364,25 @@ const AppHeaderActions: FC<Props> = ({
                 </Menu.Dropdown>
             </Menu>
 
+            {isUpgradeModalOpen && upgrade && (
+                <MantineModal
+                    opened
+                    onClose={() => setIsUpgradeModalOpen(false)}
+                    title="Upgrade app"
+                    icon={IconSparkles}
+                    confirmLabel="Upgrade"
+                    confirmLoading={isUpgrading}
+                    onConfirm={handleUpgrade}
+                >
+                    <Text size="sm">
+                        Upgrading rebuilds this app on the latest template
+                        (newest SDK, components, and agent skills). The agent
+                        fixes anything the new template breaks, then offers
+                        newly available features in chat — nothing is added
+                        until you ask.
+                    </Text>
+                </MantineModal>
+            )}
             {isUpdateModalOpen && (
                 <AppUpdateModal
                     opened

--- a/packages/frontend/src/features/apps/hooks/useUpgradeApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useUpgradeApp.ts
@@ -1,0 +1,44 @@
+import {
+    type ApiError,
+    type ApiUpgradeAppResponse,
+    type UpgradeAppRequestBody,
+} from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+
+type UpgradeAppParams = {
+    projectUuid: string;
+    appUuid: string;
+    body: UpgradeAppRequestBody;
+};
+
+type UpgradeAppResult = ApiUpgradeAppResponse['results'];
+
+const upgradeApp = ({ projectUuid, appUuid, body }: UpgradeAppParams) =>
+    lightdashApi<UpgradeAppResult>({
+        method: 'POST',
+        url: `/ee/projects/${projectUuid}/apps/${appUuid}/upgrade`,
+        body: JSON.stringify(body),
+    });
+
+export const useUpgradeApp = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError } = useToaster();
+    return useMutation<UpgradeAppResult, ApiError, UpgradeAppParams>({
+        mutationFn: upgradeApp,
+        onSuccess: (_result, { projectUuid, appUuid }) => {
+            // The new pending version lands in the app query; the build
+            // experience's polling takes over from there.
+            void queryClient.invalidateQueries({
+                queryKey: ['app', projectUuid, appUuid],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to upgrade app',
+                apiError: error,
+            });
+        },
+    });
+};

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -3230,6 +3230,11 @@ const AppGenerate: FC = () => {
                                         <AppHeaderActions
                                             projectUuid={projectUuid}
                                             appUuid={activeAppUuid}
+                                            upgrade={{
+                                                disabled:
+                                                    !previewApp ||
+                                                    isAgentWorking,
+                                            }}
                                             appName={appName}
                                             appDescription={
                                                 appDescription || null

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -319,6 +319,7 @@ export default function AppPreviewTest() {
                     <AppHeaderActions
                         projectUuid={projectUuid}
                         appUuid={appUuid}
+                        upgrade={null}
                         appName={appName}
                         appDescription={appDescription}
                         appSpaceUuid={appSpaceUuid}


### PR DESCRIPTION
## What

Adds an in-place **Upgrade app** action: `POST /api/v1/ee/projects/{projectUuid}/apps/{appUuid}/upgrade` creates a new version through the iterate machinery with an `isUpgrade` job flag. In the worker, the flag triggers a pre-step that best-effort tars the Claude session state out of the old sandbox, destroys it, and clears `sandbox_id` — so the existing iteration cold-start path rebuilds the box from the **current** template image (new SDK, skills, scaffolding), restores the latest ready `source.tar` + custom deps from S3, and then restores the carried session. The builder header gets a plain "Upgrade app" menu item with a confirm modal.

The stored row prompt is a short label ("Upgrade to the latest app template" — what chat history shows); the composed instruction in `payload.prompt` tells the agent to fix any breakage minimally without changing features/content, read the feature registry of the SDK in its workspace, and **offer** (not implement) newly available features in its final message.

## Why

Old apps never pick up new SDK or skills: on E2B, iteration pause/resumes the same container, and `skill.md` is read from inside that box — so an app iterated for months still has launch-day capabilities. The workaround has been duplicating the app (fresh sandbox by accident) and manually asking for new features. This makes the same effect a first-class, in-place action that preserves the app's identity, history, and agent session.

## Notes for review

- Failure modes match any iteration: build/agent failure → version `error`, previous version stays deployed; the box is already upgraded so "fix the build" is the next chat message. Session carry-over is explicitly best-effort (worker logs and continues).
- Validation mirrors iterate: conflict when a version is in flight; requires a ready version; `manage` on the app.
- The iterate deps carry-forward block is extracted into a shared `carryDependenciesForward` helper (behavior unchanged) so upgrade reuses it.
- No DB freshness state anywhere — staleness detection lands in the next PR of this stack, driven by the SDK manifest from the previous PR.
- New analytics event: `data_app.upgrade_requested`.

Relates: PROD-7614

🤖 Generated with [Claude Code](https://claude.com/claude-code)
