### PR TITLE
fix(mcp): scope run_sql registration to the target project

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -567,17 +567,17 @@ const makeMcpService = ({
         userAttributesModel,
     } as unknown as ConstructorParameters<typeof McpService>[0]);
 
-    if (grepFieldsEnabled) {
-        mockRegisteredMcpTools.clear();
-        service.setupHandlers({
-            projectPinned: false,
-            aiWritebackEnabled: false,
-            grepFieldsEnabled: true,
-            mcpContentWritesEnabled: true,
-            scheduledDeliveryEnabled: true,
-            runSqlEnabled: true,
-        });
-    }
+    // The constructor registers handlers fail-closed (run_sql off), so
+    // re-register here with run_sql enabled — these tests exercise the tool.
+    mockRegisteredMcpTools.clear();
+    service.setupHandlers({
+        projectPinned: false,
+        aiWritebackEnabled: false,
+        grepFieldsEnabled,
+        mcpContentWritesEnabled: true,
+        scheduledDeliveryEnabled: true,
+        runSqlEnabled: true,
+    });
 
     return {
         aiAgentService,

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1367,7 +1367,7 @@ export class McpService extends BaseService {
             grepFieldsEnabled: false,
             mcpContentWritesEnabled: true,
             scheduledDeliveryEnabled: true,
-            runSqlEnabled: true,
+            runSqlEnabled: false,
         },
     ): void {
         this.registerTrackedTool(
@@ -3307,7 +3307,7 @@ export class McpService extends BaseService {
             grepFieldsEnabled: options?.grepFieldsEnabled ?? false,
             mcpContentWritesEnabled: options?.mcpContentWritesEnabled ?? true,
             scheduledDeliveryEnabled: options?.scheduledDeliveryEnabled ?? true,
-            runSqlEnabled: options?.runSqlEnabled ?? true,
+            runSqlEnabled: options?.runSqlEnabled ?? false,
         });
         this.mcpServer = originalServer;
 
@@ -3566,14 +3566,48 @@ export class McpService extends BaseService {
     }
 
     /**
-     * Whether the run_sql tool should be registered for this caller. Gated on
-     * manage:SqlRunner so users who can never run SQL (interactive viewers and
-     * below) don't see the tool in tools/list. This is a coarse capability
-     * check — executeAsyncSqlQuery still enforces the permission per-project at
+     * Whether the run_sql tool should be registered for this caller.
+     *
+     * run_sql is gated on manage:SqlRunner. When the session already targets a
+     * known project (pinned via the X-Lightdash-Project header or a prior
+     * set_project), the permission is checked against that concrete project so
+     * the tool stays out of tools/list for a caller who is only a viewer there
+     * — even if they happen to have SqlRunner in some other project. A bare
+     * capability check on a subject *type* returns true whenever any matching
+     * conditional rule exists, which is why the project-scoped check matters.
+     *
+     * Without a resolved project we fall back to the coarse capability check;
+     * executeAsyncSqlQuery still enforces the permission per-project at
      * invocation time.
      */
-    public isRunSqlEnabled(user: SessionUser): boolean {
-        return this.createAuditedAbility(user).can('manage', 'SqlRunner');
+    public async isRunSqlEnabled(
+        user: SessionUser,
+        headerProjectUuid?: string,
+    ): Promise<boolean> {
+        const ability = this.createAuditedAbility(user);
+
+        const projectUuid =
+            headerProjectUuid ??
+            (user.organizationUuid
+                ? (
+                      await this.mcpContextModel.getContext(
+                          user.userUuid,
+                          user.organizationUuid,
+                      )
+                  )?.context.projectUuid
+                : undefined);
+
+        if (projectUuid && user.organizationUuid) {
+            return ability.can(
+                'manage',
+                subject('SqlRunner', {
+                    organizationUuid: user.organizationUuid,
+                    projectUuid,
+                }),
+            );
+        }
+
+        return ability.can('manage', 'SqlRunner');
     }
 
     public getLightdashVersion(context: McpProtocolContext): string {

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -265,7 +265,9 @@ describe('MCP tool contracts', () => {
             const viewer = buildUser(OrganizationMemberRole.VIEWER, [
                 { projectUuid: PROJECT_A, role: ProjectMemberRole.VIEWER },
             ]);
-            expect(await service.isRunSqlEnabled(viewer, PROJECT_A)).toBe(false);
+            expect(await service.isRunSqlEnabled(viewer, PROJECT_A)).toBe(
+                false,
+            );
         });
 
         it('is true for a developer of the pinned project', async () => {

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -1,6 +1,9 @@
 import { Ability } from '@casl/ability';
 import {
+    defineUserAbility,
     mcpToolDefinitions,
+    OrganizationMemberRole,
+    ProjectMemberRole,
     type PossibleAbilities,
     type SessionUser,
 } from '@lightdash/common';
@@ -152,7 +155,10 @@ describe('MCP tool contracts', () => {
 
         mockRegisteredMcpTools.length = 0;
         mockRegisteredMcpPrompts.length = 0;
-        await mcpService.createServer({ aiWritebackEnabled: true });
+        await mcpService.createServer({
+            aiWritebackEnabled: true,
+            runSqlEnabled: true,
+        });
 
         const prompts = mockRegisteredMcpPrompts.map(({ name, config }) => ({
             name,
@@ -199,6 +205,104 @@ describe('MCP tool contracts', () => {
         expect(mockRegisteredMcpTools.map(({ name }) => name)).not.toContain(
             McpToolName.RUN_SQL,
         );
+    });
+
+    describe('isRunSqlEnabled', () => {
+        const ORG_UUID = 'org-1';
+        const PROJECT_A = 'project-a';
+        const PROJECT_B = 'project-b';
+
+        const buildUser = (
+            orgRole: OrganizationMemberRole,
+            projectProfiles: {
+                projectUuid: string;
+                role: ProjectMemberRole;
+            }[] = [],
+        ): SessionUser => {
+            const userUuid = 'user-1';
+            const ability = defineUserAbility(
+                {
+                    role: orgRole,
+                    organizationUuid: ORG_UUID,
+                    userUuid,
+                    roleUuid: undefined,
+                },
+                projectProfiles.map((profile) => ({
+                    ...profile,
+                    userUuid,
+                    roleUuid: undefined,
+                })),
+            );
+            return {
+                userUuid,
+                organizationUuid: ORG_UUID,
+                ability,
+            } as unknown as SessionUser;
+        };
+
+        const makeServiceWithContextProject = (
+            projectUuid?: string,
+        ): McpService => {
+            const service = makeMcpService();
+            (
+                service as unknown as {
+                    mcpContextModel: {
+                        getContext: (...args: unknown[]) => unknown;
+                    };
+                }
+            ).mcpContextModel = {
+                getContext: vi
+                    .fn()
+                    .mockResolvedValue(
+                        projectUuid ? { context: { projectUuid } } : undefined,
+                    ),
+            };
+            return service;
+        };
+
+        it('is false for a viewer of the pinned project', async () => {
+            const service = makeServiceWithContextProject();
+            const viewer = buildUser(OrganizationMemberRole.VIEWER, [
+                { projectUuid: PROJECT_A, role: ProjectMemberRole.VIEWER },
+            ]);
+            expect(await service.isRunSqlEnabled(viewer, PROJECT_A)).toBe(false);
+        });
+
+        it('is true for a developer of the pinned project', async () => {
+            const service = makeServiceWithContextProject();
+            const developer = buildUser(OrganizationMemberRole.VIEWER, [
+                { projectUuid: PROJECT_A, role: ProjectMemberRole.DEVELOPER },
+            ]);
+            expect(await service.isRunSqlEnabled(developer, PROJECT_A)).toBe(
+                true,
+            );
+        });
+
+        it('is false when the caller is a developer elsewhere but a viewer of the pinned project', async () => {
+            const service = makeServiceWithContextProject();
+            // Developer in project B, but only an org-viewer for project A.
+            const user = buildUser(OrganizationMemberRole.VIEWER, [
+                { projectUuid: PROJECT_B, role: ProjectMemberRole.DEVELOPER },
+            ]);
+            expect(await service.isRunSqlEnabled(user, PROJECT_A)).toBe(false);
+            expect(await service.isRunSqlEnabled(user, PROJECT_B)).toBe(true);
+        });
+
+        it('resolves the project from mcp_context when no header is pinned', async () => {
+            const service = makeServiceWithContextProject(PROJECT_A);
+            const viewer = buildUser(OrganizationMemberRole.VIEWER, [
+                { projectUuid: PROJECT_A, role: ProjectMemberRole.VIEWER },
+            ]);
+            expect(await service.isRunSqlEnabled(viewer)).toBe(false);
+        });
+
+        it('falls back to the coarse capability check when no project is resolved', async () => {
+            const service = makeServiceWithContextProject();
+            const orgDeveloper = buildUser(OrganizationMemberRole.DEVELOPER);
+            const orgViewer = buildUser(OrganizationMemberRole.VIEWER);
+            expect(await service.isRunSqlEnabled(orgDeveloper)).toBe(true);
+            expect(await service.isRunSqlEnabled(orgViewer)).toBe(false);
+        });
     });
 
     it('registers content and scheduled-delivery tools independently', async () => {

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -292,10 +292,12 @@ mcpRouter.all(
                     grepFieldsEnabled,
                     mcpContentWritesEnabled,
                     scheduledDeliveryEnabled,
+                    runSqlEnabled,
                 ] = await Promise.all([
                     mcpService.isAiGrepFieldsEnabled(req.user!),
                     mcpService.isContentToolsEnabled(req.user!),
                     mcpService.isCreateScheduledDeliveryEnabled(req.user!),
+                    mcpService.isRunSqlEnabled(req.user!, headerProjectUuid),
                 ]);
                 const mcpServer = await mcpService.createServer({
                     projectPinned: headerProjectUuid !== undefined,
@@ -305,7 +307,7 @@ mcpRouter.all(
                     grepFieldsEnabled,
                     mcpContentWritesEnabled,
                     scheduledDeliveryEnabled,
-                    runSqlEnabled: mcpService.isRunSqlEnabled(req.user!),
+                    runSqlEnabled,
                 });
                 const transport = new StreamableHTTPServerTransport({
                     enableJsonResponse: true,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -3212,6 +3212,29 @@ describe('AsyncQueryService', () => {
     });
 
     describe('executeAsyncSqlQuery', () => {
+        it('throws ForbiddenError when the account lacks manage:SqlRunner', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+
+            const viewerAccount = {
+                ...sessionAccount,
+                user: {
+                    ...sessionAccount.user,
+                    ability: new Ability<PossibleAbilities>([
+                        { subject: 'Project', action: ['view'] },
+                    ]),
+                },
+            } as unknown as Account;
+
+            await expect(
+                service.executeAsyncSqlQuery({
+                    account: viewerAccount,
+                    projectUuid,
+                    sql: 'SELECT 1',
+                    context: QueryExecutionContext.SQL_RUNNER,
+                }),
+            ).rejects.toThrow(ForbiddenError);
+        });
+
         describe('cache invalidation', () => {
             it('skips cache when invalidateCache is true', async () => {
                 const service = getMockedAsyncQueryService({


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/25959

### Description:

`run_sql` was gated for `tools/list` on a coarse `ability.can('manage', 'SqlRunner')` check with **no subject conditions**. In CASL, a bare capability check against a subject *type* returns `true` whenever *any* matching conditional rule exists — so `run_sql` was registered for a caller who has SqlRunner in some other project even when they are only a Viewer of the project the MCP session actually targets.

Changes:
- **`isRunSqlEnabled` is now project-aware**: it resolves the session's target project (pinned via the `X-Lightdash-Project` header or a prior `set_project`) and checks the concrete `SqlRunner` subject `{ organizationUuid, projectUuid }` against it. It only falls back to the coarse type-level check when no project is known.
- **Fail-closed defaults**: `runSqlEnabled` in `setupHandlers`/`createServer` now defaults to `false`, so an omitted flag can never register the tool for everyone. The router still passes the resolved value explicitly.

`executeAsyncSqlQuery` already enforces `manage:SqlRunner` per project at invocation time (the definitive backstop), so a genuine Viewer would already be denied there. During investigation I confirmed every `SqlRunner` grant (built-in roles and custom-role scopes) carries an org/project condition — there is no unconditional grant that could slip past that check. This PR closes the registration-side gap and adds regression coverage.

Tests:
- `mcpToolContracts.snapshot.test.ts`: viewer of the pinned project → not enabled; developer of the pinned project → enabled; developer elsewhere but viewer of the pinned project → not enabled; project resolved from `mcp_context`; coarse fallback when no project is resolved.
- `AsyncQueryService.test.ts`: `executeAsyncSqlQuery` throws `ForbiddenError` when the account lacks `manage:SqlRunner`.

### Local verification (live MCP calls)

Reproduced against a local dev stack with a user who is org-Viewer + project-Developer on one project only, PAT auth, `X-Lightdash-Project` pinned:

- **Before**: `tools/list` pinned to the viewer project included `run_sql` (bug). Calling it returned `ForbiddenError` — the `executeAsyncSqlQuery` backstop held.
- **After**: `run_sql` absent from `tools/list` on the viewer project, still present and executing on the developer project.

Note for PROD-9147: the ticket's claim that a pure Viewer *received rows* was not reproducible — execution is blocked even without this fix. Likely the reported user had a SqlRunner grant elsewhere (which explains the tool being listed).