### PR TITLE
fix: index AI prompts by thread creation time

### DIFF
--- a/packages/backend/src/ee/database/migrations/20260723193000_index_ai_prompt_thread_created_at.ts
+++ b/packages/backend/src/ee/database/migrations/20260723193000_index_ai_prompt_thread_created_at.ts
@@ -1,0 +1,57 @@
+import { Knex } from 'knex';
+
+const AiPromptTableName = 'ai_prompt';
+const AiPromptThreadCreatedAtIndex =
+    'ai_prompt_ai_thread_uuid_created_at_index';
+
+export const config = { transaction: false };
+
+const getRowCount = (result: { rowCount?: number }): number =>
+    result.rowCount ?? 0;
+
+async function dropInvalidIndex(knex: Knex): Promise<void> {
+    const invalidIndex = await knex.raw<{ rowCount: number }>(
+        `SELECT 1
+         FROM pg_class
+         JOIN pg_index ON pg_index.indexrelid = pg_class.oid
+         WHERE pg_class.relname = ?
+           AND pg_index.indrelid = ?::regclass
+           AND NOT pg_index.indisvalid`,
+        [AiPromptThreadCreatedAtIndex, AiPromptTableName],
+    );
+
+    if (getRowCount(invalidIndex) > 0) {
+        await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ??`, [
+            AiPromptThreadCreatedAtIndex,
+        ]);
+    }
+}
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        await dropInvalidIndex(knex);
+        await knex.raw(
+            `CREATE INDEX CONCURRENTLY IF NOT EXISTS ?? ON ?? (??, ??)`,
+            [
+                AiPromptThreadCreatedAtIndex,
+                AiPromptTableName,
+                'ai_thread_uuid',
+                'created_at',
+            ],
+        );
+    } finally {
+        await knex.raw('RESET statement_timeout');
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw('SET statement_timeout = 0');
+    try {
+        await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ??`, [
+            AiPromptThreadCreatedAtIndex,
+        ]);
+    } finally {
+        await knex.raw('RESET statement_timeout');
+    }
+}


### PR DESCRIPTION
### Description

- add a concurrent composite index on `ai_prompt (ai_thread_uuid, created_at)`
- make the non-transactional migration safe to retry after an interrupted index build
- disable and restore `statement_timeout` around concurrent create/drop operations

### Validation

- `pnpm -F backend typecheck:fast`
- ESLint and oxfmt on the migration
- 50,000-row local benchmark: first `up` 29.61 ms, idempotent second `up` 2.18 ms, `down` 7.84 ms
- ordered thread lookup changed from `Seq Scan + Sort` to the composite `Index Scan`; index valid/ready; rollback left no index

Closes: ZAP-695