### PR TITLE
fix: gate fixed OTP passcode behind ALLOW_FIXED_OTP_PASSCODE opt-in flag

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -79,6 +79,7 @@ module.exports = {
             env: {
                 ...envWithPath,
                 LIGHTDASH_MODE: 'development',
+                ALLOW_FIXED_OTP_PASSCODE: 'true',
                 HEADLESS: 'true',
                 NODE_ENV: 'development',
                 SENTRY_SPOTLIGHT: `http://localhost:${spotlightPort}/stream`,

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -204,6 +204,7 @@ export const lightdashConfigMock: LightdashConfig = {
     helpMenuUrl: undefined,
     trustProxy: false,
     mode: LightdashMode.DEFAULT,
+    allowFixedOtpPasscode: false,
     license: {
         licenseKey: null,
     },

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -1011,6 +1011,32 @@ describe('process.env.LIGHTDASH_CORS_ENABLED', () => {
     });
 });
 
+describe('process.env.ALLOW_FIXED_OTP_PASSCODE', () => {
+    test('defaults to false when not set', () => {
+        const config = parseConfig();
+        expect(config.allowFixedOtpPasscode).toBe(false);
+    });
+
+    test('is false in default mode even when the flag is set', () => {
+        process.env.ALLOW_FIXED_OTP_PASSCODE = 'true';
+        const config = parseConfig();
+        expect(config.allowFixedOtpPasscode).toBe(false);
+    });
+
+    test('is true in development mode when the flag is set', () => {
+        process.env.LIGHTDASH_MODE = 'development';
+        process.env.ALLOW_FIXED_OTP_PASSCODE = 'true';
+        const config = parseConfig();
+        expect(config.allowFixedOtpPasscode).toBe(true);
+    });
+
+    test('is false in development mode without the flag', () => {
+        process.env.LIGHTDASH_MODE = 'development';
+        const config = parseConfig();
+        expect(config.allowFixedOtpPasscode).toBe(false);
+    });
+});
+
 describe('parseAndSanitizeSchedulerTasks', () => {
     beforeEach(() => {
         // Clear scheduler environment variables before each test

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1323,6 +1323,7 @@ export type LightdashConfig = {
     postmark: PostmarkConfig;
     rudder: RudderConfig;
     mode: LightdashMode;
+    allowFixedOtpPasscode: boolean;
     license: {
         licenseKey: string | null;
     };
@@ -2375,6 +2376,17 @@ export const parseConfig = (): LightdashConfig => {
 
     const mode = lightdashMode || LightdashMode.DEFAULT;
 
+    // Fixed OTP passcodes are a convenience for local/preview instances and
+    // must be explicitly opted into; they are never enabled in default mode.
+    const allowFixedOtpPasscode =
+        (mode === LightdashMode.DEV || mode === LightdashMode.PR) &&
+        process.env.ALLOW_FIXED_OTP_PASSCODE === 'true';
+    if (allowFixedOtpPasscode) {
+        console.warn(
+            'WARNING: ALLOW_FIXED_OTP_PASSCODE is enabled — one-time passcodes are fixed to 000000. Only enable this on instances that are not publicly reachable.',
+        );
+    }
+
     const siteUrl = process.env.SITE_URL || 'http://localhost:8080';
     if (
         process.env.NODE_ENV !== 'development' &&
@@ -2480,6 +2492,7 @@ export const parseConfig = (): LightdashConfig => {
 
     return {
         mode,
+        allowFixedOtpPasscode,
         cookieSameSite: iframeEmbeddingEnabled ? 'none' : 'lax',
         license: {
             licenseKey,

--- a/packages/backend/src/services/OrganizationDomainVerificationService/OrganizationDomainVerificationService.ts
+++ b/packages/backend/src/services/OrganizationDomainVerificationService/OrganizationDomainVerificationService.ts
@@ -216,7 +216,9 @@ export class OrganizationDomainVerificationService extends BaseService {
             }
         }
 
-        const passcode = generateOneTimePasscode(this.lightdashConfig.mode);
+        const passcode = generateOneTimePasscode(
+            this.lightdashConfig.allowFixedOtpPasscode,
+        );
         const { createdAt, numberOfAttempts } =
             await this.organizationDomainVerificationModel.upsertChallenge({
                 organizationUuid,

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -2079,11 +2079,9 @@ export class UserService extends BaseService {
             currentEmailStatus.otp &&
             !this.isOtpExpired(currentEmailStatus.otp.createdAt),
         );
-        const passcode =
-            this.lightdashConfig.mode === LightdashMode.PR ||
-            this.lightdashConfig.mode === LightdashMode.DEV
-                ? '000000'
-                : randomInt(999999).toString().padStart(6, '0');
+        const passcode = this.lightdashConfig.allowFixedOtpPasscode
+            ? '000000'
+            : randomInt(999999).toString().padStart(6, '0');
         const emailStatus = await this.emailModel.createPrimaryEmailOtp({
             passcode,
             userUuid: user.userUuid,

--- a/packages/backend/src/utils/oneTimePasscode.test.ts
+++ b/packages/backend/src/utils/oneTimePasscode.test.ts
@@ -1,4 +1,3 @@
-import { LightdashMode } from '@lightdash/common';
 import {
     EMAIL_ONE_TIME_PASSCODE_EXPIRY_SECONDS,
     EMAIL_ONE_TIME_PASSCODE_MAX_ATTEMPTS,
@@ -12,13 +11,12 @@ import {
 
 describe('oneTimePasscode', () => {
     describe('generateOneTimePasscode', () => {
-        it('returns 000000 in DEV and PR modes', () => {
-            expect(generateOneTimePasscode(LightdashMode.DEV)).toBe('000000');
-            expect(generateOneTimePasscode(LightdashMode.PR)).toBe('000000');
+        it('returns 000000 when the fixed passcode is enabled', () => {
+            expect(generateOneTimePasscode(true)).toBe('000000');
         });
 
         it('returns a zero-padded 6-digit code otherwise', () => {
-            const code = generateOneTimePasscode(LightdashMode.DEFAULT);
+            const code = generateOneTimePasscode(false);
             expect(code).toMatch(/^\d{6}$/);
         });
     });

--- a/packages/backend/src/utils/oneTimePasscode.ts
+++ b/packages/backend/src/utils/oneTimePasscode.ts
@@ -1,4 +1,3 @@
-import { LightdashMode } from '@lightdash/common';
 import { randomInt } from 'crypto';
 
 /**
@@ -17,11 +16,12 @@ export const EMAIL_ONE_TIME_PASSCODE_MAX_ATTEMPTS = 5;
 export const EMAIL_ONE_TIME_PASSCODE_RESEND_COOLDOWN_SECONDS = 30;
 
 /**
- * Generates a 6-digit passcode. In DEV/PR mode it is always `000000` so local
- * and preview environments can verify without a real inbox.
+ * Generates a 6-digit passcode. When `allowFixedPasscode` is set (instances
+ * that explicitly opt in via ALLOW_FIXED_OTP_PASSCODE) it is always `000000`
+ * so local environments can verify without a real inbox.
  */
-export const generateOneTimePasscode = (mode: LightdashMode): string =>
-    mode === LightdashMode.PR || mode === LightdashMode.DEV
+export const generateOneTimePasscode = (allowFixedPasscode: boolean): string =>
+    allowFixedPasscode
         ? '000000'
         : randomInt(999999).toString().padStart(6, '0');
 


### PR DESCRIPTION
Fixed one-time passcodes in development/preview mode now require explicit opt-in via ALLOW_FIXED_OTP_PASSCODE=true, with a startup warning when enabled; local PM2 dev opts in through ecosystem.config.js.

Linear: SPK-580