### PR TITLE
fix: allow all commercial env flags in EE

### DIFF
--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -19,6 +19,15 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
         };
     }
 
+    protected hasCommercialFeatureFlagHandler(featureFlagId: string): boolean {
+        return (
+            this.featureFlagHandlers !== undefined &&
+            Object.values(CommercialFeatureFlags).includes(
+                featureFlagId as CommercialFeatureFlags,
+            )
+        );
+    }
+
     // Default-off; enabled per-org via DB-backed overrides.
     private async getHomepageBuilderFlag({
         featureFlagId,

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -154,6 +154,47 @@ describe('FeatureFlagModel', () => {
             });
         });
 
+        it('enables commercial flags without a specific handler in commercial model', async () => {
+            const model = buildCommercialModel({
+                enabledFeatureFlags: new Set([
+                    CommercialFeatureFlags.Embedding,
+                ]),
+            });
+
+            const result = await model.get({
+                featureFlagId: CommercialFeatureFlags.Embedding,
+            });
+
+            expect(result).toEqual({
+                id: CommercialFeatureFlags.Embedding,
+                enabled: true,
+            });
+        });
+
+        it('refuses commercial flags without commercial handling in base model', async () => {
+            const warnSpy = vi
+                .spyOn(Logger, 'warn')
+                .mockImplementation(() => Logger);
+            const model = buildModel({
+                enabledFeatureFlags: new Set([
+                    CommercialFeatureFlags.Embedding,
+                ]),
+            });
+
+            const result = await model.get({
+                featureFlagId: CommercialFeatureFlags.Embedding,
+            });
+
+            expect(result).toEqual({
+                id: CommercialFeatureFlags.Embedding,
+                enabled: false,
+            });
+            expect(warnSpy).toHaveBeenCalledWith(
+                `Ignoring commercial feature flag ${CommercialFeatureFlags.Embedding} in LIGHTDASH_ENABLE_FEATURE_FLAGS without commercial feature flag handling`,
+            );
+            warnSpy.mockRestore();
+        });
+
         it('returns enabled for any flag listed in LIGHTDASH_ENABLE_FEATURE_FLAGS', async () => {
             const model = buildModel({
                 enabledFeatureFlags: new Set(['my-custom-flag']),

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -96,7 +96,7 @@ export class FeatureFlagModel {
         return { id: args.featureFlagId, enabled: false };
     }
 
-    private hasCommercialFeatureFlagHandler(featureFlagId: string): boolean {
+    protected hasCommercialFeatureFlagHandler(featureFlagId: string): boolean {
         return this.featureFlagHandlers[featureFlagId] !== undefined;
     }
 


### PR DESCRIPTION
## What changed

Allow licensed commercial builds to enable every value in `CommercialFeatureFlags` through `LIGHTDASH_ENABLE_FEATURE_FLAGS`, including values without dedicated model handlers. Base builds retain the refusal and warning behavior.

## Why

The previous handler-presence guard incorrectly refused `embedding` and `custom-roles` on licensed self-hosted builds.

## Runtime verification

Licensed with `LIGHTDASH_ENABLE_FEATURE_FLAGS=embedding,custom-roles,homepage-builder`:
- `GET /api/v2/feature-flag/embedding` → `{"status":"ok","results":{"id":"embedding","enabled":true}}`
- `GET /api/v2/feature-flag/custom-roles` → `{"status":"ok","results":{"id":"custom-roles","enabled":true}}`
- `GET /api/v2/feature-flag/homepage-builder` → `{"status":"ok","results":{"id":"homepage-builder","enabled":true}}`

Unlicensed restart with the license key explicitly empty:
- `embedding` → `{"status":"ok","results":{"id":"embedding","enabled":false}}`
- `custom-roles` → `{"status":"ok","results":{"id":"custom-roles","enabled":false}}`
- `homepage-builder` → `{"status":"ok","results":{"id":"homepage-builder","enabled":false}}`
- API warnings named each ignored flag: `embedding`, `custom-roles`, and `homepage-builder`.

Verified by CI (local checks intentionally skipped).

Linear: SPK-649