### PR TITLE
fix(cli): clarify warehouse validation skip

### DIFF
--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -471,7 +471,7 @@ export const compile = async (options: CompileHandlerOptions) => {
             if (options.validateWarehouseColumns === true) {
                 console.error(
                     styles.warning(
-                        '> Skipping warehouse column validation because --skip-warehouse-catalog was supplied',
+                        '> Skipping warehouse column validation because the warehouse catalog is skipped',
                     ),
                 );
             }

--- a/packages/cli/src/handlers/compileWarehouseColumnValidation.test.ts
+++ b/packages/cli/src/handlers/compileWarehouseColumnValidation.test.ts
@@ -148,7 +148,7 @@ const baseOptions = (projectDir: string): CompileHandlerOptions => ({
 });
 
 const SKIP_WARNING =
-    'Skipping warehouse column validation because --skip-warehouse-catalog was supplied';
+    'Skipping warehouse column validation because the warehouse catalog is skipped';
 
 const YML_SKIP_WARNING =
     'Skipping warehouse column validation because it is not supported for Lightdash YAML projects';


### PR DESCRIPTION
Avoids claiming that `--skip-warehouse-catalog` was supplied when catalog fetching was disabled automatically, such as for Spark projects.

Stacked on #26065.