### PR TITLE
fix(ai): prevent blank agent chat bubble from stream/persist race

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -1454,22 +1454,39 @@ export const streamAgentResponse = async ({
 
                 const stepCapReached = steps.length >= STEP_CAP;
 
-                if (stepCapReached && !completeResponse) {
-                    void dependencies.updatePrompt({
-                        promptUuid: args.promptUuid,
-                        errorMessage: getUserFacingErrorMessage(
-                            new AiAgentStepCapReachedError(steps.length),
-                        ),
-                        tokenUsage: {
-                            totalTokens: usage.totalTokens ?? 0,
-                        },
-                    });
-                } else {
-                    void dependencies.updatePrompt({
-                        response: completeResponse,
-                        promptUuid: args.promptUuid,
-                        tokenUsage: {
-                            totalTokens: usage.totalTokens ?? 0,
+                // Await the persist before onFinish resolves — the AI SDK holds
+                // the stream open until this callback completes, so the HTTP
+                // stream only closes once the response is in the DB. Without
+                // this, the client's post-stream refetch can win the race and
+                // read a still-null message, blanking the bubble until refresh.
+                try {
+                    if (stepCapReached && !completeResponse) {
+                        await dependencies.updatePrompt({
+                            promptUuid: args.promptUuid,
+                            errorMessage: getUserFacingErrorMessage(
+                                new AiAgentStepCapReachedError(steps.length),
+                            ),
+                            tokenUsage: {
+                                totalTokens: usage.totalTokens ?? 0,
+                            },
+                        });
+                    } else {
+                        await dependencies.updatePrompt({
+                            response: completeResponse,
+                            promptUuid: args.promptUuid,
+                            tokenUsage: {
+                                totalTokens: usage.totalTokens ?? 0,
+                            },
+                        });
+                    }
+                } catch (error) {
+                    Logger.error(
+                        '[AiAgent][On Finish] Failed to persist final response',
+                        error,
+                    );
+                    Sentry.captureException(error, {
+                        tags: {
+                            'ai.model': modelName,
                         },
                     });
                 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -372,10 +372,17 @@ const AssistantBubbleContent: FC<{
         }),
         [canOpenSqlRunner, projectUuid],
     );
+    // After streaming ends there's a brief window where the client has
+    // refetched the thread but the persisted message.message hasn't landed
+    // yet. The streamed content stays in redux keyed to this message, so we
+    // keep it as a fallback to avoid flashing an empty bubble (and a spurious
+    // "No response" notice) until the persisted text arrives.
+    const streamedContent = streamingState?.content ?? '';
     const hasNoResponse =
         !isStreaming &&
         !streamingError &&
         !message.message &&
+        !streamedContent &&
         !isPending &&
         !message.interrupted;
     const shouldShowRetry = hasError || hasNoResponse || !!streamingError;
@@ -391,7 +398,7 @@ const AssistantBubbleContent: FC<{
     const baseMessageContent =
         isStreaming && streamingState
             ? streamingState.content
-            : (message.message ?? '');
+            : message.message || streamedContent;
 
     const referencedArtifactsMarkdown =
         !isStreaming &&


### PR DESCRIPTION
### Description:

Sometimes an AI agent response never appears in the web chat — the stream finishes but the bubble stays empty (or shows a spurious "No response" retry card), and refreshing the page shows the full response. This is a race between response persistence and the client's post-stream refetch:

- The backend persisted the final response fire-and-forget (`void updatePrompt(...)`) in the streaming `onFinish`, so the HTTP stream could close before the DB write landed.
- On stream end the client invalidates the thread query and the bubble falls back from streamed content to the persisted `message.message`. If the refetch wins the race, `message.message` is still null → blank bubble until a manual refresh.

**Fix:**
- **Backend** (`agentV2.ts`): `await` the `updatePrompt` persist inside `onFinish`. The AI SDK holds the stream open until the callback resolves, so the HTTP stream only closes once the response is in the DB — the client's refetch then reads persisted content. Wrapped in try/catch so a persist failure is logged/reported without breaking cleanup.
- **Frontend** (`AgentChatAssistantBubble.tsx`): defense-in-depth — keep the streamed redux content (kept keyed to this message) as a fallback when the persisted `message.message` is still empty, and don't surface the "No response" notice while it's pending.
