### PR TITLE
feat(cli): allow downloading data apps by URL

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -967,7 +967,7 @@ Data apps can be **downloaded as source, versioned in git, edited, and re-upload
 
 Opt-in flags on the existing `lightdash download` / `lightdash upload` commands (off by default — core users never touch app code paths unless they ask):
 
-- **`lightdash download --apps <appUuids...>`** — download specific data apps into `lightdash/apps/<slug>/`; **`--include-apps`** downloads all of the project's apps (capped at `--apps-limit`, default 50). Each folder holds `lightdash-app.yml` (manifest) + the app's `src/` tree. The built `dist` is intentionally excluded — it's regenerated on upload.
+- **`lightdash download --apps <appReferences...>`** — download specific data apps by UUID or app URL into `lightdash/apps/<slug>/`; **`--include-apps`** downloads all of the project's apps (capped at `--apps-limit`, default 50). Each folder holds `lightdash-app.yml` (manifest) + the app's `src/` tree. The built `dist` is intentionally excluded — it's regenerated on upload.
 - **`lightdash upload --apps <appUuids...>`** — upload specific apps (matched by manifest `appUuid`); **`--include-apps`** uploads every `lightdash/apps/<slug>/` folder on disk. The server rebuilds the source. **Fire-and-forget:** the CLI posts and returns immediately — the app shows `building` in the UI until the server finishes.
 
 **Identity:** the manifest's `appUuid` is the source of truth (apps have no persistent slug; the `<slug>` folder name is derived from the app name via `generateSlug`, with a stable `untitled-app-<uuid8>` fallback for unnamed apps so re-downloads reuse the same folder). Uploading to the **same project** appends a new version of that app; uploading to a **different project** creates a new app there.

--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -11,12 +11,40 @@ import {
     computeUpsertedTotal,
     DEFAULT_APPS_LIMIT,
     ensureDownloadedAppContext,
+    getDataAppUuidFromReference,
     manifestRetargetHint,
     resolveAppsLimit,
     selectAppsToDownload,
     shouldFallBackToSpaceScopedListing,
     shouldWarnAllSkipped,
 } from './appsDownload';
+
+describe('getDataAppUuidFromReference', () => {
+    const appUuid = 'd3afc44c-6f0f-4d9f-a267-fb739efa31dd';
+    const projectUuid = 'd4c8dfd2-98c0-4eb2-8395-d924aee62611';
+
+    it('keeps a bare app UUID unchanged', () => {
+        expect(getDataAppUuidFromReference(appUuid)).toBe(appUuid);
+    });
+
+    it.each([
+        `https://app.lightdash.cloud/projects/${projectUuid}/apps/${appUuid}`,
+        `https://app.lightdash.cloud/projects/${projectUuid}/apps/${appUuid}/view`,
+        `https://app.lightdash.cloud/projects/${projectUuid}/apps/${appUuid}/versions/2/view?state=filters#preview`,
+        `https://app.lightdash.cloud/embed/${projectUuid}/app/${appUuid}`,
+    ])('extracts the app UUID from %s', (url) => {
+        expect(getDataAppUuidFromReference(url)).toBe(appUuid);
+    });
+
+    it.each([
+        'my-app',
+        `https://app.lightdash.cloud/${appUuid}`,
+        `https://app.lightdash.cloud/projects/${projectUuid}/apps/generate`,
+        `ftp://app.lightdash.cloud/projects/${projectUuid}/apps/${appUuid}`,
+    ])('leaves unsupported references unchanged: %s', (reference) => {
+        expect(getDataAppUuidFromReference(reference)).toBe(reference);
+    });
+});
 
 const makeDownload = (): DataAppCodeDownload =>
     ({
@@ -64,6 +92,19 @@ describe('selectAppsToDownload', () => {
         expect(
             selectAppsToDownload({ apps: ['uuid-a'], includeApps: true }),
         ).toEqual({ mode: 'list-all', extraAppUuids: ['uuid-a'] });
+    });
+
+    it('normalizes explicit app URLs without listing apps', () => {
+        expect(
+            selectAppsToDownload({
+                apps: [
+                    'https://app.lightdash.cloud/projects/project-uuid/apps/d3afc44c-6f0f-4d9f-a267-fb739efa31dd/view',
+                ],
+            }),
+        ).toEqual({
+            mode: 'explicit',
+            appUuids: ['d3afc44c-6f0f-4d9f-a267-fb739efa31dd'],
+        });
     });
 
     it('skips apps when neither flag is passed', () => {

--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -4,8 +4,31 @@ import {
     ParameterError,
     type DataAppCodeDownload,
 } from '@lightdash/common';
+import { validate as isUuid } from 'uuid';
 
 export const DEFAULT_APPS_LIMIT = 50;
+
+export const getDataAppUuidFromReference = (reference: string): string => {
+    let url: URL;
+    try {
+        url = new URL(reference);
+    } catch {
+        return reference;
+    }
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return reference;
+    }
+
+    const pathSegments = url.pathname.split('/').filter(Boolean);
+    const appSegmentIndex = pathSegments.findIndex(
+        (segment, index) =>
+            (segment === 'apps' || segment === 'app') &&
+            isUuid(pathSegments[index + 1]),
+    );
+
+    return appSegmentIndex >= 0 ? pathSegments[appSegmentIndex + 1] : reference;
+};
 
 /**
  * Resolves the --apps-limit flag. Commander passes the raw string (or
@@ -56,7 +79,7 @@ export const selectAppsToDownload = (request: {
     apps?: string[];
     includeApps?: boolean;
 }): AppsDownloadSelection => {
-    const explicitUuids = request.apps ?? [];
+    const explicitUuids = (request.apps ?? []).map(getDataAppUuidFromReference);
     if (request.includeApps) {
         return { mode: 'list-all', extraAppUuids: explicitUuids };
     }

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -153,7 +153,7 @@ export type DownloadHandlerOptions = {
     googleSheets: string[];
     scheduledDeliveries: string[];
     virtualViews: string[];
-    apps?: string[]; // specific app UUIDs (enterprise); absent = no explicit selection
+    apps?: string[]; // specific app UUIDs or URLs (enterprise); absent = no explicit selection
     includeAgents?: boolean;
     includeApps?: boolean; // download: all of the project's apps, capped at --apps-limit; upload: all app folders on disk
     appsLimit?: string; // download only: cap for the --include-apps listing (default 50); raw string from commander
@@ -1347,7 +1347,7 @@ export const downloadHandler = async (
         });
         if (appsOnlySelection.mode === 'none') {
             throw new ParameterError(
-                'Nothing to download: --apps-only requires --apps <appUuids...>, --include-apps, or --include-all.',
+                'Nothing to download: --apps-only requires --apps <appReferences...>, --include-apps, or --include-all.',
             );
         }
         options.skipCharts = true;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -885,8 +885,8 @@ const downloadCommand = program
         false,
     )
     .option(
-        '--apps <appUuids...>',
-        'Include specific data apps by UUID (enterprise). Works for apps not added to a space.',
+        '--apps <appReferences...>',
+        'Include specific data apps by UUID or URL (enterprise). Works for apps not added to a space.',
     )
     .option(
         '--include-apps',
@@ -900,7 +900,7 @@ const downloadCommand = program
     )
     .option(
         '--apps-only',
-        'Download only data apps (implies --skip-charts --skip-dashboards --skip-spaces). Requires --apps <appUuids...>, --include-apps, or --include-all.',
+        'Download only data apps (implies --skip-charts --skip-dashboards --skip-spaces). Requires --apps <appReferences...>, --include-apps, or --include-all.',
         false,
     )
     .option(


### PR DESCRIPTION
Closes [GLITCH-634](https://linear.app/lightdash/issue/GLITCH-634/allow-downloading-apps-by-url)

### Description
- Accept data app URLs in `lightdash download --apps`
- Extract UUIDs from builder, viewer, versioned-view, and embed URLs
- Document and test UUID/URL references