### PR TITLE
refactor(frontend): add Date-native calendar picker seam (dates v8 follow-up 1/3)

### DIFF
--- a/packages/frontend/.oxlintrc.json
+++ b/packages/frontend/.oxlintrc.json
@@ -167,6 +167,31 @@
   },
   "overrides": [
     {
+      /* Date-native picker seam: features must not touch Mantine date strings.
+         Widen the files list as more features migrate to components/common/DatePickers. */
+      "files": [
+        "src/features/funnelBuilder/**",
+        "src/features/omnibar/**"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": [
+                  "@mantine-8/dates",
+                  "**/mantineDateAdapter",
+                  "**/mantineDateSerialization"
+                ],
+                "message": "Use the Date-native pickers in components/common/DatePickers instead of raw Mantine date-string APIs."
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
       "files": ["**/*.stories.tsx", "**/*.stories.ts"],
       "rules": {
         "react-hooks/rules-of-hooks": "off",

--- a/packages/frontend/src/components/common/DatePickers/CalendarRangePicker.test.tsx
+++ b/packages/frontend/src/components/common/DatePickers/CalendarRangePicker.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import CalendarRangePicker from './CalendarRangePicker';
+import CalendarRangePickerInput from './CalendarRangePickerInput';
+
+const clickDay = async (day: string) => {
+    let control: HTMLElement | undefined;
+    await waitFor(() => {
+        control = screen
+            .getAllByRole('button')
+            .find((button) => button.textContent === day);
+        expect(control).toBeDefined();
+    });
+    if (!control) throw new Error(`Expected day control ${day}`);
+    fireEvent.click(control);
+};
+
+describe('CalendarRangePicker', () => {
+    it('round-trips Date values through the real v8 DatePicker', async () => {
+        const onChange = vi.fn();
+        const { container } = renderWithProviders(
+            <CalendarRangePicker
+                value={[new Date(2025, 4, 12), new Date(2025, 4, 14)]}
+                defaultDate={new Date(2025, 4, 1)}
+                onChange={onChange}
+            />,
+        );
+
+        expect(
+            container.querySelector('[data-first-in-range]'),
+        ).toHaveTextContent('12');
+        expect(
+            container.querySelector('[data-last-in-range]'),
+        ).toHaveTextContent('14');
+
+        await clickDay('20');
+        expect(onChange).toHaveBeenCalledWith([new Date(2025, 4, 20), null]);
+    });
+
+    it('never fires onChange for controlled prop updates', () => {
+        const onChange = vi.fn();
+        const { rerender } = renderWithProviders(
+            <CalendarRangePicker
+                value={[new Date(2025, 4, 12), new Date(2025, 4, 14)]}
+                onChange={onChange}
+            />,
+        );
+        rerender(
+            <CalendarRangePicker
+                value={[new Date(2025, 5, 2), new Date(2025, 5, 8)]}
+                onChange={onChange}
+            />,
+        );
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('formats Date bounds for the underlying picker', async () => {
+        const onChange = vi.fn();
+        renderWithProviders(
+            <CalendarRangePicker
+                value={[null, null]}
+                defaultDate={new Date(2025, 4, 1)}
+                maxDate={new Date(2025, 4, 14)}
+                onChange={onChange}
+            />,
+        );
+
+        await clickDay('20');
+        expect(onChange).not.toHaveBeenCalled();
+
+        await clickDay('14');
+        expect(onChange).toHaveBeenCalledWith([new Date(2025, 4, 14), null]);
+    });
+});
+
+describe('CalendarRangePickerInput', () => {
+    it('renders Date values and emits Dates from the real v8 DatePickerInput', async () => {
+        const onChange = vi.fn();
+        renderWithProviders(
+            <CalendarRangePickerInput
+                label="Custom Date Range"
+                value={[new Date(2025, 4, 12), new Date(2025, 4, 14)]}
+                onChange={onChange}
+            />,
+        );
+
+        const input = screen
+            .getAllByRole('button')
+            .find((button) => button.textContent?.includes('May 12, 2025'));
+        expect(input).toBeDefined();
+        if (!input) throw new Error('Expected range picker input');
+        expect(input.textContent).toContain('May 14, 2025');
+        fireEvent.click(input);
+        await clickDay('20');
+        expect(onChange).toHaveBeenCalledWith([new Date(2025, 4, 20), null]);
+    });
+
+    it('never fires onChange for controlled prop updates', () => {
+        const onChange = vi.fn();
+        const { rerender } = renderWithProviders(
+            <CalendarRangePickerInput
+                value={[new Date(2025, 4, 12), null]}
+                onChange={onChange}
+            />,
+        );
+        rerender(
+            <CalendarRangePickerInput
+                value={[new Date(2025, 5, 2), new Date(2025, 5, 8)]}
+                onChange={onChange}
+            />,
+        );
+        expect(onChange).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/components/common/DatePickers/CalendarRangePicker.tsx
+++ b/packages/frontend/src/components/common/DatePickers/CalendarRangePicker.tsx
@@ -1,0 +1,60 @@
+import { DatePicker, type DatePickerProps } from '@mantine-8/dates';
+import { useCallback, type FC } from 'react';
+import {
+    formatMantineDate,
+    formatMantineDateRange,
+    parseMantineDateRange,
+    type MantineDateRange,
+} from '../Filters/FilterInputs/mantineDateAdapter';
+import { type CalendarDateRange } from './types';
+
+type Props = Omit<
+    DatePickerProps<'range'>,
+    | 'type'
+    | 'value'
+    | 'defaultValue'
+    | 'onChange'
+    | 'minDate'
+    | 'maxDate'
+    | 'date'
+    | 'defaultDate'
+    | 'onDateChange'
+    | 'getDayProps'
+    | 'excludeDate'
+    | 'renderDay'
+> & {
+    value: CalendarDateRange;
+    onChange: (value: CalendarDateRange) => void;
+    minDate?: Date;
+    maxDate?: Date;
+    defaultDate?: Date;
+};
+
+// Date-native inline range calendar; Mantine v8's date-string contract stays private
+const CalendarRangePicker: FC<Props> = ({
+    value,
+    onChange,
+    minDate,
+    maxDate,
+    defaultDate,
+    ...rest
+}) => {
+    const handleChange = useCallback(
+        (range: MantineDateRange) => onChange(parseMantineDateRange(range)),
+        [onChange],
+    );
+
+    return (
+        <DatePicker
+            {...rest}
+            type="range"
+            minDate={formatMantineDate(minDate ?? null) ?? undefined}
+            maxDate={formatMantineDate(maxDate ?? null) ?? undefined}
+            defaultDate={formatMantineDate(defaultDate ?? null) ?? undefined}
+            value={formatMantineDateRange(value)}
+            onChange={handleChange}
+        />
+    );
+};
+
+export default CalendarRangePicker;

--- a/packages/frontend/src/components/common/DatePickers/CalendarRangePickerInput.tsx
+++ b/packages/frontend/src/components/common/DatePickers/CalendarRangePickerInput.tsx
@@ -1,0 +1,54 @@
+import { DatePickerInput, type DatePickerInputProps } from '@mantine-8/dates';
+import { useCallback, type FC } from 'react';
+import {
+    formatMantineDate,
+    formatMantineDateRange,
+    parseMantineDateRange,
+    type MantineDateRange,
+} from '../Filters/FilterInputs/mantineDateAdapter';
+import { type CalendarDateRange } from './types';
+
+type Props = Omit<
+    DatePickerInputProps<'range'>,
+    | 'type'
+    | 'value'
+    | 'defaultValue'
+    | 'onChange'
+    | 'minDate'
+    | 'maxDate'
+    | 'getDayProps'
+    | 'excludeDate'
+    | 'renderDay'
+> & {
+    value: CalendarDateRange;
+    onChange: (value: CalendarDateRange) => void;
+    minDate?: Date;
+    maxDate?: Date;
+};
+
+// Date-native range picker input; Mantine v8's date-string contract stays private
+const CalendarRangePickerInput: FC<Props> = ({
+    value,
+    onChange,
+    minDate,
+    maxDate,
+    ...rest
+}) => {
+    const handleChange = useCallback(
+        (range: MantineDateRange) => onChange(parseMantineDateRange(range)),
+        [onChange],
+    );
+
+    return (
+        <DatePickerInput
+            {...rest}
+            type="range"
+            minDate={formatMantineDate(minDate ?? null) ?? undefined}
+            maxDate={formatMantineDate(maxDate ?? null) ?? undefined}
+            value={formatMantineDateRange(value)}
+            onChange={handleChange}
+        />
+    );
+};
+
+export default CalendarRangePickerInput;

--- a/packages/frontend/src/components/common/DatePickers/types.ts
+++ b/packages/frontend/src/components/common/DatePickers/types.ts
@@ -1,0 +1,1 @@
+export type CalendarDateRange = [Date | null, Date | null];

--- a/packages/frontend/src/components/common/Filters/FilterInputs/mantineDateSerialization.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/mantineDateSerialization.ts
@@ -1,9 +1,5 @@
 import { formatDate, TimeFrames } from '@lightdash/common';
-import {
-    parseMantineDate,
-    parseMantineDateRange,
-    type MantineDateRange,
-} from './mantineDateAdapter';
+import { parseMantineDate } from './mantineDateAdapter';
 
 const PARAMETER_DATE_PATTERN =
     /^(\d{4}-\d{2}-\d{2})(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
@@ -13,16 +9,6 @@ export const parseParameterDateValue = (value: string | null): Date | null => {
 
     const match = PARAMETER_DATE_PATTERN.exec(value);
     return match ? parseMantineDate(match[1]) : null;
-};
-
-export const serializeMantineDateRangeToIso = (
-    range: MantineDateRange,
-): [string | null, string | null] => {
-    const parsedRange = parseMantineDateRange(range);
-    return [
-        parsedRange[0]?.toISOString() ?? null,
-        parsedRange[1]?.toISOString() ?? null,
-    ];
 };
 
 export const serializeParameterDateValue = (

--- a/packages/frontend/src/components/common/Filters/FilterInputs/mantineDatesSerialization.test.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/mantineDatesSerialization.test.ts
@@ -1,37 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
     parseParameterDateValue,
-    serializeMantineDateRangeToIso,
     serializeParameterDateValue,
 } from './mantineDateSerialization';
 
 describe('Mantine Dates domain serialization', () => {
-    it('serializes Funnel local calendar dates to its existing ISO boundary', () => {
-        expect(
-            serializeMantineDateRangeToIso(['2025-05-14', '2025-05-16']),
-        ).toEqual([
-            new Date(2025, 4, 14).toISOString(),
-            new Date(2025, 4, 16).toISOString(),
-        ]);
-        expect(serializeMantineDateRangeToIso(['2025-05-14', null])).toEqual([
-            new Date(2025, 4, 14).toISOString(),
-            null,
-        ]);
-    });
-
-    it('serializes Omnibar local calendar dates to its existing ISO boundary', () => {
-        expect(
-            serializeMantineDateRangeToIso(['2025-05-14', '2025-05-16']),
-        ).toEqual([
-            new Date(2025, 4, 14).toISOString(),
-            new Date(2025, 4, 16).toISOString(),
-        ]);
-        expect(serializeMantineDateRangeToIso([null, null])).toEqual([
-            null,
-            null,
-        ]);
-    });
-
     it('keeps parameter values as strict YYYY-MM-DD strings', () => {
         expect(serializeParameterDateValue('2024-02-29')).toBe('2024-02-29');
         expect(serializeParameterDateValue('2023-02-29')).toBeNull();

--- a/packages/frontend/src/features/funnelBuilder/components/FunnelDateFilter.tsx
+++ b/packages/frontend/src/features/funnelBuilder/components/FunnelDateFilter.tsx
@@ -1,12 +1,8 @@
 import { FUNNEL_DATE_PRESETS, type FunnelDatePreset } from '@lightdash/common';
 import { Group, SegmentedControl } from '@mantine-8/core';
-import { DatePickerInput } from '@mantine-8/dates';
 import { useCallback, type FC } from 'react';
-import {
-    formatMantineDateRange,
-    type MantineDateRange,
-} from '../../../components/common/Filters/FilterInputs/mantineDateAdapter';
-import { serializeMantineDateRangeToIso } from '../../../components/common/Filters/FilterInputs/mantineDateSerialization';
+import CalendarRangePickerInput from '../../../components/common/DatePickers/CalendarRangePickerInput';
+import { type CalendarDateRange } from '../../../components/common/DatePickers/types';
 import { useAppDispatch, useAppSelector } from '../store';
 import {
     selectCustomDateRange,
@@ -21,14 +17,20 @@ export const FunnelDateFilter: FC = () => {
     const customDateRange = useAppSelector(selectCustomDateRange);
 
     // Convert ISO strings to Date objects for the picker
-    const customDateRangeDates: [Date | null, Date | null] = [
+    const customDateRangeDates: CalendarDateRange = [
         customDateRange[0] ? new Date(customDateRange[0]) : null,
         customDateRange[1] ? new Date(customDateRange[1]) : null,
     ];
 
     const handleCustomDateChange = useCallback(
-        (range: MantineDateRange) => {
-            dispatch(setCustomDateRange(serializeMantineDateRangeToIso(range)));
+        (range: CalendarDateRange) => {
+            // Persisting a calendar date as an ISO instant is funnel policy
+            dispatch(
+                setCustomDateRange([
+                    range[0]?.toISOString() ?? null,
+                    range[1]?.toISOString() ?? null,
+                ]),
+            );
         },
         [dispatch],
     );
@@ -47,10 +49,9 @@ export const FunnelDateFilter: FC = () => {
             />
 
             {dateRangePreset === 'custom' && (
-                <DatePickerInput
-                    type="range"
+                <CalendarRangePickerInput
                     label="Custom Date Range"
-                    value={formatMantineDateRange(customDateRangeDates)}
+                    value={customDateRangeDates}
                     onChange={handleCustomDateChange}
                 />
             )}

--- a/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarFilters.tsx
@@ -5,7 +5,6 @@ import {
     type SearchFilters,
 } from '@lightdash/common';
 import { Button, Flex, Group, Menu, Select } from '@mantine-8/core';
-import { DatePicker } from '@mantine-8/dates';
 import { useDisclosure } from '@mantine-8/hooks';
 import {
     IconAdjustments,
@@ -25,11 +24,8 @@ import {
     IconX,
 } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
-import {
-    formatMantineDate,
-    formatMantineDateRange,
-} from '../../../components/common/Filters/FilterInputs/mantineDateAdapter';
-import { serializeMantineDateRangeToIso } from '../../../components/common/Filters/FilterInputs/mantineDateSerialization';
+import CalendarRangePicker from '../../../components/common/DatePickers/CalendarRangePicker';
+import { type CalendarDateRange } from '../../../components/common/DatePickers/types';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import { allSearchItemTypes } from '../types/searchItem';
@@ -189,25 +185,23 @@ const OmnibarFilters: FC<Props> = ({ filters, onSearchFilterChange }) => {
                 </Menu.Target>
                 <Menu.Dropdown>
                     <Flex direction="column" align="flex-end">
-                        <DatePicker
-                            type="range"
+                        <CalendarRangePicker
                             allowSingleDateInRange
-                            maxDate={formatMantineDate(new Date()) ?? undefined}
-                            value={formatMantineDateRange([
+                            maxDate={new Date()}
+                            value={[
                                 filters?.fromDate
                                     ? new Date(filters.fromDate)
                                     : null,
                                 filters?.toDate
                                     ? new Date(filters.toDate)
                                     : null,
-                            ])}
-                            onChange={(value) => {
-                                const [fromDate, toDate] =
-                                    serializeMantineDateRangeToIso(value);
+                            ]}
+                            onChange={(value: CalendarDateRange) => {
+                                // Persisting calendar dates as ISO instants is search-filter policy
                                 onSearchFilterChange({
                                     ...filters,
-                                    fromDate: fromDate ?? undefined,
-                                    toDate: toDate ?? undefined,
+                                    fromDate: value[0]?.toISOString(),
+                                    toDate: value[1]?.toISOString(),
                                 });
 
                                 if (value[0] && value[1]) {


### PR DESCRIPTION
## Summary

First PR of the seam-deepening chain on top of #26108. Four feature modules currently know that Mantine v8 date components speak date strings; this PR starts moving that knowledge behind a Date-native wrapper seam.

- **New `components/common/DatePickers/` module** — `CalendarRangePicker` (inline range calendar) and `CalendarRangePickerInput` (range picker input). Callers provide `Date | null` values and `Date` bounds; `formatMantine*`/`parseMantine*` and `@mantine-8/dates` are private to the module.
- **Funnel + Omnibar migrated.** Their calendar-date → ISO-instant persistence is now an explicit inline conversion in each feature (product policy stays visible at the feature boundary, per the seam design). The now-unused `serializeMantineDateRangeToIso` helper is removed.
- **oxlint guard** — `no-restricted-imports` bans `@mantine-8/dates`, `mantineDateAdapter`, and `mantineDateSerialization` imports inside `features/funnelBuilder` and `features/omnibar`. The files list widens as each subsequent PR migrates a feature, so raw imports can't reappear mid-chain.
- **Contract tests against the real library** (no mocks): Date round-trip through the real v8 `DatePicker`/`DatePickerInput`, `maxDate` enforcement, and — the invariant both regressions found in the #26108 review violated — **controlled prop updates never fire `onChange`**.

## Behavior / regression analysis

No user-visible behavior change intended:
- Funnel/Omnibar emitted ISO values are byte-identical: previously `parseMantineDateRange(strings)[i]?.toISOString()`, now the same `Date` from the same parse path via the wrapper, `.toISOString()` inline.
- Omnibar's `maxDate={new Date()}` day-string formatting is unchanged (same `formatMantineDate` call, now inside the wrapper).
- The wrappers pass through presentational props (`allowSingleDateInRange`, `label`, etc.) unchanged.

## Follow-ups (per the seam plan)

- PR 2: migrate Metrics Catalog ranges/timeframes (`useDateRangePicker`, `MetricExploreDatePicker`).
- PR 3: extract `ParameterDateInput` (domain string adapter) and relocate/promote the project-aware datetime module; `mantineDateAdapter` becomes fully private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMT6FGiBtQY22zupwoocGb