### PR TITLE
feat: support ordered pivot rows

### DIFF
--- a/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
@@ -191,6 +191,36 @@ describe('derivePivotConfigurationFromChart', () => {
         expect(result?.metricsAsRows).toBe(true);
     });
 
+    it('keeps a pivot row metric as a query-time value column', () => {
+        const savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'> = {
+            chartConfig: {
+                type: ChartType.TABLE,
+                config: {},
+            },
+            pivotConfig: {
+                columns: ['payments_payment_method'],
+                rows: ['orders_status', 'payments_total_revenue'],
+            },
+        };
+
+        const result = derivePivotConfigurationFromChart(
+            savedChart,
+            mockMetricQuery,
+            mockItems,
+        );
+
+        expect(result?.valuesColumns).toContainEqual({
+            reference: 'payments_total_revenue',
+            aggregation: VizAggregationOptions.ANY,
+        });
+        expect(result?.indexColumn).toEqual([
+            {
+                reference: 'orders_status',
+                type: VizIndexType.CATEGORY,
+            },
+        ]);
+    });
+
     it('does not include metricsAsRows for Cartesian charts', () => {
         const savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'> = {
             chartConfig: mockCartesianChartConfig,

--- a/packages/common/src/pivot/pivotConfig.test.ts
+++ b/packages/common/src/pivot/pivotConfig.test.ts
@@ -65,6 +65,31 @@ describe('getPivotConfig', () => {
     });
 
     describe('hidden field splitting for table charts', () => {
+        it('passes ordered pivot row fields through for rendering and exports', () => {
+            const result = getPivotConfig({
+                chartConfig: {
+                    type: ChartType.TABLE,
+                    config: {},
+                },
+                pivotConfig: {
+                    columns: ['orders_months_since_start'],
+                    rows: ['orders_cohort_month', 'orders_subscriptions'],
+                },
+                tableConfig: { columnOrder: [] },
+                metricQuery: {
+                    dimensions: [
+                        'orders_cohort_month',
+                        'orders_months_since_start',
+                    ],
+                },
+            });
+
+            expect(result?.rowFieldIds).toEqual([
+                'orders_cohort_month',
+                'orders_subscriptions',
+            ]);
+        });
+
         it('splits hidden fields into hiddenDimensionFieldIds and hiddenMetricFieldIds when metricQuery is provided', () => {
             // Chart config has both a hidden dim (orders_status) and a hidden metric (payments_total_revenue)
             const result = getPivotConfig({

--- a/packages/common/src/pivot/pivotConfig.ts
+++ b/packages/common/src/pivot/pivotConfig.ts
@@ -54,6 +54,9 @@ const getTablePivotConfig = (
     return {
         pivotDimensions: pivotConfig.columns,
         metricsAsRows: tableChartConfig.config?.metricsAsRows ?? false,
+        ...(pivotConfig.rows && {
+            rowFieldIds: pivotConfig.rows,
+        }),
         ...(hiddenMetrics.length > 0 && {
             hiddenMetricFieldIds: hiddenMetrics,
         }),

--- a/packages/common/src/pivot/pivotQueryResults.test.ts
+++ b/packages/common/src/pivot/pivotQueryResults.test.ts
@@ -1,4 +1,4 @@
-import { type ItemsMap } from '../types/field';
+import { type ItemsMap, type TableCalculation } from '../types/field';
 import { type PivotData } from '../types/pivot';
 import { type ResultRow } from '../types/results';
 import { getPivotRowContextKey } from '../utils/conditionalFormatting';
@@ -102,6 +102,456 @@ const buildWarehouseColumnTotalsFromExpected = (
 };
 
 describe('convertSqlPivotedRowsToPivotData', () => {
+    it('renders ordered row metrics once using the first pivot column value, including null', () => {
+        const rowMetricIds = [
+            'orders_total_order_amount',
+            'orders_average_order_size',
+        ];
+        const pivotDetails = {
+            ...SQL_PIVOT_DETAILS,
+            valuesColumns: SQL_PIVOT_DETAILS.valuesColumns.flatMap(
+                (column, columnIndex) => [
+                    column,
+                    ...rowMetricIds.map((metricId) => ({
+                        ...column,
+                        referenceField: metricId,
+                        pivotColumnName: `${metricId}_${columnIndex}`,
+                    })),
+                ],
+            ),
+        };
+        const rows = SQL_PIVOTED_ROWS.map((row, rowIndex) => ({
+            ...row,
+            ...Object.fromEntries(
+                SQL_PIVOT_DETAILS.valuesColumns.flatMap((_, columnIndex) =>
+                    rowMetricIds.map((metricId, metricIndex) => [
+                        `${metricId}_${columnIndex}`,
+                        {
+                            value: {
+                                raw:
+                                    rowIndex === 0 && metricIndex === 0
+                                        ? null
+                                        : 1000 * (metricIndex + 1) +
+                                          columnIndex,
+                                formatted:
+                                    rowIndex === 0 && metricIndex === 0
+                                        ? '∅'
+                                        : String(
+                                              1000 * (metricIndex + 1) +
+                                                  columnIndex,
+                                          ),
+                            },
+                        },
+                    ]),
+                ),
+            ),
+        }));
+
+        const result = convertSqlPivotedRowsToPivotData({
+            rows,
+            pivotDetails,
+            pivotConfig: {
+                rowTotals: false,
+                columnTotals: false,
+                metricsAsRows: false,
+                rowFieldIds: [
+                    'orders_average_order_size',
+                    'orders_order_date_year',
+                    'orders_total_order_amount',
+                ],
+                columnOrder: [
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                    ...rowMetricIds,
+                ],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+        });
+
+        expect(result.indexValueTypes).toEqual([
+            {
+                type: 'metric',
+                fieldId: 'orders_average_order_size',
+            },
+            {
+                type: 'dimension',
+                fieldId: 'orders_order_date_year',
+            },
+            {
+                type: 'metric',
+                fieldId: 'orders_total_order_amount',
+            },
+        ]);
+        expect(result.indexValues[0]).toEqual([
+            {
+                type: 'value',
+                fieldId: 'orders_average_order_size',
+                value: { raw: 2000, formatted: '2000' },
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: SQL_PIVOTED_ROWS[0].orders_order_date_year.value,
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'orders_total_order_amount',
+                value: { raw: null, formatted: '∅' },
+                colSpan: 1,
+            },
+        ]);
+        expect(result.dataValues[0]).toEqual(
+            SQL_PIVOT_DETAILS.valuesColumns.map(
+                ({ pivotColumnName }) =>
+                    SQL_PIVOTED_ROWS[0][pivotColumnName].value,
+            ),
+        );
+        expect(result.headerValues.at(-1)).toEqual(
+            SQL_PIVOT_DETAILS.valuesColumns.map(() => ({
+                type: 'label',
+                fieldId: 'payments_total_revenue',
+            })),
+        );
+        expect(result.retrofitData.pivotColumnInfo.slice(0, 3)).toEqual([
+            {
+                fieldId: 'orders_average_order_size',
+                baseId: undefined,
+                underlyingId: undefined,
+                columnType: 'indexValue',
+            },
+            {
+                fieldId: 'orders_order_date_year',
+                baseId: undefined,
+                underlyingId: undefined,
+                columnType: 'indexValue',
+            },
+            {
+                fieldId: 'orders_total_order_amount',
+                baseId: undefined,
+                underlyingId: undefined,
+                columnType: 'indexValue',
+            },
+        ]);
+    });
+
+    it('picks the row value from the lowest-columnIndex pivot column regardless of input order', () => {
+        const rowMetricId = 'orders_total_order_amount';
+        // Row-metric pivot columns, one per pivot group, listed in REVERSE
+        // columnIndex order so the input array order disagrees with render
+        // order. The rendered row value must still come from columnIndex 0.
+        const rowMetricColumns = [3, 2, 1, 0].map((columnIndex) => ({
+            ...SQL_PIVOT_DETAILS.valuesColumns[columnIndex],
+            referenceField: rowMetricId,
+            pivotColumnName: `${rowMetricId}_${columnIndex}`,
+            columnIndex,
+        }));
+        const pivotDetails = {
+            ...SQL_PIVOT_DETAILS,
+            valuesColumns: [
+                ...SQL_PIVOT_DETAILS.valuesColumns.map(
+                    (column, columnIndex) => ({
+                        ...column,
+                        columnIndex,
+                    }),
+                ),
+                ...rowMetricColumns,
+            ],
+        };
+        const rows = SQL_PIVOTED_ROWS.map((row) => ({
+            ...row,
+            ...Object.fromEntries(
+                [0, 1, 2, 3].map((columnIndex) => [
+                    `${rowMetricId}_${columnIndex}`,
+                    {
+                        value: {
+                            raw: (columnIndex + 1) * 10,
+                            formatted: String((columnIndex + 1) * 10),
+                        },
+                    },
+                ]),
+            ),
+        }));
+
+        const result = convertSqlPivotedRowsToPivotData({
+            rows,
+            pivotDetails,
+            pivotConfig: {
+                rowTotals: false,
+                columnTotals: false,
+                metricsAsRows: false,
+                rowFieldIds: ['orders_order_date_year', rowMetricId],
+                columnOrder: [
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                    rowMetricId,
+                ],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+        });
+
+        // columnIndex 0 -> raw 10; the array-first column was columnIndex 3 (raw
+        // 40). The row value must be 10, proving the picker follows render order.
+        expect(result.indexValues[0][1]).toEqual({
+            type: 'value',
+            fieldId: rowMetricId,
+            value: { raw: 10, formatted: '10' },
+            colSpan: 1,
+        });
+    });
+
+    it('renders a table calculation once as an ordered pivot row', () => {
+        const tableCalculation: TableCalculation = {
+            name: 'revenue_growth',
+            displayName: 'Revenue Growth',
+            sql: '${payments_total_revenue} / LAG(${payments_total_revenue})',
+        };
+        const pivotDetails = {
+            ...SQL_PIVOT_DETAILS,
+            valuesColumns: SQL_PIVOT_DETAILS.valuesColumns.flatMap(
+                (column, columnIndex) => [
+                    column,
+                    {
+                        ...column,
+                        referenceField: tableCalculation.name,
+                        pivotColumnName: `${tableCalculation.name}_${columnIndex}`,
+                    },
+                ],
+            ),
+        };
+        const rows = SQL_PIVOTED_ROWS.map((row, rowIndex) => ({
+            ...row,
+            ...Object.fromEntries(
+                SQL_PIVOT_DETAILS.valuesColumns.map((_, columnIndex) => [
+                    `${tableCalculation.name}_${columnIndex}`,
+                    {
+                        value: {
+                            raw: rowIndex + columnIndex / 10,
+                            formatted: `${rowIndex + columnIndex / 10}`,
+                        },
+                    },
+                ]),
+            ),
+        }));
+
+        const result = convertSqlPivotedRowsToPivotData({
+            rows,
+            pivotDetails,
+            pivotConfig: {
+                rowTotals: false,
+                columnTotals: false,
+                metricsAsRows: false,
+                rowFieldIds: ['orders_order_date_year', tableCalculation.name],
+                columnOrder: [
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                    tableCalculation.name,
+                ],
+            },
+            getField: (fieldId) =>
+                fieldId === tableCalculation.name
+                    ? tableCalculation
+                    : getFieldMock(fieldId),
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+        });
+
+        expect(result.indexValueTypes).toEqual([
+            {
+                type: 'dimension',
+                fieldId: 'orders_order_date_year',
+            },
+            {
+                type: 'metric',
+                fieldId: tableCalculation.name,
+            },
+        ]);
+        expect(result.indexValues[0][1]).toEqual({
+            type: 'value',
+            fieldId: tableCalculation.name,
+            value: { raw: 0, formatted: '0' },
+            colSpan: 1,
+        });
+        expect(result.dataValues[0]).toEqual(
+            SQL_PIVOT_DETAILS.valuesColumns.map(
+                ({ pivotColumnName }) =>
+                    SQL_PIVOTED_ROWS[0][pivotColumnName].value,
+            ),
+        );
+    });
+
+    it('supports moving every metric into pivot rows', () => {
+        const result = convertSqlPivotedRowsToPivotData({
+            rows: SQL_PIVOTED_ROWS,
+            pivotDetails: SQL_PIVOT_DETAILS,
+            pivotConfig: {
+                rowTotals: false,
+                columnTotals: false,
+                metricsAsRows: false,
+                rowFieldIds: [
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                ],
+                columnOrder: [
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                ],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+        });
+
+        expect(result.headerValues).toEqual([[]]);
+        expect(result.dataColumnCount).toBe(0);
+        expect(result.dataValues).toEqual([[], [], []]);
+        expect(result.indexValues[0]).toEqual([
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: SQL_PIVOTED_ROWS[0].orders_order_date_year.value,
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'payments_total_revenue',
+                value: {
+                    raw: 493.78,
+                    formatted: '493.78',
+                },
+                colSpan: 1,
+            },
+        ]);
+        expect(result.retrofitData.pivotColumnInfo).toHaveLength(2);
+    });
+
+    it('disables metrics-as-rows when every metric is already a pivot row', () => {
+        const result = convertSqlPivotedRowsToPivotData({
+            rows: SQL_PIVOTED_ROWS,
+            pivotDetails: SQL_PIVOT_DETAILS,
+            pivotConfig: {
+                rowTotals: false,
+                columnTotals: false,
+                metricsAsRows: true,
+                rowFieldIds: [
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                ],
+                columnOrder: [
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                ],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+        });
+
+        expect(result.pivotConfig.metricsAsRows).toBe(false);
+        expect(result.indexValues).toHaveLength(SQL_PIVOTED_ROWS.length);
+        expect(result.dataValues).toEqual([[], [], []]);
+        expect(result.indexValues[0]).toEqual([
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: SQL_PIVOTED_ROWS[0].orders_order_date_year.value,
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: 'payments_total_revenue',
+                value: {
+                    raw: 493.78,
+                    formatted: '493.78',
+                },
+                colSpan: 1,
+            },
+        ]);
+        expect(result.retrofitData.pivotColumnInfo).toHaveLength(2);
+    });
+
+    it('keeps metrics-as-rows enabled while another metric remains', () => {
+        const rowMetricId = 'orders_total_order_amount';
+        const pivotDetails = {
+            ...SQL_PIVOT_DETAILS,
+            valuesColumns: SQL_PIVOT_DETAILS.valuesColumns.flatMap(
+                (column, columnIndex) => [
+                    column,
+                    {
+                        ...column,
+                        referenceField: rowMetricId,
+                        pivotColumnName: `${rowMetricId}_${columnIndex}`,
+                    },
+                ],
+            ),
+        };
+        const rows = SQL_PIVOTED_ROWS.map((row) => ({
+            ...row,
+            ...Object.fromEntries(
+                SQL_PIVOT_DETAILS.valuesColumns.map((_, columnIndex) => [
+                    `${rowMetricId}_${columnIndex}`,
+                    {
+                        value: {
+                            raw: 1000 + columnIndex,
+                            formatted: String(1000 + columnIndex),
+                        },
+                    },
+                ]),
+            ),
+        }));
+
+        const result = convertSqlPivotedRowsToPivotData({
+            rows,
+            pivotDetails,
+            pivotConfig: {
+                rowTotals: false,
+                columnTotals: false,
+                metricsAsRows: true,
+                rowFieldIds: ['orders_order_date_year', rowMetricId],
+                columnOrder: [
+                    'orders_order_date_year',
+                    rowMetricId,
+                    'payments_total_revenue',
+                ],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+        });
+
+        expect(result.pivotConfig.metricsAsRows).toBe(true);
+        expect(result.indexValues).toHaveLength(rows.length);
+        expect(result.indexValues[0]).toEqual([
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: SQL_PIVOTED_ROWS[0].orders_order_date_year.value,
+                colSpan: 1,
+            },
+            {
+                type: 'value',
+                fieldId: rowMetricId,
+                value: { raw: 1000, formatted: '1000' },
+                colSpan: 1,
+            },
+            {
+                type: 'label',
+                fieldId: 'payments_total_revenue',
+            },
+        ]);
+        expect(result.dataValues[0]).toEqual(
+            SQL_PIVOT_DETAILS.valuesColumns.map(
+                ({ pivotColumnName }) =>
+                    SQL_PIVOTED_ROWS[0][pivotColumnName].value,
+            ),
+        );
+    });
+
     it('should convert SQL-pivoted rows to PivotData format', () => {
         // Convert SQL Pivoted rows to PivotData
         const result = convertSqlPivotedRowsToPivotData({

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -473,7 +473,7 @@ const getTitleFields = ({
         }
     });
     indexValueTypes.forEach((indexValueType, indexIndex) => {
-        if (indexValueType.type === FieldType.DIMENSION) {
+        if (indexValueType.fieldId) {
             titleFields[hasHeader ? headerValueTypes.length - 1 : 0][
                 indexIndex
             ] = {
@@ -515,6 +515,7 @@ export const convertSqlPivotedRowsToPivotData = ({
         | 'hiddenDimensionFieldIds'
         | 'visibleMetricFieldIds'
         | 'columnOrder'
+        | 'rowFieldIds'
     >; // only use properties that are not part of pivot details metadata
     getField: FieldFunction;
     getFieldLabel: FieldLabelFunction;
@@ -602,14 +603,14 @@ export const convertSqlPivotedRowsToPivotData = ({
     // Filter value columns: visibleMetricFieldIds (allowlist) takes precedence
     // over hiddenMetricFieldIds (blocklist). Cartesian charts use the allowlist
     // to exclude sort-only metrics injected for pivot sorting (PROD-6906).
-    let filteredValuesColumns = pivotDetails.valuesColumns.filter(
+    let visibleValuesColumns = pivotDetails.valuesColumns.filter(
         ({ referenceField }) => isMetricVisibleInPivot(referenceField),
     );
 
     // Apply column limit: keep only the first N unique pivot column groups
     if (columnLimit !== undefined && columnLimit > 0) {
         const seenGroups = new Set<string>();
-        filteredValuesColumns = filteredValuesColumns.filter((col) => {
+        visibleValuesColumns = visibleValuesColumns.filter((col) => {
             const groupKey = col.pivotValues
                 .map(
                     ({ referenceField, value }) => `${referenceField}:${value}`,
@@ -623,44 +624,92 @@ export const convertSqlPivotedRowsToPivotData = ({
         });
     }
 
+    const visibleValueFieldIds = new Set(
+        visibleValuesColumns.map(({ referenceField }) => referenceField),
+    );
+    const rowValueFieldIds = (pivotConfig.rowFieldIds ?? []).filter((fieldId) =>
+        visibleValueFieldIds.has(fieldId),
+    );
+    const rowValueFieldIdSet = new Set(rowValueFieldIds);
+    const firstPivotColumnByMetricFieldId = new Map<
+        string,
+        (typeof visibleValuesColumns)[number]
+    >();
+    // A row value renders the first rendered pivot column's value, so pick per
+    // metric from the same (columnIndex, columnOrder) render order the header
+    // and data columns use below, rather than trusting the input array order.
+    [...visibleValuesColumns]
+        .sort(
+            (a, b) =>
+                Number(a.columnIndex) - Number(b.columnIndex) ||
+                columnOrder.indexOf(a.referenceField) -
+                    columnOrder.indexOf(b.referenceField),
+        )
+        .forEach((column) => {
+            if (!firstPivotColumnByMetricFieldId.has(column.referenceField)) {
+                firstPivotColumnByMetricFieldId.set(
+                    column.referenceField,
+                    column,
+                );
+            }
+        });
+    const filteredValuesColumns = visibleValuesColumns.filter(
+        ({ referenceField }) => !rowValueFieldIdSet.has(referenceField),
+    );
+
     // Get unique base metrics from valuesColumns, preserving order
     const baseMetricsArray = filteredValuesColumns
         .map((col) => col.referenceField)
         .filter((field, index, self) => self.indexOf(field) === index)
         .sort((a, b) => columnOrder.indexOf(a) - columnOrder.indexOf(b));
+    const effectiveMetricsAsRows =
+        pivotConfig.metricsAsRows && baseMetricsArray.length > 0;
+
+    const configuredRowFieldIds = pivotConfig.rowFieldIds;
+    const rowFieldIds = configuredRowFieldIds
+        ? [
+              ...configuredRowFieldIds.filter(
+                  (fieldId) =>
+                      indexColumns.includes(fieldId) ||
+                      rowValueFieldIdSet.has(fieldId),
+              ),
+              ...indexColumns.filter(
+                  (fieldId) => !configuredRowFieldIds.includes(fieldId),
+              ),
+          ]
+        : indexColumns;
 
     // pivotDetails.groupByColumns comes from PivotConfiguration.groupByColumns,
     // which only contains VISIBLE pivot-column dims. Hidden pivot-column dims
     // that drive sort order (sortOnlyDimensions in PivotConfiguration) are
     // deliberately excluded from groupByColumns before this point, so they
     // never appear as column header rows here. No extra filtering needed.
-    const headerValueTypes = getHeaderValueTypes({
-        metricsAsRows: pivotConfig.metricsAsRows,
-        pivotDimensionNames: (pivotDetails.groupByColumns ?? []).map(
-            ({ reference }) => reference,
-        ),
-    });
+    const headerValueTypes =
+        filteredValuesColumns.length > 0
+            ? getHeaderValueTypes({
+                  metricsAsRows: effectiveMetricsAsRows,
+                  pivotDimensionNames: (pivotDetails.groupByColumns ?? []).map(
+                      ({ reference }) => reference,
+                  ),
+              })
+            : [];
 
-    const indexValueTypes: PivotData['indexValueTypes'] =
-        pivotConfig.metricsAsRows
-            ? [
-                  ...indexColumns.map((col) => ({
-                      type: FieldType.DIMENSION as const,
-                      fieldId: col,
-                  })),
-                  { type: FieldType.METRIC as const },
-              ]
-            : indexColumns.map((col) => ({
-                  type: FieldType.DIMENSION as const,
-                  fieldId: col,
-              }));
+    const rowFieldValueTypes: PivotData['indexValueTypes'] = rowFieldIds.map(
+        (fieldId) =>
+            rowValueFieldIdSet.has(fieldId)
+                ? { type: FieldType.METRIC as const, fieldId }
+                : { type: FieldType.DIMENSION as const, fieldId },
+    );
+    const indexValueTypes: PivotData['indexValueTypes'] = effectiveMetricsAsRows
+        ? [...rowFieldValueTypes, { type: FieldType.METRIC as const }]
+        : rowFieldValueTypes;
 
     // Build header values (pivot dimension values)
     const headerValues: PivotData['headerValues'] = [];
     pivotDetails.groupByColumns?.forEach(({ reference }, index) => {
         headerValues.push([]);
         let columns = filteredValuesColumns;
-        if (pivotConfig.metricsAsRows) {
+        if (effectiveMetricsAsRows) {
             // For metrics as rows, we only need unique combinations of pivot values, excluding per metric duplicates
             columns = Array.from(
                 new Map(
@@ -732,7 +781,7 @@ export const convertSqlPivotedRowsToPivotData = ({
     });
 
     // Add metric labels for columns if not metrics as rows
-    if (!pivotConfig.metricsAsRows && baseMetricsArray.length > 0) {
+    if (!effectiveMetricsAsRows && baseMetricsArray.length > 0) {
         headerValues.push(
             filteredValuesColumns
                 .sort((a, b) => {
@@ -752,21 +801,52 @@ export const convertSqlPivotedRowsToPivotData = ({
     }
 
     const filteredHeaderValues = headerValues.filter((row) => row.length > 0);
+    const renderedHeaderValues =
+        filteredHeaderValues.length > 0 ? filteredHeaderValues : [[]];
 
     // Build index values (row identifiers)
     let indexValues: PivotData['indexValues'];
 
-    if (pivotConfig.metricsAsRows) {
+    const getRowFieldValue = (row: ResultRow, fieldId: string): ResultValue => {
+        if (!rowValueFieldIdSet.has(fieldId)) {
+            return row[fieldId].value;
+        }
+
+        const firstPivotColumn = firstPivotColumnByMetricFieldId.get(fieldId);
+        const value = firstPivotColumn
+            ? row[firstPivotColumn.pivotColumnName]?.value
+            : undefined;
+        const reformatted = reformatCellWithParameters(
+            value,
+            getField(fieldId),
+            parameters,
+        );
+        return (
+            reformatted ?? {
+                raw: null,
+                formatted: formatItemValue(
+                    getField(fieldId),
+                    null,
+                    false,
+                    parameters,
+                ),
+            }
+        );
+    };
+    const getRowFieldValues = (row: ResultRow) =>
+        rowFieldIds.map((fieldId) => ({
+            type: 'value' as const,
+            fieldId,
+            value: getRowFieldValue(row, fieldId),
+            colSpan: 1,
+        }));
+
+    if (effectiveMetricsAsRows) {
         indexValues = rows.reduce<PivotData['indexValues']>((acc, row) => {
             // multiply rows per metric
             baseMetricsArray.forEach((metric) => {
                 acc.push([
-                    ...indexColumns.map((col) => ({
-                        type: 'value' as const,
-                        fieldId: col,
-                        value: row[col].value,
-                        colSpan: 1,
-                    })),
+                    ...getRowFieldValues(row),
                     {
                         type: 'label' as const,
                         fieldId: metric,
@@ -776,21 +856,14 @@ export const convertSqlPivotedRowsToPivotData = ({
             return acc;
         }, []);
     } else {
-        indexValues = rows.map((row) =>
-            indexColumns.map((col) => ({
-                type: 'value' as const,
-                fieldId: col,
-                value: row[col].value,
-                colSpan: 1,
-            })),
-        );
+        indexValues = rows.map(getRowFieldValues);
     }
 
     // Build data values (the actual pivot data)
     let dataValues: PivotData['dataValues'];
 
     // Get unique columns
-    const uniqueColumns = pivotConfig.metricsAsRows
+    const uniqueColumns = effectiveMetricsAsRows
         ? Array.from(
               new Map(
                   filteredValuesColumns.map((col) => [
@@ -806,7 +879,7 @@ export const convertSqlPivotedRowsToPivotData = ({
           )
         : filteredValuesColumns;
 
-    if (pivotConfig.metricsAsRows) {
+    if (effectiveMetricsAsRows) {
         // multiply rows per metric
         dataValues = rows.reduce<PivotData['dataValues']>((acc, row) => {
             baseMetricsArray.forEach((metric) => {
@@ -857,7 +930,10 @@ export const convertSqlPivotedRowsToPivotData = ({
     const fullPivotConfig: PivotConfig = {
         pivotDimensions:
             pivotDetails.groupByColumns?.map((col) => col.reference) || [],
-        metricsAsRows: pivotConfig.metricsAsRows || false,
+        metricsAsRows: effectiveMetricsAsRows,
+        ...(pivotConfig.rowFieldIds && {
+            rowFieldIds: pivotConfig.rowFieldIds,
+        }),
         columnOrder: pivotConfig.columnOrder,
         hiddenMetricFieldIds: pivotConfig.hiddenMetricFieldIds || [],
         ...(pivotConfig.visibleMetricFieldIds && {
@@ -873,7 +949,7 @@ export const convertSqlPivotedRowsToPivotData = ({
     const hasHeader = headerValueTypes.length > 0;
     const hasIndex = indexValueTypes.length > 0;
     const N_DATA_ROWS = hasIndex ? dataValues.length : 1;
-    const N_DATA_COLUMNS = hasHeader ? uniqueColumns.length : 1;
+    const N_DATA_COLUMNS = uniqueColumns.length;
 
     if (fullPivotConfig.rowTotals && hasHeader) {
         // Row totals are exclusively warehouse-computed: look up the value for a
@@ -964,7 +1040,7 @@ export const convertSqlPivotedRowsToPivotData = ({
         filteredValuesColumns,
         totalColumns: indexValueTypes.length,
         dataColumns: N_DATA_COLUMNS,
-        pivotConfig,
+        pivotConfig: fullPivotConfig,
         indexValues,
         hasIndex,
         warehouseColumnTotals,
@@ -1046,13 +1122,15 @@ export const convertSqlPivotedRowsToPivotData = ({
             const combinedRow: ResultRow = {};
 
             // Add index columns
-            indexColumns.forEach((col) => {
-                combinedRow[col] = row[col];
+            rowFieldIds.forEach((fieldId) => {
+                combinedRow[fieldId] = {
+                    value: getRowFieldValue(row, fieldId),
+                };
             });
 
-            if (pivotConfig.metricsAsRows) {
-                // Add metric label with correct index (after all index columns)
-                const labelIndex = indexColumns.length;
+            if (effectiveMetricsAsRows) {
+                // Add metric label with correct index (after all row fields)
+                const labelIndex = rowFieldIds.length;
                 const metricLabel =
                     getFieldLabel(baseMetricsArray[0]) || baseMetricsArray[0];
                 combinedRow[`label-${labelIndex}`] = {
@@ -1068,7 +1146,7 @@ export const convertSqlPivotedRowsToPivotData = ({
                 const pivotDimensions = (pivotDetails.groupByColumns || []).map(
                     (col) => col.reference,
                 );
-                const fieldId = pivotConfig.metricsAsRows
+                const fieldId = effectiveMetricsAsRows
                     ? `${pivotDimensions.join('__')}__${colIndex}`
                     : `${pivotDimensions.join('__')}__${
                           valueCol.referenceField
@@ -1124,16 +1202,16 @@ export const convertSqlPivotedRowsToPivotData = ({
         });
 
     const pivotColumnInfo: PivotColumn[] = [
-        ...indexColumns.map((col) => ({
-            fieldId: col,
+        ...rowFieldIds.map((fieldId) => ({
+            fieldId,
             baseId: undefined,
             underlyingId: undefined,
             columnType: 'indexValue' as const,
         })),
-        ...(pivotConfig.metricsAsRows
+        ...(effectiveMetricsAsRows
             ? [
                   {
-                      fieldId: `label-${indexColumns.length}`,
+                      fieldId: `label-${rowFieldIds.length}`,
                       baseId: undefined,
                       underlyingId: undefined,
                       columnType: 'label' as const,
@@ -1144,7 +1222,7 @@ export const convertSqlPivotedRowsToPivotData = ({
             const pivotDimensions = (pivotDetails.groupByColumns || []).map(
                 (col) => col.reference,
             );
-            const fieldId = pivotConfig.metricsAsRows
+            const fieldId = effectiveMetricsAsRows
                 ? `${pivotDimensions.join('__')}__${colIndex}`
                 : `${pivotDimensions.join('__')}__${
                       valueCol.referenceField
@@ -1152,7 +1230,7 @@ export const convertSqlPivotedRowsToPivotData = ({
 
             return {
                 fieldId,
-                baseId: pivotConfig.metricsAsRows
+                baseId: effectiveMetricsAsRows
                     ? pivotDimensions[0]
                     : valueCol.referenceField,
                 underlyingId: undefined,
@@ -1181,7 +1259,7 @@ export const convertSqlPivotedRowsToPivotData = ({
     const pivotData: PivotData = {
         titleFields,
         headerValueTypes,
-        headerValues: filteredHeaderValues,
+        headerValues: renderedHeaderValues,
         indexValueTypes,
         indexValues,
         dataColumnCount: N_DATA_COLUMNS,
@@ -1191,15 +1269,15 @@ export const convertSqlPivotedRowsToPivotData = ({
         rowTotals,
         columnTotals,
         ...(grandTotals ? { grandTotals } : {}),
-        cellsCount: pivotConfig.metricsAsRows
-            ? indexColumns.length +
+        cellsCount: effectiveMetricsAsRows
+            ? rowFieldIds.length +
               1 + // label column
               uniqueColumns.length +
               (rowTotals ? rowTotals[0].length : 0)
-            : indexColumns.length +
+            : rowFieldIds.length +
               uniqueColumns.length +
               (rowTotals ? rowTotals[0].length : 0),
-        rowsCount: pivotConfig.metricsAsRows
+        rowsCount: effectiveMetricsAsRows
             ? rows.length * baseMetricsArray.length
             : rows.length,
         pivotConfig: fullPivotConfig,
@@ -1241,10 +1319,9 @@ export const convertSqlPivotedRowsToPivotData = ({
         // passthrough value from a *different* input row, surfacing as
         // mismatched images / cross-field template values for repeated row
         // dims (PROD-7873 follow-up to PR #23452).
-        const inputRowsPerOutputRow =
-            pivotConfig.metricsAsRows && baseMetricsArray.length > 0
-                ? baseMetricsArray.length
-                : 1;
+        const inputRowsPerOutputRow = effectiveMetricsAsRows
+            ? baseMetricsArray.length
+            : 1;
         const expectedOutputLength = rows.length * inputRowsPerOutputRow;
         if (
             process.env.NODE_ENV !== 'production' &&

--- a/packages/common/src/pivot/pivotResultsAsCsv.test.ts
+++ b/packages/common/src/pivot/pivotResultsAsCsv.test.ts
@@ -12,6 +12,7 @@ const buildItemsMap = (): ItemsMap => {
         'payments_payment_method',
         'orders_order_date_year',
         'payments_total_revenue',
+        'orders_total_order_amount',
     ];
     const map: ItemsMap = {};
     fieldIds.forEach((id) => {
@@ -32,6 +33,57 @@ const PIVOT_CONFIG = {
 };
 
 describe('pivotResultsAsCsv', () => {
+    it('exports a pivot row metric once in its displayed position', () => {
+        const rowMetricId = 'orders_total_order_amount';
+        const pivotDetails = {
+            ...SQL_PIVOT_DETAILS,
+            valuesColumns: SQL_PIVOT_DETAILS.valuesColumns.flatMap(
+                (column, columnIndex) => [
+                    column,
+                    {
+                        ...column,
+                        referenceField: rowMetricId,
+                        pivotColumnName: `${rowMetricId}_${columnIndex}`,
+                    },
+                ],
+            ),
+        };
+        const rows = SQL_PIVOTED_ROWS.map((row) => ({
+            ...row,
+            ...Object.fromEntries(
+                SQL_PIVOT_DETAILS.valuesColumns.map((_, columnIndex) => [
+                    `${rowMetricId}_${columnIndex}`,
+                    {
+                        value: {
+                            raw: 1000 + columnIndex,
+                            formatted: String(1000 + columnIndex),
+                        },
+                    },
+                ]),
+            ),
+        }));
+
+        const result = pivotResultsAsCsv({
+            pivotConfig: {
+                ...PIVOT_CONFIG,
+                rowFieldIds: ['orders_order_date_year', rowMetricId],
+            },
+            rows,
+            itemMap: buildItemsMap(),
+            customLabels: undefined,
+            onlyRaw: false,
+            pivotDetails,
+        });
+
+        expect(
+            result.flat().filter((value) => value === 'Order Amount'),
+        ).toHaveLength(1);
+        expect(result[2].filter((value) => value === '1000')).toHaveLength(1);
+        expect(result[2]).not.toContain('1001');
+        expect(result[2]).not.toContain('1002');
+        expect(result[2]).not.toContain('1003');
+    });
+
     it('returns string[][] with headers and formatted data rows', () => {
         const result = pivotResultsAsCsv({
             pivotConfig: PIVOT_CONFIG,

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -3588,6 +3588,13 @@
                         "type": "string"
                     },
                     "type": "array"
+                },
+                "rows": {
+                    "description": "Ordered fields to render on the pivot row axis",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
                 }
             },
             "required": ["columns"],

--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -6,6 +6,8 @@ import type { GroupByColumn, SortBy, ValuesColumn } from './sqlRunner';
 export type PivotConfig = {
     pivotDimensions: string[];
     metricsAsRows: boolean;
+    /** Ordered dimension and value field IDs rendered once on the row axis. */
+    rowFieldIds?: string[];
     columnOrder?: string[];
     hiddenMetricFieldIds?: string[];
     visibleMetricFieldIds?: string[];
@@ -73,7 +75,7 @@ export type PivotConfiguration = {
 };
 
 type Field =
-    | { type: FieldType.METRIC; fieldId?: undefined }
+    | { type: FieldType.METRIC; fieldId?: string }
     | { type: FieldType.DIMENSION; fieldId: string };
 
 type FieldValue =

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -916,6 +916,8 @@ export type SavedChart = {
     pivotConfig?: {
         /** Fields to use as pivot columns */
         columns: string[];
+        /** Ordered fields to render on the pivot row axis */
+        rows?: string[];
     };
     /** Visualization configuration for the chart */
     chartConfig: ChartConfig;


### PR DESCRIPTION
Linear: https://linear.app/lightdash/issue/PROD-9188/allow-metrics-in-pivot-table-rows

### Description

Part 1 of 4.

- add optional persisted `pivotConfig.rows` and runtime `rowFieldIds` contracts
- reshape configured metrics and table calculations into ordered pivot row values
- preserve the exact value from the first rendered pivot group, including null
- normalize the legacy metrics-as-rows mode off when every visible value already renders in Rows
- keep `indexColumn`, query grouping, mixed metrics-as-rows layouts, and charts without configured rows unchanged
- cover CSV-compatible flattened pivot output

This branch has no frontend activation, so it is additive until the later UI PR.

### Stack

1. This PR: shared pivot support
2. #26058: backend export and rename integration
3. #26059: frontend activation
4. #26060: cohort demo and documentation

### Validation

- 85 focused common pivot tests
- common fast typecheck
- common lint
- chart-as-code schema validation after API generation
- regression reproduces and fixes the all-values-in-Rows `UnexpectedIndexError`