### PR TITLE
fix: show friendly data app failure messages

### DIFF
--- a/packages/frontend/src/features/apps/getAppVersionFailureMessage.test.ts
+++ b/packages/frontend/src/features/apps/getAppVersionFailureMessage.test.ts
@@ -1,0 +1,28 @@
+import { getAppVersionFailureMessage } from './getAppVersionFailureMessage';
+
+describe('getAppVersionFailureMessage', () => {
+    it('prefers the user-facing status message over technical details', () => {
+        expect(
+            getAppVersionFailureMessage({
+                statusMessage:
+                    'Failed to load your data models. Please try again.',
+                error: 'TypeError: s.replace is not a function',
+            }),
+        ).toBe('Failed to load your data models. Please try again.');
+    });
+
+    it('falls back to the technical error for older versions', () => {
+        expect(
+            getAppVersionFailureMessage({
+                statusMessage: null,
+                error: 'Build failed with exit code 1',
+            }),
+        ).toBe('Build failed with exit code 1');
+    });
+
+    it('uses a generic message when no failure details are available', () => {
+        expect(
+            getAppVersionFailureMessage({ statusMessage: null, error: null }),
+        ).toBe('Generation failed. Please try again.');
+    });
+});

--- a/packages/frontend/src/features/apps/getAppVersionFailureMessage.ts
+++ b/packages/frontend/src/features/apps/getAppVersionFailureMessage.ts
@@ -1,0 +1,10 @@
+type AppVersionFailure = {
+    statusMessage: string | null;
+    error: string | null;
+};
+
+export const getAppVersionFailureMessage = ({
+    statusMessage,
+    error,
+}: AppVersionFailure): string =>
+    statusMessage ?? error ?? 'Generation failed. Please try again.';

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -99,6 +99,7 @@ import AppHeaderActions from '../features/apps/components/AppHeaderActions';
 import AppSpaceChip from '../features/apps/components/AppSpaceChip';
 import DataAppVizResultCard from '../features/apps/components/DataAppVizResultCard';
 import DataAppVizTestPanel from '../features/apps/components/DataAppVizTestPanel';
+import { getAppVersionFailureMessage } from '../features/apps/getAppVersionFailureMessage';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppImageUpload } from '../features/apps/hooks/useAppImageUpload';
 import { useAppImageUrl } from '../features/apps/hooks/useAppImageUrl';
@@ -954,10 +955,7 @@ const AppGenerate: FC = () => {
             } else if (v.status === 'error') {
                 msgs.push({
                     role: 'assistant',
-                    content:
-                        v.error ??
-                        v.statusMessage ??
-                        'Generation failed. Please try again.',
+                    content: getAppVersionFailureMessage(v),
                     imagePreviewUrls: [],
                     imageResourceIds: [],
                     charts: [],


### PR DESCRIPTION
Addresses the error-display portion of #26062.

Independent companion to #26069.

## Summary
- prefer the intentionally user-facing version status message in data-app chat
- retain the technical error as a fallback for older version rows
- keep the generic fallback when neither value exists
- add focused regression tests for message precedence

## Test plan
- pnpm -F frontend test --run src/features/apps/getAppVersionFailureMessage.test.ts
- pnpm -F frontend typecheck:fast
- pnpm -F frontend lint