### PR TITLE
revert: commercial feature flag env guard (#26072, #26078)

### DIFF
--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -19,15 +19,6 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
         };
     }
 
-    protected hasCommercialFeatureFlagHandler(featureFlagId: string): boolean {
-        return (
-            this.featureFlagHandlers !== undefined &&
-            Object.values(CommercialFeatureFlags).includes(
-                featureFlagId as CommercialFeatureFlags,
-            )
-        );
-    }
-
     // Default-off; enabled per-org via DB-backed overrides.
     private async getHomepageBuilderFlag({
         featureFlagId,

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -154,47 +154,6 @@ describe('FeatureFlagModel', () => {
             });
         });
 
-        it('enables commercial flags without a specific handler in commercial model', async () => {
-            const model = buildCommercialModel({
-                enabledFeatureFlags: new Set([
-                    CommercialFeatureFlags.Embedding,
-                ]),
-            });
-
-            const result = await model.get({
-                featureFlagId: CommercialFeatureFlags.Embedding,
-            });
-
-            expect(result).toEqual({
-                id: CommercialFeatureFlags.Embedding,
-                enabled: true,
-            });
-        });
-
-        it('refuses commercial flags without commercial handling in base model', async () => {
-            const warnSpy = vi
-                .spyOn(Logger, 'warn')
-                .mockImplementation(() => Logger);
-            const model = buildModel({
-                enabledFeatureFlags: new Set([
-                    CommercialFeatureFlags.Embedding,
-                ]),
-            });
-
-            const result = await model.get({
-                featureFlagId: CommercialFeatureFlags.Embedding,
-            });
-
-            expect(result).toEqual({
-                id: CommercialFeatureFlags.Embedding,
-                enabled: false,
-            });
-            expect(warnSpy).toHaveBeenCalledWith(
-                `Ignoring commercial feature flag ${CommercialFeatureFlags.Embedding} in LIGHTDASH_ENABLE_FEATURE_FLAGS without commercial feature flag handling`,
-            );
-            warnSpy.mockRestore();
-        });
-
         it('returns enabled for any flag listed in LIGHTDASH_ENABLE_FEATURE_FLAGS', async () => {
             const model = buildModel({
                 enabledFeatureFlags: new Set(['my-custom-flag']),

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -1,4 +1,4 @@
-import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
+import { FeatureFlags } from '@lightdash/common';
 import { Knex } from 'knex';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -8,7 +8,6 @@ import {
     FeatureFlagOverridesTableName,
     FeatureFlagsTableName,
 } from '../../database/entities/featureFlags';
-import { CommercialFeatureFlagModel } from '../../ee/models/CommercialFeatureFlagModel';
 import Logger from '../../logging/logger';
 import { FeatureFlagModel } from './FeatureFlagModel';
 
@@ -26,16 +25,6 @@ const buildModel = (
 ) =>
     new FeatureFlagModel({
         database,
-        lightdashConfig: {
-            ...lightdashConfigMock,
-            enabledFeatureFlags: new Set<string>(),
-            ...configOverrides,
-        } as LightdashConfig,
-    });
-
-const buildCommercialModel = (configOverrides: Partial<LightdashConfig> = {}) =>
-    new CommercialFeatureFlagModel({
-        database: databaseStub,
         lightdashConfig: {
             ...lightdashConfigMock,
             enabledFeatureFlags: new Set<string>(),
@@ -98,62 +87,6 @@ const buildFakeDatabase = (rows: FakeRows): Knex => {
 
 describe('FeatureFlagModel', () => {
     describe('env var override', () => {
-        it('does not enable commercial flags without commercial handling', async () => {
-            const warnSpy = vi
-                .spyOn(Logger, 'warn')
-                .mockImplementation(() => Logger);
-            const model = buildModel({
-                enabledFeatureFlags: new Set([
-                    CommercialFeatureFlags.HomepageBuilder,
-                ]),
-            });
-
-            const result = await model.get({
-                featureFlagId: CommercialFeatureFlags.HomepageBuilder,
-            });
-
-            expect(result).toEqual({
-                id: CommercialFeatureFlags.HomepageBuilder,
-                enabled: false,
-            });
-            expect(warnSpy).toHaveBeenCalledWith(
-                `Ignoring commercial feature flag ${CommercialFeatureFlags.HomepageBuilder} in LIGHTDASH_ENABLE_FEATURE_FLAGS without commercial feature flag handling`,
-            );
-            warnSpy.mockRestore();
-        });
-
-        it('enables regular flags listed in LIGHTDASH_ENABLE_FEATURE_FLAGS', async () => {
-            const model = buildModel({
-                enabledFeatureFlags: new Set([FeatureFlags.NewOnboarding]),
-            });
-
-            const result = await model.get({
-                featureFlagId: FeatureFlags.NewOnboarding,
-            });
-
-            expect(result).toEqual({
-                id: FeatureFlags.NewOnboarding,
-                enabled: true,
-            });
-        });
-
-        it('enables commercial flags with commercial handling', async () => {
-            const model = buildCommercialModel({
-                enabledFeatureFlags: new Set([
-                    CommercialFeatureFlags.HomepageBuilder,
-                ]),
-            });
-
-            const result = await model.get({
-                featureFlagId: CommercialFeatureFlags.HomepageBuilder,
-            });
-
-            expect(result).toEqual({
-                id: CommercialFeatureFlags.HomepageBuilder,
-                enabled: true,
-            });
-        });
-
         it('returns enabled for any flag listed in LIGHTDASH_ENABLE_FEATURE_FLAGS', async () => {
             const model = buildModel({
                 enabledFeatureFlags: new Set(['my-custom-flag']),

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -96,7 +96,7 @@ export class FeatureFlagModel {
         return { id: args.featureFlagId, enabled: false };
     }
 
-    protected hasCommercialFeatureFlagHandler(featureFlagId: string): boolean {
+    private hasCommercialFeatureFlagHandler(featureFlagId: string): boolean {
         return this.featureFlagHandlers[featureFlagId] !== undefined;
     }
 

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -1,9 +1,4 @@
-import {
-    CommercialFeatureFlags,
-    FeatureFlag,
-    FeatureFlags,
-    LightdashUser,
-} from '@lightdash/common';
+import { FeatureFlag, FeatureFlags, LightdashUser } from '@lightdash/common';
 import { Knex } from 'knex';
 import { LightdashConfig } from '../../config/parseConfig';
 import {
@@ -60,17 +55,6 @@ export class FeatureFlagModel {
     ): Promise<FeatureFlag> {
         // 1a. Check env var enable-allowlist (self-hosted escape hatch)
         if (this.lightdashConfig.enabledFeatureFlags.has(args.featureFlagId)) {
-            if (
-                Object.values(CommercialFeatureFlags).includes(
-                    args.featureFlagId as CommercialFeatureFlags,
-                ) &&
-                !this.hasCommercialFeatureFlagHandler(args.featureFlagId)
-            ) {
-                Logger.warn(
-                    `Ignoring commercial feature flag ${args.featureFlagId} in LIGHTDASH_ENABLE_FEATURE_FLAGS without commercial feature flag handling`,
-                );
-                return { id: args.featureFlagId, enabled: false };
-            }
             return { id: args.featureFlagId, enabled: true };
         }
 
@@ -94,10 +78,6 @@ export class FeatureFlagModel {
         // Unknown flags default to disabled.
         // See: GLITCH-331
         return { id: args.featureFlagId, enabled: false };
-    }
-
-    private hasCommercialFeatureFlagHandler(featureFlagId: string): boolean {
-        return this.featureFlagHandlers[featureFlagId] !== undefined;
     }
 
     private async getEditYamlInUiEnabled({


### PR DESCRIPTION
Reverts both commercial-flag env-allowlist guard PRs in one change, restoring the pre-guard behaviour (env allowlist force-enables any flag, commercial or not, on any build).

Requested rollback pending a fuller risk review — the guard changed env-allowlist semantics for commercial flags on unlicensed builds, and the operator wants the previous behaviour back until the risk surface is assessed properly.

Clean `git revert` of both squash commits (d9c6d1f13f, 53d93709de); net diff returns the three touched files to their pre-#26072 state.

Linear: SPK-649

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNR95d1WqU9qMaXyg1Qu2G