### PR TITLE
fix: review judge grammar-too-large — split project context entry emission into a second call

### DIFF
--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import {
-    aiAgentReviewClassifierJudgeOutputSchema,
+    aiAgentReviewClassifierJudgeCallOutputSchema,
+    aiAgentReviewClassifierJudgeProjectContextCallSchema,
     assertUnreachable,
     CatalogType,
     filterExploreByTags,
@@ -13,6 +14,7 @@ import {
     type AiAgentConfigSnapshot,
     type AiAgentConfigurationSetting,
     type AiAgentEvidenceExcerpt,
+    type AiAgentJudgeProjectContextEntry,
     type AiAgentKnowledgeDocumentSnapshot,
     type AiAgentMcpServerSnapshot,
     type AiAgentReviewClassifierEventType,
@@ -1571,7 +1573,10 @@ export class AiAgentReviewClassifierService extends BaseService {
             ...model.callOptions,
             providerOptions: model.providerOptions,
             experimental_telemetry: telemetry,
-            schema: aiAgentReviewClassifierJudgeOutputSchema,
+            // This schema is near the provider's strict-output grammar-size limit;
+            // growing it breaks EVERY judge call silently ("compiled grammar is too
+            // large"). Put new fields in a follow-up call like emitProjectContextEntry.
+            schema: aiAgentReviewClassifierJudgeCallOutputSchema,
             messages: [
                 {
                     role: 'system',
@@ -1663,14 +1668,6 @@ reviewItem.description should summarize why this grouping exists.
 
 Always populate targetRefs with every object the fix would touch (model, dimension, metric, join, explore). For semantic_layer and project_context findings these drive how findings collapse into one review item, so name the same object consistently across turns rather than varying the wording.
 
-Set projectContextEntry ONLY when primaryRootCause=project_context and a single durable, project-specific fact (a business definition or acronym, routing/join guidance, or object-scoped context) would prevent this class of failure in future turns. Otherwise set it to null.
-- op: "update" if one of the project context entries already injected into the reviewed turn was present but insufficient (reference its id); otherwise "create".
-- id: the existing entry id when op="update", otherwise null.
-- kind: definition | context. Use "definition" for acronyms and business vocabulary ("X means Y"); use "context" for everything else (routing/join rules, guidance, durable object-scoped facts).
-- content: a single self-contained sentence stating the fact (e.g. '"HR" = the high-risk diabetes cohort, not human resources.').
-- terms: the prompt-facing trigger words/phrases that should surface this entry (e.g. ["HR","high risk"]). Required for definitions.
-- objects: typed semantic object refs derived from targetRefs. For an explore use {"type":"explore","name":"payments"}. For a field use {"type":"field","explore":"payments","fieldId":"payments_total_amount"}; the owning explore is required and must be one where that field exists. Use [] when purely prompt-driven.
-
 Existing review items — dedup rules. The evidence packet field existingReviewItems lists this project's existing review items (key, title, status, dismissedReason, primaryRootCause, objectSummary). Apply these rules when promoting:
 - If the finding's underlying user need matches an existing item — even when you would assign a DIFFERENT root cause or blame a DIFFERENT object — set matchedExistingItemKey to that item's key. The test is "would a human say this is the same problem?", not "same technical label". A timeout, a missing field, and a routing gap that all block the same user question are ONE problem.
 - Items with dismissedReason=expected_behavior are known non-issues already reviewed by a human. If the turn's failure is that same behavior, set promotedToFinding=false and matchedExistingItemKey=null — do not re-file it.
@@ -1684,7 +1681,114 @@ Existing review items — dedup rules. The evidence packet field existingReviewI
         });
         emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
 
-        return result.object as AiAgentReviewClassifierJudgeOutput;
+        const projectContextEntry =
+            result.object.promotedToFinding &&
+            result.object.primaryRootCause === 'project_context'
+                ? await this.emitProjectContextEntry({
+                      candidate,
+                      evidencePacket,
+                      model,
+                      judgeOutput: result.object,
+                  })
+                : null;
+
+        return {
+            ...result.object,
+            projectContextEntry,
+        } as AiAgentReviewClassifierJudgeOutput;
+    }
+
+    /**
+     * Second, smaller LLM call that emits the structured project_context entry
+     * for a promoted project_context finding. Split from the main judge call
+     * because the combined schema exceeds the provider's strict-structured-
+     * output grammar size limit ("the compiled grammar is too large") and every
+     * judge call then fails. Failure here degrades to a finding without an
+     * entry (writeback preview reports unavailable) instead of losing the
+     * whole judgment.
+     */
+    private async emitProjectContextEntry(input: {
+        candidate: AiAgentReviewClassifierTurnCandidate;
+        evidencePacket: AiAgentReviewJudgeEvidencePacket;
+        model: ReturnType<typeof getModel>;
+        judgeOutput: Omit<
+            AiAgentReviewClassifierJudgeOutput,
+            'projectContextEntry'
+        >;
+    }): Promise<AiAgentJudgeProjectContextEntry | null> {
+        const { candidate, evidencePacket, model, judgeOutput } = input;
+        this.debugLog('ProjectContextEntryRequest', {
+            promptUuid: candidate.subject.assistantPromptUuid,
+            threadUuid: candidate.subject.threadUuid,
+            judgeModelId: model.model.modelId,
+        });
+        const telemetry = getAiCallTelemetry({
+            functionId: 'aiAgentReviewClassifierJudgeProjectContextEntry',
+            feature: 'review-classifier',
+            organizationUuid: candidate.subject.organizationUuid,
+            projectUuid: candidate.subject.projectUuid,
+            agentUuid: candidate.subject.agentUuid,
+            threadUuid: candidate.subject.threadUuid,
+            promptUuid: candidate.subject.assistantPromptUuid,
+            ...getLanguageModelAttribution(model.model),
+        });
+        try {
+            const result = await generateObject({
+                model: model.model,
+                ...defaultAgentOptions,
+                ...model.callOptions,
+                providerOptions: model.providerOptions,
+                experimental_telemetry: telemetry,
+                schema: aiAgentReviewClassifierJudgeProjectContextCallSchema,
+                messages: [
+                    {
+                        role: 'system',
+                        content: `You emit the structured living-document entry for a Lightdash AI review finding whose root cause is project_context.
+
+Set projectContextEntry ONLY when a single durable, project-specific fact (a business definition or acronym, routing/join guidance, or object-scoped context) would prevent this class of failure in future turns. Otherwise set it to null.
+- op: "update" if one of the project context entries already injected into the reviewed turn was present but insufficient (reference its id); otherwise "create".
+- id: the existing entry id when op="update", otherwise null.
+- kind: definition | context. Use "definition" for acronyms and business vocabulary ("X means Y"); use "context" for everything else (routing/join rules, guidance, durable object-scoped facts).
+- content: a single self-contained sentence stating the fact (e.g. '"HR" = the high-risk diabetes cohort, not human resources.').
+- terms: the prompt-facing trigger words/phrases that should surface this entry (e.g. ["HR","high risk"]). Required for definitions.
+- objects: typed semantic object refs derived from the finding's targetRefs. For an explore use {"type":"explore","name":"payments"}. For a field use {"type":"field","explore":"payments","fieldId":"payments_total_amount"}; the owning explore is required and must be one where that field exists. Use [] when purely prompt-driven.
+
+Use only the supplied evidence packet and finding. Do not invent project fields or facts.`,
+                    },
+                    {
+                        role: 'user',
+                        content: JSON.stringify(
+                            {
+                                evidencePacket,
+                                finding: {
+                                    reviewItem: judgeOutput.reviewItem,
+                                    promotionReason:
+                                        judgeOutput.promotionReason,
+                                    targetRefs: judgeOutput.targetRefs,
+                                    subcategories: judgeOutput.subcategories,
+                                    recommendation: judgeOutput.recommendation,
+                                },
+                            },
+                            null,
+                            2,
+                        ),
+                    },
+                ],
+            });
+            emitAiUsage(telemetry, languageModelUsageToTokens(result.usage));
+            return result.object.projectContextEntry;
+        } catch (error) {
+            Logger.error(
+                'AI review project context entry emission failed; keeping finding without an entry',
+                {
+                    promptUuid: candidate.subject.assistantPromptUuid,
+                    threadUuid: candidate.subject.threadUuid,
+                    errorMessage:
+                        error instanceof Error ? error.message : String(error),
+                },
+            );
+            return null;
+        }
     }
 
     private async isEnabled(args: {

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
@@ -1,6 +1,8 @@
 import {
     aiAgentJudgeProjectContextEntrySchema,
+    aiAgentReviewClassifierJudgeCallOutputSchema,
     aiAgentReviewClassifierJudgeOutputSchema,
+    aiAgentReviewClassifierJudgeProjectContextCallSchema,
     getAiAgentConfigSnapshotHash,
     getAiAgentReviewItemFingerprint,
     getAiAgentReviewItemFingerprintScope,
@@ -368,6 +370,61 @@ describe('aiAgentJudgeProjectContextEntrySchema', () => {
             objects: [],
         });
         expect(result.success).toBe(false);
+    });
+});
+
+describe('aiAgentReviewClassifierJudgeCallOutputSchema', () => {
+    test('strips projectContextEntry — it is emitted via a separate call', () => {
+        const { projectContextEntry, ...callOutput } = baseJudgeOutput;
+        const result = aiAgentReviewClassifierJudgeCallOutputSchema.safeParse({
+            ...callOutput,
+            projectContextEntry: { anything: true },
+        });
+        expect(result.success).toBe(true);
+        expect(result.success && 'projectContextEntry' in result.data).toBe(
+            false,
+        );
+    });
+
+    test('accepts a judge output without projectContextEntry', () => {
+        const { projectContextEntry, ...callOutput } = baseJudgeOutput;
+        expect(
+            aiAgentReviewClassifierJudgeCallOutputSchema.safeParse(callOutput)
+                .success,
+        ).toBe(true);
+    });
+
+    test('applies the promotion refinement', () => {
+        const { projectContextEntry, ...callOutput } = baseJudgeOutput;
+        expect(
+            aiAgentReviewClassifierJudgeCallOutputSchema.safeParse({
+                ...callOutput,
+                promotedToFinding: true,
+                primaryRootCause: 'not_a_failure',
+            }).success,
+        ).toBe(false);
+    });
+});
+
+describe('aiAgentReviewClassifierJudgeProjectContextCallSchema', () => {
+    test('accepts a typed entry and null', () => {
+        expect(
+            aiAgentReviewClassifierJudgeProjectContextCallSchema.safeParse({
+                projectContextEntry: {
+                    op: 'create',
+                    id: null,
+                    kind: 'definition',
+                    content: '"FC" = fulfillment center.',
+                    terms: ['FC'],
+                    objects: [{ type: 'explore', name: 'orders' }],
+                },
+            }).success,
+        ).toBe(true);
+        expect(
+            aiAgentReviewClassifierJudgeProjectContextCallSchema.safeParse({
+                projectContextEntry: null,
+            }).success,
+        ).toBe(true);
     });
 });
 

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -532,37 +532,47 @@ const NOT_A_FAILURE_SIGNALS: ReadonlySet<string> = new Set([
     'acceptance_or_continuation',
 ]);
 
-export const aiAgentReviewClassifierJudgeOutputSchema = z
-    .object({
-        signal: z.enum([
-            'normal_refinement',
-            'implicit_correction',
-            'explicit_dispute',
-            'retry_after_failure',
+const aiAgentReviewClassifierJudgeOutputBaseSchema = z.object({
+    signal: z.enum([
+        'normal_refinement',
+        'implicit_correction',
+        'explicit_dispute',
+        'retry_after_failure',
+        'output_shape_correction',
+        'new_question',
+        'acceptance_or_continuation',
+        'product_capability_request',
+        'human_intervention',
+        'ambiguous',
+    ]),
+    implicitSignalSources: z.array(
+        z.enum([
+            'next_user_correction',
+            'next_user_dispute',
+            'next_user_retry',
             'output_shape_correction',
-            'new_question',
-            'acceptance_or_continuation',
+            'tool_error',
+            'assistant_no_answer',
             'product_capability_request',
             'human_intervention',
-            'ambiguous',
         ]),
-        implicitSignalSources: z.array(
-            z.enum([
-                'next_user_correction',
-                'next_user_dispute',
-                'next_user_retry',
-                'output_shape_correction',
-                'tool_error',
-                'assistant_no_answer',
-                'product_capability_request',
-                'human_intervention',
-            ]),
-        ),
-        confidence: z.enum(['low', 'medium', 'high']),
-        promotedToFinding: z.boolean(),
-        promotionReason: z.string().nullable(),
-        matchedExistingItemKey: z.string().nullable(),
-        primaryRootCause: z.enum([
+    ),
+    confidence: z.enum(['low', 'medium', 'high']),
+    promotedToFinding: z.boolean(),
+    promotionReason: z.string().nullable(),
+    matchedExistingItemKey: z.string().nullable(),
+    primaryRootCause: z.enum([
+        'semantic_layer',
+        'project_context',
+        'agent_configuration',
+        'product_capability',
+        'runtime_reliability',
+        'feedback_quality',
+        'not_a_failure',
+        'ambiguous',
+    ]),
+    secondaryRootCauses: z.array(
+        z.enum([
             'semantic_layer',
             'project_context',
             'agent_configuration',
@@ -572,117 +582,135 @@ export const aiAgentReviewClassifierJudgeOutputSchema = z
             'not_a_failure',
             'ambiguous',
         ]),
-        secondaryRootCauses: z.array(
-            z.enum([
-                'semantic_layer',
-                'project_context',
-                'agent_configuration',
-                'product_capability',
-                'runtime_reliability',
-                'feedback_quality',
-                'not_a_failure',
-                'ambiguous',
+    ),
+    subcategories: z.array(z.string()),
+    fixTargets: z.array(
+        z.enum([
+            'semantic_yaml_patch',
+            'project_context_rule',
+            'agent_configuration_change',
+            'dbt_modeling_ticket',
+            'semantic_layer_ticket',
+            'product_capability_ticket',
+            'runtime_reliability_ticket',
+            'feedback_needed',
+            'no_action',
+        ]),
+    ),
+    targetRefs: z.array(aiAgentJudgeTargetRefSchema),
+    agentConfigurationSettings: z.array(aiAgentConfigurationSettingSchema),
+    ownerType: z.enum([
+        'semantic_layer_owner',
+        'agent_admin',
+        'product',
+        'support',
+        'unknown',
+    ]),
+    evidenceExcerpts: z.array(
+        z.object({
+            source: z.enum([
+                'user_prompt',
+                'assistant_answer',
+                'next_user_prompt',
+                'conversation_context',
+                'tool_call',
+                'tool_result',
+                'agent_config',
             ]),
-        ),
-        subcategories: z.array(z.string()),
-        fixTargets: z.array(
-            z.enum([
-                'semantic_yaml_patch',
-                'project_context_rule',
-                'agent_configuration_change',
-                'dbt_modeling_ticket',
-                'semantic_layer_ticket',
-                'product_capability_ticket',
-                'runtime_reliability_ticket',
-                'feedback_needed',
+            text: z.string(),
+            redacted: z.boolean(),
+        }),
+    ),
+    recommendation: z
+        .object({
+            actionType: z.enum([
+                'update_semantic_yaml',
+                'update_agent_instructions',
+                'add_knowledge_document',
+                'enable_data_access',
+                'enable_sql_mode',
+                'enable_self_improvement',
+                'configure_mcp_server',
+                'adjust_explore_tags',
+                'update_access',
+                'route_to_product_work',
+                'request_more_evidence',
                 'no_action',
             ]),
-        ),
-        targetRefs: z.array(aiAgentJudgeTargetRefSchema),
-        agentConfigurationSettings: z.array(aiAgentConfigurationSettingSchema),
-        ownerType: z.enum([
-            'semantic_layer_owner',
-            'agent_admin',
-            'product',
-            'support',
-            'unknown',
-        ]),
-        evidenceExcerpts: z.array(
-            z.object({
-                source: z.enum([
-                    'user_prompt',
-                    'assistant_answer',
-                    'next_user_prompt',
-                    'conversation_context',
-                    'tool_call',
-                    'tool_result',
-                    'agent_config',
-                ]),
-                text: z.string(),
-                redacted: z.boolean(),
-            }),
-        ),
-        recommendation: z
-            .object({
-                actionType: z.enum([
-                    'update_semantic_yaml',
-                    'update_agent_instructions',
-                    'add_knowledge_document',
-                    'enable_data_access',
-                    'enable_sql_mode',
-                    'enable_self_improvement',
-                    'configure_mcp_server',
-                    'adjust_explore_tags',
-                    'update_access',
-                    'route_to_product_work',
-                    'request_more_evidence',
-                    'no_action',
-                ]),
-                title: z.string(),
-                rationale: z.string(),
-                targetRefs: z.array(aiAgentJudgeTargetRefSchema),
-            })
-            .nullable(),
-        reviewItem: z.object({
             title: z.string(),
-            description: z.string(),
-        }),
-        projectContextEntry: aiAgentJudgeProjectContextEntrySchema.nullable(),
-    })
-    .superRefine((output, ctx) => {
-        if (
-            output.promotedToFinding &&
-            output.primaryRootCause === 'not_a_failure'
-        ) {
-            ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                message:
-                    'promotedToFinding must be false when primaryRootCause is not_a_failure',
-                path: ['promotedToFinding'],
-            });
-        }
-        if (
-            output.promotedToFinding &&
-            NOT_A_FAILURE_SIGNALS.has(output.signal)
-        ) {
-            ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: `promotedToFinding must be false when signal is ${output.signal}; promoted findings need a failure signal`,
-                path: ['signal'],
-            });
-        }
-        if (
-            output.promotedToFinding &&
-            output.recommendation?.actionType === 'no_action'
-        ) {
-            ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                message:
-                    'promoted findings must carry an actionable recommendation, not no_action',
-                path: ['recommendation', 'actionType'],
-            });
-        }
-    });
+            rationale: z.string(),
+            targetRefs: z.array(aiAgentJudgeTargetRefSchema),
+        })
+        .nullable(),
+    reviewItem: z.object({
+        title: z.string(),
+        description: z.string(),
+    }),
+});
+
+const judgeOutputRefinement = (
+    output: {
+        promotedToFinding: boolean;
+        primaryRootCause: string;
+        signal: string;
+        recommendation: { actionType: string } | null;
+    },
+    ctx: z.RefinementCtx,
+): void => {
+    if (
+        output.promotedToFinding &&
+        output.primaryRootCause === 'not_a_failure'
+    ) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message:
+                'promotedToFinding must be false when primaryRootCause is not_a_failure',
+            path: ['promotedToFinding'],
+        });
+    }
+    if (output.promotedToFinding && NOT_A_FAILURE_SIGNALS.has(output.signal)) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `promotedToFinding must be false when signal is ${output.signal}; promoted findings need a failure signal`,
+            path: ['signal'],
+        });
+    }
+    if (
+        output.promotedToFinding &&
+        output.recommendation?.actionType === 'no_action'
+    ) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message:
+                'promoted findings must carry an actionable recommendation, not no_action',
+            path: ['recommendation', 'actionType'],
+        });
+    }
+};
+
+// LLM-call schema: projectContextEntry is deliberately EXCLUDED. The full
+// schema compiles over the provider's strict-output grammar size limit (the
+// call then fails with "the compiled grammar is too large"), so the entry is
+// emitted via a second small call on the project_context path instead.
+export const aiAgentReviewClassifierJudgeCallOutputSchema =
+    aiAgentReviewClassifierJudgeOutputBaseSchema.superRefine(
+        judgeOutputRefinement,
+    );
+
+// Second-call schema for the project_context path: just the entry.
+export const aiAgentReviewClassifierJudgeProjectContextCallSchema = z.object({
+    projectContextEntry: aiAgentJudgeProjectContextEntrySchema.nullable(),
+});
+
+// Full judge output as persisted/replayed — the merge of both calls. Never
+// pass this to a strict-structured-output LLM call (see grammar note above).
+export const aiAgentReviewClassifierJudgeOutputSchema =
+    aiAgentReviewClassifierJudgeOutputBaseSchema
+        .extend({
+            projectContextEntry:
+                aiAgentJudgeProjectContextEntrySchema.nullable(),
+        })
+        .superRefine(judgeOutputRefinement);
 
 export type AiAgentReviewClassifierJudgeOutput = z.infer<
     typeof aiAgentReviewClassifierJudgeOutputSchema


### PR DESCRIPTION
## Summary

Fixes the AI review judge failing on **every** turn with the provider error *"The compiled grammar is too large, which would cause performance issues"* — silently: per-turn errors are swallowed, so runs complete with `processed_turns: 0` and no new review items are generated org-wide.

- split `projectContextEntry` out of the judge's LLM call schema (`aiAgentReviewClassifierJudgeCallOutputSchema`)
- when a finding is promoted with `primaryRootCause=project_context`, a second small `generateObject` call (`aiAgentReviewClassifierJudgeProjectContextCallSchema`) emits the structured entry, prompted with the evidence packet + the first-pass finding
- second-call failure degrades to a finding without an entry (writeback preview reports unavailable) instead of losing the whole judgment
- full `aiAgentReviewClassifierJudgeOutputSchema` (persisted/replayed shape) is unchanged and still exported; `AiAgentReviewClassifierJudgeOutput` type unchanged

## Regression analysis

The judge output schema was already at ~99% of Anthropic's strict-structured-output grammar size limit. #25908 (typed project-context object refs) tipped it over — but empirically ANY similarly-sized addition does: replacing the union with a flat object still fails, and keeping pre-#25908 string refs while adding a 4-string-field dummy object also fails. Only removing `projectContextEntry` from the call schema (or a tiny base schema) compiles. Hence the split rather than shrinking the union.

Bisect matrix (live calls against the judge fast model):
- current schema (typed-ref union): FAIL
- pre-#25908 (string objects): OK
- no projectContextEntry: OK
- union without .strict(): FAIL
- flat object instead of union: FAIL
- string objects + similar-size dummy object: FAIL
- typed-ref union on tiny base: OK

## Validation

- live end-to-end on dev: review run on a real correction thread now completes (`processed_turns: 2, findings: 2, review item: 1`) and the second call emitted a valid typed-ref `projectContextEntry`
- backend: `vitest run src/ee/services/AiAgentReviewClassifierService` — 30 passed
- common: `vitest run src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts` — 41 passed (3 new tests for the call schemas)
- typecheck + lint + oxfmt on both packages

Note: turns judged while broken were never persisted as signals, so re-running reviews (or the backfill path) can recover the missed window.

Relates: ZAP-671

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012H8F8ZGituVWUNp8LJiajf