### PR TITLE
fix: make preview content exports portable

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -235,11 +235,15 @@ const createSavedChartVersion = async (
                 dimensions.includes(key),
             ),
         );
+        const storedDimensionOverrides =
+            Object.keys(validDimensionOverrides).length > 0
+                ? validDimensionOverrides
+                : null;
         const [version] = await trx('saved_queries_versions')
             .insert({
                 row_limit: limit,
                 metric_overrides: validMetricOverrides || null,
-                dimension_overrides: validDimensionOverrides || null,
+                dimension_overrides: storedDimensionOverrides,
                 filters: JSON.stringify(filters),
                 explore_name: tableName,
                 saved_query_id: savedChartId,

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -174,6 +174,63 @@ describe('CoderService', () => {
                 }),
             );
         });
+
+        it('omits project-local metric UUIDs and empty dimension overrides', () => {
+            const result = (
+                CoderService as unknown as {
+                    transformChart: (...args: AnyType[]) => AnyType;
+                }
+            ).transformChart(
+                {
+                    chartConfig: { type: ChartType.TABLE, config: {} },
+                    dashboardUuid: null,
+                    description: null,
+                    metricQuery: {
+                        additionalMetrics: [
+                            {
+                                name: 'custom_total',
+                                table: 'orders',
+                                type: 'sum',
+                                sql: '${TABLE}.amount',
+                                uuid: 'project-local-metric-uuid',
+                            },
+                        ],
+                        dimensionOverrides: {},
+                        dimensions: [],
+                        exploreName: 'orders',
+                        filters: {},
+                        limit: 500,
+                        metrics: ['orders_custom_total'],
+                        sorts: [],
+                        tableCalculations: [],
+                    },
+                    name: 'Portable chart',
+                    slug: 'portable-chart',
+                    spaceUuid: 'space-uuid',
+                    tableName: 'orders',
+                    uuid: 'chart-uuid',
+                },
+                [
+                    {
+                        name: 'Space',
+                        path: 'space',
+                        uuid: 'space-uuid',
+                    },
+                ],
+                {},
+                new Map(),
+            );
+
+            expect(result.metricQuery.additionalMetrics).toEqual([
+                {
+                    name: 'custom_total',
+                    table: 'orders',
+                    type: 'sum',
+                    sql: '${TABLE}.amount',
+                },
+            ]);
+            expect(result.metricQuery.dimensionOverrides).toBeUndefined();
+        });
     });
 
     describe('getChartSlugForTileUuid', () => {
@@ -734,6 +791,52 @@ describe('CoderService', () => {
             expect(result[0].uuid).toEqual(expect.any(String));
             expect(result[1].uuid).toEqual(expect.any(String));
         });
+
+        it('resolves portable tab slugs and still accepts legacy tab UUIDs', async () => {
+            const service = new CoderService({
+                analytics: {} as AnyType,
+                contentVerificationModel: {} as AnyType,
+                dashboardModel: {} as AnyType,
+                lightdashConfig: {} as AnyType,
+                projectModel: {} as AnyType,
+                promoteService: {} as AnyType,
+                savedChartModel: { find: vi.fn() } as AnyType,
+                savedSqlModel: { find: vi.fn() } as AnyType,
+                schedulerModel: {} as AnyType,
+                schedulerService: {} as AnyType,
+                savedChartService: {} as AnyType,
+                dashboardService: {} as AnyType,
+                schedulerClient: {} as AnyType,
+                spaceModel: {} as AnyType,
+                spacePermissionService: {} as AnyType,
+                groupsModel: {} as AnyType,
+                organizationMemberProfileModel: {} as AnyType,
+                userModel: {} as AnyType,
+            });
+
+            const result = await service.convertTileWithSlugsToUuids(
+                'project-uuid',
+                [
+                    {
+                        type: DashboardTileTypes.MARKDOWN,
+                        tabSlug: 'overview',
+                        properties: { title: 'Slug tile', content: '' },
+                    },
+                    {
+                        type: DashboardTileTypes.MARKDOWN,
+                        tabUuid: 'legacy-tab-uuid',
+                        properties: { title: 'Legacy tile', content: '' },
+                    },
+                ] as AnyType,
+                new Map([['overview', 'target-project-tab-uuid']]),
+            );
+
+            expect(result).toMatchObject([
+                { tabUuid: 'target-project-tab-uuid' },
+                { tabUuid: 'legacy-tab-uuid' },
+            ]);
+            expect(result[0]).not.toHaveProperty('tabSlug');
+        });
     });
 
     describe('transformDashboard', () => {
@@ -749,6 +852,98 @@ describe('CoderService', () => {
                     new Map(),
                 ),
             ).toThrow('Space space-uuid not found');
+        });
+
+        it('exports tabs and tile references as portable slugs', () => {
+            const result = (
+                CoderService as unknown as {
+                    transformDashboard: (...args: AnyType[]) => AnyType;
+                }
+            ).transformDashboard(
+                {
+                    description: null,
+                    filters: {
+                        dimensions: [],
+                        metrics: [],
+                        tableCalculations: [],
+                    },
+                    name: 'Dashboard',
+                    slug: 'dashboard',
+                    spaceUuid: 'space-uuid',
+                    tabs: [
+                        {
+                            uuid: 'source-project-tab-uuid',
+                            name: 'Overview',
+                            order: 0,
+                            hidden: false,
+                        },
+                    ],
+                    tiles: [
+                        {
+                            uuid: 'tile-uuid',
+                            type: DashboardTileTypes.MARKDOWN,
+                            x: 0,
+                            y: 0,
+                            h: 2,
+                            w: 4,
+                            tabUuid: 'source-project-tab-uuid',
+                            properties: { title: 'Tile', content: '' },
+                        },
+                    ],
+                    uuid: 'dashboard-uuid',
+                },
+                [
+                    {
+                        name: 'Space',
+                        path: 'space',
+                        uuid: 'space-uuid',
+                    },
+                ],
+                new Map(),
+            );
+
+            expect(result.tabs).toEqual([
+                {
+                    slug: 'overview',
+                    name: 'Overview',
+                    order: 0,
+                    hidden: false,
+                },
+            ]);
+            expect(result.tiles[0]).toMatchObject({
+                tabSlug: 'overview',
+            });
+            expect(result.tiles[0].tabUuid).toBeUndefined();
+        });
+
+        it('reuses target-project tab UUIDs for portable slugs', () => {
+            const result = (
+                CoderService as unknown as {
+                    convertTabsWithSlugsToUuids: (
+                        ...args: AnyType[]
+                    ) => AnyType;
+                }
+            ).convertTabsWithSlugsToUuids(
+                [{ slug: 'overview', name: 'Overview', order: 0 }],
+                [
+                    {
+                        uuid: 'target-project-tab-uuid',
+                        name: 'Overview',
+                        order: 0,
+                    },
+                ],
+            );
+
+            expect(result.tabs).toEqual([
+                {
+                    uuid: 'target-project-tab-uuid',
+                    name: 'Overview',
+                    order: 0,
+                },
+            ]);
+            expect(result.tabUuidsBySlug.get('overview')).toBe(
+                'target-project-tab-uuid',
+            );
         });
     });
 });

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -1395,12 +1395,25 @@ export class CoderService extends BaseService {
 
         const spaceSlug = getContentAsCodePathFromLtreePath(contentSpace.path);
 
+        const additionalMetrics = chart.metricQuery.additionalMetrics?.map(
+            ({ uuid: _uuid, ...metric }) => metric,
+        );
+        const dimensionOverrides =
+            chart.metricQuery.dimensionOverrides &&
+            Object.keys(chart.metricQuery.dimensionOverrides).length > 0
+                ? chart.metricQuery.dimensionOverrides
+                : undefined;
+
         return {
             name: chart.name,
             description: chart.description,
             tableName: chart.tableName,
             updatedAt: chart.updatedAt,
-            metricQuery: chart.metricQuery,
+            metricQuery: {
+                ...chart.metricQuery,
+                additionalMetrics,
+                dimensionOverrides,
+            },
             chartConfig: chart.chartConfig,
             pivotConfig: chart.pivotConfig,
             dashboardSlug: chart.dashboardUuid
@@ -1478,15 +1491,27 @@ export class CoderService extends BaseService {
         }
 
         const spaceSlug = getContentAsCodePathFromLtreePath(contentSpace.path);
+        const sortedTabs = [...dashboard.tabs].sort(
+            (left, right) => left.order - right.order,
+        );
+        const dashboardWithSortedTabs = {
+            ...dashboard,
+            tabs: sortedTabs,
+        };
 
         const tilesWithoutUuids: DashboardTileAsCode[] = dashboard.tiles.map(
             (tile): DashboardTileAsCode => {
+                const tabSlug = tile.tabUuid
+                    ? getDashboardTabSlug(dashboardWithSortedTabs, tile.tabUuid)
+                    : null;
                 if (isAnyChartTile(tile)) {
                     if (tile.type === DashboardTileTypes.SAVED_CHART) {
                         const chartTile: DashboardChartTileAsCode = {
                             ...tile,
                             type: DashboardTileTypes.SAVED_CHART,
                             uuid: undefined,
+                            tabUuid: undefined,
+                            tabSlug,
                             tileSlug: CoderService.getChartSlugForTileUuid(
                                 dashboard,
                                 tile.uuid,
@@ -1506,6 +1531,8 @@ export class CoderService extends BaseService {
                         ...tile,
                         type: DashboardTileTypes.SQL_CHART,
                         uuid: undefined,
+                        tabUuid: undefined,
+                        tabSlug,
                         tileSlug: CoderService.getChartSlugForTileUuid(
                             dashboard,
                             tile.uuid,
@@ -1525,6 +1552,8 @@ export class CoderService extends BaseService {
                         ...tile,
                         type: DashboardTileTypes.MARKDOWN,
                         uuid: undefined,
+                        tabUuid: undefined,
+                        tabSlug,
                         tileSlug: undefined,
                         properties: {
                             title: tile.properties.title,
@@ -1540,9 +1569,22 @@ export class CoderService extends BaseService {
                     ...tile,
                     tileSlug: undefined,
                     uuid: undefined,
+                    tabUuid: undefined,
+                    tabSlug,
                 };
             },
             [],
+        );
+        tilesWithoutUuids.sort(
+            (left, right) =>
+                left.y - right.y ||
+                left.x - right.x ||
+                (left.tabSlug ?? '').localeCompare(right.tabSlug ?? '') ||
+                (left.tileSlug ?? '').localeCompare(right.tileSlug ?? '') ||
+                left.type.localeCompare(right.type) ||
+                JSON.stringify(left.properties).localeCompare(
+                    JSON.stringify(right.properties),
+                ),
         );
 
         const dashboardAsCode: DashboardAsCode = {
@@ -1552,7 +1594,12 @@ export class CoderService extends BaseService {
             tiles: tilesWithoutUuids,
 
             filters: CoderService.getFiltersWithTileSlugs(dashboard),
-            tabs: dashboard.tabs,
+            tabs: sortedTabs.map(({ uuid, name, order, hidden }) => ({
+                slug: getDashboardTabSlug(dashboardWithSortedTabs, uuid),
+                name,
+                order,
+                hidden,
+            })),
             slug: dashboard.slug,
             ...(dashboard.config
                 ? {
@@ -1576,9 +1623,54 @@ export class CoderService extends BaseService {
         return dashboardAsCode;
     }
 
+    private static convertTabsWithSlugsToUuids(
+        tabs: DashboardAsCode['tabs'],
+        existingTabs: DashboardDAO['tabs'] = [],
+    ): {
+        tabs: DashboardDAO['tabs'];
+        tabUuidsBySlug: Map<string, string>;
+    } {
+        const sortedExistingTabs = [...existingTabs].sort(
+            (left, right) => left.order - right.order,
+        );
+        const existingDashboard = { tabs: sortedExistingTabs };
+        const existingTabUuidsBySlug = new Map(
+            sortedExistingTabs.map((tab) => [
+                getDashboardTabSlug(existingDashboard, tab.uuid),
+                tab.uuid,
+            ]),
+        );
+        const tabUuidsBySlug = new Map<string, string>();
+
+        const tabsWithUuids = tabs.map(({ slug, uuid, ...tab }) => {
+            if (slug && tabUuidsBySlug.has(slug)) {
+                throw new ParameterError(
+                    `Dashboard tab slug "${slug}" is duplicated`,
+                );
+            }
+
+            const resolvedUuid =
+                (slug ? existingTabUuidsBySlug.get(slug) : undefined) ??
+                uuid ??
+                uuidv4();
+
+            if (slug) {
+                tabUuidsBySlug.set(slug, resolvedUuid);
+            }
+
+            return {
+                ...tab,
+                uuid: resolvedUuid,
+            };
+        });
+
+        return { tabs: tabsWithUuids, tabUuidsBySlug };
+    }
+
     async convertTileWithSlugsToUuids(
         projectUuid: string,
         tiles: DashboardTileAsCode[],
+        tabUuidsBySlug: ReadonlyMap<string, string> = new Map(),
     ): Promise<DashboardTileWithSlug[]> {
         const chartSlugs: string[] = tiles.reduce<string[]>((acc, tile) => {
             if (!isAnyChartTile(tile) || tile.properties.chartSlug == null) {
@@ -1592,9 +1684,23 @@ export class CoderService extends BaseService {
             tile: DashboardTileAsCode,
             chartInfo?: { uuid: string; isSql: boolean },
         ): DashboardTileWithSlug => {
+            const { tabSlug, ...tileWithoutTabSlug } = tile;
+            let { tabUuid } = tile;
+            if (tabSlug === null) {
+                tabUuid = null;
+            } else if (tabSlug !== undefined) {
+                tabUuid = tabUuidsBySlug.get(tabSlug);
+            }
+            if (tabSlug && !tabUuid) {
+                throw new NotFoundError(
+                    `Dashboard tab "${tabSlug}" referenced by tile was not found`,
+                );
+            }
+
             if (!isAnyChartTile(tile)) {
                 return {
-                    ...tile,
+                    ...tileWithoutTabSlug,
+                    tabUuid,
                     uuid: tile.uuid ?? uuidv4(),
                 } as DashboardTileWithSlug;
             }
@@ -1604,7 +1710,8 @@ export class CoderService extends BaseService {
 
             if (isSqlChart) {
                 return {
-                    ...tile,
+                    ...tileWithoutTabSlug,
+                    tabUuid,
                     uuid: tile.uuid ?? uuidv4(),
                     type: DashboardTileTypes.SQL_CHART,
                     properties: {
@@ -1616,7 +1723,8 @@ export class CoderService extends BaseService {
             }
 
             return {
-                ...tile,
+                ...tileWithoutTabSlug,
+                tabUuid,
                 uuid: tile.uuid ?? uuidv4(),
                 type: DashboardTileTypes.SAVED_CHART,
                 properties: {
@@ -3402,9 +3510,22 @@ export class CoderService extends BaseService {
                   projectUuid,
               })
             : [undefined];
+        const existingDashboard = dashboardSummary
+            ? await this.dashboardModel.getByIdOrSlug(dashboardSummary.uuid)
+            : undefined;
+        const { tabs: tabsWithUuids, tabUuidsBySlug } =
+            CoderService.convertTabsWithSlugsToUuids(
+                dashboardWithDefaults.tabs,
+                existingDashboard?.tabs,
+            );
+        const dashboardWithResolvedTabs = {
+            ...dashboardWithDefaults,
+            tabs: tabsWithUuids,
+        };
         const tilesWithUuids = await this.convertTileWithSlugsToUuids(
             projectUuid,
-            dashboardWithDefaults.tiles,
+            dashboardWithResolvedTabs.tiles,
+            tabUuidsBySlug,
         );
         if (!canUploadAnyContent) {
             await this.assertTileChartsViewAccess({
@@ -3416,15 +3537,15 @@ export class CoderService extends BaseService {
         }
 
         const dashboardFilters = CoderService.getFiltersWithTileUuids(
-            dashboardWithDefaults,
+            dashboardWithResolvedTabs,
             tilesWithUuids,
         );
-        const dashboardConfig = dashboardWithDefaults.config
+        const dashboardConfig = dashboardWithResolvedTabs.config
             ? CoderService.getConfigWithDateZoomTileUuids(
-                  dashboardWithDefaults.config,
+                  dashboardWithResolvedTabs.config,
                   tilesWithUuids,
               )
-            : dashboardWithDefaults.config;
+            : dashboardWithResolvedTabs.config;
         // If chart does not exist, we can't use promoteService,
         // since it relies on information that's not available in ChartAsCode, and other uuids
         if (dashboardSummary === undefined) {
@@ -3463,7 +3584,7 @@ export class CoderService extends BaseService {
             const newDashboard = await this.dashboardModel.create(
                 space.uuid,
                 {
-                    ...dashboardWithDefaults,
+                    ...dashboardWithResolvedTabs,
                     tiles: tilesWithUuids,
                     forceSlug: shouldUseExactSlug,
                     filters: dashboardFilters,
@@ -3503,9 +3624,7 @@ export class CoderService extends BaseService {
         }
         // Use promote service to update existing dashboard
 
-        const dashboard = await this.dashboardModel.getByIdOrSlug(
-            dashboardSummary.uuid,
-        );
+        const dashboard = existingDashboard!;
 
         console.info(
             `Updating dashboard "${dashboard.name}" on project ${projectUuid}`,
@@ -3537,7 +3656,7 @@ export class CoderService extends BaseService {
         }
 
         const dashboardWithUuids = {
-            ...dashboardWithDefaults,
+            ...dashboardWithResolvedTabs,
             tiles: tilesWithUuids,
             config: dashboardConfig,
         };

--- a/packages/backend/src/services/CoderService/scheduledContent.ts
+++ b/packages/backend/src/services/CoderService/scheduledContent.ts
@@ -117,9 +117,9 @@ export const getDashboardTabSlug = (
         );
     }
     const baseSlug = getDashboardTabBaseSlug(tab);
-    const matchingTabs = dashboard.tabs.filter(
-        (candidate) => getDashboardTabBaseSlug(candidate) === baseSlug,
-    );
+    const matchingTabs = dashboard.tabs
+        .filter((candidate) => getDashboardTabBaseSlug(candidate) === baseSlug)
+        .sort((left, right) => left.order - right.order);
     if (matchingTabs.length === 1) return baseSlug;
     const index = matchingTabs.findIndex(({ uuid }) => uuid === tabUuid);
     return `${baseSlug}-${index + 1}`;

--- a/packages/common/src/schemas/generateDashboardAsCodeSchema.test.ts
+++ b/packages/common/src/schemas/generateDashboardAsCodeSchema.test.ts
@@ -3,8 +3,40 @@ import {
     buildDashboardAsCodeSchema,
     convertOpenApiToDraft07,
 } from './generateDashboardAsCodeSchema';
+import dashboardAsCodeSchema from './json/dashboard-as-code-1.0.json';
 
 describe('generateDashboardAsCodeSchema', () => {
+    test('generated schema accepts portable tab slugs and legacy tab UUIDs', () => {
+        const ajv = new Ajv({ strict: false, validateFormats: false });
+        const validate = ajv.compile(dashboardAsCodeSchema);
+        const dashboard = {
+            name: 'Dashboard',
+            slug: 'dashboard',
+            spaceSlug: 'space',
+            version: 1,
+            tiles: [],
+        };
+
+        expect(
+            validate({
+                ...dashboard,
+                tabs: [{ slug: 'overview', name: 'Overview', order: 0 }],
+            }),
+        ).toBe(true);
+        expect(
+            validate({
+                ...dashboard,
+                tabs: [
+                    {
+                        uuid: 'legacy-tab-uuid',
+                        name: 'Overview',
+                        order: 0,
+                    },
+                ],
+            }),
+        ).toBe(true);
+    });
+
     test('convertOpenApiToDraft07 rewrites refs and nullable type fields', () => {
         const input = {
             type: 'object',

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -60,7 +60,12 @@
                     "required": ["chartSlug"],
                     "type": "object"
                 },
+                "tabSlug": {
+                    "description": "Portable reference to the dashboard tab containing this tile.",
+                    "type": ["string", "null"]
+                },
                 "tabUuid": {
+                    "description": "Legacy project-local tab reference. Accepted on upload for backwards compatibility.",
                     "type": ["string", "null"]
                 },
                 "tileSlug": {
@@ -174,7 +179,12 @@
                     "required": ["appUuid", "title"],
                     "type": "object"
                 },
+                "tabSlug": {
+                    "description": "Portable reference to the dashboard tab containing this tile.",
+                    "type": ["string", "null"]
+                },
                 "tabUuid": {
+                    "description": "Legacy project-local tab reference. Accepted on upload for backwards compatibility.",
                     "type": ["string", "null"]
                 },
                 "tileSlug": {
@@ -279,7 +289,12 @@
                     "required": ["text"],
                     "type": "object"
                 },
+                "tabSlug": {
+                    "description": "Portable reference to the dashboard tab containing this tile.",
+                    "type": ["string", "null"]
+                },
                 "tabUuid": {
+                    "description": "Legacy project-local tab reference. Accepted on upload for backwards compatibility.",
                     "type": ["string", "null"]
                 },
                 "tileSlug": {
@@ -336,7 +351,12 @@
                     "required": ["url", "title"],
                     "type": "object"
                 },
+                "tabSlug": {
+                    "description": "Portable reference to the dashboard tab containing this tile.",
+                    "type": ["string", "null"]
+                },
                 "tabUuid": {
+                    "description": "Legacy project-local tab reference. Accepted on upload for backwards compatibility.",
                     "type": ["string", "null"]
                 },
                 "tileSlug": {
@@ -393,7 +413,12 @@
                     "required": ["content", "title"],
                     "type": "object"
                 },
+                "tabSlug": {
+                    "description": "Portable reference to the dashboard tab containing this tile.",
+                    "type": ["string", "null"]
+                },
                 "tabUuid": {
+                    "description": "Legacy project-local tab reference. Accepted on upload for backwards compatibility.",
                     "type": ["string", "null"]
                 },
                 "tileSlug": {
@@ -469,7 +494,12 @@
                     "required": ["chartName", "chartSlug"],
                     "type": "object"
                 },
+                "tabSlug": {
+                    "description": "Portable reference to the dashboard tab containing this tile.",
+                    "type": ["string", "null"]
+                },
                 "tabUuid": {
+                    "description": "Legacy project-local tab reference. Accepted on upload for backwards compatibility.",
                     "type": ["string", "null"]
                 },
                 "tileSlug": {
@@ -517,11 +547,16 @@
                     "minimum": 0,
                     "type": "number"
                 },
+                "slug": {
+                    "description": "Portable tab identifier used by new downloads.",
+                    "type": "string"
+                },
                 "uuid": {
+                    "description": "Legacy project-local identifier. Accepted on upload for backwards compatibility.",
                     "type": "string"
                 }
             },
-            "required": ["order", "name", "uuid"],
+            "required": ["order", "name"],
             "type": "object"
         },
         "DashboardTileAsCode": {
@@ -553,7 +588,12 @@
                     "minimum": 1,
                     "type": "number"
                 },
+                "tabSlug": {
+                    "description": "Portable reference to the dashboard tab containing this tile.",
+                    "type": ["string", "null"]
+                },
                 "tabUuid": {
+                    "description": "Legacy project-local tab reference. Accepted on upload for backwards compatibility.",
                     "type": ["string", "null"]
                 },
                 "tileSlug": {

--- a/packages/common/src/types/contentAsCode/dashboards.ts
+++ b/packages/common/src/types/contentAsCode/dashboards.ts
@@ -40,7 +40,10 @@ type DashboardTileAsCodeBase = {
      * @maximum 36
      */
     w: DashboardTile['w'];
-    tabUuid: DashboardTile['tabUuid'];
+    /** Portable reference to the dashboard tab containing this tile. */
+    tabSlug?: string | null;
+    /** Legacy project-local tab reference. Accepted on upload for backwards compatibility. */
+    tabUuid?: DashboardTile['tabUuid'];
 };
 
 export type DashboardChartTileAsCode = DashboardTileAsCodeBase & {
@@ -92,7 +95,10 @@ export type DashboardTileWithSlug = DashboardTile & {
 };
 
 export type DashboardTabAsCode = {
-    uuid: DashboardTab['uuid'];
+    /** Portable tab identifier used by new downloads. */
+    slug?: string;
+    /** Legacy project-local identifier. Accepted on upload for backwards compatibility. */
+    uuid?: DashboardTab['uuid'];
     /**
      * @minLength 1
      */


### PR DESCRIPTION
The only failure is the [OpenAPI Breaking Change Check](https://github.com/lightdash/lightdash/actions/runs/30012539925/job/89224321285), and it is directly caused by this PR:

- `tabs[].uuid` changed from required to optional on both dashboard-as-code GET endpoints.
- `tabSlug` itself is additive/backwards compatible.
- Removing `uuid` from downloaded responses is not API-backwards-compatible, even though legacy UUID uploads remain supported.
- All other CI checks passed.

Given content-as-code’s portability goal, this looks like an intentional contract change. If we accept that, add an explicit API compatibility section plus `allow-api-breaking-change` to the PR description; then I’d consider it okay to merge based on the passing tests and zero-diff round-trip.



`allow-api-breaking-change`

## Summary

- replace project-local dashboard tab UUIDs with stable tab slugs in content-as-code downloads
- resolve tab slugs to target-project UUIDs on upload while continuing to accept legacy `uuid` and `tabUuid` fields
- omit generated additional-metric UUIDs and empty dimension overrides from chart exports
- canonicalize tab and tile ordering so equivalent production and preview content produces identical YAML

## Root cause

Downloaded dashboard and chart YAML included identifiers and empty values generated inside each project. Uploading production content to a preview therefore created semantically equivalent content with different project-local UUIDs, which appeared as irrelevant diffs when downloaded again.

## Validation

- focused backend CoderService tests (45 passing)
- common dashboard-as-code schema tests (4 passing)
- common and backend fast typechecks
- targeted backend lint and common lint
- regenerated and validated the public dashboard-as-code schema
- forced CLI production → preview upload → preview download round-trip: zero dashboard YAML diff and zero chart YAML diff
- verified legacy UUID dashboard uploads still succeed

Closes: PROD-7785