### PR TITLE
fix: run org-setup for new-onboarding signups when telemetry is disabled

### DIFF
--- a/packages/backend/src/models/UserModel.test.ts
+++ b/packages/backend/src/models/UserModel.test.ts
@@ -231,6 +231,7 @@ describe('UserModel', () => {
                 first_name: '',
                 last_name: '',
                 is_active: true,
+                is_setup_complete: true,
             }),
         );
         expect(insertEmail).toHaveBeenCalledWith({

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -294,17 +294,17 @@ export class UserModel {
         trx: Transaction,
         createUser: (Omit<CreateUserWithRole, 'role'> | OpenIdUser) & {
             isActive: boolean;
+            isSetupComplete: boolean;
             isVerified?: boolean;
         },
     ) {
-        const canSkipSetupForAnalytics = !this.lightdashConfig.rudder.writeKey;
         const userIn: DbUserIn = isOpenIdUser(createUser)
             ? {
                   first_name: createUser.openId.firstName || '',
                   last_name: createUser.openId.lastName || '',
                   is_marketing_opted_in: false,
                   is_tracking_anonymized: this.canTrackingBeAnonymized(),
-                  is_setup_complete: canSkipSetupForAnalytics,
+                  is_setup_complete: createUser.isSetupComplete,
                   is_active: createUser.isActive,
               }
             : {
@@ -312,7 +312,7 @@ export class UserModel {
                   last_name: createUser.lastName.trim(),
                   is_marketing_opted_in: false,
                   is_tracking_anonymized: this.canTrackingBeAnonymized(),
-                  is_setup_complete: canSkipSetupForAnalytics,
+                  is_setup_complete: createUser.isSetupComplete,
                   is_active: createUser.isActive,
               };
         const [newUser] = await trx<DbUser>('users')
@@ -1028,6 +1028,7 @@ export class UserModel {
         organizationUuid: string,
         createUser: CreateUserWithRole,
         isActive: boolean = true,
+        isSetupComplete?: boolean,
     ): Promise<LightdashUser> {
         const [org] = await this.database(OrganizationTableName)
             .where('organization_uuid', organizationUuid)
@@ -1050,10 +1051,14 @@ export class UserModel {
             throw new ParameterError("Password doesn't meet requirements");
         }
 
+        // Default preserves the legacy analytics-consent skip.
+        const setupComplete =
+            isSetupComplete ?? !this.lightdashConfig.rudder.writeKey;
         const user = await this.database.transaction(async (trx) => {
             const newUser = await this.createUserTransaction(trx, {
                 ...createUser,
                 isActive,
+                isSetupComplete: setupComplete,
             });
             await trx(OrganizationMembershipsTableName).insert({
                 organization_id: org.organization_id,
@@ -1134,7 +1139,10 @@ export class UserModel {
     async createUser(
         createUser: CreateLocalUserArgs | OpenIdUser,
         isActive: boolean = true,
+        isSetupComplete?: boolean,
     ): Promise<LightdashUser> {
+        const setupComplete =
+            isSetupComplete ?? !this.lightdashConfig.rudder.writeKey;
         const user = await this.database.transaction(async (trx) => {
             if (
                 !isOpenIdUser(createUser) &&
@@ -1159,6 +1167,7 @@ export class UserModel {
             const newUser = await this.createUserTransaction(trx, {
                 ...createUser,
                 isActive,
+                isSetupComplete: setupComplete,
             });
             return newUser;
         });

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -76,7 +76,9 @@ const userModel = {
     addProjectMemberships: vi.fn(async () => undefined),
     getOrganizationsForUser: vi.fn(async () => [sessionUser]),
     findUserByEmail: vi.fn<UserModel['findUserByEmail']>(async () => undefined),
-    createPendingUser: vi.fn(async () => newUser),
+    createPendingUser: vi.fn<UserModel['createPendingUser']>(
+        async () => newUser,
+    ),
     findSessionUserByPrimaryEmail: vi.fn(async () => sessionUser),
     findServiceAccountByUserUuid: vi.fn(async () => undefined),
     joinOrg: vi.fn(async () => sessionUser),
@@ -459,11 +461,15 @@ describe('UserService', () => {
                 user: undefined,
                 featureFlagId: FeatureFlags.NewOnboarding,
             });
-            expect(userModel.createUser).toHaveBeenCalledWith({
-                firstName: '',
-                lastName: '',
-                email: 'email-only@example.com',
-            });
+            expect(vi.mocked(userModel.createUser)).toHaveBeenCalledWith(
+                {
+                    firstName: '',
+                    lastName: '',
+                    email: 'email-only@example.com',
+                },
+                true,
+                false,
+            );
             expect(loginMethodAllowedSpy).toHaveBeenCalledWith(
                 'email-only@example.com',
                 'email',
@@ -550,12 +556,16 @@ describe('UserService', () => {
                 user: undefined,
                 featureFlagId: FeatureFlags.NewOnboarding,
             });
-            expect(userModel.createUser).toHaveBeenCalledWith({
-                firstName: 'Full',
-                lastName: 'User',
-                email: 'full@example.com',
-                password: 'password1!',
-            });
+            expect(vi.mocked(userModel.createUser)).toHaveBeenCalledWith(
+                {
+                    firstName: 'Full',
+                    lastName: 'User',
+                    email: 'full@example.com',
+                    password: 'password1!',
+                },
+                true,
+                undefined,
+            );
             expect(sendOneTimePasscodeSpy).toHaveBeenCalledWith(
                 sessionUser,
                 'signup_verification',
@@ -2283,9 +2293,11 @@ describe('UserService', () => {
             expect(
                 userModel.createUser as import('vitest').Mock,
             ).toHaveBeenCalledTimes(1);
-            expect(
-                userModel.createUser as import('vitest').Mock,
-            ).toBeCalledWith(openIdUser);
+            expect(vi.mocked(userModel.createUser)).toBeCalledWith(
+                openIdUser,
+                true,
+                undefined,
+            );
             expect(
                 userModel.activateUser as import('vitest').Mock,
             ).toHaveBeenCalledTimes(0);
@@ -2754,9 +2766,17 @@ describe('UserService', () => {
                     inviteUser,
                 ),
             ).toEqual(inviteLink);
-            expect(
-                userModel.createPendingUser as import('vitest').Mock,
-            ).toHaveBeenCalledTimes(1);
+            expect(vi.mocked(userModel.createPendingUser)).toHaveBeenCalledWith(
+                sessionUser.organizationUuid,
+                {
+                    email: inviteUser.email,
+                    firstName: '',
+                    lastName: '',
+                    role: OrganizationMemberRole.MEMBER,
+                },
+                true,
+                undefined,
+            );
             expect(
                 inviteLinkModel.upsert as import('vitest').Mock,
             ).toHaveBeenCalledTimes(1);
@@ -2810,6 +2830,8 @@ describe('UserService', () => {
                     lastName: '',
                     role: OrganizationMemberRole.ADMIN,
                 },
+                true,
+                undefined,
             );
             expect(vi.mocked(inviteLinkModel.upsert)).toHaveBeenCalledWith(
                 expect.any(String),

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -736,6 +736,7 @@ export class UserService extends BaseService {
                 );
         }
         if (!existingUserWithEmail) {
+            const onboardingFlow = await this.getOnboardingFlow(user);
             const pendingUser = await this.userModel.createPendingUser(
                 organizationUuid,
                 {
@@ -744,6 +745,8 @@ export class UserService extends BaseService {
                     lastName: '',
                     role: userRole,
                 },
+                true,
+                onboardingFlow === 'new' ? false : undefined,
             );
             userUuid = pendingUser.userUuid;
         } else {
@@ -1832,7 +1835,11 @@ export class UserService extends BaseService {
             userConnectionType = 'email_only';
         }
 
-        const user = await this.userModel.createUser(createUser);
+        const user = await this.userModel.createUser(
+            createUser,
+            true,
+            onboardingFlow === 'new' ? false : undefined,
+        );
         this.identifyUser({
             ...user,
             isMarketingOptedIn: user.isMarketingOptedIn,


### PR DESCRIPTION
## Summary

New-onboarding signups on instances with telemetry disabled (`RUDDERSTACK_ANALYTICS_DISABLED=true`) were being created already flagged as setup-complete, so the organization-setup wizard never ran — organization name and role were silently never collected.

The root cause was `UserModel.createUserTransaction` deriving `is_setup_complete` from `!lightdashConfig.rudder.writeKey`. That heuristic predates the new-onboarding flow and was written for the old, optional analytics-consent modal, where auto-skipping made sense. Under new onboarding, org-setup is a required step, so the heuristic became stale.

This also completes the fix started in #25969, which corrected the frontend redirect gate (`health.isSuccess`) but did not touch this independent backend code path that produces the identical symptom.

## Changes

- `is_setup_complete` is now an explicit input to `createUserTransaction` rather than an internally-derived value.
- `UserModel.createUser` and `UserModel.createPendingUser` take an optional `isSetupComplete` param; when omitted they fall back to the previous telemetry heuristic, so every untouched caller (SCIM, roles, instance configuration) keeps its exact current behaviour.
- `UserService` passes `isSetupComplete: false` for both the email-only registration path and the invite-created pending-user path **only when the new-onboarding flow is active**; the legacy flow is unchanged.
- Test coverage asserts the new-flow signup creates the user with `isSetupComplete: false` and the legacy flow omits it.

## Unit checks

- `pnpm -F backend typecheck:fast` — clean
- `pnpm -F backend exec vitest run src/services/UserService.test.ts src/models/UserModel.test.ts` — 112 passed
- Lint clean on all four touched paths

## Runtime verification

Verified against a running dev instance built from this branch, configured exactly as the bug requires — `RUDDERSTACK_ANALYTICS_DISABLED=true` (so `/api/v1/health` reports `rudder: {}`), `new-onboarding` enabled, SMTP configured. This is the scenario the #25969 frontend fix alone did not cover, so it demonstrates the two fixes now interlock: the backend creates the user un-setup, and the health-loaded gate then routes them into the wizard.

A fresh email-only signup was walked in a real browser (register → email OTP `000000`), then evidence captured on both sides:

**1. Backend — the created user row is `is_setup_complete = false`:**

```
$ psql -tA -c "SELECT e.email, u.is_setup_complete, o.organization_name
               FROM users u
               JOIN emails e ON e.user_id=u.user_id AND e.is_primary
               LEFT JOIN organization_memberships om ON om.user_id=u.user_id
               LEFT JOIN organizations o ON o.organization_id=om.organization_id
               WHERE e.email='rt-verify-9202@example.com';"

rt-verify-9202@example.com|f|
```

`is_setup_complete = f` — before this change it would have been `t` on a telemetry-disabled instance, and the wizard would never fire. Org name is still empty because the wizard has not been completed yet (expected).

**2. Frontend — the browser lands on the org-setup wizard instead of silently skipping it:**

After OTP verification the browser navigated to:

```
http://localhost:3020/organization-setup?redirect=%2FcreateProject
```

and rendered the wizard — heading **"Name your organization"**, eyebrow **"Step 1 of 2 · Set up your workspace"**, the org-name field, and a (disabled-until-filled) **Continue** button. It did **not** fall through to `/createProject` or a homepage (`createProject` here is only the post-wizard redirect target carried in the query string). Screenshot retained locally at `/root/reports/prod9202-org-setup-render.png`.

Linear: PROD-9202

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESTuTsJeJamUSo3kC7rGHi
