### PR TITLE
refactor(frontend): migrate Mantine form to v8

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -45,7 +45,7 @@
         "@mantine-8/tiptap": "npm:@mantine/tiptap@8.0.0",
         "@mantine/core": "6.0.22",
         "@mantine/dates": "6.0.21",
-        "@mantine/form": "7.5.2",
+        "@mantine/form": "8.0.0",
         "@mantine/hooks": "6.0.22",
         "@monaco-editor/react": "4.6.0",
         "@pierre/diffs": "1.2.5",

--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModal.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModal.tsx
@@ -352,122 +352,131 @@ export const CustomBinDimensionModal: FC<{
     const toggleModal = () =>
         dispatch(explorerActions.toggleCustomDimensionModal());
 
-    const formSchema = z
-        .object({
-            customDimensionLabel: z.string().refine(
-                (label) => {
-                    if (!label) return true;
-                    if (!item) return true;
-                    if (isEditing && label === item.name) return true;
+    const formSchema = useMemo(
+        () =>
+            z
+                .object({
+                    customDimensionLabel: z.string().refine(
+                        (label) => {
+                            if (!label) return true;
+                            if (!item) return true;
+                            if (isEditing && label === item.name) return true;
 
-                    const dimensionName = sanitizeId(
-                        label,
-                        isEditing && isCustomDimension(item)
-                            ? item.dimensionId
-                            : item.name,
-                    );
+                            const dimensionName = sanitizeId(
+                                label,
+                                isEditing && isCustomDimension(item)
+                                    ? item.dimensionId
+                                    : item.name,
+                            );
 
-                    if (
-                        isEditing &&
-                        isCustomDimension(item) &&
-                        dimensionName === item.id
-                    ) {
-                        return true;
-                    }
+                            if (
+                                isEditing &&
+                                isCustomDimension(item) &&
+                                dimensionName === item.id
+                            ) {
+                                return true;
+                            }
 
-                    return !customDimensions?.some(
-                        (customDimension) =>
-                            customDimension.id === dimensionName,
-                    );
-                },
-                { message: 'Dimension with this label already exists' },
-            ),
-            binType: z.nativeEnum(BinType),
-            binConfig: z.object({
-                fixedNumber: z.object({
-                    binNumber: z.number().positive(),
-                }),
-                fixedWidth: z.object({
-                    binWidth: z.number().positive(),
-                }),
-                customRange: z.array(
-                    z
-                        .object({
-                            from: z.number({ coerce: true }).optional(),
-                            to: z.number({ coerce: true }).optional(),
-                        })
-                        .transform((o) => ({ from: o.from, to: o.to })),
-                ),
-                customGroups: z.array(
-                    z.object({
-                        _id: z.string(),
-                        name: z.string(),
-                        values: z.array(
+                            return !customDimensions?.some(
+                                (customDimension) =>
+                                    customDimension.id === dimensionName,
+                            );
+                        },
+                        { message: 'Dimension with this label already exists' },
+                    ),
+                    binType: z.nativeEnum(BinType),
+                    binConfig: z.object({
+                        fixedNumber: z.object({
+                            binNumber: z.number().positive(),
+                        }),
+                        fixedWidth: z.object({
+                            binWidth: z.number().positive(),
+                        }),
+                        customRange: z.array(
+                            z
+                                .object({
+                                    from: z.number({ coerce: true }).optional(),
+                                    to: z.number({ coerce: true }).optional(),
+                                })
+                                .transform((o) => ({ from: o.from, to: o.to })),
+                        ),
+                        customGroups: z.array(
                             z.object({
                                 _id: z.string(),
-                                matchType: z.nativeEnum(GroupValueMatchType),
-                                value: z.string(),
+                                name: z.string(),
+                                values: z.array(
+                                    z.object({
+                                        _id: z.string(),
+                                        matchType:
+                                            z.nativeEnum(GroupValueMatchType),
+                                        value: z.string(),
+                                    }),
+                                ),
                             }),
                         ),
                     }),
-                ),
-            }),
-        })
-        .superRefine((data, ctx) => {
-            if (data.binType === BinType.CUSTOM_GROUP) {
-                data.binConfig.customGroups.forEach((group, groupIndex) => {
-                    if (group.name.trim().length === 0) {
-                        ctx.addIssue({
-                            code: z.ZodIssueCode.too_small,
-                            minimum: 1,
-                            type: 'string',
-                            inclusive: true,
-                            message: 'Group name is required',
-                            path: [
-                                'binConfig',
-                                'customGroups',
-                                groupIndex,
-                                'name',
-                            ],
-                        });
+                })
+                .superRefine((data, ctx) => {
+                    if (data.binType === BinType.CUSTOM_GROUP) {
+                        data.binConfig.customGroups.forEach(
+                            (group, groupIndex) => {
+                                if (group.name.trim().length === 0) {
+                                    ctx.addIssue({
+                                        code: z.ZodIssueCode.too_small,
+                                        minimum: 1,
+                                        type: 'string',
+                                        inclusive: true,
+                                        message: 'Group name is required',
+                                        path: [
+                                            'binConfig',
+                                            'customGroups',
+                                            groupIndex,
+                                            'name',
+                                        ],
+                                    });
+                                }
+                                if (group.values.length === 0) {
+                                    ctx.addIssue({
+                                        code: z.ZodIssueCode.too_small,
+                                        minimum: 1,
+                                        type: 'array',
+                                        inclusive: true,
+                                        message:
+                                            'Each group must have at least one value',
+                                        path: [
+                                            'binConfig',
+                                            'customGroups',
+                                            groupIndex,
+                                            'values',
+                                        ],
+                                    });
+                                }
+                                group.values.forEach((value, valueIndex) => {
+                                    if (value.value.trim().length === 0) {
+                                        ctx.addIssue({
+                                            code: z.ZodIssueCode.too_small,
+                                            minimum: 1,
+                                            type: 'string',
+                                            inclusive: true,
+                                            message: 'Value is required',
+                                            path: [
+                                                'binConfig',
+                                                'customGroups',
+                                                groupIndex,
+                                                'values',
+                                                valueIndex,
+                                                'value',
+                                            ],
+                                        });
+                                    }
+                                });
+                            },
+                        );
                     }
-                    if (group.values.length === 0) {
-                        ctx.addIssue({
-                            code: z.ZodIssueCode.too_small,
-                            minimum: 1,
-                            type: 'array',
-                            inclusive: true,
-                            message: 'Each group must have at least one value',
-                            path: [
-                                'binConfig',
-                                'customGroups',
-                                groupIndex,
-                                'values',
-                            ],
-                        });
-                    }
-                    group.values.forEach((value, valueIndex) => {
-                        if (value.value.trim().length === 0) {
-                            ctx.addIssue({
-                                code: z.ZodIssueCode.too_small,
-                                minimum: 1,
-                                type: 'string',
-                                inclusive: true,
-                                message: 'Value is required',
-                                path: [
-                                    'binConfig',
-                                    'customGroups',
-                                    groupIndex,
-                                    'values',
-                                    valueIndex,
-                                    'value',
-                                ],
-                            });
-                        }
-                    });
-                });
-            }
-        });
+                }),
+        [customDimensions, isEditing, item],
+    );
+    const validate = useMemo(() => zodResolver(formSchema), [formSchema]);
 
     const form = useForm<FormValues>({
         initialValues: {
@@ -486,7 +495,7 @@ export const CustomBinDimensionModal: FC<{
                 customGroups: createDefaultCustomGroups(),
             },
         },
-        validate: zodResolver(formSchema),
+        validate,
     });
 
     const { setFieldValue } = form;

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -29,7 +29,7 @@ import {
     Text,
     TextInput,
 } from '@mantine-8/core';
-import { useForm } from '@mantine/form';
+import { useForm, type FormValidateInput } from '@mantine/form';
 import { IconSparkles } from '@tabler/icons-react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { type ValueOf } from 'type-fest';
@@ -219,28 +219,13 @@ export const CustomMetricModal = memo(() => {
         sourceMetric,
     ]);
 
-    const form = useForm<
-        Pick<AdditionalMetric, 'percentile'> & {
-            format: CustomFormat;
-            customMetricLabel: string;
-        }
-    >({
-        validateInputOnChange: true,
-        validateInputOnBlur: true,
-        initialValues: {
-            customMetricLabel: '',
-            percentile: 50,
-            format: {
-                type: CustomFormatType.DEFAULT,
-                round: undefined,
-                separator: NumberSeparator.DEFAULT,
-                currency: undefined,
-                compact: undefined,
-                prefix: undefined,
-                suffix: undefined,
-            },
-        },
-        validate: {
+    type FormValues = Pick<AdditionalMetric, 'percentile'> & {
+        format: CustomFormat;
+        customMetricLabel: string;
+    };
+
+    const validate = useMemo<FormValidateInput<FormValues>>(
+        () => ({
             customMetricLabel: (label) => {
                 if (!label) return null;
 
@@ -283,7 +268,27 @@ export const CustomMetricModal = memo(() => {
                     return 'Percentile must be a number between 0 and 100';
                 }
             },
+        }),
+        [additionalMetrics, exploreData, isEditing, item],
+    );
+
+    const form = useForm<FormValues>({
+        validateInputOnChange: true,
+        validateInputOnBlur: true,
+        initialValues: {
+            customMetricLabel: '',
+            percentile: 50,
+            format: {
+                type: CustomFormatType.DEFAULT,
+                round: undefined,
+                separator: NumberSeparator.DEFAULT,
+                currency: undefined,
+                compact: undefined,
+                prefix: undefined,
+                suffix: undefined,
+            },
         },
+        validate,
     });
 
     const { setFieldValue } = form;

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/GithubForm.tsx
@@ -1,4 +1,4 @@
-import { DbtProjectType } from '@lightdash/common';
+import { DbtProjectType, type DbtGithubProjectConfig } from '@lightdash/common';
 import {
     TextInput,
     Button,
@@ -262,7 +262,7 @@ const GithubForm: FC<{ disabled: boolean }> = ({ disabled }) => {
     }
 
     const formAuthorizationMethod = form.values.dbt?.authorization_method;
-    const authorizationMethod: string =
+    const authorizationMethod: DbtGithubProjectConfig['authorization_method'] =
         formAuthorizationMethod ??
         (savedProject?.dbtConnection.type === DbtProjectType.GITHUB &&
         savedProject?.dbtConnection?.personal_access_token !== undefined

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -721,7 +721,7 @@ const BigQueryForm: FC<{
                                         if (!file) {
                                             form.setFieldValue(
                                                 'warehouse.keyfileContents',
-                                                null,
+                                                BigQueryDefaultValues.keyfileContents,
                                             );
                                             return;
                                         }
@@ -749,13 +749,13 @@ const BigQueryForm: FC<{
 
                                                     form.setFieldValue(
                                                         'warehouse.keyfileContents',
-                                                        null,
+                                                        BigQueryDefaultValues.keyfileContents,
                                                     );
                                                 }
                                             } else {
                                                 form.setFieldValue(
                                                     'warehouse.keyfileContents',
-                                                    null,
+                                                    BigQueryDefaultValues.keyfileContents,
                                                 );
                                                 setTemporaryFile(null);
                                             }

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoPanel.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeCliSsoPanel.tsx
@@ -343,10 +343,7 @@ const SnowflakeCliSsoPanel: FC<Props> = ({
                     {...form.getInputProps('warehouse.database')}
                     onChange={(value) => {
                         if (value === warehouseValues?.database) return;
-                        form.setFieldValue(
-                            'warehouse.database',
-                            value ?? undefined,
-                        );
+                        form.setFieldValue('warehouse.database', value ?? '');
                         form.setFieldValue('warehouse.schema', '');
                     }}
                 />

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -517,7 +517,7 @@ const SnowflakeForm: FC<{
                                                     setTemporaryFile(undefined);
                                                     form.setFieldValue(
                                                         'warehouse.privateKey',
-                                                        null,
+                                                        undefined,
                                                     );
                                                     return;
                                                 }
@@ -542,7 +542,7 @@ const SnowflakeForm: FC<{
                                                     } else {
                                                         form.setFieldValue(
                                                             'warehouse.privateKey',
-                                                            null,
+                                                            undefined,
                                                         );
                                                     }
                                                 };
@@ -550,7 +550,7 @@ const SnowflakeForm: FC<{
                                                     setTemporaryFile(undefined);
                                                     form.setFieldValue(
                                                         'warehouse.privateKey',
-                                                        null,
+                                                        undefined,
                                                     );
                                                 };
                                                 fileReader.readAsText(file);

--- a/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
+++ b/packages/frontend/src/components/UserCompletionModal/UserCompletionModal.tsx
@@ -23,12 +23,16 @@ const UserCompletionModal: FC = () => {
 
     const canEnterOrganizationName = user.data?.organizationName === '';
 
-    const validate = zodResolver(
-        canEnterOrganizationName
-            ? CompleteUserSchema
-            : // User is not creating org, just accepting invite
-              // They cannot input org name so don't validate it for backwards compat reasons
-              CompleteUserSchema.omit({ organizationName: true }),
+    const validate = useMemo(
+        () =>
+            zodResolver(
+                canEnterOrganizationName
+                    ? CompleteUserSchema
+                    : // User is not creating org, just accepting invite
+                      // They cannot input org name so don't validate it for backwards compat reasons
+                      CompleteUserSchema.omit({ organizationName: true }),
+            ),
+        [canEnterOrganizationName],
     );
 
     const form = useForm<CompleteUserArgs>({

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard.tsx
@@ -69,6 +69,9 @@ const saveToSpaceOrDashboardSchema = z
     .merge(saveToDashboardSchema)
     // for saving to the space
     .merge(saveToSpaceSchema);
+const saveToSpaceOrDashboardResolver = zodResolver(
+    saveToSpaceOrDashboardSchema,
+);
 
 type FormValues = z.infer<typeof saveToSpaceOrDashboardSchema>;
 
@@ -148,7 +151,7 @@ export const SaveToSpaceOrDashboard: FC<Props> = ({
     } = spaceManagement;
 
     const form = useForm<FormValues>({
-        validate: zodResolver(saveToSpaceOrDashboardSchema),
+        validate: saveToSpaceOrDashboardResolver,
     });
 
     // Check if the chart has unused dimensions that may cause incorrect results

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardSaveModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiDashboardSaveModal.tsx
@@ -85,6 +85,14 @@ export const AiDashboardSaveModal: FC<Props> = ({
         artifactData.versionUuid,
     );
 
+    const validate = useMemo(
+        () => ({
+            dashboardName: (value: string) =>
+                value.length === 0 ? 'Dashboard name is required' : null,
+        }),
+        [],
+    );
+
     const form = useForm<FormValues>({
         initialValues: {
             dashboardName: dashboardConfig.title,
@@ -92,10 +100,7 @@ export const AiDashboardSaveModal: FC<Props> = ({
             spaceUuid: null,
             newSpaceName: null,
         },
-        validate: {
-            dashboardName: (value: string) =>
-                value.length === 0 ? 'Dashboard name is required' : null,
-        },
+        validate,
     });
 
     const spaceManagement = useSpaceManagement({

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.test.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.test.ts
@@ -1,0 +1,26 @@
+import { ThresholdOperator } from '@lightdash/common';
+import { describe, expect, test } from 'vitest';
+import {
+    DEFAULT_VALUES_ALERT,
+    transformFormValues,
+} from './schedulerFormContext';
+
+describe('transformFormValues', () => {
+    test('omits blank threshold values from the API payload', () => {
+        const result = transformFormValues(
+            {
+                ...DEFAULT_VALUES_ALERT,
+                thresholds: [
+                    {
+                        fieldId: 'orders_total',
+                        operator: ThresholdOperator.GREATER_THAN,
+                        value: '',
+                    },
+                ],
+            },
+            'chart',
+        );
+
+        expect(result.thresholds).toEqual([]);
+    });
+});

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -53,7 +53,7 @@ export interface SchedulerFormValues {
     thresholds?: Array<{
         fieldId: string;
         operator: ThresholdOperator;
-        value: number;
+        value: number | '';
     }>;
     includeLinks: boolean;
     notificationFrequency?: NotificationFrequency;
@@ -294,7 +294,13 @@ export const transformFormValues = (
             filters: values.chartFilters,
             parameters: values.parameters,
         }),
-        thresholds: values.thresholds,
+        thresholds: values.thresholds?.filter(
+            (
+                threshold,
+            ): threshold is typeof threshold & {
+                value: number;
+            } => typeof threshold.value === 'number',
+        ),
         enabled: true,
         notificationFrequency:
             'notificationFrequency' in values

--- a/packages/frontend/src/features/scheduler/hooks/useSchedulerFormModal.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useSchedulerFormModal.ts
@@ -11,6 +11,7 @@ import {
     type ParametersValuesMap,
     type SchedulerAndTargets,
 } from '@lightdash/common';
+import { type FormValidateInput } from '@mantine/form';
 import { type UseMutationResult } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useAiAgentButtonVisibility } from '../../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
@@ -154,38 +155,8 @@ export const useSchedulerFormModal = ({
     // Use the explicitly passed parameter values
     const dashboardParameterValues = currentParameterValues || {};
 
-    const form = useSchedulerForm({
-        initialValues:
-            scheduler.data !== undefined
-                ? getFormValuesFromScheduler({
-                      ...scheduler.data,
-                      ...getSelectedTabsForDashboardScheduler(
-                          scheduler.data,
-                          isDashboardTabsAvailable,
-                          dashboard,
-                      ),
-                  })
-                : isThresholdAlert
-                  ? DEFAULT_VALUES_ALERT
-                  : {
-                        ...DEFAULT_VALUES,
-                        // Apps only support image deliveries
-                        format: isApp
-                            ? SchedulerFormat.IMAGE
-                            : DEFAULT_VALUES.format,
-                        selectedTabs: isDashboardTabsAvailable
-                            ? dashboard?.tabs.map((tab) => tab.uuid)
-                            : null,
-                        parameters:
-                            isDashboard &&
-                            Object.keys(dashboardParameterValues).length > 0
-                                ? dashboardParameterValues
-                                : undefined,
-                        ...initialFormValues,
-                    },
-        validateInputOnBlur: ['options.customLimit'],
-
-        validate: {
+    const validate = useMemo<FormValidateInput<SchedulerFormValues>>(
+        () => ({
             name: (value) => {
                 return value.length > 0 ? null : 'Name is required';
             },
@@ -236,7 +207,42 @@ export const useSchedulerFormModal = ({
                 value && value.prompt.trim().length === 0
                     ? 'Instructions are required'
                     : null,
-        },
+        }),
+        [dashboard?.filters, isFilterRequirementsEnabled],
+    );
+
+    const form = useSchedulerForm({
+        initialValues:
+            scheduler.data !== undefined
+                ? getFormValuesFromScheduler({
+                      ...scheduler.data,
+                      ...getSelectedTabsForDashboardScheduler(
+                          scheduler.data,
+                          isDashboardTabsAvailable,
+                          dashboard,
+                      ),
+                  })
+                : isThresholdAlert
+                  ? DEFAULT_VALUES_ALERT
+                  : {
+                        ...DEFAULT_VALUES,
+                        // Apps only support image deliveries
+                        format: isApp
+                            ? SchedulerFormat.IMAGE
+                            : DEFAULT_VALUES.format,
+                        selectedTabs: isDashboardTabsAvailable
+                            ? dashboard?.tabs.map((tab) => tab.uuid)
+                            : null,
+                        parameters:
+                            isDashboard &&
+                            Object.keys(dashboardParameterValues).length > 0
+                                ? dashboardParameterValues
+                                : undefined,
+                        ...initialFormValues,
+                    },
+        validateInputOnBlur: ['options.customLimit'],
+
+        validate,
     });
 
     const numericMetrics = useMemo(

--- a/packages/frontend/src/hooks/mantineFormV8Compatibility.test.tsx
+++ b/packages/frontend/src/hooks/mantineFormV8Compatibility.test.tsx
@@ -1,0 +1,42 @@
+import { useForm, zodResolver } from '@mantine/form';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { z } from 'zod';
+
+describe('Mantine form v8 compatibility', () => {
+    test('nested field updates preserve Zod validation behavior', () => {
+        const schema = z.object({
+            user: z.object({
+                email: z.string().email('Invalid email'),
+            }),
+        });
+        const { result } = renderHook(() =>
+            useForm({
+                initialValues: {
+                    user: {
+                        email: '',
+                    },
+                },
+                validate: zodResolver(schema),
+            }),
+        );
+
+        act(() => {
+            result.current.setFieldValue('user.email', 'not-an-email');
+        });
+        expect(result.current.values.user.email).toBe('not-an-email');
+
+        act(() => {
+            result.current.validate();
+        });
+        expect(result.current.errors).toEqual({
+            'user.email': 'Invalid email',
+        });
+
+        act(() => {
+            result.current.setFieldValue('user.email', 'user@example.com');
+            result.current.validate();
+        });
+        expect(result.current.errors).toEqual({});
+    });
+});

--- a/packages/frontend/src/pages/PasswordReset.tsx
+++ b/packages/frontend/src/pages/PasswordReset.tsx
@@ -61,12 +61,13 @@ const PasswordReset: FC = () => {
                                     <form
                                         name="password-reset"
                                         onSubmit={form.onSubmit(
-                                            ({ password }) =>
-                                                code &&
+                                            ({ password }) => {
+                                                if (!code) return;
                                                 passwordResetMutation.mutate({
                                                     code,
                                                     newPassword: password,
-                                                }),
+                                                });
+                                            },
                                         )}
                                     >
                                         <Stack gap="lg">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1120,8 +1120,8 @@ importers:
         specifier: 6.0.21
         version: 6.0.21(@mantine/core@6.0.22(@emotion/react@11.10.6(@types/react@19.2.2)(react@19.2.0))(@mantine/hooks@6.0.22(react@19.2.0))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mantine/hooks@6.0.22(react@19.2.0))(dayjs@1.11.10)(react@19.2.0)
       '@mantine/form':
-        specifier: 7.5.2
-        version: 7.5.2(react@19.2.0)
+        specifier: 8.0.0
+        version: 8.0.0(react@19.2.0)
       '@mantine/hooks':
         specifier: 6.0.22
         version: 6.0.22(react@19.2.0)
@@ -1289,7 +1289,7 @@ importers:
         version: 4.18.1
       mantine-form-zod-resolver:
         specifier: 1.1.0
-        version: 1.1.0(@mantine/form@7.5.2(react@19.2.0))(zod@3.25.55)
+        version: 1.1.0(@mantine/form@8.0.0(react@19.2.0))(zod@3.25.55)
       moment:
         specifier: 2.29.4
         version: 2.29.4
@@ -4312,10 +4312,10 @@ packages:
       dayjs: '>=1.0.0'
       react: '>=16.8.0'
 
-  '@mantine/form@7.5.2':
-    resolution: {integrity: sha512-Kz4UNLvAvxB1utKflt4gr5Uzt1Dxj17thcnlLzB2JX6unzV3OkvC36b5XoXAtuoFxt/RzEyUrp5M38jZLwCLEA==}
+  '@mantine/form@8.0.0':
+    resolution: {integrity: sha512-ErbbEFMEiRsK2Rn0jmFE5ohNJXHSMSbuJsL2vDUVsbIaXo6svw6ockw1WWGdiU8oEGqxM6Pd618yI9cJWNHF3g==}
     peerDependencies:
-      react: ^18.2.0
+      react: ^18.x || ^19.x
 
   '@mantine/hooks@6.0.22':
     resolution: {integrity: sha512-e10//QTN2sAmC4Ryeu5X5L/TsxnrjXMOaGq3dxFPIPsCSwLzyxqySfjzVViWmoPWAj0Ak9MvE2MHFjzmOpA80w==}
@@ -20691,7 +20691,7 @@ snapshots:
       dayjs: 1.11.10
       react: 19.2.0
 
-  '@mantine/form@7.5.2(react@19.2.0)':
+  '@mantine/form@8.0.0(react@19.2.0)':
     dependencies:
       fast-deep-equal: 3.1.3
       klona: 2.0.6
@@ -30368,9 +30368,9 @@ snapshots:
       - bluebird
       - supports-color
 
-  mantine-form-zod-resolver@1.1.0(@mantine/form@7.5.2(react@19.2.0))(zod@3.25.55):
+  mantine-form-zod-resolver@1.1.0(@mantine/form@8.0.0(react@19.2.0))(zod@3.25.55):
     dependencies:
-      '@mantine/form': 7.5.2(react@19.2.0)
+      '@mantine/form': 8.0.0(react@19.2.0)
       zod: 3.25.55
 
   markdown-it-task-lists@2.1.1: {}


### PR DESCRIPTION
## Summary

- upgrade `@mantine/form` from 7.5.2 to 8.0.0
- adapt stricter nested field types and transient empty threshold values
- stabilize validation identities required by v8 form callback semantics
- add compatibility coverage for nested Zod validation and scheduler threshold transforms

## Stack

Stacked on #26096 (`joaoviana/migrate-mantine-hooks-v8`). Retarget to `main` after that PR merges.

## Validation

- frontend typecheck
- frontend format
- frontend lint: 0 errors (4 existing warnings)
- frontend tests: 183 files, 1,453 tests passed
- frontend production build
- frontend SDK JS/CJS/type builds
- focused `UserCompletionModal` regression: 12/12 passed twice