### PR TITLE
fix: guard commercial env feature flags

### DIFF
--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -19,10 +19,6 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
         };
     }
 
-    protected canEnableCommercialFeatureFlagsFromEnv(): boolean {
-        return true;
-    }
-
     // Default-off; enabled per-org via DB-backed overrides.
     private async getHomepageBuilderFlag({
         featureFlagId,

--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -19,6 +19,10 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
         };
     }
 
+    protected canEnableCommercialFeatureFlagsFromEnv(): boolean {
+        return true;
+    }
+
     // Default-off; enabled per-org via DB-backed overrides.
     private async getHomepageBuilderFlag({
         featureFlagId,

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -8,8 +8,8 @@ import {
     FeatureFlagOverridesTableName,
     FeatureFlagsTableName,
 } from '../../database/entities/featureFlags';
-import Logger from '../../logging/logger';
 import { CommercialFeatureFlagModel } from '../../ee/models/CommercialFeatureFlagModel';
+import Logger from '../../logging/logger';
 import { FeatureFlagModel } from './FeatureFlagModel';
 
 // Minimal stub — tests below don't exercise the database layer
@@ -33,9 +33,7 @@ const buildModel = (
         } as LightdashConfig,
     });
 
-const buildCommercialModel = (
-    configOverrides: Partial<LightdashConfig> = {},
-) =>
+const buildCommercialModel = (configOverrides: Partial<LightdashConfig> = {}) =>
     new CommercialFeatureFlagModel({
         database: databaseStub,
         lightdashConfig: {

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -1,4 +1,4 @@
-import { FeatureFlags } from '@lightdash/common';
+import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
 import { Knex } from 'knex';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -9,6 +9,7 @@ import {
     FeatureFlagsTableName,
 } from '../../database/entities/featureFlags';
 import Logger from '../../logging/logger';
+import { CommercialFeatureFlagModel } from '../../ee/models/CommercialFeatureFlagModel';
 import { FeatureFlagModel } from './FeatureFlagModel';
 
 // Minimal stub — tests below don't exercise the database layer
@@ -25,6 +26,18 @@ const buildModel = (
 ) =>
     new FeatureFlagModel({
         database,
+        lightdashConfig: {
+            ...lightdashConfigMock,
+            enabledFeatureFlags: new Set<string>(),
+            ...configOverrides,
+        } as LightdashConfig,
+    });
+
+const buildCommercialModel = (
+    configOverrides: Partial<LightdashConfig> = {},
+) =>
+    new CommercialFeatureFlagModel({
+        database: databaseStub,
         lightdashConfig: {
             ...lightdashConfigMock,
             enabledFeatureFlags: new Set<string>(),
@@ -87,6 +100,62 @@ const buildFakeDatabase = (rows: FakeRows): Knex => {
 
 describe('FeatureFlagModel', () => {
     describe('env var override', () => {
+        it('does not enable commercial flags without commercial handling', async () => {
+            const warnSpy = vi
+                .spyOn(Logger, 'warn')
+                .mockImplementation(() => Logger);
+            const model = buildModel({
+                enabledFeatureFlags: new Set([
+                    CommercialFeatureFlags.HomepageBuilder,
+                ]),
+            });
+
+            const result = await model.get({
+                featureFlagId: CommercialFeatureFlags.HomepageBuilder,
+            });
+
+            expect(result).toEqual({
+                id: CommercialFeatureFlags.HomepageBuilder,
+                enabled: false,
+            });
+            expect(warnSpy).toHaveBeenCalledWith(
+                `Ignoring commercial feature flag ${CommercialFeatureFlags.HomepageBuilder} in LIGHTDASH_ENABLE_FEATURE_FLAGS without commercial feature flag handling`,
+            );
+            warnSpy.mockRestore();
+        });
+
+        it('enables regular flags listed in LIGHTDASH_ENABLE_FEATURE_FLAGS', async () => {
+            const model = buildModel({
+                enabledFeatureFlags: new Set([FeatureFlags.NewOnboarding]),
+            });
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.NewOnboarding,
+            });
+
+            expect(result).toEqual({
+                id: FeatureFlags.NewOnboarding,
+                enabled: true,
+            });
+        });
+
+        it('enables commercial flags with commercial handling', async () => {
+            const model = buildCommercialModel({
+                enabledFeatureFlags: new Set([
+                    CommercialFeatureFlags.HomepageBuilder,
+                ]),
+            });
+
+            const result = await model.get({
+                featureFlagId: CommercialFeatureFlags.HomepageBuilder,
+            });
+
+            expect(result).toEqual({
+                id: CommercialFeatureFlags.HomepageBuilder,
+                enabled: true,
+            });
+        });
+
         it('returns enabled for any flag listed in LIGHTDASH_ENABLE_FEATURE_FLAGS', async () => {
             const model = buildModel({
                 enabledFeatureFlags: new Set(['my-custom-flag']),

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -1,4 +1,9 @@
-import { FeatureFlag, FeatureFlags, LightdashUser } from '@lightdash/common';
+import {
+    CommercialFeatureFlags,
+    FeatureFlag,
+    FeatureFlags,
+    LightdashUser,
+} from '@lightdash/common';
 import { Knex } from 'knex';
 import { LightdashConfig } from '../../config/parseConfig';
 import {
@@ -55,6 +60,16 @@ export class FeatureFlagModel {
     ): Promise<FeatureFlag> {
         // 1a. Check env var enable-allowlist (self-hosted escape hatch)
         if (this.lightdashConfig.enabledFeatureFlags.has(args.featureFlagId)) {
+            if (
+                Object.values(CommercialFeatureFlags).includes(
+                    args.featureFlagId as CommercialFeatureFlags,
+                ) && !this.canEnableCommercialFeatureFlagsFromEnv()
+            ) {
+                Logger.warn(
+                    `Ignoring commercial feature flag ${args.featureFlagId} in LIGHTDASH_ENABLE_FEATURE_FLAGS without commercial feature flag handling`,
+                );
+                return { id: args.featureFlagId, enabled: false };
+            }
             return { id: args.featureFlagId, enabled: true };
         }
 
@@ -78,6 +93,10 @@ export class FeatureFlagModel {
         // Unknown flags default to disabled.
         // See: GLITCH-331
         return { id: args.featureFlagId, enabled: false };
+    }
+
+    protected canEnableCommercialFeatureFlagsFromEnv(): boolean {
+        return false;
     }
 
     private async getEditYamlInUiEnabled({

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -63,7 +63,8 @@ export class FeatureFlagModel {
             if (
                 Object.values(CommercialFeatureFlags).includes(
                     args.featureFlagId as CommercialFeatureFlags,
-                ) && !this.canEnableCommercialFeatureFlagsFromEnv()
+                ) &&
+                !this.hasCommercialFeatureFlagHandler(args.featureFlagId)
             ) {
                 Logger.warn(
                     `Ignoring commercial feature flag ${args.featureFlagId} in LIGHTDASH_ENABLE_FEATURE_FLAGS without commercial feature flag handling`,
@@ -95,8 +96,8 @@ export class FeatureFlagModel {
         return { id: args.featureFlagId, enabled: false };
     }
 
-    protected canEnableCommercialFeatureFlagsFromEnv(): boolean {
-        return false;
+    private hasCommercialFeatureFlagHandler(featureFlagId: string): boolean {
+        return this.featureFlagHandlers[featureFlagId] !== undefined;
     }
 
     private async getEditYamlInUiEnabled({


### PR DESCRIPTION
## What

Prevent the base feature-flag model from enabling commercial flags through `LIGHTDASH_ENABLE_FEATURE_FLAGS` when commercial handling is unavailable. The commercial model explicitly preserves the allowlist behavior.

## Why

The environment allowlist was evaluated before commercial handlers, allowing an unlicensed instance to enable commercial-only flags.

## Runtime verification

Unlicensed with `LIGHTDASH_ENABLE_FEATURE_FLAGS=homepage-builder,new-onboarding`:
- `GET /api/v2/feature-flag/homepage-builder` → `{"status":"ok","results":{"id":"homepage-builder","enabled":false}}`
- API warning: `Ignoring commercial feature flag homepage-builder in LIGHTDASH_ENABLE_FEATURE_FLAGS without commercial feature flag handling`
- `GET /api/v2/feature-flag/new-onboarding` → `{"status":"ok","results":{"id":"new-onboarding","enabled":true}}`

Licensed restart:
- `GET /api/v2/feature-flag/homepage-builder` → `{"status":"ok","results":{"id":"homepage-builder","enabled":true}}`

Verified by CI (local checks intentionally skipped).

Linear: SPK-649