### PR TITLE
feat(cli): allow uploading data apps by URL

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -968,7 +968,7 @@ Data apps can be **downloaded as source, versioned in git, edited, and re-upload
 Opt-in flags on the existing `lightdash download` / `lightdash upload` commands (off by default — core users never touch app code paths unless they ask):
 
 - **`lightdash download --apps <appReferences...>`** — download specific data apps by UUID or app URL into `lightdash/apps/<slug>/`; **`--include-apps`** downloads all of the project's apps (capped at `--apps-limit`, default 50). Each folder holds `lightdash-app.yml` (manifest) + the app's `src/` tree. The built `dist` is intentionally excluded — it's regenerated on upload.
-- **`lightdash upload --apps <appUuids...>`** — upload specific apps (matched by manifest `appUuid`); **`--include-apps`** uploads every `lightdash/apps/<slug>/` folder on disk. The server rebuilds the source. **Fire-and-forget:** the CLI posts and returns immediately — the app shows `building` in the UI until the server finishes.
+- **`lightdash upload --apps <appReferences...>`** — upload specific apps by UUID or app URL (matched by manifest `appUuid`); **`--include-apps`** uploads every `lightdash/apps/<slug>/` folder on disk. The server rebuilds the source. **Fire-and-forget:** the CLI posts and returns immediately — the app shows `building` in the UI until the server finishes.
 
 **Identity:** the manifest's `appUuid` is the source of truth (apps have no persistent slug; the `<slug>` folder name is derived from the app name via `generateSlug`, with a stable `untitled-app-<uuid8>` fallback for unnamed apps so re-downloads reuse the same folder). Uploading to the **same project** appends a new version of that app; uploading to a **different project** creates a new app there.
 

--- a/packages/cli/src/handlers/apps/appsDownload.test.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.test.ts
@@ -11,6 +11,7 @@ import {
     computeUpsertedTotal,
     DEFAULT_APPS_LIMIT,
     ensureDownloadedAppContext,
+    getDataAppUploadFilter,
     getDataAppUuidFromReference,
     manifestRetargetHint,
     resolveAppsLimit,
@@ -43,6 +44,25 @@ describe('getDataAppUuidFromReference', () => {
         `ftp://app.lightdash.cloud/projects/${projectUuid}/apps/${appUuid}`,
     ])('leaves unsupported references unchanged: %s', (reference) => {
         expect(getDataAppUuidFromReference(reference)).toBe(reference);
+    });
+});
+
+describe('getDataAppUploadFilter', () => {
+    const appUuid = 'd3afc44c-6f0f-4d9f-a267-fb739efa31dd';
+
+    it('matches app manifests by UUID when a URL is passed', () => {
+        expect(
+            getDataAppUploadFilter(
+                [
+                    `https://app.lightdash.cloud/projects/project-uuid/apps/${appUuid}/view`,
+                ],
+                false,
+            ),
+        ).toEqual(new Set([appUuid]));
+    });
+
+    it('does not filter app folders when --include-apps is passed', () => {
+        expect(getDataAppUploadFilter([appUuid], true)).toBeNull();
     });
 });
 

--- a/packages/cli/src/handlers/apps/appsDownload.ts
+++ b/packages/cli/src/handlers/apps/appsDownload.ts
@@ -30,6 +30,12 @@ export const getDataAppUuidFromReference = (reference: string): string => {
     return appSegmentIndex >= 0 ? pathSegments[appSegmentIndex + 1] : reference;
 };
 
+export const getDataAppUploadFilter = (
+    references: string[],
+    includeApps: boolean,
+): Set<string> | null =>
+    includeApps ? null : new Set(references.map(getDataAppUuidFromReference));
+
 /**
  * Resolves the --apps-limit flag. Commander passes the raw string (or
  * undefined when the flag was not given, so an explicit flag is
@@ -52,7 +58,7 @@ export const resolveAppsLimit = (
         limit: parseInt(rawLimit, 10),
         noEffectWarning: includeApps
             ? null
-            : '--apps-limit only applies to --include-apps; explicit --apps UUIDs are never capped.',
+            : '--apps-limit only applies to --include-apps; explicit --apps references are never capped.',
     };
 };
 

--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -29,6 +29,7 @@ const {
     downloadSpaces,
     getDashboardChartSlugs,
     getFlatSpaceFileNames,
+    hasUploadFilters,
     readAiAgentFiles,
     readSpaceFiles,
     readSpaceNames,
@@ -41,6 +42,46 @@ const {
     validateSpaceIdentity,
     writeSpaceFiles,
 } = testHelpers;
+
+const makeUploadFilterOptions = (
+    overrides: Partial<Parameters<typeof hasUploadFilters>[0]> = {},
+): Parameters<typeof hasUploadFilters>[0] => ({
+    spacesOnly: false,
+    charts: [],
+    dashboards: [],
+    agents: [],
+    alerts: [],
+    googleSheets: [],
+    scheduledDeliveries: [],
+    virtualViews: [],
+    apps: [],
+    ...overrides,
+});
+
+describe('hasUploadFilters', () => {
+    it('treats explicit apps as a filtered upload', () => {
+        expect(
+            hasUploadFilters(
+                makeUploadFilterOptions({ apps: ['app-reference'] }),
+            ),
+        ).toBe(true);
+    });
+
+    it('keeps an unfiltered upload unfiltered', () => {
+        expect(hasUploadFilters(makeUploadFilterOptions())).toBe(false);
+    });
+
+    it('does not treat content selections as filters in spaces-only mode', () => {
+        expect(
+            hasUploadFilters(
+                makeUploadFilterOptions({
+                    spacesOnly: true,
+                    apps: ['app-reference'],
+                }),
+            ),
+        ).toBe(false);
+    });
+});
 
 type LooseDashboard = DashboardAsCode & { needsUpdating: boolean };
 

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -81,6 +81,7 @@ import {
     classifyAppDownloadError,
     classifyAppUpload,
     ensureDownloadedAppContext,
+    getDataAppUploadFilter,
     manifestRetargetHint,
     resolveAppsLimit,
     selectAppsToDownload,
@@ -203,6 +204,40 @@ const shouldDownloadAiAgents = ({
 >): boolean =>
     appsOnly !== true &&
     (includeAll === true || includeAgents === true || agents.length > 0);
+
+const hasUploadFilters = ({
+    spacesOnly,
+    charts,
+    dashboards,
+    agents,
+    alerts,
+    googleSheets,
+    scheduledDeliveries,
+    virtualViews,
+    apps,
+}: Pick<
+    DownloadHandlerOptions,
+    | 'spacesOnly'
+    | 'charts'
+    | 'dashboards'
+    | 'agents'
+    | 'alerts'
+    | 'googleSheets'
+    | 'scheduledDeliveries'
+    | 'virtualViews'
+    | 'apps'
+>): boolean =>
+    !spacesOnly &&
+    [
+        charts,
+        dashboards,
+        agents,
+        alerts,
+        googleSheets,
+        scheduledDeliveries,
+        virtualViews,
+        apps ?? [],
+    ].some((filters) => filters.length > 0);
 
 /*
     This function is used to parse the content filters.
@@ -1388,15 +1423,7 @@ export const downloadHandler = async (
         );
     }
 
-    const hasFilters =
-        !options.spacesOnly &&
-        (options.charts.length > 0 ||
-            options.dashboards.length > 0 ||
-            options.agents.length > 0 ||
-            options.alerts.length > 0 ||
-            options.googleSheets.length > 0 ||
-            options.scheduledDeliveries.length > 0 ||
-            options.virtualViews.length > 0);
+    const hasFilters = hasUploadFilters(options);
     const shouldDownloadSpaces =
         !isOrganizationDownload && !options.skipSpaces && !hasFilters;
     let skipEmbeddedSpaces = !hasFilters || options.skipSpaces;
@@ -2814,13 +2841,13 @@ export const uploadHandler = async (
             }
         }
 
-        // Upload data apps (enterprise, opt-in via --apps <uuids...> or
+        // Upload data apps (enterprise, opt-in via --apps <references...> or
         // --include-apps, fire-and-forget)
-        const explicitAppUuids = Array.isArray(options.apps)
+        const explicitAppReferences = Array.isArray(options.apps)
             ? options.apps
             : [];
         const shouldUploadApps =
-            options.includeApps === true || explicitAppUuids.length > 0;
+            options.includeApps === true || explicitAppReferences.length > 0;
 
         let appsCreated = 0;
         let appsUpdated = 0;
@@ -2838,10 +2865,12 @@ export const uploadHandler = async (
             output.completeItem('permission denied', 'warning');
         } else if (shouldUploadApps) {
             output.startItem('Data apps');
-            // --include-apps uploads every folder on disk; explicit UUIDs
+            // --include-apps uploads every folder on disk; explicit references
             // filter folders by their manifest appUuid
-            const filterUuids: Set<string> | null =
-                options.includeApps === true ? null : new Set(explicitAppUuids);
+            const filterUuids = getDataAppUploadFilter(
+                explicitAppReferences,
+                options.includeApps === true,
+            );
 
             const baseDir = getDownloadFolder(options.path);
             const appsDir = path.join(baseDir, 'apps');
@@ -3177,6 +3206,7 @@ export const testHelpers = {
     downloadSpaces,
     getFlatSpaceFileNames,
     getDashboardChartSlugs,
+    hasUploadFilters,
     readAiAgentFiles,
     readSpaceFiles,
     readSpaceNames,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -992,8 +992,8 @@ const uploadCommand = program
     .option('--validate', 'Validate charts and dashboards after upload', false)
     .option('--gzip', 'Enable gzip compression for request bodies', false)
     .option(
-        '--apps <appUuids...>',
-        'Upload specific data apps by UUID (enterprise).',
+        '--apps <appReferences...>',
+        'Upload specific data apps by UUID or URL (enterprise).',
     )
     .option(
         '--include-apps',


### PR DESCRIPTION
### Description
- Accept data app URLs in `lightdash upload --apps`
- Match parsed URL UUIDs against local app manifests
- Treat explicit `--apps` selection as a filtered upload, matching charts and dashboards