### PR TITLE
refactor(frontend): harden Mantine date pickers

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateRangePicker.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateRangePicker.test.tsx
@@ -1,0 +1,95 @@
+import { screen } from '@testing-library/react';
+import { type ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import FilterDateRangePicker from './FilterDateRangePicker';
+import FilterDateTimeRangePicker from './FilterDateTimeRangePicker';
+
+vi.mock('./FilterDatePicker', () => ({
+    default: ({
+        placeholder,
+        value,
+    }: {
+        placeholder: string;
+        value: Date | null;
+    }) => (
+        <output data-testid={placeholder}>
+            {value?.toISOString() ?? 'null'}
+        </output>
+    ),
+}));
+
+vi.mock('./FilterDateTimePicker', () => ({
+    default: ({
+        placeholder,
+        value,
+    }: {
+        placeholder: string;
+        value: Date | null;
+    }) => (
+        <output data-testid={placeholder}>
+            {value?.toISOString() ?? 'null'}
+        </output>
+    ),
+}));
+
+const initialStart = new Date(2025, 0, 1, 9, 30);
+const initialEnd = new Date(2025, 0, 2, 17, 45);
+const nextStart = new Date(2026, 5, 10, 8, 15);
+const nextEnd = new Date(2026, 5, 11, 18, 0);
+
+const commonProps = {
+    startValue: initialStart,
+    endValue: initialEnd,
+    firstDayOfWeek: 1,
+    onChange: vi.fn(),
+} satisfies ComponentProps<typeof FilterDateRangePicker>;
+
+describe.each([
+    ['date range', FilterDateRangePicker],
+    ['date-time range', FilterDateTimeRangePicker],
+] as const)('%s controlled state', (_, Component) => {
+    it('synchronizes external values without emitting a change', () => {
+        const onChange = vi.fn();
+        const { rerender } = renderWithProviders(
+            <Component {...commonProps} onChange={onChange} />,
+        );
+
+        rerender(
+            <Component
+                {...commonProps}
+                startValue={nextStart}
+                endValue={nextEnd}
+                onChange={onChange}
+            />,
+        );
+
+        expect(screen.getByTestId('Start date')).toHaveTextContent(
+            nextStart.toISOString(),
+        );
+        expect(screen.getByTestId('End date')).toHaveTextContent(
+            nextEnd.toISOString(),
+        );
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('synchronizes cleared external values', () => {
+        const onChange = vi.fn();
+        const { rerender } = renderWithProviders(
+            <Component {...commonProps} onChange={onChange} />,
+        );
+
+        rerender(
+            <Component
+                {...commonProps}
+                startValue={null}
+                endValue={null}
+                onChange={onChange}
+            />,
+        );
+
+        expect(screen.getByTestId('Start date')).toHaveTextContent('null');
+        expect(screen.getByTestId('End date')).toHaveTextContent('null');
+        expect(onChange).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateRangePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateRangePicker.tsx
@@ -1,7 +1,7 @@
 import { Flex, Text } from '@mantine-8/core';
 import { type DateInputProps, type DayOfWeek } from '@mantine/dates';
 import dayjs from 'dayjs';
-import { useState, type FC } from 'react';
+import { useEffect, useState, type FC } from 'react';
 import FilterDatePicker from './FilterDatePicker';
 import styles from './FilterDateRangePicker.module.css';
 
@@ -29,6 +29,14 @@ const FilterDateRangePicker: FC<Props> = ({
 }) => {
     const [date1, setDate1] = useState(startValue);
     const [date2, setDate2] = useState(endValue);
+
+    useEffect(() => {
+        setDate1(startValue);
+    }, [startValue]);
+
+    useEffect(() => {
+        setDate2(endValue);
+    }, [endValue]);
 
     return (
         <Flex align="center" w="100%" gap="xxs">

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimeRangePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimeRangePicker.tsx
@@ -1,7 +1,7 @@
 import { Group, Text } from '@mantine-8/core';
 import { type DateTimePickerProps, type DayOfWeek } from '@mantine/dates';
 import dayjs from 'dayjs';
-import { useState, type FC } from 'react';
+import { useEffect, useState, type FC } from 'react';
 import FilterDateTimePicker from './FilterDateTimePicker';
 import styles from './FilterDateTimeRangePicker.module.css';
 
@@ -29,6 +29,14 @@ const FilterDateTimeRangePicker: FC<Props> = ({
 }) => {
     const [date1, setDate1] = useState(startValue);
     const [date2, setDate2] = useState(endValue);
+
+    useEffect(() => {
+        setDate1(startValue);
+    }, [startValue]);
+
+    useEffect(() => {
+        setDate2(endValue);
+    }, [endValue]);
 
     return (
         <Group wrap="nowrap" align="start" w="100%" gap="xs">

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.module.css
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.module.css
@@ -1,0 +1,17 @@
+.monthControl {
+    &[data-quarter-selected] {
+        background-color: var(--mantine-color-blue-2);
+
+        &:hover {
+            background-color: var(--mantine-color-blue-2);
+        }
+    }
+
+    &[data-quarter-hovered] {
+        background-color: var(--mantine-color-blue-1);
+
+        &:hover {
+            background-color: var(--mantine-color-blue-1);
+        }
+    }
+}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { type MouseEventHandler } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import FilterQuarterPicker from './FilterQuarterPicker';
+
+vi.mock('@mantine/dates', () => ({
+    MonthPicker: ({
+        defaultDate,
+        getMonthControlProps,
+        onChange,
+        onMouseLeave,
+    }: {
+        defaultDate: Date;
+        getMonthControlProps: (date: Date) => {
+            className?: string;
+            'data-quarter-selected'?: boolean;
+            'data-quarter-hovered'?: boolean;
+            onMouseEnter: MouseEventHandler;
+            onMouseLeave: MouseEventHandler;
+        };
+        onChange: (date: Date) => void;
+        onMouseLeave: MouseEventHandler;
+    }) => (
+        <div data-testid="month-picker" onMouseLeave={onMouseLeave}>
+            {Array.from({ length: 12 }, (_, month) => {
+                const date = new Date(defaultDate.getFullYear(), month, 1);
+                return (
+                    <button
+                        key={month}
+                        type="button"
+                        data-testid={`month-${month}`}
+                        {...getMonthControlProps(date)}
+                        onClick={() => onChange(date)}
+                    >
+                        {month}
+                    </button>
+                );
+            })}
+        </div>
+    ),
+}));
+
+const renderPicker = (
+    value: Date | null,
+    onChange: (date: Date | null) => void,
+) =>
+    renderWithProviders(
+        <FilterQuarterPicker value={value} onChange={onChange} />,
+    );
+
+describe('FilterQuarterPicker', () => {
+    it('styles selected and hovered quarters with stable data attributes', async () => {
+        const onChange = vi.fn();
+        renderPicker(new Date(2025, 0, 1), onChange);
+        fireEvent.click(screen.getByRole('textbox'));
+
+        expect(await screen.findByTestId('month-0')).toHaveAttribute(
+            'data-quarter-selected',
+        );
+        expect(screen.getByTestId('month-2')).toHaveAttribute(
+            'data-quarter-selected',
+        );
+        expect(screen.getByTestId('month-3')).not.toHaveAttribute(
+            'data-quarter-selected',
+        );
+
+        fireEvent.mouseEnter(screen.getByTestId('month-4'));
+
+        expect(screen.getByTestId('month-3')).toHaveAttribute(
+            'data-quarter-hovered',
+        );
+        expect(screen.getByTestId('month-5')).toHaveAttribute(
+            'data-quarter-hovered',
+        );
+        expect(screen.getByText('2025-Q2')).toBeInTheDocument();
+
+        fireEvent.mouseLeave(screen.getByTestId('month-picker'));
+        expect(screen.queryByText('2025-Q2')).not.toBeInTheDocument();
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('normalizes user selections, not controlled prop updates', async () => {
+        const onChange = vi.fn();
+        const { rerender } = renderPicker(new Date(2025, 1, 15), onChange);
+
+        expect(onChange).not.toHaveBeenCalled();
+
+        rerender(
+            <FilterQuarterPicker
+                value={new Date(2026, 8, 20)}
+                onChange={onChange}
+            />,
+        );
+        expect(onChange).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByRole('textbox'));
+        fireEvent.click(await screen.findByTestId('month-7'));
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange.mock.calls[0][0]).toEqual(new Date(2026, 6, 1));
+    });
+});

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.tsx
@@ -1,11 +1,11 @@
 import { formatDate, TimeFrames } from '@lightdash/common';
 import { TextInput, Stack, Text, Popover } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
-import { type MantineTheme, type Sx } from '@mantine/core';
 import { MonthPicker, type MonthPickerProps } from '@mantine/dates';
 import dayjs from 'dayjs';
 import quarterOfYear from 'dayjs/plugin/quarterOfYear';
 import { useCallback, useEffect, useState, type FC } from 'react';
+import styles from './FilterQuarterPicker.module.css';
 
 dayjs.extend(quarterOfYear);
 
@@ -72,61 +72,27 @@ const FilterQuarterPicker: FC<Props> = ({
         [close, onChange, getStartOfQuarter],
     );
 
-    // Normalize value to start of quarter if needed
     useEffect(() => {
-        if (!value) return;
-
-        const startOfQuarter = getStartOfQuarter(value);
-        if (value.getTime() !== startOfQuarter.getTime()) {
-            onChange?.(startOfQuarter);
-        }
-    }, [value, getStartOfQuarter, onChange]);
+        setSelectedYear(yearValue);
+    }, [yearValue]);
 
     const getMonthControlProps = useCallback(
-        (
-            date: Date,
-        ): {
-            sx?: Sx;
-            onMouseEnter: () => void;
-            onMouseLeave?: () => void;
-        } => {
+        (date: Date) => {
             const month = date.getMonth();
             const year = date.getFullYear();
-
-            // If this is the selected quarter's months, highlight them
-            if (
-                parsedDate &&
+            const isSelected =
+                Boolean(parsedDate) &&
                 year === yearValue &&
-                getQuarterMonths(monthValue).includes(month)
-            ) {
-                return {
-                    sx: (theme: MantineTheme) => ({
-                        backgroundColor: theme.colors.blue[2],
-                        '&:hover': {
-                            backgroundColor: theme.colors.blue[2],
-                        },
-                    }),
-                    onMouseEnter: () => setHoveredMonth(month),
-                };
-            }
-
-            // If this is the hovered month's quarter, highlight all months in quarter
-            if (
+                getQuarterMonths(monthValue).includes(month);
+            const isHovered =
+                !isSelected &&
                 hoveredMonth !== null &&
-                getQuarterMonths(hoveredMonth).includes(month)
-            ) {
-                return {
-                    sx: (theme: MantineTheme) => ({
-                        backgroundColor: theme.colors.blue[1],
-                        '&:hover': {
-                            backgroundColor: theme.colors.blue[1],
-                        },
-                    }),
-                    onMouseEnter: () => setHoveredMonth(month),
-                };
-            }
+                getQuarterMonths(hoveredMonth).includes(month);
 
             return {
+                className: styles.monthControl,
+                'data-quarter-selected': isSelected || undefined,
+                'data-quarter-hovered': isHovered || undefined,
                 onMouseEnter: () => setHoveredMonth(month),
                 onMouseLeave: () => setHoveredMonth(null),
             };

--- a/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.module.css
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.module.css
@@ -1,0 +1,96 @@
+.yearLevel,
+.decadeLevel {
+    color: var(--mantine-color-ldGray-7);
+    padding: var(--mantine-spacing-xs);
+}
+
+.yearLevel[data-year-level]:not(:last-of-type),
+.decadeLevel[data-decade-level]:not(:last-of-type),
+.monthLevel[data-month-level]:not(:last-of-type) {
+    border-right: 1px solid var(--mantine-color-ldGray-2);
+    margin-right: 0;
+}
+
+.yearLevel[data-year-level]:not(:first-of-type),
+.decadeLevel[data-decade-level]:not(:first-of-type) {
+    padding-right: 0;
+}
+
+.decadeLevel[data-decade-level]:not(:first-of-type) {
+    padding-left: 0;
+}
+
+.calendarHeaderControlIcon {
+    color: var(--mantine-color-ldGray-5);
+}
+
+.calendarHeaderLevel {
+    color: var(--mantine-color-ldGray-7);
+}
+
+.monthLevel,
+.monthsList,
+.yearsList {
+    padding: var(--mantine-spacing-xs);
+}
+
+.pickerControl {
+    &[data-selected] {
+        background-color: var(--mantine-color-ldDark-7);
+        border-radius: var(--mantine-radius-md);
+    }
+
+    &[data-selected]:hover {
+        background-color: var(--mantine-color-ldDark-9);
+        border-radius: var(--mantine-radius-md);
+    }
+
+    &[data-in-range],
+    &[data-in-range]:hover {
+        background-color: var(--mantine-color-ldGray-1);
+    }
+
+    &[data-last-in-range][data-first-in-range] {
+        border-radius: var(--mantine-radius-md);
+    }
+}
+
+.day {
+    border-radius: var(--mantine-radius-lg);
+
+    &[data-weekend='true']:not([data-selected]) {
+        color: var(--mantine-color-ldGray-7);
+    }
+
+    &[data-in-range],
+    &[data-in-range]:hover {
+        background-color: var(--mantine-color-ldGray-1);
+    }
+
+    &[data-selected] {
+        background-color: var(--mantine-color-ldDark-7);
+        border-radius: var(--mantine-radius-lg);
+    }
+
+    &[data-selected]:hover {
+        background-color: var(--mantine-color-ldDark-9);
+        border-radius: var(--mantine-radius-lg);
+    }
+}
+
+.monthsListCell,
+.yearsListCell {
+    &[data-selected] {
+        background-color: var(--mantine-color-ldDark-7);
+        border-radius: var(--mantine-radius-lg);
+    }
+
+    &[data-selected]:hover {
+        background-color: var(--mantine-color-ldDark-9);
+    }
+
+    &[data-in-range],
+    &[data-in-range]:hover {
+        background-color: var(--mantine-color-ldGray-1);
+    }
+}

--- a/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.test.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.test.tsx
@@ -1,0 +1,58 @@
+import { TimeFrames } from '@lightdash/common';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useDateRangePicker } from './useDateRangePicker';
+
+const initialValue: [Date, Date] = [
+    new Date(2025, 0, 6),
+    new Date(2025, 0, 12, 23, 59, 59, 999),
+];
+
+describe('useDateRangePicker', () => {
+    it('synchronizes controlled values without emitting a change', () => {
+        const onChange = vi.fn();
+        const { result, rerender } = renderHook(
+            ({ value }) =>
+                useDateRangePicker({
+                    value,
+                    onChange,
+                    timeInterval: TimeFrames.WEEK,
+                }),
+            { initialProps: { value: initialValue } },
+        );
+
+        const nextValue: [Date, Date] = [
+            new Date(2025, 1, 3),
+            new Date(2025, 1, 9, 23, 59, 59, 999),
+        ];
+        rerender({ value: nextValue });
+
+        expect(result.current.buttonLabel).toContain('Feb');
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('keeps week selection boundaries and CSS class contracts', () => {
+        const { result } = renderHook(() =>
+            useDateRangePicker({
+                value: initialValue,
+                timeInterval: TimeFrames.WEEK,
+            }),
+        );
+
+        act(() => result.current.handleOpen(true));
+
+        const config = result.current.calendarConfig;
+        expect(config?.type).toBe(TimeFrames.WEEK);
+        if (!config || config.type !== TimeFrames.WEEK) {
+            throw new Error('Expected week picker config');
+        }
+
+        expect('classNames' in config.props).toBe(true);
+        expect('styles' in config.props).toBe(false);
+
+        const monday = config.props.getDayProps?.(new Date(2025, 0, 6));
+        const sunday = config.props.getDayProps?.(new Date(2025, 0, 12));
+        expect(monday).toMatchObject({ inRange: true, firstInRange: true });
+        expect(sunday).toMatchObject({ inRange: true, lastInRange: true });
+    });
+});

--- a/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
@@ -4,7 +4,6 @@ import {
     type MetricExplorerDateRange,
     type MetricExplorerPartialDateRange,
 } from '@lightdash/common';
-import { type MantineTheme } from '@mantine/core';
 import {
     type DatePickerProps,
     type MonthPickerProps,
@@ -14,6 +13,7 @@ import dayjs from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { formatDate, getDateRangePresets } from '../utils/metricExploreDate';
+import styles from './useDateRangePicker.module.css';
 
 dayjs.extend(isoWeek);
 
@@ -63,120 +63,6 @@ type CalendarVisualizationType =
     | YearPickerConfig
     | undefined;
 
-const getCommonCalendarStyles = (theme: MantineTheme) => ({
-    yearLevel: {
-        color: theme.colors.ldGray[7],
-        padding: theme.spacing.xs,
-        '&[data-year-level]:not(:last-of-type)': {
-            borderRight: `1px solid ${theme.colors.ldGray[2]}`,
-            marginRight: 0,
-        },
-        '&[data-year-level]:not(:first-of-type)': {
-            paddingRight: 0,
-        },
-    },
-    decadeLevel: {
-        color: theme.colors.ldGray[7],
-        padding: theme.spacing.xs,
-        '&[data-decade-level]:not(:last-of-type)': {
-            borderRight: `1px solid ${theme.colors.ldGray[2]}`,
-            marginRight: 0,
-        },
-        '&[data-decade-level]:not(:first-of-type)': {
-            paddingLeft: 0,
-            paddingRight: 0,
-        },
-    },
-    calendarHeaderControlIcon: {
-        color: theme.colors.ldGray[5],
-    },
-    calendarHeaderLevel: {
-        color: theme.colors.ldGray[7],
-    },
-    monthLevel: {
-        padding: theme.spacing.xs,
-        '&[data-month-level]:not(:last-of-type)': {
-            borderRight: `1px solid ${theme.colors.ldGray[2]}`,
-            marginRight: 0,
-        },
-    },
-    pickerControl: {
-        '&[data-selected]': {
-            backgroundColor: theme.colors.ldDark[7],
-            borderRadius: theme.radius.md,
-        },
-        '&[data-selected]:hover': {
-            backgroundColor: theme.colors.ldDark[9],
-            borderRadius: theme.radius.md,
-        },
-        '&[data-in-range]': {
-            backgroundColor: theme.colors.ldGray[1],
-        },
-        '&[data-in-range]:hover': {
-            backgroundColor: theme.colors.ldGray[1],
-        },
-        '&[data-last-in-range][data-first-in-range]': {
-            borderRadius: theme.radius.md,
-        },
-    },
-    day: {
-        borderRadius: theme.radius.lg,
-        '&[data-weekend="true"]&:not([data-selected])': {
-            color: theme.colors.ldGray[7],
-        },
-        '&[data-in-range]': {
-            backgroundColor: theme.colors.ldGray[1],
-        },
-        '&[data-in-range]:hover': {
-            backgroundColor: theme.colors.ldGray[1],
-        },
-        '&[data-selected]': {
-            backgroundColor: theme.colors.ldDark[7],
-            borderRadius: theme.radius.lg,
-        },
-        '&[data-selected]:hover': {
-            backgroundColor: theme.colors.ldDark[9],
-            borderRadius: theme.radius.lg,
-        },
-    },
-    monthsList: {
-        padding: theme.spacing.xs,
-    },
-    monthsListCell: {
-        '&[data-selected]': {
-            backgroundColor: theme.colors.ldDark[7],
-            borderRadius: theme.radius.lg,
-        },
-        '&[data-selected]:hover': {
-            backgroundColor: theme.colors.ldDark[9],
-        },
-        '&[data-in-range]': {
-            backgroundColor: theme.colors.ldGray[1],
-        },
-        '&[data-in-range]:hover': {
-            backgroundColor: theme.colors.ldGray[1],
-        },
-    },
-    yearsList: {
-        padding: theme.spacing.xs,
-    },
-    yearsListCell: {
-        '&[data-selected]': {
-            backgroundColor: theme.colors.ldDark[7],
-            borderRadius: theme.radius.lg,
-        },
-        '&[data-selected]:hover': {
-            backgroundColor: theme.colors.ldDark[9],
-        },
-        '&[data-in-range]': {
-            backgroundColor: theme.colors.ldGray[1],
-        },
-        '&[data-in-range]:hover': {
-            backgroundColor: theme.colors.ldGray[1],
-        },
-    },
-});
-
 /**
  * Hook to handle the date range picker for the metric peek
  * This hook handles the open/close state of the date range picker,
@@ -205,8 +91,7 @@ export const useDateRangePicker = ({
 
     useEffect(() => {
         setDateRange(value);
-        onChange?.(value);
-    }, [value, onChange]);
+    }, [value]);
 
     const buttonLabel = useMemo(() => {
         if (selectedPreset) {
@@ -283,7 +168,7 @@ export const useDateRangePicker = ({
                             handleDateRangeChange([startDate, endDate]);
                         },
                         numberOfColumns: 2,
-                        styles: getCommonCalendarStyles,
+                        classNames: styles,
                     },
                 } satisfies YearPickerConfig;
             case TimeFrames.MONTH:
@@ -303,7 +188,7 @@ export const useDateRangePicker = ({
                             handleDateRangeChange([startDate, endDate]);
                         },
                         numberOfColumns: 2,
-                        styles: getCommonCalendarStyles,
+                        classNames: styles,
                     },
                 } satisfies MonthPickerConfig;
             case TimeFrames.WEEK:
@@ -397,7 +282,7 @@ export const useDateRangePicker = ({
                                 lastInRange: date.getDay() === 0 && isSelected,
                             };
                         },
-                        styles: getCommonCalendarStyles,
+                        classNames: styles,
                     },
                 } satisfies WeekPickerConfig;
             case TimeFrames.DAY:
@@ -408,7 +293,7 @@ export const useDateRangePicker = ({
                         value: tempDateRange,
                         onChange: handleDateRangeChange,
                         numberOfColumns: 2,
-                        styles: getCommonCalendarStyles,
+                        classNames: styles,
                     },
                 } satisfies DayPickerConfig;
             default:


### PR DESCRIPTION
## Summary

Part 2 of the Mantine Dates v8 migration stack.

- synchronize controlled date/date-time range state without emitting callbacks
- keep quarter selection normalization at the user-interaction boundary
- replace Mantine v6 theme/Sx date styling with CSS modules and data attributes
- preserve Metrics Catalog week/range styling and boundaries
- add behavioral regression coverage

## Stack

1. #26101
2. **this PR**
3. atomic `@mantine/dates` v8 cutover (next)

## Validation

- frontend typecheck
- frontend format
- frontend lint (0 errors; 4 pre-existing warnings)
- frontend tests: 187 files, 1501 tests
- frontend app build
- frontend SDK build
