### PR TITLE
fix: invalidate cancelled prompt on next data app generation

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -13,6 +13,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { subject } from '@casl/ability';
 import {
+    APP_VERSION_CANCELLED_BY_USER,
     assertEmbeddedAuth,
     assertUnreachable,
     checkThemeLimits,
@@ -303,6 +304,27 @@ const DATA_APP_WORKSPACE: PersistentWorkspace = {
     ],
     exclude: ['node_modules'],
 };
+// Kill any in-flight `claude` process before a cancelled sandbox is paused.
+// Native-pause backends (E2B) freeze running processes into the snapshot, so
+// without this the cancelled generation resumes execution the next time the
+// sandbox is resumed. `[c]laude` keeps pkill from matching this command's own
+// shell; pkill exits 1 when nothing matched, hence the trailing `true`. The
+// prompt file is removed so nothing left in the sandbox can replay the
+// cancelled prompt (the next iteration writes a fresh one).
+const INTERRUPT_CLAUDE_COMMAND =
+    "pkill -TERM -f '[c]laude' 2>/dev/null; sleep 1; " +
+    "pkill -KILL -f '[c]laude' 2>/dev/null; rm -f /tmp/prompt.txt 2>/dev/null; true";
+
+// Prepended to the prompt when a version since the last ready one was
+// cancelled: the resumed `--continue` session still ends with the cancelled
+// instruction (and possibly its partial tool calls), and Claude would
+// otherwise treat it as outstanding work to pick back up.
+const CANCELLED_PROMPT_NOTICE =
+    '[System notice] The user cancelled the previous instruction while you were working on it. ' +
+    'Treat that instruction as withdrawn: do not resume, finish, or build on it. ' +
+    'The working tree may contain unfinished changes from the cancelled work. ' +
+    "Act only on the user's new request below.";
+
 // Maximum number of in-progress app builds allowed per project at one time.
 // Prevents trivial sandbox exhaustion via repeated POST /code calls.
 const MAX_CONCURRENT_APP_BUILDS_PER_PROJECT = 5;
@@ -2451,6 +2473,20 @@ export class AppGenerateService extends BaseService {
             turnDurationsMs: number[];
             generationAttemptCount: number;
         }> => {
+            // Bail before spawning claude when the version is no longer in
+            // progress (typically cancelled). This gates the retry and
+            // build-fix paths, which have no advanceStage check between
+            // attempts — without it a cancel could be followed by another
+            // full generation run of the cancelled prompt.
+            const status = await this.appModel.getVersionStatus(
+                appUuid,
+                version,
+            );
+            if (!isAppVersionInProgress(status)) {
+                throw new Error(
+                    `Claude generation aborted — version ${version} is ${status} (likely cancelled)`,
+                );
+            }
             const attemptStartedAfterMs = AppGenerateService.elapsed(start);
             const sessionFlags =
                 continueSession || forceContinue ? '--continue -p' : '-p';
@@ -3630,11 +3666,28 @@ export class AppGenerateService extends BaseService {
                 if (!advanced) {
                     return;
                 }
+                // A resumed sandbox's Claude session may still end with a
+                // prompt the user cancelled mid-run — disavow it so Claude
+                // doesn't treat it as outstanding work. Fresh sandboxes get
+                // a new session (no --continue), so no notice is needed.
+                const previousPromptCancelled =
+                    wasResumed &&
+                    (await this.appModel.hasCancelledVersionSinceLastReady(
+                        appUuid,
+                        version,
+                    ));
+                if (previousPromptCancelled) {
+                    this.logger.info(
+                        `App ${appUuid}: prepending cancelled-prompt notice (a version since the last ready one was cancelled)`,
+                    );
+                }
                 const catalogResult = await this.writeCatalogAndPrompt(
                     sandbox,
                     appUuid,
                     projectUuid,
-                    prompt,
+                    previousPromptCancelled
+                        ? `${CANCELLED_PROMPT_NOTICE}\n\n${prompt}`
+                        : prompt,
                     imageIds,
                     s3Client,
                     bucket,
@@ -6243,8 +6296,8 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             appUuid,
             version,
             'error',
-            'Cancelled by user',
-            'Cancelled by user',
+            APP_VERSION_CANCELLED_BY_USER,
+            APP_VERSION_CANCELLED_BY_USER,
         );
         if (!updated) {
             throw new ParameterError('This version is not currently building');
@@ -6270,16 +6323,38 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             });
         }
 
-        // Suspend the sandbox to interrupt any running commands while keeping
-        // it resumable for the next iteration (snapshot + destroy on
-        // object-store backends, preserving state).
+        // Kill the in-flight claude process, then suspend the sandbox while
+        // keeping it resumable for the next iteration (snapshot + destroy on
+        // object-store backends, preserving state). The kill must happen
+        // before the pause: on native-pause backends a frozen claude process
+        // would otherwise resume executing the cancelled instruction when the
+        // next iteration resumes the sandbox.
         // The pipeline will catch the resulting error, but markError is now
         // a no-op since the version is already in 'error' state — and
         // pipeline catches gate `trackVersionFailed` on the markError result,
         // so no spurious failed analytics event fires on top of the cancel.
         if (app.sandbox_id) {
             try {
-                await this.getSandboxManager().suspendByUuid(app.sandbox_id);
+                await this.getSandboxManager().suspendByUuid(app.sandbox_id, {
+                    beforeSuspend: async (handle) => {
+                        try {
+                            await handle.commands.run(
+                                INTERRUPT_CLAUDE_COMMAND,
+                                {
+                                    timeoutMs: 15_000,
+                                },
+                            );
+                            this.logger.info(
+                                `App ${appUuid}: interrupted in-flight claude before suspend`,
+                            );
+                        } catch (error) {
+                            // Best-effort — the suspend must still happen.
+                            this.logger.warn(
+                                `App ${appUuid}: failed to interrupt claude before suspend: ${getErrorMessage(error)}`,
+                            );
+                        }
+                    },
+                });
                 this.logger.info(
                     `App ${appUuid}: sandbox suspended after cancel (sandboxUuid=${app.sandbox_id})`,
                 );

--- a/packages/backend/src/ee/services/SandboxRuntime/SandboxManager.test.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/SandboxManager.test.ts
@@ -209,6 +209,59 @@ describe('SandboxManager', () => {
             });
         });
 
+        it('runs beforeSuspend with the connected handle before the snapshot is taken', async () => {
+            const provider = makeProvider(true);
+            const registry = makeRegistry();
+            registry.findBySandboxUuid.mockResolvedValue({
+                sandboxUuid: 'sb-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'proj-1',
+                providerSandboxId: 'live-running',
+                snapshotRef: null,
+                workspace,
+            });
+            const manager = makeManager(provider, registry);
+            const order: string[] = [];
+            provider.persist.mockImplementation(async () => {
+                order.push('persist');
+                return { kind: 'e2b-paused', sandboxId: 'live-1' };
+            });
+            const beforeSuspend = vi
+                .fn()
+                .mockImplementation(async (handle: SandboxHandle) => {
+                    order.push(`hook:${handle.sandboxId}`);
+                });
+
+            await manager.suspendByUuid('sb-1', { beforeSuspend });
+
+            // The hook must see the live container before it is frozen —
+            // running it after persist would snapshot the processes it was
+            // meant to interrupt.
+            expect(order).toEqual(['hook:live-reconnect', 'persist']);
+        });
+
+        it('propagates a beforeSuspend error without suspending', async () => {
+            const provider = makeProvider(true);
+            const registry = makeRegistry();
+            registry.findBySandboxUuid.mockResolvedValue({
+                sandboxUuid: 'sb-1',
+                organizationUuid: 'org-1',
+                projectUuid: 'proj-1',
+                providerSandboxId: 'live-running',
+                snapshotRef: null,
+                workspace,
+            });
+            const manager = makeManager(provider, registry);
+            const hookError = new Error('interrupt failed');
+
+            await expect(
+                manager.suspendByUuid('sb-1', {
+                    beforeSuspend: vi.fn().mockRejectedValue(hookError),
+                }),
+            ).rejects.toBe(hookError);
+            expect(provider.persist).not.toHaveBeenCalled();
+        });
+
         it('GCs a row that has no live sandbox to preserve', async () => {
             const provider = makeProvider(false);
             const registry = makeRegistry();
@@ -221,11 +274,14 @@ describe('SandboxManager', () => {
                 workspace,
             });
             const manager = makeManager(provider, registry);
+            const beforeSuspend = vi.fn();
 
-            await manager.suspendByUuid('sb-1');
+            await manager.suspendByUuid('sb-1', { beforeSuspend });
 
             expect(provider.connect).not.toHaveBeenCalled();
             expect(provider.persist).not.toHaveBeenCalled();
+            // No live container — nothing for the hook to interrupt.
+            expect(beforeSuspend).not.toHaveBeenCalled();
             // Storage cleanup is delegated to the provider, not the Manager.
             expect(provider.deleteSnapshot).toHaveBeenCalledWith({
                 kind: 's3-tar',

--- a/packages/backend/src/ee/services/SandboxRuntime/SandboxManager.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/SandboxManager.ts
@@ -184,13 +184,22 @@ export class SandboxManager {
      * then suspends it (snapshot + destroy on object-store backends), preserving
      * state for a later resume. A row with no live sandbox is GC'd (nothing to
      * preserve); an already-gone row is a no-op.
+     *
+     * `beforeSuspend` runs with the connected handle before the snapshot is
+     * taken — e.g. to interrupt in-flight processes so they are not frozen
+     * into it. It is skipped when there is no live container. Errors propagate
+     * and abort the suspend, so pass a non-throwing callback for best-effort
+     * work.
      */
-    async suspendByUuid(sandboxUuid: string): Promise<void> {
+    async suspendByUuid(
+        sandboxUuid: string,
+        opts?: { beforeSuspend?: (handle: SandboxHandle) => Promise<void> },
+    ): Promise<void> {
         const row = await this.registry.findBySandboxUuid(sandboxUuid);
         if (!row) {
             return;
         }
-        await this.suspendOrphan(row);
+        await this.suspendOrphan(row, opts?.beforeSuspend);
     }
 
     /** Permanently dispose of a sandbox: kill it, GC its snapshot, drop the row. */
@@ -210,13 +219,19 @@ export class SandboxManager {
         await this.registry.deleteBySandboxUuid(input.sandboxUuid);
     }
 
-    private async suspendOrphan(row: SandboxRegistryRecord): Promise<void> {
+    private async suspendOrphan(
+        row: SandboxRegistryRecord,
+        beforeSuspend?: (handle: SandboxHandle) => Promise<void>,
+    ): Promise<void> {
         if (!row.providerSandboxId) {
             // No live sandbox to snapshot — nothing to preserve.
             await this.destroy({ sandboxUuid: row.sandboxUuid });
             return;
         }
         const handle = await this.provider.connect(row.providerSandboxId);
+        if (beforeSuspend) {
+            await beforeSuspend(handle);
+        }
         await this.suspend({
             sandboxUuid: row.sandboxUuid,
             handle,

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -1,4 +1,5 @@
 import {
+    APP_VERSION_CANCELLED_BY_USER,
     DATA_APP_VIZ_TEMPLATE,
     NotFoundError,
     ProjectType,
@@ -315,6 +316,34 @@ export class AppModel {
             .orderBy('version', 'desc')
             .first();
         return row ?? null;
+    }
+
+    /**
+     * Whether any version between the latest ready version and `beforeVersion`
+     * (both exclusive) was cancelled by the user. The persistent Claude session
+     * of a resumed sandbox still ends with a cancelled instruction until a
+     * later generation supersedes it, so the pipeline uses this to decide
+     * whether to disavow that instruction in the next prompt.
+     */
+    async hasCancelledVersionSinceLastReady(
+        appId: string,
+        beforeVersion: number,
+    ): Promise<boolean> {
+        const lastReady = await this.database(AppVersionsTableName)
+            .where({ app_id: appId, status: 'ready' })
+            .max('version as version')
+            .first<{ version: number | null }>();
+        const cancelled = await this.database(AppVersionsTableName)
+            .where({
+                app_id: appId,
+                status: 'error',
+                error: APP_VERSION_CANCELLED_BY_USER,
+            })
+            .andWhere('version', '>', lastReady?.version ?? 0)
+            .andWhere('version', '<', beforeVersion)
+            .select('version')
+            .first();
+        return cancelled !== undefined;
     }
 
     async appImageExists(appId: string, imageId: string): Promise<boolean> {

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -25,6 +25,14 @@ export const APP_VERSION_STAGE_ORDER = [
 
 export const APP_VERSION_TERMINAL_STATUSES = ['ready', 'error'] as const;
 
+/**
+ * Error message stamped on a version when the user cancels its build. There is
+ * no dedicated 'cancelled' status — cancellation is an 'error' carrying this
+ * marker, which the pipeline also reads to detect that a previous prompt was
+ * cancelled mid-generation.
+ */
+export const APP_VERSION_CANCELLED_BY_USER = 'Cancelled by user';
+
 export type AppVersionStatus =
     | (typeof APP_VERSION_STAGE_ORDER)[number]
     | 'error';


### PR DESCRIPTION
Cancelling a data app generation didn't actually stop the cancelled instruction:

- on native-pause sandboxes the running `claude` process was frozen into the snapshot and resumed executing on the next iteration
- the resumed `--continue` session still ended with the cancelled prompt, so Claude treated it as outstanding work to finish

Changes:

- cancel kills the in-flight `claude` process and removes the prompt file before pausing (new `beforeSuspend` hook on `SandboxManager.suspendByUuid`)
- generation attempts bail once the version is no longer in progress, so the retry/build-fix loops can't respawn a cancelled run
- when a version since the last ready one was cancelled, the next iteration's prompt gets a system notice disavowing the cancelled instruction

Closes: PROD-8017
Closes: #23694

🤖 Generated with [Claude Code](https://claude.com/claude-code)