### PR TITLE
feat: surface Claude's thoughts in data-app build status again

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -2512,6 +2512,7 @@ export class AppGenerateService extends BaseService {
                 .run(
                     `cat /tmp/prompt.txt | claude ${sessionFlags} ` +
                         `--model ${claudeModel} ${effortFlag}` +
+                        `--thinking-display summarized ` +
                         `--verbose --output-format stream-json --include-partial-messages ` +
                         `--allowedTools "Read(//app/**),Read(//tmp/dbt-repo/**),Read(//tmp/images/**),Read(//tmp/metric-queries/**),Read(//tmp/dashboard/**),Read(//tmp/external-data/**),Write(//app/src/**),Edit(//app/src/**),Glob(//app/**),Glob(//tmp/dbt-repo/**),Glob(//tmp/metric-queries/**),Glob(//tmp/dashboard/**),Glob(//tmp/external-data/**),Grep(//app/**),Grep(//tmp/dbt-repo/**),Grep(//tmp/external-data/**)" ` +
                         `${jsonSchemaFlag}--append-system-prompt-file ${AppGenerateService.EFFECTIVE_SKILL_PATH}`,


### PR DESCRIPTION
Since claude-code 2.1.197, the `sonnet` alias resolves to Sonnet 5, where `thinking.display` defaults to `omitted` — thinking deltas stream with empty text. The build-status pipeline never got a `thinking_snippet`, so the UI sat on "Thinking ..." instead of showing Claude's actual thoughts.

Pass `--thinking-display summarized` (hidden CLI flag, verified on the pinned 2.1.215) to the generation command so summarized thinking streams again and the existing snippet pipeline works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)