### PR TITLE
refactor(frontend): migrate InputWrapper to Mantine 8

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/Inputs/MultiKeyValuePairsInput.tsx
+++ b/packages/frontend/src/components/ProjectConnection/Inputs/MultiKeyValuePairsInput.tsx
@@ -1,5 +1,11 @@
-import { TextInput, Button, Flex, Stack, ActionIcon } from '@mantine-8/core';
-import { Input } from '@mantine/core';
+import {
+    TextInput,
+    Button,
+    Flex,
+    Stack,
+    ActionIcon,
+    InputWrapper,
+} from '@mantine-8/core';
 import { IconHelpCircle, IconPlus, IconTrash } from '@tabler/icons-react';
 import get from 'lodash/get';
 import { useState, type ReactNode } from 'react';
@@ -42,7 +48,7 @@ export const MultiKeyValuePairsInput = ({
     const [isLabelInfoOpen, setIsLabelInfoOpen] = useState<boolean>(false);
 
     return (
-        <Input.Wrapper
+        <InputWrapper
             styles={{
                 label: {
                     display: 'flex',
@@ -113,6 +119,6 @@ export const MultiKeyValuePairsInput = ({
                     Add variable
                 </Button>
             </Stack>
-        </Input.Wrapper>
+        </InputWrapper>
     );
 };


### PR DESCRIPTION
### Description

Migrates `MultiKeyValuePairsInput` from Mantine 7's compound `Input.Wrapper` to Mantine 8's standalone `InputWrapper`.

This removes the component's remaining `@mantine/core` import while preserving all wrapper props, styling, validation errors, and layout.

### Validation

- Focused frontend formatting
- Focused frontend lint
- Frontend fast typecheck
- Pre-commit unused-export check