### PR TITLE
test: add pivot row cohort demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # version control
 .git
+.local/
 .worktrees/
 
 # dependencies

--- a/docs/pivoting.md
+++ b/docs/pivoting.md
@@ -97,6 +97,25 @@ rows into `PivotData`: each `status` value becomes a column header, each
 | **2026-01-01** |           100 |          40 |
 | **2026-01-02** |            80 |          60 |
 
+## Cohort-retention demo
+
+The full Jaffle Shop demo includes `subscription_cohort_retention`, a
+deterministic 12-month grid derived from the subscription seed. Use it to build
+a pivot-table retention heatmap that also exercises metrics on the row axis:
+
+1. Add **Cohort started at Month** and **Months since start** as dimensions.
+2. Add **Cohort size** and **Retention rate** as metrics.
+3. Move **Months since start** to Columns and sort it ascending so month zero is
+   the first rendered pivot group.
+4. Move **Cohort size** into Rows beside **Cohort started at Month**.
+5. Apply a color-scale conditional formatting rule to **Retention rate**.
+6. To test table calculations on Rows, add **Month-zero retention** with SQL
+   `${subscription_cohort_retention.retention_rate}` and drag it into Rows. It
+   should show the exact value from the first rendered month group.
+
+The result keeps the initial cohort size visible once per cohort while the
+retention-rate cells form the 0–11 month heatmap.
+
 ## Mini-glossary
 
 Cross-cutting terms only — fuller definitions live in the linked package docs.
@@ -116,6 +135,11 @@ Cross-cutting terms only — fuller definitions live in the linked package docs.
   still reference them.
 - **`metricsAsRows`** — layout flag; when true, metrics fan out down the rows
   instead of across the columns (affects the column-count math).
+- **`pivotConfig.rows` / `rowFieldIds`** — persisted and runtime names for the
+  ordered fields rendered once on the row axis. Metrics and table calculations
+  remain value columns in the warehouse pivot, then the shared reshape step
+  takes their exact value from the first rendered pivot group and removes their
+  repeated pivot columns.
 - **anchor (column / row)** — the reference column/row used when sorting a pivot by
   a metric value; see `QueryBuilder/CLAUDE.md`.
 - **`PivotData` / `pivotColumnInfo`** — the matrix structure (`headerValues`,

--- a/examples/full-jaffle-shop-demo/dbt/models/subscription_cohort_retention.sql
+++ b/examples/full-jaffle-shop-demo/dbt/models/subscription_cohort_retention.sql
@@ -1,0 +1,41 @@
+with subscriptions as (
+    select * from {{ ref('subscriptions') }}
+),
+
+month_offsets as (
+    select 0 as months_since_start
+    union all select 1
+    union all select 2
+    union all select 3
+    union all select 4
+    union all select 5
+    union all select 6
+    union all select 7
+    union all select 8
+    union all select 9
+    union all select 10
+    union all select 11
+),
+
+cohort_grid as (
+    select
+        subscriptions.subscription_id,
+        subscriptions.customer_id,
+        subscriptions.plan_name,
+        subscriptions.subscription_start as cohort_started_at,
+        month_offsets.months_since_start,
+        case
+            when subscriptions.duration_days >= month_offsets.months_since_start * 30
+                then true
+            else false
+        end as is_retained,
+        case
+            when subscriptions.duration_days >= month_offsets.months_since_start * 30
+                then subscriptions.subscription_id
+            else null
+        end as retained_subscription_id
+    from subscriptions
+    cross join month_offsets
+)
+
+select * from cohort_grid

--- a/examples/full-jaffle-shop-demo/dbt/models/subscription_cohort_retention.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/subscription_cohort_retention.yml
@@ -1,0 +1,90 @@
+version: 2
+
+models:
+  - name: subscription_cohort_retention
+    description: >
+      Deterministic 12-month subscription cohort grid for testing pivot-table
+      retention heatmaps. Every subscription contributes one row per month
+      offset. Build the heatmap with Cohort started at Month in Rows, Months
+      since start in Columns, and Retention rate in Metrics. Move Cohort size
+      into Rows to exercise metrics mixed with row dimensions, or create a
+      table calculation from Retention rate and move that into Rows.
+    config:
+      tags: ["core", "cohorts"]
+    meta:
+      group_label: subscriptions
+    columns:
+      - name: subscription_id
+        description: Subscription represented at each month offset.
+        tests:
+          - not_null
+        meta:
+          dimension:
+            type: number
+            hidden: true
+          metrics:
+            cohort_size:
+              type: count_distinct
+              label: Cohort size
+              description: Initial subscriptions in the cohort; constant across month offsets.
+              spotlight:
+                categories: ["core"]
+
+      - name: customer_id
+        description: Customer that owns the subscription.
+        meta:
+          dimension:
+            type: number
+
+      - name: plan_name
+        description: Subscription plan used to filter or compare retention curves.
+        meta:
+          dimension:
+            type: string
+
+      - name: cohort_started_at
+        description: Subscription start timestamp used to form acquisition cohorts.
+        tests:
+          - not_null
+        meta:
+          dimension:
+            type: timestamp
+            time_intervals: ["MONTH", "QUARTER", "YEAR"]
+
+      - name: months_since_start
+        description: Zero-based month offset along the retention curve (0 through 11).
+        tests:
+          - not_null
+        meta:
+          dimension:
+            type: number
+            format: "0"
+
+      - name: is_retained
+        description: Whether the subscription lasts through this month offset.
+        tests:
+          - not_null
+        meta:
+          dimension:
+            type: boolean
+          metrics:
+            retention_rate:
+              type: average
+              label: Retention rate
+              description: Share of subscriptions retained at each month offset.
+              sql: case when ${TABLE}.is_retained then 1 else 0 end
+              format: percent
+              spotlight:
+                categories: ["core"]
+
+      - name: retained_subscription_id
+        description: Subscription identifier when retained, otherwise null.
+        meta:
+          dimension:
+            type: number
+            hidden: true
+          metrics:
+            retained_subscriptions:
+              type: count_distinct
+              label: Retained subscriptions
+              description: Number of subscriptions retained at each month offset.

--- a/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/table-chart-reference.md
+++ b/packages/backend/src/ee/services/ai/skills/builtInSkills/developing-in-lightdash/resources/table-chart-reference.md
@@ -221,9 +221,15 @@ Pivoting transforms dimension values into column headers. For example, instead o
 
 ### Pivot Configuration
 
-| Property              | Type     | Description                                      |
-| --------------------- | -------- | ------------------------------------------------ |
-| `pivotConfig.columns` | string[] | Dimension field IDs to pivot into column headers |
+| Property              | Type     | Description                                                         |
+| --------------------- | -------- | ------------------------------------------------------------------- |
+| `pivotConfig.columns` | string[] | Dimension field IDs to pivot into column headers                    |
+| `pivotConfig.rows`    | string[] | Ordered dimensions, metrics, and table calculations on the row axis |
+
+Use `pivotConfig.rows` to place query-time metrics or table calculations
+alongside the unpivoted row dimensions. The listed order is the displayed
+row-column order; values omitted from this list remain repeated under each
+pivot group.
 
 ### Example: Pivoted Table
 

--- a/packages/frontend/src/components/common/PivotTable/CLAUDE.md
+++ b/packages/frontend/src/components/common/PivotTable/CLAUDE.md
@@ -443,7 +443,10 @@ pivot shape, and reshapes them into the `PivotData` structure the table renders.
 2. **Apply visibility + column limit** — hidden dims/metrics are filtered out and
    `columnLimit` (when set) keeps only the first N pivot column groups.
 3. **Build `headerValues` / `indexValues`** from the pivot values and index
-   columns, fanning each input row out per metric when `metricsAsRows` is set.
+   columns. Metrics and table calculations listed in
+   `pivotConfig.rowFieldIds` become ordered index-side value columns using the
+   first rendered pivot group's value; other values remain pivoted. Each input
+   row fans out per remaining metric when `metricsAsRows` is set.
 4. **Read `dataValues` directly** from each row by `pivotColumnName` (no
    client-side grouping pass is needed — the warehouse already grouped).
 5. **Calculate totals** — row totals sum across columns, column totals sum down


### PR DESCRIPTION
Linear: https://linear.app/lightdash/issue/PROD-9188/allow-metrics-in-pivot-table-rows

### Description

Part 4 of 4. Depends on #26059.

- add a deterministic `subscription_cohort_retention` demo model
- expand the existing 1,000 subscription rows across month offsets 0 through 11
- expose cohort size, retained subscriptions, and retention rate metrics
- document a cohort-month by months-since-start retention heatmap
- include a manual table-calculation-in-Rows reproduction
- document `pivotConfig.rows` and `rowFieldIds` for maintainers and AI-authored charts

A representative cohort produces a visible 100%, 83.3%, 61.9%, 23.8%, 7.1% retention curve suitable for color-scale testing.

<img width="2535" height="828" alt="CleanShot 2026-07-23 at 15 04 45" src="https://github.com/user-attachments/assets/e2e9d374-b673-4d75-bc2b-5b8c24ac778d" />

### Validation

- dbt parse succeeded
- model built 12,000 rows
- 4 dbt tests passed
- Lightdash semantic compile produced 1 explore with 0 errors

test-all