### PR TITLE
feat: configure pivot row values

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -393,6 +393,7 @@ const ValidDashboardChartTile: FC<{
             <VisualizationProvider
                 chartConfig={chart.chartConfig}
                 initialPivotDimensions={chart.pivotConfig?.columns}
+                initialPivotRows={chart.pivotConfig?.rows}
                 resultsData={resultsDataWithQueryData}
                 isLoading={resultsData.isFetchingRows}
                 onSeriesContextMenu={onSeriesContextMenu}
@@ -543,6 +544,7 @@ const ValidDashboardChartTileMinimal: FC<{
             minimal
             chartConfig={chart.chartConfig}
             initialPivotDimensions={chart.pivotConfig?.columns}
+            initialPivotRows={chart.pivotConfig?.rows}
             resultsData={resultsDataWithQueryData}
             isLoading={resultsData.isFetchingRows}
             onSeriesContextMenu={onSeriesContextMenu}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -156,9 +156,18 @@ const VisualizationCard: FC<Props> = memo((props) => {
         [query.data, queryResults],
     );
 
+    const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
+
     const handleSetPivotFields = useCallback(
         (fields: FieldId[] = []) => {
-            dispatch(explorerActions.setPivotConfig({ columns: fields }));
+            dispatch(explorerActions.setPivotColumns(fields));
+        },
+        [dispatch],
+    );
+
+    const handleSetPivotRows = useCallback(
+        (rows: FieldId[] = []) => {
+            dispatch(explorerActions.setPivotRows(rows));
         },
         [dispatch],
     );
@@ -192,8 +201,6 @@ const VisualizationCard: FC<Props> = memo((props) => {
         },
         [dispatch],
     );
-
-    const unsavedChartVersion = useExplorerSelector(selectUnsavedChartVersion);
 
     const tableCalculationsMetadata = useExplorerSelector(
         selectTableCalculationsMetadata,
@@ -330,6 +337,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
                 initialPivotDimensions={
                     unsavedChartVersion.pivotConfig?.columns
                 }
+                initialPivotRows={unsavedChartVersion.pivotConfig?.rows}
                 unsavedMetricQuery={unsavedChartVersion.metricQuery}
                 resultsData={resultsData}
                 apiErrorDetail={apiErrorDetail}
@@ -340,6 +348,7 @@ const VisualizationCard: FC<Props> = memo((props) => {
                 onChartConfigChange={handleSetChartConfig}
                 onChartTypeChange={handleSetChartType}
                 onPivotDimensionsChange={handleSetPivotFields}
+                onPivotRowsChange={handleSetPivotRows}
                 colorPalette={colorPalette}
                 tableCalculationsMetadata={tableCalculationsMetadata}
                 parameters={query.data?.usedParametersValues}

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationConfigTable.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationConfigTable.tsx
@@ -8,6 +8,8 @@ const VisualizationTableConfig: FC<VisualizationTableConfigProps> = ({
     resultsData,
     columnOrder,
     validPivotDimensions,
+    initialPivotRows,
+    onPivotRowsChange,
     initialChartConfig,
     onChartConfigChange,
     children,
@@ -20,6 +22,8 @@ const VisualizationTableConfig: FC<VisualizationTableConfigProps> = ({
         itemsMap,
         columnOrder,
         validPivotDimensions,
+        initialPivotRows,
+        onPivotRowsChange,
         invalidateCache,
         parameters,
     );

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -57,6 +57,7 @@ export type VisualizationProviderProps = {
     minimal?: boolean;
     chartConfig: ChartConfig;
     initialPivotDimensions: string[] | undefined;
+    initialPivotRows?: string[];
     unsavedMetricQuery?: MetricQuery;
     resultsData: InfiniteQueryResults & {
         metricQuery?: MetricQuery;
@@ -73,6 +74,7 @@ export type VisualizationProviderProps = {
     onChartTypeChange?: (value: ChartType) => void;
     onChartConfigChange?: (value: ChartConfig) => void;
     onPivotDimensionsChange?: (value: string[] | undefined) => void;
+    onPivotRowsChange?: (value: string[] | undefined) => void;
     savedChartUuid?: string;
     dashboardFilters?: DashboardFilters;
     invalidateCache?: boolean;
@@ -94,6 +96,7 @@ const VisualizationProvider: FC<
 > = ({
     minimal = false,
     initialPivotDimensions,
+    initialPivotRows,
     resultsData,
     isLoading,
     columnOrder,
@@ -102,6 +105,7 @@ const VisualizationProvider: FC<
     onSeriesContextMenu,
     onChartTypeChange,
     onPivotDimensionsChange,
+    onPivotRowsChange,
     children,
     savedChartUuid,
     dashboardFilters,
@@ -513,6 +517,8 @@ const VisualizationProvider: FC<
                     resultsData={lastValidResultsData}
                     columnOrder={defaultColumnOrder}
                     validPivotDimensions={validPivotDimensions}
+                    initialPivotRows={initialPivotRows}
+                    onPivotRowsChange={onPivotRowsChange}
                     initialChartConfig={chartConfig.config}
                     onChartConfigChange={handleChartConfigChange}
                     savedChartUuid={savedChartUuid}

--- a/packages/frontend/src/components/LightdashVisualization/types.ts
+++ b/packages/frontend/src/components/LightdashVisualization/types.ts
@@ -152,6 +152,8 @@ export type VisualizationTableConfigProps =
         itemsMap: ItemsMap | undefined;
         columnOrder: string[];
         validPivotDimensions: string[] | undefined;
+        initialPivotRows: string[] | undefined;
+        onPivotRowsChange?: (value: string[] | undefined) => void;
         savedChartUuid: string | undefined;
         dashboardFilters: DashboardFilters | undefined;
         invalidateCache: boolean | undefined;

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
@@ -64,7 +64,7 @@ const ColumnConfigurationInput: FC<ColumnConfigurationInputProps> = ({
     );
 };
 
-type ColumnConfigurationProps = {
+export type ColumnConfigurationProps = {
     fieldId: string;
 
     /**

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/DroppableItemsList.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/DroppableItemsList.tsx
@@ -7,7 +7,9 @@ import { Group, Stack, Text } from '@mantine-8/core';
 import React, { type FC } from 'react';
 import { createPortal } from 'react-dom';
 import { GrabIcon } from '../common/GrabIcon';
-import ColumnConfiguration from './ColumnConfiguration';
+import ColumnConfiguration, {
+    type ColumnConfigurationProps,
+} from './ColumnConfiguration';
 
 type DraggablePortalHandlerProps = {
     snapshot: DraggableStateSnapshot;
@@ -26,6 +28,10 @@ type DroppableItemsListProps = {
     isDragging: boolean;
     disableReorder: boolean;
     placeholder?: string;
+    draggableItemIds?: string[];
+    getColumnConfigurationProps?: (
+        itemId: string,
+    ) => Omit<ColumnConfigurationProps, 'fieldId'>;
 };
 
 const DroppableItemsList: FC<DroppableItemsListProps> = ({
@@ -34,6 +40,8 @@ const DroppableItemsList: FC<DroppableItemsListProps> = ({
     isDragging,
     disableReorder,
     placeholder,
+    draggableItemIds,
+    getColumnConfigurationProps,
 }) => {
     const hasItems = itemIds.length > 0;
     return (
@@ -70,6 +78,10 @@ const DroppableItemsList: FC<DroppableItemsListProps> = ({
                                 key={itemId}
                                 draggableId={itemId}
                                 index={index}
+                                isDragDisabled={
+                                    draggableItemIds !== undefined &&
+                                    !draggableItemIds.includes(itemId)
+                                }
                             >
                                 {(
                                     {
@@ -95,14 +107,22 @@ const DroppableItemsList: FC<DroppableItemsListProps> = ({
                                                 ...draggableProps.style,
                                             }}
                                         >
-                                            <GrabIcon
-                                                dragHandleProps={
-                                                    dragHandleProps
-                                                }
-                                            />
+                                            {draggableItemIds === undefined ||
+                                            draggableItemIds.includes(
+                                                itemId,
+                                            ) ? (
+                                                <GrabIcon
+                                                    dragHandleProps={
+                                                        dragHandleProps
+                                                    }
+                                                />
+                                            ) : null}
 
                                             <ColumnConfiguration
                                                 fieldId={itemId}
+                                                {...getColumnConfigurationProps?.(
+                                                    itemId,
+                                                )}
                                             />
                                         </Group>
                                     </DraggablePortalHandler>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/GeneralSettings.tsx
@@ -1,19 +1,20 @@
 import { DragDropContext, type DropResult } from '@hello-pangea/dnd';
 import { Box, Checkbox, Stack, Switch, Tooltip } from '@mantine-8/core';
 import { useCallback, useMemo, useState, type FC } from 'react';
+import { isPivotRowValue } from '../../../hooks/tableVisualization/pivotRows';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { isTableVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../common/Config';
 import { RowLimitControls } from '../common/RowLimitControls';
 import compactStyles from '../mantineTheme.module.css';
-import ColumnConfiguration from './ColumnConfiguration';
 import { MAX_PIVOTS } from './constants';
 import DroppableItemsList from './DroppableItemsList';
 
 enum DroppableIds {
     COLUMNS = 'COLUMNS',
     ROWS = 'ROWS',
+    METRICS = 'METRICS',
 }
 
 const GeneralSettings: FC = () => {
@@ -44,9 +45,7 @@ const GeneralSettings: FC = () => {
     }: { columns: string[]; rows: string[]; metrics: string[] } =
         useMemo(() => {
             const columnFields = pivotDimensions ?? [];
-            const rowsFields = [...dimensions].filter(
-                (itemId) => !pivotDimensions?.includes(itemId),
-            );
+            const rowsFields = chartConfig?.rowFieldIds ?? [];
             const metricsFields = (chartConfig?.selectedItemIds ?? [])
                 .filter((id) => ![...columnFields, ...rowsFields].includes(id))
                 .sort(
@@ -57,7 +56,7 @@ const GeneralSettings: FC = () => {
                 rows: rowsFields,
                 metrics: metricsFields,
             };
-        }, [pivotDimensions, dimensions, chartConfig, columnOrder]);
+        }, [pivotDimensions, chartConfig, columnOrder]);
 
     const handleToggleMetricsAsRows = useCallback(() => {
         if (!chartConfig) return;
@@ -91,8 +90,22 @@ const GeneralSettings: FC = () => {
             setIsDragging(false);
             if (!destination) return;
 
+            const sourceItems =
+                source.droppableId === DroppableIds.COLUMNS
+                    ? columns
+                    : source.droppableId === DroppableIds.ROWS
+                      ? rows
+                      : metrics;
+            const fieldId = sourceItems[source.index];
+            const field = resultsData?.fields?.[fieldId];
+            const isValueField = isPivotRowValue(field);
+
             if (source.droppableId !== destination.droppableId) {
-                if (destination.droppableId === DroppableIds.COLUMNS) {
+                if (
+                    destination.droppableId === DroppableIds.COLUMNS &&
+                    source.droppableId === DroppableIds.ROWS &&
+                    dimensions.includes(fieldId)
+                ) {
                     if (columns.length >= MAX_PIVOTS) {
                         showToastError({
                             title: 'Maximum number of pivots reached',
@@ -100,15 +113,18 @@ const GeneralSettings: FC = () => {
                         return;
                     }
                     // Add pivot
-                    const fieldId = rows[source.index];
                     setPivotDimensions([
                         ...columns.slice(0, destination.index),
                         fieldId,
                         ...columns.slice(destination.index),
                     ]);
-                } else {
-                    // Remove pivot
-                    const fieldId = columns[source.index];
+                    chartConfig.setRowFieldIds?.(
+                        rows.filter((key) => key !== fieldId),
+                    );
+                } else if (
+                    destination.droppableId === DroppableIds.ROWS &&
+                    source.droppableId === DroppableIds.COLUMNS
+                ) {
                     const newPivotDimensions = columns.filter(
                         (key) => key !== fieldId,
                     );
@@ -120,6 +136,36 @@ const GeneralSettings: FC = () => {
                         handleToggleMetricsAsRows();
                     }
                     setPivotDimensions(newPivotDimensions);
+                    const newRowFields = [
+                        ...rows.slice(0, destination.index),
+                        fieldId,
+                        ...rows.slice(destination.index),
+                    ];
+                    chartConfig.setRowFieldIds?.(
+                        newPivotDimensions.length > 0
+                            ? newRowFields
+                            : newRowFields.filter((rowFieldId) =>
+                                  dimensions.includes(rowFieldId),
+                              ),
+                    );
+                } else if (
+                    destination.droppableId === DroppableIds.ROWS &&
+                    source.droppableId === DroppableIds.METRICS &&
+                    isValueField
+                ) {
+                    chartConfig.setRowFieldIds?.([
+                        ...rows.slice(0, destination.index),
+                        fieldId,
+                        ...rows.slice(destination.index),
+                    ]);
+                } else if (
+                    destination.droppableId === DroppableIds.METRICS &&
+                    source.droppableId === DroppableIds.ROWS &&
+                    isValueField
+                ) {
+                    chartConfig.setRowFieldIds?.(
+                        rows.filter((key) => key !== fieldId),
+                    );
                 }
             } else if (destination.droppableId === DroppableIds.COLUMNS) {
                 // Reorder pivot
@@ -132,15 +178,27 @@ const GeneralSettings: FC = () => {
                     fieldId,
                     ...columnsWithoutReorderField.slice(destination.index),
                 ]);
+            } else if (destination.droppableId === DroppableIds.ROWS) {
+                const rowsWithoutReorderField = rows.filter(
+                    (key) => key !== fieldId,
+                );
+                chartConfig.setRowFieldIds?.([
+                    ...rowsWithoutReorderField.slice(0, destination.index),
+                    fieldId,
+                    ...rowsWithoutReorderField.slice(destination.index),
+                ]);
             }
         },
         [
             columns,
             rows,
+            metrics,
             chartConfig,
             setPivotDimensions,
             showToastError,
             handleToggleMetricsAsRows,
+            dimensions,
+            resultsData?.fields,
         ],
     );
 
@@ -148,6 +206,7 @@ const GeneralSettings: FC = () => {
 
     const {
         isPivotTableEnabled,
+        isColumnVisible,
         canUseSubtotals,
         hideRowNumbers,
         metricsAsRows,
@@ -169,6 +228,13 @@ const GeneralSettings: FC = () => {
         rowLimit,
         setRowLimit,
     } = chartConfig;
+    const canUseMetricsAsRows =
+        !!isPivotTableEnabled &&
+        metrics.some(
+            (fieldId) =>
+                isColumnVisible(fieldId) &&
+                isPivotRowValue(resultsData?.fields?.[fieldId]),
+        );
 
     return (
         <Stack>
@@ -194,10 +260,37 @@ const GeneralSettings: FC = () => {
                             droppableId={DroppableIds.ROWS}
                             itemIds={rows}
                             isDragging={isDragging}
-                            disableReorder={true}
+                            disableReorder={false}
                             placeholder={
-                                'Drag dimensions into this area to group your data'
+                                'Drag dimensions, metrics, or table calculations into this area'
                             }
+                        />
+
+                        <Config.Heading>Metrics</Config.Heading>
+                        <DroppableItemsList
+                            droppableId={DroppableIds.METRICS}
+                            itemIds={metrics}
+                            placeholder={
+                                'Drag metrics or table calculations into this area'
+                            }
+                            draggableItemIds={
+                                isPivotTableEnabled
+                                    ? metrics.filter((itemId) => {
+                                          const item =
+                                              resultsData?.fields?.[itemId];
+                                          return isPivotRowValue(item);
+                                      })
+                                    : []
+                            }
+                            isDragging={isDragging}
+                            disableReorder={true}
+                            getColumnConfigurationProps={() => ({
+                                syncFreezeWith: metricsAsRows
+                                    ? metrics
+                                    : undefined,
+                                hideFreezeToggle:
+                                    !!isPivotTableEnabled && !metricsAsRows,
+                            })}
                         />
                     </Config.Section>
                 </Config>
@@ -205,11 +298,13 @@ const GeneralSettings: FC = () => {
 
             <Config.Section>
                 <Config.Section>
-                    <Config.Heading>Metrics</Config.Heading>
+                    <Config.Heading>Metric layout</Config.Heading>
                     <Tooltip
-                        disabled={!!isPivotTableEnabled}
+                        disabled={canUseMetricsAsRows}
                         label={
-                            'To use metrics as rows, you need to move a dimension to "Columns"'
+                            isPivotTableEnabled
+                                ? 'Move a metric or table calculation back to Metrics to use this layout'
+                                : 'To use metrics as rows, you need to move a dimension to "Columns"'
                         }
                         w={300}
                         multiline
@@ -222,7 +317,7 @@ const GeneralSettings: FC = () => {
                                 classNames={{
                                     label: compactStyles.compactCheckboxLabel,
                                 }}
-                                disabled={!isPivotTableEnabled}
+                                disabled={!canUseMetricsAsRows}
                                 label="Show metrics as rows"
                                 labelPosition="right"
                                 checked={metricsAsRows}
@@ -231,24 +326,6 @@ const GeneralSettings: FC = () => {
                         </Box>
                     </Tooltip>
                 </Config.Section>
-            </Config.Section>
-
-            <Config.Section>
-                {metrics.map((itemId) => (
-                    <ColumnConfiguration
-                        key={itemId}
-                        fieldId={itemId}
-                        // metricsAsRows: there's one shared label column for
-                        // all metrics, so freeze lock icons should sync.
-                        syncFreezeWith={metricsAsRows ? metrics : undefined}
-                        // Pivoted with metrics as columns: the pivoted data
-                        // columns can't be frozen, so the toggle would do
-                        // nothing.
-                        hideFreezeToggle={
-                            !!isPivotTableEnabled && !metricsAsRows
-                        }
-                    />
-                ))}
             </Config.Section>
 
             <Config.Section>

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
@@ -73,7 +73,17 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
             ? getPivotConfig({
                   chartConfig,
                   pivotConfig: pivotDimensions
-                      ? { columns: pivotDimensions }
+                      ? {
+                            columns: pivotDimensions,
+                            ...(isTableVisualizationConfig(
+                                visualizationConfig,
+                            ) &&
+                                visualizationConfig.chartConfig
+                                    .configuredRowFieldIds && {
+                                    rows: visualizationConfig.chartConfig
+                                        .configuredRowFieldIds,
+                                }),
+                        }
                       : undefined,
                   tableConfig: {
                       columnOrder,

--- a/packages/frontend/src/components/common/PivotTable/getRowSpanMerges.test.ts
+++ b/packages/frontend/src/components/common/PivotTable/getRowSpanMerges.test.ts
@@ -36,6 +36,22 @@ describe('getGroupedDimColumnIds', () => {
             ]),
         ).toEqual([]);
     });
+
+    it('does not treat pivot row metrics as grouping dimensions', () => {
+        const indexValueTypes: PivotData['indexValueTypes'] = [
+            { type: FieldType.DIMENSION, fieldId: 'month' },
+            { type: FieldType.METRIC, fieldId: 'cohort_size' },
+            { type: FieldType.DIMENSION, fieldId: 'tier' },
+        ];
+
+        expect(
+            getGroupedDimColumnIds(indexValueTypes, [
+                'month',
+                'cohort_size',
+                'tier',
+            ]),
+        ).toEqual(['month']);
+    });
 });
 
 describe('getRowSpanMerges', () => {

--- a/packages/frontend/src/components/common/PivotTable/getRowSpanMerges.ts
+++ b/packages/frontend/src/components/common/PivotTable/getRowSpanMerges.ts
@@ -1,4 +1,4 @@
-import { type PivotData } from '@lightdash/common';
+import { FieldType, type PivotData } from '@lightdash/common';
 
 export type RowSpanMerge = {
     isBlockStart: boolean;
@@ -17,7 +17,9 @@ export const getGroupedDimColumnIds = (
     columnOrder: string[],
 ): string[] => {
     const indexDimIds = new Set(
-        indexValueTypes.map((valueType) => valueType.fieldId),
+        indexValueTypes
+            .filter((valueType) => valueType.type === FieldType.DIMENSION)
+            .map((valueType) => valueType.fieldId),
     );
     return columnOrder
         .filter((columnId) => indexDimIds.has(columnId))

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSavedChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSavedChartVisualization.tsx
@@ -78,6 +78,7 @@ const AiSavedChartVisualizationContent: FC<Props> = ({
                 minimal
                 chartConfig={savedChart.chartConfig}
                 initialPivotDimensions={savedChart.pivotConfig?.columns}
+                initialPivotRows={savedChart.pivotConfig?.rows}
                 resultsData={resultsData}
                 isLoading={isLoading}
                 columnOrder={savedChart.tableConfig.columnOrder}

--- a/packages/frontend/src/ee/features/embed/EmbedChart/components/EmbedChart.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedChart/components/EmbedChart.tsx
@@ -45,6 +45,7 @@ const MinimalChartContent = memo(() => {
             minimal
             chartConfig={savedChart.chartConfig}
             initialPivotDimensions={savedChart.pivotConfig?.columns}
+            initialPivotRows={savedChart.pivotConfig?.rows}
             resultsData={resultsData}
             isLoading={isLoadingQueryResults}
             columnOrder={savedChart.tableConfig.columnOrder}

--- a/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
@@ -1,0 +1,54 @@
+import { explorerActions, explorerReducer } from './explorerSlice';
+
+describe('explorerSlice pivot axis updates', () => {
+    it('preserves both axis changes when moving a row dimension to columns', () => {
+        const initialState = explorerReducer(
+            undefined,
+            explorerActions.setPivotConfig({
+                columns: ['months_since_start'],
+                rows: ['cohort_month', 'plan_name'],
+            }),
+        );
+
+        const withUpdatedColumns = explorerReducer(
+            initialState,
+            explorerActions.setPivotColumns([
+                'months_since_start',
+                'plan_name',
+            ]),
+        );
+        const result = explorerReducer(
+            withUpdatedColumns,
+            explorerActions.setPivotRows(['cohort_month']),
+        );
+
+        expect(result.unsavedChartVersion.pivotConfig).toEqual({
+            columns: ['months_since_start', 'plan_name'],
+            rows: ['cohort_month'],
+        });
+    });
+
+    it('preserves both axis changes when moving a column dimension to rows', () => {
+        const initialState = explorerReducer(
+            undefined,
+            explorerActions.setPivotConfig({
+                columns: ['months_since_start', 'plan_name'],
+                rows: ['cohort_month'],
+            }),
+        );
+
+        const withUpdatedColumns = explorerReducer(
+            initialState,
+            explorerActions.setPivotColumns(['months_since_start']),
+        );
+        const result = explorerReducer(
+            withUpdatedColumns,
+            explorerActions.setPivotRows(['cohort_month', 'plan_name']),
+        );
+
+        expect(result.unsavedChartVersion.pivotConfig).toEqual({
+            columns: ['months_since_start'],
+            rows: ['cohort_month', 'plan_name'],
+        });
+    });
+});

--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -54,7 +54,7 @@ function saveConfigToCache<T extends ChartType>(
     cache: Partial<ConfigCacheMap>,
     chartType: T,
     config: ConfigCacheMap[T]['chartConfig'],
-    pivotConfig?: { columns: string[] },
+    pivotConfig?: SavedChart['pivotConfig'],
 ): void {
     cache[chartType] = {
         chartConfig: config,
@@ -63,6 +63,17 @@ function saveConfigToCache<T extends ChartType>(
 }
 
 const initialState: ExplorerSliceState = defaultState;
+
+const removePivotValuesFromSorts = (sorts: SortField[]): SortField[] => {
+    const seen = new Set<string>();
+    return sorts.reduce<SortField[]>((acc, sort) => {
+        if (seen.has(sort.fieldId)) return acc;
+        seen.add(sort.fieldId);
+        const { pivotValues: _pivotValues, ...rest } = sort;
+        acc.push(rest);
+        return acc;
+    }, []);
+};
 
 const explorerSlice = createSlice({
     name: 'explorer',
@@ -257,22 +268,37 @@ const explorerSlice = createSlice({
 
         setPivotConfig: (
             state,
-            action: PayloadAction<{ columns: string[] } | undefined>,
+            action: PayloadAction<SavedChart['pivotConfig']>,
         ) => {
             state.unsavedChartVersion.pivotConfig = action.payload;
             if (!action.payload?.columns.length) {
-                const seen = new Set<string>();
                 state.unsavedChartVersion.metricQuery.sorts =
-                    state.unsavedChartVersion.metricQuery.sorts.reduce<
-                        SortField[]
-                    >((acc, sort) => {
-                        if (seen.has(sort.fieldId)) return acc;
-                        seen.add(sort.fieldId);
-                        const { pivotValues: _pivotValues, ...rest } = sort;
-                        acc.push(rest);
-                        return acc;
-                    }, []);
+                    removePivotValuesFromSorts(
+                        state.unsavedChartVersion.metricQuery.sorts,
+                    );
             }
+        },
+
+        setPivotColumns: (state, action: PayloadAction<string[]>) => {
+            const rows = state.unsavedChartVersion.pivotConfig?.rows;
+            state.unsavedChartVersion.pivotConfig = {
+                columns: action.payload,
+                ...(rows !== undefined && { rows }),
+            };
+
+            if (!action.payload.length) {
+                state.unsavedChartVersion.metricQuery.sorts =
+                    removePivotValuesFromSorts(
+                        state.unsavedChartVersion.metricQuery.sorts,
+                    );
+            }
+        },
+
+        setPivotRows: (state, action: PayloadAction<string[] | undefined>) => {
+            state.unsavedChartVersion.pivotConfig = {
+                columns: state.unsavedChartVersion.pivotConfig?.columns ?? [],
+                ...(action.payload !== undefined && { rows: action.payload }),
+            };
         },
 
         setParameter: (
@@ -485,7 +511,7 @@ const explorerSlice = createSlice({
                 before.type,
                 current(before.config),
                 beforePivotConfig
-                    ? (current(beforePivotConfig) as { columns: string[] })
+                    ? (current(beforePivotConfig) as SavedChart['pivotConfig'])
                     : undefined,
             );
 

--- a/packages/frontend/src/hooks/tableVisualization/pivotRows.test.ts
+++ b/packages/frontend/src/hooks/tableVisualization/pivotRows.test.ts
@@ -1,0 +1,115 @@
+import {
+    DimensionType,
+    FieldType,
+    type Dimension,
+    type ItemsMap,
+    type TableCalculation,
+} from '@lightdash/common';
+import {
+    isPivotRowValue,
+    resolvePivotRowFieldIds,
+    shouldDisableMetricsAsRows,
+} from './pivotRows';
+
+const dimension = (name: string): Dimension => ({
+    name,
+    type: DimensionType.STRING,
+    table: 'subscriptions',
+    tableLabel: 'Subscriptions',
+    label: name,
+    fieldType: FieldType.DIMENSION,
+    sql: `\${TABLE}.${name}`,
+    hidden: false,
+});
+
+describe('isPivotRowValue', () => {
+    it('allows table calculations on the pivot row axis', () => {
+        const tableCalculation: TableCalculation = {
+            name: 'retention_rate',
+            displayName: 'Retention rate',
+            sql: '${subscriptions_retained} / ${subscriptions_started}',
+        };
+
+        expect(isPivotRowValue(tableCalculation)).toBe(true);
+    });
+});
+
+describe('resolvePivotRowFieldIds', () => {
+    const cohortSize: TableCalculation = {
+        name: 'cohort_size',
+        displayName: 'Cohort size',
+        sql: '${subscriptions_cohort_size}',
+    };
+    const itemsMap: ItemsMap = {
+        cohort_month: dimension('cohort_month'),
+        months_since_start: dimension('months_since_start'),
+        cohort_size: cohortSize,
+    };
+
+    it('keeps selected non-pivot dimensions on Rows when they are not explicitly configured', () => {
+        expect(
+            resolvePivotRowFieldIds({
+                selectedItemIds: [
+                    'cohort_month',
+                    'months_since_start',
+                    'cohort_size',
+                ],
+                itemsMap,
+                pivotDimensions: ['months_since_start'],
+                columnOrder: [
+                    'cohort_month',
+                    'months_since_start',
+                    'cohort_size',
+                ],
+                pivotRows: ['cohort_size'],
+            }),
+        ).toEqual(['cohort_size', 'cohort_month']);
+    });
+});
+
+describe('shouldDisableMetricsAsRows', () => {
+    const revenue: TableCalculation = {
+        name: 'revenue',
+        displayName: 'Revenue',
+        sql: '${orders_total_revenue}',
+    };
+    const margin: TableCalculation = {
+        name: 'margin',
+        displayName: 'Margin',
+        sql: '${orders_total_margin}',
+    };
+    const itemsMap = { revenue, margin };
+
+    it('disables metrics-as-rows when every value field is already a pivot row', () => {
+        expect(
+            shouldDisableMetricsAsRows({
+                metricsAsRows: true,
+                selectedItemIds: ['revenue', 'margin'],
+                rowFieldIds: ['revenue', 'margin'],
+                itemsMap,
+            }),
+        ).toBe(true);
+    });
+
+    it('keeps metrics-as-rows enabled while another value field remains', () => {
+        expect(
+            shouldDisableMetricsAsRows({
+                metricsAsRows: true,
+                selectedItemIds: ['revenue', 'margin'],
+                rowFieldIds: ['revenue'],
+                itemsMap,
+            }),
+        ).toBe(false);
+    });
+
+    it('waits for query fields before normalizing loaded configuration', () => {
+        expect(
+            shouldDisableMetricsAsRows({
+                metricsAsRows: true,
+                selectedItemIds: undefined,
+                rowFieldIds: ['revenue'],
+                itemsMap: undefined,
+            }),
+        ).toBe(false);
+    });
+});

--- a/packages/frontend/src/hooks/tableVisualization/pivotRows.ts
+++ b/packages/frontend/src/hooks/tableVisualization/pivotRows.ts
@@ -1,0 +1,79 @@
+import {
+    isCustomDimension,
+    isDimension,
+    isMetric,
+    isTableCalculation,
+    type ItemsMap,
+} from '@lightdash/common';
+
+export const isPivotRowValue = (item: ItemsMap[string] | undefined): boolean =>
+    item !== undefined && (isMetric(item) || isTableCalculation(item));
+
+export const resolvePivotRowFieldIds = ({
+    selectedItemIds,
+    itemsMap,
+    pivotDimensions,
+    columnOrder,
+    pivotRows,
+}: {
+    selectedItemIds: string[] | undefined;
+    itemsMap: ItemsMap | undefined;
+    pivotDimensions: string[] | undefined;
+    columnOrder: string[];
+    pivotRows: string[] | undefined;
+}): string[] => {
+    if (!selectedItemIds || !itemsMap) return [];
+
+    const selectedItemIdSet = new Set(selectedItemIds);
+    const pivotDimensionSet = new Set(pivotDimensions ?? []);
+    const defaultRowDimensions = columnOrder.filter((fieldId) => {
+        const item = itemsMap[fieldId];
+        return (
+            selectedItemIdSet.has(fieldId) &&
+            !pivotDimensionSet.has(fieldId) &&
+            item !== undefined &&
+            (isDimension(item) || isCustomDimension(item))
+        );
+    });
+
+    if (pivotRows === undefined) return defaultRowDimensions;
+
+    const configuredFields = pivotRows.filter((fieldId) => {
+        const item = itemsMap[fieldId];
+        return (
+            selectedItemIdSet.has(fieldId) &&
+            !pivotDimensionSet.has(fieldId) &&
+            item !== undefined &&
+            (isDimension(item) ||
+                isCustomDimension(item) ||
+                (pivotDimensionSet.size > 0 && isPivotRowValue(item)))
+        );
+    });
+
+    return [
+        ...configuredFields,
+        ...defaultRowDimensions.filter(
+            (fieldId) => !configuredFields.includes(fieldId),
+        ),
+    ];
+};
+
+export const shouldDisableMetricsAsRows = ({
+    metricsAsRows,
+    selectedItemIds,
+    rowFieldIds,
+    itemsMap,
+}: {
+    metricsAsRows: boolean;
+    selectedItemIds: string[] | undefined;
+    rowFieldIds: string[];
+    itemsMap: ItemsMap | undefined;
+}): boolean => {
+    if (!metricsAsRows || !selectedItemIds || !itemsMap) return false;
+
+    const rowFieldIdSet = new Set(rowFieldIds);
+    return !selectedItemIds.some(
+        (fieldId) =>
+            !rowFieldIdSet.has(fieldId) && isPivotRowValue(itemsMap[fieldId]),
+    );
+};

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -34,6 +34,10 @@ import {
 import { useProjectUuid } from '../useProjectUuid';
 import { type InfiniteQueryResults } from '../useQueryResults';
 import getDataAndColumns from './getDataAndColumns';
+import {
+    resolvePivotRowFieldIds,
+    shouldDisableMetricsAsRows,
+} from './pivotRows';
 
 const createWorker = createWorkerFactory(
     () => import('@lightdash/common/src/pivot/pivotQueryResults'),
@@ -51,6 +55,8 @@ const useTableConfig = (
     itemsMap: ItemsMap | undefined,
     columnOrder: string[],
     pivotDimensions: string[] | undefined,
+    pivotRows: string[] | undefined,
+    onPivotRowsChange?: (value: string[] | undefined) => void,
     invalidateCache?: boolean,
     parameters?: ParametersValuesMap,
 ) => {
@@ -122,6 +128,32 @@ const useTableConfig = (
             ? itemsInMetricQuery(resultsData.metricQuery)
             : undefined;
     }, [resultsData?.metricQuery]);
+
+    const rowFieldIds = useMemo(
+        () =>
+            resolvePivotRowFieldIds({
+                selectedItemIds,
+                itemsMap,
+                pivotDimensions,
+                columnOrder,
+                pivotRows,
+            }),
+        [selectedItemIds, itemsMap, pivotDimensions, columnOrder, pivotRows],
+    );
+
+    const disableMetricsAsRows = shouldDisableMetricsAsRows({
+        metricsAsRows,
+        selectedItemIds: selectedItemIds?.filter(
+            (fieldId) => columnProperties[fieldId]?.visible !== false,
+        ),
+        rowFieldIds,
+        itemsMap,
+    });
+    const effectiveMetricsAsRows = metricsAsRows && !disableMetricsAsRows;
+
+    useEffect(() => {
+        if (disableMetricsAsRows) setMetricsAsRows(false);
+    }, [disableMetricsAsRows]);
 
     const getFieldLabelDefault = useCallback(
         (fieldId: string | null | undefined) => {
@@ -393,7 +425,8 @@ const useTableConfig = (
 
         const pivotConfig: PivotConfig = {
             pivotDimensions,
-            metricsAsRows,
+            metricsAsRows: effectiveMetricsAsRows,
+            rowFieldIds,
             columnOrder,
             hiddenMetricFieldIds,
             hiddenDimensionFieldIds,
@@ -423,7 +456,8 @@ const useTableConfig = (
         resultsData?.metricQuery,
         resultsData?.rows,
         resultsData?.pivotDetails,
-        metricsAsRows,
+        effectiveMetricsAsRows,
+        rowFieldIds,
         columnOrder,
         selectedItemIds,
         getField,
@@ -684,7 +718,7 @@ const useTableConfig = (
             columns: columnProperties,
             hideRowNumbers,
             conditionalFormattings,
-            metricsAsRows,
+            metricsAsRows: effectiveMetricsAsRows,
             rowLimit,
         }),
         [
@@ -698,7 +732,7 @@ const useTableConfig = (
             showRowGrouping,
             columnProperties,
             conditionalFormattings,
-            metricsAsRows,
+            effectiveMetricsAsRows,
             rowLimit,
         ],
     );
@@ -739,8 +773,11 @@ const useTableConfig = (
             conditionalFormattings,
             onSetConditionalFormattings: handleSetConditionalFormattings,
             pivotTableData,
-            metricsAsRows,
+            metricsAsRows: effectiveMetricsAsRows,
             setMetricsAsRows,
+            rowFieldIds,
+            configuredRowFieldIds: pivotRows,
+            setRowFieldIds: onPivotRowsChange,
             isPivotTableEnabled,
             isPivotResultStale,
             canUseSubtotals,
@@ -788,8 +825,11 @@ const useTableConfig = (
             conditionalFormattings,
             handleSetConditionalFormattings,
             pivotTableData,
-            metricsAsRows,
+            effectiveMetricsAsRows,
             setMetricsAsRows,
+            rowFieldIds,
+            pivotRows,
+            onPivotRowsChange,
             isPivotTableEnabled,
             isPivotResultStale,
             canUseSubtotals,

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -143,6 +143,7 @@ const MinimalExplorerContent = memo(() => {
                 minimal
                 chartConfig={savedChart.chartConfig}
                 initialPivotDimensions={savedChart.pivotConfig?.columns}
+                initialPivotRows={savedChart.pivotConfig?.rows}
                 resultsData={resultsData}
                 isLoading={isLoadingQueryResults}
                 columnOrder={savedChart.tableConfig.columnOrder}

--- a/packages/frontend/src/providers/Explorer/types.ts
+++ b/packages/frontend/src/providers/Explorer/types.ts
@@ -76,7 +76,7 @@ export enum ActionType {
 
 export type ChartConfigCache<T = AnyType> = {
     chartConfig: T;
-    pivotConfig?: { columns: string[] };
+    pivotConfig?: SavedChart['pivotConfig'];
 };
 
 /**

--- a/packages/frontend/src/providers/Explorer/utils.ts
+++ b/packages/frontend/src/providers/Explorer/utils.ts
@@ -1,4 +1,9 @@
-import { ChartType, type ChartConfig, type Series } from '@lightdash/common';
+import {
+    ChartType,
+    type ChartConfig,
+    type SavedChart,
+    type Series,
+} from '@lightdash/common';
 import omit from 'lodash/omit';
 import { EMPTY_CARTESIAN_CHART_CONFIG } from '../../hooks/cartesianChartConfig/useCartesianChartConfig';
 import { type ConfigCacheMap } from './types';
@@ -42,7 +47,7 @@ export const getValidChartConfig = (
 export const getCachedPivotConfig = (
     chartType: ChartType,
     cachedConfigs?: Partial<ConfigCacheMap>,
-): { columns: string[] } | undefined => {
+): SavedChart['pivotConfig'] => {
     return cachedConfigs?.[chartType]?.pivotConfig;
 };
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9188/allow-metrics-in-pivot-table-rows

### Description

Part 3 of 4. Depends on #26058.

- let query-time metrics and table calculations move between Metrics and pivot Rows
- reorder dimensions, metrics, and table calculations together on the row axis
- persist the ordered layout in top-level pivot configuration rows
- resolve legacy charts to their existing dimension order without writing a new property
- keep SQL grouping restricted to dimensions
- hydrate saved rows in Explorer, dashboards, embeds, minimal views, downloads, and AI saved-chart rendering
- update Rows and Columns through axis-specific store actions so a two-axis drag cannot restore stale state
- turn off and disable Show metrics as rows when no visible values remain in Metrics
- show an empty-state placeholder in Metrics explaining where values can be dropped

This is the activation boundary. Reverting this PR removes the UI behavior while the lower optional compatibility and persistence layers remain safe.

### Validation

- 17 focused frontend tests, including both dimension drag directions and metrics-as-rows normalization
- full and fast frontend typechecks
- frontend lint, format, unused-export, and commit hooks