### PR TITLE
feat: pass dashboard structure blueprint to data app generation

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -51,10 +51,12 @@ import {
     type AppVersionDependencyEntry,
     type AppVersionExternalConnectionResource,
     type AppVersionResources,
+    type ChartConfig,
     type ChartReference,
     type ChartSampleData,
     type CompiledExploreJoin,
     type CompiledTable,
+    type DashboardBlueprint,
     type DataAppClaudeModel,
     type DataAppCode,
     type DataAppCodeDownload,
@@ -179,6 +181,12 @@ import {
     type ClaudeGenerationUsage,
 } from './ClaudeStreamProcessor';
 import {
+    buildDashboardBlueprint,
+    DASHBOARD_BLUEPRINT_PATH,
+    dashboardBlueprintPromptBlock,
+    describeDashboardBlueprint,
+} from './dashboardBlueprint';
+import {
     assertDependenciesHaveNoKnownMalware,
     assertDependenciesMeetMinReleaseAge,
 } from './dependencyGuards';
@@ -206,6 +214,8 @@ export const buildChartReference = (
         description?: string;
         tableName: string;
         metricQuery: MetricQuery;
+        chartConfig: ChartConfig;
+        pivotConfig?: { columns: string[] };
     },
     chartUuid: string,
     linked: boolean,
@@ -215,6 +225,8 @@ export const buildChartReference = (
     chartDescription: chart.description ?? '',
     exploreName: chart.tableName,
     metricQuery: chart.metricQuery,
+    chartConfig: chart.chartConfig,
+    pivotConfig: chart.pivotConfig ?? null,
     sampleData,
     chartUuid,
     linked,
@@ -1898,6 +1910,30 @@ export class AppGenerateService extends BaseService {
     }
 
     /**
+     * Write the attached dashboard's structural blueprint (tabs, tile layout,
+     * filters) into the sandbox and return a prompt block framing it as the
+     * layout spec. The blueprint complements the flattened chart references:
+     * they carry the queries, this carries the design.
+     */
+    private async writeDashboardBlueprint(
+        sandbox: SandboxHandle,
+        appUuid: string,
+        blueprint: DashboardBlueprint,
+    ): Promise<string> {
+        await sandbox.commands.run('mkdir -p /tmp/dashboard', {
+            timeoutMs: 10_000,
+        });
+        await sandbox.files.write(
+            DASHBOARD_BLUEPRINT_PATH,
+            JSON.stringify(blueprint, null, 2),
+        );
+        this.logger.info(
+            `App ${appUuid}: wrote dashboard blueprint for "${blueprint.name}" (${describeDashboardBlueprint(blueprint)}) to ${DASHBOARD_BLUEPRINT_PATH}`,
+        );
+        return dashboardBlueprintPromptBlock(blueprint);
+    }
+
+    /**
      * For each linked external connection, write a self-contained API-doc JSON
      * to /tmp/external-data/{alias}.json in the sandbox and return a prompt
      * block listing each file. Writes a file for every connection — the
@@ -2014,6 +2050,7 @@ export class AppGenerateService extends BaseService {
         s3Client: S3Client,
         bucket: string,
         chartReferences: ChartReference[] | undefined,
+        dashboardBlueprint: DashboardBlueprint | undefined,
         template: DataAppTemplate | undefined,
         isDataAppViz: boolean,
     ): Promise<{
@@ -2052,7 +2089,7 @@ export class AppGenerateService extends BaseService {
         // different ownership (e.g. root-owned after Claude CLI execution),
         // which would cause a permission error on write.
         await sandbox.commands.run(
-            'rm -f /tmp/dbt-repo/models/schema.yml /tmp/dbt-repo/lightdash.config.yml /tmp/prompt.txt 2>/dev/null; rm -rf /tmp/images /tmp/metric-queries /tmp/external-data 2>/dev/null; true',
+            'rm -f /tmp/dbt-repo/models/schema.yml /tmp/dbt-repo/lightdash.config.yml /tmp/prompt.txt 2>/dev/null; rm -rf /tmp/images /tmp/metric-queries /tmp/dashboard /tmp/external-data 2>/dev/null; true',
             { timeoutMs: 10_000 },
         );
 
@@ -2073,6 +2110,18 @@ export class AppGenerateService extends BaseService {
                 chartReferences,
             );
             finalPrompt = referenceBlock + finalPrompt;
+        }
+
+        // Attached dashboard: write its structural blueprint and prepend the
+        // layout-spec block. Prepended after the chart block so it lands above
+        // it in the final prompt — structure first, then the queries.
+        if (dashboardBlueprint) {
+            const blueprintBlock = await this.writeDashboardBlueprint(
+                sandbox,
+                appUuid,
+                dashboardBlueprint,
+            );
+            finalPrompt = blueprintBlock + finalPrompt;
         }
 
         // Linked external connections: write an API-doc file per connection into
@@ -2464,7 +2513,7 @@ export class AppGenerateService extends BaseService {
                     `cat /tmp/prompt.txt | claude ${sessionFlags} ` +
                         `--model ${claudeModel} ${effortFlag}` +
                         `--verbose --output-format stream-json --include-partial-messages ` +
-                        `--allowedTools "Read(//app/**),Read(//tmp/dbt-repo/**),Read(//tmp/images/**),Read(//tmp/metric-queries/**),Read(//tmp/external-data/**),Write(//app/src/**),Edit(//app/src/**),Glob(//app/**),Glob(//tmp/dbt-repo/**),Glob(//tmp/metric-queries/**),Glob(//tmp/external-data/**),Grep(//app/**),Grep(//tmp/dbt-repo/**),Grep(//tmp/external-data/**)" ` +
+                        `--allowedTools "Read(//app/**),Read(//tmp/dbt-repo/**),Read(//tmp/images/**),Read(//tmp/metric-queries/**),Read(//tmp/dashboard/**),Read(//tmp/external-data/**),Write(//app/src/**),Edit(//app/src/**),Glob(//app/**),Glob(//tmp/dbt-repo/**),Glob(//tmp/metric-queries/**),Glob(//tmp/dashboard/**),Glob(//tmp/external-data/**),Grep(//app/**),Grep(//tmp/dbt-repo/**),Grep(//tmp/external-data/**)" ` +
                         `${jsonSchemaFlag}--append-system-prompt-file ${AppGenerateService.EFFECTIVE_SKILL_PATH}`,
                     {
                         cwd: '/app',
@@ -3639,6 +3688,7 @@ export class AppGenerateService extends BaseService {
                     s3Client,
                     bucket,
                     chartReferences,
+                    payload.dashboardBlueprint,
                     template,
                     isDataAppViz,
                 );
@@ -4070,14 +4120,18 @@ export class AppGenerateService extends BaseService {
     }
 
     /**
-     * Extract UUID v4 patterns from the prompt, attempt to resolve each as a
-     * saved chart (permission-checked), and return structured references for
-     * any that resolve.
+     * Resolve an attached dashboard (permission-checked) into the chart uuids
+     * of its saved-chart tiles plus a structural blueprint of the dashboard
+     * itself — tabs, tile layout, filters.
      */
-    private async resolveDashboardToChartUuids(
+    private async resolveDashboardReference(
         dashboardUuid: string,
         user: SessionUser,
-    ): Promise<{ chartUuids: string[]; dashboardName: string }> {
+    ): Promise<{
+        chartUuids: string[];
+        dashboardName: string;
+        blueprint: DashboardBlueprint;
+    }> {
         const dashboard = await this.dashboardService.getByIdOrSlug(
             user,
             dashboardUuid,
@@ -4089,6 +4143,7 @@ export class AppGenerateService extends BaseService {
         return {
             chartUuids: [...new Set(chartUuids)],
             dashboardName: dashboard.name,
+            blueprint: buildDashboardBlueprint(dashboard),
         };
     }
 
@@ -4106,6 +4161,7 @@ export class AppGenerateService extends BaseService {
     ): Promise<{
         refs: AppChartReference[];
         dashboardName: string | null;
+        dashboardBlueprint: DashboardBlueprint | null;
     }> {
         const flagByUuid = new Map<
             string,
@@ -4122,12 +4178,14 @@ export class AppGenerateService extends BaseService {
             });
         }
         let dashboardName: string | null = null;
+        let dashboardBlueprint: DashboardBlueprint | null = null;
         if (dashboard) {
-            const result = await this.resolveDashboardToChartUuids(
+            const result = await this.resolveDashboardReference(
                 dashboard.uuid,
                 user,
             );
             dashboardName = result.dashboardName;
+            dashboardBlueprint = result.blueprint;
             for (const uuid of result.chartUuids) {
                 const prev = flagByUuid.get(uuid) ?? {
                     sample: false,
@@ -4146,7 +4204,7 @@ export class AppGenerateService extends BaseService {
                 linkLive: link,
             }),
         );
-        return { refs, dashboardName };
+        return { refs, dashboardName, dashboardBlueprint };
     }
 
     /**
@@ -4492,18 +4550,26 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         user: SessionUser,
     ): Promise<{
         charts: { name: string; exploreName: string }[];
-        dashboardName: string | null;
+        dashboard: { name: string; structureSummary: string } | null;
     }> {
         const uuids = new Set<string>();
         for (const c of charts ?? []) uuids.add(c.uuid);
-        let dashboardName: string | null = null;
+        let resolvedDashboard: {
+            name: string;
+            structureSummary: string;
+        } | null = null;
         if (dashboard) {
             try {
-                const result = await this.resolveDashboardToChartUuids(
+                const result = await this.resolveDashboardReference(
                     dashboard.uuid,
                     user,
                 );
-                dashboardName = result.dashboardName;
+                resolvedDashboard = {
+                    name: result.dashboardName,
+                    structureSummary: describeDashboardBlueprint(
+                        result.blueprint,
+                    ),
+                };
                 for (const uuid of result.chartUuids) uuids.add(uuid);
             } catch (error) {
                 this.logger.warn(
@@ -4512,7 +4578,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             }
         }
         if (uuids.size === 0) {
-            return { charts: [], dashboardName };
+            return { charts: [], dashboard: resolvedDashboard };
         }
         const account = fromSession(user);
         const chartResults = await Promise.allSettled(
@@ -4527,7 +4593,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 });
             }
         }
-        return { charts: resolvedCharts, dashboardName };
+        return { charts: resolvedCharts, dashboard: resolvedDashboard };
     }
 
     /**
@@ -4538,13 +4604,17 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
     private static formatAttachedResourcesForClarifier(
         attached: {
             charts: { name: string; exploreName: string }[];
-            dashboardName: string | null;
+            dashboard: { name: string; structureSummary: string } | null;
         },
         imageCount: number,
     ): string {
         const lines: string[] = [];
-        if (attached.dashboardName) {
-            lines.push(`- Dashboard: "${attached.dashboardName}"`);
+        if (attached.dashboard) {
+            // Surface that the layout is already known so the clarifier does
+            // not ask structural questions the blueprint answers.
+            lines.push(
+                `- Dashboard: "${attached.dashboard.name}" (structure attached: ${attached.dashboard.structureSummary})`,
+            );
         }
         for (const chart of attached.charts) {
             lines.push(
@@ -4685,11 +4755,8 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             })`,
         );
 
-        const { refs, dashboardName } = await this.collectChartReferences(
-            charts,
-            dashboard,
-            user,
-        );
+        const { refs, dashboardName, dashboardBlueprint } =
+            await this.collectChartReferences(charts, dashboard, user);
         const {
             references: chartReferences,
             chartResources,
@@ -4747,6 +4814,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             charts: chartResources,
             externalConnections: externalConnectionResources,
             dashboardName,
+            dashboardUuid: dashboardBlueprint?.dashboardUuid ?? null,
             clarifications: clarifications ?? [],
             claudeModel,
             design: designSnapshot,
@@ -4813,6 +4881,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             isIteration: false,
             chartReferences:
                 chartReferences.length > 0 ? chartReferences : undefined,
+            dashboardBlueprint: dashboardBlueprint ?? undefined,
             claudeModel,
             designUuid: resolvedDesignUuid,
         });
@@ -4872,11 +4941,8 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             })`,
         );
 
-        const { refs, dashboardName } = await this.collectChartReferences(
-            charts,
-            dashboard,
-            user,
-        );
+        const { refs, dashboardName, dashboardBlueprint } =
+            await this.collectChartReferences(charts, dashboard, user);
         const {
             references: chartReferences,
             chartResources,
@@ -4930,6 +4996,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             charts: chartResources,
             externalConnections: externalConnectionResources,
             dashboardName,
+            dashboardUuid: dashboardBlueprint?.dashboardUuid ?? null,
             clarifications: [],
             claudeModel,
             design: designSnapshot,
@@ -5039,6 +5106,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             isIteration: true,
             chartReferences:
                 chartReferences.length > 0 ? chartReferences : undefined,
+            dashboardBlueprint: dashboardBlueprint ?? undefined,
             claudeModel,
             designUuid: effectiveDesignUuid,
         });
@@ -5445,6 +5513,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             charts: sourceResources?.charts ?? [],
             externalConnections: sourceResources?.externalConnections ?? [],
             dashboardName: sourceResources?.dashboardName ?? null,
+            dashboardUuid: sourceResources?.dashboardUuid ?? null,
             clarifications: [],
             ...(sourceResources?.claudeModel
                 ? { claudeModel: sourceResources.claudeModel }

--- a/packages/backend/src/ee/services/AppGenerateService/buildChartReference.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/buildChartReference.test.ts
@@ -1,11 +1,18 @@
-import { type ChartSampleData, type MetricQuery } from '@lightdash/common';
+import {
+    ChartType,
+    type ChartConfig,
+    type ChartSampleData,
+    type MetricQuery,
+} from '@lightdash/common';
 import { buildChartReference } from './AppGenerateService';
 
 describe('buildChartReference', () => {
+    const chartConfig: ChartConfig = { type: ChartType.BIG_NUMBER };
     const chart = {
         name: 'Revenue',
         tableName: 'orders',
         metricQuery: {} as MetricQuery,
+        chartConfig,
     };
     it('carries chartUuid and linked=true, no sample, for a linked chart', () => {
         const ref = buildChartReference(chart, 'chart-1', true, null);

--- a/packages/backend/src/ee/services/AppGenerateService/dashboardBlueprint.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/dashboardBlueprint.ts
@@ -1,0 +1,73 @@
+import {
+    DashboardTileTypes,
+    type Dashboard,
+    type DashboardBlueprint,
+} from '@lightdash/common';
+
+export const DASHBOARD_BLUEPRINT_PATH = '/tmp/dashboard/blueprint.json';
+
+export const buildDashboardBlueprint = (
+    dashboard: Dashboard,
+): DashboardBlueprint => ({
+    dashboardUuid: dashboard.uuid,
+    name: dashboard.name,
+    description: dashboard.description ?? null,
+    tabs: [...dashboard.tabs].sort((a, b) => a.order - b.order),
+    tiles: dashboard.tiles,
+    filters: dashboard.filters,
+    parameters: dashboard.parameters ?? null,
+    config: dashboard.config ?? null,
+});
+
+const TILE_TYPE_LABELS: Record<DashboardTileTypes, string> = {
+    [DashboardTileTypes.SAVED_CHART]: 'chart',
+    [DashboardTileTypes.SQL_CHART]: 'SQL chart',
+    [DashboardTileTypes.MARKDOWN]: 'markdown',
+    [DashboardTileTypes.LOOM]: 'video',
+    [DashboardTileTypes.HEADING]: 'heading',
+    [DashboardTileTypes.DATA_APP]: 'data app',
+};
+
+/**
+ * Compact one-line summary of the blueprint's shape, e.g.
+ * "2 tabs, 12 tiles (8 chart, 3 markdown, 1 heading), 4 filters".
+ */
+export const describeDashboardBlueprint = (
+    blueprint: DashboardBlueprint,
+): string => {
+    const counts = new Map<DashboardTileTypes, number>();
+    for (const tile of blueprint.tiles) {
+        counts.set(tile.type, (counts.get(tile.type) ?? 0) + 1);
+    }
+    const tileBreakdown = [...counts.entries()]
+        .map(([type, count]) => `${count} ${TILE_TYPE_LABELS[type]}`)
+        .join(', ');
+    const filterCount =
+        blueprint.filters.dimensions.length +
+        blueprint.filters.metrics.length +
+        blueprint.filters.tableCalculations.length;
+    return [
+        `${blueprint.tabs.length} tab${blueprint.tabs.length === 1 ? '' : 's'}`,
+        `${blueprint.tiles.length} tile${
+            blueprint.tiles.length === 1 ? '' : 's'
+        }${tileBreakdown ? ` (${tileBreakdown})` : ''}`,
+        `${filterCount} filter${filterCount === 1 ? '' : 's'}`,
+    ].join(', ');
+};
+
+/**
+ * Prompt block prepended above the chart-reference listing when a dashboard
+ * is attached. Frames the blueprint as the layout spec so the agent recreates
+ * the dashboard's structure instead of designing one from scratch.
+ */
+export const dashboardBlueprintPromptBlock = (
+    blueprint: DashboardBlueprint,
+): string =>
+    `[Attached dashboard "${blueprint.name}" — structural blueprint at ${DASHBOARD_BLUEPRINT_PATH}]\n` +
+    `The user attached a Lightdash dashboard (${describeDashboardBlueprint(
+        blueprint,
+    )}). ` +
+    `The blueprint JSON maps its full structure: tabs, tile grid positions, tile types and titles, dashboard filters, and which saved chart each tile renders. ` +
+    `Match chart tiles to the metric-query files via properties.savedChartUuid = chartUuid. ` +
+    `Read /app/references/dashboard-blueprint.md for the JSON shape and layout mapping rules. ` +
+    `Unless the user asks for a different design, treat the blueprint as the layout spec: recreate its tabs, tile arrangement, and filters rather than inventing a new structure.\n\n`;

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -2,10 +2,18 @@ import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { type ApiSuccess, type ApiSuccessEmpty } from '../../types/api/success';
 import {
+    type DashboardConfig,
+    type DashboardTab,
+    type DashboardTile,
+} from '../../types/dashboard';
+import { type DashboardFilters } from '../../types/filter';
+import {
     type KnexPaginateArgs,
     type KnexPaginatedData,
 } from '../../types/knex-paginate';
 import { type MetricQuery } from '../../types/metricQuery';
+import { type DashboardParameters } from '../../types/parameters';
+import { type ChartConfig } from '../../types/savedCharts';
 
 /**
  * Ordered pipeline stages. Index position determines progression — used to
@@ -97,6 +105,28 @@ export type AppChartReference = {
 export type AppDashboardReference = {
     uuid: string;
     includeSampleData: boolean;
+};
+
+/**
+ * Structural snapshot of an attached dashboard, written into the sandbox so
+ * the agent can recreate the dashboard's design — tabs, tile layout, filters —
+ * instead of inventing a layout from the flattened chart queries. Built
+ * server-side at enqueue time from the resolved dashboard.
+ */
+export type DashboardBlueprint = {
+    dashboardUuid: string;
+    name: string;
+    description: string | null;
+    /** Sorted by `order`. Empty when the dashboard has no tabs. */
+    tabs: DashboardTab[];
+    /** Tile positions use the dashboard's 36-column grid: `x`/`w` are column
+     *  units, `y`/`h` are row units. `tabUuid` links a tile to its tab. Chart
+     *  tiles carry `properties.savedChartUuid` — the same uuid as the matching
+     *  ChartReference in the sandbox. */
+    tiles: DashboardTile[];
+    filters: DashboardFilters;
+    parameters: DashboardParameters | null;
+    config: DashboardConfig | null;
 };
 
 /**
@@ -223,6 +253,11 @@ export type AppVersionResources = {
     charts: AppVersionChartResource[];
     externalConnections?: AppVersionExternalConnectionResource[];
     dashboardName: string | null;
+    // Uuid of the attached dashboard, so later features can re-resolve its
+    // structure (the name alone is ambiguous). Optional for backwards
+    // compatibility — versions built before dashboard blueprints shipped
+    // don't carry the field.
+    dashboardUuid?: string | null;
     // Pre-build Q&A captured at the time of generation. Persisted alongside
     // the prompt so the chat history can render the clarifications as their
     // own card on the user message — rather than mashing them into the
@@ -414,6 +449,11 @@ export type ChartReference = {
     chartDescription: string;
     exploreName: string;
     metricQuery: MetricQuery;
+    /** Saved visualization config (bar/line/table/big number…) so the agent
+     *  can reproduce the chart type and styling, not just the query. */
+    chartConfig: ChartConfig;
+    /** Pivot dimensions when the saved chart pivots its results. */
+    pivotConfig: { columns: string[] } | null;
     sampleData: ChartSampleData | null; // null when the user did not opt in
     /** Saved chart UUID — surfaced into the sandbox so a linked chart can be
      *  run live via savedChart(uuid). */

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -10,6 +10,7 @@ import {
     type AiDeepResearchJobPayload,
     type AiWritebackSource,
     type ChartReference,
+    type DashboardBlueprint,
     type DataAppClaudeModel,
     type DataAppTemplate,
     type EmbedArtifactVersionJobPayload,
@@ -56,6 +57,10 @@ export type AppGeneratePipelineJobPayload = TraceTaskBase & {
     imageIds?: string[];
     isIteration: boolean;
     chartReferences?: ChartReference[];
+    // Structural snapshot of the attached dashboard (tabs, tile layout,
+    // filters). Written into the sandbox as a layout blueprint alongside the
+    // flattened chartReferences. Absent when no dashboard was attached.
+    dashboardBlueprint?: DashboardBlueprint;
     // Claude model the user picked for this version. Absent on jobs enqueued
     // before the picker shipped — the pipeline falls back to
     // DEFAULT_DATA_APP_CLAUDE_MODEL in that case.

--- a/sandboxes/data-apps/template/references/chart-references.md
+++ b/sandboxes/data-apps/template/references/chart-references.md
@@ -22,6 +22,15 @@ Each file contains:
 - `metricQuery.sorts` — sort order
 - `metricQuery.limit` — row limit
 - `metricQuery.tableCalculations` — computed columns (may be empty)
+- `chartConfig` — the saved visualization config. `chartConfig.type` tells you
+  what to render: `big_number` (KPI stat), `cartesian` (bar/line/area/scatter —
+  the series type is inside `chartConfig.config.eChartsConfig.series`), `table`,
+  `pie`, `funnel`, `treemap`, `gauge`, `map`, `sankey`, or `custom`. Reproduce
+  the chart type instead of guessing one from the data shape; deeper styling
+  details inside the config are optional inspiration, not a spec.
+- `pivotConfig` — pivot dimension field IDs when the saved chart pivots its
+  results (`null` otherwise). A pivoted table/bar means one series per value of
+  the pivot dimension.
 
 **How to use these:**
 1. Read the JSON file(s) to understand what data the user wants in their app

--- a/sandboxes/data-apps/template/references/dashboard-blueprint.md
+++ b/sandboxes/data-apps/template/references/dashboard-blueprint.md
@@ -1,0 +1,100 @@
+# Dashboard blueprint (dashboard attached to the prompt)
+
+> Read this when the prompt announces an attached dashboard with a blueprint at
+> `/tmp/dashboard/blueprint.json`.
+
+## Contents
+
+- What the blueprint JSON contains
+- How to map tabs, the tile grid, and tile types to app structure
+- How to wire dashboard filters as interactive controls
+- What to skip and when to deviate
+
+The user attached a Lightdash dashboard. The blueprint is its full structural
+definition — use it as the layout spec and recreate the dashboard's design,
+instead of inventing a layout from scratch. The chart queries themselves live in
+`/tmp/metric-queries/*.json` (see `chart-references.md`); the blueprint tells you
+how those charts were arranged and filtered.
+
+## Blueprint shape
+
+```jsonc
+{
+  "dashboardUuid": "…",
+  "name": "Sales overview",          // use as the app title unless the user names it
+  "description": "…",                // may be null
+  "tabs": [                          // sorted by order; [] when the dashboard has no tabs
+    { "uuid": "tab-1", "name": "Summary", "order": 0, "hidden": false }
+  ],
+  "tiles": [ /* see below */ ],
+  "filters": {                       // dashboard-level filters
+    "dimensions": [ /* DashboardFilterRule */ ],
+    "metrics": [],
+    "tableCalculations": []
+  },
+  "parameters": { /* default parameter values, or null */ },
+  "config": { /* date-zoom settings etc., or null */ }
+}
+```
+
+### Tiles
+
+Every tile has: `uuid`, `type`, `x`, `y`, `w`, `h`, `tabUuid`, `properties`.
+
+**Grid geometry:** positions are on a **36-column grid** — `x`/`w` are column
+units (a full-width tile is `w: 36`, a half-width tile `w: 18`), `y`/`h` are row
+units of roughly 55px. Translate proportionally into your layout (e.g. CSS grid
+with 12 columns: divide `x`/`w` by 3). Preserve the relative arrangement — what
+sits side by side, what spans full width, the top-to-bottom order — rather than
+the pixel-exact math. `tabUuid` says which tab the tile belongs to (`null` when
+the dashboard has no tabs).
+
+Tile types and their `properties`:
+
+- `saved_chart` — `savedChartUuid`, `chartName`, optional `title` (falls back to
+  the chart name) and `hideTitle`. **Match it to its metric-query file via
+  `savedChartUuid` = the `chartUuid` field inside each
+  `/tmp/metric-queries/*.json`.** Build the tile's visualization from that
+  file's `metricQuery` + `chartConfig` (or `savedChart(uuid)` when the file says
+  LINKED).
+- `markdown` — `title`, `content` (markdown source). Recreate as a text/prose
+  section.
+- `heading` — `text`, `showDivider`. Recreate as a section header.
+- `loom` — `title`, `url`. Recreate as a link out to the video (do not embed
+  arbitrary iframes).
+- `sql_chart` — `savedSqlUuid`, `chartName`. Its query is NOT available in
+  `/tmp/metric-queries/`. Keep its place in the layout: render a clearly
+  labelled placeholder card with the tile's title, or rebuild it from catalog
+  fields if the prompt makes the intent obvious.
+- `data_app` — an embedded data app. Skip it; note it in a comment.
+
+### Tabs
+
+Recreate tabs as top-level navigation (tab bar / segmented control), one view
+per tab, tiles assigned by `tabUuid`, ordered by `order`. Skip tabs with
+`hidden: true`. Single implicit tab (empty `tabs`) → a single page, no tab
+chrome.
+
+### Dashboard filters
+
+Each rule in `filters.dimensions` is a `DashboardFilterRule`: `target`
+(`fieldId`, `tableName`), `operator`, `values`, `label`, and `tileTargets`.
+Recreate these as the app's interactive filter controls (see the global-filters
+guidance in `skill.md`):
+
+- One control per rule; `label` (or the target field's label) is the control's
+  caption; `values` are the default selection; `disabled: true` means "no
+  default value" — start unfiltered.
+- `tileTargets` maps tile `uuid` → the field to filter on for that tile, or
+  `false` when the rule must NOT apply to that tile. A missing entry means
+  "apply with the rule's own target field". Respect exclusions — that a chart is
+  exempt from a filter is deliberate dashboard design.
+- Apply selections via `.filters()` — inline convention for `query(...)`,
+  qualified ids for `savedChart(...)` (rules in `chart-references.md`).
+
+## When to deviate
+
+The blueprint wins on structure (tabs, arrangement, which filters exist) unless
+the user's prompt asks for something different — the prompt always wins. You may
+modernize presentation (spacing, typography, card styling per the design skill)
+while keeping the structure recognizably the same dashboard.

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -148,6 +148,10 @@ These metrics are **not additive over time**. A balance on Monday plus the balan
 
 If the prompt lists referenced charts (files under `/tmp/metric-queries/*.json`), read `/app/references/chart-references.md` before writing any query code — it defines the JSON shape, linked-vs-copied chart semantics (`savedChart`), and the field-id mapping rules.
 
+## Attached dashboard blueprint
+
+If the prompt announces an attached dashboard (blueprint at `/tmp/dashboard/blueprint.json`), read `/app/references/dashboard-blueprint.md` before designing any layout — the blueprint defines the dashboard's tabs, tile grid, and filters, and it is the layout spec to recreate unless the user asks for a different design.
+
 ## Linked external connections
 
 If the prompt lists external connections (files under `/tmp/external-data/`), read `/app/references/external-apis.md` before calling any external API — it documents each connection file and the `externalFetch` rules.


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8381/data-apps-i-want-to-easily-recreate-a-lightdash-dashboard-as-a-data

### Description:
When a dashboard is attached to a data app prompt, write its structural blueprint (tabs, tile grid, filters, config) into the sandbox alongside the flattened metric queries, so the agent recreates the dashboard's layout instead of inventing one. Chart references now also carry the saved chartConfig/pivotConfig so tile visualizations match.


### Testing:
I used my [F1 dashboard](https://analytics.lightdash.cloud/projects/3b82b3bb-cefd-481d-8059-744b66aa2dfe/dashboards/93b305e8-0595-41d6-97ce-1cca4a62ae5a/view) for testing, which contains a filter for the season and 4 different tabs with various charts, none of which was considered thus far, when attaching a dashboard to the data app prompt.

#### The dashboard:
<img width="2568" height="1611" alt="image" src="https://github.com/user-attachments/assets/0d4eddea-31ea-4767-a70d-34608a0ea4ae" />


#### Before (current prod):
While it used the same queries, the design has nothing to do with the original dashboard. It's just one page and charts that don't match the style nor positioning. The generation took ~7 minutes.

<img width="2568" height="1584" alt="image" src="https://github.com/user-attachments/assets/e7f4653a-369d-4bc8-97c6-f2a6e6e20b05" />


#### After (this branch):
The filter, tabs, charts type and positioning all match the original dashboard. The generation took ~7 minutes.

<img width="2568" height="1596" alt="image" src="https://github.com/user-attachments/assets/f524e942-426b-4f51-a5a2-723c61da3d55" />
