### PR TITLE
feat: persist pivot rows in backend flows

### DIFF
--- a/packages/api-tests/tests/savedChart.test.ts
+++ b/packages/api-tests/tests/savedChart.test.ts
@@ -129,6 +129,36 @@ describe('Saved chart space selection', () => {
         expect(spaceUuids).toContain(fetchedChart.spaceUuid);
     });
 
+    it('Should persist ordered pivot rows when the chart is reloaded', async () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+        const body: CreateChartInSpace = {
+            ...chartMock,
+            name: uniqueName('Chart with ordered pivot rows'),
+            pivotConfig: {
+                columns: ['orders_status'],
+                rows: ['orders_average_order_size'],
+            },
+            spaceUuid: undefined,
+            dashboardUuid: null,
+        };
+
+        const response = await admin.post<{ results: SavedChart }>(
+            `${apiUrl}/projects/${projectUuid}/saved`,
+            body,
+        );
+        expect(response.status).toBe(200);
+        createdChartUuids.push(response.body.results.uuid);
+
+        const getResponse = await admin.get<{ results: SavedChart }>(
+            `${apiUrl}/saved/${response.body.results.uuid}`,
+        );
+        expect(getResponse.status).toBe(200);
+        expect(getResponse.body.results.pivotConfig).toEqual({
+            columns: ['orders_status'],
+            rows: ['orders_average_order_size'],
+        });
+    });
+
     it('Should create a chart belonging to a dashboard', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
 

--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -105,6 +105,7 @@ export type DbSavedChartVersion = {
     saved_query_id: number;
     chart_config: ChartConfig['config'] | null;
     pivot_dimensions: string[] | null;
+    pivot_rows: string[] | null;
     parameters: AnyType | null; // JSONB
     updated_by_user_uuid: string | null;
     timezone: TimezoneSetting;
@@ -125,6 +126,7 @@ export type CreateDbSavedChartVersion = Pick<
     | 'dimension_overrides'
     | 'chart_type'
     | 'pivot_dimensions'
+    | 'pivot_rows'
     | 'chart_config'
     | 'parameters'
     | 'updated_by_user_uuid'

--- a/packages/backend/src/database/migrations/20260723123000_add_pivot_rows_to_saved_chart_versions.ts
+++ b/packages/backend/src/database/migrations/20260723123000_add_pivot_rows_to_saved_chart_versions.ts
@@ -1,0 +1,16 @@
+import { Knex } from 'knex';
+
+const SavedChartVersionsTableName = 'saved_queries_versions';
+const PivotRowsColumnName = 'pivot_rows';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SavedChartVersionsTableName, (table) => {
+        table.specificType(PivotRowsColumnName, 'TEXT[]').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SavedChartVersionsTableName, (table) => {
+        table.dropColumn(PivotRowsColumnName);
+    });
+}

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -76,6 +76,7 @@ import {
     type MetricQuery,
     type PromoteAppAction,
     type PromoteAppDiff,
+    type SavedChart,
     type SessionUser,
     type TogglePinnedItemInfo,
 } from '@lightdash/common';
@@ -209,14 +210,11 @@ import { getTemplateInstructions } from './templates';
  * full async service.
  */
 export const buildChartReference = (
-    chart: {
-        name: string;
-        description?: string;
-        tableName: string;
-        metricQuery: MetricQuery;
-        chartConfig: ChartConfig;
-        pivotConfig?: { columns: string[] };
-    },
+    chart: Pick<
+        SavedChart,
+        'name' | 'tableName' | 'metricQuery' | 'chartConfig'
+    > &
+        Partial<Pick<SavedChart, 'description' | 'pivotConfig'>>,
     chartUuid: string,
     linked: boolean,
     sampleData: ChartSampleData | null,

--- a/packages/backend/src/ee/services/AppGenerateService/buildChartReference.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/buildChartReference.test.ts
@@ -30,4 +30,24 @@ describe('buildChartReference', () => {
         expect(ref.linked).toBe(false);
         expect(ref.sampleData).toBe(sample);
     });
+
+    it('preserves ordered pivot rows', () => {
+        const ref = buildChartReference(
+            {
+                ...chart,
+                pivotConfig: {
+                    columns: ['orders_status'],
+                    rows: ['orders_order_date', 'orders_total_revenue'],
+                },
+            },
+            'chart-3',
+            false,
+            null,
+        );
+
+        expect(ref.pivotConfig).toEqual({
+            columns: ['orders_status'],
+            rows: ['orders_order_date', 'orders_total_revenue'],
+        });
+    });
 });

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -113,6 +113,7 @@ type DbSavedChartDetails = {
     chart_type: ChartConfig['type'];
     chart_config: ChartConfig['config'] | undefined;
     pivot_dimensions: string[] | undefined;
+    pivot_rows: string[] | undefined;
     parameters: AnyType | null;
     created_at: Date;
     organization_uuid: string;
@@ -123,6 +124,18 @@ type DbSavedChartDetails = {
     dashboard_uuid: string | null;
     timezone: TimezoneSetting;
     color_palette_uuid: string | null;
+};
+
+const getSavedChartPivotConfig = (
+    pivotDimensions: string[] | null | undefined,
+    pivotRows: string[] | null | undefined,
+): CreateSavedChartVersion['pivotConfig'] => {
+    if (!pivotDimensions && !pivotRows) return undefined;
+
+    return {
+        columns: pivotDimensions ?? [],
+        ...(pivotRows && { rows: pivotRows }),
+    };
 };
 
 const createSavedChartVersionFields = async (
@@ -248,6 +261,7 @@ const createSavedChartVersion = async (
                 explore_name: tableName,
                 saved_query_id: savedChartId,
                 pivot_dimensions: pivotConfig ? pivotConfig.columns : null,
+                pivot_rows: pivotConfig?.rows ?? null,
                 chart_type: chartConfig.type,
                 chart_config: chartConfig.config,
                 parameters: parameters ? JSON.stringify(parameters) : null,
@@ -1410,6 +1424,7 @@ export class SavedChartModel {
                         'saved_queries_versions.created_at',
                         'saved_queries_versions.chart_config',
                         'saved_queries_versions.pivot_dimensions',
+                        'saved_queries_versions.pivot_rows',
                         'saved_queries_versions.timezone',
                         'saved_queries_versions.parameters',
                         `${OrganizationTableName}.organization_uuid`,
@@ -1729,13 +1744,10 @@ export class SavedChartModel {
                         columnOrder,
                     },
                     organizationUuid: savedQuery.organization_uuid,
-                    ...(savedQuery.pivot_dimensions
-                        ? {
-                              pivotConfig: {
-                                  columns: savedQuery.pivot_dimensions,
-                              },
-                          }
-                        : {}),
+                    pivotConfig: getSavedChartPivotConfig(
+                        savedQuery.pivot_dimensions,
+                        savedQuery.pivot_rows,
+                    ),
                     spaceUuid: savedQuery.space_uuid,
                     spaceName: savedQuery.spaceName,
                     pinnedListUuid: savedQuery.pinned_list_uuid,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -2142,6 +2142,7 @@ describe('AsyncQueryService', () => {
         const pivotConfig = {
             pivotDimensions: ['order_date'],
             metricsAsRows: false,
+            rowFieldIds: ['user_id', 'amount'],
         };
 
         const baseReadyQueryHistory = (
@@ -2268,6 +2269,15 @@ describe('AsyncQueryService', () => {
             ).resolves.toMatchObject({ fileUrl: 'pivot-url' });
 
             expect(pivotSpy).toHaveBeenCalledTimes(1);
+            expect(pivotSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    options: expect.objectContaining({
+                        pivotConfig: expect.objectContaining({
+                            rowFieldIds: ['user_id', 'amount'],
+                        }),
+                    }),
+                }),
+            );
             expect(flatSpy).not.toHaveBeenCalled();
         });
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1611,6 +1611,7 @@ export class AsyncQueryService extends ProjectService {
                       metricsAsRows:
                           queryHistory.pivotConfiguration?.metricsAsRows ??
                           false,
+                      rowFieldIds: pivotConfig?.rowFieldIds,
                       columnOrder: validColumnOrder,
                       hiddenMetricFieldIds: pivotConfig?.hiddenMetricFieldIds,
                       hiddenDimensionFieldIds:

--- a/packages/backend/src/services/RenameService/rename.test.ts
+++ b/packages/backend/src/services/RenameService/rename.test.ts
@@ -1224,6 +1224,7 @@ describe('renameSavedChart', () => {
             },
             pivotConfig: {
                 columns: ['payment_type'],
+                rows: ['payment_id', 'payment_amount'],
             },
         } as SavedChartDAO;
 
@@ -1260,6 +1261,10 @@ describe('renameSavedChart', () => {
             'invoice_amount',
         ]);
         expect(updatedChart.pivotConfig?.columns).toEqual(['invoice_type']);
+        expect(updatedChart.pivotConfig?.rows).toEqual([
+            'invoice_id',
+            'invoice_amount',
+        ]);
     });
 
     // Regression test for PROD-7548: model rename silently skipped charts

--- a/packages/backend/src/services/RenameService/rename.ts
+++ b/packages/backend/src/services/RenameService/rename.ts
@@ -849,6 +849,9 @@ export const renameSavedChart = ({
     if (chart.pivotConfig && containsModelName(chart.pivotConfig)) {
         updatedChart.pivotConfig = {
             columns: replaceList(updatedChart.pivotConfig?.columns || []),
+            ...(updatedChart.pivotConfig?.rows && {
+                rows: replaceList(updatedChart.pivotConfig.rows),
+            }),
         };
     }
 

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -13,7 +13,7 @@ import {
 } from '../../types/knex-paginate';
 import { type MetricQuery } from '../../types/metricQuery';
 import { type DashboardParameters } from '../../types/parameters';
-import { type ChartConfig } from '../../types/savedCharts';
+import { type ChartConfig, type SavedChart } from '../../types/savedCharts';
 
 /**
  * Ordered pipeline stages. Index position determines progression — used to
@@ -452,8 +452,8 @@ export type ChartReference = {
     /** Saved visualization config (bar/line/table/big number…) so the agent
      *  can reproduce the chart type and styling, not just the query. */
     chartConfig: ChartConfig;
-    /** Pivot dimensions when the saved chart pivots its results. */
-    pivotConfig: { columns: string[] } | null;
+    /** Saved pivot layout, including ordered row fields when configured. */
+    pivotConfig: NonNullable<SavedChart['pivotConfig']> | null;
     sampleData: ChartSampleData | null; // null when the user did not opt in
     /** Saved chart UUID — surfaced into the sandbox so a linked chart can be
      *  run live via savedChart(uuid). */


### PR DESCRIPTION
Linear: https://linear.app/lightdash/issue/PROD-9188/allow-metrics-in-pivot-table-rows

### Description

Part 2 of 4. Depends on #26052.

- add nullable saved-chart-version storage for ordered pivot rows
- persist and reload the complete optional pivot configuration on save/view
- forward runtime row field IDs into asynchronous pivot CSV and XLSX exports
- preserve and rename top-level pivot row references
- keep existing saved charts unchanged when the optional property is absent

### Rollback

Revert #26059 before this PR so frontend activation is removed first. The
database column is additive and nullable, and older application code ignores
it. Explicitly reversing the migration drops only the new row-layout metadata;
saves made while rolled back continue to reflect the old UI.

### Validation

- 116 focused backend tests
- backend and API-test typechecks
- migration applied successfully to the local development database
- live API create-then-fetch regression confirms columns and ordered rows survive reload
