### PR TITLE
fix(frontend): preserve metrics search icon padding

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -344,7 +344,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                             input: {
                                 height: 32,
                                 width: 309,
-                                padding: `${theme.spacing.xs} ${theme.spacing.sm}`,
+                                paddingBlock: theme.spacing.xs,
                                 textOverflow: 'ellipsis',
                                 fontSize: theme.fontSizes.sm,
                                 fontWeight: 400,


### PR DESCRIPTION
## What changed
- Preserve Mantine's section-aware inline padding on the Metrics Catalog search input.
- Keep the existing vertical padding with `paddingBlock`.

## Why
The component's `padding` shorthand overwrote Mantine's computed 28px start padding with 12px, placing the search icon over the placeholder and entered text.

## Impact
The search placeholder and input text now start after the magnifying-glass icon.

## Validation
- Reproduced on the Metrics Catalog page via DOM geometry/computed styles.
- Targeted frontend lint passed.
- Formatting and `git diff --check` passed.
- Full frontend typecheck could not run cleanly against the borrowed local dependency tree; it reported unrelated existing Mantine form and `better-ajv-errors` type errors.