### PR TITLE
feat(deep-research): add chart summaries to report markdown

### DIFF
--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchAgent.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchAgent.ts
@@ -1,5 +1,6 @@
 import type { AgentCreateParams } from '@anthropic-ai/sdk/resources/beta/agents';
 import {
+    AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS,
     AI_DEEP_RESEARCH_MAX_CHARTS,
     AI_DEEP_RESEARCH_MAX_INLINE_COLUMNS,
     AI_DEEP_RESEARCH_MAX_INLINE_ROWS,
@@ -130,7 +131,7 @@ Structure:
 - Cite external evidence inline with bracketed markers like [1] and list every source in a final "## Sources" section as a numbered list: 1. [Source label](https://...) — why it matters. Cite warehouse evidence through charts, not URLs.
 
 Charts:
-- Define every chart in the charts argument and reference it inline in the markdown, at the exact position it belongs, as a link: [Chart title](#chart-<key>). Never embed chart JSON or code fences in the markdown.
+- Define every chart in the charts argument and reference it inline in the markdown, at the exact position it belongs, as: <chart id="<key>" title="<chart title>" description="<standalone summary of the chart's important pattern, at most ${AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS} characters>">. The description is for readers that do not inspect the separate chart data, so make it specific and useful without repeating the surrounding prose. Use HTML entities for double quotes, ampersands, or angle brackets inside attribute values. Never embed chart JSON or code fences in the markdown.
 - Warehouse charts ({"source": "warehouse"}): the key is the exact completed queryUuid returned by run_metric_query in THIS session; charts referencing anything else are removed from the report. Apply the business-relevant time range, comparison baseline, and filters in run_metric_query; choose a chart type, axes, sort, and limit that make the conclusion inspectable.
 - Inline charts ({"source": "inline"}): use ONLY when the visualization is a derived computation or external (MCP/web) data that no single warehouse query can produce. Provide a short lowercase slug key, columns, and rows (at most ${AI_DEEP_RESEARCH_MAX_INLINE_ROWS} rows and ${AI_DEEP_RESEARCH_MAX_INLINE_COLUMNS} columns), and cite the completed queryUuids the data was derived from in derivedFrom. Inline charts are labelled agent-computed to the reader — prefer warehouse charts whenever possible.
 - Reference each chart exactly once, at most one chart per finding section, and at most ${AI_DEEP_RESEARCH_MAX_CHARTS} charts in total. Prefer 2-6 complementary charts when warehouse data materially helps. groupBy is not supported and must always be null; when a breakdown across a second dimension matters, use a separate chart per segment or a different single-dimension cut.
@@ -204,8 +205,7 @@ Call submit_research_report after initial useful findings and again as the inves
                     markdown: {
                         type: 'string',
                         maxLength: MAX_REPORT_MARKDOWN_CHARS,
-                        description:
-                            'The complete research report as a single markdown document. Reference each chart as [Chart title](#chart-<key>).',
+                        description: `The complete research report as a single markdown document. Reference each chart as <chart id="<key>" title="<chart title>" description="<standalone chart summary of at most ${AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS} characters>">.`,
                     },
                     charts: {
                         type: 'array',

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchExecutor.test.ts
@@ -42,7 +42,7 @@ const reportMarkdown = `Revenue fell after the promotion ended, with high confid
 
 The timing makes the promotion the strongest explanation for the decline.
 
-[Revenue trend](#chart-${QUERY_UUID})
+<chart id="${QUERY_UUID}" title="Revenue trend" description="Revenue declined after the promotion ended.">
 
 The trajectory change aligns with the promotion end date.
 
@@ -177,7 +177,7 @@ describe('AiDeepResearchExecutor', () => {
         expect(() =>
             parseAiDeepResearchReport({
                 markdown: reportMarkdown.replace(
-                    `[Revenue trend](#chart-${QUERY_UUID})`,
+                    `<chart id="${QUERY_UUID}" title="Revenue trend" description="Revenue declined after the promotion ended.">`,
                     '```chart\n{}\n```',
                 ),
                 charts: [],

--- a/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
+++ b/packages/backend/src/ee/services/AiDeepResearchService/AiDeepResearchService.test.ts
@@ -81,7 +81,7 @@ const chart = {
     },
 };
 
-const chartRef = `[${chart.title}](#chart-${chart.queryUuid})`;
+const chartRef = `<chart id="${chart.queryUuid}" title="${chart.title}" description="Revenue remained stable across the period.">`;
 
 const reportMarkdown = `Revenue held steady overall, with high confidence.
 
@@ -910,7 +910,7 @@ describe('AiDeepResearchService', () => {
             };
             const inlineMarkdown = reportMarkdown.replace(
                 'The baseline trend is stable.',
-                `The baseline trend is stable.\n\n[${inlineChart.title}](#chart-${inlineChart.key})`,
+                `The baseline trend is stable.\n\n<chart id="${inlineChart.key}" title="${inlineChart.title}" description="The enterprise ratio was lower than the SMB ratio.">`,
             );
             const { service, model } = buildService({
                 executor: vi.fn().mockResolvedValue({
@@ -972,7 +972,7 @@ describe('AiDeepResearchService', () => {
             expect(queryHistoryModel.getByQueryUuid).not.toHaveBeenCalled();
             const [, persisted, chartData] = model.markCompleted.mock.calls[0];
             expect(chartData).toEqual({});
-            expect(persisted).not.toContain('#chart-');
+            expect(persisted).not.toContain(`<chart id="${chart.queryUuid}"`);
             expect(persisted).toContain('*(chart omitted:');
             expect(persisted).toContain(
                 'Some proposed charts were omitted because their query evidence could not be verified.',
@@ -1011,7 +1011,7 @@ describe('AiDeepResearchService', () => {
 
             const [, persisted, chartData] = model.markCompleted.mock.calls[0];
             expect(chartData).toEqual({});
-            expect(persisted).not.toContain('#chart-');
+            expect(persisted).not.toContain(`<chart id="${chart.queryUuid}"`);
             expect(persisted).toContain('*(chart omitted:');
         });
 

--- a/packages/common/src/ee/aiDeepResearch/markdown.test.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.test.ts
@@ -5,12 +5,18 @@ import {
     findDeepResearchChartRefs,
     getDeepResearchChartKey,
     lintDeepResearchReport,
+    renderDeepResearchChartRefs,
     spliceDeepResearchRanges,
     type AiDeepResearchChartDefinition,
 } from './markdown';
 
 const UUID_A = '11111111-1111-4111-8111-111111111111';
 const UUID_B = '22222222-2222-4222-8222-222222222222';
+const chartTag = (
+    id: string,
+    title = 'Revenue by month',
+    description = 'Revenue rose steadily until spring.',
+) => `<chart id="${id}" title="${title}" description="${description}">`;
 
 const chartConfig = {
     defaultVizType: 'bar' as const,
@@ -63,7 +69,7 @@ const validReport = `The seasonal dip is driven by B2B churn, with high confiden
 
 Revenue grew steadily until spring.
 
-[Revenue by month](#chart-${UUID_A})
+${chartTag(UUID_A)}
 
 The dip aligns with contract renewals.
 
@@ -73,19 +79,20 @@ The dip aligns with contract renewals.
 `;
 
 describe('findDeepResearchChartRefs', () => {
-    it('finds chart reference links with offsets', () => {
+    it('finds chart tags with offsets and summaries', () => {
         const refs = findDeepResearchChartRefs(validReport);
         expect(refs).toHaveLength(1);
         expect(refs[0].key).toBe(UUID_A);
         expect(refs[0].title).toBe('Revenue by month');
+        expect(refs[0].description).toBe('Revenue rose steadily until spring.');
         expect(validReport.slice(refs[0].start, refs[0].end)).toBe(
-            `[Revenue by month](#chart-${UUID_A})`,
+            chartTag(UUID_A),
         );
     });
 
     it('ignores references inside code fences', () => {
         const refs = findDeepResearchChartRefs(
-            '```md\n[Example](#chart-abc)\n```\n\n[Real](#chart-xyz-1)',
+            `\`\`\`md\n${chartTag('abc')}\n\`\`\`\n\n${chartTag('xyz-1')}`,
         );
         expect(refs).toHaveLength(1);
         expect(refs[0].key).toBe('xyz-1');
@@ -98,11 +105,51 @@ describe('findDeepResearchChartRefs', () => {
             ),
         ).toHaveLength(0);
     });
+
+    it('does not support legacy chart links', () => {
+        expect(
+            findDeepResearchChartRefs(`[Revenue by month](#chart-${UUID_A})`),
+        ).toHaveLength(0);
+    });
+
+    it('renders chart tags as internal links without exposing descriptions', () => {
+        expect(renderDeepResearchChartRefs(validReport)).toContain(
+            `[Revenue by month](#chart-${UUID_A})`,
+        );
+        expect(renderDeepResearchChartRefs(validReport)).not.toContain(
+            'Revenue rose steadily until spring.',
+        );
+    });
+
+    it('escapes chart titles before rendering internal links', () => {
+        const markdown = chartTag(
+            UUID_A,
+            'Revenue ](https://attacker.example) [details',
+        );
+        const rendered = renderDeepResearchChartRefs(markdown);
+
+        expect(rendered.trim()).toBe(
+            `[Revenue \\](https://attacker.example) \\[details](#chart-${UUID_A})`,
+        );
+        expect(rendered).not.toContain('[Revenue ](https://attacker.example)');
+    });
+
+    it('decodes HTML entities before validating description length', () => {
+        const description = '&amp;'.repeat(300);
+        const refs = findDeepResearchChartRefs(
+            `<chart id="${UUID_A}" title="Revenue &amp; margin" description="${description}">`,
+        );
+
+        expect(refs[0]).toMatchObject({
+            title: 'Revenue & margin',
+            description: '&'.repeat(300),
+        });
+    });
 });
 
 describe('spliceDeepResearchRanges', () => {
     it('replaces multiple ranges without invalidating offsets', () => {
-        const markdown = `a ${'[X](#chart-k1)'} b ${'[Y](#chart-k2)'} c`;
+        const markdown = `a ${chartTag('k1', 'X')} b ${chartTag('k2', 'Y')} c`;
         const refs = findDeepResearchChartRefs(markdown);
         const result = spliceDeepResearchRanges(
             markdown,
@@ -113,7 +160,7 @@ describe('spliceDeepResearchRanges', () => {
         );
         expect(result).toContain('[removed 0]');
         expect(result).toContain('[removed 1]');
-        expect(result).not.toContain('#chart-');
+        expect(result).not.toContain('<chart');
     });
 });
 
@@ -142,8 +189,8 @@ describe('lintDeepResearchReport', () => {
 
     it('accepts an inline chart referenced by key', () => {
         const markdown = validReport.replace(
-            `[Revenue by month](#chart-${UUID_A})`,
-            '[Derived ratio](#chart-tickets-per-1k)',
+            chartTag(UUID_A),
+            chartTag('tickets-per-1k', 'Derived ratio'),
         );
         expect(
             lintDeepResearchReport(markdown, [inlineChart('tickets-per-1k')]),
@@ -175,7 +222,10 @@ describe('lintDeepResearchReport', () => {
     it('rejects a chart referenced twice', () => {
         const markdown = validReport.replace(
             'The dip aligns with contract renewals.',
-            `The dip aligns with contract renewals.\n\n[Again](#chart-${UUID_A})`,
+            `The dip aligns with contract renewals.\n\n${chartTag(
+                UUID_A,
+                'Again',
+            )}`,
         );
         const errors = lintDeepResearchReport(markdown, [
             warehouseChart(UUID_A),
@@ -186,7 +236,10 @@ describe('lintDeepResearchReport', () => {
     it('rejects more than one chart reference in a finding section', () => {
         const markdown = validReport.replace(
             'The dip aligns with contract renewals.',
-            `The dip aligns with contract renewals.\n\n[Second](#chart-${UUID_B})`,
+            `The dip aligns with contract renewals.\n\n${chartTag(
+                UUID_B,
+                'Second',
+            )}`,
         );
         const errors = lintDeepResearchReport(markdown, [
             warehouseChart(UUID_A),
@@ -204,7 +257,10 @@ describe('lintDeepResearchReport', () => {
     it('accepts one chart in each of two finding sections', () => {
         const markdown = validReport.replace(
             '## Conclusion',
-            `## Second finding\n\n<confidence level="medium">ok</confidence>\n\nMore prose.\n\n[Second](#chart-${UUID_B})\n\n## Conclusion`,
+            `## Second finding\n\n<confidence level="medium">ok</confidence>\n\nMore prose.\n\n${chartTag(
+                UUID_B,
+                'Second',
+            )}\n\n## Conclusion`,
         );
         expect(
             lintDeepResearchReport(markdown, [
@@ -232,7 +288,7 @@ describe('lintDeepResearchReport', () => {
 
     it('rejects legacy chart code fences', () => {
         const markdown = validReport.replace(
-            `[Revenue by month](#chart-${UUID_A})`,
+            chartTag(UUID_A),
             `\`\`\`chart\n{"queryUuid":"${UUID_A}"}\n\`\`\``,
         );
         const errors = lintDeepResearchReport(markdown, [
@@ -241,6 +297,50 @@ describe('lintDeepResearchReport', () => {
         expect(errors.some((e) => e.includes('Do not embed ```chart'))).toBe(
             true,
         );
+    });
+
+    it('rejects descriptions longer than 300 characters', () => {
+        const markdown = validReport.replace(
+            chartTag(UUID_A),
+            chartTag(UUID_A, 'Revenue by month', 'x'.repeat(301)),
+        );
+        const errors = lintDeepResearchReport(markdown, [
+            warehouseChart(UUID_A),
+        ]);
+        expect(
+            errors.some(
+                (error) =>
+                    error.includes('description') && error.includes('300'),
+            ),
+        ).toBe(true);
+    });
+
+    it('accepts descriptions exactly 300 characters long', () => {
+        const markdown = validReport.replace(
+            chartTag(UUID_A),
+            chartTag(UUID_A, 'Revenue by month', 'x'.repeat(300)),
+        );
+        expect(
+            lintDeepResearchReport(markdown, [warehouseChart(UUID_A)]),
+        ).toEqual([]);
+    });
+
+    it('requires the tag and chart definition to use the same title', () => {
+        const markdown = validReport.replace(
+            chartTag(UUID_A),
+            chartTag(UUID_A, 'Different title'),
+        );
+        const errors = lintDeepResearchReport(markdown, [
+            warehouseChart(UUID_A),
+        ]);
+
+        expect(
+            errors.some(
+                (error) =>
+                    error.includes('Different title') &&
+                    error.includes('Revenue by month'),
+            ),
+        ).toBe(true);
     });
 
     it('requires intro prose before the first heading', () => {

--- a/packages/common/src/ee/aiDeepResearch/markdown.ts
+++ b/packages/common/src/ee/aiDeepResearch/markdown.ts
@@ -16,6 +16,7 @@ import {
 
 export const AI_DEEP_RESEARCH_CHART_LANGUAGE = 'chart';
 export const AI_DEEP_RESEARCH_MAX_CHARTS = 8;
+export const AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS = 300;
 export const AI_DEEP_RESEARCH_MAX_INLINE_ROWS = 100;
 export const AI_DEEP_RESEARCH_MAX_INLINE_COLUMNS = 10;
 
@@ -215,16 +216,54 @@ export const buildInlineChartMetricQuery = (
 });
 
 // ---------------------------------------------------------------------------
-// Chart references: charts appear in the markdown as plain links,
-// [Title](#chart-<key>), resolved against the chart definitions.
+// Chart references: chart data is stored separately, while the markdown keeps
+// compact metadata that lets an LLM understand the chart without reading it.
 // ---------------------------------------------------------------------------
 
-const CHART_REF_RE = /\[([^\]\n]*)\]\(#chart-([A-Za-z0-9-]+)\)/g;
+const CHART_REF_RE = /<chart\b([^>]*)>/g;
+const CHART_ATTRIBUTE_RE = /\b(id|title|description)="([^"]*)"/g;
+const HTML_ENTITY_RE = /&(#x[\da-f]+|#\d+|amp|quot|lt|gt);/gi;
+const NAMED_HTML_ENTITIES: Record<string, string> = {
+    amp: '&',
+    quot: '"',
+    lt: '<',
+    gt: '>',
+};
+
+const decodeHtmlEntities = (value: string): string =>
+    value.replace(HTML_ENTITY_RE, (entity, code: string) => {
+        const named = NAMED_HTML_ENTITIES[code.toLowerCase()];
+        if (named) {
+            return named;
+        }
+        const isHex = code.toLowerCase().startsWith('#x');
+        const codePoint = Number.parseInt(
+            code.slice(isHex ? 2 : 1),
+            isHex ? 16 : 10,
+        );
+        return Number.isSafeInteger(codePoint) && codePoint <= 0x10ffff
+            ? String.fromCodePoint(codePoint)
+            : entity;
+    });
+
+const encodeHtmlAttribute = (value: string): string =>
+    value
+        .replaceAll('&', '&amp;')
+        .replaceAll('"', '&quot;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;');
+
+const escapeMarkdownLabel = (value: string): string =>
+    value
+        .replaceAll('\\', '\\\\')
+        .replaceAll('[', '\\[')
+        .replaceAll(']', '\\]');
 
 export type AiDeepResearchChartRef = {
     key: string;
     title: string;
-    /** Char range of the whole link in the markdown. */
+    description: string;
+    /** Char range of the whole tag in the markdown. */
     start: number;
     end: number;
     raw: string;
@@ -233,7 +272,11 @@ export type AiDeepResearchChartRef = {
 export const getDeepResearchChartRefMarkdown = (
     title: string,
     key: string,
-): string => `[${title}](#chart-${key})`;
+    description: string,
+): string =>
+    `<chart id="${encodeHtmlAttribute(key)}" title="${encodeHtmlAttribute(
+        title,
+    )}" description="${encodeHtmlAttribute(description)}">`;
 
 // ---------------------------------------------------------------------------
 // Legacy fenced ```chart blocks. Kept for the data migration that converts
@@ -408,16 +451,46 @@ export const findDeepResearchChartRefs = (
         match !== null;
         match = CHART_REF_RE.exec(masked)
     ) {
-        refs.push({
-            key: match[2],
-            title: match[1],
-            start: match.index,
-            end: match.index + match[0].length,
-            raw: markdown.slice(match.index, match.index + match[0].length),
-        });
+        const attributes = Object.fromEntries(
+            [...match[1].matchAll(CHART_ATTRIBUTE_RE)].map(
+                ([, name, value]) => [name, value],
+            ),
+        );
+        const id = attributes.id && decodeHtmlEntities(attributes.id);
+        const title = attributes.title && decodeHtmlEntities(attributes.title);
+        const description =
+            attributes.description &&
+            decodeHtmlEntities(attributes.description);
+        const isValid =
+            id &&
+            /^[A-Za-z0-9-]+$/.test(id) &&
+            title &&
+            description &&
+            description.length <= AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS;
+        if (isValid) {
+            refs.push({
+                key: id,
+                title,
+                description,
+                start: match.index,
+                end: match.index + match[0].length,
+                raw: markdown.slice(match.index, match.index + match[0].length),
+            });
+        }
     }
     return refs;
 };
+
+export const renderDeepResearchChartRefs = (markdown: string): string =>
+    spliceDeepResearchRanges(
+        markdown,
+        findDeepResearchChartRefs(markdown).map((ref) => ({
+            match: ref,
+            replacement: `[${escapeMarkdownLabel(ref.title)}](#chart-${
+                ref.key
+            })`,
+        })),
+    );
 
 const CONFIDENCE_TAG_RE = /<confidence\b[^>]*>/g;
 
@@ -475,6 +548,7 @@ const lintHtmlTags = (masked: string): string[] => {
     const errors: string[] = [];
     const allowedTags = new Set([
         ...Object.keys(AI_DEEP_RESEARCH_MARKDOWN_TAGS),
+        'chart',
         'br',
     ]);
     const tagCounts = new Map<string, { open: number; close: number }>();
@@ -490,7 +564,7 @@ const lintHtmlTags = (masked: string): string[] => {
         const name = rawName.toLowerCase();
         if (!allowedTags.has(name)) {
             disallowed.add(rawName);
-        } else if (name !== 'br') {
+        } else if (name !== 'br' && name !== 'chart') {
             const counts = tagCounts.get(name) ?? { open: 0, close: 0 };
             if (slash) counts.close += 1;
             else counts.open += 1;
@@ -522,7 +596,7 @@ const lintHtmlTags = (masked: string): string[] => {
 /**
  * Validates a submitted report: the markdown structure and the referential
  * integrity between chart definitions (tool arguments) and the
- * [title](#chart-key) references in the markdown. Returns actionable errors
+ * <chart> references in the markdown. Returns actionable errors
  * the agent can self-correct from.
  */
 export const lintDeepResearchReport = (
@@ -576,11 +650,11 @@ export const lintDeepResearchReport = (
         });
     });
 
-    // Charts are tool arguments referenced by [title](#chart-<key>) links;
+    // Charts are tool arguments referenced by compact <chart> tags;
     // fenced ```chart blocks are the legacy form and are rejected.
     if (findDeepResearchChartBlocks(markdown).length > 0) {
         errors.push(
-            'Do not embed ```chart code fences in the markdown; define charts in the `charts` argument and reference each one inline with a [Chart title](#chart-<key>) link.',
+            'Do not embed ```chart code fences in the markdown; define charts in the `charts` argument and reference each one inline with a <chart id="..." title="..." description="..."> tag.',
         );
     }
 
@@ -591,9 +665,11 @@ export const lintDeepResearchReport = (
     }
 
     const keyCounts = new Map<string, number>();
+    const chartTitles = new Map<string, string>();
     charts.forEach((chart) => {
         const key = getDeepResearchChartKey(chart);
         keyCounts.set(key, (keyCounts.get(key) ?? 0) + 1);
+        chartTitles.set(key, chart.title);
     });
     keyCounts.forEach((count, key) => {
         if (count > 1) {
@@ -604,16 +680,28 @@ export const lintDeepResearchReport = (
     });
 
     const refs = findDeepResearchChartRefs(markdown);
+    const chartTagCount = masked.match(/<chart\b[^>]*>/g)?.length ?? 0;
+    if (chartTagCount !== refs.length) {
+        errors.push(
+            `Every <chart> tag must have a valid id, a non-empty title, and a non-empty description of at most ${AI_DEEP_RESEARCH_MAX_CHART_DESCRIPTION_CHARS} characters.`,
+        );
+    }
     const refCounts = new Map<string, number>();
     refs.forEach((ref) => {
         refCounts.set(ref.key, (refCounts.get(ref.key) ?? 0) + 1);
+        const chartTitle = chartTitles.get(ref.key);
+        if (chartTitle !== undefined && ref.title !== chartTitle) {
+            errors.push(
+                `Chart ${ref.key} has title "${ref.title}" in the markdown but "${chartTitle}" in the charts argument; use the same title in both places.`,
+            );
+        }
     });
 
     keyCounts.forEach((_, key) => {
         const refCount = refCounts.get(key) ?? 0;
         if (refCount !== 1) {
             errors.push(
-                `Chart ${key} must be referenced exactly once in the markdown as [Chart title](#chart-${key}) (found ${refCount} references).`,
+                `Chart ${key} must be referenced exactly once in the markdown as <chart id="${key}" title="..." description="..."> (found ${refCount} references).`,
             );
         }
     });

--- a/packages/common/src/ee/aiDeepResearch/types.ts
+++ b/packages/common/src/ee/aiDeepResearch/types.ts
@@ -104,7 +104,7 @@ export type AiDeepResearchChartSnapshot = {
 /**
  * Everything the UI needs to render one report chart, keyed by chart key in
  * `AiDeepResearchRun.resultChartData`. Written entirely by the backend at
- * publish time; the markdown only carries [title](#chart-<key>) references.
+ * publish time; the markdown only carries compact <chart> references.
  */
 export type AiDeepResearchChartData = {
     source: 'warehouse' | 'inline';
@@ -205,7 +205,7 @@ export type AiDeepResearchRun = {
     promptUuid: string | null;
     prompt: string;
     status: AiDeepResearchRunStatus;
-    /** The report narrative with [title](#chart-<key>) chart references. */
+    /** The report narrative with compact <chart> references. */
     resultMarkdown: string | null;
     /** Render data for each referenced chart, keyed by chart key. */
     resultChartData: AiDeepResearchChartDataMap | null;

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchMarkdownReport.tsx
@@ -1,5 +1,6 @@
 import {
     AI_DEEP_RESEARCH_MARKDOWN_TAGS,
+    renderDeepResearchChartRefs,
     type AiDeepResearchChartDataMap,
     type AiDeepResearchConfidence,
 } from '@lightdash/common';
@@ -64,9 +65,9 @@ const ConfidenceBadge: FC<{ level: unknown; children?: ReactNode }> = ({
 const CHART_HREF_PREFIX = '#chart-';
 
 /**
- * Chart references arrive as plain links, [Title](#chart-<key>), and hydrate
- * into chart tiles from the run's persisted chart data. Every other link
- * renders as a regular external anchor.
+ * Chart tags are converted to these internal links before rendering and
+ * hydrate into chart tiles from the run's persisted chart data. Every other
+ * link renders as a regular external anchor.
  */
 const ReportLink: FC<AnchorHTMLAttributes<HTMLAnchorElement>> = ({
     href,
@@ -160,7 +161,7 @@ type Props = {
 
 /**
  * Renders a deep research report markdown document as one linear flow:
- * prose via streamdown, [title](#chart-<key>) references hydrated into
+ * prose via streamdown, <chart> references hydrated into
  * chart tiles from the run's chart data, and the whitelisted
  * callout/confidence tags mapped to house components.
  */
@@ -170,6 +171,10 @@ export const DeepResearchMarkdownReport: FC<Props> = ({
     projectUuid,
     runUuid,
 }) => {
+    const renderMarkdown = useMemo(
+        () => renderDeepResearchChartRefs(markdown),
+        [markdown],
+    );
     const contextValue = useMemo(
         () => ({ projectUuid, runUuid, chartData }),
         [projectUuid, runUuid, chartData],
@@ -181,7 +186,7 @@ export const DeepResearchMarkdownReport: FC<Props> = ({
                 rehypePlugins={REHYPE_PLUGINS}
                 components={MARKDOWN_COMPONENTS}
             >
-                {markdown}
+                {renderMarkdown}
             </AiMarkdown>
         </DeepResearchReportContext.Provider>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/DeepResearch/DeepResearchReport.test.tsx
@@ -46,6 +46,11 @@ describe('DeepResearchReport', () => {
             'Enterprise retention by incident exposure',
         );
         expect(
+            screen.queryByText(
+                'Three incident-affected renewals account for most churn in the quarter.',
+            ),
+        ).not.toBeInTheDocument();
+        expect(
             Boolean(
                 setup.compareDocumentPosition(chart) &
                 Node.DOCUMENT_POSITION_FOLLOWING,

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/fixtures.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/fixtures.ts
@@ -35,7 +35,7 @@ const deepResearchReportMarkdownFixture = `Retention fell because three large cu
 
 The renewal cohort joins contracted ARR, renewal outcome, and production incident exposure for the quarter [1].
 
-[${deepResearchChartFixture.title}](#chart-${deepResearchChartQueryUuid})
+<chart id="${deepResearchChartQueryUuid}" title="${deepResearchChartFixture.title}" description="Three incident-affected renewals account for most churn in the quarter.">
 
 The concentration of churn among incident-exposed accounts makes reliability the strongest explanation for the quarter's retention decline.
 

--- a/packages/frontend/src/ee/features/aiCopilot/deepResearch/types.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/deepResearch/types.ts
@@ -50,7 +50,7 @@ export type DeepResearchRunView = {
         label: string;
         createdAt: string;
     }>;
-    /** The report narrative with [title](#chart-<key>) chart references. */
+    /** The report narrative with compact <chart> references. */
     resultMarkdown: string | null;
     /** Render data for each referenced chart, keyed by chart key. */
     resultChartData: AiDeepResearchChartDataMap | null;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9181/chart-tags

## Summary

Adds compact chart tags to Deep Research report Markdown so an LLM can understand a chart's main finding without loading its detailed data. Each tag contains an `id`, `title`, and required description capped at 300 decoded characters.

## How it works

### Report contract

- The managed agent writes `<chart id="..." title="..." description="...">` at the chart's narrative position.
- Common parsing validates all three properties, the 300-character boundary, unique references, and title consistency with structured chart data.
- HTML entities are decoded before validation, while Markdown metacharacters are escaped before UI hydration.

### Rendering

- Detailed chart definitions and snapshots remain separate from Markdown.
- The frontend converts valid tags to internal chart placeholders immediately before rendering.
- The description remains available to document-reading LLMs but is not shown in the user-facing report.

Before:

```md
[Monthly revenue](#chart-550e8400-e29b-41d4-a716-446655440000)
```

After:

```html
<chart id="550e8400-e29b-41d4-a716-446655440000" title="Monthly revenue" description="Revenue rose from £120k in April to £181k in June, with the strongest increase between May and June.">
```

## Regression analysis

- New Deep Research reports use the greenfield tag contract; legacy chart-link submissions fail validation.
- User-facing charts keep their existing title, data, configuration, position, and unavailable-chart behavior.
- Chart descriptions are LLM-only and never render in the report UI.
- No database migration, new dependency, permission change, or tenant-scoping change is introduced.

## Test plan

- [x] Common chart parser/linter tests — 37/37 passed.
- [x] Backend Deep Research report tests — 58/58 passed.
- [x] Frontend Deep Research report tests — 7/7 passed.
- [x] Common, backend, and frontend `typecheck:fast`.
- [x] Changed-file common, backend, and frontend lint.
- [x] `pnpm generate-api`.
- [x] `git diff --check`.
- [x] Exact 300-character description accepted; 301 rejected.
- [x] Missing descriptions and legacy links rejected.
- [x] Link-shaped titles cannot escape the internal chart placeholder.
- [x] Chart renders in narrative order while its description stays hidden.
