### PR TITLE
fix: preserve BigQuery time filter pruning

### DIFF
--- a/packages/api-tests/tests/dataTimezone.test.ts
+++ b/packages/api-tests/tests/dataTimezone.test.ts
@@ -41,9 +41,28 @@ import {
 let admin: ApiClient;
 
 const DIMENSION_KEY = 'timezone_test_event_timestamp_day';
+const YEAR_NUM_DIMENSION_KEY = 'timezone_test_event_timestamp_year_num';
 const METRIC_KEY = 'timezone_test_count';
 const DIMENSIONS = [DIMENSION_KEY];
 const METRICS = [METRIC_KEY];
+
+const timestampFilter = (
+    fieldId: string,
+    operator: 'equals' | 'greaterThan' | 'inBetween',
+    values: Array<string | number>,
+) => ({
+    dimensions: {
+        id: 'tz-test',
+        and: [
+            {
+                id: 'tz-filter',
+                target: { fieldId },
+                operator,
+                values,
+            },
+        ],
+    },
+});
 
 describe('Data timezone', () => {
     beforeAll(async () => {
@@ -522,6 +541,102 @@ describe.skipIf(!hasBigqueryCredentials())(
                 '2024-01-16': 2,
             });
         });
+
+        it('aware DAY filter, dataTz=Asia/Tokyo, queryTz=Asia/Tokyo: equals uses the shared calendar day', async () => {
+            await updateDataTimezone(
+                bqAdmin,
+                'Asia/Tokyo',
+                bigqueryProjectUuid,
+            );
+            const rows = await runTimezoneTestQuery(bqAdmin, {
+                dimensions: [DIMENSION_KEY],
+                metrics: [METRIC_KEY],
+                filters: timestampFilter(DIMENSION_KEY, 'equals', [
+                    '2024-01-15',
+                ]),
+                timezone: 'Asia/Tokyo',
+                projectUuid: bigqueryProjectUuid,
+                maxAttempts: BIGQUERY_MAX_ATTEMPTS,
+            });
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(5);
+        });
+
+        it('aware DAY filter, dataTz=Asia/Tokyo, queryTz=UTC: equals follows the project timezone', async () => {
+            await updateDataTimezone(
+                bqAdmin,
+                'Asia/Tokyo',
+                bigqueryProjectUuid,
+            );
+            const rows = await runTimezoneTestQuery(bqAdmin, {
+                dimensions: [DIMENSION_KEY],
+                metrics: [METRIC_KEY],
+                filters: timestampFilter(DIMENSION_KEY, 'equals', [
+                    '2024-01-15',
+                ]),
+                timezone: 'UTC',
+                projectUuid: bigqueryProjectUuid,
+                maxAttempts: BIGQUERY_MAX_ATTEMPTS,
+            });
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(6);
+        });
+
+        it('aware DAY range filters, dataTz=Asia/Tokyo, queryTz=Pacific/Pago_Pago: use the optimized project calendar', async () => {
+            await updateDataTimezone(
+                bqAdmin,
+                'Asia/Tokyo',
+                bigqueryProjectUuid,
+            );
+            const greaterThanRows = await runTimezoneTestQuery(bqAdmin, {
+                dimensions: [DIMENSION_KEY],
+                metrics: [METRIC_KEY],
+                filters: timestampFilter(DIMENSION_KEY, 'greaterThan', [
+                    '2024-01-15',
+                ]),
+                timezone: 'Pacific/Pago_Pago',
+                projectUuid: bigqueryProjectUuid,
+                maxAttempts: BIGQUERY_MAX_ATTEMPTS,
+            });
+            expect(getTotalCount(greaterThanRows, METRIC_KEY)).toBe(2);
+
+            const inBetweenRows = await runTimezoneTestQuery(bqAdmin, {
+                dimensions: [DIMENSION_KEY],
+                metrics: [METRIC_KEY],
+                filters: timestampFilter(DIMENSION_KEY, 'inBetween', [
+                    '2024-01-14',
+                    '2024-01-15',
+                ]),
+                timezone: 'Pacific/Pago_Pago',
+                projectUuid: bigqueryProjectUuid,
+                maxAttempts: BIGQUERY_MAX_ATTEMPTS,
+            });
+            expect(getTotalCount(inBetweenRows, METRIC_KEY)).toBe(8);
+        });
+
+        it.each([
+            ['Asia/Tokyo', 2024],
+            ['Pacific/Pago_Pago', 2023],
+        ])(
+            'aware YEAR_NUM filter, dataTz=Asia/Tokyo, queryTz=%s: boundary instant belongs to %i',
+            async (timezone, year) => {
+                await updateDataTimezone(
+                    bqAdmin,
+                    'Asia/Tokyo',
+                    bigqueryProjectUuid,
+                );
+                const rows = await runTimezoneTestQuery(bqAdmin, {
+                    dimensions: [YEAR_NUM_DIMENSION_KEY],
+                    metrics: [METRIC_KEY],
+                    filters: timestampFilter(YEAR_NUM_DIMENSION_KEY, 'equals', [
+                        year,
+                    ]),
+                    timezone,
+                    projectUuid: bigqueryProjectUuid,
+                    maxAttempts: BIGQUERY_MAX_ATTEMPTS,
+                    eventIds: [17],
+                });
+                expect(getTotalCount(rows, METRIC_KEY)).toBe(1);
+            },
+        );
 
         it('raw frame, dataTz=Asia/Tokyo, queryTz=Asia/Tokyo: raw equals the hour bucket and shows the stored wall clock', async () => {
             await updateDataTimezone(

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -14,10 +14,12 @@ import {
     renderFilterRuleSqlFromField,
     SortByDirection,
     SupportedDbtAdapter,
+    timeFrameConfigs,
     TimeFrames,
     UnitOfTime,
     VizAggregationOptions,
     VizIndexType,
+    WeekDay,
     type CompiledDimension,
     type CompiledMetric,
     type MetricFilterRule,
@@ -5313,6 +5315,356 @@ describe('Timezone-aware DATE_TRUNC day-or-coarser → DATE cast (GLITCH-452)', 
         expect(query).not.toContain(`'2024-01-15'::timestamp`);
     });
 
+    const bigQueryUtcFilterParityFrames = [
+        TimeFrames.RAW,
+        TimeFrames.MILLISECOND,
+        TimeFrames.SECOND,
+        TimeFrames.MINUTE,
+        TimeFrames.HOUR,
+        TimeFrames.DAY,
+        TimeFrames.WEEK,
+        TimeFrames.MONTH,
+        TimeFrames.QUARTER,
+        TimeFrames.YEAR,
+        TimeFrames.DAY_OF_WEEK_INDEX,
+        TimeFrames.DAY_OF_MONTH_NUM,
+        TimeFrames.DAY_OF_YEAR_NUM,
+        TimeFrames.WEEK_NUM,
+        TimeFrames.MONTH_NUM,
+        TimeFrames.QUARTER_NUM,
+        TimeFrames.YEAR_NUM,
+        TimeFrames.HOUR_OF_DAY_NUM,
+        TimeFrames.MINUTE_OF_HOUR_NUM,
+        TimeFrames.DAY_OF_WEEK_NAME,
+        TimeFrames.MONTH_NAME,
+        TimeFrames.QUARTER_NAME,
+    ] as const;
+
+    const bigQueryDateProjectionFrames: ReadonlySet<TimeFrames> = new Set([
+        TimeFrames.DAY,
+        TimeFrames.WEEK,
+        TimeFrames.MONTH,
+        TimeFrames.QUARTER,
+        TimeFrames.YEAR,
+    ]);
+
+    const getWhereClause = (query: string) =>
+        query.slice(query.indexOf('WHERE'), query.indexOf('GROUP BY'));
+
+    const buildBigQueryNoOpCase = (
+        timeFrame: (typeof bigQueryUtcFilterParityFrames)[number],
+    ) => {
+        const explore = buildDayExplore(
+            DimensionType.TIMESTAMP,
+            SupportedDbtAdapter.BIGQUERY,
+        );
+        explore.tables.events.dimensions.occurred_at.timestampDomain = 'aware';
+
+        const suffix = timeFrame.toLowerCase();
+        const dimensionName = `occurred_at_${suffix}`;
+        const fieldId = `events_${dimensionName}`;
+        const compiledSql = timeFrameConfigs[timeFrame].getSql(
+            SupportedDbtAdapter.BIGQUERY,
+            timeFrame,
+            '"events".occurred_at',
+            DimensionType.TIMESTAMP,
+            undefined,
+        );
+        const dimensionType = timeFrameConfigs[timeFrame].getDimensionType(
+            DimensionType.TIMESTAMP,
+        );
+        const filterValue = (() => {
+            switch (dimensionType) {
+                case DimensionType.NUMBER:
+                    return 1;
+                case DimensionType.STRING:
+                    return 'January';
+                case DimensionType.TIMESTAMP:
+                    return '2024-01-15 01:02:03.004';
+                default:
+                    return '2024-01-15';
+            }
+        })();
+
+        explore.tables.events.dimensions[dimensionName] = {
+            ...explore.tables.events.dimensions.occurred_at_day,
+            type: dimensionType,
+            name: dimensionName,
+            label: dimensionName,
+            sql: compiledSql,
+            compiledSql,
+            timeInterval: timeFrame,
+        };
+
+        const compiledMetricQuery: CompiledMetricQuery = {
+            ...dayQuery,
+            dimensions: [fieldId],
+            filters: {
+                dimensions: {
+                    id: 'root',
+                    and: [
+                        {
+                            id: 'f1',
+                            target: { fieldId },
+                            operator: FilterOperator.EQUALS,
+                            values: [filterValue],
+                        },
+                    ],
+                },
+            },
+        };
+
+        return { compiledMetricQuery, compiledSql, explore, fieldId };
+    };
+
+    test.each(bigQueryUtcFilterParityFrames)(
+        'BigQuery %s filter: flag on + UTC no-op keeps flag-off WHERE',
+        (timeFrame) => {
+            const { compiledMetricQuery, compiledSql, explore, fieldId } =
+                buildBigQueryNoOpCase(timeFrame);
+            const commonArgs = {
+                explore,
+                compiledMetricQuery,
+                warehouseSqlBuilder: bigqueryClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            };
+
+            const flagOffQuery = buildQuery({
+                ...commonArgs,
+                useTimezoneAwareDateTrunc: false,
+            }).query;
+            const flagOnQuery = buildQuery({
+                ...commonArgs,
+                useTimezoneAwareDateTrunc: true,
+            }).query;
+            const flagOnSelectClause = flagOnQuery.slice(
+                0,
+                flagOnQuery.indexOf('FROM'),
+            );
+
+            expect(getWhereClause(flagOnQuery)).toBe(
+                getWhereClause(flagOffQuery),
+            );
+            expect(getWhereClause(flagOnQuery)).toContain(compiledSql);
+            if (bigQueryDateProjectionFrames.has(timeFrame)) {
+                expect(flagOnSelectClause).toContain(
+                    `CAST(${compiledSql} AS DATE) AS \`${fieldId}\``,
+                );
+            }
+        },
+    );
+
+    const bigQueryAwareOptimizedFrames = [
+        TimeFrames.DAY,
+        TimeFrames.WEEK,
+        TimeFrames.MONTH,
+        TimeFrames.QUARTER,
+        TimeFrames.YEAR,
+        TimeFrames.YEAR_NUM,
+    ] as const;
+
+    const getBigQueryAwareFilterLhs = (
+        timeFrame: (typeof bigQueryAwareOptimizedFrames)[number],
+        timezone: string,
+        startOfWeek?: WeekDay | null,
+    ) => {
+        const dateSql = `DATE("events".occurred_at, '${timezone}')`;
+        if (timeFrame === TimeFrames.DAY) return dateSql;
+        if (timeFrame === TimeFrames.YEAR_NUM) {
+            return `EXTRACT(YEAR FROM ${dateSql})`;
+        }
+        const datePart =
+            timeFrame === TimeFrames.WEEK && startOfWeek != null
+                ? `WEEK(${WeekDay[startOfWeek]})`
+                : timeFrame;
+        return `DATE_TRUNC(${dateSql}, ${datePart})`;
+    };
+
+    const buildBigQueryFilterCase = ({
+        timeFrame,
+        timezone,
+        columnTimezone,
+        timestampDomain = 'aware',
+        operator = FilterOperator.EQUALS,
+        values,
+        settings,
+        warehouseSqlBuilder = bigqueryClientMock,
+    }: {
+        timeFrame: (typeof bigQueryUtcFilterParityFrames)[number];
+        timezone: string;
+        columnTimezone: string;
+        timestampDomain?: TimestampDomain | null;
+        operator?: FilterOperator;
+        values?: Array<string | number>;
+        settings?: { unitOfTime: UnitOfTime; completed: boolean };
+        warehouseSqlBuilder?: typeof bigqueryClientMock;
+    }) => {
+        const { compiledMetricQuery, explore, fieldId } =
+            buildBigQueryNoOpCase(timeFrame);
+        explore.tables.events.dimensions.occurred_at.timestampDomain =
+            timestampDomain ?? undefined;
+        const { type } =
+            explore.tables.events.dimensions[fieldId.replace('events_', '')];
+        const defaultValue =
+            type === DimensionType.NUMBER ? 2024 : '2024-01-15';
+        const { query } = buildQuery({
+            explore,
+            compiledMetricQuery: {
+                ...compiledMetricQuery,
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'f1',
+                                target: { fieldId },
+                                operator,
+                                values: values ?? [defaultValue],
+                                settings,
+                            },
+                        ],
+                    },
+                },
+            },
+            warehouseSqlBuilder,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone,
+            columnTimezone,
+            useTimezoneAwareDateTrunc: true,
+        });
+        return { fieldId, query, where: getWhereClause(query) };
+    };
+
+    test.each([
+        ['America/New_York', 'UTC'],
+        ['America/New_York', 'America/New_York'],
+        ['America/New_York', 'Asia/Tokyo'],
+        ['UTC', 'Asia/Tokyo'],
+    ])(
+        'BigQuery known-aware filters use the project DATE domain for project=%s data=%s',
+        (timezone, columnTimezone) => {
+            for (const timeFrame of bigQueryAwareOptimizedFrames) {
+                const { query, where } = buildBigQueryFilterCase({
+                    timeFrame,
+                    timezone,
+                    columnTimezone,
+                });
+                const lhs = getBigQueryAwareFilterLhs(timeFrame, timezone);
+                expect(where).toContain(lhs);
+                expect(where.replaceAll(lhs, '')).not.toContain(
+                    '"events".occurred_at',
+                );
+
+                if (timeFrame !== TimeFrames.YEAR_NUM) {
+                    const selectClause = query.slice(0, query.indexOf('FROM'));
+                    expect(selectClause).toContain(
+                        `CAST(DATETIME_TRUNC(DATETIME(TIMESTAMP("events".occurred_at), '${timezone}'), ${timeFrame}) AS DATE)`,
+                    );
+                    expect(selectClause).not.toContain(lhs);
+                }
+            }
+        },
+    );
+
+    test.each([
+        ['naive', 'America/New_York', 'America/New_York'],
+        ['naive', 'America/New_York', 'Asia/Tokyo'],
+        [null, 'America/New_York', 'America/New_York'],
+        [null, 'America/New_York', 'Asia/Tokyo'],
+    ] as const)(
+        'BigQuery %s domain keeps the wrapper for project=%s data=%s',
+        (timestampDomain, timezone, columnTimezone) => {
+            const { where } = buildBigQueryFilterCase({
+                timeFrame: TimeFrames.DAY,
+                timezone,
+                columnTimezone,
+                timestampDomain,
+            });
+            expect(where).toContain('DATETIME_TRUNC(');
+            expect(where).not.toContain(
+                getBigQueryAwareFilterLhs(TimeFrames.DAY, timezone),
+            );
+        },
+    );
+
+    test.each([
+        {
+            timeFrame: TimeFrames.HOUR,
+            convertedSql: `TIMESTAMP(DATETIME_TRUNC(DATETIME(TIMESTAMP("events".occurred_at), 'America/New_York'), HOUR), 'America/New_York')`,
+        },
+        {
+            timeFrame: TimeFrames.MONTH_NUM,
+            convertedSql: `EXTRACT(MONTH FROM TIMESTAMP("events".occurred_at) AT TIME ZONE 'America/New_York')`,
+        },
+        {
+            timeFrame: TimeFrames.MONTH_NAME,
+            convertedSql: `FORMAT_TIMESTAMP('%B', TIMESTAMP("events".occurred_at), 'America/New_York')`,
+        },
+    ])(
+        'BigQuery known-aware non-UTC $timeFrame filter keeps its current LHS',
+        ({ timeFrame, convertedSql }) => {
+            const { where } = buildBigQueryFilterCase({
+                timeFrame,
+                timezone: 'America/New_York',
+                columnTimezone: 'Asia/Tokyo',
+            });
+            expect(where).toContain(convertedSql);
+        },
+    );
+
+    test('BigQuery known-aware WEEK filter reuses a non-default start day', () => {
+        const warehouseSqlBuilder = {
+            ...bigqueryClientMock,
+            getStartOfWeek: () => WeekDay.WEDNESDAY,
+        };
+        const { where } = buildBigQueryFilterCase({
+            timeFrame: TimeFrames.WEEK,
+            timezone: 'America/New_York',
+            columnTimezone: 'Asia/Tokyo',
+            warehouseSqlBuilder,
+        });
+        expect(where).toContain(
+            getBigQueryAwareFilterLhs(
+                TimeFrames.WEEK,
+                'America/New_York',
+                WeekDay.WEDNESDAY,
+            ),
+        );
+    });
+
+    test.each([
+        [FilterOperator.EQUALS, ['2024-01-15'], undefined],
+        [FilterOperator.EQUALS, ['2024-01-15', '2024-01-16'], undefined],
+        [FilterOperator.GREATER_THAN, ['2024-01-15'], undefined],
+        [FilterOperator.IN_BETWEEN, ['2024-01-15', '2024-01-16'], undefined],
+        [
+            FilterOperator.IN_THE_PAST,
+            [7],
+            { unitOfTime: UnitOfTime.days, completed: false },
+        ],
+    ] as const)(
+        'BigQuery known-aware filter operator %s uses only the DATE-domain LHS',
+        (operator, values, settings) => {
+            const { where } = buildBigQueryFilterCase({
+                timeFrame: TimeFrames.DAY,
+                timezone: 'America/New_York',
+                columnTimezone: 'Asia/Tokyo',
+                operator,
+                values: [...values],
+                settings,
+            });
+            const lhs = getBigQueryAwareFilterLhs(
+                TimeFrames.DAY,
+                'America/New_York',
+            );
+            expect(where).toContain(lhs);
+            expect(where.replaceAll(lhs, '')).not.toContain(
+                '"events".occurred_at',
+            );
+        },
+    );
+
     // GLITCH-510: Date Zoom re-grains the raw base TIMESTAMP dim in place, so the
     // zoomed dim's timeIntervalBaseDimensionName points at its own (now DATE-typed)
     // id. The base lookup must resolve from originalExplore to recover the raw
@@ -5364,6 +5716,49 @@ describe('Timezone-aware DATE_TRUNC day-or-coarser → DATE cast (GLITCH-452)', 
         // Bug: the un-recomputed plain DATE_TRUNC must not leak into the SELECT.
         expect(query).not.toMatch(
             /DATE_TRUNC\('MONTH', "events"\.occurred_at\) AS "events_occurred_at"/,
+        );
+    });
+
+    test('BigQuery known-aware Date Zoom filter recovers the original TIMESTAMP base', () => {
+        const originalExplore = buildDayExplore(
+            DimensionType.TIMESTAMP,
+            SupportedDbtAdapter.BIGQUERY,
+        );
+        originalExplore.tables.events.dimensions.occurred_at.timestampDomain =
+            'aware';
+        const explore = buildBaseZoomedExplore();
+        explore.targetDatabase = SupportedDbtAdapter.BIGQUERY;
+        const { query } = buildQuery({
+            explore,
+            originalExplore,
+            compiledMetricQuery: {
+                ...baseZoomedQuery,
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'zoom-filter',
+                                target: { fieldId: 'events_occurred_at' },
+                                operator: FilterOperator.EQUALS,
+                                values: ['2024-01-01'],
+                            },
+                        ],
+                    },
+                },
+            },
+            warehouseSqlBuilder: bigqueryClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'America/New_York',
+            columnTimezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+            dateZoomFilterTargetFieldId: 'events_occurred_at',
+        });
+        expect(getWhereClause(query)).toContain(
+            `DATE_TRUNC(DATE("events".occurred_at, 'America/New_York'), MONTH)`,
+        );
+        expect(query.slice(0, query.indexOf('FROM'))).toContain(
+            `CAST(DATETIME_TRUNC(DATETIME(TIMESTAMP("events".occurred_at), 'America/New_York'), MONTH) AS DATE)`,
         );
     });
 
@@ -5433,6 +5828,97 @@ describe('Timezone-aware DATE_TRUNC day-or-coarser → DATE cast (GLITCH-452)', 
             /DATE_TRUNC\('DAY', "events"\.occurred_at\)\s*>=/,
         );
         expect(query).not.toContain(`AT TIME ZONE`);
+    });
+
+    test('flag on + UTC no-op keeps a bare user filter but DATE-typed PoP range bounds', () => {
+        const { query } = buildQuery({
+            explore: buildDayExplore(),
+            compiledMetricQuery: {
+                ...popDayQuery,
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'day-filter',
+                                target: {
+                                    fieldId: 'events_occurred_at_day',
+                                },
+                                operator: FilterOperator.EQUALS,
+                                values: ['2024-01-15'],
+                            },
+                        ],
+                    },
+                },
+            },
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        expect(query).toContain(
+            `(DATE_TRUNC('DAY', "events".occurred_at)) = ('2024-01-15')`,
+        );
+        expect(query).not.toContain(
+            `(CAST(DATE_TRUNC('DAY', "events".occurred_at) AS DATE)) = ('2024-01-15')`,
+        );
+        expect(query).toMatch(
+            /CAST\(DATE_TRUNC\('DAY', "events"\.occurred_at\) AS DATE\) >= pop_min_max_[a-z0-9_]+\.min_date - INTERVAL '1 DAY'/,
+        );
+        expect(query).toMatch(
+            /CAST\(DATE_TRUNC\('DAY', "events"\.occurred_at\) AS DATE\) <= pop_min_max_[a-z0-9_]+\.max_date - INTERVAL '1 DAY'/,
+        );
+    });
+
+    test('BigQuery known-aware PoP keeps optimized user filter separate from projection bounds', () => {
+        const explore = buildDayExplore(
+            DimensionType.TIMESTAMP,
+            SupportedDbtAdapter.BIGQUERY,
+        );
+        explore.tables.events.dimensions.occurred_at.timestampDomain = 'aware';
+        const { query } = buildQuery({
+            explore,
+            compiledMetricQuery: {
+                ...popDayQuery,
+                filters: {
+                    dimensions: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: 'day-filter',
+                                target: {
+                                    fieldId: 'events_occurred_at_day',
+                                },
+                                operator: FilterOperator.EQUALS,
+                                values: ['2024-01-15'],
+                            },
+                        ],
+                    },
+                },
+            },
+            warehouseSqlBuilder: bigqueryClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'America/New_York',
+            columnTimezone: 'Asia/Tokyo',
+            useTimezoneAwareDateTrunc: true,
+        });
+
+        expect(query).toContain(
+            `(DATE("events".occurred_at, 'America/New_York')) = ('2024-01-15')`,
+        );
+        const projectionLhs = `CAST(DATETIME_TRUNC(DATETIME(TIMESTAMP("events".occurred_at), 'America/New_York'), DAY) AS DATE)`;
+        expect(query).toMatch(
+            new RegExp(
+                `DATE\\(${escapeRegExp(projectionLhs)}\\) >= DATE_SUB\\(DATE\\(pop_min_max_[a-z0-9_]+\\.min_date\\), INTERVAL 1 DAY\\)`,
+            ),
+        );
+        expect(query).toMatch(
+            new RegExp(
+                `DATE\\(${escapeRegExp(projectionLhs)}\\) <= DATE_SUB\\(DATE\\(pop_min_max_[a-z0-9_]+\\.max_date\\), INTERVAL 1 DAY\\)`,
+            ),
+        );
     });
 
     // A MIN/MAX over a day-grain DATE dim aggregates the project-tz wall-clock

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -21,6 +21,7 @@ import {
     FilterGroupItem,
     FilterOperator,
     FilterRule,
+    getBigQueryAwareTimestampFilterSql,
     getCustomMetricDimensionId,
     getDimensionMapFromTables,
     getDimensions,
@@ -47,6 +48,7 @@ import {
     isNonAggregateMetric,
     isPeriodOverPeriodAdditionalMetric,
     isPostCalculationMetric,
+    isSubDayTimeFrame,
     isTimezoneRoundTripNoOp,
     ItemsMap,
     lightdashVariablePattern,
@@ -186,6 +188,8 @@ export type BuildQueryProps = {
      */
     totalConfiguration?: TotalConfiguration;
 };
+
+type TimeDimensionSqlPurpose = 'projection' | 'filterRule';
 
 /**
  * Semi-joins every raw scan of this query to the distinct dimension groups of
@@ -798,6 +802,7 @@ export class MetricQueryBuilder {
         adapterType: SupportedDbtAdapter,
         startOfWeek: WeekDay | null | undefined,
         respectConvertTimezone: boolean = true,
+        purpose: TimeDimensionSqlPurpose = 'projection',
     ): { sql: string; lhsMode: TimestampFilterLhsMode } {
         const { timezone, useTimezoneAwareDateTrunc } = this.args;
 
@@ -885,6 +890,42 @@ export class MetricQueryBuilder {
             };
         }
 
+        const roundTripNoOp = isTimezoneRoundTripNoOp(
+            adapterType,
+            timezone,
+            this.columnTimezone,
+            timestampDomain,
+        );
+
+        if (isTruncatable) {
+            // Day-or-coarser projections are DATE-cast for type integrity, but
+            // a no-op filter must retain the flag-off LHS for partition pruning.
+            if (
+                purpose === 'filterRule' &&
+                roundTripNoOp &&
+                !isSubDayTimeFrame(dimension.timeInterval)
+            ) {
+                return { sql: dimension.compiledSql, lhsMode: 'legacy' };
+            }
+        }
+
+        if (
+            purpose === 'filterRule' &&
+            adapterType === SupportedDbtAdapter.BIGQUERY &&
+            timestampDomain === 'aware' &&
+            !roundTripNoOp
+        ) {
+            const sql = getBigQueryAwareTimestampFilterSql(
+                dimension.timeInterval,
+                baseDimension.compiledSql,
+                timezone,
+                startOfWeek,
+            );
+            if (sql !== undefined) {
+                return { sql, lhsMode: 'legacy' };
+            }
+        }
+
         if (isTruncatable) {
             return {
                 sql: getSqlForTruncatedDate(
@@ -900,14 +941,7 @@ export class MetricQueryBuilder {
                     // so day-or-coarser grains emit a real DATE (matches metadata).
                     true,
                 ),
-                lhsMode: isTimezoneRoundTripNoOp(
-                    adapterType,
-                    timezone,
-                    this.columnTimezone,
-                    timestampDomain,
-                )
-                    ? 'legacy'
-                    : 'wrapped',
+                lhsMode: roundTripNoOp ? 'legacy' : 'wrapped',
             };
         }
 
@@ -992,6 +1026,7 @@ export class MetricQueryBuilder {
             adapterType,
             startOfWeek,
             false,
+            'filterRule',
         );
 
         return {

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -5,6 +5,7 @@ import {
     dateExtractsTimezoneConversions,
     dateTruncTimezoneConversions,
     extractableTimeFrames,
+    getBigQueryAwareTimestampFilterSql,
     getDateDimension,
     getSqlForDatePart,
     getSqlForDatePartName,
@@ -18,6 +19,88 @@ import {
 } from './timeFrames';
 
 describe('TimeFrames', () => {
+    describe('getBigQueryAwareTimestampFilterSql', () => {
+        const baseSql = '${TABLE}.created';
+        const timezone = 'America/New_York';
+
+        test.each([
+            [TimeFrames.DAY, `DATE(${baseSql}, '${timezone}')`],
+            [
+                TimeFrames.MONTH,
+                `DATE_TRUNC(DATE(${baseSql}, '${timezone}'), MONTH)`,
+            ],
+            [
+                TimeFrames.QUARTER,
+                `DATE_TRUNC(DATE(${baseSql}, '${timezone}'), QUARTER)`,
+            ],
+            [
+                TimeFrames.YEAR,
+                `DATE_TRUNC(DATE(${baseSql}, '${timezone}'), YEAR)`,
+            ],
+            [
+                TimeFrames.YEAR_NUM,
+                `EXTRACT(YEAR FROM DATE(${baseSql}, '${timezone}'))`,
+            ],
+        ])('renders the aware TIMESTAMP %s filter domain', (frame, sql) => {
+            expect(
+                getBigQueryAwareTimestampFilterSql(
+                    frame,
+                    baseSql,
+                    timezone,
+                    null,
+                ),
+            ).toBe(sql);
+        });
+
+        test.each([
+            [WeekDay.MONDAY, 'MONDAY'],
+            [WeekDay.TUESDAY, 'TUESDAY'],
+            [WeekDay.WEDNESDAY, 'WEDNESDAY'],
+            [WeekDay.THURSDAY, 'THURSDAY'],
+            [WeekDay.FRIDAY, 'FRIDAY'],
+            [WeekDay.SATURDAY, 'SATURDAY'],
+            [WeekDay.SUNDAY, 'SUNDAY'],
+        ])('renders WEEK with %s as the start day', (startOfWeek, weekday) => {
+            expect(
+                getBigQueryAwareTimestampFilterSql(
+                    TimeFrames.WEEK,
+                    baseSql,
+                    timezone,
+                    startOfWeek,
+                ),
+            ).toBe(
+                `DATE_TRUNC(DATE(${baseSql}, '${timezone}'), WEEK(${weekday}))`,
+            );
+        });
+
+        test('renders WEEK without a configured start day', () => {
+            expect(
+                getBigQueryAwareTimestampFilterSql(
+                    TimeFrames.WEEK,
+                    baseSql,
+                    timezone,
+                    null,
+                ),
+            ).toBe(`DATE_TRUNC(DATE(${baseSql}, '${timezone}'), WEEK)`);
+        });
+
+        test.each([
+            TimeFrames.RAW,
+            TimeFrames.HOUR,
+            TimeFrames.MONTH_NUM,
+            TimeFrames.DAY_OF_WEEK_NAME,
+        ])('returns undefined for unsupported %s filters', (frame) => {
+            expect(
+                getBigQueryAwareTimestampFilterSql(
+                    frame,
+                    baseSql,
+                    timezone,
+                    null,
+                ),
+            ).toBeUndefined();
+        });
+    });
+
     describe('getSqlForTruncatedDate', () => {
         test('should get sql where stat of the week is Wednesday', async () => {
             expect(

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -459,6 +459,33 @@ const bigqueryStartOfWeekMap: Record<WeekDay, string> = {
     [WeekDay.SUNDAY]: 'SUNDAY',
 };
 
+export const getBigQueryAwareTimestampFilterSql = (
+    timeFrame: TimeFrames,
+    originalSql: string,
+    timezone: string,
+    startOfWeek?: WeekDay | null,
+): string | undefined => {
+    const dateSql = `DATE(${originalSql}, '${timezone}')`;
+    switch (timeFrame) {
+        case TimeFrames.DAY:
+            return dateSql;
+        case TimeFrames.WEEK: {
+            const datePart = isWeekDay(startOfWeek)
+                ? `WEEK(${bigqueryStartOfWeekMap[startOfWeek]})`
+                : TimeFrames.WEEK;
+            return `DATE_TRUNC(${dateSql}, ${datePart})`;
+        }
+        case TimeFrames.MONTH:
+        case TimeFrames.QUARTER:
+        case TimeFrames.YEAR:
+            return `DATE_TRUNC(${dateSql}, ${timeFrame})`;
+        case TimeFrames.YEAR_NUM:
+            return `EXTRACT(YEAR FROM ${dateSql})`;
+        default:
+            return undefined;
+    }
+};
+
 const bigqueryConfig: WarehouseConfig = {
     // BigQuery: on the timezone-wrapped path `toProjectTz` has already shifted
     // the value into a naive project-TZ DATETIME, so truncate with


### PR DESCRIPTION
## Summary

- preserve the original compiled filter SQL for timezone round trips that are semantic no-ops, while keeping day-or-coarser projections as real `DATE` values
- use an explicit project-timezone `DATE` domain for catalog-known aware BigQuery TIMESTAMP filters at day/week/month/quarter/year and YEAR_NUM grain
- keep projection, PoP-generated bounds, sub-day filters, recurring extracts, known-naive timestamps, and unknown/custom timestamp domains unchanged
- add regression coverage for UTC parity, non-UTC project/data combinations, filter operators, Date Zoom, PoP, and real BigQuery row semantics

## Why

Timezone-aware day-grain filtering reused the projection expression introduced for GLITCH-452. On affected BigQuery tables, the nested `CAST(DATETIME_TRUNC(...))` filter expression prevented partition pruning even when the timezone conversion was a no-op.

For known-aware BigQuery TIMESTAMP columns, `DATE(base, project_timezone)` and DATE-domain truncation preserve the current calendar semantics while allowing BigQuery to prune equivalently to the matching raw timestamp bounds.

## Verification

- `pnpm -F common exec vitest run --config vitest.config.ts src/utils/timeFrames.test.ts` — 142 passed
- `pnpm -F backend exec vitest run --config vitest.config.ts src/utils/QueryBuilder/MetricQueryBuilder.test.ts` — 233 passed
- common, backend, and api-tests fast typechecks
- focused ESLint, formatting, and `git diff --check`
- uncached BigQuery `/sql` pruning matrix — 11/11 passed; candidate bytes matched equivalent raw bounds
  - day equality: 848 bytes versus 16,040 for the old wrapper
  - day IN: 1,648 bytes versus 16,040
  - day range: 3,408 bytes versus 16,040
  - empty YEAR and YEAR_NUM: 0 bytes versus 16,040
- stored-credential BigQuery metric-query regressions — 6/6 passed
- six-warehouse timezone/filter/DST matrix — 111/111 passed
- persisted timezone audit: BigQuery restored to `Asia/Tokyo`; all other warehouse projects restored to unset

## Notes

The new credentialed BigQuery API tests are included in `dataTimezone.test.ts`. Locally, that block skipped because `e2e/cypress/fixtures/credentials.json` is unavailable; the equivalent cases passed against the existing stored-credential BigQuery project and will execute automatically where the fixture is present.

Related: GLITCH-628
