### PR TITLE
[duplicate] feat(apps): make build panel collapsible

### DIFF
--- a/packages/frontend/src/features/apps/components/AppBuilderSidebarToggle.test.tsx
+++ b/packages/frontend/src/features/apps/components/AppBuilderSidebarToggle.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import AppBuilderSidebarToggle from './AppBuilderSidebarToggle';
+
+describe('AppBuilderSidebarToggle', () => {
+    it.each([
+        [false, 'Hide build panel'],
+        [true, 'Show build panel'],
+    ])(
+        'exposes the correct action when collapsed is %s',
+        (collapsed, label) => {
+            const onToggle = vi.fn();
+            renderWithProviders(
+                <AppBuilderSidebarToggle
+                    collapsed={collapsed}
+                    onToggle={onToggle}
+                />,
+            );
+
+            fireEvent.click(screen.getByRole('button', { name: label }));
+
+            expect(onToggle).toHaveBeenCalledOnce();
+        },
+    );
+});

--- a/packages/frontend/src/features/apps/components/AppBuilderSidebarToggle.tsx
+++ b/packages/frontend/src/features/apps/components/AppBuilderSidebarToggle.tsx
@@ -1,0 +1,39 @@
+import { ActionIcon, Tooltip } from '@mantine-8/core';
+import {
+    IconLayoutSidebarLeftCollapse,
+    IconLayoutSidebarLeftExpand,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+
+type Props = {
+    collapsed: boolean;
+    onToggle: () => void;
+};
+
+const AppBuilderSidebarToggle: FC<Props> = ({ collapsed, onToggle }) => {
+    const label = collapsed ? 'Show build panel' : 'Hide build panel';
+
+    return (
+        <Tooltip label={label} withArrow position="bottom">
+            <ActionIcon
+                variant="subtle"
+                size="sm"
+                color="ldGray.6"
+                onClick={onToggle}
+                aria-label={label}
+            >
+                <MantineIcon
+                    icon={
+                        collapsed
+                            ? IconLayoutSidebarLeftExpand
+                            : IconLayoutSidebarLeftCollapse
+                    }
+                    size={16}
+                />
+            </ActionIcon>
+        </Tooltip>
+    );
+};
+
+export default AppBuilderSidebarToggle;

--- a/packages/frontend/src/features/apps/components/AppBuilderSidebarToggle.tsx
+++ b/packages/frontend/src/features/apps/components/AppBuilderSidebarToggle.tsx
@@ -15,7 +15,7 @@ const AppBuilderSidebarToggle: FC<Props> = ({ collapsed, onToggle }) => {
     const label = collapsed ? 'Show build panel' : 'Hide build panel';
 
     return (
-        <Tooltip label={label} withArrow position="bottom">
+        <Tooltip label={label} withArrow position="right">
             <ActionIcon
                 variant="subtle"
                 size="sm"

--- a/packages/frontend/src/pages/AppGenerate.module.css
+++ b/packages/frontend/src/pages/AppGenerate.module.css
@@ -20,6 +20,10 @@
     min-width: 300px;
 }
 
+.chatPanelOuter[data-collapsed='true'] {
+    min-width: 0;
+}
+
 /* Compose stage: the chat panel becomes a centered card on the muted
    backdrop, then morphs into the split sidebar (see .chatPanel's
    view-transition-name) on first submit. */

--- a/packages/frontend/src/pages/AppGenerate.module.css
+++ b/packages/frontend/src/pages/AppGenerate.module.css
@@ -20,8 +20,27 @@
     min-width: 300px;
 }
 
+/* Collapsed: the panel becomes a slim rail that keeps the toggle visible in
+   the same top-left spot. Collapse is CSS-only — the panel-group layout is
+   untouched, so expanding restores the exact pre-collapse width. Rail width
+   = sidebarHeader horizontal padding (2 × xs) + the 22px ActionIcon. */
 .chatPanelOuter[data-collapsed='true'] {
-    min-width: 0;
+    min-width: 38px;
+    max-width: 38px;
+}
+
+/* Hide the chat content from view, the tab order, and the a11y tree —
+   only the header row hosting the toggle stays interactive. */
+.chatPanelOuter[data-collapsed='true'] .chatMessages,
+.chatPanelOuter[data-collapsed='true'] .chatInputArea {
+    visibility: hidden;
+}
+
+/* Toggle row pinned to the sidebar's top-left. */
+.sidebarHeader {
+    display: flex;
+    flex: 0 0 auto;
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-xs) 0;
 }
 
 /* Compose stage: the chat panel becomes a centered card on the muted
@@ -375,6 +394,13 @@
             background-color: var(--mantine-color-ldDark-6);
             box-shadow: 0 0 0 1px var(--mantine-color-ldDark-6);
         }
+    }
+
+    /* Disabled while the chat panel is collapsed — keep the 1px divider as
+       the rail's edge but drop the resize affordance. */
+    &[data-panel-resize-handle-enabled='false'] {
+        cursor: default;
+        pointer-events: none;
     }
 }
 

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -56,12 +56,7 @@ import {
     type FC,
 } from 'react';
 import { flushSync } from 'react-dom';
-import {
-    Panel,
-    PanelGroup,
-    PanelResizeHandle,
-    type ImperativePanelHandle,
-} from 'react-resizable-panels';
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import {
     Link,
     Navigate,
@@ -572,14 +567,12 @@ const AppGenerate: FC = () => {
         null,
     );
     const previewRef = useRef<AppIframePreviewHandle>(null);
-    const chatPanelRef = useRef<ImperativePanelHandle>(null);
+    // Collapse is pure UI state driven by CSS (see chatPanelOuter[data-collapsed])
+    // — the panel-group layout is never touched, so expanding restores the
+    // exact pre-collapse width.
     const [isChatPanelCollapsed, setIsChatPanelCollapsed] = useState(false);
     const handleToggleChatPanel = useCallback(() => {
-        if (chatPanelRef.current?.isCollapsed()) {
-            chatPanelRef.current.expand();
-        } else {
-            chatPanelRef.current?.collapse();
-        }
+        setIsChatPanelCollapsed((collapsed) => !collapsed);
     }, []);
     const {
         queries: trackedQueries,
@@ -732,6 +725,7 @@ const AppGenerate: FC = () => {
         setPendingClarification(null);
         setClarificationAnswers([]);
         setTestVizContext(null);
+        setIsChatPanelCollapsed(false);
         versionCacheRef.current.clear();
         versionCacheAppRef.current = undefined;
         sentImagesByPrompt.current.forEach((urls) =>
@@ -2009,14 +2003,9 @@ const AppGenerate: FC = () => {
             >
                 {/* Chat Panel */}
                 <Panel
-                    ref={chatPanelRef}
                     defaultSize={newAppLanding ? 100 : 30}
                     minSize={newAppLanding ? 100 : 22}
                     maxSize={newAppLanding ? 100 : 50}
-                    collapsible={!newAppLanding}
-                    collapsedSize={0}
-                    onCollapse={() => setIsChatPanelCollapsed(true)}
-                    onExpand={() => setIsChatPanelCollapsed(false)}
                     data-collapsed={isChatPanelCollapsed || undefined}
                     className={`${classes.chatPanelOuter}${
                         newAppLanding ? ` ${classes.chatPanelOuterCompose}` : ''
@@ -2027,6 +2016,14 @@ const AppGenerate: FC = () => {
                             newAppLanding ? ` ${classes.chatPanelCompose}` : ''
                         }`}
                     >
+                        {!newAppLanding && (
+                            <Box className={classes.sidebarHeader}>
+                                <AppBuilderSidebarToggle
+                                    collapsed={isChatPanelCollapsed}
+                                    onToggle={handleToggleChatPanel}
+                                />
+                            </Box>
+                        )}
                         {newAppLanding && (
                             <Stack gap="lg" className={classes.composeHeading}>
                                 <Stack gap={6}>
@@ -3072,7 +3069,10 @@ const AppGenerate: FC = () => {
                 </Panel>
 
                 {!newAppLanding && (
-                    <PanelResizeHandle className={classes.resizeHandle} />
+                    <PanelResizeHandle
+                        className={classes.resizeHandle}
+                        disabled={isChatPanelCollapsed}
+                    />
                 )}
 
                 {/* Preview Panel */}
@@ -3111,74 +3111,68 @@ const AppGenerate: FC = () => {
                                         />
                                     }
                                     rightSection={
-                                        <Group gap="xs" wrap="nowrap">
-                                            <AppBuilderSidebarToggle
-                                                collapsed={isChatPanelCollapsed}
-                                                onToggle={handleToggleChatPanel}
-                                            />
-                                            <AppHeaderActions
-                                                projectUuid={projectUuid}
-                                                appUuid={activeAppUuid}
-                                                appName={appName}
-                                                appDescription={
-                                                    appDescription || null
-                                                }
-                                                appSpaceUuid={appSpaceUuid}
-                                                appCreatedByUserUuid={
-                                                    appCreatedByUserUuid
-                                                }
-                                                latestVersionNumber={
-                                                    latestReadyVersion?.version ??
-                                                    null
-                                                }
-                                                latestVersionStatus={
-                                                    latestReadyVersion?.status ??
-                                                    null
-                                                }
-                                                onRefresh={handleRefreshPreview}
-                                                refreshDisabled={!previewApp}
-                                                captureThumbnail={{
-                                                    onCapture: () =>
-                                                        void handleCaptureThumbnail(),
-                                                    disabled:
-                                                        !previewApp ||
-                                                        !screenshotAvailable ||
-                                                        isCapturingScreenshot,
-                                                }}
-                                                capturePreviewScreenshot={
-                                                    screenshotAvailable
-                                                        ? capturePreviewScreenshot
-                                                        : null
-                                                }
-                                                onViewNetwork={() =>
-                                                    setNetworkPanelHidden(false)
-                                                }
-                                                onDeleted={() =>
-                                                    void navigate(
-                                                        `/projects/${projectUuid}/apps/generate`,
-                                                    )
-                                                }
-                                                navItem={
-                                                    previewApp ? (
-                                                        <Menu.Item
-                                                            component={Link}
-                                                            to={`/projects/${projectUuid}/apps/${previewApp.appUuid}/view`}
-                                                            target="_blank"
-                                                            leftSection={
-                                                                <MantineIcon
-                                                                    icon={
-                                                                        IconExternalLink
-                                                                    }
-                                                                    size={14}
-                                                                />
-                                                            }
-                                                        >
-                                                            Preview latest
-                                                        </Menu.Item>
-                                                    ) : null
-                                                }
-                                            />
-                                        </Group>
+                                        <AppHeaderActions
+                                            projectUuid={projectUuid}
+                                            appUuid={activeAppUuid}
+                                            appName={appName}
+                                            appDescription={
+                                                appDescription || null
+                                            }
+                                            appSpaceUuid={appSpaceUuid}
+                                            appCreatedByUserUuid={
+                                                appCreatedByUserUuid
+                                            }
+                                            latestVersionNumber={
+                                                latestReadyVersion?.version ??
+                                                null
+                                            }
+                                            latestVersionStatus={
+                                                latestReadyVersion?.status ??
+                                                null
+                                            }
+                                            onRefresh={handleRefreshPreview}
+                                            refreshDisabled={!previewApp}
+                                            captureThumbnail={{
+                                                onCapture: () =>
+                                                    void handleCaptureThumbnail(),
+                                                disabled:
+                                                    !previewApp ||
+                                                    !screenshotAvailable ||
+                                                    isCapturingScreenshot,
+                                            }}
+                                            capturePreviewScreenshot={
+                                                screenshotAvailable
+                                                    ? capturePreviewScreenshot
+                                                    : null
+                                            }
+                                            onViewNetwork={() =>
+                                                setNetworkPanelHidden(false)
+                                            }
+                                            onDeleted={() =>
+                                                void navigate(
+                                                    `/projects/${projectUuid}/apps/generate`,
+                                                )
+                                            }
+                                            navItem={
+                                                previewApp ? (
+                                                    <Menu.Item
+                                                        component={Link}
+                                                        to={`/projects/${projectUuid}/apps/${previewApp.appUuid}/view`}
+                                                        target="_blank"
+                                                        leftSection={
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconExternalLink
+                                                                }
+                                                                size={14}
+                                                            />
+                                                        }
+                                                    >
+                                                        Preview latest
+                                                    </Menu.Item>
+                                                ) : null
+                                            }
+                                        />
                                     }
                                 />
                             )}

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -56,7 +56,12 @@ import {
     type FC,
 } from 'react';
 import { flushSync } from 'react-dom';
-import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
+import {
+    Panel,
+    PanelGroup,
+    PanelResizeHandle,
+    type ImperativePanelHandle,
+} from 'react-resizable-panels';
 import {
     Link,
     Navigate,
@@ -94,6 +99,7 @@ import {
 import AppTemplatePicker from '../features/apps/AppTemplatePicker';
 import ChatBubbleMeta from '../features/apps/ChatBubbleMeta';
 import ChatMessageContent from '../features/apps/ChatMessageContent';
+import AppBuilderSidebarToggle from '../features/apps/components/AppBuilderSidebarToggle';
 import AppHeader from '../features/apps/components/AppHeader';
 import AppHeaderActions from '../features/apps/components/AppHeaderActions';
 import AppSpaceChip from '../features/apps/components/AppSpaceChip';
@@ -566,6 +572,15 @@ const AppGenerate: FC = () => {
         null,
     );
     const previewRef = useRef<AppIframePreviewHandle>(null);
+    const chatPanelRef = useRef<ImperativePanelHandle>(null);
+    const [isChatPanelCollapsed, setIsChatPanelCollapsed] = useState(false);
+    const handleToggleChatPanel = useCallback(() => {
+        if (chatPanelRef.current?.isCollapsed()) {
+            chatPanelRef.current.expand();
+        } else {
+            chatPanelRef.current?.collapse();
+        }
+    }, []);
     const {
         queries: trackedQueries,
         persistLogs,
@@ -1994,9 +2009,15 @@ const AppGenerate: FC = () => {
             >
                 {/* Chat Panel */}
                 <Panel
+                    ref={chatPanelRef}
                     defaultSize={newAppLanding ? 100 : 30}
                     minSize={newAppLanding ? 100 : 22}
                     maxSize={newAppLanding ? 100 : 50}
+                    collapsible={!newAppLanding}
+                    collapsedSize={0}
+                    onCollapse={() => setIsChatPanelCollapsed(true)}
+                    onExpand={() => setIsChatPanelCollapsed(false)}
+                    data-collapsed={isChatPanelCollapsed || undefined}
                     className={`${classes.chatPanelOuter}${
                         newAppLanding ? ` ${classes.chatPanelOuterCompose}` : ''
                     }`}
@@ -3090,68 +3111,74 @@ const AppGenerate: FC = () => {
                                         />
                                     }
                                     rightSection={
-                                        <AppHeaderActions
-                                            projectUuid={projectUuid}
-                                            appUuid={activeAppUuid}
-                                            appName={appName}
-                                            appDescription={
-                                                appDescription || null
-                                            }
-                                            appSpaceUuid={appSpaceUuid}
-                                            appCreatedByUserUuid={
-                                                appCreatedByUserUuid
-                                            }
-                                            latestVersionNumber={
-                                                latestReadyVersion?.version ??
-                                                null
-                                            }
-                                            latestVersionStatus={
-                                                latestReadyVersion?.status ??
-                                                null
-                                            }
-                                            onRefresh={handleRefreshPreview}
-                                            refreshDisabled={!previewApp}
-                                            captureThumbnail={{
-                                                onCapture: () =>
-                                                    void handleCaptureThumbnail(),
-                                                disabled:
-                                                    !previewApp ||
-                                                    !screenshotAvailable ||
-                                                    isCapturingScreenshot,
-                                            }}
-                                            capturePreviewScreenshot={
-                                                screenshotAvailable
-                                                    ? capturePreviewScreenshot
-                                                    : null
-                                            }
-                                            onViewNetwork={() =>
-                                                setNetworkPanelHidden(false)
-                                            }
-                                            onDeleted={() =>
-                                                void navigate(
-                                                    `/projects/${projectUuid}/apps/generate`,
-                                                )
-                                            }
-                                            navItem={
-                                                previewApp ? (
-                                                    <Menu.Item
-                                                        component={Link}
-                                                        to={`/projects/${projectUuid}/apps/${previewApp.appUuid}/view`}
-                                                        target="_blank"
-                                                        leftSection={
-                                                            <MantineIcon
-                                                                icon={
-                                                                    IconExternalLink
-                                                                }
-                                                                size={14}
-                                                            />
-                                                        }
-                                                    >
-                                                        Preview latest
-                                                    </Menu.Item>
-                                                ) : null
-                                            }
-                                        />
+                                        <Group gap="xs" wrap="nowrap">
+                                            <AppBuilderSidebarToggle
+                                                collapsed={isChatPanelCollapsed}
+                                                onToggle={handleToggleChatPanel}
+                                            />
+                                            <AppHeaderActions
+                                                projectUuid={projectUuid}
+                                                appUuid={activeAppUuid}
+                                                appName={appName}
+                                                appDescription={
+                                                    appDescription || null
+                                                }
+                                                appSpaceUuid={appSpaceUuid}
+                                                appCreatedByUserUuid={
+                                                    appCreatedByUserUuid
+                                                }
+                                                latestVersionNumber={
+                                                    latestReadyVersion?.version ??
+                                                    null
+                                                }
+                                                latestVersionStatus={
+                                                    latestReadyVersion?.status ??
+                                                    null
+                                                }
+                                                onRefresh={handleRefreshPreview}
+                                                refreshDisabled={!previewApp}
+                                                captureThumbnail={{
+                                                    onCapture: () =>
+                                                        void handleCaptureThumbnail(),
+                                                    disabled:
+                                                        !previewApp ||
+                                                        !screenshotAvailable ||
+                                                        isCapturingScreenshot,
+                                                }}
+                                                capturePreviewScreenshot={
+                                                    screenshotAvailable
+                                                        ? capturePreviewScreenshot
+                                                        : null
+                                                }
+                                                onViewNetwork={() =>
+                                                    setNetworkPanelHidden(false)
+                                                }
+                                                onDeleted={() =>
+                                                    void navigate(
+                                                        `/projects/${projectUuid}/apps/generate`,
+                                                    )
+                                                }
+                                                navItem={
+                                                    previewApp ? (
+                                                        <Menu.Item
+                                                            component={Link}
+                                                            to={`/projects/${projectUuid}/apps/${previewApp.appUuid}/view`}
+                                                            target="_blank"
+                                                            leftSection={
+                                                                <MantineIcon
+                                                                    icon={
+                                                                        IconExternalLink
+                                                                    }
+                                                                    size={14}
+                                                                />
+                                                            }
+                                                        >
+                                                            Preview latest
+                                                        </Menu.Item>
+                                                    ) : null
+                                                }
+                                            />
+                                        </Group>
                                     }
                                 />
                             )}


### PR DESCRIPTION
Mirror of #25958 (external contribution by @ricardophantom), pushed to a same-repo branch so CI runs. The diff is identical to the original PR — merging this branch will mark the original PR as merged automatically, since it contains the same commit.

### Description

Adds an accessible control to hide and restore the Data Apps build panel from the app header. The panel collapses to zero width, preserves the existing resize behavior, and remains full-width on the new-app composer.

### Validation

- Focused component test for both accessible labels and the toggle callback
- Frontend lint, formatting, and fast typecheck

Closes: GLITCH-631
Closes: #25957
