### PR TITLE
fix: use row-level semantics for table calculation sorts in pivot queries

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -1522,6 +1522,36 @@ describe('PivotQueryBuilder', () => {
             expect(result).toContain('month_order_ca_value');
         });
 
+        test('pinned sort-only table calc keeps the anchor path', () => {
+            const pinnedConfiguration = {
+                ...tableCalcSortConfiguration,
+                sortBy: [
+                    {
+                        reference: 'month_order',
+                        direction: SortByDirection.ASC,
+                        pivotValues: [{ reference: 'year', value: '2020' }],
+                    },
+                    { reference: 'year', direction: SortByDirection.ASC },
+                ],
+            };
+
+            const result = new PivotQueryBuilder(
+                baseSql,
+                pinnedConfiguration,
+                mockWarehouseSqlBuilder,
+                500,
+                itemsMap,
+            ).toSql();
+
+            expect(result).toContain('"month_order_anchor_column" AS (');
+            expect(replaceWhitespace(result)).toContain(
+                'MAX(CASE WHEN (q."year" = ac."anchor_year" OR (q."year" IS NULL AND ac."anchor_year" IS NULL)) THEN q."month_order_any" END) AS "month_order_ra_value"',
+            );
+            expect(replaceWhitespace(result)).not.toContain(
+                'MAX(q."month_order_any") AS "month_order_ra_value"',
+            );
+        });
+
         test('displayed table calc sorts keep anchor semantics', () => {
             const displayedTcConfiguration = {
                 indexColumn: [

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -1397,9 +1397,10 @@ describe('PivotQueryBuilder', () => {
     });
 
     describe('Table calculation sorts (row-level, non-anchor semantics)', () => {
-        // Table-calc sorts order rows by MAX across all pivot columns and are
-        // excluded from column ordering — anchor semantics would NULL out every
-        // index tuple absent from the anchor group.
+        // Sort-only (undisplayed) table-calc sorts order rows by MAX across
+        // all pivot columns — anchor semantics would NULL out every index
+        // tuple absent from the anchor group. Column ordering and displayed
+        // table-calc sorts keep the existing anchor behavior.
         const itemsMap = {
             month_order: {
                 name: 'month_order',
@@ -1458,7 +1459,7 @@ describe('PivotQueryBuilder', () => {
             );
         });
 
-        test('column ordering ignores the table calc sort — columns order by group dimensions', () => {
+        test('column ordering still honors the calc anchor — group-companion sorts preserved', () => {
             const result = new PivotQueryBuilder(
                 baseSql,
                 tableCalcSortConfiguration,
@@ -1467,9 +1468,8 @@ describe('PivotQueryBuilder', () => {
                 itemsMap,
             ).toSql();
 
-            expect(result).not.toContain('month_order_ca_value');
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY g."year" ASC) AS "col_idx"',
+                'DENSE_RANK() OVER (ORDER BY g."month_order_ca_value" ASC, g."year" ASC) AS "col_idx"',
             );
         });
 
@@ -1515,11 +1515,45 @@ describe('PivotQueryBuilder', () => {
             );
             expect(result).toContain('revenue_ca_value');
 
-            // Table calc gets row-level MAX and no column anchor
+            // Table calc gets row-level MAX; column anchoring stays intact
             expect(replaceWhitespace(result)).toContain(
                 'MAX(q."month_order_any") AS "month_order_ra_value"',
             );
-            expect(result).not.toContain('month_order_ca_value');
+            expect(result).toContain('month_order_ca_value');
+        });
+
+        test('displayed table calc sorts keep anchor semantics', () => {
+            const displayedTcConfiguration = {
+                indexColumn: [
+                    { reference: 'month_name', type: VizIndexType.CATEGORY },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'cumulative_volume',
+                        aggregation: VizAggregationOptions.ANY,
+                    },
+                ],
+                groupByColumns: [{ reference: 'year' }],
+                sortBy: [
+                    {
+                        reference: 'cumulative_volume',
+                        direction: SortByDirection.ASC,
+                    },
+                ],
+            };
+
+            const result = new PivotQueryBuilder(
+                baseSql,
+                displayedTcConfiguration,
+                mockWarehouseSqlBuilder,
+                500,
+                itemsMap,
+            ).toSql();
+
+            expect(result).toContain('anchor_column AS (');
+            expect(replaceWhitespace(result)).toContain(
+                'MAX(CASE WHEN (q."year" = ac."anchor_year" OR (q."year" IS NULL AND ac."anchor_year" IS NULL)) THEN q."cumulative_volume_any" END) AS "cumulative_volume_ra_value"',
+            );
         });
 
         test('single-scan path (no CTE materialization) also uses plain MAX for table calc sorts', () => {
@@ -1541,7 +1575,7 @@ describe('PivotQueryBuilder', () => {
                 'MAX(g."month_order_any") OVER (PARTITION BY g."month_name", g."month") AS "month_order_ra_value"',
             );
             expect(result).not.toContain('MAX(CASE WHEN');
-            expect(result).not.toContain('month_order_ca_value');
+            expect(result).toContain('month_order_ca_value');
         });
     });
 

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -1396,6 +1396,155 @@ describe('PivotQueryBuilder', () => {
         });
     });
 
+    describe('Table calculation sorts (row-level, non-anchor semantics)', () => {
+        // Table-calc sorts order rows by MAX across all pivot columns and are
+        // excluded from column ordering — anchor semantics would NULL out every
+        // index tuple absent from the anchor group.
+        const itemsMap = {
+            month_order: {
+                name: 'month_order',
+                displayName: 'Month Order',
+                sql: 'MOD(CAST(${orders.month_num} AS INT) + 8, 12)',
+                type: TableCalculationType.NUMBER,
+            },
+            cumulative_volume: {
+                name: 'cumulative_volume',
+                displayName: 'Cumulative Volume',
+                sql: 'SUM(${orders.count}) OVER (PARTITION BY ${orders.year} ORDER BY ${orders.month})',
+                type: TableCalculationType.NUMBER,
+            },
+        } as unknown as ItemsMap;
+
+        const tableCalcSortConfiguration = {
+            indexColumn: [
+                { reference: 'month_name', type: VizIndexType.CATEGORY },
+                { reference: 'month', type: VizIndexType.TIME },
+            ],
+            valuesColumns: [
+                {
+                    reference: 'cumulative_volume',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+            ],
+            sortOnlyColumns: [
+                {
+                    reference: 'month_order',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+            ],
+            groupByColumns: [{ reference: 'year' }],
+            sortBy: [
+                { reference: 'month_order', direction: SortByDirection.ASC },
+                { reference: 'year', direction: SortByDirection.ASC },
+            ],
+        };
+
+        test('row_ranking orders by MAX across all groups instead of the anchor column value', () => {
+            const result = new PivotQueryBuilder(
+                baseSql,
+                tableCalcSortConfiguration,
+                mockWarehouseSqlBuilder,
+                500,
+                itemsMap,
+            ).toSql();
+
+            expect(replaceWhitespace(result)).toContain(
+                'MAX(q."month_order_any") AS "month_order_ra_value"',
+            );
+            expect(result).not.toContain('MAX(CASE WHEN');
+            expect(result).not.toContain('anchor_column AS (');
+            expect(replaceWhitespace(result)).toContain(
+                'ORDER BY g."month_order_ra_value" ASC',
+            );
+        });
+
+        test('column ordering ignores the table calc sort — columns order by group dimensions', () => {
+            const result = new PivotQueryBuilder(
+                baseSql,
+                tableCalcSortConfiguration,
+                mockWarehouseSqlBuilder,
+                500,
+                itemsMap,
+            ).toSql();
+
+            expect(result).not.toContain('month_order_ca_value');
+            expect(replaceWhitespace(result)).toContain(
+                'DENSE_RANK() OVER (ORDER BY g."year" ASC) AS "col_idx"',
+            );
+        });
+
+        test('metric sorts keep anchor semantics when mixed with a table calc sort', () => {
+            const mixedConfiguration = {
+                indexColumn: [
+                    { reference: 'month_name', type: VizIndexType.CATEGORY },
+                ],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                sortOnlyColumns: [
+                    {
+                        reference: 'month_order',
+                        aggregation: VizAggregationOptions.ANY,
+                    },
+                ],
+                groupByColumns: [{ reference: 'year' }],
+                sortBy: [
+                    { reference: 'revenue', direction: SortByDirection.DESC },
+                    {
+                        reference: 'month_order',
+                        direction: SortByDirection.ASC,
+                    },
+                ],
+            };
+
+            const result = new PivotQueryBuilder(
+                baseSql,
+                mixedConfiguration,
+                mockWarehouseSqlBuilder,
+                500,
+                itemsMap,
+            ).toSql();
+
+            // Metric keeps the anchor path
+            expect(result).toContain('anchor_column AS (');
+            expect(replaceWhitespace(result)).toContain(
+                'MAX(CASE WHEN (q."year" = ac."anchor_year" OR (q."year" IS NULL AND ac."anchor_year" IS NULL)) THEN q."revenue_sum" END) AS "revenue_ra_value"',
+            );
+            expect(result).toContain('revenue_ca_value');
+
+            // Table calc gets row-level MAX and no column anchor
+            expect(replaceWhitespace(result)).toContain(
+                'MAX(q."month_order_any") AS "month_order_ra_value"',
+            );
+            expect(result).not.toContain('month_order_ca_value');
+        });
+
+        test('single-scan path (no CTE materialization) also uses plain MAX for table calc sorts', () => {
+            const mockTrinoBuilder = {
+                ...mockWarehouseSqlBuilder,
+                getAdapterType: () => SupportedDbtAdapter.TRINO,
+                supportsCteMaterialization: () => false,
+            } as unknown as WarehouseSqlBuilder;
+
+            const result = new PivotQueryBuilder(
+                baseSql,
+                tableCalcSortConfiguration,
+                mockTrinoBuilder,
+                500,
+                itemsMap,
+            ).toSql();
+
+            expect(replaceWhitespace(result)).toContain(
+                'MAX(g."month_order_any") OVER (PARTITION BY g."month_name", g."month") AS "month_order_ra_value"',
+            );
+            expect(result).not.toContain('MAX(CASE WHEN');
+            expect(result).not.toContain('month_order_ca_value');
+        });
+    });
+
     describe('Sort handling', () => {
         test('Should handle single sort ascending', () => {
             const pivotConfiguration = {

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -209,18 +209,24 @@ export class PivotQueryBuilder {
     }
 
     /**
-     * Sort-only (undisplayed) table-calc sorts use row-level semantics — MAX
-     * across all pivot columns — instead of the metric-sort anchor: anchoring
-     * a per-(index, group) calc to one group yields NULL for every index tuple
-     * absent from that group. Displayed table calcs and metrics keep anchor
-     * semantics; column ordering is not affected either way.
+     * Unpinned sort-only (undisplayed) table-calc sorts use row-level
+     * semantics — MAX across all pivot columns — instead of the metric-sort
+     * anchor: anchoring a per-(index, group) calc to one group yields NULL for
+     * every index tuple absent from that group. Displayed table calcs, metrics
+     * and explicitly pinned sorts (`pivotValues`) keep anchor semantics;
+     * column ordering is not affected either way.
      */
     private isSortOnlyTableCalculation(reference: string): boolean {
         const item = this.itemsMap[reference];
         if (!item || !isTableCalculation(item)) return false;
-        return (this.pivotConfiguration.sortOnlyColumns ?? []).some(
+        const isSortOnly = (this.pivotConfiguration.sortOnlyColumns ?? []).some(
             (col) => col.reference === reference,
         );
+        if (!isSortOnly) return false;
+        const sort = this.pivotConfiguration.sortBy?.find(
+            (s) => s.reference === reference,
+        );
+        return !sort?.pivotValues?.length;
     }
 
     /**

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -209,13 +209,18 @@ export class PivotQueryBuilder {
     }
 
     /**
-     * Table-calc sorts use row-level semantics (MAX across all pivot columns),
-     * not the metric-sort anchor — anchoring a per-(index, group) calc to one
-     * group yields NULL for every index tuple absent from that group.
+     * Sort-only (undisplayed) table-calc sorts use row-level semantics — MAX
+     * across all pivot columns — instead of the metric-sort anchor: anchoring
+     * a per-(index, group) calc to one group yields NULL for every index tuple
+     * absent from that group. Displayed table calcs and metrics keep anchor
+     * semantics; column ordering is not affected either way.
      */
-    private isTableCalculationReference(reference: string): boolean {
+    private isSortOnlyTableCalculation(reference: string): boolean {
         const item = this.itemsMap[reference];
-        return !!item && isTableCalculation(item);
+        if (!item || !isTableCalculation(item)) return false;
+        return (this.pivotConfiguration.sortOnlyColumns ?? []).some(
+            (col) => col.reference === reference,
+        );
     }
 
     /**
@@ -799,8 +804,6 @@ export class PivotQueryBuilder {
                 (sort) => sort.reference === valCol.reference,
             );
             if (!sortConfig) return;
-            // Table-calc sorts don't drive column ordering (row-level semantics)
-            if (this.isTableCalculationReference(valCol.reference)) return;
 
             const fieldName = PivotQueryBuilder.getValueColumnFieldName(
                 valCol.reference,
@@ -870,9 +873,6 @@ export class PivotQueryBuilder {
                     (sort) => sort.reference === valCol.reference,
                 );
                 if (!sortConfig) return acc;
-                // Table-calc sorts don't drive column ordering
-                if (this.isTableCalculationReference(valCol.reference))
-                    return acc;
 
                 const fieldName = PivotQueryBuilder.getValueColumnFieldName(
                     valCol.reference,
@@ -1152,8 +1152,8 @@ export class PivotQueryBuilder {
 
             const rowAnchorCteName = `${valCol.reference}_ra`;
 
-            // Table-calc sorts aggregate across ALL pivot columns — no anchor
-            if (this.isTableCalculationReference(valCol.reference)) {
+            // Sort-only table calcs aggregate across ALL pivot columns — no anchor
+            if (this.isSortOnlyTableCalculation(valCol.reference)) {
                 result[rowAnchorCteName] = {
                     cteName: rowAnchorCteName,
                     sql: `SELECT ${indexColumnRefs}, MAX(q.${q}${fieldName}${q}) AS ${q}${rowAnchorCteName}_value${q} FROM group_by_query q GROUP BY ${indexColumnGroupBy}`,
@@ -1231,11 +1231,11 @@ export class PivotQueryBuilder {
             sortBy?.some((sort) => sort.reference === valCol.reference),
         );
         const hasMetricSort = sortedValueColumns.length > 0;
-        // Table-calc sorts use row-level semantics (MAX across all pivot
+        // Sort-only table-calc sorts use row-level semantics (MAX across all pivot
         // columns), so they don't need the anchor_column CTE — only metric
         // sorts anchored to the first pivot column do.
         const hasAnchoredMetricSort = sortedValueColumns.some(
-            (valCol) => !this.isTableCalculationReference(valCol.reference),
+            (valCol) => !this.isSortOnlyTableCalculation(valCol.reference),
         );
         // A sort-only dimension also drives the column ORDER BY, which means
         // we need column_ranking (for the precomputed ranking path) even when
@@ -1279,9 +1279,7 @@ export class PivotQueryBuilder {
                             (s) => s.reference === valCol.reference,
                         );
                         if (!sortConfig) return;
-                        if (
-                            this.isTableCalculationReference(valCol.reference)
-                        ) {
+                        if (this.isSortOnlyTableCalculation(valCol.reference)) {
                             return;
                         }
                         const anchorCteName = `${valCol.reference}_anchor_column`;
@@ -1373,10 +1371,10 @@ export class PivotQueryBuilder {
             sortBy?.some((sort) => sort.reference === valCol.reference),
         );
 
-        // Table-calc sorts aggregate across ALL pivot columns (row-level
+        // Sort-only table calcs aggregate across ALL pivot columns (row-level
         // semantics) — only metric sorts need an anchor column.
         const anchoredValueColumns = sortedValueColumns.filter(
-            (valCol) => !this.isTableCalculationReference(valCol.reference),
+            (valCol) => !this.isSortOnlyTableCalculation(valCol.reference),
         );
 
         // Each value column's anchor column (shared `anchor_column` or, for
@@ -1411,7 +1409,7 @@ export class PivotQueryBuilder {
                 valCol.reference,
                 valCol.aggregation,
             );
-            if (this.isTableCalculationReference(valCol.reference)) {
+            if (this.isSortOnlyTableCalculation(valCol.reference)) {
                 return `MAX(q.${q}${fieldName}${q}) AS ${q}${valCol.reference}_ra_value${q}`;
             }
             const alias = aliasByAnchor.get(
@@ -1520,15 +1518,12 @@ export class PivotQueryBuilder {
             .join(', ');
 
         // Layer 1 — column anchor: FIRST_VALUE per sorted value column.
-        // Table-calc sorts are excluded — they don't drive column ordering.
         const firstValueSelects = (valuesColumns ?? []).reduce<string[]>(
             (acc, valCol) => {
                 const sortConfig = sortBy?.find(
                     (sort) => sort.reference === valCol.reference,
                 );
                 if (!sortConfig) return acc;
-                if (this.isTableCalculationReference(valCol.reference))
-                    return acc;
 
                 const fieldName = PivotQueryBuilder.getValueColumnFieldName(
                     valCol.reference,
@@ -1582,8 +1577,8 @@ export class PivotQueryBuilder {
                     valCol.reference,
                     valCol.aggregation,
                 );
-                // Table-calc sorts aggregate across ALL pivot columns — no anchor
-                if (this.isTableCalculationReference(valCol.reference)) {
+                // Sort-only table calcs aggregate across ALL pivot columns — no anchor
+                if (this.isSortOnlyTableCalculation(valCol.reference)) {
                     acc.push(
                         `MAX(g.${q}${fieldName}${q}) OVER (PARTITION BY ${indexPartition}) AS ${q}${valCol.reference}_ra_value${q}`,
                     );

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -209,6 +209,16 @@ export class PivotQueryBuilder {
     }
 
     /**
+     * Table-calc sorts use row-level semantics (MAX across all pivot columns),
+     * not the metric-sort anchor — anchoring a per-(index, group) calc to one
+     * group yields NULL for every index tuple absent from that group.
+     */
+    private isTableCalculationReference(reference: string): boolean {
+        const item = this.itemsMap[reference];
+        return !!item && isTableCalculation(item);
+    }
+
+    /**
      * Replaces `"reference"` with `alias."reference"` in a sort expression.
      * For custom bin dimensions, also replaces `"reference_order"` with `alias."reference_order"`.
      */
@@ -789,6 +799,8 @@ export class PivotQueryBuilder {
                 (sort) => sort.reference === valCol.reference,
             );
             if (!sortConfig) return;
+            // Table-calc sorts don't drive column ordering (row-level semantics)
+            if (this.isTableCalculationReference(valCol.reference)) return;
 
             const fieldName = PivotQueryBuilder.getValueColumnFieldName(
                 valCol.reference,
@@ -858,6 +870,9 @@ export class PivotQueryBuilder {
                     (sort) => sort.reference === valCol.reference,
                 );
                 if (!sortConfig) return acc;
+                // Table-calc sorts don't drive column ordering
+                if (this.isTableCalculationReference(valCol.reference))
+                    return acc;
 
                 const fieldName = PivotQueryBuilder.getValueColumnFieldName(
                     valCol.reference,
@@ -1136,6 +1151,16 @@ export class PivotQueryBuilder {
             );
 
             const rowAnchorCteName = `${valCol.reference}_ra`;
+
+            // Table-calc sorts aggregate across ALL pivot columns — no anchor
+            if (this.isTableCalculationReference(valCol.reference)) {
+                result[rowAnchorCteName] = {
+                    cteName: rowAnchorCteName,
+                    sql: `SELECT ${indexColumnRefs}, MAX(q.${q}${fieldName}${q}) AS ${q}${rowAnchorCteName}_value${q} FROM group_by_query q GROUP BY ${indexColumnGroupBy}`,
+                };
+                return;
+            }
+
             const anchorCteName =
                 perMetricAnchorCte?.get(valCol.reference) ?? 'anchor_column';
             const anchorCteRef =
@@ -1202,8 +1227,15 @@ export class PivotQueryBuilder {
         // Row anchor CTEs (and the anchor_column CTE that feeds them) only
         // make sense when there are row dimensions to rank — without them
         // every row has row_index = 1.
-        const hasMetricSort = valuesColumns?.some((valCol) =>
+        const sortedValueColumns = (valuesColumns ?? []).filter((valCol) =>
             sortBy?.some((sort) => sort.reference === valCol.reference),
+        );
+        const hasMetricSort = sortedValueColumns.length > 0;
+        // Table-calc sorts use row-level semantics (MAX across all pivot
+        // columns), so they don't need the anchor_column CTE — only metric
+        // sorts anchored to the first pivot column do.
+        const hasAnchoredMetricSort = sortedValueColumns.some(
+            (valCol) => !this.isTableCalculationReference(valCol.reference),
         );
         // A sort-only dimension also drives the column ORDER BY, which means
         // we need column_ranking (for the precomputed ranking path) even when
@@ -1238,12 +1270,20 @@ export class PivotQueryBuilder {
                 const hasAnyPin =
                     sortBy?.some((s) => s.pivotValues?.length) ?? false;
 
-                if (hasAnyPin && valuesColumns) {
+                if (!hasAnchoredMetricSort) {
+                    // Only table-calc sorts: rows order by MAX across all pivot
+                    // columns, no anchor CTE needed.
+                } else if (hasAnyPin && valuesColumns) {
                     valuesColumns.forEach((valCol) => {
                         const sortConfig = sortBy?.find(
                             (s) => s.reference === valCol.reference,
                         );
                         if (!sortConfig) return;
+                        if (
+                            this.isTableCalculationReference(valCol.reference)
+                        ) {
+                            return;
+                        }
                         const anchorCteName = `${valCol.reference}_anchor_column`;
                         const anchorSQL = this.getAnchorColumnSQL(
                             groupByColumns,
@@ -1333,11 +1373,17 @@ export class PivotQueryBuilder {
             sortBy?.some((sort) => sort.reference === valCol.reference),
         );
 
+        // Table-calc sorts aggregate across ALL pivot columns (row-level
+        // semantics) — only metric sorts need an anchor column.
+        const anchoredValueColumns = sortedValueColumns.filter(
+            (valCol) => !this.isTableCalculationReference(valCol.reference),
+        );
+
         // Each value column's anchor column (shared `anchor_column` or, for
         // pinned sorts, a per-metric `${ref}_anchor_column`). Distinct anchors
         // are CROSS JOINed once; a single anchor keeps the `ac` alias.
         const anchorByValCol = new Map<string, string>(
-            sortedValueColumns.map((valCol) => [
+            anchoredValueColumns.map((valCol) => [
                 valCol.reference,
                 perMetricAnchorCte?.get(valCol.reference) ?? 'anchor_column',
             ]),
@@ -1356,15 +1402,18 @@ export class PivotQueryBuilder {
                     name === 'anchor_column'
                         ? 'anchor_column'
                         : `${q}${name}${q}`;
-                return `CROSS JOIN ${ref} ${aliasByAnchor.get(name)}`;
+                return ` CROSS JOIN ${ref} ${aliasByAnchor.get(name)}`;
             })
-            .join(' ');
+            .join('');
 
         const maxCaseSelects = sortedValueColumns.map((valCol) => {
             const fieldName = PivotQueryBuilder.getValueColumnFieldName(
                 valCol.reference,
                 valCol.aggregation,
             );
+            if (this.isTableCalculationReference(valCol.reference)) {
+                return `MAX(q.${q}${fieldName}${q}) AS ${q}${valCol.reference}_ra_value${q}`;
+            }
             const alias = aliasByAnchor.get(
                 anchorByValCol.get(valCol.reference)!,
             )!;
@@ -1381,7 +1430,7 @@ export class PivotQueryBuilder {
 
         return `SELECT ${indexSelect}, ${maxCaseSelects.join(
             ', ',
-        )} FROM group_by_query q ${crossJoins} GROUP BY ${indexSelect}`;
+        )} FROM group_by_query q${crossJoins} GROUP BY ${indexSelect}`;
     }
 
     /**
@@ -1471,12 +1520,15 @@ export class PivotQueryBuilder {
             .join(', ');
 
         // Layer 1 — column anchor: FIRST_VALUE per sorted value column.
+        // Table-calc sorts are excluded — they don't drive column ordering.
         const firstValueSelects = (valuesColumns ?? []).reduce<string[]>(
             (acc, valCol) => {
                 const sortConfig = sortBy?.find(
                     (sort) => sort.reference === valCol.reference,
                 );
                 if (!sortConfig) return acc;
+                if (this.isTableCalculationReference(valCol.reference))
+                    return acc;
 
                 const fieldName = PivotQueryBuilder.getValueColumnFieldName(
                     valCol.reference,
@@ -1530,6 +1582,13 @@ export class PivotQueryBuilder {
                     valCol.reference,
                     valCol.aggregation,
                 );
+                // Table-calc sorts aggregate across ALL pivot columns — no anchor
+                if (this.isTableCalculationReference(valCol.reference)) {
+                    acc.push(
+                        `MAX(g.${q}${fieldName}${q}) OVER (PARTITION BY ${indexPartition}) AS ${q}${valCol.reference}_ra_value${q}`,
+                    );
+                    return acc;
+                }
                 const anchorPredicate = this.buildAnchorWhereClause(
                     sortConfig.pivotValues,
                     groupByColumns,


### PR DESCRIPTION
## Description

Sorting a grouped (pivoted) chart by a table calculation that isn't on any axis — a "companion" sort like a fiscal month-order calc ordering a month-name x-axis — was misclassified as a **metric sort** and took the anchor path in `PivotQueryBuilder`: `row_ranking` ordered rows by the calc's value **in the first pivot column only** (`MAX(CASE WHEN <group> = <anchor> THEN <calc> END)`, `NULLS LAST`), so every index tuple absent from the anchor group clumped behind the anchor block. Chart results came out "sorted correctly for the first group, then scrambled", and line series looped back on themselves (points draw in row order).

## Fix

Sort entries referencing a **sort-only (undisplayed) table calculation** now get row-level semantics in `row_ranking`: rows order by `MAX(<calc>)` across **all** pivot columns instead of the anchor `CASE`. For row-constant companions this is exactly their value; for per-group calcs it stays deterministic; row cardinality is unchanged. The `anchor_column` CTE is only emitted when a non-table-calc sort still needs it. Covers both the 3-CTE precomputed-rankings path and the single-scan (no CTE materialization) path.

## Deliberately narrow scope (lessons from #22458 → #22622)

The previous attempt at the companion-sort family (#22458) fixed the column-companion case, broke the row-companion case, and was reverted. To avoid mirroring that:

- **Column ordering is untouched.** Sorted table calcs keep their `FIRST_VALUE` participation in `column_ranking`, so group-companion calc sorts (e.g. ordering series by a rank calc — which works correctly today) are unaffected. Verified with a rank-calc scenario: columns still order by rank, not alphabetically.
- **Displayed table-calc sorts are untouched** and keep anchor semantics end to end (guarded by a test).
- **Metric sorts are untouched** — all 149 pre-existing `PivotQueryBuilder` tests pass unmodified.

The residual row-vs-column-companion ambiguity is inherent to inferring intent from a bare sort and is the custom-dimension-sorting project's problem to solve properly; this PR only stops the row-companion case from producing scrambled output.

## Testing

- 5 new unit tests (row-level MAX, column participation preserved, mixed metric + table-calc sorts, displayed-TC anchor guard, single-scan path); full backend unit suite green (330 files / 4770 tests).
- Verified end-to-end on local dev with a dense multi-year dataset reproducing the reported chart: pivoted rows sort month-major across all groups, legend order intact, each line series draws as a single monotonic strand (previously non-anchor series looped back on themselves).
- Live regression probes: group-companion rank-calc sort (column order preserved), classic displayed-metric sort (anchor CTEs byte-identical).

Closes: PROD-9208
Closes: #26083

test-frontend