### PR TITLE
feat(frontend): expand Mantine 8 component theme

### DIFF
--- a/packages/frontend/src/mantine8CssVariablesResolver.ts
+++ b/packages/frontend/src/mantine8CssVariablesResolver.ts
@@ -16,12 +16,14 @@ import {
     SIDEBAR_RESIZE_HANDLE_WIDTH,
     SIDEBAR_TOGGLE_RESERVE,
 } from './components/common/Page/constants';
+import { themeCssVariables } from './mantine8Theme/tokens';
 import { LD_FIELD_COLORS } from './mantineTheme';
 
 // Bridges JS layout constants to global CSS variables so CSS modules can
 // reference them without re-declaring the literal values.
 export const cssVariablesResolver: CSSVariablesResolver = () => ({
     variables: {
+        ...themeCssVariables.variables,
         '--navbar-height': `${NAVBAR_HEIGHT}px`,
         '--banner-height': `${BANNER_HEIGHT}px`,
         '--page-header-height': `${PAGE_HEADER_HEIGHT}px`,
@@ -45,6 +47,6 @@ export const cssVariablesResolver: CSSVariablesResolver = () => ({
         '--ld-field-default-bg-hover': LD_FIELD_COLORS.DEFAULT.bgHover,
         '--ld-field-default-color': LD_FIELD_COLORS.DEFAULT.color,
     },
-    light: {},
-    dark: {},
+    light: { ...themeCssVariables.light },
+    dark: { ...themeCssVariables.dark },
 });

--- a/packages/frontend/src/mantine8Theme.ts
+++ b/packages/frontend/src/mantine8Theme.ts
@@ -1,356 +1,97 @@
 import {
-    Accordion,
-    Badge,
-    Button,
-    Card,
-    Loader,
-    Modal,
-    MultiSelect,
-    NumberInput,
-    Paper,
-    PasswordInput,
-    Pill,
-    PillsInput,
-    ScrollArea,
-    Select,
-    TagsInput,
-    Textarea,
-    TextInput,
-    Tooltip,
+    type ActionIconVariant,
     type ButtonVariant,
     type DefaultMantineColor,
     type MantineColorsTuple,
-    type MantineTheme,
     type MantineThemeOverride,
 } from '@mantine-8/core';
 import { type ColorScheme } from '@mantine/styles';
-import { DotsLoader } from './ee/features/aiCopilot/components/ChatElements/DotsLoader/DotsLoader';
+import { actionsComponents } from './mantine8Theme/components/actions';
+import { dataDisplayComponents } from './mantine8Theme/components/dataDisplay';
+import { feedbackComponents } from './mantine8Theme/components/feedback';
+import { inputsComponents } from './mantine8Theme/components/inputs';
+import { navigationComponents } from './mantine8Theme/components/navigation';
+import { textComponents } from './mantine8Theme/components/text';
+import { accent, getThemeTokens } from './mantine8Theme/tokens';
 import { getMantineThemeOverride as getMantine6ThemeOverride } from './mantineTheme';
-// eslint-disable-next-line css-modules/no-unused-class
-import accordionStyles from './styles/mantine-overrides/accordion.module.css';
-// eslint-disable-next-line css-modules/no-unused-class
-import styles from './styles/mantine-overrides/tooltip.module.css';
 
 declare module '@mantine-8/core' {
     interface AccordionProps {
-        // When true, the active item won't get the variant's filled background.
         transparentActiveItem?: boolean;
     }
-}
 
-declare module '@mantine-8/core' {
-    export interface ButtonProps {
-        variant?: ButtonVariant | 'compact-outline' | 'dark';
+    interface ActionIconProps {
+        variant?: ActionIconVariant | 'quiet' | 'raised';
     }
 
-    export interface PaperProps {
-        variant?: 'dotted';
+    interface ButtonProps {
+        variant?: ButtonVariant | 'compact-outline' | 'dark' | 'raised';
     }
 
-    export interface LoaderProps {
-        /**
-         * Displays a message after 8s. Only available when type='dots'
-         */
+    interface LoaderProps {
         delayedMessage?: string;
     }
 
-    export interface MantineThemeColorsOverride {
+    interface MantineThemeColorsOverride {
         colors: Record<ExtendedCustomColors, MantineColorsTuple>;
+    }
+
+    interface PaperProps {
+        variant?: 'dotted' | 'glass' | 'panel';
     }
 }
 
-type ExtendedCustomColors = 'ldGray' | 'ldDark' | DefaultMantineColor;
-
-const subtleInputStyles = (theme: MantineTheme) => ({
-    input: {
-        fontWeight: 500,
-        fontSize: 14,
-        '--input-bd': theme.colors.ldGray[2],
-        borderRadius: theme.radius.md,
-        boxShadow: theme.shadows.subtle,
-        padding: `${theme.spacing.xs} ${theme.spacing.sm}`,
-        color: theme.colors.ldGray[7],
-    },
-    label: {
-        fontWeight: 500,
-        color: theme.colors.ldGray[7],
-        marginBottom: theme.spacing.xxs,
-    },
-    pill: {
-        background: theme.colors.ldGray[1],
-        color: theme.colors.ldGray[9],
-    },
-});
-
-const subtlePasswordInputStyles = (theme: MantineTheme) => {
-    const subtleStyles = subtleInputStyles(theme);
-
-    return {
-        input: {
-            '--input-bd': theme.colors.ldGray[2],
-            borderRadius: theme.radius.md,
-            boxShadow: theme.shadows.subtle,
-        },
-        innerInput: {
-            fontWeight: subtleStyles.input.fontWeight,
-            fontSize: subtleStyles.input.fontSize,
-            color: subtleStyles.input.color,
-        },
-        label: subtleStyles.label,
-    };
-};
-
-const paperDottedStyles = (theme: MantineTheme) => ({
-    border: `1px dashed ${theme.colors.ldGray[3]}`,
-    background: 'inherit',
-});
+type ExtendedCustomColors =
+    | 'accent'
+    | 'ldDark'
+    | 'ldGray'
+    | DefaultMantineColor;
 
 export const getMantine8ThemeOverride = (
     colorScheme: ColorScheme,
-    overrides?: Partial<MantineThemeOverride>,
+    overrides: Partial<MantineThemeOverride> = {},
 ) => {
     const { colors, components, ...legacyTheme } =
         getMantine6ThemeOverride(colorScheme);
-
     const { Button: _Button, ...legacyComponentsTheme } = components;
+    const themeTokens = getThemeTokens(colorScheme);
+    const {
+        colors: overrideColors,
+        components: overrideComponents,
+        shadows: overrideShadows,
+        spacing: overrideSpacing,
+        ...overrideTheme
+    } = overrides;
 
     return {
         ...legacyTheme,
-        ...overrides,
-        colors,
-        fontFamily: `Inter, ${legacyTheme.fontFamily}`,
-        headings: {
-            fontFamily: `Inter, ${legacyTheme.fontFamily}`,
-            fontWeight: `600`,
+        ...themeTokens,
+        ...overrideTheme,
+        colors: {
+            ...colors,
+            accent,
+            ...overrideColors,
+        },
+        shadows: {
+            ...legacyTheme.shadows,
+            ...themeTokens.shadows,
+            ...overrideShadows,
         },
         spacing: {
             ...legacyTheme.spacing,
-            xxs: `0.125rem`,
-            // Large padding for page bottoms to allow scrolling past last elements
-            emptySpace: `6rem`,
+            xxs: '0.125rem',
+            emptySpace: '6rem',
+            ...overrideSpacing,
         },
-
         components: {
             ...legacyComponentsTheme,
-            Accordion: Accordion.extend({
-                classNames: (_theme, props) =>
-                    props.transparentActiveItem
-                        ? { item: accordionStyles.transparentActiveItem }
-                        : {},
-            }),
-            Badge: Badge.extend({
-                defaultProps: {
-                    radius: 'sm',
-                },
-                styles: {
-                    root: {
-                        textTransform: 'none',
-                        fontWeight: 400,
-                    },
-                },
-            }),
-            Card: Card.extend({
-                styles: (theme, props) => ({
-                    root: {
-                        borderColor: theme.colors.ldGray[2],
-                        ...(props.variant === 'dotted' &&
-                            paperDottedStyles(theme)),
-                    },
-                }),
-            }),
-            Pill: Pill.extend({
-                styles: (theme, props) =>
-                    props.variant === 'outline'
-                        ? {
-                              root: {
-                                  border: `1px solid ${theme.colors.ldGray[2]}`,
-                                  color: theme.colors.ldGray[7],
-                                  '&:hover': {
-                                      backgroundColor: theme.colors.ldGray[1],
-                                  },
-                              },
-                          }
-                        : {},
-            }),
-            Button: Button.extend({
-                vars: (theme, props) => {
-                    if (props.variant === 'compact-outline') {
-                        return {
-                            root: {
-                                '--button-bd': `1px solid ${theme.colors.ldGray[2]}`,
-                            },
-                        };
-                    }
-                    if (props.variant === 'subtle') {
-                        return {
-                            root: {
-                                '--button-color': theme.colors.ldGray[7],
-                                '--button-hover': theme.colors.ldGray[1],
-                            },
-                        };
-                    }
-                    if (props.variant === 'dark') {
-                        return {
-                            root: {
-                                '--button-bg': theme.colors.ldDark[9],
-                                '--button-hover': theme.colors.ldDark[8],
-                                '--button-color': theme.colors.ldGray[0],
-                                '--button-bd': `none`,
-                            },
-                        };
-                    }
-                    return { root: {} };
-                },
-                styles: (theme) => ({
-                    root: {
-                        fontFamily: theme.fontFamily,
-                        fontWeight: 500,
-                    },
-                }),
-                defaultProps: {
-                    radius: 'md',
-                    variant: 'dark',
-                },
-            }),
-            ScrollArea: ScrollArea.extend({
-                styles: (theme) => ({
-                    thumb: {
-                        backgroundColor: theme.colors.ldGray[3],
-                    },
-                    scrollbar: {
-                        backgroundColor: `transparent`,
-                    },
-                }),
-            }),
-            Tooltip: Tooltip.extend({
-                classNames: {
-                    tooltip: styles.tooltip,
-                },
-                defaultProps: {
-                    openDelay: 200,
-                    withinPortal: true,
-                    withArrow: true,
-                    multiline: true,
-                    maw: 250,
-                    fz: 'xs',
-                },
-            }),
-            Popover: {
-                defaultProps: {
-                    withinPortal: true,
-                    radius: 'md',
-                    shadow: 'sm',
-                },
-            },
-            Paper: Paper.extend({
-                defaultProps: {
-                    radius: 'md',
-                    shadow: 'subtle',
-                    withBorder: true,
-                },
-                styles: (theme, props) => ({
-                    root: {
-                        borderColor: `var(--mantine-color-ldGray-2)`,
-                        ...(props.variant === 'dotted' &&
-                            paperDottedStyles(theme)),
-                    },
-                }),
-            }),
-            Loader: Loader.extend({
-                defaultProps: {
-                    loaders: { ...Loader.defaultLoaders, dots: DotsLoader },
-                },
-            }),
-
-            Select: Select.extend({
-                defaultProps: {
-                    radius: 'md',
-                },
-                styles: (theme) => ({
-                    input: { fontFamily: theme.fontFamily },
-                    option: { fontFamily: theme.fontFamily },
-                    groupLabel: { fontFamily: theme.fontFamily },
-                }),
-                vars: (theme, props) => {
-                    if (props.variant === 'subtle')
-                        return subtleInputStyles(theme);
-                    return {};
-                },
-            }),
-
-            TextInput: TextInput.extend({
-                defaultProps: {
-                    radius: 'md',
-                },
-                vars: (theme, props) => {
-                    if (props.variant === 'subtle')
-                        return subtleInputStyles(theme);
-                    return {};
-                },
-            }),
-
-            NumberInput: NumberInput.extend({
-                defaultProps: {
-                    radius: 'md',
-                },
-            }),
-
-            PasswordInput: PasswordInput.extend({
-                defaultProps: {
-                    radius: 'md',
-                },
-                styles: (theme, props) =>
-                    props.variant === 'subtle'
-                        ? subtlePasswordInputStyles(theme)
-                        : {},
-            }),
-
-            Textarea: Textarea.extend({
-                defaultProps: {
-                    radius: 'md',
-                },
-                vars: (theme, props) => {
-                    if (props.variant === 'subtle')
-                        return subtleInputStyles(theme);
-                    return {};
-                },
-            }),
-            TagsInput: TagsInput.extend({
-                vars: (theme, props) => {
-                    if (props.variant === 'subtle')
-                        return subtleInputStyles(theme);
-                    return {};
-                },
-            }),
-            PillsInput: PillsInput.extend({
-                vars: (theme, props) => {
-                    if (props.variant === 'subtle') {
-                        return subtleInputStyles(theme);
-                    }
-                    return {};
-                },
-            }),
-            MultiSelect: MultiSelect.extend({
-                vars: (theme, props) => {
-                    if (props.variant === 'subtle')
-                        return subtleInputStyles(theme);
-                    return {};
-                },
-                defaultProps: {
-                    radius: 'md',
-                },
-            }),
-            Modal: Modal.extend({
-                styles: () => ({
-                    header: {
-                        paddingBottom: 'var(--mantine-spacing-sm)',
-                    },
-                    body: {
-                        paddingTop: 'var(--mantine-spacing-sm)',
-                    },
-                }),
-            }),
-            ...overrides?.components,
+            ...textComponents,
+            ...actionsComponents,
+            ...inputsComponents,
+            ...dataDisplayComponents,
+            ...feedbackComponents,
+            ...navigationComponents,
+            ...overrideComponents,
         },
     } satisfies MantineThemeOverride;
 };

--- a/packages/frontend/src/mantine8Theme/components/actions.module.css
+++ b/packages/frontend/src/mantine8Theme/components/actions.module.css
@@ -1,0 +1,130 @@
+@media (prefers-reduced-motion: no-preference) {
+    .button,
+    .actionIcon,
+    .closeButton,
+    .chipLabel,
+    .kbd {
+        transition:
+            background-color 140ms var(--app-ease-out),
+            border-color 140ms var(--app-ease-out),
+            box-shadow 140ms var(--app-ease-out),
+            color 140ms var(--app-ease-out),
+            transform 140ms var(--app-ease-out);
+    }
+}
+
+.button[data-variant='filled'],
+.actionIcon[data-variant='filled'] {
+    box-shadow: var(--app-inset-highlight), var(--app-shadow-raised);
+}
+
+.button[data-variant='default'],
+.button[data-variant='outline'],
+.actionIcon[data-variant='default'],
+.actionIcon[data-variant='outline'] {
+    border-color: var(--mantine-color-default-border);
+}
+
+.button[data-variant='filled']:where(
+        :not(:disabled, [data-disabled], [data-loading])
+    ):hover,
+.actionIcon[data-variant='filled']:where(
+        :not(:disabled, [data-disabled], [data-loading])
+    ):hover {
+    box-shadow: var(--app-inset-highlight), var(--app-shadow-raised-hover);
+}
+
+.button:focus-visible,
+.actionIcon:focus-visible,
+.closeButton:focus-visible,
+.kbd:focus-visible {
+    outline: none;
+    box-shadow: var(--app-focus-ring);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .button:where(:not(:disabled, [data-disabled], [data-loading])):active,
+    .actionIcon:where(:not(:disabled, [data-disabled], [data-loading])):active {
+        transform: scale(0.97);
+    }
+}
+
+.button:where(
+    :disabled:not([data-loading]),
+    [data-disabled]:not([data-loading])
+),
+.actionIcon:where(
+    :disabled:not([data-loading]),
+    [data-disabled]:not([data-loading])
+) {
+    opacity: 0.5;
+}
+
+.quiet {
+    color: var(--app-muted);
+}
+
+.quiet:hover {
+    color: var(--mantine-color-text);
+    background-color: var(--mantine-color-default-hover);
+}
+
+.raised,
+.kbd {
+    border: 1px solid var(--app-border-strong);
+    box-shadow: var(--app-shadow-raised), var(--app-inset-highlight);
+}
+
+.anchor {
+    transition: color 140ms ease;
+}
+
+.chipLabel[data-checked] {
+    font-weight: 500;
+}
+
+.checkbox,
+.radio {
+    background-color: transparent;
+    border-color: var(--mantine-primary-color-filled);
+}
+
+.checkbox:checked,
+.checkbox:indeterminate,
+.radio:checked {
+    box-shadow: var(--app-inset-highlight);
+}
+
+.checkbox:focus-visible,
+.radio:focus-visible {
+    outline: none;
+    box-shadow: var(--app-focus-ring);
+}
+
+.switchTrack {
+    --switch-bg: var(--mantine-color-default-hover);
+
+    border: 1px solid var(--mantine-color-default-border);
+}
+
+.switchThumb {
+    background: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-0)
+    );
+    border: 1px solid light-dark(rgba(9, 9, 11, 0.06), rgba(0, 0, 0, 0.35));
+    box-shadow: var(--app-shadow-raised);
+}
+
+.switchInput:checked + .switchTrack {
+    border-color: transparent;
+    box-shadow: var(--app-inset-highlight);
+}
+
+.switchInput:checked + .switchTrack .switchThumb {
+    background: var(--mantine-primary-color-contrast);
+}
+
+.switchInput:focus-visible + .switchTrack {
+    box-shadow: var(--app-focus-ring);
+}

--- a/packages/frontend/src/mantine8Theme/components/actions.ts
+++ b/packages/frontend/src/mantine8Theme/components/actions.ts
@@ -1,0 +1,107 @@
+import {
+    ActionIcon,
+    Anchor,
+    Button,
+    Checkbox,
+    Chip,
+    CloseButton,
+    Kbd,
+    Progress,
+    Radio,
+    Switch,
+    type MantineTheme,
+} from '@mantine-8/core';
+import classes from './actions.module.css';
+
+const customButtonVars = (theme: MantineTheme, variant: string | undefined) => {
+    if (variant === 'compact-outline') {
+        return {
+            root: {
+                '--button-bd': `1px solid ${theme.colors.ldGray[2]}`,
+            },
+        };
+    }
+    if (variant === 'subtle') {
+        return {
+            root: {
+                '--button-color': theme.colors.ldGray[7],
+                '--button-hover': theme.colors.ldGray[1],
+            },
+        };
+    }
+    if (variant === 'dark') {
+        return {
+            root: {
+                '--button-bg': theme.colors.ldDark[9],
+                '--button-hover': theme.colors.ldDark[8],
+                '--button-color': theme.colors.ldGray[0],
+                '--button-bd': 'none',
+            },
+        };
+    }
+
+    return { root: {} };
+};
+
+export const actionsComponents = {
+    ActionIcon: ActionIcon.extend({
+        classNames: (_theme, props) => ({
+            root: `${classes.actionIcon} ${
+                props.variant === 'quiet' ? classes.quiet : ''
+            } ${props.variant === 'raised' ? classes.raised : ''}`,
+        }),
+        defaultProps: { radius: 'md' },
+    }),
+    Anchor: Anchor.extend({
+        classNames: { root: classes.anchor },
+        defaultProps: { underline: 'not-hover' },
+        styles: {
+            root: { fontWeight: 500, letterSpacing: '-0.006em' },
+        },
+    }),
+    Button: Button.extend({
+        classNames: (_theme, props) => ({
+            root: `${classes.button} ${
+                props.variant === 'raised' ? classes.raised : ''
+            }`,
+        }),
+        defaultProps: { radius: 'md', variant: 'filled' },
+        styles: {
+            root: { fontWeight: 500, letterSpacing: '-0.006em' },
+            section: { opacity: 0.9 },
+        },
+        vars: (theme, props) =>
+            customButtonVars(theme, props.variant as string),
+    }),
+    Checkbox: Checkbox.extend({
+        classNames: { input: classes.checkbox },
+        defaultProps: {
+            iconColor: 'var(--mantine-primary-color-contrast)',
+            radius: 'sm',
+        },
+    }),
+    Chip: Chip.extend({
+        classNames: { label: classes.chipLabel },
+        defaultProps: { radius: 'sm' },
+        styles: { label: { fontWeight: 500, letterSpacing: '-0.006em' } },
+    }),
+    CloseButton: CloseButton.extend({
+        classNames: { root: classes.closeButton },
+        defaultProps: { radius: 'md' },
+    }),
+    Kbd: Kbd.extend({ classNames: { root: classes.kbd } }),
+    Progress: Progress.extend({
+        defaultProps: { color: 'ldDark', radius: 'xl', size: 'sm' },
+    }),
+    Radio: Radio.extend({
+        classNames: { radio: classes.radio },
+    }),
+    Switch: Switch.extend({
+        classNames: {
+            input: classes.switchInput,
+            thumb: classes.switchThumb,
+            track: classes.switchTrack,
+        },
+        defaultProps: { radius: 'xl' },
+    }),
+};

--- a/packages/frontend/src/mantine8Theme/components/dataDisplay.module.css
+++ b/packages/frontend/src/mantine8Theme/components/dataDisplay.module.css
@@ -1,0 +1,85 @@
+.card,
+.paper {
+    border-color: var(--app-border);
+}
+
+.card {
+    padding: var(--card-padding) !important;
+    background: var(--mantine-color-default);
+}
+
+.panel {
+    background: var(--app-surface);
+    border: 1px solid var(--app-border);
+    box-shadow: var(--app-shadow-raised);
+}
+
+.glass {
+    background: color-mix(in srgb, var(--app-surface) 72%, transparent);
+    border: 1px solid var(--app-border);
+    backdrop-filter: saturate(140%) blur(6px);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .card,
+    .paper {
+        transition:
+            border-color 180ms ease,
+            box-shadow 180ms ease;
+    }
+}
+
+@media (hover: hover) and (pointer: fine) {
+    .card:hover,
+    .paper:hover {
+        border-color: var(--app-muted);
+        box-shadow: var(--mantine-shadow-sm);
+    }
+}
+
+.badge[data-variant='filled'] {
+    box-shadow: var(--app-inset-highlight);
+}
+
+.chip {
+    color: var(--mantine-color-text);
+    background: var(--app-surface);
+    border: 1px solid var(--app-border);
+}
+
+.table thead th {
+    border-bottom: 1px solid var(--app-border-strong);
+}
+
+.table tbody td {
+    height: 44px;
+}
+
+.timelineBullet {
+    color: var(--mantine-color-dimmed);
+    background: var(--app-surface);
+    border-color: var(--app-border-strong);
+    border-width: 1px;
+}
+
+.blockquote {
+    background: var(--mantine-color-default);
+    border: 1px solid var(--app-border);
+}
+
+.spoilerControl {
+    color: var(--mantine-color-accent-6);
+    font-weight: 500;
+}
+
+.mark {
+    padding: 0 3px;
+    margin: 0 -1px;
+    border-radius: 3px;
+    box-decoration-break: clone;
+}
+
+.avatarRoot[data-within-group] {
+    border: 2px solid var(--app-surface);
+    box-shadow: 0 0 0 1px var(--app-border);
+}

--- a/packages/frontend/src/mantine8Theme/components/dataDisplay.ts
+++ b/packages/frontend/src/mantine8Theme/components/dataDisplay.ts
@@ -1,0 +1,133 @@
+import {
+    Avatar,
+    Badge,
+    Blockquote,
+    Card,
+    Code,
+    Image,
+    List,
+    Mark,
+    Paper,
+    Spoiler,
+    Table,
+    ThemeIcon,
+    Timeline,
+    Title,
+    rem,
+    type MantineTheme,
+} from '@mantine-8/core';
+import classes from './dataDisplay.module.css';
+
+const paperDottedStyles = (theme: MantineTheme) => ({
+    border: `1px dashed ${theme.colors.ldGray[3]}`,
+    background: 'inherit',
+});
+
+export const dataDisplayComponents = {
+    Avatar: Avatar.extend({
+        classNames: { root: classes.avatarRoot },
+        defaultProps: { radius: 'xl' },
+        styles: { placeholder: { fontWeight: 500 } },
+    }),
+    Badge: Badge.extend({
+        classNames: (_theme, props) => ({
+            root: `${classes.badge} ${
+                props.variant === 'chip' ? classes.chip : ''
+            }`,
+        }),
+        defaultProps: { radius: 'sm', variant: 'light' },
+        styles: {
+            root: {
+                fontWeight: 500,
+                letterSpacing: '-0.003em',
+                textTransform: 'none',
+            },
+        },
+    }),
+    Card: Card.extend({
+        classNames: { root: classes.card },
+        defaultProps: {
+            padding: 'md',
+            radius: 'lg',
+            shadow: 'xs',
+            withBorder: true,
+        },
+        styles: (theme, props) => ({
+            root: {
+                ...(props.variant === 'dotted' && paperDottedStyles(theme)),
+            },
+        }),
+    }),
+    Paper: Paper.extend({
+        classNames: (_theme, props) => ({
+            root: `${classes.paper} ${
+                props.variant === 'panel' ? classes.panel : ''
+            } ${props.variant === 'glass' ? classes.glass : ''}`,
+        }),
+        defaultProps: {
+            radius: 'md',
+            shadow: 'subtle',
+            withBorder: true,
+        },
+        styles: (theme, props) => ({
+            root: {
+                ...(props.variant === 'dotted' && paperDottedStyles(theme)),
+            },
+        }),
+    }),
+    Table: Table.extend({
+        classNames: { table: classes.table },
+        defaultProps: {
+            highlightOnHover: true,
+            horizontalSpacing: 'md',
+            striped: false,
+            verticalSpacing: 'sm',
+            withColumnBorders: false,
+        },
+        styles: {
+            th: {
+                color: 'var(--mantine-color-dimmed)',
+                fontFamily: 'var(--mantine-font-family-monospace)',
+                fontSize: rem(11),
+                fontWeight: 500,
+                letterSpacing: '0.04em',
+                textTransform: 'uppercase',
+            },
+        },
+    }),
+    ThemeIcon: ThemeIcon.extend({ defaultProps: { radius: 'md' } }),
+    Title: Title.extend({
+        styles: { root: { letterSpacing: '-0.025em' } },
+    }),
+    Code: Code.extend({
+        styles: {
+            root: {
+                background: 'var(--mantine-color-default-hover)',
+                border: '1px solid var(--app-border)',
+                borderRadius: rem(6),
+                fontFamily: 'var(--mantine-font-family-monospace)',
+            },
+        },
+    }),
+    List: List.extend({ defaultProps: { spacing: 'xs' } }),
+    Timeline: Timeline.extend({
+        classNames: { itemBullet: classes.timelineBullet },
+        defaultProps: {
+            bulletSize: 22,
+            color: 'ldDark',
+            lineWidth: 2,
+        },
+        styles: {
+            itemTitle: { fontSize: rem(13), fontWeight: 600 },
+        },
+    }),
+    Blockquote: Blockquote.extend({
+        classNames: { root: classes.blockquote },
+        defaultProps: { color: 'ldDark', iconSize: 30, radius: 'md' },
+    }),
+    Spoiler: Spoiler.extend({
+        classNames: { control: classes.spoilerControl },
+    }),
+    Image: Image.extend({ defaultProps: { radius: 'md' } }),
+    Mark: Mark.extend({ classNames: { root: classes.mark } }),
+};

--- a/packages/frontend/src/mantine8Theme/components/feedback.module.css
+++ b/packages/frontend/src/mantine8Theme/components/feedback.module.css
@@ -1,0 +1,45 @@
+.tooltip {
+    --tooltip-bg: var(--mantine-color-ldDark-9);
+    --tooltip-color: var(--mantine-color-ldGray-0);
+
+    font-weight: 500;
+    letter-spacing: -0.006em;
+    box-shadow: var(--mantine-shadow-md);
+}
+
+.notification,
+.dialog {
+    background: var(--app-surface);
+    border-color: var(--app-border);
+    box-shadow: var(--mantine-shadow-sm);
+}
+
+.modalContent,
+.drawerContent {
+    border: 1px solid var(--app-border-strong);
+    box-shadow: var(--mantine-shadow-lg);
+}
+
+.overlayHeader {
+    border-bottom: 1px solid var(--app-border);
+}
+
+.backdrop {
+    backdrop-filter: blur(3px);
+}
+
+.popoverDropdown {
+    background: var(--mantine-color-body);
+    border-color: var(--app-border);
+    box-shadow: var(--mantine-shadow-md);
+}
+
+.loader {
+    --loader-color: var(--mantine-primary-color-filled);
+}
+
+.alert {
+    border: 1px solid
+        color-mix(in srgb, var(--alert-color) 22%, var(--app-border));
+    box-shadow: var(--mantine-shadow-xs);
+}

--- a/packages/frontend/src/mantine8Theme/components/feedback.ts
+++ b/packages/frontend/src/mantine8Theme/components/feedback.ts
@@ -1,0 +1,183 @@
+import {
+    Alert,
+    Dialog,
+    Drawer,
+    HoverCard,
+    Loader,
+    LoadingOverlay,
+    Modal,
+    Notification,
+    Overlay,
+    Popover,
+    RingProgress,
+    Skeleton,
+    Tooltip,
+} from '@mantine-8/core';
+import { DotsLoader } from '../../ee/features/aiCopilot/components/ChatElements/DotsLoader/DotsLoader';
+import classes from './feedback.module.css';
+
+const popTransition = {
+    duration: 160,
+    timingFunction: 'var(--app-ease-out)',
+    transition: 'pop',
+} as const;
+
+const backdrop = { backgroundOpacity: 0.35, blur: 3 } as const;
+
+export const feedbackComponents = {
+    Alert: Alert.extend({
+        classNames: { root: classes.alert },
+        defaultProps: { radius: 'md', variant: 'light' },
+        styles: {
+            icon: { marginTop: 1 },
+            message: {
+                color: 'var(--mantine-color-dimmed)',
+                fontSize: 'var(--mantine-font-size-sm)',
+            },
+            title: {
+                fontSize: 'var(--mantine-font-size-sm)',
+                fontWeight: 600,
+                letterSpacing: '-0.006em',
+            },
+        },
+    }),
+    Tooltip: Tooltip.extend({
+        classNames: { tooltip: classes.tooltip },
+        defaultProps: {
+            arrowSize: 5,
+            fz: 'xs',
+            maw: 250,
+            multiline: true,
+            openDelay: 120,
+            radius: 'sm',
+            transitionProps: {
+                ...popTransition,
+                transition: 'fade-down',
+            },
+            withArrow: true,
+            withinPortal: true,
+        },
+    }),
+    RingProgress: RingProgress.extend({
+        defaultProps: { roundCaps: true, thickness: 8 },
+    }),
+    Loader: Loader.extend({
+        classNames: { root: classes.loader },
+        defaultProps: {
+            color: 'ldDark',
+            loaders: { ...Loader.defaultLoaders, dots: DotsLoader },
+            size: 'sm',
+        },
+    }),
+    Notification: Notification.extend({
+        classNames: { root: classes.notification },
+        defaultProps: {
+            color: 'ldDark',
+            radius: 'md',
+            withBorder: true,
+        },
+        styles: {
+            description: {
+                color: 'var(--mantine-color-dimmed)',
+                fontSize: 'var(--mantine-font-size-xs)',
+            },
+            title: {
+                fontSize: 'var(--mantine-font-size-sm)',
+                fontWeight: 600,
+                letterSpacing: '-0.006em',
+            },
+        },
+    }),
+    Modal: Modal.extend({
+        classNames: {
+            content: classes.modalContent,
+            header: classes.overlayHeader,
+            overlay: classes.backdrop,
+        },
+        defaultProps: {
+            centered: true,
+            overlayProps: backdrop,
+            radius: 'lg',
+            transitionProps: {
+                duration: 180,
+                timingFunction: 'var(--app-ease-out)',
+                transition: 'fade',
+            },
+        },
+        styles: {
+            body: { paddingTop: 'var(--mantine-spacing-sm)' },
+            header: { paddingBottom: 'var(--mantine-spacing-sm)' },
+            title: {
+                fontSize: 'var(--mantine-font-size-md)',
+                fontWeight: 600,
+                letterSpacing: '-0.01em',
+            },
+        },
+    }),
+    Drawer: Drawer.extend({
+        classNames: {
+            content: classes.drawerContent,
+            header: classes.overlayHeader,
+            overlay: classes.backdrop,
+        },
+        defaultProps: {
+            overlayProps: backdrop,
+            transitionProps: {
+                duration: 180,
+                timingFunction: 'var(--app-ease-out)',
+            },
+        },
+        styles: {
+            title: {
+                fontSize: 'var(--mantine-font-size-md)',
+                fontWeight: 600,
+                letterSpacing: '-0.01em',
+            },
+        },
+    }),
+    Popover: Popover.extend({
+        classNames: { dropdown: classes.popoverDropdown },
+        defaultProps: {
+            radius: 'md',
+            shadow: 'md',
+            transitionProps: popTransition,
+            withArrow: false,
+            withinPortal: true,
+        },
+    }),
+    HoverCard: HoverCard.extend({
+        classNames: { dropdown: classes.popoverDropdown },
+        defaultProps: {
+            closeDelay: 120,
+            openDelay: 160,
+            radius: 'md',
+            shadow: 'md',
+            transitionProps: popTransition,
+            withArrow: false,
+        },
+    }),
+    LoadingOverlay: LoadingOverlay.extend({
+        defaultProps: {
+            loaderProps: { color: 'ldDark', size: 'sm' },
+            overlayProps: {
+                backgroundOpacity: 0.55,
+                blur: 2,
+                radius: 'lg',
+            },
+            transitionProps: { duration: 160 },
+        },
+    }),
+    Overlay: Overlay.extend({
+        defaultProps: { backgroundOpacity: 0.4, blur: 2 },
+    }),
+    Dialog: Dialog.extend({
+        classNames: { root: classes.dialog },
+        defaultProps: {
+            radius: 'lg',
+            shadow: 'lg',
+            transitionProps: popTransition,
+            withBorder: true,
+        },
+    }),
+    Skeleton: Skeleton.extend({ defaultProps: { radius: 'md' } }),
+};

--- a/packages/frontend/src/mantine8Theme/components/inputs.module.css
+++ b/packages/frontend/src/mantine8Theme/components/inputs.module.css
@@ -1,0 +1,84 @@
+.input {
+    background-color: transparent;
+    border: 1px solid var(--app-border);
+    box-shadow: none;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .input {
+        transition:
+            background-color 140ms var(--app-ease-out),
+            border-color 140ms var(--app-ease-out),
+            box-shadow 140ms var(--app-ease-out);
+    }
+}
+
+.input:hover:not(:disabled):not([data-disabled]):not([aria-invalid='true']) {
+    border-color: var(--app-border-strong);
+}
+
+.input:focus,
+.input:focus-within {
+    border-color: var(--mantine-primary-color-filled);
+    box-shadow: var(--app-focus-ring);
+}
+
+.input[aria-invalid='true'] {
+    border-color: var(--mantine-color-error);
+}
+
+.dropdown {
+    padding: 4px;
+    background: var(--mantine-color-body);
+    border: 1px solid var(--app-border);
+    border-radius: var(--mantine-radius-md);
+    box-shadow: var(--mantine-shadow-md);
+}
+
+.option {
+    padding-block: 6px;
+    padding-inline: 9px;
+    border-radius: var(--mantine-radius-sm);
+}
+
+.option:hover:not([data-combobox-disabled]),
+.option[data-combobox-active] {
+    background-color: var(--mantine-color-default-hover);
+}
+
+.option[data-combobox-selected] {
+    color: var(--mantine-primary-color-contrast);
+    background-color: var(--mantine-primary-color-filled);
+}
+
+.pill {
+    display: inline-flex;
+    align-items: center;
+    font-weight: 500;
+    background: var(--app-surface);
+    border: 1px solid var(--app-border);
+}
+
+.fieldset {
+    background: var(--app-surface);
+    border: 1px solid var(--app-border);
+    box-shadow: var(--app-shadow-raised);
+}
+
+.fieldsetLegend {
+    padding-inline: var(--mantine-spacing-xs);
+    font-size: var(--mantine-font-size-sm);
+    font-weight: 600;
+    letter-spacing: -0.01em;
+}
+
+.composer,
+.composer:hover,
+.composer:focus,
+.composer:focus-within {
+    padding: 0;
+    background: transparent;
+    border: 0;
+    outline: 0;
+    box-shadow: none;
+}

--- a/packages/frontend/src/mantine8Theme/components/inputs.ts
+++ b/packages/frontend/src/mantine8Theme/components/inputs.ts
@@ -1,0 +1,174 @@
+import {
+    Autocomplete,
+    ColorInput,
+    ColorPicker,
+    Combobox,
+    Fieldset,
+    FileInput,
+    Input,
+    JsonInput,
+    MultiSelect,
+    NativeSelect,
+    NumberInput,
+    PasswordInput,
+    Pill,
+    PillsInput,
+    PinInput,
+    Rating,
+    Select,
+    TagsInput,
+    Textarea,
+    TextInput,
+    rem,
+    type MantineTheme,
+} from '@mantine-8/core';
+import classes from './inputs.module.css';
+
+const subtleInputStyles = (theme: MantineTheme) => ({
+    input: {
+        fontWeight: 500,
+        fontSize: 14,
+        '--input-bd': theme.colors.ldGray[2],
+        borderRadius: theme.radius.md,
+        boxShadow: theme.shadows.subtle,
+        padding: `${theme.spacing.xs} ${theme.spacing.sm}`,
+        color: theme.colors.ldGray[7],
+    },
+    label: {
+        fontWeight: 500,
+        color: theme.colors.ldGray[7],
+        marginBottom: theme.spacing.xxs,
+    },
+    pill: {
+        background: theme.colors.ldGray[1],
+        color: theme.colors.ldGray[9],
+    },
+});
+
+const fieldStyles = {
+    label: {
+        fontSize: rem(13),
+        fontWeight: 500,
+        letterSpacing: '-0.006em',
+        marginBottom: rem(6),
+    },
+    description: { fontSize: rem(12) },
+};
+
+const fieldClassNames = { input: classes.input };
+const dropdownClassNames = {
+    dropdown: classes.dropdown,
+    option: classes.option,
+};
+const composerClassNames = (
+    _theme: MantineTheme,
+    props: { variant?: string },
+) => ({
+    input:
+        props.variant === 'composer'
+            ? `${classes.input} ${classes.composer}`
+            : classes.input,
+});
+
+const inputExtension = {
+    defaultProps: { radius: 'md' as const },
+    classNames: fieldClassNames,
+    styles: fieldStyles,
+};
+
+export const inputsComponents = {
+    Input: Input.extend({
+        defaultProps: { radius: 'md' },
+        classNames: fieldClassNames,
+    }),
+    TextInput: TextInput.extend({
+        ...inputExtension,
+        classNames: composerClassNames,
+        vars: (theme, props) =>
+            props.variant === 'subtle' ? subtleInputStyles(theme) : {},
+    }),
+    Textarea: Textarea.extend({
+        ...inputExtension,
+        classNames: composerClassNames,
+        vars: (theme, props) =>
+            props.variant === 'subtle' ? subtleInputStyles(theme) : {},
+    }),
+    Select: Select.extend({
+        ...inputExtension,
+        classNames: { ...fieldClassNames, ...dropdownClassNames },
+        defaultProps: {
+            checkIconPosition: 'right',
+            radius: 'md',
+        },
+        vars: (theme, props) =>
+            props.variant === 'subtle' ? subtleInputStyles(theme) : {},
+    }),
+    NumberInput: NumberInput.extend(inputExtension),
+    PasswordInput: PasswordInput.extend({
+        ...inputExtension,
+        styles: (theme, props) => ({
+            ...fieldStyles,
+            ...(props.variant === 'subtle' ? subtleInputStyles(theme) : {}),
+        }),
+    }),
+    Autocomplete: Autocomplete.extend({
+        ...inputExtension,
+        classNames: { ...fieldClassNames, ...dropdownClassNames },
+    }),
+    MultiSelect: MultiSelect.extend({
+        ...inputExtension,
+        classNames: { ...fieldClassNames, ...dropdownClassNames },
+        defaultProps: {
+            checkIconPosition: 'right',
+            radius: 'md',
+        },
+        vars: (theme, props) =>
+            props.variant === 'subtle' ? subtleInputStyles(theme) : {},
+    }),
+    TagsInput: TagsInput.extend({
+        ...inputExtension,
+        classNames: { ...fieldClassNames, ...dropdownClassNames },
+        vars: (theme, props) =>
+            props.variant === 'subtle' ? subtleInputStyles(theme) : {},
+    }),
+    PillsInput: PillsInput.extend({
+        ...inputExtension,
+        vars: (theme, props) =>
+            props.variant === 'subtle' ? subtleInputStyles(theme) : {},
+    }),
+    PinInput: PinInput.extend({
+        defaultProps: { radius: 'md' },
+        classNames: fieldClassNames,
+    }),
+    JsonInput: JsonInput.extend({
+        ...inputExtension,
+        defaultProps: { autosize: true, minRows: 4, radius: 'md' },
+        styles: {
+            ...fieldStyles,
+            input: {
+                fontFamily: 'var(--mantine-font-family-monospace)',
+                fontSize: rem(13),
+            },
+        },
+    }),
+    NativeSelect: NativeSelect.extend(inputExtension),
+    FileInput: FileInput.extend(inputExtension),
+    ColorInput: ColorInput.extend(inputExtension),
+    ColorPicker: ColorPicker.extend({
+        defaultProps: { format: 'hex' },
+    }),
+    Rating: Rating.extend({}),
+    Fieldset: Fieldset.extend({
+        classNames: {
+            legend: classes.fieldsetLegend,
+            root: classes.fieldset,
+        },
+        defaultProps: { radius: 'md', variant: 'default' },
+    }),
+    Pill: Pill.extend({
+        classNames: { root: classes.pill },
+    }),
+    Combobox: Combobox.extend({
+        classNames: dropdownClassNames,
+    }),
+};

--- a/packages/frontend/src/mantine8Theme/components/navigation.module.css
+++ b/packages/frontend/src/mantine8Theme/components/navigation.module.css
@@ -1,0 +1,90 @@
+.tabsList {
+    border-color: var(--app-border);
+}
+
+.tabsTab {
+    font-weight: 500;
+    letter-spacing: -0.006em;
+}
+
+.accordionControl {
+    font-weight: 500;
+}
+
+.accordionChevron {
+    color: var(--app-muted);
+}
+
+.transparentActiveItem[data-active] {
+    background-color: transparent;
+}
+
+.paginationControl,
+.segmentIndicator {
+    border-color: var(--app-border-strong);
+    box-shadow: var(--app-shadow-raised);
+}
+
+.breadcrumbs {
+    font-size: var(--mantine-font-size-sm);
+}
+
+.navLink {
+    letter-spacing: -0.006em;
+}
+
+.stepperIcon {
+    border-color: var(--app-border-strong);
+}
+
+.stepperSeparator {
+    background: var(--app-border);
+}
+
+.menuDropdown {
+    padding: 4px;
+    background: var(--mantine-color-body);
+    border-color: var(--app-border);
+    box-shadow: var(--mantine-shadow-md);
+}
+
+.menuItem,
+.treeLabel {
+    padding: 6px 9px;
+    border-radius: var(--mantine-radius-sm);
+}
+
+.segmentRoot {
+    background: var(--mantine-color-default-hover);
+    border: 1px solid var(--app-border);
+}
+
+.segmentIndicator {
+    background: var(--app-surface);
+    border: 1px solid var(--app-border-strong);
+    box-shadow: var(--app-shadow-raised), var(--app-inset-highlight);
+}
+
+.segmentLabel {
+    padding-inline: 20px;
+    color: var(--mantine-color-dimmed);
+    font-weight: 500;
+    letter-spacing: -0.006em;
+}
+
+.segmentControl[data-active] .segmentLabel,
+.segmentLabel[data-active],
+.segmentControl .segmentLabel:hover {
+    color: var(--mantine-color-text);
+}
+
+.scrollThumb {
+    background: var(--app-muted);
+}
+
+.burger:focus-visible,
+.menuItem:focus-visible,
+.treeLabel:focus-visible {
+    outline: none;
+    box-shadow: var(--app-focus-ring);
+}

--- a/packages/frontend/src/mantine8Theme/components/navigation.ts
+++ b/packages/frontend/src/mantine8Theme/components/navigation.ts
@@ -1,0 +1,129 @@
+import {
+    Accordion,
+    Breadcrumbs,
+    Burger,
+    Divider,
+    Menu,
+    NavLink,
+    Pagination,
+    ScrollArea,
+    SegmentedControl,
+    Stepper,
+    Tabs,
+    Tree,
+    rem,
+} from '@mantine-8/core';
+import classes from './navigation.module.css';
+
+export const navigationComponents = {
+    Tabs: Tabs.extend({
+        classNames: {
+            list: classes.tabsList,
+            tab: classes.tabsTab,
+        },
+        defaultProps: { color: 'ldDark' },
+    }),
+    Accordion: Accordion.extend({
+        classNames: (_theme, props) => ({
+            chevron: classes.accordionChevron,
+            control: classes.accordionControl,
+            item: props.transparentActiveItem
+                ? classes.transparentActiveItem
+                : '',
+        }),
+        defaultProps: { chevronPosition: 'right', radius: 'md' },
+        styles: {
+            content: {
+                fontSize: 'var(--mantine-font-size-sm)',
+                paddingTop: 4,
+            },
+            panel: { color: 'var(--mantine-color-dimmed)' },
+        },
+    }),
+    Pagination: Pagination.extend({
+        classNames: { control: classes.paginationControl },
+        defaultProps: { color: 'ldDark', radius: 'md' },
+    }),
+    Breadcrumbs: Breadcrumbs.extend({
+        classNames: { root: classes.breadcrumbs },
+        styles: { separator: { color: 'var(--app-muted)' } },
+    }),
+    NavLink: NavLink.extend({
+        classNames: { root: classes.navLink },
+        styles: {
+            root: {
+                borderRadius: 'var(--mantine-radius-md)',
+                padding: '8px 12px',
+            },
+        },
+    }),
+    Divider: Divider.extend({
+        defaultProps: { color: 'var(--app-border)' },
+        styles: {
+            label: {
+                color: 'var(--mantine-color-dimmed)',
+                fontWeight: 500,
+            },
+        },
+    }),
+    Stepper: Stepper.extend({
+        classNames: {
+            separator: classes.stepperSeparator,
+            stepIcon: classes.stepperIcon,
+        },
+        defaultProps: {
+            color: 'ldDark',
+            iconSize: 30,
+            radius: 'xl',
+            size: 'sm',
+        },
+        styles: {
+            stepDescription: { color: 'var(--mantine-color-dimmed)' },
+            stepLabel: { fontWeight: 500, letterSpacing: '-0.006em' },
+        },
+    }),
+    Menu: Menu.extend({
+        classNames: {
+            dropdown: classes.menuDropdown,
+            item: classes.menuItem,
+        },
+        defaultProps: {
+            radius: 'md',
+            shadow: 'md',
+            withArrow: false,
+        },
+        styles: {
+            divider: { borderColor: 'var(--app-border)' },
+            dropdown: { padding: 4 },
+            label: {
+                color: 'var(--app-muted)',
+                fontSize: rem(11),
+                letterSpacing: '0.04em',
+                textTransform: 'uppercase',
+            },
+        },
+    }),
+    SegmentedControl: SegmentedControl.extend({
+        classNames: {
+            control: classes.segmentControl,
+            indicator: classes.segmentIndicator,
+            label: classes.segmentLabel,
+            root: classes.segmentRoot,
+        },
+        defaultProps: { color: 'ldDark', radius: 'md' },
+    }),
+    Tree: Tree.extend({
+        classNames: {
+            label: classes.treeLabel,
+        },
+    }),
+    ScrollArea: ScrollArea.extend({
+        classNames: { thumb: classes.scrollThumb },
+        defaultProps: { scrollbarSize: 8, type: 'hover' },
+        styles: { scrollbar: { backgroundColor: 'transparent' } },
+    }),
+    Burger: Burger.extend({
+        classNames: { root: classes.burger },
+        defaultProps: { size: 'sm' },
+    }),
+};

--- a/packages/frontend/src/mantine8Theme/components/text.module.css
+++ b/packages/frontend/src/mantine8Theme/components/text.module.css
@@ -1,0 +1,45 @@
+.eyebrow {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.meta {
+    color: var(--mantine-color-dimmed);
+    font-size: var(--mantine-font-size-xs);
+}
+
+.secondary {
+    color: var(--mantine-color-dimmed);
+}
+
+.label {
+    font-size: var(--mantine-font-size-sm);
+    font-weight: 500;
+    letter-spacing: -0.006em;
+}
+
+.numeric {
+    font-variant-numeric: tabular-nums;
+}
+
+.body {
+    letter-spacing: -0.006em;
+}
+
+.row {
+    width: 100%;
+    padding: 8px 12px;
+    text-align: start;
+    border-radius: var(--mantine-radius-md);
+}
+
+.row:hover {
+    background: var(--mantine-color-default-hover);
+}
+
+.row:focus-visible {
+    outline: none;
+    box-shadow: var(--app-focus-ring);
+}

--- a/packages/frontend/src/mantine8Theme/components/text.ts
+++ b/packages/frontend/src/mantine8Theme/components/text.ts
@@ -1,0 +1,27 @@
+import { Text, UnstyledButton } from '@mantine-8/core';
+import classes from './text.module.css';
+
+const textVariants: Record<string, string> = {
+    body: classes.body,
+    eyebrow: classes.eyebrow,
+    label: classes.label,
+    meta: classes.meta,
+    numeric: classes.numeric,
+    secondary: classes.secondary,
+};
+
+export const textComponents = {
+    Text: Text.extend({
+        classNames: (_theme, props) => ({
+            root: textVariants[props.variant as string],
+        }),
+        styles: {
+            root: { letterSpacing: '-0.006em' },
+        },
+    }),
+    UnstyledButton: UnstyledButton.extend({
+        classNames: (_theme, props) => ({
+            root: props.variant === 'row' ? classes.row : '',
+        }),
+    }),
+};

--- a/packages/frontend/src/mantine8Theme/global.css
+++ b/packages/frontend/src/mantine8Theme/global.css
@@ -1,0 +1,7 @@
+body[data-color-mode] {
+    color: var(--mantine-color-text);
+    letter-spacing: -0.006em;
+    background-color: var(--app-bg);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizelegibility;
+}

--- a/packages/frontend/src/mantine8Theme/tokens.ts
+++ b/packages/frontend/src/mantine8Theme/tokens.ts
@@ -1,0 +1,153 @@
+import {
+    defaultVariantColorsResolver,
+    rem,
+    type MantineColorsTuple,
+    type MantineThemeOverride,
+    type VariantColorsResolver,
+} from '@mantine-8/core';
+import { type ColorScheme } from '@mantine/styles';
+
+export const accent: MantineColorsTuple = [
+    '#eef2ff',
+    '#e0e7ff',
+    '#c7d2fe',
+    '#a5b4fc',
+    '#818cf8',
+    '#6366f1',
+    '#4f46e5',
+    '#4338ca',
+    '#3730a3',
+    '#312e81',
+];
+
+const variantColorResolver: VariantColorsResolver = (input) => {
+    const resolved = defaultVariantColorsResolver(input);
+    const isPrimary = !input.color || input.color === input.theme.primaryColor;
+
+    return isPrimary && (input.variant ?? 'filled') === 'filled'
+        ? {
+              ...resolved,
+              color: 'var(--mantine-primary-color-contrast)',
+          }
+        : resolved;
+};
+
+export const getThemeTokens = (
+    colorScheme: ColorScheme,
+): MantineThemeOverride => ({
+    autoContrast: true,
+    black: '#09090b',
+    cursorType: 'pointer',
+    defaultRadius: 'md',
+    focusRing: 'auto',
+    fontFamily:
+        "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+    fontFamilyMonospace:
+        'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+    headings: {
+        fontFamily:
+            "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+        fontWeight: '600',
+        sizes: {
+            h1: {
+                fontSize: rem(34),
+                lineHeight: '1.15',
+                fontWeight: '600',
+            },
+            h2: {
+                fontSize: rem(26),
+                lineHeight: '1.2',
+                fontWeight: '600',
+            },
+            h3: {
+                fontSize: rem(20),
+                lineHeight: '1.3',
+                fontWeight: '600',
+            },
+            h4: {
+                fontSize: rem(17),
+                lineHeight: '1.35',
+                fontWeight: '600',
+            },
+            h5: {
+                fontSize: rem(15),
+                lineHeight: '1.4',
+                fontWeight: '600',
+            },
+            h6: {
+                fontSize: rem(13),
+                lineHeight: '1.45',
+                fontWeight: '600',
+            },
+        },
+    },
+    luminanceThreshold: 0.4,
+    primaryColor: 'ldDark',
+    primaryShade: { light: 9, dark: 9 },
+    radius: {
+        xs: rem(5),
+        sm: rem(6),
+        md: rem(8),
+        lg: rem(12),
+        xl: rem(16),
+    },
+    shadows:
+        colorScheme === 'dark'
+            ? {
+                  xs: '0 1px 2px rgba(0, 0, 0, 0.45), 0 1px 1px rgba(0, 0, 0, 0.3)',
+                  sm: '0 1px 2px rgba(0, 0, 0, 0.42), 0 2px 5px rgba(0, 0, 0, 0.3), 0 4px 10px rgba(0, 0, 0, 0.2)',
+                  md: '0 2px 5px rgba(0, 0, 0, 0.45), 0 5px 12px rgba(0, 0, 0, 0.32), 0 10px 24px rgba(0, 0, 0, 0.22)',
+                  lg: '0 4px 10px rgba(0, 0, 0, 0.5), 0 10px 24px rgba(0, 0, 0, 0.38), 0 20px 44px rgba(0, 0, 0, 0.26)',
+                  xl: '0 8px 24px rgba(0, 0, 0, 0.52), 0 18px 46px rgba(0, 0, 0, 0.4), 0 32px 70px rgba(0, 0, 0, 0.3)',
+                  subtle: '0 1px 2px rgba(0, 0, 0, 0.45), 0 1px 1px rgba(0, 0, 0, 0.3)',
+                  heavy: '0 4px 10px rgba(0, 0, 0, 0.5), 0 10px 24px rgba(0, 0, 0, 0.38), 0 20px 44px rgba(0, 0, 0, 0.26)',
+              }
+            : {
+                  xs: '0 1px 2px rgba(9, 9, 11, 0.05), 0 1px 1px rgba(9, 9, 11, 0.04)',
+                  sm: '0 1px 2px rgba(9, 9, 11, 0.05), 0 2px 4px rgba(9, 9, 11, 0.05), 0 4px 8px rgba(9, 9, 11, 0.03)',
+                  md: '0 2px 4px rgba(9, 9, 11, 0.04), 0 4px 8px rgba(9, 9, 11, 0.05), 0 8px 16px rgba(9, 9, 11, 0.05)',
+                  lg: '0 4px 8px rgba(9, 9, 11, 0.04), 0 8px 20px rgba(9, 9, 11, 0.06), 0 16px 32px rgba(9, 9, 11, 0.06)',
+                  xl: '0 8px 24px rgba(9, 9, 11, 0.08), 0 16px 40px rgba(9, 9, 11, 0.08), 0 32px 64px rgba(9, 9, 11, 0.06)',
+                  subtle: '0 1px 2px rgba(9, 9, 11, 0.06), 0 1px 1px rgba(9, 9, 11, 0.04)',
+                  heavy: '0 4px 8px rgba(9, 9, 11, 0.04), 0 8px 20px rgba(9, 9, 11, 0.06), 0 16px 32px rgba(9, 9, 11, 0.06)',
+              },
+    variantColorResolver,
+});
+
+export const themeCssVariables = {
+    variables: {
+        '--app-control-height-xs': '30px',
+        '--app-control-height-sm': '36px',
+        '--app-control-height-md': '42px',
+        '--app-control-height-lg': '48px',
+        '--app-control-height-xl': '58px',
+        '--app-ease-out': 'cubic-bezier(0.23, 1, 0.32, 1)',
+        '--app-inset-highlight': 'inset 0 1px 0 rgba(255, 255, 255, 0.1)',
+    },
+    light: {
+        '--mantine-primary-color-contrast': '#ffffff',
+        '--app-bg': 'var(--mantine-color-ldGray-0)',
+        '--app-surface': 'var(--mantine-color-background-0)',
+        '--app-border': 'var(--mantine-color-ldGray-2)',
+        '--app-border-strong': 'var(--mantine-color-ldGray-3)',
+        '--app-muted': 'var(--mantine-color-ldGray-5)',
+        '--app-shadow-raised':
+            '0 1px 2px rgba(9, 9, 11, 0.06), 0 1px 1px rgba(9, 9, 11, 0.04)',
+        '--app-shadow-raised-hover':
+            '0 2px 4px rgba(9, 9, 11, 0.08), 0 1px 2px rgba(9, 9, 11, 0.05)',
+        '--app-focus-ring': '0 0 0 3px rgba(9, 9, 11, 0.1)',
+    },
+    dark: {
+        '--mantine-primary-color-contrast': '#09090b',
+        '--app-bg': 'var(--mantine-color-background-0)',
+        '--app-surface': 'var(--mantine-color-ldDark-1)',
+        '--app-border': 'var(--mantine-color-ldDark-3)',
+        '--app-border-strong': 'var(--mantine-color-ldDark-4)',
+        '--app-muted': 'var(--mantine-color-ldDark-7)',
+        '--app-shadow-raised':
+            '0 1px 2px rgba(0, 0, 0, 0.45), 0 1px 1px rgba(0, 0, 0, 0.3)',
+        '--app-shadow-raised-hover':
+            '0 2px 5px rgba(0, 0, 0, 0.52), 0 1px 2px rgba(0, 0, 0, 0.38)',
+        '--app-focus-ring': '0 0 0 3px rgba(255, 255, 255, 0.12)',
+    },
+} as const;

--- a/packages/frontend/src/providers/Mantine8Provider.tsx
+++ b/packages/frontend/src/providers/Mantine8Provider.tsx
@@ -6,6 +6,7 @@ import { useMantineColorScheme } from '@mantine/core';
 import { useMemo, type FC } from 'react';
 import { cssVariablesResolver } from '../mantine8CssVariablesResolver';
 import { getMantine8ThemeOverride } from '../mantine8Theme';
+import '../mantine8Theme/global.css';
 import CodeHighlightProvider from './CodeHighlightProvider';
 
 type Props = {

--- a/packages/frontend/src/styles/mantine-overrides/accordion.module.css
+++ b/packages/frontend/src/styles/mantine-overrides/accordion.module.css
@@ -1,3 +1,0 @@
-.transparentActiveItem[data-active] {
-    background-color: transparent;
-}


### PR DESCRIPTION
## What changed

- reorganizes the Mantine 8 theme into component-level extensions for actions, inputs, data display, feedback, navigation, and text
- adds shared semantic CSS variables, global defaults, refined sizing, radius, shadows, focus states, and overlay transitions
- keeps `ldGray` and `ldDark` as the battle-tested primitives for primary controls and semantic surfaces
- adds a restrained accent palette without replacing Lightdash's existing `dark` palette
- keeps the Mantine `pop` transition for popovers, hover cards, and dialogs
- removes the global Card/Paper hover lift while retaining subtle border and shadow feedback
- removes the superseded standalone accordion override

## Why

This makes Mantine's theme the source of truth for component polish, reducing one-off UI styling and making Mantine 8 components feel coherent by default. Direction is based on [joaoviana/whatifmantinelookedbetter](https://github.com/joaoviana/whatifmantinelookedbetter), adapted to preserve Lightdash's existing color semantics.

## Impact

Mantine 8 components receive consistent defaults and variants automatically. Existing `ldGray`/`ldDark` usages remain valid and continue to define Lightdash's neutral behavior in light and dark modes.

## Validation

- `pnpm -F frontend typecheck:fast`
- `pnpm -F frontend format`
- targeted frontend `oxlint` (0 warnings/errors)
- `pnpm -F frontend build`
- commit hooks: frontend lint/format and unused exports