### PR TITLE
test(frontend): lock Mantine date contracts

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.utils.test.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.utils.test.ts
@@ -7,9 +7,11 @@ import {
 describe('FilterDateTimePicker timezone shift', () => {
     it.each([
         ['America/New_York', new Date(Date.UTC(2024, 5, 15, 10, 30, 0))],
+        ['America/New_York', new Date(Date.UTC(2024, 0, 15, 10, 30, 0))],
         ['Europe/Helsinki', new Date(Date.UTC(2024, 5, 15, 22, 0, 0))],
         ['Asia/Tokyo', new Date(Date.UTC(2024, 5, 15, 23, 30, 0))],
         ['Pacific/Auckland', new Date(Date.UTC(2024, 5, 15, 0, 15, 0))],
+        ['Pacific/Auckland', new Date(Date.UTC(2024, 0, 15, 0, 15, 0))],
         ['UTC', new Date(Date.UTC(2024, 5, 15, 12, 0, 0))],
     ])(
         'round-trips unshift(shift(value)) === value for %s',
@@ -22,4 +24,42 @@ describe('FilterDateTimePicker timezone shift', () => {
             expect(restored.toISOString()).toBe(value.toISOString());
         },
     );
+
+    it('normalizes a New York DST gap using the existing Day.js policy', () => {
+        const nonexistentWallClock = new Date(2024, 2, 10, 2, 30);
+
+        const restored = unshiftFromProjectTimezone(
+            nonexistentWallClock,
+            'America/New_York',
+        );
+        const normalized = shiftToProjectTimezone(restored, 'America/New_York');
+
+        expect(restored.toISOString()).toBe('2024-03-10T07:30:00.000Z');
+        expect([
+            normalized.getFullYear(),
+            normalized.getMonth(),
+            normalized.getDate(),
+            normalized.getHours(),
+            normalized.getMinutes(),
+        ]).toEqual([2024, 2, 10, 3, 30]);
+    });
+
+    it('selects the earlier New York offset during a DST fold', () => {
+        const ambiguousWallClock = new Date(2024, 10, 3, 1, 30);
+
+        const restored = unshiftFromProjectTimezone(
+            ambiguousWallClock,
+            'America/New_York',
+        );
+        const shifted = shiftToProjectTimezone(restored, 'America/New_York');
+
+        expect(restored.toISOString()).toBe('2024-11-03T05:30:00.000Z');
+        expect([
+            shifted.getFullYear(),
+            shifted.getMonth(),
+            shifted.getDate(),
+            shifted.getHours(),
+            shifted.getMinutes(),
+        ]).toEqual([2024, 10, 3, 1, 30]);
+    });
 });

--- a/packages/frontend/src/components/common/Filters/FilterInputs/mantineDateAdapter.test.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/mantineDateAdapter.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import {
+    formatMantineDate,
+    formatMantineDateRange,
+    formatMantineDateTime,
+    parseMantineDate,
+    parseMantineDateRange,
+    parseMantineDateTime,
+} from './mantineDateAdapter';
+
+describe('mantineDateAdapter', () => {
+    it('formats a Date as a local calendar date', () => {
+        expect(formatMantineDate(new Date(2024, 5, 15, 12, 30))).toBe(
+            '2024-06-15',
+        );
+    });
+
+    it('parses a Mantine date as a local calendar date', () => {
+        expect(parseMantineDate('2024-06-15')).toEqual(new Date(2024, 5, 15));
+    });
+
+    it.each([
+        [new Date(1000, 0, 1), '1000-01-01'],
+        [new Date(2024, 1, 29), '2024-02-29'],
+        [new Date(9999, 11, 31), '9999-12-31'],
+    ])('supports the calendar boundary %s', (value, expected) => {
+        expect(formatMantineDate(value)).toBe(expected);
+        expect(parseMantineDate(expected)).toEqual(value);
+    });
+
+    it('returns null for absent and invalid Dates', () => {
+        expect(formatMantineDate(null)).toBeNull();
+        expect(formatMantineDate(new Date(Number.NaN))).toBeNull();
+        expect(formatMantineDateTime(null)).toBeNull();
+        expect(formatMantineDateTime(new Date(Number.NaN))).toBeNull();
+        expect(parseMantineDate(null)).toBeNull();
+        expect(parseMantineDateTime(null)).toBeNull();
+    });
+
+    it.each([
+        '2023-02-29',
+        '2024-02-30',
+        '2024-00-01',
+        '2024-13-01',
+        '2024-01-00',
+        '2024-01-32',
+        '2024-1-01',
+        '2024-01-1',
+        'not-a-date',
+        '',
+    ])('rejects invalid or malformed date %j', (value) => {
+        expect(parseMantineDate(value)).toBeNull();
+    });
+
+    it('formats a DateTime with second precision', () => {
+        expect(
+            formatMantineDateTime(new Date(2024, 5, 15, 23, 59, 58, 987)),
+        ).toBe('2024-06-15 23:59:58');
+    });
+
+    it('parses a Mantine DateTime as local wall-clock time', () => {
+        expect(parseMantineDateTime('2024-06-15 23:59:58')).toEqual(
+            new Date(2024, 5, 15, 23, 59, 58),
+        );
+    });
+
+    it.each([
+        [new Date(2024, 5, 15, 0, 0, 0), '2024-06-15 00:00:00'],
+        [new Date(2024, 5, 15, 12, 0, 0), '2024-06-15 12:00:00'],
+        [new Date(2024, 5, 15, 23, 59, 59), '2024-06-15 23:59:59'],
+    ])('round-trips the local wall-clock boundary %s', (value, expected) => {
+        expect(formatMantineDateTime(value)).toBe(expected);
+        expect(parseMantineDateTime(expected)).toEqual(value);
+    });
+
+    it.each([
+        '2023-02-29 12:00:00',
+        '2024-06-15 24:00:00',
+        '2024-06-15 23:60:00',
+        '2024-06-15 23:59:60',
+        '2024-06-15T23:59:58',
+        '2024-06-15 1:02:03',
+        '2024-06-15',
+        '',
+    ])('rejects invalid or malformed DateTime %j', (value) => {
+        expect(parseMantineDateTime(value)).toBeNull();
+    });
+
+    it('preserves complete and partial date ranges', () => {
+        const complete: [Date | null, Date | null] = [
+            new Date(2024, 0, 31),
+            new Date(2024, 1, 29),
+        ];
+        const partial: [Date | null, Date | null] = [
+            null,
+            new Date(2024, 11, 31),
+        ];
+
+        expect(formatMantineDateRange(complete)).toEqual([
+            '2024-01-31',
+            '2024-02-29',
+        ]);
+        expect(parseMantineDateRange(formatMantineDateRange(complete))).toEqual(
+            complete,
+        );
+        expect(formatMantineDateRange(partial)).toEqual([null, '2024-12-31']);
+        expect(parseMantineDateRange(formatMantineDateRange(partial))).toEqual(
+            partial,
+        );
+    });
+});

--- a/packages/frontend/src/components/common/Filters/FilterInputs/mantineDateAdapter.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/mantineDateAdapter.ts
@@ -1,0 +1,104 @@
+const padTwoDigits = (value: number): string => String(value).padStart(2, '0');
+const MANTINE_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const MANTINE_DATE_TIME_PATTERN =
+    /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/;
+
+export type MantineDateRange = [string | null, string | null];
+export type LightdashDateRange = [Date | null, Date | null];
+
+export const formatMantineDate = (value: Date | null): string | null => {
+    if (value === null || Number.isNaN(value.getTime())) return null;
+
+    return [
+        String(value.getFullYear()).padStart(4, '0'),
+        padTwoDigits(value.getMonth() + 1),
+        padTwoDigits(value.getDate()),
+    ].join('-');
+};
+
+export const formatMantineDateTime = (value: Date | null): string | null => {
+    const date = formatMantineDate(value);
+    if (date === null || value === null) return null;
+
+    const time = [
+        padTwoDigits(value.getHours()),
+        padTwoDigits(value.getMinutes()),
+        padTwoDigits(value.getSeconds()),
+    ].join(':');
+
+    return `${date} ${time}`;
+};
+
+export const parseMantineDate = (value: string | null): Date | null => {
+    if (value === null) return null;
+
+    const match = MANTINE_DATE_PATTERN.exec(value);
+    if (match === null) return null;
+
+    const [, yearSource, monthSource, daySource] = match;
+    const year = Number(yearSource);
+    const monthIndex = Number(monthSource) - 1;
+    const day = Number(daySource);
+    const parsed = new Date(year, monthIndex, day);
+
+    if (
+        parsed.getFullYear() !== year ||
+        parsed.getMonth() !== monthIndex ||
+        parsed.getDate() !== day
+    ) {
+        return null;
+    }
+
+    return parsed;
+};
+
+export const parseMantineDateTime = (value: string | null): Date | null => {
+    if (value === null) return null;
+
+    const match = MANTINE_DATE_TIME_PATTERN.exec(value);
+    if (match === null) return null;
+
+    const [
+        ,
+        yearSource,
+        monthSource,
+        daySource,
+        hourSource,
+        minuteSource,
+        secondSource,
+    ] = match;
+    const year = Number(yearSource);
+    const monthIndex = Number(monthSource) - 1;
+    const day = Number(daySource);
+    const hour = Number(hourSource);
+    const minute = Number(minuteSource);
+    const second = Number(secondSource);
+    const parsed = new Date(year, monthIndex, day, hour, minute, second);
+
+    if (
+        parsed.getFullYear() !== year ||
+        parsed.getMonth() !== monthIndex ||
+        parsed.getDate() !== day ||
+        parsed.getHours() !== hour ||
+        parsed.getMinutes() !== minute ||
+        parsed.getSeconds() !== second
+    ) {
+        return null;
+    }
+
+    return parsed;
+};
+
+export const formatMantineDateRange = (
+    value: LightdashDateRange,
+): MantineDateRange => [
+    formatMantineDate(value[0]),
+    formatMantineDate(value[1]),
+];
+
+export const parseMantineDateRange = (
+    value: MantineDateRange,
+): LightdashDateRange => [
+    parseMantineDate(value[0]),
+    parseMantineDate(value[1]),
+];


### PR DESCRIPTION
## Summary

Part 1 of the Mantine Dates v8 migration chain.

- add strict local-calendar and wall-clock adapters for Mantine v8 string values
- reject malformed, impossible, and silently rolled-over dates
- preserve null and partial date ranges
- lock existing project-timezone behavior across summer/winter, the New York DST gap, and the New York DST fold

This PR does not change dependencies, renderers, or production behavior. The adapters will be wired during the final Dates v8 cutover.

## Chain

1. **Date adapters and timezone contracts — this PR**
2. v8-compatible date styles and controlled-state hardening
3. atomic Mantine Dates v8 cutover

## Validation

- adapter and timezone suites in separate `TZ=UTC`, `TZ=America/Los_Angeles`, and `TZ=Pacific/Auckland` processes: 39/39 each
- frontend tests: 184 files, 1,493 tests passed
- frontend typecheck
- frontend format
- frontend lint: 0 errors (4 existing warnings)
- frontend production build
- frontend SDK JS/CJS/type builds