### PR TITLE
fix: tolerate legacy object refs in persisted project context writeback entries

### DIFF
--- a/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.test.ts
+++ b/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.test.ts
@@ -3,11 +3,11 @@ import {
     DbtProjectType,
     ForbiddenError,
     NotFoundError,
+    ParseError,
     type MemberAbility,
     type ProjectContextEntry,
     type SessionUser,
 } from '@lightdash/common';
-import { ZodError } from 'zod';
 import {
     createBranch,
     createPullRequest,
@@ -259,20 +259,40 @@ describe('ProjectContextService.writebackEntry', () => {
         });
     });
 
-    test('rejects writeback from a persisted legacy string ref', async () => {
+    test('drops persisted legacy string refs instead of failing', async () => {
+        mockGetFileContent.mockRejectedValue(new NotFoundError('missing'));
+        const { service } = makeService({});
+
+        const result = await service.writebackEntry({
+            projectUuid: PROJECT_UUID,
+            entry: { ...judgeEntry, objects: ['orders'] },
+            branchTimestamp: 1000,
+            sourceThread: null,
+        });
+
+        expect(result).toMatchObject({ op: 'create', entryId: 'hr' });
+        const commitArgs = mockCreateSignedCommitOnBranch.mock.calls[0][0];
+        const written = Buffer.from(
+            commitArgs.fileChanges.additions[0].contents,
+            'base64',
+        ).toString('utf8');
+        expect(written).toContain('objects: []');
+        expect(written).not.toContain('orders');
+    });
+
+    test('rejects an entry that is invalid beyond legacy refs', async () => {
         const { service } = makeService({});
 
         const error = await service
             .writebackEntry({
                 projectUuid: PROJECT_UUID,
-                entry: { ...judgeEntry, objects: ['orders'] },
+                entry: { ...judgeEntry, op: 'update' as const, id: null },
                 branchTimestamp: 1000,
                 sourceThread: null,
             })
             .catch((caught: unknown) => caught);
 
-        expect(error).toBeInstanceOf(ZodError);
-        expect((error as ZodError).issues[0].path).toEqual(['objects', 0]);
+        expect(error).toBeInstanceOf(ParseError);
         expect(mockGetFileContent).not.toHaveBeenCalled();
     });
 

--- a/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.ts
+++ b/packages/backend/src/ee/services/ProjectContextService/ProjectContextService.ts
@@ -1,11 +1,12 @@
 import { subject } from '@casl/ability';
 import {
-    aiAgentJudgeProjectContextEntrySchema,
     applyProjectContextWriteback,
     DbtProjectType,
     ForbiddenError,
     loadProjectContextFile,
     NotFoundError,
+    ParseError,
+    persistedAiAgentJudgeProjectContextEntrySchema,
     type AiAgentJudgeProjectContextEntry,
     type DbtProjectConfig,
     type SessionUser,
@@ -68,8 +69,16 @@ type ProjectContextServiceDeps = {
     projectContextModel: ProjectContextModel;
 };
 
-const parseWritebackEntry = (entry: AiAgentJudgeProjectContextEntry) =>
-    aiAgentJudgeProjectContextEntrySchema.parse(entry);
+const parseWritebackEntry = (entry: AiAgentJudgeProjectContextEntry) => {
+    const result =
+        persistedAiAgentJudgeProjectContextEntrySchema.safeParse(entry);
+    if (!result.success) {
+        throw new ParseError(
+            `Invalid project context writeback entry: ${result.error.message}`,
+        );
+    }
+    return result.data;
+};
 
 export class ProjectContextService extends BaseService {
     private readonly projectModel: ProjectModel;
@@ -221,6 +230,7 @@ export class ProjectContextService extends BaseService {
         after: string;
         op: 'create' | 'update';
         entryId: string;
+        upgradesFileToV2: boolean;
     }> {
         const entry = parseWritebackEntry(args.entry);
         const access = await this.resolveGithubAccess(args.projectUuid);
@@ -252,8 +262,9 @@ export class ProjectContextService extends BaseService {
             content: after,
             entryId,
             op,
+            upgradesFileToV2,
         } = applyProjectContextWriteback(before, entry);
-        return { fileName, before, after, op, entryId };
+        return { fileName, before, after, op, entryId, upgradesFileToV2 };
     }
 
     async writebackEntry(args: {

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
@@ -4,6 +4,7 @@ import {
     getAiAgentConfigSnapshotHash,
     getAiAgentReviewItemFingerprint,
     getAiAgentReviewItemFingerprintScope,
+    persistedAiAgentJudgeProjectContextEntrySchema,
     shouldReopenReviewItem,
     type AiAgentConfigSnapshot,
     type AiAgentReviewItemFingerprintInput,
@@ -366,6 +367,69 @@ describe('aiAgentJudgeProjectContextEntrySchema', () => {
             terms: [],
             objects: [],
         });
+        expect(result.success).toBe(false);
+    });
+});
+
+describe('persistedAiAgentJudgeProjectContextEntrySchema', () => {
+    test('drops legacy string object refs from persisted entries', () => {
+        const result = persistedAiAgentJudgeProjectContextEntrySchema.safeParse(
+            {
+                op: 'create',
+                id: null,
+                kind: 'context',
+                content: 'Use the payments explore.',
+                terms: [],
+                objects: ['payments'],
+            },
+        );
+        expect(result.success).toBe(true);
+        expect(result.success && result.data.objects).toEqual([]);
+    });
+
+    test('drops the whole objects array when refs are mixed', () => {
+        const result = persistedAiAgentJudgeProjectContextEntrySchema.safeParse(
+            {
+                op: 'create',
+                id: null,
+                kind: 'context',
+                content: 'Use the payments explore.',
+                terms: [],
+                objects: [{ type: 'explore', name: 'payments' }, 'orders'],
+            },
+        );
+        expect(result.success).toBe(true);
+        expect(result.success && result.data.objects).toEqual([]);
+    });
+
+    test('preserves valid typed object refs', () => {
+        const result = persistedAiAgentJudgeProjectContextEntrySchema.safeParse(
+            {
+                op: 'update',
+                id: 'payments-routing',
+                kind: 'context',
+                content: 'Use the payments explore.',
+                terms: [],
+                objects: [{ type: 'explore', name: 'payments' }],
+            },
+        );
+        expect(result.success).toBe(true);
+        expect(result.success && result.data.objects).toEqual([
+            { type: 'explore', name: 'payments' },
+        ]);
+    });
+
+    test('still rejects entries invalid beyond legacy objects', () => {
+        const result = persistedAiAgentJudgeProjectContextEntrySchema.safeParse(
+            {
+                op: 'update',
+                id: null,
+                kind: 'context',
+                content: 'x',
+                terms: [],
+                objects: ['payments'],
+            },
+        );
         expect(result.success).toBe(false);
     });
 });

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -491,6 +491,28 @@ export const aiAgentJudgeProjectContextEntrySchema = z
         }
     });
 
+// Lenient parse for persisted findings, which can predate typed object refs:
+// drops the whole `objects` array when it isn't a valid typed-ref array,
+// mirroring loadProjectContextFile's legacy handling.
+export const persistedAiAgentJudgeProjectContextEntrySchema = z.preprocess(
+    (entry) => {
+        if (
+            typeof entry !== 'object' ||
+            entry === null ||
+            Array.isArray(entry)
+        ) {
+            return entry;
+        }
+        const candidate = entry as Record<string, unknown>;
+        return z
+            .array(aiProjectContextTypedObjectRefSchema)
+            .safeParse(candidate.objects).success
+            ? entry
+            : { ...candidate, objects: [] };
+    },
+    aiAgentJudgeProjectContextEntrySchema,
+);
+
 // Concrete type (not z.infer) so tsoa can resolve it in API responses. The
 // string union preserves persisted findings written before typed refs.
 export type AiAgentJudgeProjectContextEntry = {
@@ -791,6 +813,8 @@ export type AiAgentReviewItemWritebackPreview =
           after: string;
           op: 'create' | 'update';
           entryId: string;
+          // True when the PR also rewrites a legacy (pre-v2) file as canonical v2.
+          upgradesFileToV2: boolean;
       }
     | { available: false };
 

--- a/packages/common/src/ee/AiAgent/projectContext.test.ts
+++ b/packages/common/src/ee/AiAgent/projectContext.test.ts
@@ -462,15 +462,19 @@ entries:
     content: Use orders.
     objects: [orders]
 `;
-        const { content } = applyProjectContextWriteback(existing, {
-            op: 'create',
-            id: 'payments',
-            kind: 'context',
-            content: 'Use payments.',
-            terms: [],
-            objects: [{ type: 'explore', name: 'payments' }],
-        });
+        const { content, upgradesFileToV2 } = applyProjectContextWriteback(
+            existing,
+            {
+                op: 'create',
+                id: 'payments',
+                kind: 'context',
+                content: 'Use payments.',
+                terms: [],
+                objects: [{ type: 'explore', name: 'payments' }],
+            },
+        );
 
+        expect(upgradesFileToV2).toBe(true);
         expect(content).toContain('version: 2');
         expect(loadProjectContextFile(content)).toEqual([
             {
@@ -491,17 +495,19 @@ entries:
     });
 
     test('creates a canonical file from empty content', () => {
-        const { content, entryId, op } = applyProjectContextWriteback('', {
-            op: 'create',
-            id: null,
-            kind: 'definition',
-            content: 'MRR means monthly recurring revenue.',
-            terms: ['MRR'],
-            objects: [],
-        });
+        const { content, entryId, op, upgradesFileToV2 } =
+            applyProjectContextWriteback('', {
+                op: 'create',
+                id: null,
+                kind: 'definition',
+                content: 'MRR means monthly recurring revenue.',
+                terms: ['MRR'],
+                objects: [],
+            });
         expect(op).toBe('create');
         expect(entryId).toBe('mrr');
         expect(content).toContain('version: 2');
+        expect(upgradesFileToV2).toBe(false);
         expect(content.startsWith(PROJECT_CONTEXT_FILE_HEADER)).toBe(true);
         expect(loadProjectContextFile(content)).toEqual([
             {
@@ -547,15 +553,19 @@ entries:
     terms: [HR]
     objects: []
 `;
-        const { content, op } = applyProjectContextWriteback(existing, {
-            op: 'create',
-            id: null,
-            kind: 'definition',
-            content: 'MRR means monthly recurring revenue.',
-            terms: ['MRR'],
-            objects: [],
-        });
+        const { content, op, upgradesFileToV2 } = applyProjectContextWriteback(
+            existing,
+            {
+                op: 'create',
+                id: null,
+                kind: 'definition',
+                content: 'MRR means monthly recurring revenue.',
+                terms: ['MRR'],
+                objects: [],
+            },
+        );
         expect(op).toBe('create');
+        expect(upgradesFileToV2).toBe(false);
         // The human comment, the original quoting, the flow style and the entry
         // content all survive byte-for-byte — this is the whole point: a minimal,
         // reviewable diff (just the added entry) rather than a full-file rewrite.

--- a/packages/common/src/ee/AiAgent/projectContext.ts
+++ b/packages/common/src/ee/AiAgent/projectContext.ts
@@ -341,7 +341,14 @@ export const loadProjectContextFile = (
 export const applyProjectContextWriteback = (
     existingContent: string,
     judgeEntry: ProjectContextWritebackEntry,
-): { content: string; entryId: string; op: 'create' | 'update' } => {
+): {
+    content: string;
+    entryId: string;
+    op: 'create' | 'update';
+    // True when a non-empty legacy (v1 / bare-array) file was rewritten as
+    // canonical v2, so callers can surface the migration to the user.
+    upgradesFileToV2: boolean;
+} => {
     const { entries, entryId, op } = mergeProjectContextEntry(
         loadProjectContextFile(existingContent),
         judgeEntry,
@@ -380,9 +387,15 @@ export const applyProjectContextWriteback = (
                 }),
                 entryId,
                 op,
+                upgradesFileToV2: false,
             };
         }
     }
 
-    return { content: serializeProjectContextFile(entries), entryId, op };
+    return {
+        content: serializeProjectContextFile(entries),
+        entryId,
+        op,
+        upgradesFileToV2: existingContent.trim() !== '',
+    };
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectContextWritebackModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectContextWritebackModal.tsx
@@ -1,6 +1,7 @@
 import { Loader, Stack, Text, ThemeIcon } from '@mantine-8/core';
 import { IconCheck, IconGitPullRequest, IconX } from '@tabler/icons-react';
 import { type FC, useState } from 'react';
+import Callout from '../../../../../components/common/Callout';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
 import {
@@ -152,6 +153,15 @@ export const ProjectContextWritebackModal: FC<
                             still open the PR and review it on GitHub.
                         </Text>
                     )}
+
+                    {previewData?.available === true &&
+                        previewData.upgradesFileToV2 && (
+                            <Callout variant="info">
+                                This PR also upgrades your project context file
+                                to v2 — more performance improvements coming
+                                soon.
+                            </Callout>
+                        )}
 
                     {previewData?.available === true && (
                         <ProjectContextDiffPreview


### PR DESCRIPTION
## Summary

Fixes a production 500 on `GET /api/v1/aiAgents/admin/review-items/{fingerprint}/writeback-preview` (and the matching "Create PR" writeback path) for review items whose findings were persisted before project-context object refs became typed (#25908).

- add `persistedAiAgentJudgeProjectContextEntrySchema`: a lenient variant of the judge entry schema that drops the whole `objects` array when it isn't a valid typed-ref array, mirroring `loadProjectContextFile`'s legacy handling in the parent PR
- `ProjectContextService.parseWritebackEntry` now uses it and surfaces genuinely invalid entries as a 400 `ParseError` instead of an unhandled `ZodError` 500
- `applyProjectContextWriteback` now reports `upgradesFileToV2` (true when a non-empty legacy file is rewritten as canonical v2); the preview endpoint returns it and the writeback preview modal shows an info callout: the PR also upgrades the project context file to v2

## Regression analysis

#25908 tightened `aiAgentJudgeProjectContextEntrySchema.objects` to typed refs only, while the `AiAgentJudgeProjectContextEntry` TS type deliberately kept the string union "to preserve persisted findings written before typed refs" — but the runtime `.parse()` in `parseWritebackEntry` was never widened to match. Any preview/writeback on a pre-#25908 finding with string refs threw a raw `ZodError` → 500. The judge's own output validation stays strict: this lenient schema is only used for persisted entries entering the writeback path.

One existing backend test codified the broken behavior ("rejects writeback from a persisted legacy string ref" expecting `ZodError`); it now asserts the legacy refs are dropped and the writeback proceeds, plus a new test that entries invalid beyond legacy refs still fail (as 400).

## Validation

- `vitest run src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts src/ee/AiAgent/projectContext.test.ts` (common) — 74 passed
- `vitest run src/ee/services/ProjectContextService/ProjectContextService.test.ts` (backend) — 16 passed
- `pnpm -F common typecheck:fast`, `pnpm -F backend typecheck:fast`, package lint + oxfmt checks

Relates: ZAP-671
Stacked on #26037

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012H8F8ZGituVWUNp8LJiajf

