### PR TITLE
fix(cli): restore validation help scope

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1253,7 +1253,7 @@ program
     )
     .option(
         '--validate-warehouse-columns',
-        validateWarehouseColumnsDescription,
+        `${validateWarehouseColumnsDescription} Only applies when tables are validated.`,
         false,
     )
     .option(


### PR DESCRIPTION
Restores the validate-specific help text explaining that warehouse column checks only run when table validation is included.

Follow-up to #26024.