### PR TITLE
fix: harden AI hint parsing

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.exploresToYaml.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.exploresToYaml.test.ts
@@ -136,4 +136,59 @@ describe('AppGenerateService.exploresToYaml', () => {
             metricCount: 2,
         });
     });
+
+    it('drops malformed AI hints without failing YAML generation', () => {
+        const explore = {
+            name: 'orders',
+            baseTable: 'orders',
+            joinedTables: [],
+            tables: {
+                orders: {
+                    metrics: {
+                        total_revenue: {
+                            name: 'total_revenue',
+                            type: 'sum',
+                            aiHint: [{ Formula: 'clicks + keys' }],
+                        },
+                    },
+                    dimensions: {
+                        status: {
+                            name: 'status',
+                            type: 'string',
+                            aiHint: [
+                                'Valid hint with a control character: \u0000',
+                                { invalid: true },
+                            ],
+                            groups: ['broken'],
+                        },
+                    },
+                    groupDetails: {
+                        broken: {
+                            label: 'Broken',
+                            aiHint: { invalid: true },
+                        },
+                    },
+                },
+            },
+        } as unknown as Explore;
+
+        const result = exploresToYaml([explore]);
+        const parsed = parseYaml(result.yaml) as {
+            models: Array<{
+                meta?: {
+                    metrics?: Record<string, { ai_hints?: string[] }>;
+                };
+                columns?: Array<{ name: string; ai_hints?: string[] }>;
+            }>;
+        };
+        const orders = parsed.models[0];
+
+        expect(orders?.meta?.metrics?.total_revenue).not.toHaveProperty(
+            'ai_hints',
+        );
+        expect(orders?.columns?.[0]?.ai_hints).toEqual([
+            'Valid hint with a control character: \u0000',
+        ]);
+        expect(result.yaml).not.toContain('[object Object]');
+    });
 });

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7244,12 +7244,9 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
     }
 
     /** Escape a string into a safe, single-line double-quoted YAML scalar. */
-    private static yamlQuote(s: string): string {
-        const cleaned = s
-            .replace(/[\r\n\t]+/g, ' ')
-            .replace(/\\/g, '\\\\')
-            .replace(/"/g, '\\"');
-        return `"${cleaned}"`;
+    private static yamlQuote(value: unknown): string {
+        const cleaned = String(value).replace(/[\r\n\t]+/g, ' ');
+        return JSON.stringify(cleaned);
     }
 
     /** Render a single Lightdash parameter as indented YAML lines. */

--- a/packages/backend/src/ee/services/ai/tools/getMetadata.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/getMetadata.test.ts
@@ -137,6 +137,38 @@ describe('getMetadata group AI hints', () => {
             'hint: Use for zephyr settlement questions.',
         );
     });
+
+    it('ignores malformed explore, field, and group hints', async () => {
+        const explore = makeExplore({});
+        explore.aiHint = { invalid: true } as unknown as string[];
+        explore.tables.orders.dimensions.status.aiHint = [
+            'Valid field hint.',
+            { Formula: 'clicks + keys' },
+        ] as unknown as string[];
+        explore.tables.orders.dimensions.status.groups = ['settlements'];
+        explore.tables.orders.groupDetails = {
+            settlements: {
+                label: 'Settlements',
+                aiHint: { invalid: true } as unknown as string[],
+            },
+        };
+
+        const exploreResult = await execute(explore, [
+            { type: 'explore', exploreIds: ['sales'] },
+        ]);
+        const fieldResult = await execute(explore, [
+            {
+                type: 'field',
+                fields: [{ exploreId: 'sales', fieldId: 'orders_status' }],
+            },
+        ]);
+
+        expect(exploreResult.metadata).toEqual({ status: 'success' });
+        expect(exploreResult.result).not.toContain('[object Object]');
+        expect(fieldResult.metadata).toEqual({ status: 'success' });
+        expect(fieldResult.result).toContain('hint: Valid field hint.');
+        expect(fieldResult.result).not.toContain('[object Object]');
+    });
 });
 
 describe('getMetadata explore field listing', () => {

--- a/packages/backend/src/ee/services/ai/tools/getMetadata.ts
+++ b/packages/backend/src/ee/services/ai/tools/getMetadata.ts
@@ -1,4 +1,5 @@
 import {
+    flattenAiHints,
     getEffectiveFieldAiHints,
     getFilterTypeFromItemType,
     getMetadataToolDefinition,
@@ -23,9 +24,6 @@ const toolDefinition = getMetadataToolDefinition.for('agent');
 type Dependencies = {
     availableExplores: Explore[];
 };
-
-const flatHint = (hint?: string | string[]): string =>
-    Array.isArray(hint) ? hint.join(' ') : (hint ?? '');
 
 const collapse = (text: string, max = 240): string =>
     text.replace(/\s+/g, ' ').trim().slice(0, max);
@@ -71,7 +69,7 @@ const renderExplore = (explore: Explore): string => {
     if (baseTable?.description) {
         lines.push(`  description: ${collapse(baseTable.description)}`);
     }
-    const hint = flatHint(explore.aiHint);
+    const hint = flattenAiHints(explore.aiHint);
     if (hint) lines.push(`  hint: ${collapse(hint)}`);
     lines.push(`  base table: ${explore.baseTable}`);
     const joined = explore.joinedTables.map((join) => join.table);
@@ -159,7 +157,7 @@ const renderField = (
             `  description: ${collapse(field.description, FIELD_DESCRIPTION_MAX)}`,
         );
     }
-    const hint = flatHint(
+    const hint = flattenAiHints(
         getEffectiveFieldAiHints(field, explore.tables[field.table]),
     );
     if (hint) lines.push(`  hint: ${collapse(hint, FIELD_DESCRIPTION_MAX)}`);
@@ -170,7 +168,7 @@ const buildExploreStructuredResult = (
     explore: Explore,
 ): GetMetadataResult['explores'][number] => {
     const baseTable = explore.tables[explore.baseTable];
-    const hint = flatHint(explore.aiHint);
+    const hint = flattenAiHints(explore.aiHint);
     const dimensionIds = getVisibleFieldIds(
         Object.values(baseTable?.dimensions ?? {}),
     );
@@ -206,7 +204,7 @@ const buildFieldStructuredResult = (
 ): GetMetadataResult['fields'][number] => {
     const { field, isJoined } = found;
     const exploreId = explore.name;
-    const hint = flatHint(
+    const hint = flattenAiHints(
         getEffectiveFieldAiHints(field, explore.tables[field.table]),
     );
     const defaultTimeDimension = getResolvedDefaultTimeDimension(

--- a/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.grepPrecision.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.grepPrecision.test.ts
@@ -36,7 +36,7 @@ type FieldSpec = {
     name: string;
     label?: string;
     description?: string;
-    aiHint?: string;
+    aiHint?: string | string[];
     groups?: string[];
 };
 
@@ -315,6 +315,33 @@ describe('buildFieldIndex haystack scope', () => {
         );
         expect(compileMatcher('zephyr')(entry.hintHaystack)).toBe(true);
     });
+
+    it('ignores malformed field and group hints while keeping valid hints', () => {
+        const malformedExplore = makeExplore({
+            name: 'payments',
+            groupDetails: {
+                settlements: {
+                    label: 'Settlements',
+                    aiHint: { invalid: true } as unknown as string[],
+                },
+            },
+            fields: [
+                {
+                    name: 'total_revenue',
+                    aiHint: [
+                        'Canonical revenue metric.',
+                        { Formula: 'clicks + keys' },
+                    ] as unknown as string[],
+                    groups: ['settlements'],
+                },
+            ],
+        });
+
+        expect(() => buildFieldIndex([malformedExplore])).not.toThrow();
+        const [entry] = buildFieldIndex([malformedExplore]);
+        expect(entry.aiHint).toBe('Canonical revenue metric.');
+        expect(entry.hintHaystack).not.toContain('[object object]');
+    });
 });
 
 describe('buildExploreIndex', () => {
@@ -334,6 +361,19 @@ describe('buildExploreIndex', () => {
         const matches = compileMatcher('comment');
         const hits = index.filter((e) => matches(e.haystack));
         expect(hits.map((e) => e.exploreName)).toEqual(['learner_reviews']);
+    });
+
+    it('ignores malformed explore-level hints', () => {
+        const malformedExplore = makeExplore({
+            name: 'orders',
+            aiHint: { Formula: 'clicks + keys' } as unknown as string[],
+            fields: [{ name: 'status' }],
+        });
+
+        expect(() => buildExploreIndex([malformedExplore])).not.toThrow();
+        expect(buildExploreIndex([malformedExplore])[0].haystack).not.toContain(
+            '[object object]',
+        );
     });
 });
 

--- a/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.ts
+++ b/packages/backend/src/ee/services/ai/tools/grepFieldsIndex.ts
@@ -1,5 +1,6 @@
 import {
     convertFieldRefToFieldId,
+    flattenAiHints,
     getDefaultTimeDimension,
     getEffectiveFieldAiHints,
     getFieldIdForDateDimension,
@@ -9,10 +10,6 @@ import {
     type CompiledTable,
     type Explore,
 } from '@lightdash/common';
-
-/** aiHint can be a string or string[]; flatten to one space-joined string. */
-const flatHint = (hint?: string | string[]): string =>
-    Array.isArray(hint) ? hint.join(' ') : (hint ?? '');
 
 type DefaultTimeDimensionFieldIds = {
     defaultTimeDimension: string;
@@ -105,7 +102,7 @@ export const buildExploreIndex = (explores: Explore[]): ExploreEntry[] =>
         haystack: [
             explore.name,
             explore.label,
-            flatHint(explore.aiHint),
+            flattenAiHints(explore.aiHint),
             ...(explore.tags ?? []),
         ]
             .filter(Boolean)
@@ -137,7 +134,7 @@ export const buildFieldIndex = (
                 if (!field.hidden) {
                     const fieldId = `${field.table}_${field.name}`;
                     const description = field.description ?? '';
-                    const aiHint = flatHint(
+                    const aiHint = flattenAiHints(
                         getEffectiveFieldAiHints(field, table),
                     );
                     const nameHaystack = [fieldId, field.label]

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
@@ -88,6 +88,77 @@ models:
     });
 });
 
+describe('AI hint schema validation', () => {
+    it.each([
+        {
+            name: 'model',
+            metadata: `    ai_hint:
+      - Formula: clicks + keys`,
+        },
+        {
+            name: 'field group',
+            metadata: `    group_details:
+      finance:
+        label: Finance
+        ai_hint:
+          - Formula: clicks + keys`,
+        },
+        {
+            name: 'model metric',
+            metadata: `    metrics:
+      revenue:
+        type: sum
+        sql: '\${TABLE}.revenue'
+        ai_hint:
+          - Formula: clicks + keys`,
+        },
+    ])('rejects malformed $name hints', ({ metadata }) => {
+        const schema = `version: 2
+models:
+  - name: orders
+    meta:
+${metadata}`;
+
+        expect(() => new DbtSchemaEditor(schema)).toThrowError(ParseError);
+    });
+
+    it.each([
+        {
+            name: 'column metric',
+            metadata: `        metrics:
+          revenue:
+            type: sum
+            ai_hint:
+              - Formula: clicks + keys`,
+        },
+        {
+            name: 'dimension',
+            metadata: `        dimension:
+          ai_hint:
+            - Formula: clicks + keys`,
+        },
+        {
+            name: 'additional dimension',
+            metadata: `        additional_dimensions:
+          normalized_name:
+            type: string
+            sql: '\${TABLE}.name'
+            ai_hint:
+              - Formula: clicks + keys`,
+        },
+    ])('rejects malformed $name hints', ({ metadata }) => {
+        const schema = `version: 2
+models:
+  - name: orders
+    columns:
+      - name: status
+        meta:
+${metadata}`;
+
+        expect(() => new DbtSchemaEditor(schema)).toThrowError(ParseError);
+    });
+});
+
 describe('case-insensitive column matching', () => {
     const MIXED_CASE_SCHEMA = `version: 2
 models:

--- a/packages/common/src/dbt/schemas/lightdashMetadata.json
+++ b/packages/common/src/dbt/schemas/lightdashMetadata.json
@@ -185,6 +185,19 @@
                 }
             ]
         },
+        "AiHint": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
         "LightdashDimension": {
             "type": "object",
             "required": [],
@@ -202,6 +215,9 @@
                 },
                 "description": {
                     "type": "string"
+                },
+                "ai_hint": {
+                    "$ref": "#/definitions/AiHint"
                 },
                 "sql": {
                     "type": "string"
@@ -288,6 +304,9 @@
                 "description": {
                     "type": "string"
                 },
+                "ai_hint": {
+                    "$ref": "#/definitions/AiHint"
+                },
                 "sql": {
                     "type": "string"
                 },
@@ -371,6 +390,9 @@
                 },
                 "description": {
                     "type": "string"
+                },
+                "ai_hint": {
+                    "$ref": "#/definitions/AiHint"
                 },
                 "sql": {
                     "type": "string"
@@ -561,6 +583,28 @@
                         "minLength": 1
                     },
                     "maxItems": 5
+                },
+                "group_details": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                            "label": {
+                                "type": "string",
+                                "minLength": 1
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "ai_hint": {
+                                "$ref": "#/definitions/AiHint"
+                            }
+                        },
+                        "required": ["label"]
+                    }
+                },
+                "ai_hint": {
+                    "$ref": "#/definitions/AiHint"
                 },
                 "metrics": {
                     "type": "object",

--- a/packages/common/src/dbt/schemas/lightdashMetadata.json
+++ b/packages/common/src/dbt/schemas/lightdashMetadata.json
@@ -185,19 +185,6 @@
                 }
             ]
         },
-        "AiHint": {
-            "oneOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
         "LightdashDimension": {
             "type": "object",
             "required": [],
@@ -215,9 +202,6 @@
                 },
                 "description": {
                     "type": "string"
-                },
-                "ai_hint": {
-                    "$ref": "#/definitions/AiHint"
                 },
                 "sql": {
                     "type": "string"
@@ -304,9 +288,6 @@
                 "description": {
                     "type": "string"
                 },
-                "ai_hint": {
-                    "$ref": "#/definitions/AiHint"
-                },
                 "sql": {
                     "type": "string"
                 },
@@ -390,9 +371,6 @@
                 },
                 "description": {
                     "type": "string"
-                },
-                "ai_hint": {
-                    "$ref": "#/definitions/AiHint"
                 },
                 "sql": {
                     "type": "string"
@@ -583,28 +561,6 @@
                         "minLength": 1
                     },
                     "maxItems": 5
-                },
-                "group_details": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "object",
-                        "properties": {
-                            "label": {
-                                "type": "string",
-                                "minLength": 1
-                            },
-                            "description": {
-                                "type": "string"
-                            },
-                            "ai_hint": {
-                                "$ref": "#/definitions/AiHint"
-                            }
-                        },
-                        "required": ["label"]
-                    }
-                },
-                "ai_hint": {
-                    "$ref": "#/definitions/AiHint"
                 },
                 "metrics": {
                     "type": "object",

--- a/packages/common/src/dbt/validation.test.ts
+++ b/packages/common/src/dbt/validation.test.ts
@@ -1,5 +1,6 @@
 import { model } from '../compiler/translator.mock';
 import { DbtManifestVersion, type DbtRawModelNode } from '../types/dbt';
+import { DimensionType, MetricType } from '../types/field';
 import { ManifestValidator } from './validation';
 
 const metadataSchemaId =
@@ -7,9 +8,23 @@ const metadataSchemaId =
 const defaultTimeDimensionValidator = ManifestValidator.getValidator(
     `${metadataSchemaId}#/definitions/DefaultTimeDimension`,
 );
+const aiHintValidator = ManifestValidator.getValidator(
+    `${metadataSchemaId}#/definitions/AiHint`,
+);
 
 const withMeta = (meta: Record<string, unknown>): DbtRawModelNode =>
     ({ ...model, meta }) as unknown as DbtRawModelNode;
+
+const withColumnMeta = (meta: Record<string, unknown>): DbtRawModelNode =>
+    ({
+        ...model,
+        columns: {
+            myColumnName: {
+                ...model.columns.myColumnName,
+                config: { meta },
+            },
+        },
+    }) as unknown as DbtRawModelNode;
 
 const usesColumnConfigMeta = (manifestVersion: DbtManifestVersion) =>
     manifestVersion === DbtManifestVersion.V12 ||
@@ -78,6 +93,100 @@ describe('DefaultTimeDimension metadata schema', () => {
                 interval: 'MONTH',
             }),
         ).toEqual([true, undefined]);
+    });
+});
+
+describe('AI hint metadata schema', () => {
+    test.each(['Use the canonical value.', ['First hint.', 'Second hint.']])(
+        'accepts %j',
+        (value) => {
+            expect(ManifestValidator.isValid(aiHintValidator, value)).toEqual([
+                true,
+                undefined,
+            ]);
+        },
+    );
+
+    test.each([
+        { Formula: 'clicks + keys' },
+        [{ Formula: 'clicks + keys' }],
+        42,
+        true,
+        null,
+    ])('rejects %j', (value) => {
+        const [isValid, error] = ManifestValidator.isValid(
+            aiHintValidator,
+            value,
+        );
+
+        expect(isValid).toBe(false);
+        expect(error).toBeDefined();
+    });
+
+    test.each([
+        {
+            name: 'model',
+            model: withMeta({ ai_hint: [{ invalid: true }] }),
+        },
+        {
+            name: 'field group',
+            model: withMeta({
+                group_details: {
+                    finance: {
+                        label: 'Finance',
+                        ai_hint: [{ invalid: true }],
+                    },
+                },
+            }),
+        },
+        {
+            name: 'model metric',
+            model: withMeta({
+                metrics: {
+                    revenue: {
+                        type: MetricType.SUM,
+                        sql: '${TABLE}.revenue',
+                        ai_hint: [{ invalid: true }],
+                    },
+                },
+            }),
+        },
+        {
+            name: 'column metric',
+            model: withColumnMeta({
+                metrics: {
+                    revenue: {
+                        type: MetricType.SUM,
+                        ai_hint: [{ invalid: true }],
+                    },
+                },
+            }),
+        },
+        {
+            name: 'dimension',
+            model: withColumnMeta({
+                dimension: { ai_hint: [{ invalid: true }] },
+            }),
+        },
+        {
+            name: 'additional dimension',
+            model: withColumnMeta({
+                additional_dimensions: {
+                    normalized_name: {
+                        type: DimensionType.STRING,
+                        sql: '${TABLE}.name',
+                        ai_hint: [{ invalid: true }],
+                    },
+                },
+            }),
+        },
+    ])('validates the $name path', ({ model: modelWithInvalidHint }) => {
+        const [isValid, error] = new ManifestValidator(
+            DbtManifestVersion.V12,
+        ).isModelValid(modelWithInvalidHint);
+
+        expect(isValid).toBe(false);
+        expect(error).toContain('must be string');
     });
 });
 

--- a/packages/common/src/dbt/validation.test.ts
+++ b/packages/common/src/dbt/validation.test.ts
@@ -1,6 +1,5 @@
 import { model } from '../compiler/translator.mock';
 import { DbtManifestVersion, type DbtRawModelNode } from '../types/dbt';
-import { DimensionType, MetricType } from '../types/field';
 import { ManifestValidator } from './validation';
 
 const metadataSchemaId =
@@ -8,23 +7,8 @@ const metadataSchemaId =
 const defaultTimeDimensionValidator = ManifestValidator.getValidator(
     `${metadataSchemaId}#/definitions/DefaultTimeDimension`,
 );
-const aiHintValidator = ManifestValidator.getValidator(
-    `${metadataSchemaId}#/definitions/AiHint`,
-);
-
 const withMeta = (meta: Record<string, unknown>): DbtRawModelNode =>
     ({ ...model, meta }) as unknown as DbtRawModelNode;
-
-const withColumnMeta = (meta: Record<string, unknown>): DbtRawModelNode =>
-    ({
-        ...model,
-        columns: {
-            myColumnName: {
-                ...model.columns.myColumnName,
-                config: { meta },
-            },
-        },
-    }) as unknown as DbtRawModelNode;
 
 const usesColumnConfigMeta = (manifestVersion: DbtManifestVersion) =>
     manifestVersion === DbtManifestVersion.V12 ||
@@ -96,97 +80,57 @@ describe('DefaultTimeDimension metadata schema', () => {
     });
 });
 
-describe('AI hint metadata schema', () => {
-    test.each(['Use the canonical value.', ['First hint.', 'Second hint.']])(
-        'accepts %j',
-        (value) => {
-            expect(ManifestValidator.isValid(aiHintValidator, value)).toEqual([
-                true,
-                undefined,
-            ]);
-        },
-    );
-
-    test.each([
-        { Formula: 'clicks + keys' },
-        [{ Formula: 'clicks + keys' }],
-        42,
-        true,
-        null,
-    ])('rejects %j', (value) => {
-        const [isValid, error] = ManifestValidator.isValid(
-            aiHintValidator,
-            value,
-        );
-
-        expect(isValid).toBe(false);
-        expect(error).toBeDefined();
-    });
-
-    test.each([
-        {
-            name: 'model',
-            model: withMeta({ ai_hint: [{ invalid: true }] }),
-        },
-        {
-            name: 'field group',
-            model: withMeta({
+describe('AI hint manifest compatibility', () => {
+    test('does not invalidate an explore with malformed optional hints', () => {
+        const malformedHint = { Formula: 'clicks + keys' };
+        const modelWithMalformedHints = {
+            ...model,
+            meta: {
+                ai_hint: malformedHint,
                 group_details: {
                     finance: {
                         label: 'Finance',
-                        ai_hint: [{ invalid: true }],
+                        ai_hint: [malformedHint],
                     },
                 },
-            }),
-        },
-        {
-            name: 'model metric',
-            model: withMeta({
                 metrics: {
                     revenue: {
-                        type: MetricType.SUM,
+                        type: 'sum',
                         sql: '${TABLE}.revenue',
-                        ai_hint: [{ invalid: true }],
+                        ai_hint: [malformedHint],
                     },
                 },
-            }),
-        },
-        {
-            name: 'column metric',
-            model: withColumnMeta({
-                metrics: {
-                    revenue: {
-                        type: MetricType.SUM,
-                        ai_hint: [{ invalid: true }],
+            },
+            columns: {
+                myColumnName: {
+                    ...model.columns.myColumnName,
+                    config: {
+                        meta: {
+                            metrics: {
+                                revenue: {
+                                    type: 'sum',
+                                    ai_hint: [malformedHint],
+                                },
+                            },
+                            dimension: { ai_hint: [malformedHint] },
+                            additional_dimensions: {
+                                normalized_name: {
+                                    type: 'string',
+                                    sql: '${TABLE}.name',
+                                    ai_hint: [malformedHint],
+                                },
+                            },
+                        },
                     },
                 },
-            }),
-        },
-        {
-            name: 'dimension',
-            model: withColumnMeta({
-                dimension: { ai_hint: [{ invalid: true }] },
-            }),
-        },
-        {
-            name: 'additional dimension',
-            model: withColumnMeta({
-                additional_dimensions: {
-                    normalized_name: {
-                        type: DimensionType.STRING,
-                        sql: '${TABLE}.name',
-                        ai_hint: [{ invalid: true }],
-                    },
-                },
-            }),
-        },
-    ])('validates the $name path', ({ model: modelWithInvalidHint }) => {
-        const [isValid, error] = new ManifestValidator(
-            DbtManifestVersion.V12,
-        ).isModelValid(modelWithInvalidHint);
+            },
+        } as unknown as DbtRawModelNode;
 
-        expect(isValid).toBe(false);
-        expect(error).toContain('must be string');
+        expect(
+            new ManifestValidator(DbtManifestVersion.V12).isModelValid(
+                modelWithMalformedHints,
+            ),
+        ).toEqual([true, undefined]);
     });
 });
 

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -431,6 +431,19 @@
                 "apostrophePeriod"
             ]
         },
+        "aiHint": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
         "filterItem": {
             "type": "object",
             "additionalProperties": {
@@ -528,23 +541,17 @@
                                     "type": "string"
                                 },
                                 "ai_hint": {
-                                    "oneOf": [
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    ],
+                                    "$ref": "#/$defs/aiHint",
                                     "description": "Hints inherited by fields in this group for AI-powered query generation"
                                 }
                             },
                             "required": ["label"]
                         }
                     }
+                },
+                "ai_hint": {
+                    "$ref": "#/$defs/aiHint",
+                    "description": "Hints for AI-powered query generation"
                 },
                 "metrics": {
                     "type": "object",
@@ -581,6 +588,10 @@
                                 "description": {
                                     "type": "string",
                                     "minLength": 1
+                                },
+                                "ai_hint": {
+                                    "$ref": "#/$defs/aiHint",
+                                    "description": "Hints for AI-powered query generation"
                                 },
                                 "sql": {
                                     "type": "string",
@@ -1195,6 +1206,10 @@
                                     "type": "string",
                                     "minLength": 1
                                 },
+                                "ai_hint": {
+                                    "$ref": "#/$defs/aiHint",
+                                    "description": "Hints for AI-powered query generation"
+                                },
                                 "sql": {
                                     "type": "string",
                                     "minLength": 1
@@ -1445,6 +1460,10 @@
                         "description": {
                             "type": "string",
                             "minLength": 1
+                        },
+                        "ai_hint": {
+                            "$ref": "#/$defs/aiHint",
+                            "description": "Hints for AI-powered query generation"
                         },
                         "sql": {
                             "type": "string",
@@ -1715,6 +1734,10 @@
                                 "description": {
                                     "type": "string",
                                     "minLength": 1
+                                },
+                                "ai_hint": {
+                                    "$ref": "#/$defs/aiHint",
+                                    "description": "Hints for AI-powered query generation"
                                 },
                                 "sql": {
                                     "type": "string",

--- a/packages/common/src/types/dbt.test.ts
+++ b/packages/common/src/types/dbt.test.ts
@@ -1,6 +1,8 @@
 import {
     convertColumnMetric,
     convertModelMetric,
+    convertToAiHints,
+    flattenAiHints,
     getEffectiveFieldAiHints,
     getModelsFromManifest,
     patchPathParts,
@@ -8,6 +10,47 @@ import {
 } from './dbt';
 import { DimensionType, MetricType } from './field';
 import { TimeFrames } from './timeFrames';
+
+describe('convertToAiHints', () => {
+    it('normalizes strings and arrays of strings', () => {
+        expect(convertToAiHints('Use the canonical value.')).toEqual([
+            'Use the canonical value.',
+        ]);
+        expect(convertToAiHints(['First hint.', 'Second hint.'])).toEqual([
+            'First hint.',
+            'Second hint.',
+        ]);
+    });
+
+    it('drops non-string values without discarding valid array entries', () => {
+        expect(
+            convertToAiHints([
+                'Valid hint.',
+                { Formula: 'clicks + keys' },
+                null,
+                42,
+                false,
+            ]),
+        ).toEqual(['Valid hint.']);
+        expect(convertToAiHints({ Formula: 'clicks + keys' })).toBeUndefined();
+        expect(convertToAiHints(42)).toBeUndefined();
+        expect(convertToAiHints(null)).toBeUndefined();
+    });
+
+    it('returns undefined when no usable hints remain', () => {
+        expect(convertToAiHints('')).toBeUndefined();
+        expect(convertToAiHints([])).toBeUndefined();
+        expect(
+            convertToAiHints([{ Formula: 'clicks + keys' }]),
+        ).toBeUndefined();
+    });
+
+    it('flattens only validated hints', () => {
+        expect(
+            flattenAiHints(['First hint.', { invalid: true }, 'Second hint.']),
+        ).toBe('First hint. Second hint.');
+    });
+});
 
 describe('getEffectiveFieldAiHints', () => {
     it('combines field and group hints without changing their source metadata', () => {
@@ -35,6 +78,36 @@ describe('getEffectiveFieldAiHints', () => {
         expect(field.aiHint).toEqual([
             'Use as the canonical value.',
             'Shared guidance.',
+        ]);
+    });
+
+    it('ignores malformed field and group hints', () => {
+        const field = {
+            aiHint: [
+                'Valid field hint.',
+                { Formula: 'clicks + keys' },
+            ] as unknown as string[],
+            groups: ['settlements', 'broken'],
+        };
+        const table = {
+            groupDetails: {
+                settlements: {
+                    label: 'Settlements',
+                    aiHint: [
+                        { invalid: true },
+                        'Valid group hint.',
+                    ] as unknown as string[],
+                },
+                broken: {
+                    label: 'Broken',
+                    aiHint: { invalid: true } as unknown as string[],
+                },
+            },
+        };
+
+        expect(getEffectiveFieldAiHints(field, table)).toEqual([
+            'Valid field hint.',
+            'Valid group hint.',
         ]);
     });
 });

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -568,17 +568,22 @@ export const convertToGroups = (
     return groups;
 };
 
-export const convertToAiHints = (
-    aiHint: string | string[] | undefined,
-): string[] | undefined => {
-    if (!aiHint) {
+export const convertToAiHints = (aiHint: unknown): string[] | undefined => {
+    if (typeof aiHint === 'string') {
+        return aiHint ? [aiHint] : undefined;
+    }
+    if (!Array.isArray(aiHint)) {
         return undefined;
     }
-    if (typeof aiHint === 'string') {
-        return [aiHint];
-    }
-    return aiHint;
+
+    const hints = aiHint.filter(
+        (hint): hint is string => typeof hint === 'string',
+    );
+    return hints.length > 0 ? hints : undefined;
 };
+
+export const flattenAiHints = (aiHint: unknown): string =>
+    convertToAiHints(aiHint)?.join(' ') ?? '';
 
 export const getEffectiveFieldAiHints = (
     field: Pick<Dimension | Metric, 'aiHint' | 'groups'>,


### PR DESCRIPTION
Addresses #26062.

## Summary
- normalize untrusted AI hint values before they enter compiled explores or consumers
- validate AI hints at every supported dbt YAML authoring location while keeping compiled-manifest ingestion backwards-compatible
- share defensive flattening across AI search and metadata tools
- make data-app YAML scalar serialization robust to malformed cached values and control characters
- add regression coverage for maps, mixed arrays, inherited group hints, corrupt cached explores, and tolerant manifest ingestion

## Test plan
- pnpm -F common test src/types/dbt.test.ts src/dbt/validation.test.ts src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
- pnpm -F backend test --run src/ee/services/AppGenerateService/AppGenerateService.exploresToYaml.test.ts src/ee/services/ai/tools/grepFieldsIndex.grepPrecision.test.ts src/ee/services/ai/tools/getMetadata.test.ts
- pnpm -F common typecheck:fast
- pnpm -F backend typecheck:fast
- pnpm -F common lint
- NODE_OPTIONS="--max-old-space-size=8192" pnpm -F backend lint