### PR TITLE
fix(frontend): trim code in CodeBlock so line numbers stay aligned

### DIFF
--- a/packages/frontend/src/components/common/CodeBlock/CodeBlock.tsx
+++ b/packages/frontend/src/components/common/CodeBlock/CodeBlock.tsx
@@ -56,7 +56,8 @@ const CodeBlock: FC<Props> = ({
     withLineNumbers = false,
     ...props
 }) => {
-    const lineCount = code.trim().split('\n').length;
+    const trimmedCode = code.trim();
+    const lineCount = trimmedCode.split('\n').length;
     const lineNumbers = Array.from(
         { length: lineCount },
         (_, index) => index + 1,
@@ -84,7 +85,7 @@ const CodeBlock: FC<Props> = ({
 
             <CodeHighlight
                 {...props}
-                code={code}
+                code={trimmedCode}
                 copiedLabel={copiedLabel}
                 copyLabel={copyLabel}
                 controls={
@@ -92,7 +93,7 @@ const CodeBlock: FC<Props> = ({
                         ? [
                               <CodeBlockCopyControl
                                   key="copy"
-                                  code={code}
+                                  code={trimmedCode}
                                   copiedLabel={copiedLabel}
                                   copyLabel={copyLabel}
                                   onCopy={onCopy}


### PR DESCRIPTION
## Summary

Follow-up to #26074, addressing [this review comment](https://github.com/lightdash/lightdash/pull/26074#discussion_r3638911437): `CodeBlock` computed its line-number column from `code.trim()` but rendered the untrimmed `code`, so input with leading/trailing newlines (AI-generated SQL, raw file contents) rendered line numbers misaligned with the code.

Fix: trim once and use the trimmed code everywhere — line count, `CodeHighlight` render, and the copy button. This keeps numbers and lines in sync and also normalizes display (no blank first/last lines), matching how the previous Prism component behaved.

## Regression analysis

Behavior change: rendered and copied code is now trimmed of leading/trailing whitespace. No caller depends on preserving that whitespace — it was previously invisible-but-misaligning in the line-number gutter, and copying without stray newlines is an improvement.

## Validation

- frontend typecheck:fast
- frontend lint (0 errors)

Relates: #26074