### PR TITLE
feat(ai): fall back to createContent for unsupported chart types

### DIFF
--- a/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
@@ -428,6 +428,50 @@ describe('getSystemPromptV2 change-validation policy', () => {
     });
 });
 
+describe('getSystemPromptV2 chart types limitation', () => {
+    test('states other chart types are not supported when content tools are off', () => {
+        const content = promptText({
+            availableExplores: [],
+            enableContentTools: false,
+        });
+        expect(content).toContain(
+            'Available chart types: bar, horizontal bar, line, area, scatter, pie, funnel, table. Other chart types are not supported.',
+        );
+        expect(content).not.toContain('## Content tools');
+    });
+
+    test('offers a createContent fallback for unsupported chart types when content tools are on', () => {
+        const content = promptText({
+            availableExplores: [],
+            enableDataAccess: true,
+            enableContentTools: true,
+        });
+        // The hard "not supported" statement is replaced by a fallback.
+        expect(content).not.toContain('Other chart types are not supported.');
+        expect(content).toContain(
+            'build it as a saved chart with createContent',
+        );
+        // Content tools section spells out the fallback + sidebar link.
+        expect(content).toContain('## Content tools');
+        expect(content).toContain('Fallback for unsupported visualizations');
+        expect(content).toContain('open and iterate on it in the sidebar');
+        expect(content).toContain('you do not need a dashboard');
+    });
+
+    test('leaves no unfilled chart_types_limitation placeholder', () => {
+        expect(
+            promptText({ availableExplores: [], enableContentTools: false }),
+        ).not.toContain('{{chart_types_limitation}}');
+        expect(
+            promptText({
+                availableExplores: [],
+                enableDataAccess: true,
+                enableContentTools: true,
+            }),
+        ).not.toContain('{{chart_types_limitation}}');
+    });
+});
+
 describe('getSystemPromptV2 repo-fs code search caveat', () => {
     const repoFsArgs = {
         availableExplores: [],

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.ts
@@ -94,6 +94,14 @@ export const getSystemPromptV2 = (args: {
         ? ''
         : '\n- You cannot execute raw SQL or add custom SQL expressions to a query.';
 
+    // generateVisualization only renders a fixed set of chart types. When the
+    // content tools are available, the agent can fall back to createContent to
+    // build any other chart type as a saved chart, so the limitation is softened
+    // into a fallback instruction rather than a hard "not supported".
+    const chartTypesLimitation = enableContentTools
+        ? '- generateVisualization renders these chart types: bar, horizontal bar, line, area, scatter, pie, funnel, table. If the user asks for a chart type or advanced visualization feature outside this list (e.g. big number, gauge, map, sankey, treemap, or a fully custom visualization), do not refuse or approximate it with an ASCII/markdown chart — build it as a saved chart with createContent instead (see Content tools).'
+        : '- Available chart types: bar, horizontal bar, line, area, scatter, pie, funnel, table. Other chart types are not supported.';
+
     const renderKnowledgeDocument = (doc: AiAgentDocumentContext): string => {
         const { summary } = doc;
         const children: string[] = [
@@ -215,6 +223,7 @@ export const getSystemPromptV2 = (args: {
         )
         .replace('{{cross_explore_join_rule}}', crossExploreJoinRule)
         .replace('{{custom_sql_limitation}}', customSqlLimitation)
+        .replace('{{chart_types_limitation}}', chartTypesLimitation)
         .replace('{{agent_name}}', agentName)
         .replace(
             '{{instructions}}',

--- a/packages/backend/src/ee/services/ai/prompts/systemV2ContentTools.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2ContentTools.ts
@@ -1,7 +1,8 @@
 export const CONTENT_TOOLS_SECTION = `
 ## Content tools
 
-- Use generateVisualization when the user's intent is to answer a data question or produce an ad hoc chart.
+- Use generateVisualization when the user's intent is to answer a data question or produce an ad hoc chart with one of its supported types (bar, horizontal bar, line, area, scatter, pie, funnel, table).
+- Fallback for unsupported visualizations: if the user asks for a chart type or advanced visualization feature that generateVisualization does not support (e.g. big number, gauge, map, sankey, treemap, or a fully custom visualization), do not refuse or fake it with an ASCII/markdown chart. Build it as a saved chart with createContent, using runContentQuery to verify the query first, then share the returned chart link so the user can open and iterate on it in the sidebar. This works for a standalone chart — you do not need a dashboard.
 - When the user's intent is to create or edit saved Lightdash content, use the content tools:
   - listContent, readContent, createContent, editContent, and runContentQuery.
   - Follow the developing-in-lightdash skill for chart and dashboard guidance.

--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -130,7 +130,7 @@ See the CRITICAL section at the top of this prompt: reasoning is user-visible. D
 ## Limitations
 
 - You cannot create custom dimensions or modify the underlying SQL of an explore.{{custom_sql_limitation}}
-- Available chart types: bar, horizontal bar, line, area, scatter, pie, funnel, table. Other chart types are not supported.
+{{chart_types_limitation}}
 - You cannot forecast, predict, or project future values. This includes "simple" extrapolations like averaging past periods and presenting the result as a future estimate — **do not do this even with a disclaimer.** When the user asks for a forecast / prediction / projection / "what's next month going to be":
   1. State up front that you cannot produce a forecast.
   2. Then offer historical analysis only (trends, period-over-period change, growth rates). Label these explicitly as historical. Do not use the words "forecast", "projection", "predicted", or "estimate for next" anywhere in the response. Do not produce future-dated rows or future-period numbers.


### PR DESCRIPTION
## Problem

When a user asks the AI agent for a chart type or advanced visualization feature that `generateVisualization` can't render (big number, gauge, map, sankey, treemap, custom viz), the agent either refuses or fakes an ASCII/markdown chart. But `createContent` (chart-as-code) can build all of these — it just was never used as a fallback.

## Approach (v0, prompt-only)

Steer the agent to fall back to `createContent` / `runContentQuery` for unsupported visualizations, then share the returned chart link that opens in the chat sidebar. The guidance only appears when content tools are available (Editor+ with data access), so it respects existing permission gates and keeps the role-based positioning: the more advanced your role, the more the agent can do.

- `systemV2ContentTools.ts` — new "Fallback for unsupported visualizations" bullet: build the chart with `createContent`, verify with `runContentQuery`, share the link (works for a standalone chart, no dashboard needed).
- `systemV2Template.ts` / `systemV2.ts` — the hard "other chart types are not supported" limitation is now conditional. Without content tools it stays as-is; with content tools it becomes a fallback instruction instead.

## Tests

Added cases in `systemV2.test.ts` covering both variants (hard limitation vs. fallback) and no unfilled placeholder.
