### PR TITLE
refactor(frontend): migrate Mantine hooks to v8

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -46,8 +46,8 @@ import {
     Portal,
     Tooltip,
 } from '@mantine-8/core';
+import { useClipboard, useElementSize } from '@mantine-8/hooks';
 import { useMantineColorScheme } from '@mantine/core';
-import { useClipboard, useElementSize } from '@mantine/hooks';
 import {
     IconAlertCircle,
     IconAlertTriangle,

--- a/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/AddChartTilesModal.tsx
@@ -16,8 +16,8 @@ import {
     Text,
     Tooltip,
 } from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { useForm } from '@mantine/form';
-import { useDebouncedValue } from '@mantine/hooks';
 import { IconChartAreaLine } from '@tabler/icons-react';
 import uniqBy from 'lodash/uniqBy';
 import React, {

--- a/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/ChartUpdateModal.tsx
@@ -6,8 +6,8 @@ import {
     type DashboardSqlChartTile,
 } from '@lightdash/common';
 import { ActionIcon, Button, Flex, Loader, TextInput } from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { useForm } from '@mantine/form';
-import { useDebouncedValue } from '@mantine/hooks';
 import { IconEye, IconEyeOff, IconPencil } from '@tabler/icons-react';
 import uniqBy from 'lodash/uniqBy';
 import { useEffect, useRef, useState } from 'react';

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { ExploreType, type SummaryExplore } from '@lightdash/common';
 import { TextInput, Stack, ActionIcon } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import {
     IconAlertCircle,
     IconAlertTriangle,

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
@@ -13,7 +13,7 @@ import {
     Paper,
     Stack,
 } from '@mantine-8/core';
-import { useToggle } from '@mantine/hooks';
+import { useToggle } from '@mantine-8/hooks';
 import {
     IconAlertTriangle,
     IconInfoCircle,

--- a/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/index.tsx
@@ -9,7 +9,7 @@ import {
     type Metric,
 } from '@lightdash/common';
 import { TextInput, Loader, ActionIcon } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { IconSearch, IconX } from '@tabler/icons-react';
 import {
     memo,

--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -11,7 +11,7 @@ import {
     type TableCalculation,
 } from '@lightdash/common';
 import { Menu, Text } from '@mantine-8/core';
-import { useClipboard } from '@mantine/hooks';
+import { useClipboard } from '@mantine-8/hooks';
 import { IconCopy, IconFilter, IconStack } from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
 import { useCallback, useMemo, type FC } from 'react';

--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -13,7 +13,7 @@ import {
     SegmentedControl,
     Tooltip,
 } from '@mantine-8/core';
-import { useHover } from '@mantine/hooks';
+import { useHover } from '@mantine-8/hooks';
 import { IconCheck, IconClipboard } from '@tabler/icons-react';
 import {
     lazy,

--- a/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/SeriesContextMenu.tsx
@@ -6,7 +6,7 @@ import {
     type EChartsSeries,
 } from '@lightdash/common';
 import { Menu, Portal } from '@mantine-8/core';
-import { useClipboard } from '@mantine/hooks';
+import { useClipboard } from '@mantine-8/hooks';
 import { IconCopy, IconStack } from '@tabler/icons-react';
 import {
     memo,

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -13,8 +13,8 @@ import {
     type FieldId,
 } from '@lightdash/common';
 import { Button } from '@mantine-8/core';
+import { useElementSize } from '@mantine-8/hooks';
 import { useMantineColorScheme } from '@mantine/core';
-import { useElementSize } from '@mantine/hooks';
 import {
     IconLayoutSidebarLeftCollapse,
     IconLayoutSidebarLeftExpand,

--- a/packages/frontend/src/components/FunnelChart/FunnelChartContextMenu.tsx
+++ b/packages/frontend/src/components/FunnelChart/FunnelChartContextMenu.tsx
@@ -1,6 +1,6 @@
 import { type ResultRow, type ResultValue } from '@lightdash/common';
 import { Box, Menu, Portal, type MenuProps } from '@mantine-8/core';
-import { useClipboard } from '@mantine/hooks';
+import { useClipboard } from '@mantine-8/hooks';
 import { IconCopy } from '@tabler/icons-react';
 import { type FC } from 'react';
 import useToaster from '../../hooks/toaster/useToaster';

--- a/packages/frontend/src/components/FunnelChart/index.tsx
+++ b/packages/frontend/src/components/FunnelChart/index.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mantine-8/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import { IconFilterOff } from '@tabler/icons-react';
 import { type ECElementEvent } from 'echarts';
 import { type EChartsReactProps, type Opts } from 'echarts-for-react/lib/types';

--- a/packages/frontend/src/components/JobDetailsDrawer/index.tsx
+++ b/packages/frontend/src/components/JobDetailsDrawer/index.tsx
@@ -17,7 +17,7 @@ import {
     Drawer,
     type DefaultMantineColor,
 } from '@mantine-8/core';
-import { useInterval } from '@mantine/hooks';
+import { useInterval } from '@mantine-8/hooks';
 import {
     IconAlertTriangle,
     IconAlertTriangleFilled,

--- a/packages/frontend/src/components/MetricQueryData/CellContextMenu.tsx
+++ b/packages/frontend/src/components/MetricQueryData/CellContextMenu.tsx
@@ -1,6 +1,6 @@
 import { isField, type FieldUrl, type ResultValue } from '@lightdash/common';
 import { Menu } from '@mantine-8/core';
-import { useClipboard } from '@mantine/hooks';
+import { useClipboard } from '@mantine-8/hooks';
 import { IconCopy } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
 import useToaster from '../../hooks/toaster/useToaster';

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -19,7 +19,7 @@ import {
     TextInput,
     Tooltip,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import {
     IconArrowRight,
     IconChevronDown,

--- a/packages/frontend/src/components/PasswordTextInput/index.tsx
+++ b/packages/frontend/src/components/PasswordTextInput/index.tsx
@@ -1,6 +1,6 @@
 import { getPasswordSchema } from '@lightdash/common';
 import { Group, Popover, Progress, Stack, Text } from '@mantine-8/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import { IconCheck, IconX } from '@tabler/icons-react';
 import React, { type FC } from 'react';
 import MantineIcon from '../common/MantineIcon';

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectUsingCLI.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectUsingCLI.tsx
@@ -11,7 +11,7 @@ import {
     Text,
     Avatar,
 } from '@mantine-8/core';
-import { useOs } from '@mantine/hooks';
+import { useOs } from '@mantine-8/hooks';
 import { IconChevronLeft, IconClock } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -21,7 +21,7 @@ import {
     Switch,
     Tooltip,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { IconCheck, IconExclamationCircle } from '@tabler/icons-react';
 import {
     useEffect,

--- a/packages/frontend/src/components/SchedulersView/LogsTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/LogsTable.tsx
@@ -15,7 +15,7 @@ import {
     Tooltip,
     useMantineTheme,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import {
     IconAlertTriangleFilled,
     IconClock,

--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -18,7 +18,7 @@ import {
     Tooltip,
     useMantineTheme,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import {
     IconArrowDown,
     IconArrowsSort,

--- a/packages/frontend/src/components/SchedulersView/filters/CreatedByFilter.tsx
+++ b/packages/frontend/src/components/SchedulersView/filters/CreatedByFilter.tsx
@@ -1,4 +1,4 @@
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { useInfiniteOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import FilterFacet, { type FilterFacetOption } from '../../common/FilterFacet';

--- a/packages/frontend/src/components/SettingsValidator/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/index.tsx
@@ -7,7 +7,7 @@ import {
     type ValidationSourceType,
 } from '@lightdash/common';
 import { Button, Group, Loader, Paper, Text } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { IconCheck } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { useLocation, useNavigate } from 'react-router';

--- a/packages/frontend/src/components/SimpleMap/MapContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleMap/MapContextMenu.tsx
@@ -14,7 +14,7 @@ import {
     Text,
     type MenuProps,
 } from '@mantine-8/core';
-import { useClipboard } from '@mantine/hooks';
+import { useClipboard } from '@mantine-8/hooks';
 import { IconCopy } from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
 import { useMemo, type FC } from 'react';

--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -3,7 +3,7 @@ import {
     MapChartType,
     MapTileBackground,
 } from '@lightdash/common';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import { captureException } from '@sentry/react';
 import { IconMap } from '@tabler/icons-react';
 import { scaleSqrt } from 'd3-scale';

--- a/packages/frontend/src/components/SimplePieChart/PieChartContextMenu.tsx
+++ b/packages/frontend/src/components/SimplePieChart/PieChartContextMenu.tsx
@@ -7,7 +7,7 @@ import {
     type ResultValue,
 } from '@lightdash/common';
 import { Box, Menu, Portal, type MenuProps } from '@mantine-8/core';
-import { useClipboard } from '@mantine/hooks';
+import { useClipboard } from '@mantine-8/hooks';
 import { IconCopy } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useLocation } from 'react-router';

--- a/packages/frontend/src/components/SimplePieChart/index.tsx
+++ b/packages/frontend/src/components/SimplePieChart/index.tsx
@@ -1,4 +1,4 @@
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import { IconChartPieOff } from '@tabler/icons-react';
 import { type ECElementEvent } from 'echarts';
 import { type EChartsReactProps, type Opts } from 'echarts-for-react/lib/types';

--- a/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/BigNumberContextMenu.tsx
@@ -1,6 +1,6 @@
 import { type ResultValue } from '@lightdash/common';
 import { Menu, Text } from '@mantine-8/core';
-import { useClipboard } from '@mantine/hooks';
+import { useClipboard } from '@mantine-8/hooks';
 import { IconArrowBarToDown, IconCopy } from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
 import { useMemo, type FC } from 'react';

--- a/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/CellContextMenu.tsx
@@ -7,7 +7,7 @@ import {
     type ResultValue,
 } from '@lightdash/common';
 import { Menu } from '@mantine-8/core';
-import { useClipboard } from '@mantine/hooks';
+import { useClipboard } from '@mantine-8/hooks';
 import { IconCopy, IconStack } from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
 import { useCallback, useMemo, type FC } from 'react';

--- a/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardCellContextMenu.tsx
@@ -11,7 +11,7 @@ import {
     type ResultValue,
 } from '@lightdash/common';
 import { Menu } from '@mantine-8/core';
-import { useClipboard } from '@mantine/hooks';
+import { useClipboard } from '@mantine-8/hooks';
 import { IconCopy, IconStack } from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
 import { useCallback, useMemo, type FC } from 'react';

--- a/packages/frontend/src/components/SimpleTable/MinimalCellContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/MinimalCellContextMenu.tsx
@@ -1,6 +1,6 @@
 import { isDimension, isField, type ResultValue } from '@lightdash/common';
 import { Menu } from '@mantine-8/core';
-import { useClipboard } from '@mantine/hooks';
+import { useClipboard } from '@mantine-8/hooks';
 import { IconCopy } from '@tabler/icons-react';
 import mapValues from 'lodash/mapValues';
 import { useCallback, useMemo, type FC } from 'react';

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
@@ -11,7 +11,7 @@ import {
     Menu,
     Tooltip,
 } from '@mantine-8/core';
-import { useClipboard } from '@mantine/hooks';
+import { useClipboard } from '@mantine-8/hooks';
 import {
     IconDotsVertical,
     IconEdit,

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
@@ -12,7 +12,7 @@ import {
     Tooltip,
     useMantineTheme,
 } from '@mantine-8/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import {
     IconArrowDown,
     IconArrowsSort,

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsTable.tsx
@@ -7,7 +7,7 @@ import {
     Text,
     useMantineTheme,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import {
     IconArrowDown,
     IconArrowsSort,

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
@@ -18,7 +18,7 @@ import {
     Text,
     useMantineTheme,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import {
     IconArrowDown,
     IconArrowsSort,

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -1,7 +1,7 @@
 import { FeatureFlags } from '@lightdash/common';
 import { Flex, Group, Loader, Text, Button } from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { useMantineTheme } from '@mantine/core';
-import { useDebouncedValue } from '@mantine/hooks';
 import Editor, { type EditorProps, type Monaco } from '@monaco-editor/react';
 import { type IDisposable, type languages } from 'monaco-editor';
 import React, { memo, useEffect, useMemo, useRef, useState } from 'react';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipConfig.tsx
@@ -9,7 +9,7 @@ import {
     Tooltip,
     useMantineColorScheme,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import {
     Editor,
     type BeforeMount,

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
@@ -8,7 +8,7 @@ import {
     type TableCalculation,
 } from '@lightdash/common';
 import { Box, Group } from '@mantine-8/core';
-import { useDebouncedState } from '@mantine/hooks';
+import { useDebouncedState } from '@mantine-8/hooks';
 import { IconPalette } from '@tabler/icons-react';
 import { type FC } from 'react';
 import type useCartesianChartConfig from '../../../../hooks/cartesianChartConfig/useCartesianChartConfig';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormattingRule.tsx
@@ -16,7 +16,7 @@ import {
     Select,
     Tooltip,
 } from '@mantine-8/core';
-import { useHover } from '@mantine/hooks';
+import { useHover } from '@mantine-8/hooks';
 import { IconChevronDown, IconChevronUp, IconTrash } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
@@ -15,7 +15,7 @@ import {
     Select,
     Popover,
 } from '@mantine-8/core';
-import { useDebouncedState, useHover } from '@mantine/hooks';
+import { useDebouncedState, useHover } from '@mantine-8/hooks';
 import {
     IconChevronDown,
     IconChevronUp,

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapFieldConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapFieldConfiguration.tsx
@@ -1,6 +1,6 @@
 import { getItemLabelWithoutTableName } from '@lightdash/common';
 import { TextInput, Box, Group, ActionIcon, Tooltip } from '@mantine-8/core';
-import { useDebouncedState } from '@mantine/hooks';
+import { useDebouncedState } from '@mantine-8/hooks';
 import { IconEye, IconEyeOff } from '@tabler/icons-react';
 import { useEffect, useState, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/GroupItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/GroupItem.tsx
@@ -14,7 +14,7 @@ import {
     ActionIcon,
     Tooltip,
 } from '@mantine-8/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
 import { forwardRef } from 'react';
 import MantineIcon from '../../common/MantineIcon';

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
@@ -6,7 +6,7 @@ import {
     TextInput,
     Tooltip,
 } from '@mantine-8/core';
-import { useDebouncedState } from '@mantine/hooks';
+import { useDebouncedState } from '@mantine-8/hooks';
 import {
     IconEye,
     IconEyeOff,

--- a/packages/frontend/src/components/VisualizationConfigs/common/LabelEditor.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/LabelEditor.tsx
@@ -1,5 +1,5 @@
 import { Input, Paper, Text, useMantineColorScheme } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import {
     Editor,
     type BeforeMount,

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -18,7 +18,7 @@ import {
     Tooltip,
     UnstyledButton,
 } from '@mantine-8/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import {
     IconAlertTriangle,
     IconBolt,

--- a/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon, Menu, Text, Tooltip } from '@mantine-8/core';
-import { useInterval } from '@mantine/hooks';
+import { useInterval } from '@mantine-8/hooks';
 import { IconCheck, IconChevronDown, IconRefresh } from '@tabler/icons-react';
 import {
     memo,

--- a/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.tsx
+++ b/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.tsx
@@ -14,7 +14,7 @@ import {
     Text,
     Tooltip,
 } from '@mantine-8/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import {
     IconBolt,
     IconChevronDown,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMonthAndYearPicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMonthAndYearPicker.tsx
@@ -1,9 +1,9 @@
+import { useDisclosure } from '@mantine-8/hooks';
 import {
     MonthPicker,
     MonthPickerInput,
     type MonthPickerInputProps,
 } from '@mantine/dates';
-import { useDisclosure } from '@mantine/hooks';
 import dayjs from 'dayjs';
 import { type FC } from 'react';
 import InvalidDateInput from './InvalidDateInput';

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.tsx
@@ -1,8 +1,8 @@
 import { formatDate, TimeFrames } from '@lightdash/common';
 import { TextInput, Stack, Text, Popover } from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
 import { type MantineTheme, type Sx } from '@mantine/core';
 import { MonthPicker, type MonthPickerProps } from '@mantine/dates';
-import { useDisclosure } from '@mantine/hooks';
 import dayjs from 'dayjs';
 import quarterOfYear from 'dayjs/plugin/quarterOfYear';
 import { useCallback, useEffect, useState, type FC } from 'react';

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -12,7 +12,7 @@ import {
     type ComboboxProps,
     type PillsInputProps,
 } from '@mantine-8/core';
-import { useDisclosure, useHover } from '@mantine/hooks';
+import { useDisclosure, useHover } from '@mantine-8/hooks';
 import {
     IconAlertCircle,
     IconListDetails,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterYearPicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterYearPicker.tsx
@@ -1,9 +1,9 @@
+import { useDisclosure } from '@mantine-8/hooks';
 import {
     YearPicker,
     YearPickerInput,
     type YearPickerInputProps,
 } from '@mantine/dates';
-import { useDisclosure } from '@mantine/hooks';
 import dayjs from 'dayjs';
 import { type FC } from 'react';
 import InvalidDateInput from './InvalidDateInput';

--- a/packages/frontend/src/components/common/Filters/FilterInputs/InvalidDateInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/InvalidDateInput.tsx
@@ -1,5 +1,5 @@
 import { TextInput, Popover } from '@mantine-8/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import { type FC, type ReactNode } from 'react';
 
 type Props = {

--- a/packages/frontend/src/components/common/LightTable/index.tsx
+++ b/packages/frontend/src/components/common/LightTable/index.tsx
@@ -9,8 +9,8 @@ import {
     Text,
     Tooltip,
 } from '@mantine-8/core';
+import { getHotkeyHandler, useClipboard, useId } from '@mantine-8/hooks';
 import { useMantineTheme } from '@mantine/core';
-import { getHotkeyHandler, useClipboard, useId } from '@mantine/hooks';
 import debounce from 'lodash/debounce';
 import {
     createContext,

--- a/packages/frontend/src/components/common/MantineModal/index.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.tsx
@@ -14,7 +14,7 @@ import {
     type ModalHeaderProps,
     type ModalRootProps,
 } from '@mantine-8/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import { IconTrash, type Icon as IconType } from '@tabler/icons-react';
 import React, { useCallback, useEffect } from 'react';
 import MantineIcon from '../MantineIcon';

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -24,9 +24,8 @@ import {
     Anchor,
     Tooltip,
 } from '@mantine-8/core';
-import { useDebouncedCallback } from '@mantine-8/hooks';
+import { useDebouncedCallback, useDisclosure } from '@mantine-8/hooks';
 import { useMantineTheme } from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
 import {
     IconAppWindow,
     IconArrowDown,

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
@@ -1,6 +1,6 @@
 import { type ResourceViewChartItem } from '@lightdash/common';
 import { Box, Flex, Group, Paper, Text, Tooltip } from '@mantine-8/core';
-import { useDisclosure, useHover } from '@mantine/hooks';
+import { useDisclosure, useHover } from '@mantine-8/hooks';
 import { IconCircleCheckFilled, IconEye } from '@tabler/icons-react';
 import { type FC, type ReactNode } from 'react';
 import { ResourceIcon, ResourceIndicator } from '../../ResourceIcon';

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
@@ -1,6 +1,6 @@
 import { type ResourceViewDashboardItem } from '@lightdash/common';
 import { Box, Flex, Group, Paper, Text, Tooltip } from '@mantine-8/core';
-import { useDisclosure, useHover } from '@mantine/hooks';
+import { useDisclosure, useHover } from '@mantine-8/hooks';
 import { IconCircleCheckFilled, IconEye } from '@tabler/icons-react';
 import { type FC, type ReactNode } from 'react';
 import { ResourceIcon, ResourceIndicator } from '../../ResourceIcon';

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDataAppItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDataAppItem.tsx
@@ -3,7 +3,7 @@ import {
     type ResourceViewDataAppItem,
 } from '@lightdash/common';
 import { Box, Flex, Group, Paper, Text, Tooltip } from '@mantine-8/core';
-import { useDisclosure, useHover } from '@mantine/hooks';
+import { useDisclosure, useHover } from '@mantine-8/hooks';
 import { IconEye } from '@tabler/icons-react';
 import { type FC, type ReactNode } from 'react';
 import AppThumbnailHoverCard from '../../../../features/apps/components/AppThumbnailHoverCard';

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
@@ -1,6 +1,6 @@
 import { FeatureFlags, type ResourceViewSpaceItem } from '@lightdash/common';
 import { Box, Flex, Group, Paper, Stack, Text } from '@mantine-8/core';
-import { useDisclosure, useHover } from '@mantine/hooks';
+import { useDisclosure, useHover } from '@mantine-8/hooks';
 import {
     IconAppWindow,
     IconChartBar,

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
@@ -24,7 +24,7 @@ import {
     type ResourceViewItem,
 } from '@lightdash/common';
 import { Box, SimpleGrid, Stack, Text } from '@mantine-8/core';
-import { mergeRefs, useHover } from '@mantine/hooks';
+import { mergeRefs, useHover } from '@mantine-8/hooks';
 import { IconGripVertical } from '@tabler/icons-react';
 import { produce } from 'immer';
 import orderBy from 'lodash/orderBy';

--- a/packages/frontend/src/components/common/Select/SelectWithFooter.tsx
+++ b/packages/frontend/src/components/common/Select/SelectWithFooter.tsx
@@ -13,7 +13,7 @@ import {
     type ScrollAreaProps,
     type SelectProps,
 } from '@mantine-8/core';
-import { useUncontrolled } from '@mantine/hooks';
+import { useUncontrolled } from '@mantine-8/hooks';
 import { useEffect, useMemo, type FC, type ReactNode } from 'react';
 
 type Props = Omit<

--- a/packages/frontend/src/components/common/SlackChannelSelect/index.tsx
+++ b/packages/frontend/src/components/common/SlackChannelSelect/index.tsx
@@ -13,7 +13,7 @@ import {
     useCombobox,
     type PillsInputProps,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { IconRefresh, IconX } from '@tabler/icons-react';
 import compact from 'lodash/compact';
 import uniq from 'lodash/uniq';

--- a/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
@@ -5,7 +5,7 @@ import {
     type SpaceSummary,
 } from '@lightdash/common';
 import { Paper, Stack, TextInput } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { useMemo, useState } from 'react';
 import useApp from '../../../providers/App/useApp';
 import AdminContentViewFilter from '../ResourceView/AdminContentViewFilter';

--- a/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
@@ -6,13 +6,13 @@ import {
     type RawResultRow,
     type ResultRow,
 } from '@lightdash/common';
-import { clsx } from '@mantine/core';
 import {
     getHotkeyHandler,
     useClipboard,
     useDisclosure,
     useTimeout,
-} from '@mantine/hooks';
+} from '@mantine-8/hooks';
+import { clsx } from '@mantine/core';
 import { type Cell } from '@tanstack/react-table';
 import {
     useCallback,

--- a/packages/frontend/src/components/common/UserSelect/index.tsx
+++ b/packages/frontend/src/components/common/UserSelect/index.tsx
@@ -1,5 +1,5 @@
 import { Group, Loader, Select, Stack, Text } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { useCallback, useMemo, useRef, useState, type FC } from 'react';
 import { useInfiniteOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import { LightdashUserAvatar } from '../../Avatar';

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
@@ -7,7 +7,7 @@ import {
     TextInput,
     useCombobox,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { IconX } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import { useNavigate } from 'react-router';

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
@@ -9,7 +9,7 @@ import {
     Text,
     Tooltip,
 } from '@mantine-8/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import {
     IconArrowRight,
     IconExternalLink,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/UsersFilter.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/UsersFilter.tsx
@@ -1,4 +1,4 @@
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { IconUser } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import FilterFacet, {

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -26,8 +26,8 @@ import {
     Title,
     Tooltip,
 } from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
 import { type useForm } from '@mantine/form';
-import { useDisclosure } from '@mantine/hooks';
 import {
     IconAdjustmentsAlt,
     IconAlertTriangle,

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -27,8 +27,8 @@ import {
     Title,
     Tooltip,
 } from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
 import { useForm, zodResolver } from '@mantine/form';
-import { useDisclosure } from '@mantine/hooks';
 import {
     IconAlertTriangle,
     IconBrandGithub,

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedReviewEntityCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedReviewEntityCard.tsx
@@ -12,7 +12,7 @@ import {
     Stack,
     Text,
 } from '@mantine-8/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import {
     IconChevronRight,
     IconFlask,

--- a/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiCustomDimensionInput.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiCustomDimensionInput.tsx
@@ -1,6 +1,6 @@
 import type { GeneratedCustomDimension } from '@lightdash/common';
 import { ActionIcon, Text } from '@mantine-8/core';
-import { useHotkeys } from '@mantine/hooks';
+import { useHotkeys } from '@mantine-8/hooks';
 import { IconArrowUp } from '@tabler/icons-react';
 import { type Editor } from '@tiptap/react';
 import { useCallback, useRef, useState, type FC } from 'react';

--- a/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiTableCalculationInput.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiTableCalculationInput.tsx
@@ -1,6 +1,6 @@
 import type { GeneratedTableCalculation } from '@lightdash/common';
 import { Text, ActionIcon } from '@mantine-8/core';
-import { useHotkeys } from '@mantine/hooks';
+import { useHotkeys } from '@mantine-8/hooks';
 import { IconArrowUp } from '@tabler/icons-react';
 import { type Editor } from '@tiptap/react';
 import { useCallback, useRef, useState, type FC } from 'react';

--- a/packages/frontend/src/ee/features/ambientAi/components/tooltip/AiTooltipInput.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/tooltip/AiTooltipInput.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon, Box, Group, Text, Textarea } from '@mantine-8/core';
-import { useHotkeys } from '@mantine/hooks';
+import { useHotkeys } from '@mantine-8/hooks';
 import { IconArrowUp, IconSparkles } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
 import { useParams } from 'react-router';

--- a/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
+++ b/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
@@ -9,7 +9,7 @@ import {
     Text,
     Tooltip,
 } from '@mantine-8/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import { IconDots, IconEdit, IconTrash } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { Link } from 'react-router';

--- a/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
@@ -16,8 +16,8 @@ import {
     Title,
     UnstyledButton,
 } from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { type UseFormReturnType } from '@mantine/form';
-import { useDebouncedValue } from '@mantine/hooks';
 import {
     IconAlertTriangleFilled,
     IconChevronDown,

--- a/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/HomepageEditor.tsx
@@ -37,7 +37,7 @@ import {
     Text,
     Tooltip,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import {
     IconArrowBackUp,
     IconArrowDown,

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/CollectionBlock.tsx
@@ -32,7 +32,7 @@ import {
     Text,
     TextInput,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import {
     IconLayoutGrid,
     IconPin,

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/DataAppPickerModal.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/DataAppPickerModal.tsx
@@ -14,7 +14,7 @@ import {
     Text,
     TextInput,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { IconAppWindow, IconSearch } from '@tabler/icons-react';
 import { useMemo, useRef, useState, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/MetricsBlock.tsx
@@ -21,7 +21,7 @@ import {
     Text,
     TextInput,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { IconChartDots, IconHash, IconPlus, IconX } from '@tabler/icons-react';
 import {
     useCallback,

--- a/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
+++ b/packages/frontend/src/ee/features/homepageBuilder/blocks/QuickActionsBlock.tsx
@@ -11,7 +11,7 @@ import {
     Text,
     TextInput,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import {
     IconArrowLeft,
     IconArrowRight,

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
@@ -7,7 +7,7 @@ import {
     Button,
     Anchor,
 } from '@mantine-8/core';
-import { useClipboard } from '@mantine/hooks';
+import { useClipboard } from '@mantine-8/hooks';
 import { IconCopy } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
 import {

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsTable.tsx
@@ -25,7 +25,7 @@ import {
     TextInput,
     Tooltip,
 } from '@mantine-8/core';
-import { useClipboard, useDisclosure } from '@mantine/hooks';
+import { useClipboard, useDisclosure } from '@mantine-8/hooks';
 import {
     IconCalendar,
     IconClock,

--- a/packages/frontend/src/ee/features/serviceAccounts/index.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Group, Stack, Title } from '@mantine-8/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import { IconUsersGroup } from '@tabler/icons-react';
 import { useState } from 'react';
 import { EmptyState } from '../../../components/common/EmptyState';

--- a/packages/frontend/src/features/apps/AppResourcePicker.tsx
+++ b/packages/frontend/src/features/apps/AppResourcePicker.tsx
@@ -23,7 +23,7 @@ import {
     Tooltip,
     UnstyledButton,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import {
     IconArrowLeft,
     IconCamera,

--- a/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppVizLibraryPicker.tsx
@@ -1,6 +1,6 @@
 import { getAppDisplayName, type DataAppViz } from '@lightdash/common';
 import { Box, Loader, Select, Text, type ComboboxItem } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { IconPuzzle } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';

--- a/packages/frontend/src/features/comments/components/CommentDetail.tsx
+++ b/packages/frontend/src/features/comments/components/CommentDetail.tsx
@@ -9,7 +9,7 @@ import {
     Text,
     Tooltip,
 } from '@mantine-8/core';
-import { useHover } from '@mantine/hooks';
+import { useHover } from '@mantine-8/hooks';
 import {
     IconArrowBackUp,
     IconCircleCheck,

--- a/packages/frontend/src/features/comments/components/DashboardCommentAndReplies.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardCommentAndReplies.tsx
@@ -1,6 +1,6 @@
 import { type Comment } from '@lightdash/common';
 import { Box, Button, Collapse, Divider, Stack } from '@mantine-8/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import { useCallback, useState, type FC } from 'react';
 import useApp from '../../../providers/App/useApp';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';

--- a/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
@@ -12,7 +12,7 @@ import {
     Tooltip,
     type PopoverProps,
 } from '@mantine-8/core';
-import { useDisclosure, useScrollIntoView } from '@mantine/hooks';
+import { useDisclosure, useScrollIntoView } from '@mantine-8/hooks';
 import {
     IconChevronDown,
     IconChevronUp,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -13,7 +13,7 @@ import {
     Popover,
     Tooltip,
 } from '@mantine-8/core';
-import { useDisclosure, useHover } from '@mantine/hooks';
+import { useDisclosure, useHover } from '@mantine-8/hooks';
 import { IconCode, IconDots, IconTrash } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/MetricExploreModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/MetricExploreModal.tsx
@@ -27,7 +27,7 @@ import {
     Tooltip,
     type ModalProps,
 } from '@mantine-8/core';
-import { useHotkeys } from '@mantine/hooks';
+import { useHotkeys } from '@mantine-8/hooks';
 import {
     IconChevronDown,
     IconChevronUp,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumnName.tsx
@@ -8,8 +8,8 @@ import {
     Highlight,
     Portal,
 } from '@mantine-8/core';
+import { useClickOutside } from '@mantine-8/hooks';
 import { getDefaultZIndex } from '@mantine/core';
-import { useClickOutside } from '@mantine/hooks';
 import { IconTrash } from '@tabler/icons-react';
 import EmojiPicker, {
     Emoji,

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogColumns.tsx
@@ -7,7 +7,7 @@ import {
     Text,
     useComputedColorScheme,
 } from '@mantine-8/core';
-import { useHover } from '@mantine/hooks';
+import { useHover } from '@mantine-8/hooks';
 import { IconPlus, IconUser } from '@tabler/icons-react';
 import { useMemo } from 'react';
 import { type ContentTableColumnDef } from '../../../components/common/ContentTable';

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -10,8 +10,8 @@ import {
     ActionIcon,
     Popover,
 } from '@mantine-8/core';
+import { useClickOutside, useDisclosure } from '@mantine-8/hooks';
 import { useMantineTheme } from '@mantine/core';
-import { useClickOutside, useDisclosure } from '@mantine/hooks';
 import { IconRefresh, IconSparkles, IconX } from '@tabler/icons-react';
 import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { useNavigate, useParams } from 'react-router';

--- a/packages/frontend/src/features/metricsCatalog/components/SelectItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/SelectItem.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from '@mantine-8/core';
-import { mergeRefs, useHover } from '@mantine/hooks';
+import { mergeRefs, useHover } from '@mantine-8/hooks';
 import { forwardRef, type ComponentPropsWithoutRef } from 'react';
 
 const SelectItem = forwardRef<

--- a/packages/frontend/src/features/omnibar/components/Omnibar.tsx
+++ b/packages/frontend/src/features/omnibar/components/Omnibar.tsx
@@ -17,7 +17,7 @@ import {
     useDisclosure,
     useHotkeys,
     useScrollIntoView,
-} from '@mantine/hooks';
+} from '@mantine-8/hooks';
 import { IconCircleXFilled, IconSearch } from '@tabler/icons-react';
 import {
     useEffect,

--- a/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
@@ -5,8 +5,8 @@ import {
     type SearchFilters,
 } from '@lightdash/common';
 import { Button, Flex, Group, Menu, Select } from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
 import { DatePicker } from '@mantine/dates';
-import { useDisclosure } from '@mantine/hooks';
 import {
     IconAdjustments,
     IconAppWindow,

--- a/packages/frontend/src/features/omnibar/components/OmnibarTarget.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarTarget.tsx
@@ -1,5 +1,5 @@
 import { Badge, Text } from '@mantine-8/core';
-import { useOs } from '@mantine/hooks';
+import { useOs } from '@mantine-8/hooks';
 import { IconSearch } from '@tabler/icons-react';
 import { type CSSProperties, type FC, type MouseEvent } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';

--- a/packages/frontend/src/features/recentlyDeleted/components/DeletedByFilter.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/DeletedByFilter.tsx
@@ -1,4 +1,4 @@
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import FilterFacet, {
     type FilterFacetOption,

--- a/packages/frontend/src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx
@@ -16,7 +16,7 @@ import {
     Tooltip,
     useMantineTheme,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import {
     IconAppWindow,
     IconCalendar,

--- a/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeDrawer/index.tsx
+++ b/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeDrawer/index.tsx
@@ -1,6 +1,6 @@
 import { ProjectType } from '@lightdash/common';
 import { Drawer } from '@mantine-8/core';
-import { useHotkeys } from '@mantine/hooks';
+import { useHotkeys } from '@mantine-8/hooks';
 import { lazy, Suspense, type FC } from 'react';
 import {
     BANNER_HEIGHT,

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -21,8 +21,8 @@ import {
     Transition,
     Tooltip,
 } from '@mantine-8/core';
+import { useElementSize, useHotkeys } from '@mantine-8/hooks';
 import { notifications } from '@mantine-8/notifications';
-import { useElementSize, useHotkeys } from '@mantine/hooks';
 import {
     IconAlertCircle,
     IconChartHistogram,

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -10,7 +10,7 @@ import {
     Menu,
     Tooltip,
 } from '@mantine-8/core';
-import { useClipboard } from '@mantine/hooks';
+import { useClipboard } from '@mantine-8/hooks';
 import {
     IconBrandGithub,
     IconChevronDown,

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderView.tsx
@@ -10,7 +10,7 @@ import {
     Menu,
     Tooltip,
 } from '@mantine-8/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import {
     IconCirclesRelation,
     IconDatabaseExport,

--- a/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SqlQueryHistory.tsx
@@ -8,8 +8,8 @@ import {
     Popover,
     Tooltip,
 } from '@mantine-8/core';
+import { useHover } from '@mantine-8/hooks';
 import { useMantineTheme } from '@mantine/core';
-import { useHover } from '@mantine/hooks';
 import { Editor } from '@monaco-editor/react';
 import {
     IconClock,

--- a/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TableFields.tsx
@@ -12,7 +12,7 @@ import {
     ScrollArea,
     Tooltip,
 } from '@mantine-8/core';
-import { useDebouncedValue, useHover } from '@mantine/hooks';
+import { useDebouncedValue, useHover } from '@mantine-8/hooks';
 import { IconCopy, IconSearch, IconX } from '@tabler/icons-react';
 import { memo, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -15,7 +15,7 @@ import {
     ScrollArea,
     Tooltip,
 } from '@mantine-8/core';
-import { useDebouncedValue, useHover } from '@mantine/hooks';
+import { useDebouncedValue, useHover } from '@mantine-8/hooks';
 import {
     IconChevronDown,
     IconChevronRight,

--- a/packages/frontend/src/features/sqlRunner/components/TablesPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/TablesPanel.tsx
@@ -1,5 +1,5 @@
 import { Box, LoadingOverlay, Text } from '@mantine-8/core';
-import { useTimeout } from '@mantine/hooks';
+import { useTimeout } from '@mantine-8/hooks';
 import { IconGripHorizontal } from '@tabler/icons-react';
 import { useEffect, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';

--- a/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.tsx
@@ -13,8 +13,8 @@ import {
     TextInput,
     Tooltip,
 } from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { useForm, zodResolver } from '@mantine/form';
-import { useDebouncedValue } from '@mantine/hooks';
 import { IconBrandGithub, IconInfoCircle } from '@tabler/icons-react';
 import { useCallback, useEffect, useState, type FC } from 'react';
 import { z } from 'zod';

--- a/packages/frontend/src/features/sqlRunner/hooks/useSqlEditorPreferences.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSqlEditorPreferences.tsx
@@ -1,5 +1,5 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { useLocalStorage } from '@mantine/hooks';
+import { useLocalStorage } from '@mantine-8/hooks';
 
 export type SqlEditorPreferences = {
     quotePreference: 'always' | 'never';

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -11,8 +11,8 @@ import {
     ScrollArea,
     Text,
 } from '@mantine-8/core';
+import { useLocalStorage } from '@mantine-8/hooks';
 import { useMantineTheme } from '@mantine/core';
-import { useLocalStorage } from '@mantine/hooks';
 import { IconAlertCircle, IconSparkles, IconWand } from '@tabler/icons-react';
 import { useCallback, type CSSProperties, type FC } from 'react';
 import AceEditor, { type IAceEditorProps } from 'react-ace';

--- a/packages/frontend/src/features/users/components/LoginLanding.tsx
+++ b/packages/frontend/src/features/users/components/LoginLanding.tsx
@@ -22,8 +22,8 @@ import {
     PasswordInput,
     Card,
 } from '@mantine-8/core';
+import { useTimeout } from '@mantine-8/hooks';
 import { useForm, zodResolver } from '@mantine/form';
-import { useTimeout } from '@mantine/hooks';
 import { IconX } from '@tabler/icons-react';
 import {
     useCallback,

--- a/packages/frontend/src/hooks/mantineHooksV8Compatibility.test.tsx
+++ b/packages/frontend/src/hooks/mantineHooksV8Compatibility.test.tsx
@@ -1,0 +1,171 @@
+import { useElementSize, useInterval, useTimeout } from '@mantine-8/hooks';
+import { act, render, renderHook, screen } from '@testing-library/react';
+import { useEffect, useState } from 'react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const useControlledInterval = (enabled: boolean) => {
+    const [ticks, setTicks] = useState(0);
+    const interval = useInterval(() => setTicks((value) => value + 1), 1_000);
+
+    useEffect(() => {
+        if (enabled) {
+            interval.start();
+        } else {
+            interval.stop();
+        }
+
+        return interval.stop;
+        // Matches the controlled interval pattern used by JobDetailsDrawer.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [enabled]);
+
+    return ticks;
+};
+
+const useDelayedFlag = (pending: boolean) => {
+    const [visible, setVisible] = useState(false);
+    const { start, clear } = useTimeout(() => setVisible(true), 400);
+
+    useEffect(() => {
+        if (pending) {
+            start();
+        } else {
+            clear();
+            setVisible(false);
+        }
+    }, [pending, start, clear]);
+
+    return visible;
+};
+
+const ElementSizeProbe = () => {
+    const { ref, width, height } = useElementSize<HTMLDivElement>();
+
+    return (
+        <div ref={ref} data-testid="element-size">
+            {width}x{height}
+        </div>
+    );
+};
+
+describe('Mantine v8 hooks compatibility', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    test('controlled intervals keep running across callback rerenders and stop when disabled', () => {
+        vi.useFakeTimers();
+        const { result, rerender } = renderHook(
+            ({ enabled }) => useControlledInterval(enabled),
+            { initialProps: { enabled: true } },
+        );
+
+        act(() => {
+            vi.advanceTimersByTime(2_000);
+        });
+        expect(result.current).toBe(2);
+
+        rerender({ enabled: false });
+        act(() => {
+            vi.advanceTimersByTime(2_000);
+        });
+        expect(result.current).toBe(2);
+    });
+
+    test('delayed state appears after its timeout and stays hidden when cancelled', () => {
+        vi.useFakeTimers();
+        const { result, rerender } = renderHook(
+            ({ pending }) => useDelayedFlag(pending),
+            { initialProps: { pending: true } },
+        );
+
+        act(() => {
+            vi.advanceTimersByTime(399);
+        });
+        expect(result.current).toBe(false);
+
+        act(() => {
+            vi.advanceTimersByTime(1);
+        });
+        expect(result.current).toBe(true);
+
+        rerender({ pending: false });
+        rerender({ pending: true });
+        act(() => {
+            vi.advanceTimersByTime(200);
+        });
+        rerender({ pending: false });
+        act(() => {
+            vi.advanceTimersByTime(400);
+        });
+        expect(result.current).toBe(false);
+    });
+
+    test('element size updates after the first ResizeObserver measurement', () => {
+        let resizeCallback: ResizeObserverCallback | undefined;
+        const observer = {
+            observe: vi.fn(),
+            unobserve: vi.fn(),
+            disconnect: vi.fn(),
+        } as unknown as ResizeObserver;
+
+        vi.stubGlobal(
+            'ResizeObserver',
+            class {
+                constructor(callback: ResizeObserverCallback) {
+                    resizeCallback = callback;
+                }
+
+                observe = observer.observe;
+
+                unobserve = observer.unobserve;
+
+                disconnect = observer.disconnect;
+            },
+        );
+        vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
+            (callback) => {
+                callback(0);
+                return 1;
+            },
+        );
+
+        render(<ElementSizeProbe />);
+        expect(screen.getByTestId('element-size')).toHaveTextContent('0x0');
+        expect(observer.observe).toHaveBeenCalled();
+
+        const contentRect = {
+            x: 0,
+            y: 0,
+            top: 0,
+            left: 0,
+            bottom: 480,
+            right: 640,
+            width: 640,
+            height: 480,
+        } as DOMRectReadOnly;
+        const boxSize: ResizeObserverSize = {
+            inlineSize: 640,
+            blockSize: 480,
+        };
+
+        act(() => {
+            resizeCallback?.(
+                [
+                    {
+                        target: screen.getByTestId('element-size'),
+                        contentRect,
+                        borderBoxSize: [boxSize],
+                        contentBoxSize: [boxSize],
+                        devicePixelContentBoxSize: [boxSize],
+                    },
+                ],
+                observer,
+            );
+        });
+
+        expect(screen.getByTestId('element-size')).toHaveTextContent('640x480');
+    });
+});

--- a/packages/frontend/src/hooks/useExplorerQueryEffects.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryEffects.ts
@@ -3,7 +3,7 @@ import {
     getFieldsFromMetricQuery,
     assertUnreachable,
 } from '@lightdash/common';
-import { useLocalStorage } from '@mantine/hooks';
+import { useLocalStorage } from '@mantine-8/hooks';
 import { useEffect, useMemo } from 'react';
 import {
     AUTO_FETCH_ENABLED_DEFAULT,

--- a/packages/frontend/src/hooks/useFunnelChartConfig.ts
+++ b/packages/frontend/src/hooks/useFunnelChartConfig.ts
@@ -12,7 +12,7 @@ import {
     type TableCalculation,
     type TableCalculationMetadata,
 } from '@lightdash/common';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { type FunnelSeriesDataPoint } from './echarts/useEchartsFunnelConfig';
 import { type InfiniteQueryResults } from './useQueryResults';

--- a/packages/frontend/src/hooks/useIsLineClamped/index.tsx
+++ b/packages/frontend/src/hooks/useIsLineClamped/index.tsx
@@ -1,4 +1,4 @@
-import { useElementSize } from '@mantine/hooks';
+import { useElementSize } from '@mantine-8/hooks';
 import { useEffect, useState } from 'react';
 
 /**

--- a/packages/frontend/src/hooks/useIsTruncated/index.tsx
+++ b/packages/frontend/src/hooks/useIsTruncated/index.tsx
@@ -1,4 +1,4 @@
-import { useElementSize } from '@mantine/hooks';
+import { useElementSize } from '@mantine-8/hooks';
 import { useEffect, useState } from 'react';
 
 /**

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -19,7 +19,7 @@ import {
     type TableCalculation,
     type TableCalculationMetadata,
 } from '@lightdash/common';
-import { useDebouncedValue } from '@mantine/hooks';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
 import mapValues from 'lodash/mapValues';

--- a/packages/frontend/src/pages/Explorer.tsx
+++ b/packages/frontend/src/pages/Explorer.tsx
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import { useHotkeys } from '@mantine/hooks';
+import { useHotkeys } from '@mantine-8/hooks';
 import { memo, useCallback, useState } from 'react';
 import { Provider } from 'react-redux';
 import { useNavigate, useParams } from 'react-router';

--- a/packages/frontend/src/pages/MinimalDashboard.tsx
+++ b/packages/frontend/src/pages/MinimalDashboard.tsx
@@ -16,7 +16,7 @@ import {
     SessionStorageKeys,
 } from '@lightdash/common';
 import { Stack, Text, Title } from '@mantine-8/core';
-import { useSessionStorage } from '@mantine/hooks';
+import { useSessionStorage } from '@mantine-8/hooks';
 import { IconLayoutDashboard } from '@tabler/icons-react';
 import {
     Fragment,

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -52,7 +52,7 @@ const MinimalExplorerContent = memo(() => {
     const { health } = useApp();
 
     // The in-repo useResizeObserver tracks ref changes via setState (unlike
-    // @mantine/hooks' useElementSize, whose [ref.current] effect dep doesn't
+    // @mantine-8/hooks' useElementSize, whose [ref.current] effect dep doesn't
     // re-run on ref attachment). Without this, containerWidth/containerHeight
     // stay at 0 and Vega-Lite charts render at 0x0 in the minimal/export view.
     const [measureRef, { width: containerWidth, height: containerHeight }] =

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -7,7 +7,7 @@ import {
     type ResourceViewSpaceItem,
 } from '@lightdash/common';
 import { Box, Group, Menu, Stack, Button, ActionIcon } from '@mantine-8/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure } from '@mantine-8/hooks';
 import {
     IconDots,
     IconFolderCog,


### PR DESCRIPTION
## Summary

- migrate all 120 remaining application imports from `@mantine/hooks` v6 to the `@mantine-8/hooks` v8 alias
- consolidate the one file that already mixed v6 and v8 hook imports
- add focused compatibility tests for controlled intervals, delayed timeout cancellation, and `ResizeObserver`-driven element sizing
- retain the direct v6 dependency temporarily because legacy `@mantine/core` and `@mantine/dates` still require it as a peer; it can be removed with their migration

All 19 hook APIs used by the migrated call sites remain available in v8. The focused tests cover the timing and measurement behavior most likely to regress.

## Validation

- frozen lockfile install
- frontend formatting
- frontend lint: 0 errors (4 existing warnings)
- frontend tests: 181 files, 1,451 tests passed
- frontend production build
- frontend SDK build
- frontend typecheck: no new errors; only the same two pre-existing pivot-table errors present on `main`