### PR TITLE
fix(ai): harden agent response persistence and recovery

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -4595,15 +4595,26 @@ export class AiAgentModel {
     async updateModelResponse(
         data: UpdateSlackResponse | UpdateWebAppResponse,
     ) {
+        // A new response supersedes any previous error for this prompt
+        const outcome: {
+            response?: string | null;
+            error_message?: string | null;
+        } =
+            'response' in data
+                ? {
+                      response: data.response ?? null,
+                      error_message: data.errorMessage ?? null,
+                  }
+                : {
+                      ...(data.errorMessage
+                          ? { error_message: data.errorMessage }
+                          : {}),
+                  };
+
         await this.database(AiPromptTableName)
             .update({
                 responded_at: this.database.fn.now(),
-                ...('response' in data
-                    ? { response: data.response ?? null }
-                    : {}),
-                ...(data.errorMessage
-                    ? { error_message: data.errorMessage }
-                    : {}),
+                ...outcome,
                 ...(data.humanScore !== undefined
                     ? { human_score: data.humanScore }
                     : {}),

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -97,6 +97,70 @@ const createAiAgentLogger =
 
 const STEP_CAP = 40;
 
+const PERSIST_TIMEOUT_MS = 10_000;
+
+/**
+ * Decorates updatePrompt with the stream-close contract: awaiting it never
+ * throws and never holds the HTTP stream open past PERSIST_TIMEOUT_MS (the
+ * write continues in the background on timeout). If persisting a response
+ * fails outright, the update degrades to an error marker so a later page load
+ * shows a retry card instead of a silently vanished answer.
+ */
+const makeStreamSafePersist = (
+    updatePrompt: AiAgentDependencies['updatePrompt'],
+    modelName: string,
+) => {
+    const report = (error: unknown) => {
+        Logger.error('[AiAgent][Persist] Failed to persist prompt', error);
+        Sentry.captureException(error, {
+            tags: { 'ai.model': modelName },
+        });
+    };
+
+    const bounded = async (
+        update: Parameters<AiAgentDependencies['updatePrompt']>[0],
+    ): Promise<'persisted' | 'timeout' | 'failed'> => {
+        let timer: NodeJS.Timeout | undefined;
+        try {
+            const persist = updatePrompt(update);
+            const outcome = await Promise.race([
+                persist.then(() => 'persisted' as const),
+                new Promise<'timeout'>((resolve) => {
+                    timer = setTimeout(
+                        () => resolve('timeout'),
+                        PERSIST_TIMEOUT_MS,
+                    );
+                }),
+            ]);
+            if (outcome === 'timeout') {
+                Logger.warn(
+                    `[AiAgent][Persist] Persist exceeded ${PERSIST_TIMEOUT_MS}ms, continuing in background`,
+                );
+                persist.catch(report);
+            }
+            return outcome;
+        } catch (error) {
+            report(error);
+            return 'failed';
+        } finally {
+            clearTimeout(timer);
+        }
+    };
+
+    return async (
+        update: Parameters<AiAgentDependencies['updatePrompt']>[0],
+    ): Promise<void> => {
+        const outcome = await bounded(update);
+        if (outcome === 'failed' && update.response !== undefined) {
+            await bounded({
+                promptUuid: update.promptUuid,
+                errorMessage:
+                    'Something went wrong while saving the response. Please try again.',
+            });
+        }
+    };
+};
+
 const withToolHints = (
     messageHistory: ModelMessage[],
     toolHints: string[],
@@ -1144,6 +1208,10 @@ export const streamAgentResponse = async ({
     let firstTextTime: number | null = null;
     let mcpClientsClosed = false;
     const modelName = getAiAgentModelName(args.model);
+    const persistPrompt = makeStreamSafePersist(
+        dependencies.updatePrompt,
+        modelName,
+    );
 
     const cleanupMcpClients = async () => {
         if (mcpClientsClosed) {
@@ -1454,39 +1522,25 @@ export const streamAgentResponse = async ({
 
                 const stepCapReached = steps.length >= STEP_CAP;
 
-                // Await the persist before onFinish resolves — the AI SDK holds
-                // the stream open until this callback completes, so the HTTP
-                // stream only closes once the response is in the DB. Without
-                // this, the client's post-stream refetch can win the race and
-                // read a still-null message, blanking the bubble until refresh.
-                try {
-                    if (stepCapReached && !completeResponse) {
-                        await dependencies.updatePrompt({
-                            promptUuid: args.promptUuid,
-                            errorMessage: getUserFacingErrorMessage(
-                                new AiAgentStepCapReachedError(steps.length),
-                            ),
-                            tokenUsage: {
-                                totalTokens: usage.totalTokens ?? 0,
-                            },
-                        });
-                    } else {
-                        await dependencies.updatePrompt({
-                            response: completeResponse,
-                            promptUuid: args.promptUuid,
-                            tokenUsage: {
-                                totalTokens: usage.totalTokens ?? 0,
-                            },
-                        });
-                    }
-                } catch (error) {
-                    Logger.error(
-                        '[AiAgent][On Finish] Failed to persist final response',
-                        error,
-                    );
-                    Sentry.captureException(error, {
-                        tags: {
-                            'ai.model': modelName,
+                // The AI SDK holds the stream open until onFinish resolves, so
+                // the HTTP stream only closes once the response is persisted —
+                // the client's post-stream refetch then reads persisted content.
+                if (stepCapReached && !completeResponse) {
+                    await persistPrompt({
+                        promptUuid: args.promptUuid,
+                        errorMessage: getUserFacingErrorMessage(
+                            new AiAgentStepCapReachedError(steps.length),
+                        ),
+                        tokenUsage: {
+                            totalTokens: usage.totalTokens ?? 0,
+                        },
+                    });
+                } else {
+                    await persistPrompt({
+                        response: completeResponse,
+                        promptUuid: args.promptUuid,
+                        tokenUsage: {
+                            totalTokens: usage.totalTokens ?? 0,
                         },
                     });
                 }
@@ -1530,7 +1584,7 @@ export const streamAgentResponse = async ({
                 delayInMs: 20,
                 chunking: 'word',
             }),
-            onError: ({ error }) => {
+            onError: async ({ error }) => {
                 console.error(error);
                 const errorMessage =
                     error instanceof Error ? error.message : 'Unknown error';
@@ -1550,7 +1604,7 @@ export const streamAgentResponse = async ({
                     'Something went wrong while streaming the response. Please try again.',
                 );
 
-                void dependencies.updatePrompt({
+                await persistPrompt({
                     promptUuid: args.promptUuid,
                     errorMessage: userFacingMessage,
                 });


### PR DESCRIPTION
### Description

Stacked on #26088. That PR closes the stream/persist race; this one hardens the persistence path around it and fixes error recovery.

All persistence guarantees now live in a single decorator, `makeStreamSafePersist` (`agentV2.ts`), applied once to `updatePrompt` — every persist in the streaming path is a plain `await persistPrompt(...)`:

- **Never throws**: a failed persist is logged + reported to Sentry instead of breaking `onFinish` cleanup.
- **Bounded**: the await never holds the HTTP stream open past 10s. On timeout the write continues in the background (its failure is still reported). This only bounds the DB write after generation completes — long generations (2–3 min) are unaffected.
- **Degrades on failure**: if persisting a *response* fails outright, the update degrades to an error marker on the prompt, so a later page load shows a retry card instead of a silently vanished answer.
- The `onError` persist is now awaited under the same contract instead of `void`, shrinking the equivalent refetch race for error responses.

**Model fix** (`AiAgentModel.updateModelResponse`): persisting a response now clears `error_message` — a new answer supersedes a previous error. Without this, a successful "Try again" left the stale error card showing forever next to the new answer.

### Regression analysis

- `updateModelResponse` callers audited: the two other call sites (dbt-source disambiguation reply, Slack response) both persist real responses, where clearing a stale error is the intended semantic. Error-only and humanScore-only updates are untouched (error-only persists keep any existing response).
- The 10s bound can only *delay* stream close relative to #26088, never lose a write — timeout falls back to the pre-#26088 fire-and-forget behavior plus logging.
- Slack path (non-streaming) doesn't use the decorator; it only picks up the error-clearing model change, verified live.

### Testing (live, fault-injected)

- Forced persist failure → bubble keeps streamed answer + shows error card; refresh shows retry card; DB has error marker. Retry → clean answer, error card gone, `error_message` NULL.
- Forced 15s persist hang → stream closed at the 10s bound, response landed ~5s later in background; nothing lost.
- Happy path web + Slack verified; backend typecheck, lint, and 112 tests pass.

### Known gaps (not this PR)

Retry always re-runs the thread's **latest** prompt (the stream endpoint takes no messageUuid), so retrying an older errored message re-runs the wrong one, and re-running an already-answered prompt errors and stamps an error onto a good message. Both pre-existing; worth a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7cwhTCFXb1ARWGwDH635u