### PR TITLE
Remove brand name from appearance settings preview

### DIFF
--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandPreview.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/BrandPreview.tsx
@@ -140,9 +140,6 @@ export const BrandPreview: FC<BrandPreviewProps> = ({
                             </Text>
                         </Box>
                     )}
-                    <Text size="sm" fw={600} c="white" ff={bodyFamily}>
-                        {displayName}
-                    </Text>
                 </Group>
                 <Group gap="lg" wrap="nowrap" visibleFrom="xs">
                     <Text size="xs" c="white" ff={bodyFamily}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Removes the company name text shown next to the brand logo in the Appearance settings brand preview (and the shared org setup preview).
- Logos typically already include the brand name, so the preview now shows logo-only (with the existing letter fallback when no logo is set).

## Test plan
- [ ] Open Appearance settings and configure a brand with a logo
- [ ] Confirm the preview nav shows the logo without the brand name beside it
- [ ] Confirm the letter fallback still appears when no logo is set
- [ ] Confirm org setup preview behaves the same way
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f87b3275-cc55-4577-be27-c095049d7e1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f87b3275-cc55-4577-be27-c095049d7e1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

