### PR TITLE
fix: make data-app tables scrollable with max-h ScrollArea

### DIFF
--- a/sandboxes/data-apps/template/src/chart-overrides.css
+++ b/sandboxes/data-apps/template/src/chart-overrides.css
@@ -1,6 +1,6 @@
 /* Lightdash chart palette + template-managed floating-surface chrome.
 
-   Two responsibilities:
+   Three responsibilities:
      1. Replaces shadcn's monochrome chart tokens with the categorical palette used by
         every native Lightdash chart. Source of truth: ECHARTS_DEFAULT_COLORS in
         packages/common/src/types/savedCharts.ts.
@@ -9,6 +9,7 @@
         class used by custom Recharts tooltips. Self-adapts to whatever theme the generated
         app picks by mixing --background toward --foreground (which is always the opposite
         end of the lightness scale in a well-formed theme).
+     3. Makes `max-h-*` on shadcn's ScrollArea actually scroll (see below).
 
    Imported after index.css in main.jsx — CSS cascade gives these declarations the win
    without needing @layer wrapping (which would also break Tailwind's per-file processing). */
@@ -35,6 +36,20 @@
     --chart-7: #3ba272;
     --chart-8: #9a60b4;
     --chart-9: #ea7ccc;
+}
+
+/* ── ScrollArea max-height fix ─────────────────────────────────────────────
+   shadcn's ScrollArea puts the caller's className on the Radix Root
+   (overflow-hidden) while the Viewport inside it is h-full. A max-h-* on the
+   Root therefore never constrains the Viewport: height:100% resolves against
+   the Root's auto height, the Viewport grows to the full content height, and
+   the Root clips it — so `<ScrollArea className="max-h-[600px]">` (the
+   pattern skill.md prescribes for tables) renders clipped and unscrollable.
+   Inheriting the Root's max-height makes the Viewport the element that
+   actually scrolls. Roots without a max-height inherit `none` — no change. */
+
+[data-radix-scroll-area-viewport] {
+    max-height: inherit;
 }
 
 /* ── Floating-surface chrome ───────────────────────────────────────────────


### PR DESCRIPTION
shadcn's `ScrollArea` puts `max-h-*` on the Radix Root (`overflow-hidden`) while the Viewport inside is `h-full` — the viewport grows to full content height and gets clipped, so tables built with the skill's canonical `<ScrollArea className="max-h-[600px]">` pattern rendered clipped and unscrollable.

Fix: `[data-radix-scroll-area-viewport] { max-height: inherit; }` in the template's managed `chart-overrides.css` (survives shadcn regeneration, applies to all ScrollArea uses incl. dialogs). Verified in-browser against Radix 1.2.14: viewport now caps at the root's max-height and scrolls.

Only fresh template builds pick this up; existing apps restore their old `src/` from the source tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)