### PR TITLE
feat(frontend): harmonize settings layouts

### DIFF
--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -801,6 +801,8 @@ export class UserAppsController extends BaseController {
         @Query() page?: number,
         @Query() pageSize?: number,
         @Query() excludePreviewProjects?: boolean,
+        @Query() projectUuids?: string[],
+        @Query() search?: string,
     ): Promise<ApiMyAppsResponse> {
         assertRegisteredAccount(req.account);
         const result = await this.services
@@ -808,7 +810,7 @@ export class UserAppsController extends BaseController {
             .listMyApps(
                 toSessionUser(req.account),
                 page && pageSize ? { page, pageSize } : undefined,
-                { excludePreviewProjects },
+                { excludePreviewProjects, projectUuids, search },
             );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -6607,7 +6607,11 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
     async listMyApps(
         user: SessionUser,
         paginateArgs?: { page: number; pageSize: number },
-        options: { excludePreviewProjects?: boolean } = {},
+        options: {
+            excludePreviewProjects?: boolean;
+            projectUuids?: string[];
+            search?: string;
+        } = {},
     ): Promise<{
         data: {
             appUuid: string;

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -831,7 +831,11 @@ export class AppModel {
     async listMyApps(
         userUuid: string,
         paginateArgs?: KnexPaginateArgs,
-        options: { excludePreviewProjects?: boolean } = {},
+        options: {
+            excludePreviewProjects?: boolean;
+            projectUuids?: string[];
+            search?: string;
+        } = {},
     ): Promise<
         KnexPaginatedData<
             {
@@ -875,6 +879,29 @@ export class AppModel {
                         `${ProjectTableName}.project_type`,
                         ProjectType.PREVIEW,
                     );
+                }
+
+                if (options.projectUuids?.length) {
+                    void queryBuilder.whereIn(
+                        `${AppsTableName}.project_uuid`,
+                        options.projectUuids,
+                    );
+                }
+
+                const search = options.search?.trim();
+                if (search) {
+                    void queryBuilder.where((searchQueryBuilder) => {
+                        void searchQueryBuilder
+                            .whereILike(`${AppsTableName}.name`, `%${search}%`)
+                            .orWhereILike(
+                                `${ProjectTableName}.name`,
+                                `%${search}%`,
+                            )
+                            .orWhereILike(
+                                `${SpaceTableName}.name`,
+                                `%${search}%`,
+                            );
+                    });
                 }
             })
             .select(

--- a/packages/frontend/src/components/CompilationHistory/index.tsx
+++ b/packages/frontend/src/components/CompilationHistory/index.tsx
@@ -43,7 +43,7 @@ const CompilationHistory: FC<CompilationHistoryProps> = ({ projectUuid }) => {
                 <Stack gap="md">
                     <Group justify="space-between">
                         <Stack gap={2}>
-                            <Title order={5}>Compilation History</Title>
+                            <Title order={5}>Compilation runs</Title>
                             <Text c="dimmed" size="xs">
                                 View the history of all dbt compilations for
                                 this project, including CLI deploys and UI

--- a/packages/frontend/src/components/CompilationHistory/index.tsx
+++ b/packages/frontend/src/components/CompilationHistory/index.tsx
@@ -1,19 +1,11 @@
-import {
-    ActionIcon,
-    Card,
-    Group,
-    LoadingOverlay,
-    Stack,
-    Text,
-    Title,
-    Tooltip,
-} from '@mantine-8/core';
+import { Button, Card, LoadingOverlay } from '@mantine-8/core';
 import { IconRefresh } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { type FC } from 'react';
 import useToaster from '../../hooks/toaster/useToaster';
 import { useProject } from '../../hooks/useProject';
 import MantineIcon from '../common/MantineIcon';
+import { SettingsPage } from '../common/Settings/SettingsPage';
 import CompilationHistoryTable from './CompilationHistoryTable';
 
 type CompilationHistoryProps = {
@@ -39,36 +31,26 @@ const CompilationHistory: FC<CompilationHistoryProps> = ({ projectUuid }) => {
         <>
             <LoadingOverlay visible={isLoadingProject} />
 
-            <Card pb="xxl">
-                <Stack gap="md">
-                    <Group justify="space-between">
-                        <Stack gap={2}>
-                            <Title order={5}>Compilation runs</Title>
-                            <Text c="dimmed" size="xs">
-                                View the history of all dbt compilations for
-                                this project, including CLI deploys and UI
-                                refreshes.
-                            </Text>
-                        </Stack>
-                        <Group gap="xs"></Group>
-                        <Tooltip label="Click to refresh the compilation history">
-                            <ActionIcon
-                                onClick={handleRefresh}
-                                variant="subtle"
-                                size="md"
-                            >
-                                <MantineIcon
-                                    icon={IconRefresh}
-                                    color="ldGray.6"
-                                    stroke={2}
-                                />
-                            </ActionIcon>
-                        </Tooltip>
-                    </Group>
-
+            <SettingsPage
+                title="Compilation history"
+                description="Review recent dbt compilation runs for this project."
+                actions={
+                    <Button
+                        onClick={handleRefresh}
+                        variant="default"
+                        size="xs"
+                        leftSection={
+                            <MantineIcon icon={IconRefresh} stroke={2} />
+                        }
+                    >
+                        Refresh
+                    </Button>
+                }
+            >
+                <Card pb="xxl">
                     <CompilationHistoryTable projectUuid={projectUuid} />
-                </Stack>
-            </Card>
+                </Card>
+            </SettingsPage>
         </>
     );
 };

--- a/packages/frontend/src/components/DataOps/index.tsx
+++ b/packages/frontend/src/components/DataOps/index.tsx
@@ -22,7 +22,7 @@ export const DataOps: FC<{ projectUuid: string }> = ({ projectUuid }) => {
 
             <SettingsGridCard>
                 <div>
-                    <Title order={4}>Promote content</Title>
+                    <Title order={5}>Promote content</Title>
                     <Text c="ldGray.6" fz="xs">
                         Developers and admins on this organization can copy
                         content from this project into the selected upstream

--- a/packages/frontend/src/components/DefaultUserSpaces/index.tsx
+++ b/packages/frontend/src/components/DefaultUserSpaces/index.tsx
@@ -10,34 +10,27 @@ export const DefaultUserSpaces: FC<{ projectUuid: string }> = ({
     const { mutate, isLoading } = useUpdateDefaultUserSpaces(projectUuid);
 
     return (
-        <>
-            <Text c="dimmed">
-                Manage default personal spaces for project members
-            </Text>
-
-            <SettingsGridCard>
-                <Box>
-                    <Title order={4}>Default user spaces</Title>
-                    <Text c="ldGray.6" fz="xs">
-                        When enabled, each project member will automatically get
-                        a personal space where they can save their own charts
-                        and dashboards.
-                    </Text>
-                </Box>
-                <Box>
-                    <Switch
-                        label="Enable default user spaces"
-                        checked={project?.hasDefaultUserSpaces ?? false}
-                        disabled={isLoading}
-                        onChange={(event) => {
-                            mutate({
-                                hasDefaultUserSpaces:
-                                    event.currentTarget.checked,
-                            });
-                        }}
-                    />
-                </Box>
-            </SettingsGridCard>
-        </>
+        <SettingsGridCard>
+            <Box>
+                <Title order={5}>Personal spaces</Title>
+                <Text c="ldGray.6" fz="xs">
+                    When enabled, each project member will automatically get a
+                    personal space where they can save their own charts and
+                    dashboards.
+                </Text>
+            </Box>
+            <Box>
+                <Switch
+                    label="Enable default user spaces"
+                    checked={project?.hasDefaultUserSpaces ?? false}
+                    disabled={isLoading}
+                    onChange={(event) => {
+                        mutate({
+                            hasDefaultUserSpaces: event.currentTarget.checked,
+                        });
+                    }}
+                />
+            </Box>
+        </SettingsGridCard>
     );
 };

--- a/packages/frontend/src/components/PreAggregateAudit/index.tsx
+++ b/packages/frontend/src/components/PreAggregateAudit/index.tsx
@@ -1,12 +1,9 @@
 import {
     Button,
     Card,
-    Group,
     LoadingOverlay,
     SimpleGrid,
-    Stack,
     Text,
-    Title,
 } from '@mantine-8/core';
 import { IconRefresh } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -15,6 +12,7 @@ import useToaster from '../../hooks/toaster/useToaster';
 import { usePreAggregateStats } from '../../hooks/usePreAggregateStats';
 import { useProject } from '../../hooks/useProject';
 import MantineIcon from '../common/MantineIcon';
+import { SettingsPage } from '../common/Settings/SettingsPage';
 import PreAggregateStatsTable from './PreAggregateStatsTable';
 
 type PreAggregateAuditProps = {
@@ -79,16 +77,10 @@ const PreAggregateAudit: FC<PreAggregateAuditProps> = ({ projectUuid }) => {
         <>
             <LoadingOverlay visible={isLoadingProject} />
 
-            <Stack gap="md">
-                <Group justify="space-between">
-                    <Stack gap={2}>
-                        <Title order={5}>Pre-Aggregate Analytics</Title>
-                        <Text c="dimmed" size="xs">
-                            Track cache performance for your pre-aggregates.
-                            Data is retained for 3 days.
-                        </Text>
-                    </Stack>
-
+            <SettingsPage
+                title="Pre-aggregate analytics"
+                description="Track cache performance for this project's pre-aggregates. Data is retained for 3 days."
+                actions={
                     <Button
                         onClick={handleRefresh}
                         variant="default"
@@ -97,8 +89,8 @@ const PreAggregateAudit: FC<PreAggregateAuditProps> = ({ projectUuid }) => {
                     >
                         Refresh stats
                     </Button>
-                </Group>
-
+                }
+            >
                 <SimpleGrid cols={3}>
                     <Card withBorder p="md">
                         <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
@@ -134,7 +126,7 @@ const PreAggregateAudit: FC<PreAggregateAuditProps> = ({ projectUuid }) => {
                     isError={isError}
                     projectUuid={projectUuid}
                 />
-            </Stack>
+            </SettingsPage>
         </>
     );
 };

--- a/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
+++ b/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
@@ -17,7 +17,6 @@ import {
     Stack,
     Text,
     TextInput,
-    Title,
     Tooltip,
 } from '@mantine-8/core';
 import { useDisclosure, useLocalStorage } from '@mantine-8/hooks';
@@ -61,6 +60,7 @@ import {
 } from '../common/ContentTable';
 import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
+import { SettingsPage } from '../common/Settings/SettingsPage';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import MaterializationDetailDrawer from './MaterializationDetailDrawer';
 import classes from './PreAggregateMaterializations.module.css';
@@ -703,16 +703,10 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
         <>
             <LoadingOverlay visible={isLoadingProject} />
 
-            <Stack gap="md">
-                <Group justify="space-between" align="flex-start">
-                    <Stack gap={2}>
-                        <Title order={5}>Pre-Aggregate Materializations</Title>
-                        <Text c="dimmed" size="xs">
-                            Overview of all pre-aggregate definitions and their
-                            current materialization status.
-                        </Text>
-                    </Stack>
-
+            <SettingsPage
+                title="Pre-aggregate materializations"
+                description="Overview of all pre-aggregate definitions and their current materialization status."
+                actions={
                     <Group gap="xs">
                         <Button
                             component="a"
@@ -740,8 +734,8 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
                             Rebuild all
                         </Button>
                     </Group>
-                </Group>
-
+                }
+            >
                 {requiresUserCredentials && (
                     <Callout variant="warning">
                         <Text fz="xs">
@@ -772,7 +766,7 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
                 ) : (
                     <ContentTable table={table} />
                 )}
-            </Stack>
+            </SettingsPage>
 
             <MaterializationDetailDrawer
                 summary={selectedSummary}

--- a/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
+++ b/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
@@ -28,7 +28,6 @@ import {
     IconCalendarTime,
     IconClock,
     IconColumns,
-    IconExternalLink,
     IconFile,
     IconFilter,
     IconFilterExclamation,
@@ -60,7 +59,11 @@ import {
 import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
 import { SettingsEmptyState } from '../common/Settings/SettingsEmptyState';
-import { SettingsPage } from '../common/Settings/SettingsPage';
+import {
+    SettingsPage,
+    SettingsPageActions,
+    SettingsPageDocumentationLink,
+} from '../common/Settings/SettingsPage';
 import MaterializationDetailDrawer from './MaterializationDetailDrawer';
 import classes from './PreAggregateMaterializations.module.css';
 import { StatusBadge } from './StatusBadge';
@@ -706,22 +709,8 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
                 title="Pre-aggregate materializations"
                 description="Overview of all pre-aggregate definitions and their current materialization status."
                 actions={
-                    <Group gap="xs">
-                        <Button
-                            component="a"
-                            href="https://docs.lightdash.com/references/pre-aggregates"
-                            target="_blank"
-                            variant="default"
-                            size="xs"
-                            rightSection={
-                                <MantineIcon
-                                    icon={IconExternalLink}
-                                    size="sm"
-                                />
-                            }
-                        >
-                            Documentation
-                        </Button>
+                    <SettingsPageActions>
+                        <SettingsPageDocumentationLink href="https://docs.lightdash.com/references/pre-aggregates" />
                         <Button
                             size="xs"
                             leftSection={
@@ -732,7 +721,7 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
                         >
                             Rebuild all
                         </Button>
-                    </Group>
+                    </SettingsPageActions>
                 }
             >
                 {requiresUserCredentials && (

--- a/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
+++ b/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
@@ -10,7 +10,6 @@ import {
     Button,
     Group,
     LoadingOverlay,
-    Paper,
     Popover,
     Radio,
     ScrollArea,
@@ -60,8 +59,8 @@ import {
 } from '../common/ContentTable';
 import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
+import { SettingsEmptyState } from '../common/Settings/SettingsEmptyState';
 import { SettingsPage } from '../common/Settings/SettingsPage';
-import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import MaterializationDetailDrawer from './MaterializationDetailDrawer';
 import classes from './PreAggregateMaterializations.module.css';
 import { StatusBadge } from './StatusBadge';
@@ -756,13 +755,11 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
                 )}
 
                 {!isLoading && materializations.length === 0 ? (
-                    <Paper withBorder radius="md" p="xxl">
-                        <SuboptimalState
-                            icon={IconBolt}
-                            title="No pre-aggregates defined yet"
-                            description="Define pre-aggregates in your dbt YAML to serve queries from materialized results instead of hitting your warehouse."
-                        />
-                    </Paper>
+                    <SettingsEmptyState
+                        icon={IconBolt}
+                        title="No pre-aggregates defined yet"
+                        description="Define pre-aggregates in your dbt YAML to serve queries from materialized results instead of hitting your warehouse."
+                    />
                 ) : (
                     <ContentTable table={table} />
                 )}

--- a/packages/frontend/src/components/ProjectAccess/index.tsx
+++ b/packages/frontend/src/components/ProjectAccess/index.tsx
@@ -1,5 +1,5 @@
 import { FeatureFlags } from '@lightdash/common';
-import { Anchor, Stack, Tabs, Text } from '@mantine-8/core';
+import { Stack, Tabs } from '@mantine-8/core';
 import { IconUser, IconUsersGroup } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { ProjectGroupAccess } from '../../features/projectGroupAccess';
@@ -26,18 +26,6 @@ const ProjectUserAccess: FC<ProjectUserAccessProps> = ({ projectUuid }) => {
 
     return (
         <Stack gap="md">
-            <Text c="dimmed" fz="sm">
-                Learn more about permissions in our{' '}
-                <Anchor
-                    href="https://docs.lightdash.com/references/roles"
-                    target="_blank"
-                    rel="noreferrer"
-                    fz="sm"
-                >
-                    docs
-                </Anchor>
-            </Text>
-
             <Tabs
                 keepMounted={false}
                 defaultValue="users"

--- a/packages/frontend/src/components/ProjectAppearance/ProjectAppearance.tsx
+++ b/packages/frontend/src/components/ProjectAppearance/ProjectAppearance.tsx
@@ -53,7 +53,7 @@ const ProjectAppearance: FC<Props> = ({ projectUuid }) => {
             <LoadingOverlay visible={isLoading} />
             <SettingsGridCard>
                 <Stack gap="xs">
-                    <Title order={4}>Appearance</Title>
+                    <Title order={5}>Color palette</Title>
                     <Text c="ldGray.6" fz="sm">
                         Choose which organization color palette charts in this
                         project should use, or inherit the organization's active

--- a/packages/frontend/src/components/ProjectParameters/ProjectParameters.tsx
+++ b/packages/frontend/src/components/ProjectParameters/ProjectParameters.tsx
@@ -1,7 +1,6 @@
 import type { ProjectParameterSummary } from '@lightdash/common';
 import {
     ActionIcon,
-    Anchor,
     Badge,
     Box,
     Code,
@@ -175,19 +174,6 @@ const ProjectParameters: FC<ProjectParametersProps> = ({ projectUuid }) => {
 
     return (
         <Stack>
-            <Text c="dimmed">
-                Learn more about parameters in our{' '}
-                <Anchor
-                    role="button"
-                    href="https://docs.lightdash.com/guides/using-parameters#how-to-use-parameters"
-                    target="_blank"
-                    rel="noreferrer"
-                >
-                    docs
-                </Anchor>
-                .
-            </Text>
-
             <SettingsCard shadow="none" p={0}>
                 <Paper p="sm" bd={0}>
                     <Group gap="md" align="center">

--- a/packages/frontend/src/components/ProjectParameters/ProjectParameters.tsx
+++ b/packages/frontend/src/components/ProjectParameters/ProjectParameters.tsx
@@ -191,7 +191,7 @@ const ProjectParameters: FC<ProjectParametersProps> = ({ projectUuid }) => {
             <SettingsCard shadow="none" p={0}>
                 <Paper p="sm" bd={0}>
                     <Group gap="md" align="center">
-                        <Title order={5}>Parameters</Title>
+                        <Title order={5}>Defined parameters</Title>
                     </Group>
 
                     <Box mt="sm">

--- a/packages/frontend/src/components/ProjectPreviewExpiration/index.tsx
+++ b/packages/frontend/src/components/ProjectPreviewExpiration/index.tsx
@@ -138,7 +138,7 @@ const ProjectPreviewExpiration: FC<Props> = ({ projectUuid }) => {
     return (
         <SettingsGridCard>
             <Box>
-                <Title order={4}>Preview projects</Title>
+                <Title order={5}>Preview projects</Title>
                 <Text c="ldGray.6" fz="xs">
                     Control how long preview projects created from this project
                     stick around before they're auto-deleted. Users can override

--- a/packages/frontend/src/components/SchedulersView/index.tsx
+++ b/packages/frontend/src/components/SchedulersView/index.tsx
@@ -1,5 +1,6 @@
 import {
     ActionIcon,
+    Button,
     Card,
     Group,
     Stack,
@@ -14,6 +15,7 @@ import { useSearchParams } from 'react-router';
 import { useGetSlackChannelName } from '../../hooks/slack/useGetSlackChannelName';
 import useToaster from '../../hooks/toaster/useToaster';
 import MantineIcon from '../common/MantineIcon';
+import { SettingsPage } from '../common/Settings/SettingsPage';
 import LogsTable from './LogsTable';
 import SchedulersTable from './SchedulersTable';
 import classes from './SchedulersView.module.css';
@@ -63,6 +65,31 @@ const SchedulersView: FC<{ projectUuid?: string; isUserScope?: boolean }> = ({
         });
     };
 
+    if (isUserScope) {
+        return (
+            <SettingsPage
+                title="My scheduled deliveries"
+                description="Review and manage deliveries scheduled across your projects."
+                actions={
+                    <Button
+                        size="xs"
+                        variant="default"
+                        leftSection={<MantineIcon icon={IconRefresh} />}
+                        onClick={handleRefresh}
+                    >
+                        Refresh
+                    </Button>
+                }
+            >
+                <SchedulersTable
+                    getSlackChannelName={getSlackChannelName}
+                    onSlackChannelIdsChange={setSchedulerSlackChannelIds}
+                    isUserScope
+                />
+            </SettingsPage>
+        );
+    }
+
     return (
         <Card>
             <Stack gap="sm">
@@ -106,36 +133,31 @@ const SchedulersView: FC<{ projectUuid?: string; isUserScope?: boolean }> = ({
                         >
                             All schedulers
                         </Tabs.Tab>
-                        {!isUserScope && (
-                            <Tabs.Tab
-                                value={SchedulersViewTab.RUN_HISTORY}
-                                leftSection={<MantineIcon icon={IconClock} />}
-                            >
-                                Run history
-                            </Tabs.Tab>
-                        )}
+                        <Tabs.Tab
+                            value={SchedulersViewTab.RUN_HISTORY}
+                            leftSection={<MantineIcon icon={IconClock} />}
+                        >
+                            Run history
+                        </Tabs.Tab>
                     </Tabs.List>
 
                     <Tabs.Panel value={SchedulersViewTab.ALL_SCHEDULERS}>
-                        {(isUserScope || projectUuid) && (
+                        {projectUuid ? (
                             <SchedulersTable
                                 projectUuid={projectUuid}
                                 getSlackChannelName={getSlackChannelName}
                                 onSlackChannelIdsChange={
                                     setSchedulerSlackChannelIds
                                 }
-                                isUserScope={isUserScope}
                             />
-                        )}
+                        ) : null}
                     </Tabs.Panel>
-                    {!isUserScope && (
-                        <Tabs.Panel value={SchedulersViewTab.RUN_HISTORY}>
-                            <LogsTable
-                                projectUuid={projectUuid}
-                                getSlackChannelName={getSlackChannelName}
-                            />
-                        </Tabs.Panel>
-                    )}
+                    <Tabs.Panel value={SchedulersViewTab.RUN_HISTORY}>
+                        <LogsTable
+                            projectUuid={projectUuid}
+                            getSlackChannelName={getSlackChannelName}
+                        />
+                    </Tabs.Panel>
                 </Tabs>
             </Stack>
         </Card>

--- a/packages/frontend/src/components/SchedulersView/index.tsx
+++ b/packages/frontend/src/components/SchedulersView/index.tsx
@@ -73,6 +73,7 @@ const SchedulersView: FC<{ projectUuid?: string; isUserScope?: boolean }> = ({
                 actions={
                     <Button
                         size="xs"
+                        variant="white"
                         leftSection={<MantineIcon icon={IconRefresh} />}
                         onClick={handleRefresh}
                     >

--- a/packages/frontend/src/components/SchedulersView/index.tsx
+++ b/packages/frontend/src/components/SchedulersView/index.tsx
@@ -73,7 +73,6 @@ const SchedulersView: FC<{ projectUuid?: string; isUserScope?: boolean }> = ({
                 actions={
                     <Button
                         size="xs"
-                        variant="default"
                         leftSection={<MantineIcon icon={IconRefresh} />}
                         onClick={handleRefresh}
                     >

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/index.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/index.tsx
@@ -1,13 +1,13 @@
 import { type ExternalConnection } from '@lightdash/common';
-import { Button, Group, Skeleton, Stack, Text, Title } from '@mantine-8/core';
+import { Button, Group, Skeleton, Stack, Text } from '@mantine-8/core';
 import { IconPlug, IconPlus } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
 import { useSearchParams } from 'react-router';
 import { useExternalConnections } from '../../../features/externalConnections/hooks/useExternalConnections';
 import Callout from '../../common/Callout';
-import { EmptyState } from '../../common/EmptyState';
 import MantineIcon from '../../common/MantineIcon';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
+import { SettingsEmptyState } from '../../common/Settings/SettingsEmptyState';
 import { AddConnectionWizard } from './AddConnectionWizard';
 import { ConnectionsTable } from './ConnectionsTable';
 import { DeleteConnectionModal } from './DeleteConnectionModal';
@@ -39,72 +39,69 @@ const DataAppConnectionsPanel: FC<Props> = ({ projectUuid }) => {
     const [connectionToDelete, setConnectionToDelete] = useState<
         ExternalConnection | undefined
     >(undefined);
+    const addConnectionButton = (
+        <Button
+            size="xs"
+            variant="default"
+            leftSection={<MantineIcon icon={IconPlus} />}
+            onClick={() => setIsCreating(true)}
+        >
+            Add connection
+        </Button>
+    );
+    const dataWarning = (
+        <Callout variant="warning" title="Data leaves Lightdash">
+            Apps linked to a connection can send any data they can query to that
+            connection&apos;s external host. Only add connections to hosts you
+            trust with this project&apos;s data.
+        </Callout>
+    );
 
     return (
         <>
-            <Stack gap="sm">
-                <Group gap="xxs">
-                    <Title order={5}>Data app connections</Title>
-                </Group>
+            <Stack gap="md">
+                {isLoading || (connections && connections.length > 0) ? (
+                    <SettingsCard>
+                        <Stack gap="md">
+                            <Group justify="space-between">
+                                <Text c="ldGray.6" size="sm">
+                                    External HTTP connections that data apps in
+                                    this project can call. Each app must be
+                                    linked to a connection under an alias.
+                                </Text>
+                                {addConnectionButton}
+                            </Group>
 
-                <SettingsCard mb="lg">
+                            {dataWarning}
+
+                            {isLoading ? (
+                                <Stack gap="xs">
+                                    <Skeleton height={48} />
+                                    <Skeleton height={48} />
+                                </Stack>
+                            ) : (
+                                <ConnectionsTable
+                                    connections={connections}
+                                    setConnectionToEdit={setConnectionToEdit}
+                                    setConnectionToDelete={
+                                        setConnectionToDelete
+                                    }
+                                />
+                            )}
+                        </Stack>
+                    </SettingsCard>
+                ) : (
                     <Stack gap="md">
-                        <Group justify="space-between">
-                            <Text c="ldGray.6" size="sm">
-                                External HTTP connections that data apps in this
-                                project can call. Each app must be linked to a
-                                connection under an alias.
-                            </Text>
-                            <Button
-                                size="xs"
-                                variant="default"
-                                leftSection={<MantineIcon icon={IconPlus} />}
-                                onClick={() => setIsCreating(true)}
-                                style={{ alignSelf: 'flex-end' }}
-                            >
-                                Add connection
-                            </Button>
-                        </Group>
-
-                        <Callout
-                            variant="warning"
-                            title="Data leaves Lightdash"
+                        {dataWarning}
+                        <SettingsEmptyState
+                            icon={IconPlug}
+                            title="No connections"
+                            description="Create a connection to let data apps call an external HTTP service."
                         >
-                            Apps linked to a connection can send any data they
-                            can query to that connection&apos;s external host.
-                            Only add connections to hosts you trust with this
-                            project&apos;s data.
-                        </Callout>
-
-                        {isLoading ? (
-                            <Stack gap="xs">
-                                <Skeleton height={48} />
-                                <Skeleton height={48} />
-                            </Stack>
-                        ) : connections && connections.length > 0 ? (
-                            <ConnectionsTable
-                                connections={connections}
-                                setConnectionToEdit={setConnectionToEdit}
-                                setConnectionToDelete={setConnectionToDelete}
-                            />
-                        ) : (
-                            <EmptyState
-                                icon={
-                                    <MantineIcon
-                                        icon={IconPlug}
-                                        color="ldGray.6"
-                                        stroke={1}
-                                        size="5xl"
-                                    />
-                                }
-                                title="No connections"
-                                description="You haven't created any data app connections yet!"
-                                pt="xl"
-                                pb="xl"
-                            />
-                        )}
+                            {addConnectionButton}
+                        </SettingsEmptyState>
                     </Stack>
-                </SettingsCard>
+                )}
             </Stack>
 
             {isCreating && (

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/index.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/index.tsx
@@ -1,5 +1,5 @@
 import { type ExternalConnection } from '@lightdash/common';
-import { Button, Group, Skeleton, Stack, Text } from '@mantine-8/core';
+import { Button, Skeleton, Stack } from '@mantine-8/core';
 import { IconPlug, IconPlus } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
 import { useSearchParams } from 'react-router';
@@ -8,6 +8,7 @@ import Callout from '../../common/Callout';
 import MantineIcon from '../../common/MantineIcon';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
 import { SettingsEmptyState } from '../../common/Settings/SettingsEmptyState';
+import { SettingsPage } from '../../common/Settings/SettingsPage';
 import { AddConnectionWizard } from './AddConnectionWizard';
 import { ConnectionsTable } from './ConnectionsTable';
 import { DeleteConnectionModal } from './DeleteConnectionModal';
@@ -59,50 +60,47 @@ const DataAppConnectionsPanel: FC<Props> = ({ projectUuid }) => {
 
     return (
         <>
-            <Stack gap="md">
-                {isLoading || (connections && connections.length > 0) ? (
-                    <SettingsCard>
+            <SettingsPage
+                title="Data app connections"
+                description="Manage external connections used by this project's data apps."
+                actions={addConnectionButton}
+            >
+                <Stack gap="md">
+                    {isLoading || (connections && connections.length > 0) ? (
+                        <SettingsCard>
+                            <Stack gap="md">
+                                {dataWarning}
+
+                                {isLoading ? (
+                                    <Stack gap="xs">
+                                        <Skeleton height={48} />
+                                        <Skeleton height={48} />
+                                    </Stack>
+                                ) : (
+                                    <ConnectionsTable
+                                        connections={connections}
+                                        setConnectionToEdit={
+                                            setConnectionToEdit
+                                        }
+                                        setConnectionToDelete={
+                                            setConnectionToDelete
+                                        }
+                                    />
+                                )}
+                            </Stack>
+                        </SettingsCard>
+                    ) : (
                         <Stack gap="md">
-                            <Group justify="space-between">
-                                <Text c="ldGray.6" size="sm">
-                                    External HTTP connections that data apps in
-                                    this project can call. Each app must be
-                                    linked to a connection under an alias.
-                                </Text>
-                                {addConnectionButton}
-                            </Group>
-
                             {dataWarning}
-
-                            {isLoading ? (
-                                <Stack gap="xs">
-                                    <Skeleton height={48} />
-                                    <Skeleton height={48} />
-                                </Stack>
-                            ) : (
-                                <ConnectionsTable
-                                    connections={connections}
-                                    setConnectionToEdit={setConnectionToEdit}
-                                    setConnectionToDelete={
-                                        setConnectionToDelete
-                                    }
-                                />
-                            )}
+                            <SettingsEmptyState
+                                icon={IconPlug}
+                                title="No connections"
+                                description="Create a connection to let data apps call an external HTTP service."
+                            />
                         </Stack>
-                    </SettingsCard>
-                ) : (
-                    <Stack gap="md">
-                        {dataWarning}
-                        <SettingsEmptyState
-                            icon={IconPlug}
-                            title="No connections"
-                            description="Create a connection to let data apps call an external HTTP service."
-                        >
-                            {addConnectionButton}
-                        </SettingsEmptyState>
-                    </Stack>
-                )}
-            </Stack>
+                    )}
+                </Stack>
+            </SettingsPage>
 
             {isCreating && (
                 <AddConnectionWizard

--- a/packages/frontend/src/components/Settings/ProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/ProjectSettings.tsx
@@ -1,7 +1,12 @@
 import { subject } from '@casl/ability';
 import { FeatureFlags } from '@lightdash/common';
-import { Anchor, Stack, Text, Title } from '@mantine-8/core';
-import { useMemo, type FC, type PropsWithChildren } from 'react';
+import { Stack, Text, Title } from '@mantine-8/core';
+import {
+    useMemo,
+    type FC,
+    type PropsWithChildren,
+    type ReactNode,
+} from 'react';
 import {
     matchPath,
     Navigate,
@@ -24,6 +29,7 @@ import { SettingsGridCard } from '../common/Settings/SettingsCard';
 import {
     SettingsPage,
     SettingsPageContainer,
+    SettingsPageDocumentationLink,
 } from '../common/Settings/SettingsPage';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import CompilationHistory from '../CompilationHistory';
@@ -50,14 +56,16 @@ import SemanticLayerConnectionPanel from './SemanticLayerConnectionPanel';
 type ProjectSettingsPageProps = PropsWithChildren<{
     title: string;
     description: string;
+    actions?: ReactNode;
 }>;
 
 const ProjectSettingsPage: FC<ProjectSettingsPageProps> = ({
     title,
     description,
+    actions,
     children,
 }) => (
-    <SettingsPage title={title} description={description}>
+    <SettingsPage title={title} description={description} actions={actions}>
         {children}
     </SettingsPage>
 );
@@ -127,6 +135,12 @@ const ProjectSettings: FC = () => {
                     <ProjectSettingsPage
                         title="Project access"
                         description="Manage who can access this project and what they can do."
+                        actions={
+                            <SettingsPageDocumentationLink
+                                href="https://docs.lightdash.com/references/roles"
+                                label="Roles documentation"
+                            />
+                        }
                     >
                         <ProjectUserAccess projectUuid={projectUuid} />
                     </ProjectSettingsPage>
@@ -167,14 +181,7 @@ const ProjectSettings: FC = () => {
             },
             {
                 path: `/validator`,
-                element: (
-                    <ProjectSettingsPage
-                        title="Validator"
-                        description="Find content errors and issues across this project."
-                    >
-                        <SettingsValidator projectUuid={projectUuid} />
-                    </ProjectSettingsPage>
-                ),
+                element: <SettingsValidator projectUuid={projectUuid} />,
             },
             {
                 path: `/verifiedContent`,
@@ -232,6 +239,9 @@ const ProjectSettings: FC = () => {
                     <ProjectSettingsPage
                         title="Parameters"
                         description="Review reusable values defined for project queries and content."
+                        actions={
+                            <SettingsPageDocumentationLink href="https://docs.lightdash.com/guides/using-parameters#how-to-use-parameters" />
+                        }
                     >
                         <ProjectParameters projectUuid={projectUuid} />
                     </ProjectSettingsPage>
@@ -243,6 +253,9 @@ const ProjectSettings: FC = () => {
                     <ProjectSettingsPage
                         title="Project time zone"
                         description="Set the default time zone used by this project."
+                        actions={
+                            <SettingsPageDocumentationLink href="https://docs.lightdash.com/guides/developer/timezones" />
+                        }
                     >
                         <SettingsQueryTimezone projectUuid={projectUuid} />
                     </ProjectSettingsPage>
@@ -261,14 +274,7 @@ const ProjectSettings: FC = () => {
             },
             {
                 path: `/compilationHistory`,
-                element: (
-                    <ProjectSettingsPage
-                        title="Compilation history"
-                        description="Review recent dbt compilation runs for this project."
-                    >
-                        <CompilationHistory projectUuid={projectUuid} />
-                    </ProjectSettingsPage>
-                ),
+                element: <CompilationHistory projectUuid={projectUuid} />,
             },
             ...(isPgWireEnabled
                 ? [
@@ -353,6 +359,12 @@ const ProjectSettings: FC = () => {
                               <ProjectSettingsPage
                                   title="CORS"
                                   description="Control which external browser origins can call the Lightdash API."
+                                  actions={
+                                      <SettingsPageDocumentationLink
+                                          href="https://docs.lightdash.com/guides/embedding/how-to-embed-content#cors"
+                                          label="Embedding documentation"
+                                      />
+                                  }
                               >
                                   <SettingsGridCard>
                                       <Stack gap="xs">
@@ -368,20 +380,6 @@ const ProjectSettings: FC = () => {
                                               *.example.com. Use regex only for
                                               advanced patterns.
                                           </Text>
-                                          <Text c="ldGray.6" fz="xs">
-                                              This is commonly needed for
-                                              embedding Lightdash in another
-                                              application.{' '}
-                                              <Anchor
-                                                  inherit
-                                                  href="https://docs.lightdash.com/guides/embedding/how-to-embed-content#cors"
-                                                  target="_blank"
-                                                  rel="noreferrer"
-                                              >
-                                                  Read the embedding docs
-                                              </Anchor>
-                                              .
-                                          </Text>
                                       </Stack>
                                       <CorsSettingsPanel />
                                   </SettingsGridCard>
@@ -395,14 +393,9 @@ const ProjectSettings: FC = () => {
                       {
                           path: `/dataAppConnections`,
                           element: (
-                              <ProjectSettingsPage
-                                  title="Data app connections"
-                                  description="Manage external connections used by this project's data apps."
-                              >
-                                  <DataAppConnectionsPanel
-                                      projectUuid={projectUuid}
-                                  />
-                              </ProjectSettingsPage>
+                              <DataAppConnectionsPanel
+                                  projectUuid={projectUuid}
+                              />
                           ),
                       },
                   ]

--- a/packages/frontend/src/components/Settings/ProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/ProjectSettings.tsx
@@ -21,6 +21,7 @@ import { DocumentTitle } from '../common/DocumentTitle';
 import ErrorState from '../common/ErrorState';
 import PageBreadcrumbs from '../common/PageBreadcrumbs';
 import { SettingsGridCard } from '../common/Settings/SettingsCard';
+import { SettingsPageContainer } from '../common/Settings/SettingsPage';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import CompilationHistory from '../CompilationHistory';
 import { DataOps } from '../DataOps';
@@ -302,18 +303,20 @@ const ProjectSettings: FC = () => {
             <DocumentTitle title="Project Settings" />
 
             <Stack gap="xl">
-                <PageBreadcrumbs
-                    items={[
-                        {
-                            title: 'All projects',
-                            to: '/generalSettings/projectManagement',
-                        },
-                        {
-                            title: project.name,
-                            active: true,
-                        },
-                    ]}
-                />
+                <SettingsPageContainer>
+                    <PageBreadcrumbs
+                        items={[
+                            {
+                                title: 'All projects',
+                                to: '/generalSettings/projectManagement',
+                            },
+                            {
+                                title: project.name,
+                                active: true,
+                            },
+                        ]}
+                    />
+                </SettingsPageContainer>
                 {routesElements}
             </Stack>
         </>

--- a/packages/frontend/src/components/Settings/ProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/ProjectSettings.tsx
@@ -1,7 +1,7 @@
 import { subject } from '@casl/ability';
 import { FeatureFlags } from '@lightdash/common';
 import { Anchor, Stack, Text, Title } from '@mantine-8/core';
-import { useMemo, type FC } from 'react';
+import { useMemo, type FC, type PropsWithChildren } from 'react';
 import {
     matchPath,
     Navigate,
@@ -21,7 +21,10 @@ import { DocumentTitle } from '../common/DocumentTitle';
 import ErrorState from '../common/ErrorState';
 import PageBreadcrumbs from '../common/PageBreadcrumbs';
 import { SettingsGridCard } from '../common/Settings/SettingsCard';
-import { SettingsPageContainer } from '../common/Settings/SettingsPage';
+import {
+    SettingsPage,
+    SettingsPageContainer,
+} from '../common/Settings/SettingsPage';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import CompilationHistory from '../CompilationHistory';
 import { DataOps } from '../DataOps';
@@ -43,6 +46,21 @@ import CorsSettingsPanel from '../UserSettings/CorsSettingsPanel';
 import VerifiedContentPanel from '../VerifiedContent/VerifiedContentPanel';
 import DataAppConnectionsPanel from './DataAppConnectionsPanel';
 import SemanticLayerConnectionPanel from './SemanticLayerConnectionPanel';
+
+type ProjectSettingsPageProps = PropsWithChildren<{
+    title: string;
+    description: string;
+}>;
+
+const ProjectSettingsPage: FC<ProjectSettingsPageProps> = ({
+    title,
+    description,
+    children,
+}) => (
+    <SettingsPage title={title} description={description}>
+        {children}
+    </SettingsPage>
+);
 
 const ProjectSettings: FC = () => {
     const { projectUuid } = useParams<{
@@ -83,80 +101,188 @@ const ProjectSettings: FC = () => {
         return [
             {
                 path: `/settings`,
-                element: <UpdateProjectConnection projectUuid={projectUuid} />,
+                element: (
+                    <ProjectSettingsPage
+                        title="Connection settings"
+                        description="Manage this project's warehouse and dbt connections."
+                    >
+                        <UpdateProjectConnection projectUuid={projectUuid} />
+                    </ProjectSettingsPage>
+                ),
             },
             {
                 path: `/tablesConfiguration`,
                 element: (
-                    <ProjectTablesConfiguration projectUuid={projectUuid} />
+                    <ProjectSettingsPage
+                        title="Tables configuration"
+                        description="Choose which dbt models are available in this project."
+                    >
+                        <ProjectTablesConfiguration projectUuid={projectUuid} />
+                    </ProjectSettingsPage>
                 ),
             },
             {
                 path: `/projectAccess`,
-                element: <ProjectUserAccess projectUuid={projectUuid} />,
+                element: (
+                    <ProjectSettingsPage
+                        title="Project access"
+                        description="Manage who can access this project and what they can do."
+                    >
+                        <ProjectUserAccess projectUuid={projectUuid} />
+                    </ProjectSettingsPage>
+                ),
             },
             {
                 path: `/appearance`,
-                element: <ProjectAppearance projectUuid={projectUuid} />,
+                element: (
+                    <ProjectSettingsPage
+                        title="Appearance"
+                        description="Customize colors and chart styling for this project."
+                    >
+                        <ProjectAppearance projectUuid={projectUuid} />
+                    </ProjectSettingsPage>
+                ),
             },
             {
                 path: `/usageAnalytics`,
-                element: <SettingsUsageAnalytics projectUuid={projectUuid} />,
+                element: (
+                    <ProjectSettingsPage
+                        title="Usage analytics"
+                        description="Review how people use this project's content."
+                    >
+                        <SettingsUsageAnalytics projectUuid={projectUuid} />
+                    </ProjectSettingsPage>
+                ),
             },
             {
                 path: `/scheduledDeliveries`,
-                element: <SettingsScheduler projectUuid={projectUuid} />,
+                element: (
+                    <ProjectSettingsPage
+                        title="Syncs & scheduled deliveries"
+                        description="Configure delivery defaults and manage this project's schedules."
+                    >
+                        <SettingsScheduler projectUuid={projectUuid} />
+                    </ProjectSettingsPage>
+                ),
             },
             {
                 path: `/validator`,
-                element: <SettingsValidator projectUuid={projectUuid} />,
+                element: (
+                    <ProjectSettingsPage
+                        title="Validator"
+                        description="Find content errors and issues across this project."
+                    >
+                        <SettingsValidator projectUuid={projectUuid} />
+                    </ProjectSettingsPage>
+                ),
             },
             {
                 path: `/verifiedContent`,
-                element: <VerifiedContentPanel projectUuid={projectUuid} />,
+                element: (
+                    <ProjectSettingsPage
+                        title="Verified content"
+                        description="Review verified charts and dashboards in this project."
+                    >
+                        <VerifiedContentPanel projectUuid={projectUuid} />
+                    </ProjectSettingsPage>
+                ),
             },
             {
                 path: `/dataOps`,
-                element: <DataOps projectUuid={projectUuid} />,
+                element: (
+                    <ProjectSettingsPage
+                        title="Data ops"
+                        description="Configure workflows for promoting content between projects."
+                    >
+                        <DataOps projectUuid={projectUuid} />
+                    </ProjectSettingsPage>
+                ),
             },
             {
                 path: `/defaultUserSpaces`,
-                element: <DefaultUserSpaces projectUuid={projectUuid} />,
+                element: (
+                    <ProjectSettingsPage
+                        title="Default user spaces"
+                        description="Choose whether project members receive a personal space automatically."
+                    >
+                        <DefaultUserSpaces projectUuid={projectUuid} />
+                    </ProjectSettingsPage>
+                ),
             },
             ...(isSoftDeleteEnabled
                 ? [
                       {
                           path: `/recentlyDeleted`,
                           element: (
-                              <RecentlyDeletedPage projectUuid={projectUuid} />
+                              <ProjectSettingsPage
+                                  title="Recently deleted"
+                                  description="Review and restore recently deleted project content."
+                              >
+                                  <RecentlyDeletedPage
+                                      projectUuid={projectUuid}
+                                  />
+                              </ProjectSettingsPage>
                           ),
                       },
                   ]
                 : []),
             {
                 path: `/parameters`,
-                element: <ProjectParameters projectUuid={projectUuid} />,
+                element: (
+                    <ProjectSettingsPage
+                        title="Parameters"
+                        description="Review reusable values defined for project queries and content."
+                    >
+                        <ProjectParameters projectUuid={projectUuid} />
+                    </ProjectSettingsPage>
+                ),
             },
             {
                 path: `/queryTimezone`,
-                element: <SettingsQueryTimezone projectUuid={projectUuid} />,
+                element: (
+                    <ProjectSettingsPage
+                        title="Project time zone"
+                        description="Set the default time zone used by this project."
+                    >
+                        <SettingsQueryTimezone projectUuid={projectUuid} />
+                    </ProjectSettingsPage>
+                ),
             },
             {
                 path: `/previewsConfig`,
-                element: <ProjectPreviewExpiration projectUuid={projectUuid} />,
+                element: (
+                    <ProjectSettingsPage
+                        title="Preview settings"
+                        description="Configure preview project expiration and cleanup."
+                    >
+                        <ProjectPreviewExpiration projectUuid={projectUuid} />
+                    </ProjectSettingsPage>
+                ),
             },
             {
                 path: `/compilationHistory`,
-                element: <CompilationHistory projectUuid={projectUuid} />,
+                element: (
+                    <ProjectSettingsPage
+                        title="Compilation history"
+                        description="Review recent dbt compilation runs for this project."
+                    >
+                        <CompilationHistory projectUuid={projectUuid} />
+                    </ProjectSettingsPage>
+                ),
             },
             ...(isPgWireEnabled
                 ? [
                       {
                           path: `/semanticLayer`,
                           element: (
-                              <SemanticLayerConnectionPanel
-                                  projectUuid={projectUuid}
-                              />
+                              <ProjectSettingsPage
+                                  title="Semantic layer"
+                                  description="Configure this project's semantic layer connection."
+                              >
+                                  <SemanticLayerConnectionPanel
+                                      projectUuid={projectUuid}
+                                  />
+                              </ProjectSettingsPage>
                           ),
                       },
                   ]
@@ -166,7 +292,12 @@ const ProjectSettings: FC = () => {
                       {
                           path: `/pullRequests`,
                           element: (
-                              <PullRequestsPage projectUuid={projectUuid} />
+                              <ProjectSettingsPage
+                                  title="Pull requests"
+                                  description="Review pull requests opened for this project's code."
+                              >
+                                  <PullRequestsPage projectUuid={projectUuid} />
+                              </ProjectSettingsPage>
                           ),
                       },
                   ]
@@ -205,17 +336,29 @@ const ProjectSettings: FC = () => {
             },
             {
                 path: '/embed', // commercial route
-                element: <SettingsEmbed projectUuid={projectUuid} />,
+                element: (
+                    <ProjectSettingsPage
+                        title="Embed configuration"
+                        description="Configure embedded access for this project."
+                    >
+                        <SettingsEmbed projectUuid={projectUuid} />
+                    </ProjectSettingsPage>
+                ),
             },
             ...(user.data?.ability.can('manage', 'Organization')
                 ? [
                       {
                           path: '/embed/cors',
                           element: (
-                              <Stack gap="xl">
+                              <ProjectSettingsPage
+                                  title="CORS"
+                                  description="Control which external browser origins can call the Lightdash API."
+                              >
                                   <SettingsGridCard>
                                       <Stack gap="xs">
-                                          <Title order={4}>CORS</Title>
+                                          <Title order={5}>
+                                              Allowed origins
+                                          </Title>
                                           <Text c="ldGray.6" fz="xs">
                                               CORS controls which external
                                               browser origins can call the
@@ -242,7 +385,7 @@ const ProjectSettings: FC = () => {
                                       </Stack>
                                       <CorsSettingsPanel />
                                   </SettingsGridCard>
-                              </Stack>
+                              </ProjectSettingsPage>
                           ),
                       },
                   ]
@@ -252,9 +395,14 @@ const ProjectSettings: FC = () => {
                       {
                           path: `/dataAppConnections`,
                           element: (
-                              <DataAppConnectionsPanel
-                                  projectUuid={projectUuid}
-                              />
+                              <ProjectSettingsPage
+                                  title="Data app connections"
+                                  description="Manage external connections used by this project's data apps."
+                              >
+                                  <DataAppConnectionsPanel
+                                      projectUuid={projectUuid}
+                                  />
+                              </ProjectSettingsPage>
                           ),
                       },
                   ]

--- a/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
+++ b/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
@@ -145,7 +145,7 @@ const SettingsQueryTimezone: FC<SettingsQueryTimezoneProps> = ({
             <LoadingOverlay visible={isLoadingProject} />
             <SettingsGridCard>
                 <Stack gap="xs">
-                    <Title order={4}>Project time zone</Title>
+                    <Title order={5}>Time zone behavior</Title>
                     <Text c="ldGray.6" fz="sm">
                         {timezoneSupportEnabled ? (
                             <>

--- a/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
+++ b/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
@@ -5,7 +5,6 @@ import {
     type Project,
 } from '@lightdash/common';
 import {
-    Anchor,
     Button,
     Flex,
     LoadingOverlay,
@@ -165,17 +164,6 @@ const SettingsQueryTimezone: FC<SettingsQueryTimezoneProps> = ({
                                 session time zone.
                             </>
                         )}
-                    </Text>
-                    <Text c="ldGray.6" fz="xs">
-                        Learn more in our{' '}
-                        <Anchor
-                            href="https://docs.lightdash.com/guides/developer/timezones"
-                            target="_blank"
-                            fz="xs"
-                        >
-                            docs guide
-                        </Anchor>
-                        .
                     </Text>
                 </Stack>
                 <div>

--- a/packages/frontend/src/components/SettingsScheduler/index.tsx
+++ b/packages/frontend/src/components/SettingsScheduler/index.tsx
@@ -65,7 +65,7 @@ const SettingsScheduler: FC<SettingsSchedulerProps> = ({ projectUuid }) => {
             <LoadingOverlay visible={isLoadingProject} />
             <SettingsGridCard>
                 <Stack gap="xs">
-                    <Title order={4}>Settings</Title>
+                    <Title order={5}>Delivery defaults</Title>
                     <Text c="ldGray.6" fz="sm">
                         Default settings applied to all of this project's
                         scheduled deliveries. Owners can override these

--- a/packages/frontend/src/components/SettingsUsageAnalytics/index.tsx
+++ b/packages/frontend/src/components/SettingsUsageAnalytics/index.tsx
@@ -12,33 +12,26 @@ const SettingsUsageAnalytics: FC<ProjectUserAccessProps> = ({
     projectUuid,
 }) => {
     return (
-        <>
-            <Text c="dimmed">
-                Lightdash curated dashboards that show usage and performance
-                information about your project.
-            </Text>
-
-            <Stack gap="md">
-                <Card
-                    component={Link}
-                    shadow="sm"
-                    withBorder
-                    style={{ cursor: 'pointer' }}
-                    to={`/projects/${projectUuid}/user-activity`}
-                >
-                    <Group>
-                        <MantineIcon
-                            icon={IconLayoutDashboard}
-                            size="xl"
-                            color="ldGray.6"
-                        />
-                        <Text fw={600} fz="lg">
-                            User Activity
-                        </Text>
-                    </Group>
-                </Card>
-            </Stack>
-        </>
+        <Stack gap="md">
+            <Card
+                component={Link}
+                shadow="sm"
+                withBorder
+                style={{ cursor: 'pointer' }}
+                to={`/projects/${projectUuid}/user-activity`}
+            >
+                <Group>
+                    <MantineIcon
+                        icon={IconLayoutDashboard}
+                        size="xl"
+                        color="ldGray.6"
+                    />
+                    <Text fw={600} fz="lg">
+                        User Activity
+                    </Text>
+                </Group>
+            </Card>
+        </Stack>
     );
 };
 

--- a/packages/frontend/src/components/SettingsValidator/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/index.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../hooks/validation/useValidation';
 import useApp from '../../providers/App/useApp';
 import MantineIcon from '../common/MantineIcon';
+import { SettingsPage } from '../common/Settings/SettingsPage';
 import { ValidatorTable } from './ValidatorTable';
 import { ChartConfigurationErrorModal } from './ValidatorTable/ChartConfigurationErrorModal';
 import { FixDashboardFilterModal } from './ValidatorTable/FixDashboardFilterModal';
@@ -99,7 +100,7 @@ export const SettingsValidator: FC<{
     const hasActiveFilters =
         searchQuery !== '' || sourceTypeFilter.length > 0 || showConfigWarnings;
 
-    return (
+    const content = (
         <>
             <FixValidationErrorModal
                 validationError={selectedValidationError}
@@ -121,25 +122,6 @@ export const SettingsValidator: FC<{
                     setSelectedConfigError(undefined);
                 }}
             />
-            {!flush && (
-                <Group gap="md" justify="space-between" mb="md">
-                    <Text c="dimmed">
-                        Use the project validator to check what content is
-                        broken in your project.
-                    </Text>
-                    <Button
-                        size="xs"
-                        onClick={() => {
-                            setIsValidating(true);
-                            validateProject();
-                        }}
-                        loading={isValidating}
-                    >
-                        Run validation
-                    </Button>
-                </Group>
-            )}
-
             {isLoading ? (
                 <Paper withBorder shadow="sm">
                     <Group justify="center" gap="xs" p="md">
@@ -193,5 +175,30 @@ export const SettingsValidator: FC<{
                 </Paper>
             )}
         </>
+    );
+
+    if (flush) {
+        return content;
+    }
+
+    return (
+        <SettingsPage
+            title="Validator"
+            description="Find content errors and issues across this project."
+            actions={
+                <Button
+                    size="xs"
+                    onClick={() => {
+                        setIsValidating(true);
+                        validateProject();
+                    }}
+                    loading={isValidating}
+                >
+                    Run validation
+                </Button>
+            }
+        >
+            {content}
+        </SettingsPage>
     );
 };

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
@@ -17,11 +17,9 @@ const AccessTokensPanel: FC = () => {
             title="Personal access tokens"
             description="Create and revoke tokens used to access the Lightdash API."
             actions={
-                hasAvailableTokens ? (
-                    <Button onClick={() => setIsCreatingToken(true)}>
-                        Generate new token
-                    </Button>
-                ) : null
+                <Button size="xs" onClick={() => setIsCreatingToken(true)}>
+                    Generate new token
+                </Button>
             }
         >
             {hasAvailableTokens ? (
@@ -31,11 +29,7 @@ const AccessTokensPanel: FC = () => {
                     icon={IconKey}
                     title="No tokens"
                     description="Generate a token to access the Lightdash API."
-                >
-                    <Button onClick={() => setIsCreatingToken(true)}>
-                        Generate token
-                    </Button>
-                </SettingsEmptyState>
+                />
             )}
 
             {isCreatingToken && (

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
@@ -27,8 +27,8 @@ const AccessTokensPanel: FC = () => {
             ) : (
                 <SettingsEmptyState
                     icon={IconKey}
-                    title="No tokens"
-                    description="Generate a token to access the Lightdash API."
+                    title="No personal access tokens"
+                    description="Generate your first token to authenticate with the Lightdash API."
                 />
             )}
 

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/index.tsx
@@ -1,9 +1,9 @@
-import { Button, Group, Stack, Title } from '@mantine-8/core';
+import { Button } from '@mantine-8/core';
 import { IconKey } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { useAccessToken } from '../../../hooks/useAccessToken';
-import { EmptyState } from '../../common/EmptyState';
-import MantineIcon from '../../common/MantineIcon';
+import { SettingsEmptyState } from '../../common/Settings/SettingsEmptyState';
+import { SettingsPage } from '../../common/Settings/SettingsPage';
 import { CreateTokenModal } from './CreateTokenModal';
 import { TokensTable } from './TokensTable';
 
@@ -13,34 +13,29 @@ const AccessTokensPanel: FC = () => {
     const hasAvailableTokens = data && data.length > 0;
 
     return (
-        <Stack mb="lg">
+        <SettingsPage
+            title="Personal access tokens"
+            description="Create and revoke tokens used to access the Lightdash API."
+            actions={
+                hasAvailableTokens ? (
+                    <Button onClick={() => setIsCreatingToken(true)}>
+                        Generate new token
+                    </Button>
+                ) : null
+            }
+        >
             {hasAvailableTokens ? (
-                <>
-                    <Group justify="space-between">
-                        <Title order={5}>Personal access tokens</Title>
-                        <Button onClick={() => setIsCreatingToken(true)}>
-                            Generate new token
-                        </Button>
-                    </Group>
-                    <TokensTable />
-                </>
+                <TokensTable />
             ) : (
-                <EmptyState
-                    icon={
-                        <MantineIcon
-                            icon={IconKey}
-                            color="ldGray.6"
-                            stroke={1}
-                            size="5xl"
-                        />
-                    }
+                <SettingsEmptyState
+                    icon={IconKey}
                     title="No tokens"
-                    description="You haven't generated any tokens yet!, generate your first token"
+                    description="Generate a token to access the Lightdash API."
                 >
                     <Button onClick={() => setIsCreatingToken(true)}>
                         Generate token
                     </Button>
-                </EmptyState>
+                </SettingsEmptyState>
             )}
 
             {isCreatingToken && (
@@ -48,7 +43,7 @@ const AccessTokensPanel: FC = () => {
                     onBackClick={() => setIsCreatingToken(false)}
                 />
             )}
-        </Stack>
+        </SettingsPage>
     );
 };
 

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/index.tsx
@@ -1,13 +1,6 @@
 import { subject } from '@casl/ability';
-import {
-    ActionIcon,
-    Button,
-    Group,
-    Skeleton,
-    Stack,
-    Tooltip,
-} from '@mantine-8/core';
-import { IconInfoCircle, IconPlus } from '@tabler/icons-react';
+import { Button, Skeleton, Stack } from '@mantine-8/core';
+import { IconPlus } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
 import {
     useColorPalettes,
@@ -18,21 +11,26 @@ import { useOrganization } from '../../../hooks/organization/useOrganization';
 import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../../common/MantineIcon';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
-import { SettingsPage } from '../../common/Settings/SettingsPage';
+import {
+    SettingsPage,
+    SettingsPageActions,
+    SettingsPageDocumentationLink,
+} from '../../common/Settings/SettingsPage';
 import { BrandAppearanceSettings } from './BrandAppearanceSettings';
 import { CreatePaletteModal } from './CreatePaletteModal';
 import { PaletteItem } from './PaletteItem';
 
-const AppearanceColorSettings: FC<{ canManage: boolean }> = ({ canManage }) => {
+const AppearanceColorSettings: FC<{
+    canManage: boolean;
+    isCreatePaletteModalOpen: boolean;
+    onCloseCreatePaletteModal: () => void;
+}> = ({ canManage, isCreatePaletteModalOpen, onCloseCreatePaletteModal }) => {
     const { data: organization } = useOrganization();
     const { data: health, isLoading: isHealthLoading } = useHealth();
     const { data: palettes = [], isLoading: isPalettesLoading } =
         useColorPalettes();
 
     const setActivePalette = useSetActiveColorPalette();
-
-    const [isCreatePaletteModalOpen, setIsCreatePaletteModalOpen] =
-        useState(false);
 
     const handleSetActive = useCallback(
         (uuid: string) => {
@@ -47,20 +45,6 @@ const AppearanceColorSettings: FC<{ canManage: boolean }> = ({ canManage }) => {
 
     return (
         <Stack gap="md">
-            {canManage ? (
-                <Group justify="flex-end">
-                    <Button
-                        leftSection={<MantineIcon icon={IconPlus} />}
-                        onClick={() => setIsCreatePaletteModalOpen(true)}
-                        variant="default"
-                        size="xs"
-                        disabled={hasColorPaletteOverride}
-                    >
-                        Add new palette
-                    </Button>
-                </Group>
-            ) : null}
-
             <Stack gap="xs">
                 {isPalettesLoading || isHealthLoading ? (
                     <>
@@ -115,9 +99,7 @@ const AppearanceColorSettings: FC<{ canManage: boolean }> = ({ canManage }) => {
             <CreatePaletteModal
                 key={`create-palette-modal-${isCreatePaletteModalOpen}`}
                 opened={isCreatePaletteModalOpen}
-                onClose={() => {
-                    setIsCreatePaletteModalOpen(false);
-                }}
+                onClose={onCloseCreatePaletteModal}
             />
         </Stack>
     );
@@ -125,6 +107,9 @@ const AppearanceColorSettings: FC<{ canManage: boolean }> = ({ canManage }) => {
 
 const AppearanceSettingsPanel: FC = () => {
     const { user } = useApp();
+    const { data: health } = useHealth();
+    const [isCreatePaletteModalOpen, setIsCreatePaletteModalOpen] =
+        useState(false);
 
     const canManageOrgSettings =
         user.data?.ability?.can('update', 'Organization') ?? false;
@@ -135,34 +120,40 @@ const AppearanceSettingsPanel: FC = () => {
                 organizationUuid: user.data?.organizationUuid,
             }),
         ) ?? false;
+    const hasColorPaletteOverride =
+        !!health?.appearance.overrideColorPalette &&
+        health.appearance.overrideColorPalette.length > 0;
 
     return (
         <SettingsPage
             title="Appearance"
             description="Customize organization branding and the color palettes used in charts and visualizations."
             actions={
-                <Tooltip
-                    label="Click here to learn more about customizing the appearance of your project"
-                    position="bottom"
-                >
-                    <ActionIcon
-                        component="a"
-                        href="https://docs.lightdash.com/guides/customizing-the-appearance-of-your-project"
-                        target="_blank"
-                        rel="noreferrer"
-                        size="xs"
-                        color="gray"
-                        variant="subtle"
-                        aria-label="Learn about appearance settings"
-                    >
-                        <MantineIcon icon={IconInfoCircle} />
-                    </ActionIcon>
-                </Tooltip>
+                <SettingsPageActions>
+                    <SettingsPageDocumentationLink href="https://docs.lightdash.com/guides/customizing-the-appearance-of-your-project" />
+                    {canManageColorPalette ? (
+                        <Button
+                            size="xs"
+                            leftSection={<MantineIcon icon={IconPlus} />}
+                            onClick={() => setIsCreatePaletteModalOpen(true)}
+                            variant="default"
+                            disabled={hasColorPaletteOverride}
+                        >
+                            Add palette
+                        </Button>
+                    ) : null}
+                </SettingsPageActions>
             }
         >
             {canManageOrgSettings && <BrandAppearanceSettings />}
             <SettingsCard>
-                <AppearanceColorSettings canManage={canManageColorPalette} />
+                <AppearanceColorSettings
+                    canManage={canManageColorPalette}
+                    isCreatePaletteModalOpen={isCreatePaletteModalOpen}
+                    onCloseCreatePaletteModal={() =>
+                        setIsCreatePaletteModalOpen(false)
+                    }
+                />
             </SettingsCard>
         </SettingsPage>
     );

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/index.tsx
@@ -5,8 +5,6 @@ import {
     Group,
     Skeleton,
     Stack,
-    Text,
-    Title,
     Tooltip,
 } from '@mantine-8/core';
 import { IconInfoCircle, IconPlus } from '@tabler/icons-react';
@@ -20,6 +18,7 @@ import { useOrganization } from '../../../hooks/organization/useOrganization';
 import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../../common/MantineIcon';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
+import { SettingsPage } from '../../common/Settings/SettingsPage';
 import { BrandAppearanceSettings } from './BrandAppearanceSettings';
 import { CreatePaletteModal } from './CreatePaletteModal';
 import { PaletteItem } from './PaletteItem';
@@ -48,25 +47,19 @@ const AppearanceColorSettings: FC<{ canManage: boolean }> = ({ canManage }) => {
 
     return (
         <Stack gap="md">
-            <Group justify="space-between">
-                <Text size="sm" c="ldGray.6">
-                    Customize the color palettes used in your charts and
-                    visualizations.
-                </Text>
-
-                {canManage && (
+            {canManage ? (
+                <Group justify="flex-end">
                     <Button
                         leftSection={<MantineIcon icon={IconPlus} />}
                         onClick={() => setIsCreatePaletteModalOpen(true)}
                         variant="default"
                         size="xs"
-                        style={{ alignSelf: 'flex-end' }}
                         disabled={hasColorPaletteOverride}
                     >
                         Add new palette
                     </Button>
-                )}
-            </Group>
+                </Group>
+            ) : null}
 
             <Stack gap="xs">
                 {isPalettesLoading || isHealthLoading ? (
@@ -144,9 +137,10 @@ const AppearanceSettingsPanel: FC = () => {
         ) ?? false;
 
     return (
-        <Stack gap="sm">
-            <Group gap="xxs">
-                <Title order={5}>Appearance settings</Title>
+        <SettingsPage
+            title="Appearance"
+            description="Customize organization branding and the color palettes used in charts and visualizations."
+            actions={
                 <Tooltip
                     label="Click here to learn more about customizing the appearance of your project"
                     position="bottom"
@@ -159,16 +153,18 @@ const AppearanceSettingsPanel: FC = () => {
                         size="xs"
                         color="gray"
                         variant="subtle"
+                        aria-label="Learn about appearance settings"
                     >
                         <MantineIcon icon={IconInfoCircle} />
                     </ActionIcon>
                 </Tooltip>
-            </Group>
+            }
+        >
             {canManageOrgSettings && <BrandAppearanceSettings />}
-            <SettingsCard mb="lg">
+            <SettingsCard>
                 <AppearanceColorSettings canManage={canManageColorPalette} />
             </SettingsCard>
-        </Stack>
+        </SettingsPage>
     );
 };
 

--- a/packages/frontend/src/components/UserSettings/EmailWhitelabel/EmailWhitelabelPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/EmailWhitelabel/EmailWhitelabelPanel.tsx
@@ -13,7 +13,6 @@ import {
     Table,
     Text,
     TextInput,
-    Title,
     Tooltip,
 } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
@@ -21,7 +20,6 @@ import {
     IconCheck,
     IconCopy,
     IconInfoCircle,
-    IconMailForward,
     IconTrash,
 } from '@tabler/icons-react';
 import { type FC } from 'react';
@@ -35,6 +33,7 @@ import {
 import EmptyStateLoader from '../../common/EmptyStateLoader';
 import MantineIcon from '../../common/MantineIcon';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
+import { SettingsPage } from '../../common/Settings/SettingsPage';
 
 const STATUS_BADGE: Record<
     OrganizationEmailWhitelabel['status'],
@@ -290,30 +289,26 @@ const EmailWhitelabelPanel: FC = () => {
     const { data: config, isInitialLoading } = useEmailWhitelabel();
 
     return (
-        <SettingsCard p="lg">
-            <Stack gap="md">
-                <Group gap="sm" wrap="nowrap" align="flex-start">
-                    <MantineIcon icon={IconMailForward} size="lg" />
-                    <Stack gap={2}>
-                        <Title order={5}>Email sending domain</Title>
-                        <Text c="dimmed" size="sm" maw={560}>
-                            Send report emails from your own domain instead of a
-                            Lightdash address. Until this is verified and
-                            enabled, emails send from Lightdash with your
-                            address as reply-to.
-                        </Text>
-                    </Stack>
-                </Group>
-
-                {isInitialLoading ? (
-                    <EmptyStateLoader mih={60} />
-                ) : config ? (
-                    <ConfiguredView config={config} />
-                ) : (
-                    <SetupForm />
-                )}
-            </Stack>
-        </SettingsCard>
+        <SettingsPage
+            title="Email sending domain"
+            description="Send report emails from your own domain instead of a Lightdash address."
+        >
+            <SettingsCard>
+                <Stack gap="md">
+                    <Text c="dimmed" size="sm">
+                        Until your domain is verified and enabled, emails send
+                        from Lightdash with your address as reply-to.
+                    </Text>
+                    {isInitialLoading ? (
+                        <EmptyStateLoader mih={60} />
+                    ) : config ? (
+                        <ConfiguredView config={config} />
+                    ) : (
+                        <SetupForm />
+                    )}
+                </Stack>
+            </SettingsCard>
+        </SettingsPage>
     );
 };
 

--- a/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
@@ -71,7 +71,7 @@ const GithubSettingsPanel: FC = () => {
             <Box>
                 <Group gap="sm">
                     <Avatar src={githubIcon} size="md" alt="" />
-                    <Title order={4}>Github</Title>
+                    <Title order={5}>GitHub</Title>
                 </Group>
             </Box>
 

--- a/packages/frontend/src/components/UserSettings/GithubUserSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubUserSettingsPanel/index.tsx
@@ -33,7 +33,7 @@ const GithubUserSettingsPanel: FC = () => {
             <Box>
                 <Group gap="sm">
                     <Avatar src={githubIcon} size="md" />
-                    <Title order={4}>My GitHub account</Title>
+                    <Title order={5}>My GitHub account</Title>
                 </Group>
             </Box>
 

--- a/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GitlabSettingsPanel/index.tsx
@@ -38,7 +38,7 @@ const GitlabSettingsPanel: FC = () => {
             <Box>
                 <Group gap="sm">
                     <Avatar src={gitlabIcon} size="md" alt="" />
-                    <Title order={4}>GitLab</Title>
+                    <Title order={5}>GitLab</Title>
                 </Group>
             </Box>
 

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/MyAppsPanel.module.css
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/MyAppsPanel.module.css
@@ -1,0 +1,25 @@
+.tableSurface {
+    border-radius: var(--mantine-spacing-sm);
+}
+
+.segmentedControl {
+    background: var(--mantine-color-background-0);
+    border: 1px solid var(--mantine-color-ldGray-3);
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.segmentedIndicator {
+    background: var(--mantine-color-indigo-0);
+    border: 1px solid var(--mantine-color-indigo-2);
+
+    @mixin dark {
+        background: var(--mantine-color-indigo-8);
+        border-color: var(--mantine-color-indigo-4);
+    }
+}
+
+.segmentedLabel {
+    color: var(--mantine-color-foreground);
+    font-size: var(--mantine-font-size-xs);
+    font-weight: 500;
+}

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -45,6 +45,7 @@ import {
 import MantineIcon from '../../common/MantineIcon';
 import AppDeleteModal from '../../common/modal/AppDeleteModal';
 import AppUpdateModal from '../../common/modal/AppUpdateModal';
+import { SettingsEmptyState } from '../../common/Settings/SettingsEmptyState';
 
 const hasReadyVersion = (app: ApiAppSummary) =>
     app.lastVersionStatus === 'ready' && !!app.lastVersionNumber;
@@ -431,11 +432,15 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
                 />
             </Group>
             {!isLoading && !isError && flatData.length === 0 ? (
-                <Text c="dimmed" fz="sm" p="md">
-                    {includePreviewApps
-                        ? "You haven't created any apps yet."
-                        : 'No apps in production projects. Turn on Include apps in previews to show apps from preview projects.'}
-                </Text>
+                <SettingsEmptyState
+                    icon={IconLayoutDashboard}
+                    title="No apps"
+                    description={
+                        includePreviewApps
+                            ? 'Create an app to see it here.'
+                            : 'No apps are available in production projects. Include preview apps to see work from preview projects.'
+                    }
+                />
             ) : (
                 <ContentTable table={table} />
             )}

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -4,24 +4,18 @@ import {
     Anchor,
     Badge,
     Group,
-    Loader,
     Menu,
-    Stack,
     Switch,
     Text,
 } from '@mantine-8/core';
 import {
-    IconClock,
     IconCode,
     IconDots,
     IconEdit,
     IconExternalLink,
-    IconFolder,
     IconFolderPlus,
     IconFolderSymlink,
     IconLayoutDashboard,
-    IconRadar,
-    IconTextCaption,
     IconTrash,
 } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -46,6 +40,7 @@ import MantineIcon from '../../common/MantineIcon';
 import AppDeleteModal from '../../common/modal/AppDeleteModal';
 import AppUpdateModal from '../../common/modal/AppUpdateModal';
 import { SettingsEmptyState } from '../../common/Settings/SettingsEmptyState';
+import { SettingsPage } from '../../common/Settings/SettingsPage';
 
 const hasReadyVersion = (app: ApiAppSummary) =>
     app.lastVersionStatus === 'ready' && !!app.lastVersionNumber;
@@ -169,12 +164,6 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
                 header: 'Name',
                 enableSorting: false,
                 size: 200,
-                Header: ({ column }) => (
-                    <Group gap="two" wrap="nowrap">
-                        <MantineIcon icon={IconTextCaption} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
                 Cell: ({ row }) => {
                     const app = row.original;
                     return <AppNameCell app={app} />;
@@ -185,15 +174,6 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
                 header: 'Project',
                 enableSorting: false,
                 size: 150,
-                Header: ({ column }) => (
-                    <Group gap="two" wrap="nowrap">
-                        <MantineIcon
-                            icon={IconLayoutDashboard}
-                            color="ldGray.6"
-                        />
-                        {column.columnDef.header}
-                    </Group>
-                ),
                 Cell: ({ row }) => (
                     <Text fz="sm" c="ldGray.7">
                         {row.original.projectName}
@@ -205,12 +185,6 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
                 header: 'Space',
                 enableSorting: false,
                 size: 150,
-                Header: ({ column }) => (
-                    <Group gap="two" wrap="nowrap">
-                        <MantineIcon icon={IconFolder} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
                 Cell: ({ row }) => {
                     const { spaceUuid, spaceName, projectUuid } = row.original;
                     if (!spaceUuid || !spaceName) {
@@ -240,12 +214,6 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
                 header: 'Status',
                 enableSorting: false,
                 size: 100,
-                Header: ({ column }) => (
-                    <Group gap="two" wrap="nowrap">
-                        <MantineIcon icon={IconRadar} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
                 Cell: ({ row }) => {
                     const { lastVersionStatus, lastVersionNumber } =
                         row.original;
@@ -272,12 +240,6 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
                 header: 'Created',
                 enableSorting: false,
                 size: 120,
-                Header: ({ column }) => (
-                    <Group gap="two" wrap="nowrap">
-                        <MantineIcon icon={IconClock} color="ldGray.6" />
-                        {column.columnDef.header}
-                    </Group>
-                ),
                 Cell: ({ row }) => (
                     <Text fz="sm" c="ldGray.7">
                         {new Date(row.original.createdAt).toLocaleDateString()}
@@ -298,8 +260,8 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
                         <Menu position="bottom-end" withinPortal>
                             <Menu.Target>
                                 <ActionIcon
-                                    variant="subtle"
-                                    color="gray"
+                                    variant="transparent"
+                                    color="ldGray.6"
                                     size="sm"
                                 >
                                     <MantineIcon icon={IconDots} size={16} />
@@ -391,11 +353,31 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
         columns,
         data: flatData,
         enableColumnActions: false,
+        enableColumnResizing: false,
         enableColumnFilters: false,
+        enableDensityToggle: false,
+        enableFilters: false,
+        enableFullScreenToggle: false,
+        enableGlobalFilter: false,
+        enableGlobalFilterModes: false,
+        enableHiding: false,
         enablePagination: false,
+        enableRowNumbers: false,
         enableSorting: false,
         enableTopToolbar: false,
         enableBottomToolbar: false,
+        enableStickyHeader: true,
+        mantinePaperProps: {
+            shadow: undefined,
+        },
+        mantineTableHeadCellProps: {
+            px: 'lg',
+            py: 'sm',
+        },
+        mantineTableBodyCellProps: {
+            px: 'lg',
+            py: 'sm',
+        },
         mantineTableContainerProps: {
             ref: tableContainerRef,
             style: { maxHeight: 'calc(100dvh - 420px)' },
@@ -412,25 +394,22 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
         },
     });
 
-    if (isLoading && flatData.length === 0) {
-        return (
-            <Group justify="center" p="xl">
-                <Loader size="sm" />
-            </Group>
-        );
-    }
-
     return (
-        <Stack gap="md">
-            <Group justify="flex-end">
+        <SettingsPage
+            title="My apps"
+            description="Manage the data apps you can access and edit."
+            actions={
                 <Switch
-                    label="Include apps in previews"
+                    size="sm"
+                    label="Include preview apps"
+                    labelPosition="left"
                     checked={includePreviewApps}
                     onChange={(event) =>
                         setIncludePreviewApps(event.currentTarget.checked)
                     }
                 />
-            </Group>
+            }
+        >
             {!isLoading && !isError && flatData.length === 0 ? (
                 <SettingsEmptyState
                     icon={IconLayoutDashboard}
@@ -471,7 +450,7 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
                     onConfirm={() => setAppToRename(null)}
                 />
             )}
-        </Stack>
+        </SettingsPage>
     );
 };
 

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -6,6 +6,7 @@ import {
     Group,
     Menu,
     SegmentedControl,
+    Stack,
     Text,
 } from '@mantine-8/core';
 import {
@@ -403,31 +404,35 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
         <SettingsPage
             title="My apps"
             description="Manage the data apps you can access and edit."
-            actions={
-                <SegmentedControl
-                    size="xs"
-                    aria-label="App project scope"
-                    value={includePreviewApps ? 'with-previews' : 'production'}
-                    onChange={(value) =>
-                        setIncludePreviewApps(value === 'with-previews')
-                    }
-                    data={APP_SCOPE_OPTIONS}
-                />
-            }
         >
-            {!isLoading && !isError && flatData.length === 0 ? (
-                <SettingsEmptyState
-                    icon={IconLayoutDashboard}
-                    title="No apps"
-                    description={
-                        includePreviewApps
-                            ? 'Create an app to see it here.'
-                            : 'No apps are available in production projects. Include preview apps to see work from preview projects.'
-                    }
-                />
-            ) : (
-                <ContentTable table={table} />
-            )}
+            <Stack gap="xs">
+                <Group justify="flex-end">
+                    <SegmentedControl
+                        size="xs"
+                        aria-label="App project scope"
+                        value={
+                            includePreviewApps ? 'with-previews' : 'production'
+                        }
+                        onChange={(value) =>
+                            setIncludePreviewApps(value === 'with-previews')
+                        }
+                        data={APP_SCOPE_OPTIONS}
+                    />
+                </Group>
+                {!isLoading && !isError && flatData.length === 0 ? (
+                    <SettingsEmptyState
+                        icon={IconLayoutDashboard}
+                        title="No apps"
+                        description={
+                            includePreviewApps
+                                ? 'Create an app to see it here.'
+                                : 'No apps are available in production projects. Include preview apps to see work from preview projects.'
+                        }
+                    />
+                ) : (
+                    <ContentTable table={table} />
+                )}
+            </Stack>
             {appToDelete && (
                 <AppDeleteModal
                     opened

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -423,10 +423,11 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
             highlightOnHover: true,
         },
         emptyState: {
-            emptyMessage: 'No apps to display',
+            emptyMessage: includePreviewApps
+                ? "You haven't created any apps yet."
+                : 'No apps in production projects. Switch to All projects to include apps from preview projects.',
             entityName: 'apps',
-            hasActiveFilters:
-                includePreviewApps || selectedProjectUuids.length > 0,
+            hasActiveFilters: selectedProjectUuids.length > 0,
             onClearFilters: resetFilters,
             search,
         },

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -5,7 +5,7 @@ import {
     Badge,
     Group,
     Menu,
-    Switch,
+    SegmentedControl,
     Text,
 } from '@mantine-8/core';
 import {
@@ -44,6 +44,11 @@ import { SettingsPage } from '../../common/Settings/SettingsPage';
 
 const hasReadyVersion = (app: ApiAppSummary) =>
     app.lastVersionStatus === 'ready' && !!app.lastVersionNumber;
+
+const APP_SCOPE_OPTIONS = [
+    { label: 'Production only', value: 'production' },
+    { label: 'Include previews', value: 'with-previews' },
+];
 
 const MoveAppToSpaceModal: FC<{
     app: ApiAppSummary;
@@ -399,14 +404,14 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
             title="My apps"
             description="Manage the data apps you can access and edit."
             actions={
-                <Switch
-                    size="sm"
-                    label="Include preview apps"
-                    labelPosition="left"
-                    checked={includePreviewApps}
-                    onChange={(event) =>
-                        setIncludePreviewApps(event.currentTarget.checked)
+                <SegmentedControl
+                    size="xs"
+                    aria-label="App project scope"
+                    value={includePreviewApps ? 'with-previews' : 'production'}
+                    onChange={(value) =>
+                        setIncludePreviewApps(value === 'with-previews')
                     }
+                    data={APP_SCOPE_OPTIONS}
                 />
             }
         >

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -3,12 +3,13 @@ import {
     ActionIcon,
     Anchor,
     Badge,
+    Divider,
     Group,
     Menu,
     SegmentedControl,
-    Stack,
     Text,
 } from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine-8/hooks';
 import {
     IconCode,
     IconDots,
@@ -16,7 +17,6 @@ import {
     IconExternalLink,
     IconFolderPlus,
     IconFolderSymlink,
-    IconLayoutDashboard,
     IconTrash,
 } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -32,23 +32,26 @@ import { Link } from 'react-router';
 import AppThumbnailHoverCard from '../../../features/apps/components/AppThumbnailHoverCard';
 import { MoveAppToSpaceModal as SharedMoveAppToSpaceModal } from '../../../features/apps/components/MoveAppToSpaceModal';
 import { useMyApps } from '../../../features/apps/hooks/useMyApps';
+import { useProjects } from '../../../hooks/useProjects';
 import {
     ContentTable,
+    ContentTableSearchInput,
     useContentTable,
     type ContentTableColumnDef,
 } from '../../common/ContentTable';
+import FilterFacet, { type FilterFacetOption } from '../../common/FilterFacet';
 import MantineIcon from '../../common/MantineIcon';
 import AppDeleteModal from '../../common/modal/AppDeleteModal';
 import AppUpdateModal from '../../common/modal/AppUpdateModal';
-import { SettingsEmptyState } from '../../common/Settings/SettingsEmptyState';
 import { SettingsPage } from '../../common/Settings/SettingsPage';
+import classes from './MyAppsPanel.module.css';
 
 const hasReadyVersion = (app: ApiAppSummary) =>
     app.lastVersionStatus === 'ready' && !!app.lastVersionNumber;
 
-const APP_SCOPE_OPTIONS = [
-    { label: 'Production only', value: 'production' },
-    { label: 'Include previews', value: 'with-previews' },
+const PROJECT_SCOPE_OPTIONS = [
+    { label: 'Production', value: 'production' },
+    { label: 'All projects', value: 'all' },
 ];
 
 const MoveAppToSpaceModal: FC<{
@@ -127,8 +130,16 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
     const [includePreviewApps, setIncludePreviewApps] = useState(
         includePreviewAppsByDefault,
     );
+    const [selectedProjectUuids, setSelectedProjectUuids] = useState<string[]>(
+        [],
+    );
+    const [search, setSearch] = useState('');
+    const [debouncedSearch] = useDebouncedValue(search.trim(), 300);
+    const { data: projects = [], isLoading: isLoadingProjects } = useProjects();
     const { data, fetchNextPage, isFetching, isLoading, isError } = useMyApps({
         excludePreviewProjects: !includePreviewApps,
+        projectUuids: selectedProjectUuids,
+        search: debouncedSearch || undefined,
     });
     const [appToDelete, setAppToDelete] = useState<ApiAppSummary | null>(null);
     const [appToMove, setAppToMove] = useState<ApiAppSummary | null>(null);
@@ -163,13 +174,30 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
         fetchMoreOnBottomReached(tableContainerRef.current);
     }, [fetchMoreOnBottomReached]);
 
+    const resetFilters = useCallback(() => {
+        setSearch('');
+        setIncludePreviewApps(false);
+        setSelectedProjectUuids([]);
+    }, []);
+
+    const projectOptions = useMemo<FilterFacetOption[]>(
+        () =>
+            projects
+                .map((project) => ({
+                    label: project.name,
+                    value: project.projectUuid,
+                }))
+                .sort((a, b) => a.label.localeCompare(b.label)),
+        [projects],
+    );
+
     const columns: ContentTableColumnDef<ApiAppSummary>[] = useMemo(
         () => [
             {
                 accessorKey: 'name',
                 header: 'Name',
                 enableSorting: false,
-                size: 200,
+                size: 300,
                 Cell: ({ row }) => {
                     const app = row.original;
                     return <AppNameCell app={app} />;
@@ -370,10 +398,11 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
         enablePagination: false,
         enableRowNumbers: false,
         enableSorting: false,
-        enableTopToolbar: false,
+        enableTopToolbar: true,
         enableBottomToolbar: false,
         enableStickyHeader: true,
         mantinePaperProps: {
+            className: classes.tableSurface,
             shadow: undefined,
         },
         mantineTableHeadCellProps: {
@@ -393,6 +422,47 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
         mantineTableProps: {
             highlightOnHover: true,
         },
+        emptyState: {
+            emptyMessage: 'No apps to display',
+            entityName: 'apps',
+            hasActiveFilters:
+                includePreviewApps || selectedProjectUuids.length > 0,
+            onClearFilters: resetFilters,
+            search,
+        },
+        renderTopToolbar: () => (
+            <Group px="md" py="sm" gap="xs" wrap="nowrap">
+                <ContentTableSearchInput
+                    placeholder="Search apps..."
+                    tooltipLabel="Search by app, project, or space"
+                    value={search}
+                    onChange={setSearch}
+                />
+                <Divider orientation="vertical" h={20} />
+                <SegmentedControl
+                    size="xs"
+                    radius="md"
+                    aria-label="App project scope"
+                    value={includePreviewApps ? 'all' : 'production'}
+                    onChange={(value) => setIncludePreviewApps(value === 'all')}
+                    data={PROJECT_SCOPE_OPTIONS}
+                    classNames={{
+                        root: classes.segmentedControl,
+                        indicator: classes.segmentedIndicator,
+                        label: classes.segmentedLabel,
+                    }}
+                />
+                <Divider orientation="vertical" h={20} />
+                <FilterFacet
+                    label="Project"
+                    options={projectOptions}
+                    selected={selectedProjectUuids}
+                    onChange={setSelectedProjectUuids}
+                    tooltipLabel="Filter apps by project"
+                    loading={isLoadingProjects}
+                />
+            </Group>
+        ),
         state: {
             isLoading,
             showProgressBars: isFetching,
@@ -405,34 +475,7 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
             title="My apps"
             description="Manage the data apps you can access and edit."
         >
-            <Stack gap="xs">
-                <Group justify="flex-end">
-                    <SegmentedControl
-                        size="xs"
-                        aria-label="App project scope"
-                        value={
-                            includePreviewApps ? 'with-previews' : 'production'
-                        }
-                        onChange={(value) =>
-                            setIncludePreviewApps(value === 'with-previews')
-                        }
-                        data={APP_SCOPE_OPTIONS}
-                    />
-                </Group>
-                {!isLoading && !isError && flatData.length === 0 ? (
-                    <SettingsEmptyState
-                        icon={IconLayoutDashboard}
-                        title="No apps"
-                        description={
-                            includePreviewApps
-                                ? 'Create an app to see it here.'
-                                : 'No apps are available in production projects. Include preview apps to see work from preview projects.'
-                        }
-                    />
-                ) : (
-                    <ContentTable table={table} />
-                )}
-            </Stack>
+            <ContentTable table={table} />
             {appToDelete && (
                 <AppDeleteModal
                     opened

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/index.tsx
@@ -45,7 +45,6 @@ export const MyWarehouseConnectionsPanel = () => {
             actions={
                 <Button
                     size="xs"
-                    variant="default"
                     leftSection={<MantineIcon icon={IconPlus} />}
                     onClick={() => setIsCreatingCredentials(true)}
                 >

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/index.tsx
@@ -43,14 +43,13 @@ export const MyWarehouseConnectionsPanel = () => {
             title="My warehouse connections"
             description="Manage the personal credentials used to connect Lightdash to warehouses."
             actions={
-                credentials && credentials.length > 0 ? (
-                    <Button
-                        leftSection={<MantineIcon icon={IconPlus} />}
-                        onClick={() => setIsCreatingCredentials(true)}
-                    >
-                        Add credentials
-                    </Button>
-                ) : null
+                <Button
+                    size="xs"
+                    leftSection={<MantineIcon icon={IconPlus} />}
+                    onClick={() => setIsCreatingCredentials(true)}
+                >
+                    Add credentials
+                </Button>
             }
         >
             {credentials && credentials.length > 0 ? (
@@ -73,9 +72,6 @@ export const MyWarehouseConnectionsPanel = () => {
                     description="Add personal credentials for projects that require them."
                 >
                     {personalConnectionsCallout}
-                    <Button onClick={() => setIsCreatingCredentials(true)}>
-                        Add credentials
-                    </Button>
                 </SettingsEmptyState>
             )}
 

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/index.tsx
@@ -1,10 +1,11 @@
 import { type UserWarehouseCredentials } from '@lightdash/common';
-import { Anchor, Button, Group, Stack, Text, Title } from '@mantine-8/core';
+import { Anchor, Button, Text } from '@mantine-8/core';
 import { IconDatabaseCog, IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useUserWarehouseCredentials } from '../../../hooks/userWarehouseCredentials/useUserWarehouseCredentials';
-import { EmptyState } from '../../common/EmptyState';
 import MantineIcon from '../../common/MantineIcon';
+import { SettingsEmptyState } from '../../common/Settings/SettingsEmptyState';
+import { SettingsPage } from '../../common/Settings/SettingsPage';
 import { CreateCredentialsModal } from './CreateCredentialsModal';
 import { CredentialsTable } from './CredentialsTable';
 import { DeleteCredentialsModal } from './DeleteCredentialsModal';
@@ -38,67 +39,45 @@ export const MyWarehouseConnectionsPanel = () => {
     );
 
     return (
-        <>
-            <Stack mb="lg">
-                {credentials && credentials.length > 0 ? (
-                    <>
-                        <Group justify="space-between">
-                            <Stack gap="one">
-                                <Title order={5}>
-                                    My Warehouse connections
-                                </Title>
-                                <Text c="ldGray.6" fz="xs">
-                                    Add credentials to connect to your
-                                    warehouse.
-                                </Text>
-                            </Stack>
-                            <Button
-                                size="xs"
-                                leftSection={<MantineIcon icon={IconPlus} />}
-                                onClick={() => setIsCreatingCredentials(true)}
-                            >
-                                Add new credentials
-                            </Button>
-                        </Group>
-                        {personalConnectionsCallout}
-                        <CredentialsTable
-                            credentials={credentials}
-                            setWarehouseCredentialsToBeDeleted={
-                                setWarehouseCredentialsToBeDeleted
-                            }
-                            setWarehouseCredentialsToBeEdited={
-                                setWarehouseCredentialsToBeEdited
-                            }
-                        />
-                    </>
-                ) : (
-                    <EmptyState
-                        icon={
-                            <MantineIcon
-                                icon={IconDatabaseCog}
-                                color="ldGray.6"
-                                stroke={1}
-                                size="5xl"
-                            />
-                        }
-                        title="No credentials"
-                        description={
-                            <>
-                                <Text>
-                                    You haven't created any personal warehouse
-                                    connections yet!
-                                </Text>
-                                <br />
-                                {personalConnectionsCallout}
-                            </>
-                        }
+        <SettingsPage
+            title="My warehouse connections"
+            description="Manage the personal credentials used to connect Lightdash to warehouses."
+            actions={
+                credentials && credentials.length > 0 ? (
+                    <Button
+                        leftSection={<MantineIcon icon={IconPlus} />}
+                        onClick={() => setIsCreatingCredentials(true)}
                     >
-                        <Button onClick={() => setIsCreatingCredentials(true)}>
-                            Add new credentials
-                        </Button>
-                    </EmptyState>
-                )}
-            </Stack>
+                        Add credentials
+                    </Button>
+                ) : null
+            }
+        >
+            {credentials && credentials.length > 0 ? (
+                <>
+                    {personalConnectionsCallout}
+                    <CredentialsTable
+                        credentials={credentials}
+                        setWarehouseCredentialsToBeDeleted={
+                            setWarehouseCredentialsToBeDeleted
+                        }
+                        setWarehouseCredentialsToBeEdited={
+                            setWarehouseCredentialsToBeEdited
+                        }
+                    />
+                </>
+            ) : (
+                <SettingsEmptyState
+                    icon={IconDatabaseCog}
+                    title="No warehouse connections"
+                    description="Add personal credentials for projects that require them."
+                >
+                    {personalConnectionsCallout}
+                    <Button onClick={() => setIsCreatingCredentials(true)}>
+                        Add credentials
+                    </Button>
+                </SettingsEmptyState>
+            )}
 
             {!!warehouseCredentialsToBeEdited && (
                 <EditCredentialsModal
@@ -126,6 +105,6 @@ export const MyWarehouseConnectionsPanel = () => {
                     }
                 />
             )}
-        </>
+        </SettingsPage>
     );
 };

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/index.tsx
@@ -45,6 +45,7 @@ export const MyWarehouseConnectionsPanel = () => {
             actions={
                 <Button
                     size="xs"
+                    variant="default"
                     leftSection={<MantineIcon icon={IconPlus} />}
                     onClick={() => setIsCreatingCredentials(true)}
                 >

--- a/packages/frontend/src/components/UserSettings/OAuthClientsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/OAuthClientsPanel/index.tsx
@@ -17,11 +17,9 @@ const OAuthClientsPanel: FC = () => {
             title="OAuth applications"
             description="Register applications that authenticate users through Lightdash."
             actions={
-                hasClients ? (
-                    <Button onClick={() => setIsCreating(true)}>
-                        Register new application
-                    </Button>
-                ) : null
+                <Button size="xs" onClick={() => setIsCreating(true)}>
+                    Register new application
+                </Button>
             }
         >
             {hasClients ? (
@@ -31,11 +29,7 @@ const OAuthClientsPanel: FC = () => {
                     icon={IconPlug}
                     title="No OAuth applications"
                     description="Register an OAuth application to let external apps authenticate users via Lightdash."
-                >
-                    <Button onClick={() => setIsCreating(true)}>
-                        Register new application
-                    </Button>
-                </SettingsEmptyState>
+                />
             )}
 
             {isCreating && (

--- a/packages/frontend/src/components/UserSettings/OAuthClientsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/OAuthClientsPanel/index.tsx
@@ -1,9 +1,9 @@
-import { Button, Group, Stack, Title } from '@mantine-8/core';
+import { Button } from '@mantine-8/core';
 import { IconPlug } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { useOAuthClients } from '../../../hooks/useOAuthClients';
-import { EmptyState } from '../../common/EmptyState';
-import MantineIcon from '../../common/MantineIcon';
+import { SettingsEmptyState } from '../../common/Settings/SettingsEmptyState';
+import { SettingsPage } from '../../common/Settings/SettingsPage';
 import { CreateOAuthClientModal } from './CreateOAuthClientModal';
 import { OAuthClientsTable } from './OAuthClientsTable';
 
@@ -13,40 +13,35 @@ const OAuthClientsPanel: FC = () => {
     const hasClients = data && data.length > 0;
 
     return (
-        <Stack mb="lg">
+        <SettingsPage
+            title="OAuth applications"
+            description="Register applications that authenticate users through Lightdash."
+            actions={
+                hasClients ? (
+                    <Button onClick={() => setIsCreating(true)}>
+                        Register new application
+                    </Button>
+                ) : null
+            }
+        >
             {hasClients ? (
-                <>
-                    <Group justify="space-between">
-                        <Title order={5}>OAuth applications</Title>
-                        <Button onClick={() => setIsCreating(true)}>
-                            Register new application
-                        </Button>
-                    </Group>
-                    <OAuthClientsTable clients={data} />
-                </>
+                <OAuthClientsTable clients={data} />
             ) : (
-                <EmptyState
-                    icon={
-                        <MantineIcon
-                            icon={IconPlug}
-                            color="ldGray.6"
-                            stroke={1}
-                            size="5xl"
-                        />
-                    }
+                <SettingsEmptyState
+                    icon={IconPlug}
                     title="No OAuth applications"
                     description="Register an OAuth application to let external apps authenticate users via Lightdash."
                 >
                     <Button onClick={() => setIsCreating(true)}>
                         Register new application
                     </Button>
-                </EmptyState>
+                </SettingsEmptyState>
             )}
 
             {isCreating && (
                 <CreateOAuthClientModal onClose={() => setIsCreating(false)} />
             )}
-        </Stack>
+        </SettingsPage>
     );
 };
 

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/index.tsx
@@ -1,18 +1,11 @@
 import { type OrganizationWarehouseCredentials } from '@lightdash/common';
-import {
-    Box,
-    Button,
-    Group,
-    LoadingOverlay,
-    Stack,
-    Text,
-    Title,
-} from '@mantine-8/core';
+import { Box, Button, LoadingOverlay } from '@mantine-8/core';
 import { IconDatabaseCog, IconPlus } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useOrganizationWarehouseCredentials } from '../../../hooks/organization/useOrganizationWarehouseCredentials';
-import { EmptyState } from '../../common/EmptyState';
 import MantineIcon from '../../common/MantineIcon';
+import { SettingsEmptyState } from '../../common/Settings/SettingsEmptyState';
+import { SettingsPage } from '../../common/Settings/SettingsPage';
 import { CreateCredentialsModal } from './CreateCredentialsModal';
 import { CredentialsTable } from './CredentialsTable';
 import { DeleteCredentialsModal } from './DeleteCredentialsModal';
@@ -31,63 +24,52 @@ export const OrganizationWarehouseCredentialsPanel = () => {
 
     if (isLoading) {
         return (
-            <Box pos="relative" mih={120}>
-                <LoadingOverlay visible={isLoading} />
-            </Box>
+            <SettingsPage
+                title="Warehouse credentials"
+                description="Manage shared credentials available across your organization."
+            >
+                <Box pos="relative" mih={120}>
+                    <LoadingOverlay visible />
+                </Box>
+            </SettingsPage>
         );
     }
     return (
-        <>
-            <Stack mb="lg">
-                {credentials && credentials.length > 0 ? (
-                    <>
-                        <Group justify="space-between">
-                            <Stack gap="one">
-                                <Title order={5}>
-                                    Organization warehouse credentials
-                                </Title>
-                                <Text c="ldGray.6" fz="xs">
-                                    Shared credentials that can be used across
-                                    all projects in your organization.
-                                </Text>
-                            </Stack>
-                            <Button
-                                size="xs"
-                                leftSection={<MantineIcon icon={IconPlus} />}
-                                onClick={() => setIsCreatingCredentials(true)}
-                            >
-                                Add new credentials
-                            </Button>
-                        </Group>
-                        <CredentialsTable
-                            credentials={credentials}
-                            setWarehouseCredentialsToBeDeleted={
-                                setWarehouseCredentialsToBeDeleted
-                            }
-                            setWarehouseCredentialsToBeEdited={
-                                setWarehouseCredentialsToBeEdited
-                            }
-                        />
-                    </>
-                ) : (
-                    <EmptyState
-                        icon={
-                            <MantineIcon
-                                icon={IconDatabaseCog}
-                                color="ldGray.6"
-                                stroke={1}
-                                size="5xl"
-                            />
-                        }
-                        title="No credentials"
-                        description="You haven't created any organization warehouse credentials yet!"
+        <SettingsPage
+            title="Warehouse credentials"
+            description="Manage shared credentials available across your organization."
+            actions={
+                credentials && credentials.length > 0 ? (
+                    <Button
+                        leftSection={<MantineIcon icon={IconPlus} />}
+                        onClick={() => setIsCreatingCredentials(true)}
                     >
-                        <Button onClick={() => setIsCreatingCredentials(true)}>
-                            Add new credentials
-                        </Button>
-                    </EmptyState>
-                )}
-            </Stack>
+                        Add credentials
+                    </Button>
+                ) : null
+            }
+        >
+            {credentials && credentials.length > 0 ? (
+                <CredentialsTable
+                    credentials={credentials}
+                    setWarehouseCredentialsToBeDeleted={
+                        setWarehouseCredentialsToBeDeleted
+                    }
+                    setWarehouseCredentialsToBeEdited={
+                        setWarehouseCredentialsToBeEdited
+                    }
+                />
+            ) : (
+                <SettingsEmptyState
+                    icon={IconDatabaseCog}
+                    title="No warehouse credentials"
+                    description="Add shared credentials for projects across your organization."
+                >
+                    <Button onClick={() => setIsCreatingCredentials(true)}>
+                        Add credentials
+                    </Button>
+                </SettingsEmptyState>
+            )}
 
             {!!warehouseCredentialsToBeEdited && (
                 <EditCredentialsModal
@@ -115,6 +97,6 @@ export const OrganizationWarehouseCredentialsPanel = () => {
                     }
                 />
             )}
-        </>
+        </SettingsPage>
     );
 };

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/index.tsx
@@ -22,34 +22,25 @@ export const OrganizationWarehouseCredentialsPanel = () => {
         setWarehouseCredentialsToBeDeleted,
     ] = useState<OrganizationWarehouseCredentials | undefined>(undefined);
 
-    if (isLoading) {
-        return (
-            <SettingsPage
-                title="Warehouse credentials"
-                description="Manage shared credentials available across your organization."
-            >
-                <Box pos="relative" mih={120}>
-                    <LoadingOverlay visible />
-                </Box>
-            </SettingsPage>
-        );
-    }
     return (
         <SettingsPage
             title="Warehouse credentials"
             description="Manage shared credentials available across your organization."
             actions={
-                credentials && credentials.length > 0 ? (
-                    <Button
-                        leftSection={<MantineIcon icon={IconPlus} />}
-                        onClick={() => setIsCreatingCredentials(true)}
-                    >
-                        Add credentials
-                    </Button>
-                ) : null
+                <Button
+                    size="xs"
+                    leftSection={<MantineIcon icon={IconPlus} />}
+                    onClick={() => setIsCreatingCredentials(true)}
+                >
+                    Add credentials
+                </Button>
             }
         >
-            {credentials && credentials.length > 0 ? (
+            {isLoading ? (
+                <Box pos="relative" mih={120}>
+                    <LoadingOverlay visible />
+                </Box>
+            ) : credentials && credentials.length > 0 ? (
                 <CredentialsTable
                     credentials={credentials}
                     setWarehouseCredentialsToBeDeleted={
@@ -64,11 +55,7 @@ export const OrganizationWarehouseCredentialsPanel = () => {
                     icon={IconDatabaseCog}
                     title="No warehouse credentials"
                     description="Add shared credentials for projects across your organization."
-                >
-                    <Button onClick={() => setIsCreatingCredentials(true)}>
-                        Add credentials
-                    </Button>
-                </SettingsEmptyState>
+                />
             )}
 
             {!!warehouseCredentialsToBeEdited && (

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
@@ -967,9 +967,7 @@ const ProjectManagementPanel: FC = () => {
         ),
     });
 
-    if (isLoadingProjects || isLoadingLastProject) return null;
-
-    if (projects.length === 0) {
+    if (!isLoadingProjects && !isLoadingLastProject && projects.length === 0) {
         return <Navigate to="/createProject" />;
     }
 
@@ -984,7 +982,7 @@ const ProjectManagementPanel: FC = () => {
                         organizationUuid: user.data?.organizationUuid,
                     }),
                 ) && (
-                    <Button component={Link} to="/createProject">
+                    <Button size="xs" component={Link} to="/createProject">
                         Create project
                     </Button>
                 )

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
@@ -23,7 +23,6 @@ import {
     SegmentedControl,
     Stack,
     Text,
-    Title,
     Tooltip,
     UnstyledButton,
     useMantineTheme,
@@ -57,6 +56,7 @@ import {
 } from '../../common/ContentTable';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
+import { SettingsPage } from '../../common/Settings/SettingsPage';
 import {
     getWarehouseIcon,
     getWarehouseLabel,
@@ -974,22 +974,22 @@ const ProjectManagementPanel: FC = () => {
     }
 
     return (
-        <Stack mb="lg">
-            <Group justify="space-between">
-                <Title order={5}>Project Management</Title>
-
-                {user.data?.ability.can(
+        <SettingsPage
+            title="All projects"
+            description="Manage projects, connections, access, and project lifecycle."
+            actions={
+                user.data?.ability.can(
                     'create',
                     subject('Project', {
                         organizationUuid: user.data?.organizationUuid,
                     }),
                 ) && (
                     <Button component={Link} to="/createProject">
-                        Create new
+                        Create project
                     </Button>
-                )}
-            </Group>
-
+                )
+            }
+        >
             <ContentTable table={table} />
 
             {deletingProjectUuid ? (
@@ -1042,7 +1042,7 @@ const ProjectManagementPanel: FC = () => {
                     </Stack>
                 )}
             </MantineModal>
-        </Stack>
+        </SettingsPage>
     );
 };
 

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -169,7 +169,7 @@ const SlackSettingsPanel: FC = () => {
                 <Box>
                     <Group gap="sm">
                         <Avatar src={slackSvg} size="md" />
-                        <Title order={4}>Slack</Title>
+                        <Title order={5}>Slack</Title>
                     </Group>
                 </Box>
             </Stack>

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributesTopToolbar.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributesTopToolbar.tsx
@@ -1,22 +1,20 @@
 import {
-    Button,
     Group,
     TextInput,
     useMantineTheme,
     type GroupProps,
 } from '@mantine-8/core';
-import { IconPlus, IconSearch } from '@tabler/icons-react';
+import { IconSearch } from '@tabler/icons-react';
 import { memo, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 
 type UserAttributesTopToolbarProps = GroupProps & {
-    onAddClick: () => void;
     searchQuery: string;
     onSearchChange: (value: string) => void;
 };
 
 export const UserAttributesTopToolbar: FC<UserAttributesTopToolbarProps> = memo(
-    ({ onAddClick, searchQuery, onSearchChange, ...props }) => {
+    ({ searchQuery, onSearchChange, ...props }) => {
         const theme = useMantineTheme();
 
         return (
@@ -34,15 +32,6 @@ export const UserAttributesTopToolbar: FC<UserAttributesTopToolbarProps> = memo(
                     size="xs"
                     w={240}
                 />
-
-                <Button
-                    size="xs"
-                    leftSection={<MantineIcon icon={IconPlus} />}
-                    onClick={onAddClick}
-                    style={{ flexShrink: 0 }}
-                >
-                    Add new attribute
-                </Button>
             </Group>
         );
     },

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
@@ -8,7 +8,6 @@ import {
     Menu,
     Stack,
     Text,
-    Title,
     Tooltip,
     useMantineTheme,
 } from '@mantine-8/core';
@@ -38,6 +37,7 @@ import {
 import EmptyStateLoader from '../../common/EmptyStateLoader';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
+import { SettingsPage } from '../../common/Settings/SettingsPage';
 import ForbiddenPanel from '../../ForbiddenPanel';
 import UserAttributeModal from './UserAttributeModal';
 import { UserAttributesTopToolbar } from './UserAttributesTopToolbar';
@@ -320,44 +320,36 @@ const UserAttributesPanel: FC = () => {
     if (!user.data) return null;
 
     return (
-        <>
-            <Stack gap="sm">
-                <Group gap="xs" align="center" pb="xs">
-                    <Title order={5}>
-                        {isGroupManagementEnabled
-                            ? 'User and group attributes'
-                            : 'User attributes'}
-                    </Title>
-                    <Tooltip
-                        multiline
-                        w={400}
-                        withArrow
-                        position="bottom-start"
-                        label={
-                            <Box>
-                                User attributes are metadata defined by your
-                                organization. They can be used to control and
-                                customize the user experience through data
-                                access and personalization. Learn more about
-                                using user attributes by clicking on this icon.
-                            </Box>
-                        }
+        <SettingsPage
+            title={
+                isGroupManagementEnabled
+                    ? 'User and group attributes'
+                    : 'User attributes'
+            }
+            description="Define organization metadata used for data access and personalization."
+            actions={
+                <Tooltip
+                    multiline
+                    w={400}
+                    withArrow
+                    position="bottom-end"
+                    label="Learn more about using user attributes."
+                >
+                    <ActionIcon
+                        component="a"
+                        href="https://docs.lightdash.com/references/user-attributes"
+                        target="_blank"
+                        rel="noreferrer"
+                        variant="subtle"
+                        color="ldGray.6"
+                        aria-label="Open user attributes documentation"
                     >
-                        <ActionIcon
-                            component="a"
-                            href="https://docs.lightdash.com/references/user-attributes"
-                            target="_blank"
-                            rel="noreferrer"
-                            variant="subtle"
-                            size="xs"
-                            color="ldGray.6"
-                        >
-                            <MantineIcon icon={IconInfoCircle} />
-                        </ActionIcon>
-                    </Tooltip>
-                </Group>
-                <ContentTable table={table} />
-            </Stack>
+                        <MantineIcon icon={IconInfoCircle} />
+                    </ActionIcon>
+                </Tooltip>
+            }
+        >
+            <ContentTable table={table} />
 
             <UserAttributeModal
                 opened={showAddAttributeModal}
@@ -388,7 +380,7 @@ const UserAttributesPanel: FC = () => {
                     }}
                 />
             )}
-        </>
+        </SettingsPage>
     );
 };
 

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/index.tsx
@@ -4,6 +4,7 @@ import {
     ActionIcon,
     Anchor,
     Box,
+    Button,
     Group,
     Menu,
     Stack,
@@ -19,6 +20,7 @@ import {
     IconDots,
     IconEdit,
     IconInfoCircle,
+    IconPlus,
     IconTrash,
 } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
@@ -34,10 +36,13 @@ import {
     useContentTable,
     type ContentTableColumnDef,
 } from '../../common/ContentTable';
-import EmptyStateLoader from '../../common/EmptyStateLoader';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
-import { SettingsPage } from '../../common/Settings/SettingsPage';
+import {
+    SettingsPage,
+    SettingsPageActions,
+    SettingsPageDocumentationLink,
+} from '../../common/Settings/SettingsPage';
 import ForbiddenPanel from '../../ForbiddenPanel';
 import UserAttributeModal from './UserAttributeModal';
 import { UserAttributesTopToolbar } from './UserAttributesTopToolbar';
@@ -259,7 +264,6 @@ const UserAttributesPanel: FC = () => {
         },
         renderTopToolbar: () => (
             <UserAttributesTopToolbar
-                onAddClick={addAttributeModal.open}
                 searchQuery={searchQuery}
                 onSearchChange={setSearchQuery}
             />
@@ -313,10 +317,6 @@ const UserAttributesPanel: FC = () => {
         return <ForbiddenPanel />;
     }
 
-    if (isInitialLoading) {
-        return <EmptyStateLoader my="xl" title="Loading user attributes" />;
-    }
-
     if (!user.data) return null;
 
     return (
@@ -328,25 +328,16 @@ const UserAttributesPanel: FC = () => {
             }
             description="Define organization metadata used for data access and personalization."
             actions={
-                <Tooltip
-                    multiline
-                    w={400}
-                    withArrow
-                    position="bottom-end"
-                    label="Learn more about using user attributes."
-                >
-                    <ActionIcon
-                        component="a"
-                        href="https://docs.lightdash.com/references/user-attributes"
-                        target="_blank"
-                        rel="noreferrer"
-                        variant="subtle"
-                        color="ldGray.6"
-                        aria-label="Open user attributes documentation"
+                <SettingsPageActions>
+                    <SettingsPageDocumentationLink href="https://docs.lightdash.com/references/user-attributes" />
+                    <Button
+                        size="xs"
+                        leftSection={<MantineIcon icon={IconPlus} />}
+                        onClick={addAttributeModal.open}
                     >
-                        <MantineIcon icon={IconInfoCircle} />
-                    </ActionIcon>
-                </Tooltip>
+                        Add attribute
+                    </Button>
+                </SettingsPageActions>
             }
         >
             <ContentTable table={table} />

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsTable.tsx
@@ -40,11 +40,10 @@ const fetchSize = 50;
 const GROUP_MEMBERS_PER_PAGE = 2000;
 
 interface GroupsTableProps {
-    onAddClick: () => void;
     onEditGroup: (group: GroupWithMembers) => void;
 }
 
-const GroupsTable: FC<GroupsTableProps> = ({ onAddClick, onEditGroup }) => {
+const GroupsTable: FC<GroupsTableProps> = ({ onEditGroup }) => {
     const theme = useMantineTheme();
     const { user: activeUser } = useApp();
     const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -301,14 +300,7 @@ const GroupsTable: FC<GroupsTableProps> = ({ onAddClick, onEditGroup }) => {
             };
         },
         renderTopToolbar: () => (
-            <GroupsTopToolbar
-                search={search}
-                setSearch={setSearch}
-                isFetching={isFetching || isLoading}
-                currentResultsCount={totalFetched}
-                canManage={canManageGroups}
-                onAddClick={onAddClick}
-            />
+            <GroupsTopToolbar search={search} setSearch={setSearch} />
         ),
         renderBottomToolbar: () => (
             <Box

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsTopToolbar.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsTopToolbar.tsx
@@ -1,92 +1,65 @@
 import {
     ActionIcon,
-    Button,
     Group,
     TextInput,
     Tooltip,
     useMantineTheme,
     type GroupProps,
 } from '@mantine-8/core';
-import { IconPlus, IconSearch, IconX } from '@tabler/icons-react';
+import { IconSearch, IconX } from '@tabler/icons-react';
 import { memo, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 
 type GroupsTopToolbarProps = GroupProps & {
     search: string;
     setSearch: (value: string) => void;
-    isFetching: boolean;
-    currentResultsCount: number;
-    canManage: boolean;
-    onAddClick: () => void;
 };
 
 export const GroupsTopToolbar: FC<GroupsTopToolbarProps> = memo(
-    ({
-        search,
-        setSearch,
-        isFetching,
-        currentResultsCount,
-        canManage,
-        onAddClick,
-        ...props
-    }) => {
+    ({ search, setSearch, ...props }) => {
         const theme = useMantineTheme();
 
         return (
             <Group
-                justify="space-between"
                 p={`${theme.spacing.sm} ${theme.spacing.md}`}
                 wrap="nowrap"
                 {...props}
             >
-                <Group gap="xs" wrap="nowrap" style={{ flex: 1, minWidth: 0 }}>
-                    <Tooltip
-                        withinPortal
-                        label="Search by name, members or member email"
-                    >
-                        <TextInput
-                            size="xs"
-                            radius="md"
-                            type="search"
-                            variant="default"
-                            placeholder="Search groups by name, members or member email"
-                            value={search ?? ''}
-                            leftSection={
-                                <MantineIcon
-                                    size="md"
-                                    color="ldGray.6"
-                                    icon={IconSearch}
-                                />
-                            }
-                            onChange={(e) => setSearch(e.target.value)}
-                            rightSection={
-                                search && (
-                                    <ActionIcon
-                                        onClick={() => setSearch('')}
-                                        variant="transparent"
-                                        size="xs"
-                                        color="ldGray.5"
-                                    >
-                                        <MantineIcon icon={IconX} />
-                                    </ActionIcon>
-                                )
-                            }
-                            miw={350}
-                            maw={400}
-                        />
-                    </Tooltip>
-                </Group>
-
-                {canManage && (
-                    <Button
+                <Tooltip
+                    withinPortal
+                    label="Search by name, members or member email"
+                >
+                    <TextInput
                         size="xs"
-                        leftSection={<MantineIcon icon={IconPlus} />}
-                        onClick={onAddClick}
-                        style={{ flexShrink: 0 }}
-                    >
-                        Add group
-                    </Button>
-                )}
+                        radius="md"
+                        type="search"
+                        variant="default"
+                        placeholder="Search groups by name, members or member email"
+                        value={search ?? ''}
+                        leftSection={
+                            <MantineIcon
+                                size="md"
+                                color="ldGray.6"
+                                icon={IconSearch}
+                            />
+                        }
+                        onChange={(e) => setSearch(e.target.value)}
+                        rightSection={
+                            search ? (
+                                <ActionIcon
+                                    onClick={() => setSearch('')}
+                                    variant="transparent"
+                                    size="xs"
+                                    color="ldGray.5"
+                                >
+                                    <MantineIcon icon={IconX} />
+                                </ActionIcon>
+                            ) : null
+                        }
+                        miw={350}
+                        maw={400}
+                    />
+                </Tooltip>
             </Group>
         );
     },

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsView.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/GroupsView.tsx
@@ -1,38 +1,13 @@
 import { type GroupWithMembers } from '@lightdash/common';
-import { Stack } from '@mantine-8/core';
-import { useState, type FC } from 'react';
-import CreateGroupModal from './CreateGroupModal';
+import { type FC } from 'react';
 import GroupsTable from './GroupsTable';
 
-const GroupsView: FC = () => {
-    const [showCreateAndEditModal, setShowCreateAndEditModal] = useState(false);
-    const [groupToEdit, setGroupToEdit] = useState<
-        GroupWithMembers | undefined
-    >(undefined);
-
-    return (
-        <Stack gap="xs">
-            <GroupsTable
-                onAddClick={() => setShowCreateAndEditModal(true)}
-                onEditGroup={(group) => {
-                    setGroupToEdit(group);
-                    setShowCreateAndEditModal(true);
-                }}
-            />
-            {showCreateAndEditModal && (
-                <CreateGroupModal
-                    key={`create-group-modal-${showCreateAndEditModal}`}
-                    opened={showCreateAndEditModal}
-                    onClose={() => {
-                        setShowCreateAndEditModal(false);
-                        setGroupToEdit(undefined);
-                    }}
-                    groupToEdit={groupToEdit}
-                    isEditing={groupToEdit !== undefined}
-                />
-            )}
-        </Stack>
-    );
+type GroupsViewProps = {
+    onEditGroup: (group: GroupWithMembers) => void;
 };
+
+const GroupsView: FC<GroupsViewProps> = ({ onEditGroup }) => (
+    <GroupsTable onEditGroup={onEditGroup} />
+);
 
 export default GroupsView;

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersAndGroupsPanel.module.css
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersAndGroupsPanel.module.css
@@ -6,7 +6,10 @@
     font-weight: 500;
     font-size: 0.875rem;
     padding: 0.5rem 1rem;
-    transition: all 150ms ease;
+    transition:
+        background-color 150ms ease,
+        border-color 150ms ease,
+        color 150ms ease;
     border-radius: var(--mantine-radius-md);
     border: 1px solid
         light-dark(var(--mantine-color-ldGray-3), var(--mantine-color-ldDark-4));
@@ -56,8 +59,4 @@
 
 .panel {
     padding-top: 1rem;
-}
-
-.header {
-    padding-bottom: 0.75rem;
 }

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
@@ -61,11 +61,7 @@ type PendingRoleChange = {
     roleId: string;
 };
 
-interface UsersTableProps {
-    onInviteClick: () => void;
-}
-
-const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
+const UsersTable: FC = () => {
     const theme = useMantineTheme();
     const { user: activeUser } = useApp();
     const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -500,14 +496,7 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
             };
         },
         renderTopToolbar: () => (
-            <UsersTopToolbar
-                search={search}
-                setSearch={setSearch}
-                isFetching={isFetching || isLoading}
-                currentResultsCount={totalFetched}
-                canInvite={canInvite}
-                onInviteClick={onInviteClick}
-            />
+            <UsersTopToolbar search={search} setSearch={setSearch} />
         ),
         renderBottomToolbar: () => (
             <Box

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTopToolbar.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTopToolbar.tsx
@@ -1,35 +1,22 @@
 import {
     ActionIcon,
-    Button,
     Group,
     TextInput,
     Tooltip,
     useMantineTheme,
     type GroupProps,
 } from '@mantine-8/core';
-import { IconPlus, IconSearch, IconX } from '@tabler/icons-react';
+import { IconSearch, IconX } from '@tabler/icons-react';
 import { memo, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 
 type UsersTopToolbarProps = GroupProps & {
     search: string;
     setSearch: (value: string) => void;
-    isFetching: boolean;
-    currentResultsCount: number;
-    canInvite: boolean;
-    onInviteClick: () => void;
 };
 
 export const UsersTopToolbar: FC<UsersTopToolbarProps> = memo(
-    ({
-        search,
-        setSearch,
-        isFetching,
-        currentResultsCount,
-        canInvite,
-        onInviteClick,
-        ...props
-    }) => {
+    ({ search, setSearch, ...props }) => {
         const theme = useMantineTheme();
 
         return (
@@ -77,17 +64,6 @@ export const UsersTopToolbar: FC<UsersTopToolbarProps> = memo(
                         />
                     </Tooltip>
                 </Group>
-
-                {canInvite && (
-                    <Button
-                        size="xs"
-                        leftSection={<MantineIcon icon={IconPlus} />}
-                        onClick={onInviteClick}
-                        style={{ flexShrink: 0 }}
-                    >
-                        Add user
-                    </Button>
-                )}
             </Group>
         );
     },

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersView.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersView.tsx
@@ -1,19 +1,11 @@
 import { Stack } from '@mantine-8/core';
-import { useState, type FC } from 'react';
-import InvitesModal from './InvitesModal';
+import { type FC } from 'react';
 import UsersTable from './UsersTable';
 
 const UsersView: FC = () => {
-    const [showInviteModal, setShowInviteModal] = useState(false);
-
     return (
         <Stack gap="xs">
-            <UsersTable onInviteClick={() => setShowInviteModal(true)} />
-            <InvitesModal
-                key={`invite-modal-${showInviteModal}`}
-                opened={showInviteModal}
-                onClose={() => setShowInviteModal(false)}
-            />
+            <UsersTable />
         </Stack>
     );
 };

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/index.tsx
@@ -1,17 +1,11 @@
 import { FeatureFlags } from '@lightdash/common';
-import {
-    ActionIcon,
-    Group,
-    Stack,
-    Tabs,
-    Title,
-    Tooltip,
-} from '@mantine-8/core';
+import { ActionIcon, Tabs, Tooltip } from '@mantine-8/core';
 import { IconInfoCircle, IconUsers, IconUsersGroup } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../../common/MantineIcon';
+import { SettingsPage } from '../../common/Settings/SettingsPage';
 import ForbiddenPanel from '../../ForbiddenPanel';
 import GroupsView from './GroupsView';
 import classes from './UsersAndGroupsPanel.module.css';
@@ -32,8 +26,31 @@ const UsersAndGroupsPanel: FC = () => {
     const isGroupManagementEnabled =
         userGroupsFeatureFlagQuery.data?.enabled ?? false;
 
+    const title = isGroupManagementEnabled
+        ? 'Users & groups'
+        : 'User management';
+
     return (
-        <Stack gap="sm">
+        <SettingsPage
+            title={title}
+            description="Manage organization members, roles, and group membership."
+            actions={
+                <Tooltip label="Learn more about user roles" position="bottom">
+                    <ActionIcon
+                        component="a"
+                        href="https://docs.lightdash.com/references/roles"
+                        target="_blank"
+                        rel="noreferrer"
+                        variant="subtle"
+                        size="xs"
+                        color="ldGray.6"
+                        aria-label="Learn about user roles"
+                    >
+                        <MantineIcon icon={IconInfoCircle} />
+                    </ActionIcon>
+                </Tooltip>
+            }
+        >
             <Tabs
                 keepMounted={false}
                 defaultValue="users"
@@ -44,29 +61,6 @@ const UsersAndGroupsPanel: FC = () => {
                     panel: classes.panel,
                 }}
             >
-                <Group gap="xs" align="center" className={classes.header}>
-                    <Title order={5}>
-                        {isGroupManagementEnabled
-                            ? 'Users and groups'
-                            : 'User management settings'}
-                    </Title>
-                    <Tooltip
-                        label="Click here to learn more about user roles"
-                        position="right"
-                    >
-                        <ActionIcon
-                            component="a"
-                            href="https://docs.lightdash.com/references/roles"
-                            target="_blank"
-                            rel="noreferrer"
-                            variant="subtle"
-                            size="xs"
-                            color="ldGray.6"
-                        >
-                            <MantineIcon icon={IconInfoCircle} />
-                        </ActionIcon>
-                    </Tooltip>
-                </Group>
                 {isGroupManagementEnabled && (
                     <Tabs.List>
                         <Tabs.Tab
@@ -90,7 +84,7 @@ const UsersAndGroupsPanel: FC = () => {
                     <GroupsView />
                 </Tabs.Panel>
             </Tabs>
-        </Stack>
+        </SettingsPage>
     );
 };
 

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/index.tsx
@@ -1,13 +1,19 @@
-import { FeatureFlags } from '@lightdash/common';
-import { ActionIcon, Tabs, Tooltip } from '@mantine-8/core';
-import { IconInfoCircle, IconUsers, IconUsersGroup } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { FeatureFlags, type GroupWithMembers } from '@lightdash/common';
+import { Button, Tabs } from '@mantine-8/core';
+import { IconPlus, IconUsers, IconUsersGroup } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../../common/MantineIcon';
-import { SettingsPage } from '../../common/Settings/SettingsPage';
+import {
+    SettingsPage,
+    SettingsPageActions,
+    SettingsPageDocumentationLink,
+} from '../../common/Settings/SettingsPage';
 import ForbiddenPanel from '../../ForbiddenPanel';
+import CreateGroupModal from './CreateGroupModal';
 import GroupsView from './GroupsView';
+import InvitesModal from './InvitesModal';
 import classes from './UsersAndGroupsPanel.module.css';
 import UsersView from './UsersView';
 
@@ -16,6 +22,13 @@ const UsersAndGroupsPanel: FC = () => {
     const userGroupsFeatureFlagQuery = useServerFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
     );
+    const [showInviteModal, setShowInviteModal] = useState(false);
+    const [activeTab, setActiveTab] = useState<'users' | 'groups'>('users');
+    const [showCreateAndEditGroupModal, setShowCreateAndEditGroupModal] =
+        useState(false);
+    const [groupToEdit, setGroupToEdit] = useState<
+        GroupWithMembers | undefined
+    >();
 
     if (!user.data) return null;
 
@@ -29,31 +42,53 @@ const UsersAndGroupsPanel: FC = () => {
     const title = isGroupManagementEnabled
         ? 'Users & groups'
         : 'User management';
+    const canInvite = user.data.ability.can('create', 'InviteLink');
+    const canManageGroups = user.data.ability.can('manage', 'Group');
+
+    const closeGroupModal = () => {
+        setShowCreateAndEditGroupModal(false);
+        setGroupToEdit(undefined);
+    };
 
     return (
         <SettingsPage
             title={title}
             description="Manage organization members, roles, and group membership."
             actions={
-                <Tooltip label="Learn more about user roles" position="bottom">
-                    <ActionIcon
-                        component="a"
+                <SettingsPageActions>
+                    <SettingsPageDocumentationLink
                         href="https://docs.lightdash.com/references/roles"
-                        target="_blank"
-                        rel="noreferrer"
-                        variant="subtle"
-                        size="xs"
-                        color="ldGray.6"
-                        aria-label="Learn about user roles"
-                    >
-                        <MantineIcon icon={IconInfoCircle} />
-                    </ActionIcon>
-                </Tooltip>
+                        label="Roles documentation"
+                    />
+                    {activeTab === 'users' && canInvite ? (
+                        <Button
+                            size="xs"
+                            leftSection={<MantineIcon icon={IconPlus} />}
+                            onClick={() => setShowInviteModal(true)}
+                        >
+                            Add user
+                        </Button>
+                    ) : null}
+                    {activeTab === 'groups' && canManageGroups ? (
+                        <Button
+                            size="xs"
+                            leftSection={<MantineIcon icon={IconPlus} />}
+                            onClick={() => setShowCreateAndEditGroupModal(true)}
+                        >
+                            Add group
+                        </Button>
+                    ) : null}
+                </SettingsPageActions>
             }
         >
             <Tabs
                 keepMounted={false}
-                defaultValue="users"
+                value={activeTab}
+                onChange={(value) => {
+                    if (value === 'users' || value === 'groups') {
+                        setActiveTab(value);
+                    }
+                }}
                 variant="pills"
                 classNames={{
                     list: classes.tabsList,
@@ -81,9 +116,29 @@ const UsersAndGroupsPanel: FC = () => {
                     <UsersView />
                 </Tabs.Panel>
                 <Tabs.Panel value="groups">
-                    <GroupsView />
+                    <GroupsView
+                        onEditGroup={(group) => {
+                            setGroupToEdit(group);
+                            setShowCreateAndEditGroupModal(true);
+                        }}
+                    />
                 </Tabs.Panel>
             </Tabs>
+
+            <InvitesModal
+                key={`invite-modal-${showInviteModal}`}
+                opened={showInviteModal}
+                onClose={() => setShowInviteModal(false)}
+            />
+            {showCreateAndEditGroupModal ? (
+                <CreateGroupModal
+                    key={`create-group-modal-${showCreateAndEditGroupModal}`}
+                    opened={showCreateAndEditGroupModal}
+                    onClose={closeGroupModal}
+                    groupToEdit={groupToEdit}
+                    isEditing={groupToEdit !== undefined}
+                />
+            ) : null}
         </SettingsPage>
     );
 };

--- a/packages/frontend/src/components/UserSettings/VerifiedDomains/VerifiedDomainsPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/VerifiedDomains/VerifiedDomainsPanel.tsx
@@ -1,12 +1,4 @@
-import {
-    Badge,
-    Button,
-    Group,
-    Menu,
-    Stack,
-    Text,
-    Title,
-} from '@mantine-8/core';
+import { Badge, Button, Group, Menu, Stack, Text } from '@mantine-8/core';
 import {
     IconCircleCheck,
     IconMail,
@@ -24,6 +16,8 @@ import EmptyStateLoader from '../../common/EmptyStateLoader';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
 import { SettingsCard } from '../../common/Settings/SettingsCard';
+import { SettingsEmptyState } from '../../common/Settings/SettingsEmptyState';
+import { SettingsPage } from '../../common/Settings/SettingsPage';
 import AddVerifiedDomainModal from './AddVerifiedDomainModal';
 
 const VerifiedDomainsPanel: FC = () => {
@@ -33,73 +27,13 @@ const VerifiedDomainsPanel: FC = () => {
     const [addOpen, setAddOpen] = useState(false);
 
     return (
-        <SettingsCard p="lg">
-            <Stack gap="md">
-                <Group gap="sm" wrap="nowrap" align="flex-start">
-                    <MantineIcon icon={IconWorldCheck} size="lg" />
-                    <Stack gap={2}>
-                        <Title order={5}>Verified domains</Title>
-                        <Text c="dimmed" size="sm" maw={520}>
-                            Verify the domains your organization owns. Verified
-                            domains can be routed to your SSO providers.
-                        </Text>
-                    </Stack>
-                </Group>
-
-                {isInitialLoading ? (
-                    <EmptyStateLoader mih={60} />
-                ) : (
-                    <Stack gap="xs">
-                        {(verifiedDomains ?? []).length === 0 ? (
-                            <Text size="sm" c="dimmed">
-                                No verified domains yet.
-                            </Text>
-                        ) : (
-                            (verifiedDomains ?? []).map((d) => (
-                                <Group
-                                    key={d.domain}
-                                    justify="space-between"
-                                    wrap="nowrap"
-                                >
-                                    <Group gap="xs" wrap="nowrap">
-                                        <MantineIcon
-                                            icon={IconCircleCheck}
-                                            color="green"
-                                        />
-                                        <Text fw={500}>{d.domain}</Text>
-                                        <Badge
-                                            color="green"
-                                            variant="light"
-                                            size="sm"
-                                        >
-                                            Verified
-                                        </Badge>
-                                    </Group>
-                                    <Button
-                                        variant="subtle"
-                                        color="red"
-                                        size="compact-sm"
-                                        leftSection={
-                                            <MantineIcon icon={IconTrash} />
-                                        }
-                                        onClick={() =>
-                                            setDomainToDelete(d.domain)
-                                        }
-                                    >
-                                        Remove
-                                    </Button>
-                                </Group>
-                            ))
-                        )}
-                    </Stack>
-                )}
-
-                <Menu position="bottom-start" withinPortal>
+        <SettingsPage
+            title="Verified domains"
+            description="Verify domains your organization owns and route them to your SSO providers."
+            actions={
+                <Menu position="bottom-end" withinPortal>
                     <Menu.Target>
-                        <Button
-                            w="fit-content"
-                            leftSection={<MantineIcon icon={IconPlus} />}
-                        >
+                        <Button leftSection={<MantineIcon icon={IconPlus} />}>
                             Add domain
                         </Button>
                     </Menu.Target>
@@ -124,7 +58,57 @@ const VerifiedDomainsPanel: FC = () => {
                         </Menu.Item>
                     </Menu.Dropdown>
                 </Menu>
-            </Stack>
+            }
+        >
+            {isInitialLoading ? (
+                <SettingsCard>
+                    <EmptyStateLoader mih={60} />
+                </SettingsCard>
+            ) : (verifiedDomains ?? []).length === 0 ? (
+                <SettingsEmptyState
+                    icon={IconWorldCheck}
+                    title="No verified domains"
+                    description="Add a domain before routing sign-in to an SSO provider."
+                />
+            ) : (
+                <SettingsCard>
+                    <Stack gap="xs">
+                        {(verifiedDomains ?? []).map((d) => (
+                            <Group
+                                key={d.domain}
+                                justify="space-between"
+                                wrap="nowrap"
+                            >
+                                <Group gap="xs" wrap="nowrap">
+                                    <MantineIcon
+                                        icon={IconCircleCheck}
+                                        color="green"
+                                    />
+                                    <Text fw={500}>{d.domain}</Text>
+                                    <Badge
+                                        color="green"
+                                        variant="light"
+                                        size="sm"
+                                    >
+                                        Verified
+                                    </Badge>
+                                </Group>
+                                <Button
+                                    variant="subtle"
+                                    color="red"
+                                    size="compact-sm"
+                                    leftSection={
+                                        <MantineIcon icon={IconTrash} />
+                                    }
+                                    onClick={() => setDomainToDelete(d.domain)}
+                                >
+                                    Remove
+                                </Button>
+                            </Group>
+                        ))}
+                    </Stack>
+                </SettingsCard>
+            )}
 
             {addOpen && (
                 <AddVerifiedDomainModal
@@ -160,7 +144,7 @@ const VerifiedDomainsPanel: FC = () => {
                     </Text>
                 </MantineModal>
             )}
-        </SettingsCard>
+        </SettingsPage>
     );
 };
 

--- a/packages/frontend/src/components/UserSettings/VerifiedDomains/VerifiedDomainsPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/VerifiedDomains/VerifiedDomainsPanel.tsx
@@ -33,7 +33,10 @@ const VerifiedDomainsPanel: FC = () => {
             actions={
                 <Menu position="bottom-end" withinPortal>
                     <Menu.Target>
-                        <Button leftSection={<MantineIcon icon={IconPlus} />}>
+                        <Button
+                            size="xs"
+                            leftSection={<MantineIcon icon={IconPlus} />}
+                        >
                             Add domain
                         </Button>
                     </Menu.Target>

--- a/packages/frontend/src/components/VerifiedContent/VerifiedContentPanel.tsx
+++ b/packages/frontend/src/components/VerifiedContent/VerifiedContentPanel.tsx
@@ -4,12 +4,9 @@ import {
     Anchor,
     Badge,
     Button,
-    Group,
     Menu,
-    Paper,
     Stack,
     Text,
-    Title,
     useMantineTheme,
 } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
@@ -33,7 +30,7 @@ import {
 } from '../common/ContentTable';
 import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
-import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
+import { SettingsEmptyState } from '../common/Settings/SettingsEmptyState';
 
 type Props = {
     projectUuid: string;
@@ -281,21 +278,16 @@ const VerifiedContentPanel: FC<Props> = ({ projectUuid }) => {
 
     if (!isLoading && items.length === 0) {
         return (
-            <Paper p="xl">
-                <SuboptimalState
-                    icon={IconCircleX}
-                    title="No verified content"
-                    description="Charts and dashboards that are verified will appear here."
-                />
-            </Paper>
+            <SettingsEmptyState
+                icon={IconCircleX}
+                title="No verified content"
+                description="Charts and dashboards that are verified will appear here."
+            />
         );
     }
 
     return (
         <Stack gap="md">
-            <Group justify="space-between">
-                <Title order={4}>Verified content</Title>
-            </Group>
             <ContentTable table={table} />
 
             <MantineModal

--- a/packages/frontend/src/components/common/Settings/SettingsCard.module.css
+++ b/packages/frontend/src/components/common/Settings/SettingsCard.module.css
@@ -1,3 +1,21 @@
+.settingsGrid {
+    display: grid;
+    grid-template-columns: minmax(180px, 240px) minmax(0, 1fr);
+    gap: var(--mantine-spacing-xl);
+    align-items: start;
+}
+
+.settingsGrid > :only-child {
+    grid-column: 1 / -1;
+}
+
+@media (max-width: 60em) {
+    .settingsGrid {
+        grid-template-columns: minmax(0, 1fr);
+        gap: var(--mantine-spacing-md);
+    }
+}
+
 .projectCreationCard {
     position: relative;
     display: flex;

--- a/packages/frontend/src/components/common/Settings/SettingsCard.tsx
+++ b/packages/frontend/src/components/common/Settings/SettingsCard.tsx
@@ -1,30 +1,30 @@
-import { Paper, SimpleGrid, type PaperProps } from '@mantine-8/core';
-import { type FC } from 'react';
+import { Paper, type PaperProps } from '@mantine-8/core';
+import { type FC, type PropsWithChildren } from 'react';
 import classes from './SettingsCard.module.css';
 
-const SettingsCard: FC<React.PropsWithChildren<PaperProps>> = ({
+const SettingsCard: FC<PropsWithChildren<PaperProps>> = ({
     children,
     ...rest
 }) => {
     return (
-        <Paper shadow="subtle" withBorder p="md" radius="md" {...rest}>
+        <Paper shadow="subtle" withBorder p="lg" radius="md" {...rest}>
             {children}
         </Paper>
     );
 };
 
-const SettingsGridCard: FC<React.PropsWithChildren<PaperProps>> = ({
+const SettingsGridCard: FC<PropsWithChildren<PaperProps>> = ({
     children,
     ...rest
 }) => {
     return (
         <SettingsCard {...rest}>
-            <SimpleGrid cols={2}>{children}</SimpleGrid>
+            <div className={classes.settingsGrid}>{children}</div>
         </SettingsCard>
     );
 };
 
-const ProjectCreationCard: FC<React.PropsWithChildren<PaperProps>> = ({
+const ProjectCreationCard: FC<PropsWithChildren<PaperProps>> = ({
     children,
 }) => {
     return (

--- a/packages/frontend/src/components/common/Settings/SettingsEmptyState.test.tsx
+++ b/packages/frontend/src/components/common/Settings/SettingsEmptyState.test.tsx
@@ -1,0 +1,30 @@
+import { Button } from '@mantine-8/core';
+import { IconKey } from '@tabler/icons-react';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { SettingsEmptyState } from './SettingsEmptyState';
+
+describe('SettingsEmptyState', () => {
+    it('renders a compact section heading, description, and action', () => {
+        renderWithProviders(
+            <SettingsEmptyState
+                icon={IconKey}
+                title="No tokens"
+                description="Create a token to access the API."
+            >
+                <Button>Create token</Button>
+            </SettingsEmptyState>,
+        );
+
+        expect(
+            screen.getByRole('heading', { level: 5, name: 'No tokens' }),
+        ).toBeVisible();
+        expect(
+            screen.getByText('Create a token to access the API.'),
+        ).toBeVisible();
+        expect(
+            screen.getByRole('button', { name: 'Create token' }),
+        ).toBeVisible();
+    });
+});

--- a/packages/frontend/src/components/common/Settings/SettingsEmptyState.tsx
+++ b/packages/frontend/src/components/common/Settings/SettingsEmptyState.tsx
@@ -1,0 +1,40 @@
+import { Stack, Text, Title } from '@mantine-8/core';
+import { type Icon as TablerIconType } from '@tabler/icons-react';
+import { type FC, type PropsWithChildren, type ReactNode } from 'react';
+import MantineIcon from '../MantineIcon';
+import { SettingsCard } from './SettingsCard';
+
+type SettingsEmptyStateProps = {
+    icon: TablerIconType;
+    title: ReactNode;
+    description: ReactNode;
+};
+
+const SettingsEmptyState: FC<PropsWithChildren<SettingsEmptyStateProps>> = ({
+    icon,
+    title,
+    description,
+    children,
+}) => (
+    <SettingsCard w="100%" maw="var(--page-content-width)" mx="auto">
+        <Stack align="center" justify="center" gap="lg" py="3xl" px="lg">
+            <MantineIcon
+                icon={icon}
+                color="ldGray.5"
+                stroke={1.25}
+                size="3xl"
+            />
+            <Stack align="center" gap={4} maw={480}>
+                <Title order={5} ta="center">
+                    {title}
+                </Title>
+                <Text fz="sm" c="ldGray.6" ta="center">
+                    {description}
+                </Text>
+            </Stack>
+            {children}
+        </Stack>
+    </SettingsCard>
+);
+
+export { SettingsEmptyState };

--- a/packages/frontend/src/components/common/Settings/SettingsPage.module.css
+++ b/packages/frontend/src/components/common/Settings/SettingsPage.module.css
@@ -1,0 +1,46 @@
+.page {
+    width: 100%;
+    min-width: 0;
+    padding-bottom: var(--mantine-spacing-lg);
+}
+
+.header {
+    width: 100%;
+    max-width: var(--page-content-width);
+    margin-inline: auto;
+    min-width: 0;
+}
+
+.heading {
+    min-width: 0;
+    max-width: 720px;
+}
+
+.title {
+    line-height: 1.3;
+    text-wrap: balance;
+}
+
+.description {
+    line-height: 1.5;
+    text-wrap: pretty;
+}
+
+.actions {
+    flex-shrink: 0;
+}
+
+.content {
+    min-width: 0;
+}
+
+@media (max-width: 48em) {
+    .header {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .actions {
+        align-self: flex-start;
+    }
+}

--- a/packages/frontend/src/components/common/Settings/SettingsPage.module.css
+++ b/packages/frontend/src/components/common/Settings/SettingsPage.module.css
@@ -4,10 +4,13 @@
     padding-bottom: var(--mantine-spacing-lg);
 }
 
-.header {
+.container {
     width: 100%;
     max-width: var(--page-content-width);
     margin-inline: auto;
+}
+
+.header {
     min-width: 0;
 }
 

--- a/packages/frontend/src/components/common/Settings/SettingsPage.test.tsx
+++ b/packages/frontend/src/components/common/Settings/SettingsPage.test.tsx
@@ -2,7 +2,11 @@ import { Button } from '@mantine-8/core';
 import { screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
-import { SettingsPage } from './SettingsPage';
+import {
+    SettingsPage,
+    SettingsPageActions,
+    SettingsPageDocumentationLink,
+} from './SettingsPage';
 
 describe('SettingsPage', () => {
     it('renders a consistent page heading, description, actions, and content', () => {
@@ -38,5 +42,29 @@ describe('SettingsPage', () => {
             screen.getByRole('heading', { level: 4, name: 'Profile' }),
         ).toBeVisible();
         expect(screen.getByText('Profile content')).toBeVisible();
+    });
+
+    it('renders grouped page actions and external documentation links', () => {
+        renderWithProviders(
+            <SettingsPage
+                title="Users"
+                actions={
+                    <SettingsPageActions>
+                        <SettingsPageDocumentationLink href="https://docs.example.com/users" />
+                        <Button>Add user</Button>
+                    </SettingsPageActions>
+                }
+            >
+                <div>Users content</div>
+            </SettingsPage>,
+        );
+
+        expect(
+            screen.getByRole('link', { name: 'Documentation' }),
+        ).toHaveAttribute('href', 'https://docs.example.com/users');
+        expect(
+            screen.getByRole('link', { name: 'Documentation' }),
+        ).toHaveAttribute('target', '_blank');
+        expect(screen.getByRole('button', { name: 'Add user' })).toBeVisible();
     });
 });

--- a/packages/frontend/src/components/common/Settings/SettingsPage.test.tsx
+++ b/packages/frontend/src/components/common/Settings/SettingsPage.test.tsx
@@ -1,0 +1,42 @@
+import { Button } from '@mantine-8/core';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { SettingsPage } from './SettingsPage';
+
+describe('SettingsPage', () => {
+    it('renders a consistent page heading, description, actions, and content', () => {
+        renderWithProviders(
+            <SettingsPage
+                title="User management"
+                description="Manage members and groups."
+                actions={<Button>Add user</Button>}
+            >
+                <div>Settings content</div>
+            </SettingsPage>,
+        );
+
+        expect(
+            screen.getByRole('heading', {
+                level: 4,
+                name: 'User management',
+            }),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Manage members and groups.')).toBeVisible();
+        expect(screen.getByRole('button', { name: 'Add user' })).toBeVisible();
+        expect(screen.getByText('Settings content')).toBeVisible();
+    });
+
+    it('does not require a description or actions', () => {
+        renderWithProviders(
+            <SettingsPage title="Profile">
+                <div>Profile content</div>
+            </SettingsPage>,
+        );
+
+        expect(
+            screen.getByRole('heading', { level: 4, name: 'Profile' }),
+        ).toBeVisible();
+        expect(screen.getByText('Profile content')).toBeVisible();
+    });
+});

--- a/packages/frontend/src/components/common/Settings/SettingsPage.tsx
+++ b/packages/frontend/src/components/common/Settings/SettingsPage.tsx
@@ -1,5 +1,7 @@
-import { Box, Group, Stack, Text, Title } from '@mantine-8/core';
+import { Box, Button, Group, Stack, Text, Title } from '@mantine-8/core';
+import { IconExternalLink } from '@tabler/icons-react';
 import { type FC, type PropsWithChildren, type ReactNode } from 'react';
+import MantineIcon from '../MantineIcon';
 import classes from './SettingsPage.module.css';
 
 type SettingsPageProps = {
@@ -10,6 +12,29 @@ type SettingsPageProps = {
 
 const SettingsPageContainer: FC<PropsWithChildren> = ({ children }) => (
     <Box className={classes.container}>{children}</Box>
+);
+
+const SettingsPageActions: FC<PropsWithChildren> = ({ children }) => (
+    <Group gap="xs" wrap="nowrap">
+        {children}
+    </Group>
+);
+
+const SettingsPageDocumentationLink: FC<{
+    href: string;
+    label?: string;
+}> = ({ href, label = 'Documentation' }) => (
+    <Button
+        component="a"
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        variant="default"
+        size="xs"
+        rightSection={<MantineIcon icon={IconExternalLink} size="sm" />}
+    >
+        {label}
+    </Button>
 );
 
 const SettingsPage: FC<PropsWithChildren<SettingsPageProps>> = ({
@@ -53,4 +78,9 @@ const SettingsPage: FC<PropsWithChildren<SettingsPageProps>> = ({
     </Stack>
 );
 
-export { SettingsPage, SettingsPageContainer };
+export {
+    SettingsPage,
+    SettingsPageActions,
+    SettingsPageContainer,
+    SettingsPageDocumentationLink,
+};

--- a/packages/frontend/src/components/common/Settings/SettingsPage.tsx
+++ b/packages/frontend/src/components/common/Settings/SettingsPage.tsx
@@ -8,6 +8,10 @@ type SettingsPageProps = {
     actions?: ReactNode;
 };
 
+const SettingsPageContainer: FC<PropsWithChildren> = ({ children }) => (
+    <Box className={classes.container}>{children}</Box>
+);
+
 const SettingsPage: FC<PropsWithChildren<SettingsPageProps>> = ({
     title,
     description,
@@ -15,25 +19,33 @@ const SettingsPage: FC<PropsWithChildren<SettingsPageProps>> = ({
     children,
 }) => (
     <Stack gap="lg" className={classes.page}>
-        <Group
-            justify="space-between"
-            align="flex-start"
-            wrap="nowrap"
-            gap="lg"
-            className={classes.header}
-        >
-            <Stack gap={4} className={classes.heading}>
-                <Title order={4} className={classes.title}>
-                    {title}
-                </Title>
-                {description ? (
-                    <Text fz="sm" c="ldGray.6" className={classes.description}>
-                        {description}
-                    </Text>
+        <SettingsPageContainer>
+            <Group
+                justify="space-between"
+                align="flex-start"
+                wrap="nowrap"
+                gap="lg"
+                className={classes.header}
+            >
+                <Stack gap={4} className={classes.heading}>
+                    <Title order={4} className={classes.title}>
+                        {title}
+                    </Title>
+                    {description ? (
+                        <Text
+                            fz="sm"
+                            c="ldGray.6"
+                            className={classes.description}
+                        >
+                            {description}
+                        </Text>
+                    ) : null}
+                </Stack>
+                {actions ? (
+                    <Box className={classes.actions}>{actions}</Box>
                 ) : null}
-            </Stack>
-            {actions ? <Box className={classes.actions}>{actions}</Box> : null}
-        </Group>
+            </Group>
+        </SettingsPageContainer>
 
         <Stack gap="lg" className={classes.content}>
             {children}
@@ -41,4 +53,4 @@ const SettingsPage: FC<PropsWithChildren<SettingsPageProps>> = ({
     </Stack>
 );
 
-export { SettingsPage };
+export { SettingsPage, SettingsPageContainer };

--- a/packages/frontend/src/components/common/Settings/SettingsPage.tsx
+++ b/packages/frontend/src/components/common/Settings/SettingsPage.tsx
@@ -1,0 +1,44 @@
+import { Box, Group, Stack, Text, Title } from '@mantine-8/core';
+import { type FC, type PropsWithChildren, type ReactNode } from 'react';
+import classes from './SettingsPage.module.css';
+
+type SettingsPageProps = {
+    title: string;
+    description?: ReactNode;
+    actions?: ReactNode;
+};
+
+const SettingsPage: FC<PropsWithChildren<SettingsPageProps>> = ({
+    title,
+    description,
+    actions,
+    children,
+}) => (
+    <Stack gap="lg" className={classes.page}>
+        <Group
+            justify="space-between"
+            align="flex-start"
+            wrap="nowrap"
+            gap="lg"
+            className={classes.header}
+        >
+            <Stack gap={4} className={classes.heading}>
+                <Title order={4} className={classes.title}>
+                    {title}
+                </Title>
+                {description ? (
+                    <Text fz="sm" c="ldGray.6" className={classes.description}>
+                        {description}
+                    </Text>
+                ) : null}
+            </Stack>
+            {actions ? <Box className={classes.actions}>{actions}</Box> : null}
+        </Group>
+
+        <Stack gap="lg" className={classes.content}>
+            {children}
+        </Stack>
+    </Stack>
+);
+
+export { SettingsPage };

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiAgentsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiAgentsSettingsPage.tsx
@@ -20,6 +20,7 @@ export const AiAgentsSettingsPage = () => {
                     leftIcon={IconRobotFace}
                     variant="default"
                     radius="md"
+                    size="xs"
                 >
                     New Agent
                 </LinkButton>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiAgentsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiAgentsSettingsPage.tsx
@@ -1,7 +1,6 @@
-import { Group, Stack } from '@mantine-8/core';
 import { IconRobotFace } from '@tabler/icons-react';
 import LinkButton from '../../../../../../components/common/LinkButton';
-import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
+import { SettingsPage } from '../../../../../../components/common/Settings/SettingsPage';
 import { useActiveProjectUuid } from '../../../../../../hooks/useActiveProject';
 import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSettings';
 import AiAgentAdminAgentsTable from '../AiAgentAdminAgentsTable';
@@ -12,14 +11,10 @@ export const AiAgentsSettingsPage = () => {
     const { data: settings } = useAiOrganizationSettings();
 
     return (
-        <Stack mb="lg" gap="md">
-            <Group justify="space-between" align="flex-start">
-                <PageBreadcrumbs
-                    items={[
-                        { title: 'Ask AI', to: '/generalSettings/ai/general' },
-                        { title: 'Agents', active: true },
-                    ]}
-                />
+        <SettingsPage
+            title="Agents"
+            description="Manage the AI agents available across your organization."
+            actions={
                 <LinkButton
                     href={`/projects/${activeProjectUuid}/ai-agents/new`}
                     leftIcon={IconRobotFace}
@@ -28,11 +23,11 @@ export const AiAgentsSettingsPage = () => {
                 >
                     New Agent
                 </LinkButton>
-            </Group>
-
+            }
+        >
             {settings?.aiAgentsVisible === false && <AiFeaturesDisabledAlert />}
 
             <AiAgentAdminAgentsTable />
-        </Stack>
+        </SettingsPage>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -17,8 +17,8 @@ import { Link } from 'react-router';
 import { BetaBadge } from '../../../../../../components/common/BetaBadge';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import { getModelKey } from '../../../../../../components/common/ModelSelector/utils';
-import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
 import { SettingsCard } from '../../../../../../components/common/Settings/SettingsCard';
+import { SettingsPage } from '../../../../../../components/common/Settings/SettingsPage';
 import { useServerFeatureFlag } from '../../../../../../hooks/useServerOrClientFeatureFlag';
 import {
     getAiAgentModelConfig,
@@ -71,14 +71,10 @@ export const AiGeneralSettingsPage = () => {
     });
 
     return (
-        <Stack mb="lg" gap="md">
-            <PageBreadcrumbs
-                items={[
-                    { title: 'Ask AI', to: '/generalSettings/ai/general' },
-                    { title: 'General', active: true },
-                ]}
-            />
-
+        <SettingsPage
+            title="Ask AI"
+            description="Configure organization-wide AI features, providers, and defaults."
+        >
             {isSettingsLoading || !settings ? (
                 <Group justify="center" mt="xl">
                     <Loader size="sm" />
@@ -409,6 +405,6 @@ export const AiGeneralSettingsPage = () => {
                     </SettingsCard>
                 </>
             )}
-        </Stack>
+        </SettingsPage>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Group, SegmentedControl, Stack, Text } from '@mantine-8/core';
+import { Button, Group, SegmentedControl, Stack } from '@mantine-8/core';
 import { useLocalStorage } from '@mantine-8/hooks';
 import {
     IconLayoutKanban,
@@ -10,7 +10,7 @@ import { useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 import { GuidedTour } from '../../../../../../components/common/GuidedTour';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
-import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
+import { SettingsPage } from '../../../../../../components/common/Settings/SettingsPage';
 import { useGuidedTour } from '../../../../../../hooks/useGuidedTour';
 import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSettings';
 import { openCreateIssue } from '../../../store/createIssueSlice';
@@ -126,97 +126,91 @@ export const AiReviewsSettingsPage = () => {
 
     return (
         <Stack mb="lg" gap="md">
-            <Stack gap={4} data-tour="reviews-intro">
-                <Group justify="space-between" align="flex-start">
-                    <PageBreadcrumbs
-                        items={[
-                            {
-                                title: 'Ask AI',
-                                to: '/generalSettings/ai/general',
-                            },
-                            { title: 'Issues', active: true },
-                        ]}
-                    />
-                    <Group gap="xs">
-                        <Button
-                            size="compact-xs"
-                            leftSection={<MantineIcon icon={IconPlus} />}
-                            onClick={() => dispatch(openCreateIssue(null))}
-                        >
-                            New issue
-                        </Button>
-                        <SegmentedControl
-                            size="xs"
-                            value={effectiveView}
-                            onChange={(value) =>
-                                setView(value as 'board' | 'table')
+            <div data-tour="reviews-intro">
+                <SettingsPage
+                    title="Issues"
+                    description={
+                        <>
+                            An actionable queue of data issues from AI findings
+                            and human asks. Semantic layer fixes open a dbt pull
+                            request; project context fixes add guidance your
+                            agents read before answering.
+                        </>
+                    }
+                    actions={
+                        <Group gap="xs">
+                            <Button
+                                size="compact-xs"
+                                leftSection={<MantineIcon icon={IconPlus} />}
+                                onClick={() => dispatch(openCreateIssue(null))}
+                            >
+                                New issue
+                            </Button>
+                            <SegmentedControl
+                                size="xs"
+                                value={effectiveView}
+                                onChange={(value) =>
+                                    setView(value as 'board' | 'table')
+                                }
+                                data={[
+                                    {
+                                        value: 'board',
+                                        label: (
+                                            <Group gap={6} wrap="nowrap">
+                                                <MantineIcon
+                                                    icon={IconLayoutKanban}
+                                                />
+                                                Board
+                                            </Group>
+                                        ),
+                                    },
+                                    {
+                                        value: 'table',
+                                        label: (
+                                            <Group gap={6} wrap="nowrap">
+                                                <MantineIcon icon={IconTable} />
+                                                Table
+                                            </Group>
+                                        ),
+                                    },
+                                ]}
+                            />
+                            <Button
+                                variant="subtle"
+                                color="gray"
+                                size="compact-xs"
+                                leftSection={<MantineIcon icon={IconRoute} />}
+                                onClick={startTour}
+                            >
+                                Take the tour
+                            </Button>
+                        </Group>
+                    }
+                >
+                    {settings?.aiAgentsVisible === false && (
+                        <AiFeaturesDisabledAlert />
+                    )}
+
+                    {effectiveView === 'board' ? (
+                        <ReviewKanbanBoard
+                            selectedReviewItemUuid={
+                                selectedReviewItem?.reviewItemUuid
                             }
-                            data={[
-                                {
-                                    value: 'board',
-                                    label: (
-                                        <Group gap={6} wrap="nowrap">
-                                            <MantineIcon
-                                                icon={IconLayoutKanban}
-                                            />
-                                            Board
-                                        </Group>
-                                    ),
-                                },
-                                {
-                                    value: 'table',
-                                    label: (
-                                        <Group gap={6} wrap="nowrap">
-                                            <MantineIcon icon={IconTable} />
-                                            Table
-                                        </Group>
-                                    ),
-                                },
-                            ]}
+                            onReviewItemSelect={handleReviewItemSelect}
+                            showOnboardingExamples={isTourOpen}
+                            initialProjectUuids={initialProjectUuids}
                         />
-                        <Button
-                            variant="subtle"
-                            color="gray"
-                            size="compact-xs"
-                            leftSection={<MantineIcon icon={IconRoute} />}
-                            onClick={startTour}
-                        >
-                            Take the tour
-                        </Button>
-                    </Group>
-                </Group>
-
-                <Text c="dimmed" fz="sm" maw={760}>
-                    An actionable queue of data issues from AI findings and
-                    human asks. Open an issue to inspect the thread, metadata,
-                    and suggested fix.{' '}
-                    <Text span fw={600} fz="inherit">
-                        Semantic layer
-                    </Text>{' '}
-                    fixes open a dbt PR.{' '}
-                    <Text span fw={600} fz="inherit">
-                        Project context
-                    </Text>{' '}
-                    fixes add a note your agents read before answering.
-                </Text>
-            </Stack>
-
-            {settings?.aiAgentsVisible === false && <AiFeaturesDisabledAlert />}
-
-            {effectiveView === 'board' ? (
-                <ReviewKanbanBoard
-                    selectedReviewItemUuid={selectedReviewItem?.reviewItemUuid}
-                    onReviewItemSelect={handleReviewItemSelect}
-                    showOnboardingExamples={isTourOpen}
-                    initialProjectUuids={initialProjectUuids}
-                />
-            ) : (
-                <AiAgentAdminReviewItemsTable
-                    selectedReviewItemUuid={selectedReviewItem?.reviewItemUuid}
-                    onReviewItemSelect={handleReviewItemSelect}
-                    initialProjectUuids={initialProjectUuids}
-                />
-            )}
+                    ) : (
+                        <AiAgentAdminReviewItemsTable
+                            selectedReviewItemUuid={
+                                selectedReviewItem?.reviewItemUuid
+                            }
+                            onReviewItemSelect={handleReviewItemSelect}
+                            initialProjectUuids={initialProjectUuids}
+                        />
+                    )}
+                </SettingsPage>
+            </div>
 
             <GuidedTour
                 steps={REVIEWS_TOUR_STEPS}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -10,7 +10,10 @@ import { useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 import { GuidedTour } from '../../../../../../components/common/GuidedTour';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
-import { SettingsPage } from '../../../../../../components/common/Settings/SettingsPage';
+import {
+    SettingsPage,
+    SettingsPageActions,
+} from '../../../../../../components/common/Settings/SettingsPage';
 import { useGuidedTour } from '../../../../../../hooks/useGuidedTour';
 import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSettings';
 import { openCreateIssue } from '../../../store/createIssueSlice';
@@ -138,9 +141,9 @@ export const AiReviewsSettingsPage = () => {
                         </>
                     }
                     actions={
-                        <Group gap="xs">
+                        <SettingsPageActions>
                             <Button
-                                size="compact-xs"
+                                size="xs"
                                 leftSection={<MantineIcon icon={IconPlus} />}
                                 onClick={() => dispatch(openCreateIssue(null))}
                             >
@@ -178,13 +181,13 @@ export const AiReviewsSettingsPage = () => {
                             <Button
                                 variant="subtle"
                                 color="gray"
-                                size="compact-xs"
+                                size="xs"
                                 leftSection={<MantineIcon icon={IconRoute} />}
                                 onClick={startTour}
                             >
                                 Take the tour
                             </Button>
-                        </Group>
+                        </SettingsPageActions>
                     }
                 >
                     {settings?.aiAgentsVisible === false && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiThreadsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiThreadsSettingsPage.tsx
@@ -1,5 +1,5 @@
 import { type AiAgentAdminThreadSummary } from '@lightdash/common';
-import { Button, Drawer, Group } from '@mantine-8/core';
+import { Button, Drawer } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
 import { IconChartDots, IconMessageCircleShare } from '@tabler/icons-react';
 import { useState } from 'react';
@@ -7,7 +7,10 @@ import LinkButton from '../../../../../../components/common/LinkButton';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../../components/common/MantineModal';
 import { NAVBAR_HEIGHT } from '../../../../../../components/common/Page/constants';
-import { SettingsPage } from '../../../../../../components/common/Settings/SettingsPage';
+import {
+    SettingsPage,
+    SettingsPageActions,
+} from '../../../../../../components/common/Settings/SettingsPage';
 import useHealth from '../../../../../../hooks/health/useHealth';
 import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSettings';
 import AiAgentAdminThreadsTable from '../AiAgentAdminThreadsTable';
@@ -47,7 +50,7 @@ export const AiThreadsSettingsPage = () => {
             title="Threads"
             description="Review AI conversations across your organization."
             actions={
-                <Group gap="xs">
+                <SettingsPageActions>
                     {isAnalyticsEmbedEnabled && (
                         <Button
                             onClick={toggleAnalyticsEmbed}
@@ -63,10 +66,11 @@ export const AiThreadsSettingsPage = () => {
                         leftIcon={IconMessageCircleShare}
                         variant="default"
                         radius="md"
+                        size="xs"
                     >
                         New Thread
                     </LinkButton>
-                </Group>
+                </SettingsPageActions>
             }
         >
             {settings?.aiAgentsVisible === false && <AiFeaturesDisabledAlert />}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiThreadsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiThreadsSettingsPage.tsx
@@ -1,5 +1,5 @@
 import { type AiAgentAdminThreadSummary } from '@lightdash/common';
-import { Button, Drawer, Group, Stack } from '@mantine-8/core';
+import { Button, Drawer, Group } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
 import { IconChartDots, IconMessageCircleShare } from '@tabler/icons-react';
 import { useState } from 'react';
@@ -7,7 +7,7 @@ import LinkButton from '../../../../../../components/common/LinkButton';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../../components/common/MantineModal';
 import { NAVBAR_HEIGHT } from '../../../../../../components/common/Page/constants';
-import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
+import { SettingsPage } from '../../../../../../components/common/Settings/SettingsPage';
 import useHealth from '../../../../../../hooks/health/useHealth';
 import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSettings';
 import AiAgentAdminThreadsTable from '../AiAgentAdminThreadsTable';
@@ -43,14 +43,10 @@ export const AiThreadsSettingsPage = () => {
         health?.ai.analyticsProjectUuid && health?.ai.analyticsDashboardUuid;
 
     return (
-        <Stack mb="lg" gap="md">
-            <Group justify="space-between" align="flex-start">
-                <PageBreadcrumbs
-                    items={[
-                        { title: 'Ask AI', to: '/generalSettings/ai/general' },
-                        { title: 'Threads', active: true },
-                    ]}
-                />
+        <SettingsPage
+            title="Threads"
+            description="Review AI conversations across your organization."
+            actions={
                 <Group gap="xs">
                     {isAnalyticsEmbedEnabled && (
                         <Button
@@ -71,8 +67,8 @@ export const AiThreadsSettingsPage = () => {
                         New Thread
                     </LinkButton>
                 </Group>
-            </Group>
-
+            }
+        >
             {settings?.aiAgentsVisible === false && <AiFeaturesDisabledAlert />}
 
             <AiAgentAdminThreadsTable
@@ -117,6 +113,6 @@ export const AiThreadsSettingsPage = () => {
             >
                 <AnalyticsEmbedDashboard />
             </MantineModal>
-        </Stack>
+        </SettingsPage>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/McpActivitySettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/McpActivitySettingsPage.tsx
@@ -2,10 +2,10 @@ import {
     type McpActivityItem,
     type McpActivityStatsFilters,
 } from '@lightdash/common';
-import { Box, Drawer, Group, Stack, Text } from '@mantine-8/core';
+import { Box, Drawer, Text } from '@mantine-8/core';
 import { useMemo, useState } from 'react';
 import { NAVBAR_HEIGHT } from '../../../../../../components/common/Page/constants';
-import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
+import { SettingsPage } from '../../../../../../components/common/Settings/SettingsPage';
 import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSettings';
 import { useMcpActivityStats } from '../../../hooks/useMcpActivity';
 import { useMcpActivityFilters } from '../../../hooks/useMcpActivityFilters';
@@ -53,19 +53,15 @@ export const McpActivitySettingsPage = () => {
     } = useMcpActivityStats(statsFilters);
 
     return (
-        <Stack mb="lg" gap="md">
-            <Group justify="space-between" align="flex-start">
-                <PageBreadcrumbs
-                    items={[
-                        { title: 'Ask AI', to: '/generalSettings/ai/general' },
-                        { title: 'MCP', active: true },
-                    ]}
-                />
+        <SettingsPage
+            title="MCP activity"
+            description="Monitor MCP tool calls and investigate errors across your organization."
+            actions={
                 <Text fz="xs" c="ldGray.6">
-                    Showing the last 90 days of MCP tool calls
+                    Last 90 days
                 </Text>
-            </Group>
-
+            }
+        >
             {settings?.aiAgentsVisible === false && <AiFeaturesDisabledAlert />}
 
             <Box className={overviewClasses.layout}>
@@ -117,6 +113,6 @@ export const McpActivitySettingsPage = () => {
             >
                 {selectedCall && <McpActivityDetail toolCall={selectedCall} />}
             </Drawer>
-        </Stack>
+        </SettingsPage>
     );
 };

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
@@ -1,19 +1,10 @@
-import {
-    TextInput,
-    Group,
-    Stack,
-    Text,
-    Title,
-    Button,
-    Anchor,
-} from '@mantine-8/core';
+import { TextInput, Stack, Text, Title, Button, Anchor } from '@mantine-8/core';
 import { useClipboard } from '@mantine-8/hooks';
-import { IconCopy } from '@tabler/icons-react';
+import { IconCopy, IconKey } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
-import {
-    SettingsCard,
-    SettingsGridCard,
-} from '../../../../../components/common/Settings/SettingsCard';
+import { SettingsGridCard } from '../../../../../components/common/Settings/SettingsCard';
+import { SettingsEmptyState } from '../../../../../components/common/Settings/SettingsEmptyState';
+import { SettingsPage } from '../../../../../components/common/Settings/SettingsPage';
 import useToaster from '../../../../../hooks/toaster/useToaster';
 import useApp from '../../../../../providers/App/useApp';
 import { useScimTokenList } from '../../hooks/useScimAccessToken';
@@ -36,17 +27,18 @@ const ScimAccessTokensPanel: FC = () => {
     }, [scimURL, clipboard, showToastSuccess]);
 
     return (
-        <Stack mb="lg">
-            <Group justify="space-between">
-                <Title order={5}>SCIM access tokens</Title>
+        <SettingsPage
+            title="SCIM access tokens"
+            description="Connect your identity provider and manage tokens used for user provisioning."
+            actions={
                 <Button onClick={() => setIsCreatingToken(true)}>
                     Generate new token
                 </Button>
-            </Group>
-
+            }
+        >
             <SettingsGridCard>
                 <Stack gap="sm">
-                    <Title order={4}>SCIM URL</Title>
+                    <Title order={5}>SCIM URL</Title>
                     <Text c="dimmed">
                         Use the URL to connect your identity provider to
                         Lightdash via SCIM.
@@ -80,9 +72,11 @@ const ScimAccessTokensPanel: FC = () => {
             {hasAvailableTokens ? (
                 <TokensTable />
             ) : (
-                <SettingsCard shadow="none">
-                    You haven't generated any tokens yet.
-                </SettingsCard>
+                <SettingsEmptyState
+                    icon={IconKey}
+                    title="No SCIM tokens"
+                    description="Generate a token to connect your identity provider."
+                />
             )}
 
             {isCreatingToken && (
@@ -90,7 +84,7 @@ const ScimAccessTokensPanel: FC = () => {
                     onBackClick={() => setIsCreatingToken(false)}
                 />
             )}
-        </Stack>
+        </SettingsPage>
     );
 };
 

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/index.tsx
@@ -31,7 +31,7 @@ const ScimAccessTokensPanel: FC = () => {
             title="SCIM access tokens"
             description="Connect your identity provider and manage tokens used for user provisioning."
             actions={
-                <Button onClick={() => setIsCreatingToken(true)}>
+                <Button size="xs" onClick={() => setIsCreatingToken(true)}>
                     Generate new token
                 </Button>
             }

--- a/packages/frontend/src/ee/features/serviceAccounts/index.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/index.tsx
@@ -1,7 +1,8 @@
 import { Button } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
-import { IconUsersGroup } from '@tabler/icons-react';
+import { IconPlus, IconUsersGroup } from '@tabler/icons-react';
 import { useState } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
 import { SettingsEmptyState } from '../../../components/common/Settings/SettingsEmptyState';
 import { SettingsPage } from '../../../components/common/Settings/SettingsPage';
 import { ServiceAccountsCreateModal } from './ServiceAccountsCreateModal';
@@ -38,9 +39,13 @@ export function ServiceAccountsPage() {
             title="Service accounts"
             description="Manage non-human accounts used for automated access to Lightdash."
             actions={
-                hasAccounts ? (
-                    <Button onClick={open}>Add service account</Button>
-                ) : null
+                <Button
+                    size="xs"
+                    leftSection={<MantineIcon icon={IconPlus} />}
+                    onClick={open}
+                >
+                    Add service account
+                </Button>
             }
         >
             {!isInitialLoading && !hasAccounts ? (
@@ -48,9 +53,7 @@ export function ServiceAccountsPage() {
                     icon={IconUsersGroup}
                     title="No service accounts"
                     description="Create a service account for automated access to Lightdash."
-                >
-                    <Button onClick={open}>Create service account</Button>
-                </SettingsEmptyState>
+                />
             ) : (
                 <ServiceAccountsTable
                     accounts={accountsData ?? []}

--- a/packages/frontend/src/ee/features/serviceAccounts/index.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/index.tsx
@@ -1,9 +1,9 @@
-import { Button, Group, Stack, Title } from '@mantine-8/core';
+import { Button } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
 import { IconUsersGroup } from '@tabler/icons-react';
 import { useState } from 'react';
-import { EmptyState } from '../../../components/common/EmptyState';
-import MantineIcon from '../../../components/common/MantineIcon';
+import { SettingsEmptyState } from '../../../components/common/Settings/SettingsEmptyState';
+import { SettingsPage } from '../../../components/common/Settings/SettingsPage';
 import { ServiceAccountsCreateModal } from './ServiceAccountsCreateModal';
 import { ServiceAccountsTable } from './ServiceAccountsTable';
 import { useServiceAccounts } from './useServiceAccounts';
@@ -31,53 +31,34 @@ export function ServiceAccountsPage() {
     const isInitialLoading = listAccounts.isLoading && !accountsData;
     const hasAccounts = (accountsData?.length ?? 0) > 0;
 
-    // Truly-empty path keeps the friendly EmptyState with the Create CTA;
-    // the table's own renderEmptyRowsFallback handles "filters returned 0"
-    // separately so the toolbar stays visible while filters are applied.
-    if (!isInitialLoading && !hasAccounts) {
-        return (
-            <Stack mb="lg">
-                <EmptyState
-                    icon={
-                        <MantineIcon
-                            icon={IconUsersGroup}
-                            color="ldGray.6"
-                            stroke={1}
-                            size="5xl"
-                        />
-                    }
+    // The table owns filtered empty states; this page-level state is only for
+    // organizations that have not created a service account yet.
+    return (
+        <SettingsPage
+            title="Service accounts"
+            description="Manage non-human accounts used for automated access to Lightdash."
+            actions={
+                hasAccounts ? (
+                    <Button onClick={open}>Add service account</Button>
+                ) : null
+            }
+        >
+            {!isInitialLoading && !hasAccounts ? (
+                <SettingsEmptyState
+                    icon={IconUsersGroup}
                     title="No service accounts"
-                    description="You haven't created any service accounts yet. Create your first service account"
+                    description="Create a service account for automated access to Lightdash."
                 >
                     <Button onClick={open}>Create service account</Button>
-                </EmptyState>
-
-                <ServiceAccountsCreateModal
-                    isOpen={opened}
-                    onClose={handleCloseModal}
-                    onSave={handleSaveAccount}
-                    isWorking={createAccount.isLoading}
-                    token={token}
+                </SettingsEmptyState>
+            ) : (
+                <ServiceAccountsTable
+                    accounts={accountsData ?? []}
+                    isLoading={isInitialLoading}
+                    onDelete={deleteAccount.mutate}
+                    isDeleting={deleteAccount.isLoading}
                 />
-            </Stack>
-        );
-    }
-
-    return (
-        <Stack mb="lg">
-            <Group justify="space-between">
-                <Title order={5}>Service accounts</Title>
-                <Button onClick={open} size="xs">
-                    Add service account
-                </Button>
-            </Group>
-
-            <ServiceAccountsTable
-                accounts={accountsData ?? []}
-                isLoading={isInitialLoading}
-                onDelete={deleteAccount.mutate}
-                isDeleting={deleteAccount.isLoading}
-            />
+            )}
 
             <ServiceAccountsCreateModal
                 isOpen={opened}
@@ -86,6 +67,6 @@ export function ServiceAccountsPage() {
                 isWorking={createAccount.isLoading}
                 token={token}
             />
-        </Stack>
+        </SettingsPage>
     );
 }

--- a/packages/frontend/src/ee/pages/customRoles/CustomRoles.tsx
+++ b/packages/frontend/src/ee/pages/customRoles/CustomRoles.tsx
@@ -3,9 +3,9 @@ import { Badge, Group, Stack, Tabs, Text } from '@mantine-8/core';
 import { IconBuilding, IconFolder, IconIdBadge2 } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
-import { EmptyState } from '../../../components/common/EmptyState';
 import MantineIcon from '../../../components/common/MantineIcon';
-import PageBreadcrumbs from '../../../components/common/PageBreadcrumbs';
+import { SettingsEmptyState } from '../../../components/common/Settings/SettingsEmptyState';
+import { SettingsPage } from '../../../components/common/Settings/SettingsPage';
 import PageSpinner from '../../../components/PageSpinner';
 import { AddRoleButton } from '../../features/customRoles/components/AddRoleButton';
 import { CustomRolesTable } from '../../features/customRoles/CustomRolesTable';
@@ -70,26 +70,13 @@ export const CustomRoles = () => {
         );
 
     return (
-        <Stack mb="lg" gap="md">
-            <Group justify="space-between" align="flex-start">
-                <PageBreadcrumbs
-                    items={[
-                        {
-                            title: 'Custom roles',
-                            active: true,
-                        },
-                    ]}
-                />
-                {hasRoles && <AddRoleButton size="xs" />}
-            </Group>
-
+        <SettingsPage
+            title="Custom roles"
+            description="Create reusable permission sets for users, groups, and service accounts."
+            actions={hasRoles ? <AddRoleButton size="xs" /> : null}
+        >
             {hasRoles ? (
                 <Stack gap="md">
-                    <Text c="dimmed" fz="sm">
-                        Roles you create here can be assigned to users, groups
-                        and service accounts
-                    </Text>
-
                     <Tabs
                         keepMounted={false}
                         value={level}
@@ -157,21 +144,14 @@ export const CustomRoles = () => {
                     </Tabs>
                 </Stack>
             ) : (
-                <EmptyState
-                    icon={
-                        <MantineIcon
-                            icon={IconIdBadge2}
-                            color="ldGray.6"
-                            stroke={1}
-                            size="5xl"
-                        />
-                    }
+                <SettingsEmptyState
+                    icon={IconIdBadge2}
                     title="No custom roles"
-                    description="You haven't created any custom roles yet. Custom roles allow you to define specific permissions for your organization."
+                    description="Create a role to define reusable organization or project permissions."
                 >
                     <AddRoleButton size="md" />
-                </EmptyState>
+                </SettingsEmptyState>
             )}
-        </Stack>
+        </SettingsPage>
     );
 };

--- a/packages/frontend/src/ee/pages/customRoles/CustomRoles.tsx
+++ b/packages/frontend/src/ee/pages/customRoles/CustomRoles.tsx
@@ -47,10 +47,6 @@ export const CustomRoles = () => {
         [sortedRoles],
     );
 
-    if (listRoles.isLoading) {
-        return <PageSpinner />;
-    }
-
     const hasRoles = sortedRoles.length > 0;
 
     const renderRolesTable = (roles: RoleWithScopes[], level: RoleLevel) =>
@@ -73,9 +69,11 @@ export const CustomRoles = () => {
         <SettingsPage
             title="Custom roles"
             description="Create reusable permission sets for users, groups, and service accounts."
-            actions={hasRoles ? <AddRoleButton size="xs" /> : null}
+            actions={<AddRoleButton size="xs" />}
         >
-            {hasRoles ? (
+            {listRoles.isLoading ? (
+                <PageSpinner />
+            ) : hasRoles ? (
                 <Stack gap="md">
                     <Tabs
                         keepMounted={false}
@@ -148,9 +146,7 @@ export const CustomRoles = () => {
                     icon={IconIdBadge2}
                     title="No custom roles"
                     description="Create a role to define reusable organization or project permissions."
-                >
-                    <AddRoleButton size="md" />
-                </SettingsEmptyState>
+                />
             )}
         </SettingsPage>
     );

--- a/packages/frontend/src/features/apps/hooks/useMyApps.ts
+++ b/packages/frontend/src/features/apps/hooks/useMyApps.ts
@@ -12,11 +12,19 @@ const fetchMyApps = async (
     page: number,
     pageSize: number,
     excludePreviewProjects: boolean,
+    projectUuids: string[],
+    search?: string,
 ): Promise<MyAppsResult> => {
     const params = new URLSearchParams({
         page: String(page),
         pageSize: String(pageSize),
         excludePreviewProjects: String(excludePreviewProjects),
+    });
+    if (search) {
+        params.set('search', search);
+    }
+    projectUuids.forEach((projectUuid) => {
+        params.append('projectUuids', projectUuid);
     });
 
     const data = await lightdashApi<MyAppsResult>({
@@ -29,18 +37,28 @@ const fetchMyApps = async (
 
 const FETCH_SIZE = 25;
 
-export const useMyApps = (options: { excludePreviewProjects?: boolean } = {}) =>
+export const useMyApps = (
+    options: {
+        excludePreviewProjects?: boolean;
+        projectUuids?: string[];
+        search?: string;
+    } = {},
+) =>
     useInfiniteQuery<MyAppsResult, ApiError>({
         queryKey: [
             'myApps',
             FETCH_SIZE,
             options.excludePreviewProjects ?? true,
+            options.projectUuids ?? [],
+            options.search,
         ],
         queryFn: async ({ pageParam = 1 }) =>
             fetchMyApps(
                 pageParam as number,
                 FETCH_SIZE,
                 options.excludePreviewProjects ?? true,
+                options.projectUuids ?? [],
+                options.search,
             ),
         getNextPageParam: (_lastGroup, groups) => {
             const currentPage = groups.length;

--- a/packages/frontend/src/features/organizationDesigns/components/DesignListPage.tsx
+++ b/packages/frontend/src/features/organizationDesigns/components/DesignListPage.tsx
@@ -137,8 +137,9 @@ const DesignListPage: FC = () => {
             title="Themes"
             description="Manage shared brand assets and instructions used when building data apps."
             actions={
-                canManage && designs.length > 0 ? (
+                canManage ? (
                     <Button
+                        size="xs"
                         leftSection={<MantineIcon icon={IconPlus} />}
                         variant="default"
                         onClick={() => setCreateOpen(true)}
@@ -160,16 +161,7 @@ const DesignListPage: FC = () => {
                     icon={IconPalette}
                     title="No themes"
                     description="Create a theme to share brand assets and instructions across data apps."
-                >
-                    {canManage ? (
-                        <Button
-                            leftSection={<MantineIcon icon={IconPlus} />}
-                            onClick={() => setCreateOpen(true)}
-                        >
-                            Create theme
-                        </Button>
-                    ) : null}
-                </SettingsEmptyState>
+                />
             ) : (
                 <SettingsCard>
                     <Paper withBorder>

--- a/packages/frontend/src/features/organizationDesigns/components/DesignListPage.tsx
+++ b/packages/frontend/src/features/organizationDesigns/components/DesignListPage.tsx
@@ -10,11 +10,11 @@ import {
     Stack,
     Table,
     Text,
-    Title,
 } from '@mantine-8/core';
 import {
     IconCheck,
     IconDots,
+    IconPalette,
     IconPencil,
     IconPlus,
     IconTrash,
@@ -23,6 +23,8 @@ import { useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import { SettingsCard } from '../../../components/common/Settings/SettingsCard';
+import { SettingsEmptyState } from '../../../components/common/Settings/SettingsEmptyState';
+import { SettingsPage } from '../../../components/common/Settings/SettingsPage';
 import tableStyles from '../../../hooks/styles/tableStyles.module.css';
 import useApp from '../../../providers/App/useApp';
 import {
@@ -131,78 +133,80 @@ const DesignListPage: FC = () => {
         useState<ApiOrganizationDesign | null>(null);
 
     return (
-        <Stack gap="sm">
-            <Group gap="xxs">
-                <Title order={5}>Themes</Title>
-            </Group>
-            <SettingsCard mb="lg">
-                <Stack gap="md">
-                    <Group justify="space-between">
-                        <Text size="sm" c="ldGray.6">
-                            Shared brand assets — CSS, fonts, images, and design
-                            instructions — that can be used when building data
-                            apps. New apps will automatically use the default
-                            theme.
-                        </Text>
-                        {canManage && (
-                            <Button
-                                leftSection={<MantineIcon icon={IconPlus} />}
-                                variant="default"
-                                size="xs"
-                                onClick={() => setCreateOpen(true)}
-                                style={{ alignSelf: 'flex-end' }}
-                            >
-                                New theme
-                            </Button>
-                        )}
-                    </Group>
-
-                    {isInitialLoading ? (
-                        <Stack gap="xs">
-                            <Skeleton height={48} />
-                            <Skeleton height={48} />
-                        </Stack>
-                    ) : designs.length === 0 ? null : (
-                        <Paper withBorder style={{ overflow: 'hidden' }}>
-                            <Table
-                                className={`${tableStyles.root} ${tableStyles.alignLastTdRight}`}
-                            >
-                                <Table.Thead>
-                                    <Table.Tr>
-                                        <Table.Th w={500}>Theme</Table.Th>
-                                        <Table.Th>Files</Table.Th>
-                                        <Table.Th />
-                                    </Table.Tr>
-                                </Table.Thead>
-                                <Table.Tbody>
-                                    {designs.map((design) => (
-                                        <DesignRow
-                                            key={design.designUuid}
-                                            design={design}
-                                            onOpenDetail={() =>
-                                                setActiveDetailUuid(
-                                                    design.designUuid,
-                                                )
-                                            }
-                                            onSetDefault={() =>
-                                                setDefault.mutate(
-                                                    design.designUuid,
-                                                )
-                                            }
-                                            onDelete={() =>
-                                                setDesignToDelete(design)
-                                            }
-                                            settingDefault={
-                                                setDefault.isLoading
-                                            }
-                                        />
-                                    ))}
-                                </Table.Tbody>
-                            </Table>
-                        </Paper>
-                    )}
-                </Stack>
-            </SettingsCard>
+        <SettingsPage
+            title="Themes"
+            description="Manage shared brand assets and instructions used when building data apps."
+            actions={
+                canManage && designs.length > 0 ? (
+                    <Button
+                        leftSection={<MantineIcon icon={IconPlus} />}
+                        variant="default"
+                        onClick={() => setCreateOpen(true)}
+                    >
+                        New theme
+                    </Button>
+                ) : null
+            }
+        >
+            {isInitialLoading ? (
+                <SettingsCard>
+                    <Stack gap="xs">
+                        <Skeleton height={48} />
+                        <Skeleton height={48} />
+                    </Stack>
+                </SettingsCard>
+            ) : designs.length === 0 ? (
+                <SettingsEmptyState
+                    icon={IconPalette}
+                    title="No themes"
+                    description="Create a theme to share brand assets and instructions across data apps."
+                >
+                    {canManage ? (
+                        <Button
+                            leftSection={<MantineIcon icon={IconPlus} />}
+                            onClick={() => setCreateOpen(true)}
+                        >
+                            Create theme
+                        </Button>
+                    ) : null}
+                </SettingsEmptyState>
+            ) : (
+                <SettingsCard>
+                    <Paper withBorder>
+                        <Table
+                            className={`${tableStyles.root} ${tableStyles.alignLastTdRight}`}
+                        >
+                            <Table.Thead>
+                                <Table.Tr>
+                                    <Table.Th w={500}>Theme</Table.Th>
+                                    <Table.Th>Files</Table.Th>
+                                    <Table.Th />
+                                </Table.Tr>
+                            </Table.Thead>
+                            <Table.Tbody>
+                                {designs.map((design) => (
+                                    <DesignRow
+                                        key={design.designUuid}
+                                        design={design}
+                                        onOpenDetail={() =>
+                                            setActiveDetailUuid(
+                                                design.designUuid,
+                                            )
+                                        }
+                                        onSetDefault={() =>
+                                            setDefault.mutate(design.designUuid)
+                                        }
+                                        onDelete={() =>
+                                            setDesignToDelete(design)
+                                        }
+                                        settingDefault={setDefault.isLoading}
+                                    />
+                                ))}
+                            </Table.Tbody>
+                        </Table>
+                    </Paper>
+                </SettingsCard>
+            )}
 
             <CreateDesignModal
                 opened={createOpen}
@@ -239,7 +243,7 @@ const DesignListPage: FC = () => {
                     <DesignDetailPanel designUuid={activeDetailUuid} />
                 )}
             </MantineModal>
-        </Stack>
+        </SettingsPage>
     );
 };
 

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -733,18 +733,6 @@ const Settings: FC = () => {
             ) &&
             !matchPath(
                 {
-                    path: '/generalSettings/userScheduledDeliveries',
-                },
-                location.pathname,
-            ) &&
-            !matchPath(
-                {
-                    path: '/generalSettings/myApps',
-                },
-                location.pathname,
-            ) &&
-            !matchPath(
-                {
                     path: '/generalSettings/projectManagement/:projectUuid/compilationHistory',
                 },
                 location.pathname,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -264,17 +264,12 @@ const Settings: FC = () => {
             allowedRoutes.push({
                 path: '/myApps',
                 element: (
-                    <SettingsPage
-                        title="My apps"
-                        description="Manage the data apps you can access and edit."
-                    >
-                        <MyAppsPanel
-                            key={String(project?.type === ProjectType.PREVIEW)}
-                            includePreviewAppsByDefault={
-                                project?.type === ProjectType.PREVIEW
-                            }
-                        />
-                    </SettingsPage>
+                    <MyAppsPanel
+                        key={String(project?.type === ProjectType.PREVIEW)}
+                        includePreviewAppsByDefault={
+                            project?.type === ProjectType.PREVIEW
+                        }
+                    />
                 ),
             });
         }

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -30,6 +30,7 @@ import MantineIcon from '../components/common/MantineIcon';
 import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import { SettingsGridCard } from '../components/common/Settings/SettingsCard';
+import { SettingsPage } from '../components/common/Settings/SettingsPage';
 import PageSpinner from '../components/PageSpinner';
 import ProjectSettings from '../components/Settings/ProjectSettings';
 import SettingsNavigation from '../components/Settings/SettingsNavigation';
@@ -180,16 +181,19 @@ const Settings: FC = () => {
             {
                 path: '/profile',
                 element: (
-                    <Stack gap="xl">
+                    <SettingsPage
+                        title="Profile"
+                        description="Manage your personal details and account preferences."
+                    >
                         <SettingsGridCard>
-                            <Title order={4}>Profile settings</Title>
+                            <Title order={5}>Profile details</Title>
                             <ProfilePanel />
                         </SettingsGridCard>
                         {health?.hasGithub && <GithubUserSettingsPanel />}
                         {isLeaveOrganizationEnabled && (
                             <SettingsGridCard>
                                 <Box>
-                                    <Title order={4}>Danger zone</Title>
+                                    <Title order={5}>Danger zone</Title>
                                     <Text c="ldGray.6" fz="xs">
                                         Leave the organization to remove
                                         yourself from it (you cannot leave if
@@ -200,7 +204,7 @@ const Settings: FC = () => {
                                 <LeaveOrganizationPanel />
                             </SettingsGridCard>
                         )}
-                    </Stack>
+                    </SettingsPage>
                 ),
             },
             {
@@ -213,19 +217,22 @@ const Settings: FC = () => {
             allowedRoutes.push({
                 path: '/password',
                 element: (
-                    <Stack gap="xl">
+                    <SettingsPage
+                        title="Password"
+                        description="Update your password and manage the ways you sign in."
+                    >
                         <SettingsGridCard>
-                            <Title order={4}>Password settings</Title>
+                            <Title order={5}>Password</Title>
                             <PasswordPanel />
                         </SettingsGridCard>
 
                         {hasSocialLogin && (
                             <SettingsGridCard>
-                                <Title order={4}>Social logins</Title>
+                                <Title order={5}>Social logins</Title>
                                 <SocialLoginsPanel />
                             </SettingsGridCard>
                         )}
-                    </Stack>
+                    </SettingsPage>
                 ),
             });
         }
@@ -244,12 +251,12 @@ const Settings: FC = () => {
             allowedRoutes.push({
                 path: '/userScheduledDeliveries',
                 element: (
-                    <Stack gap="xl">
-                        <SettingsGridCard>
-                            <Title order={4}>My scheduled deliveries</Title>
-                        </SettingsGridCard>
+                    <SettingsPage
+                        title="My scheduled deliveries"
+                        description="Review and manage deliveries scheduled across your projects."
+                    >
                         <UserScheduledDeliveriesPanel />
-                    </Stack>
+                    </SettingsPage>
                 ),
             });
         }
@@ -257,17 +264,17 @@ const Settings: FC = () => {
             allowedRoutes.push({
                 path: '/myApps',
                 element: (
-                    <Stack gap="xl">
-                        <SettingsGridCard>
-                            <Title order={4}>My apps</Title>
-                        </SettingsGridCard>
+                    <SettingsPage
+                        title="My apps"
+                        description="Manage the data apps you can access and edit."
+                    >
                         <MyAppsPanel
                             key={String(project?.type === ProjectType.PREVIEW)}
                             includePreviewAppsByDefault={
                                 project?.type === ProjectType.PREVIEW
                             }
                         />
-                    </Stack>
+                    </SettingsPage>
                 ),
             });
         }
@@ -275,15 +282,18 @@ const Settings: FC = () => {
             allowedRoutes.push({
                 path: '/organization',
                 element: (
-                    <Stack gap="xl">
+                    <SettingsPage
+                        title="General"
+                        description="Manage organization-wide defaults, access, and account controls."
+                    >
                         <SettingsGridCard>
-                            <Title order={4}>General</Title>
+                            <Title order={5}>Organization</Title>
                             <OrganizationPanel />
                         </SettingsGridCard>
 
                         <SettingsGridCard>
                             <div>
-                                <Title order={4}>Allowed email domains</Title>
+                                <Title order={5}>Allowed email domains</Title>
                                 <Text c="ldGray.6" fz="xs">
                                     Anyone with email addresses at these domains
                                     can automatically join the organization.
@@ -294,7 +304,7 @@ const Settings: FC = () => {
 
                         <SettingsGridCard>
                             <div>
-                                <Title order={4}>Default Project</Title>
+                                <Title order={5}>Default project</Title>
                                 <Text c="ldGray.6" fz="xs">
                                     This is the project users will see when they
                                     log in for the first time or from a new
@@ -307,13 +317,13 @@ const Settings: FC = () => {
 
                         {showImpersonationPanel && (
                             <SettingsGridCard>
-                                <Title order={4}>User impersonation</Title>
+                                <Title order={5}>User impersonation</Title>
                                 <ImpersonationPanel />
                             </SettingsGridCard>
                         )}
 
                         <SettingsGridCard>
-                            <Title order={4}>Lightdash support access</Title>
+                            <Title order={5}>Lightdash support access</Title>
                             <SupportImpersonationPanel />
                         </SettingsGridCard>
 
@@ -321,7 +331,7 @@ const Settings: FC = () => {
                             user.ability?.can('delete', 'Organization')) && (
                             <SettingsGridCard>
                                 <div>
-                                    <Title order={4}>Danger zone </Title>
+                                    <Title order={5}>Danger zone</Title>
                                     <Text c="ldGray.6" fz="xs">
                                         {isLeaveOrganizationEnabled &&
                                             'Leave the organization to remove yourself from it (you cannot leave if you are the only admin). '}
@@ -344,7 +354,7 @@ const Settings: FC = () => {
                                 </Stack>
                             </SettingsGridCard>
                         )}
-                    </Stack>
+                    </SettingsPage>
                 ),
             });
         }
@@ -352,10 +362,13 @@ const Settings: FC = () => {
             allowedRoutes.push({
                 path: '/exporting',
                 element: (
-                    <Stack gap="xl">
+                    <SettingsPage
+                        title="Exporting"
+                        description="Control how exported files are shared outside Lightdash."
+                    >
                         <SettingsGridCard>
                             <div>
-                                <Title order={4}>Scheduled deliveries</Title>
+                                <Title order={5}>Scheduled deliveries</Title>
                                 <Text c="ldGray.6" fz="xs">
                                     Control how files exported from your
                                     organization — starting with scheduled
@@ -373,7 +386,7 @@ const Settings: FC = () => {
                             </div>
                             <ExportingPanel />
                         </SettingsGridCard>
-                    </Stack>
+                    </SettingsPage>
                 ),
             });
         }
@@ -381,10 +394,13 @@ const Settings: FC = () => {
             allowedRoutes.push({
                 path: '/limits',
                 element: (
-                    <Stack gap="xl">
+                    <SettingsPage
+                        title="Limits"
+                        description="Set organization-wide query and export limits."
+                    >
                         <SettingsGridCard>
                             <div>
-                                <Title order={4}>Limits</Title>
+                                <Title order={5}>Query and export limits</Title>
                                 <Text c="ldGray.6" fz="xs">
                                     Limit how many rows a query can return and
                                     how many cells a CSV or Excel export can
@@ -393,7 +409,7 @@ const Settings: FC = () => {
                             </div>
                             <LimitsPanel />
                         </SettingsGridCard>
-                    </Stack>
+                    </SettingsPage>
                 ),
             });
         }
@@ -490,8 +506,10 @@ const Settings: FC = () => {
             allowedRoutes.push({
                 path: '/integrations',
                 element: (
-                    <Stack>
-                        <Title order={4}>Integrations</Title>
+                    <SettingsPage
+                        title="Integrations"
+                        description="Connect Lightdash to the tools your organization uses."
+                    >
                         {!health?.hasSlack &&
                             !health?.hasGithub &&
                             !health?.hasGitlab &&
@@ -499,7 +517,7 @@ const Settings: FC = () => {
                         {health?.hasSlack && <SlackSettingsPanel />}
                         {health?.hasGithub && <GithubSettingsPanel />}
                         {health?.hasGitlab && <GitlabSettingsPanel />}
-                    </Stack>
+                    </SettingsPage>
                 ),
             });
         }
@@ -538,15 +556,10 @@ const Settings: FC = () => {
             allowedRoutes.push({
                 path: '/sso',
                 element: (
-                    <Stack gap="md">
-                        <Stack gap="xs">
-                            <Title order={5}>Single Sign-On</Title>
-                            <Text c="ldGray.6" fz="xs">
-                                Configure SSO providers for your organization.
-                                Users are routed to the matching provider based
-                                on their email domain.
-                            </Text>
-                        </Stack>
+                    <SettingsPage
+                        title="Single Sign-On"
+                        description="Configure organization identity providers and account linking."
+                    >
                         <AzureAdSsoPanel />
                         <OktaSsoPanel />
                         <GenericOidcSsoPanel />
@@ -555,7 +568,7 @@ const Settings: FC = () => {
                             toggle when Google is enabled instance-wide. */}
                         {health?.auth.google.enabled && <GoogleSsoPanel />}
                         <AccountLinkingPanel />
-                    </Stack>
+                    </SettingsPage>
                 ),
             });
         }

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -222,7 +222,7 @@ const Settings: FC = () => {
                         description="Update your password and manage the ways you sign in."
                     >
                         <SettingsGridCard>
-                            <Title order={5}>Password</Title>
+                            <Title order={5}>Change password</Title>
                             <PasswordPanel />
                         </SettingsGridCard>
 
@@ -275,7 +275,7 @@ const Settings: FC = () => {
                         description="Manage organization-wide defaults, access, and account controls."
                     >
                         <SettingsGridCard>
-                            <Title order={5}>Organization</Title>
+                            <Title order={5}>Organization details</Title>
                             <OrganizationPanel />
                         </SettingsGridCard>
 
@@ -546,7 +546,7 @@ const Settings: FC = () => {
                 element: (
                     <SettingsPage
                         title="Single Sign-On"
-                        description="Configure organization identity providers and account linking."
+                        description="Configure SSO providers and account linking. Users are routed to the matching provider based on their email domain."
                     >
                         <AzureAdSsoPanel />
                         <OktaSsoPanel />

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -250,14 +250,7 @@ const Settings: FC = () => {
             // Since the service returns specifically the user's scheduled deliveries, this is completely intended behavior.
             allowedRoutes.push({
                 path: '/userScheduledDeliveries',
-                element: (
-                    <SettingsPage
-                        title="My scheduled deliveries"
-                        description="Review and manage deliveries scheduled across your projects."
-                    >
-                        <UserScheduledDeliveriesPanel />
-                    </SettingsPage>
-                ),
+                element: <UserScheduledDeliveriesPanel />,
             });
         }
         if (dataAppsFlag?.enabled && user?.ability.can('create', 'DataApp')) {


### PR DESCRIPTION
## Summary

- introduce a shared settings page header and content rhythm
- standardize responsive settings cards and heading hierarchy across personal, organization, AI, and commercial routes
- introduce a compact settings empty state for page-level empty collections while keeping filtered table states lightweight
- preserve existing permissions, routing, and `ldGray`/`ldDark` theme tokens

## Why

Settings routes had accumulated different title placement, widths, card spacing, two-column ratios, and empty-state treatments. Moving those decisions into shared settings primitives makes the surface consistent while allowing dense tables and workspaces to remain full-width.

## Validation

- `pnpm -F frontend format`
- `pnpm -F frontend lint` (0 errors; 4 existing unrelated warnings)
- `pnpm -F frontend typecheck:fast`
- focused settings primitive tests: 3 passed
- full frontend suite: 1,459 tests passed
- visual QA: Profile, General, Appearance, Users & groups, Ask AI, Personal access tokens, and Custom roles
