### PR TITLE
fix: make data freshness alert unshrinkable

### DIFF
--- a/packages/frontend/src/pages/ChartHistory.tsx
+++ b/packages/frontend/src/pages/ChartHistory.tsx
@@ -266,7 +266,11 @@ const ChartHistory = () => {
                             />
                         ))}
                     </Stack>
-                    <Callout variant="info" title="Data freshness">
+                    <Callout
+                        variant="info"
+                        title="Data freshness"
+                        flex="0 0 auto"
+                    >
                         Version history preview changes chart configuration and
                         setup, but always queries the latest version of the data
                         itself


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: a visual bug <!-- reference the related issue e.g. #150 -->

### Description:
Before (unreadable, cutoff):
<img width="385" height="326" alt="Screenshot 2026-07-23 at 20 13 29" src="https://github.com/user-attachments/assets/b8d8afd1-737c-4b0d-8e31-b4f3f68bb450" />

After:
<img width="391" height="333" alt="Screenshot 2026-07-23 at 20 13 44" src="https://github.com/user-attachments/assets/60114705-a6e9-4cae-9463-91bd9b5329c7" />


<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
