### PR TITLE
fix: track AI thread prompt activity

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -18,6 +18,9 @@ export type DbAiThread = {
     ai_thread_uuid: string;
     share_source_thread_share_uuid: string | null;
     created_at: Date;
+    // Last prompt activity only; don't bump on other thread updates.
+    // Regenerating a response on an existing prompt must bump it.
+    updated_at: Date | null;
     organization_uuid: string;
     project_uuid: string;
     created_from: AiThreadCreatedFrom;
@@ -41,7 +44,7 @@ export type AiThreadTable = Knex.CompositeTableType<
             | 'project_uuid'
             | 'share_source_thread_share_uuid'
             | 'sql_auto_approved_at'
-        >
+        > & { updated_at: Date | Knex.Raw }
     >
 >;
 

--- a/packages/backend/src/ee/database/migrations/20260723140000_add_updated_at_to_ai_thread.ts
+++ b/packages/backend/src/ee/database/migrations/20260723140000_add_updated_at_to_ai_thread.ts
@@ -1,0 +1,21 @@
+import { Knex } from 'knex';
+
+const AiThreadTableName = 'ai_thread';
+const UpdatedAtIndexName = 'ai_thread_updated_at_idx';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        table.timestamp('updated_at', { useTz: false }).nullable();
+    });
+
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        table.index(['updated_at'], UpdatedAtIndexName);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiThreadTableName, (table) => {
+        table.dropIndex(['updated_at'], UpdatedAtIndexName);
+        table.dropColumn('updated_at');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.integration.test.ts
@@ -1,0 +1,160 @@
+import { SEED_ORG_1, SEED_ORG_1_ADMIN, SEED_PROJECT } from '@lightdash/common';
+import { type Knex } from 'knex';
+import { getModels, getTestContext } from '../../vitest.setup.integration';
+import { AiPromptTableName, AiThreadTableName } from '../database/entities/ai';
+import { AiAgentModel } from './AiAgentModel';
+
+describe('AiAgentModel prompt activity', () => {
+    let database: Knex;
+    let model: AiAgentModel;
+    const threadUuids = new Set<string>();
+
+    beforeAll(() => {
+        const context = getTestContext();
+        database = context.db;
+        model = getModels(context.app).aiAgentModel;
+    });
+
+    afterEach(async () => {
+        if (threadUuids.size === 0) return;
+        await database(AiThreadTableName)
+            .whereIn('ai_thread_uuid', [...threadUuids])
+            .delete();
+        threadUuids.clear();
+    });
+
+    const createWebAppThread = async (): Promise<string> => {
+        const threadUuid = await model.createWebAppThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            userUuid: SEED_ORG_1_ADMIN.user_uuid,
+            createdFrom: 'web_app',
+            agentUuid: null,
+        });
+        threadUuids.add(threadUuid);
+        return threadUuid;
+    };
+
+    const getThreadUpdatedAt = async (
+        threadUuid: string,
+    ): Promise<Date | null> => {
+        const row = await database(AiThreadTableName)
+            .select('updated_at')
+            .where('ai_thread_uuid', threadUuid)
+            .first();
+        return row?.updated_at ?? null;
+    };
+
+    it('sets thread updated_at to the inserted web prompt created_at', async () => {
+        const threadUuid = await createWebAppThread();
+        expect(await getThreadUpdatedAt(threadUuid)).toBeNull();
+
+        const promptUuid = await model.createWebAppPrompt({
+            threadUuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            prompt: 'Track this prompt activity',
+        });
+        const prompt = await database(AiPromptTableName)
+            .select('created_at')
+            .where('ai_prompt_uuid', promptUuid)
+            .first();
+
+        expect(await getThreadUpdatedAt(threadUuid)).toEqual(
+            prompt?.created_at,
+        );
+    });
+
+    it('keeps Slack prompt activity monotonic', async () => {
+        const suffix = crypto.randomUUID();
+        const threadUuid = await model.createSlackThread({
+            organizationUuid: SEED_ORG_1.organization_uuid,
+            projectUuid: SEED_PROJECT.project_uuid,
+            createdFrom: 'slack',
+            slackUserId: 'U123',
+            slackChannelId: `C-${suffix}`,
+            slackThreadTs: `thread-${suffix}`,
+            agentUuid: null,
+        });
+        threadUuids.add(threadUuid);
+        const historicalCreatedAt = new Date('2026-01-01T00:00:00.123Z');
+
+        await model.bulkCreateSlackPrompts(threadUuid, [
+            {
+                createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                prompt: 'Historical context',
+                slackUserId: 'U123',
+                slackChannelId: `C-${suffix}`,
+                promptSlackTs: `historical-${suffix}`,
+                createdAt: historicalCreatedAt,
+            },
+        ]);
+        expect(await getThreadUpdatedAt(threadUuid)).toEqual(
+            historicalCreatedAt,
+        );
+
+        const promptUuid = await model.createSlackPrompt({
+            threadUuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            prompt: 'Current Slack prompt',
+            slackUserId: 'U123',
+            slackChannelId: `C-${suffix}`,
+            promptSlackTs: `current-${suffix}`,
+        });
+        const prompt = await database(AiPromptTableName)
+            .select('created_at')
+            .where('ai_prompt_uuid', promptUuid)
+            .first();
+        expect(await getThreadUpdatedAt(threadUuid)).toEqual(
+            prompt?.created_at,
+        );
+
+        await model.bulkCreateSlackPrompts(threadUuid, [
+            {
+                createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+                prompt: 'Older historical context',
+                slackUserId: 'U123',
+                slackChannelId: `C-${suffix}`,
+                promptSlackTs: `older-${suffix}`,
+                createdAt: new Date('2025-01-01T00:00:00.123Z'),
+            },
+        ]);
+        expect(await getThreadUpdatedAt(threadUuid)).toEqual(
+            prompt?.created_at,
+        );
+    });
+
+    it('sets a clone updated_at to its last prompt final created_at', async () => {
+        const sourceThreadUuid = await createWebAppThread();
+        const sourcePromptUuid = await model.createWebAppPrompt({
+            threadUuid: sourceThreadUuid,
+            createdByUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            prompt: 'Clone this prompt',
+        });
+        const historicalCreatedAt = new Date('2026-01-02T00:00:00.456Z');
+        await database.raw('UPDATE ?? SET ?? = ? WHERE ?? = ?', [
+            AiPromptTableName,
+            'created_at',
+            historicalCreatedAt,
+            'ai_prompt_uuid',
+            sourcePromptUuid,
+        ]);
+
+        const cloneThreadUuid = await model.cloneThread({
+            sourceThreadUuid,
+            sourcePromptUuid,
+            targetUserUuid: SEED_ORG_1_ADMIN.user_uuid,
+            includeSelectedPromptResponse: true,
+        });
+        threadUuids.add(cloneThreadUuid);
+        const clonedPrompt = await database(AiPromptTableName)
+            .select('created_at')
+            .where('ai_thread_uuid', cloneThreadUuid)
+            .orderBy('created_at', 'desc')
+            .first();
+
+        expect(clonedPrompt?.created_at).toEqual(historicalCreatedAt);
+        expect(await getThreadUpdatedAt(cloneThreadUuid)).toEqual(
+            clonedPrompt?.created_at,
+        );
+    });
+});

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -366,6 +366,21 @@ export class AiAgentModel {
         return db.transaction(callback);
     }
 
+    private static async bumpThreadUpdatedAt(
+        threadUuid: string,
+        promptCreatedAt: Date,
+        { trx }: { trx: Knex.Transaction },
+    ): Promise<void> {
+        await trx(AiThreadTableName)
+            .where('ai_thread_uuid', threadUuid)
+            .update({
+                updated_at: trx.raw('GREATEST(??, ?)', [
+                    'updated_at',
+                    promptCreatedAt,
+                ]),
+            });
+    }
+
     async filterExistingProjectUuids(
         projectUuids: string[],
     ): Promise<string[]> {
@@ -4554,11 +4569,17 @@ export class AiAgentModel {
                     prompt: data.prompt,
                     model_config: data.modelConfig,
                 })
-                .returning('ai_prompt_uuid');
+                .returning(['ai_prompt_uuid', 'created_at']);
 
             if (row === undefined) {
                 throw new Error('Failed to create prompt');
             }
+
+            await AiAgentModel.bumpThreadUpdatedAt(
+                data.threadUuid,
+                row.created_at,
+                { trx },
+            );
 
             await trx(AiSlackPromptTableName).insert({
                 ai_prompt_uuid: row.ai_prompt_uuid,
@@ -5318,11 +5339,17 @@ export class AiAgentModel {
                     ...(data.modelConfig && { model_config: data.modelConfig }),
                     ...(data.hidden !== undefined && { hidden: data.hidden }),
                 })
-                .returning('ai_prompt_uuid');
+                .returning(['ai_prompt_uuid', 'created_at']);
 
             if (row === undefined) {
                 throw new Error('Failed to create prompt');
             }
+
+            await AiAgentModel.bumpThreadUpdatedAt(
+                data.threadUuid,
+                row.created_at,
+                { trx },
+            );
 
             await trx(AiWebAppPromptTableName).insert({
                 ai_prompt_uuid: row.ai_prompt_uuid,
@@ -5955,11 +5982,22 @@ export class AiAgentModel {
                             : {}),
                     })),
                 )
-                .returning('ai_prompt_uuid');
+                .returning(['ai_prompt_uuid', 'created_at']);
 
             if (promptRows.length !== promptsData.length) {
                 throw new Error('Failed to create all prompts');
             }
+
+            const latestPromptCreatedAt = promptRows.reduce(
+                (latest, row) =>
+                    row.created_at > latest ? row.created_at : latest,
+                promptRows[0].created_at,
+            );
+            await AiAgentModel.bumpThreadUpdatedAt(
+                threadUuid,
+                latestPromptCreatedAt,
+                { trx },
+            );
 
             await trx(AiSlackPromptTableName).insert(
                 promptRows.map((row, index) => ({
@@ -8369,6 +8407,20 @@ export class AiAgentModel {
                 });
                 promptMapping.set(promptToClone.ai_prompt_uuid, newPromptUuid);
             }
+
+            const lastSourcePromptUuid = promptsToClone.at(-1)!.ai_prompt_uuid;
+            const lastClonedPromptUuid =
+                promptMapping.get(lastSourcePromptUuid)!;
+            const lastClonedPrompt = await trx(AiPromptTableName)
+                .select('created_at')
+                .where('ai_prompt_uuid', lastClonedPromptUuid)
+                .first();
+            if (!lastClonedPrompt) {
+                throw new Error('Failed to find last cloned prompt');
+            }
+            await trx(AiThreadTableName)
+                .where('ai_thread_uuid', newThreadUuid)
+                .update({ updated_at: lastClonedPrompt.created_at });
 
             if (copyCompactions) {
                 await this.cloneThreadCompactions({


### PR DESCRIPTION
## Summary

- add nullable, non-timezone `ai_thread.updated_at` and its index in one migration
- bump it monotonically from JS-returned prompt timestamps for web and Slack inserts
- correct cloned threads to their final cloned prompt timestamp
- cover web, historical Slack, and clone semantics with integration tests

## Validation

- `pnpm -F backend typecheck:fast`
- targeted backend lint
- `AiAgentModel.integration.test.ts`: 3 passed

Closes: ZAP-694