### PR TITLE
refactor(frontend): migrate metrics catalog to Date-native picker seam (2/3)

### DIFF
--- a/packages/frontend/.oxlintrc.json
+++ b/packages/frontend/.oxlintrc.json
@@ -171,6 +171,7 @@
          Widen the files list as more features migrate to components/common/DatePickers. */
       "files": [
         "src/features/funnelBuilder/**",
+        "src/features/metricsCatalog/**",
         "src/features/omnibar/**"
       ],
       "rules": {

--- a/packages/frontend/src/components/common/DatePickers/CalendarRangePicker.tsx
+++ b/packages/frontend/src/components/common/DatePickers/CalendarRangePicker.tsx
@@ -3,12 +3,15 @@ import { useCallback, type FC } from 'react';
 import {
     formatMantineDate,
     formatMantineDateRange,
+    parseMantineDate,
     parseMantineDateRange,
     type MantineDateRange,
 } from '../Filters/FilterInputs/mantineDateAdapter';
 import { type CalendarDateRange } from './types';
 
-type Props = Omit<
+type MantineGetDayProps = NonNullable<DatePickerProps<'range'>['getDayProps']>;
+
+export type CalendarRangePickerProps = Omit<
     DatePickerProps<'range'>,
     | 'type'
     | 'value'
@@ -28,20 +31,30 @@ type Props = Omit<
     minDate?: Date;
     maxDate?: Date;
     defaultDate?: Date;
+    getDayProps?: (date: Date) => ReturnType<MantineGetDayProps>;
 };
 
 // Date-native inline range calendar; Mantine v8's date-string contract stays private
-const CalendarRangePicker: FC<Props> = ({
+const CalendarRangePicker: FC<CalendarRangePickerProps> = ({
     value,
     onChange,
     minDate,
     maxDate,
     defaultDate,
+    getDayProps,
     ...rest
 }) => {
     const handleChange = useCallback(
         (range: MantineDateRange) => onChange(parseMantineDateRange(range)),
         [onChange],
+    );
+
+    const handleGetDayProps = useCallback<MantineGetDayProps>(
+        (dateString) => {
+            const date = parseMantineDate(dateString);
+            return date && getDayProps ? getDayProps(date) : {};
+        },
+        [getDayProps],
     );
 
     return (
@@ -53,6 +66,7 @@ const CalendarRangePicker: FC<Props> = ({
             defaultDate={formatMantineDate(defaultDate ?? null) ?? undefined}
             value={formatMantineDateRange(value)}
             onChange={handleChange}
+            getDayProps={getDayProps ? handleGetDayProps : undefined}
         />
     );
 };

--- a/packages/frontend/src/components/common/DatePickers/MonthRangePicker.tsx
+++ b/packages/frontend/src/components/common/DatePickers/MonthRangePicker.tsx
@@ -1,0 +1,39 @@
+import { MonthPicker, type MonthPickerProps } from '@mantine-8/dates';
+import { useCallback, type FC } from 'react';
+import {
+    formatMantineDateRange,
+    parseMantineDateRange,
+    type MantineDateRange,
+} from '../Filters/FilterInputs/mantineDateAdapter';
+import { type CalendarDateRange } from './types';
+
+export type MonthRangePickerProps = Omit<
+    MonthPickerProps<'range'>,
+    'type' | 'value' | 'defaultValue' | 'onChange' | 'minDate' | 'maxDate'
+> & {
+    value: CalendarDateRange;
+    onChange: (value: CalendarDateRange) => void;
+};
+
+// Date-native month range picker; Mantine v8's date-string contract stays private
+const MonthRangePicker: FC<MonthRangePickerProps> = ({
+    value,
+    onChange,
+    ...rest
+}) => {
+    const handleChange = useCallback(
+        (range: MantineDateRange) => onChange(parseMantineDateRange(range)),
+        [onChange],
+    );
+
+    return (
+        <MonthPicker
+            {...rest}
+            type="range"
+            value={formatMantineDateRange(value)}
+            onChange={handleChange}
+        />
+    );
+};
+
+export default MonthRangePicker;

--- a/packages/frontend/src/components/common/DatePickers/YearRangePicker.tsx
+++ b/packages/frontend/src/components/common/DatePickers/YearRangePicker.tsx
@@ -1,0 +1,39 @@
+import { YearPicker, type YearPickerProps } from '@mantine-8/dates';
+import { useCallback, type FC } from 'react';
+import {
+    formatMantineDateRange,
+    parseMantineDateRange,
+    type MantineDateRange,
+} from '../Filters/FilterInputs/mantineDateAdapter';
+import { type CalendarDateRange } from './types';
+
+export type YearRangePickerProps = Omit<
+    YearPickerProps<'range'>,
+    'type' | 'value' | 'defaultValue' | 'onChange' | 'minDate' | 'maxDate'
+> & {
+    value: CalendarDateRange;
+    onChange: (value: CalendarDateRange) => void;
+};
+
+// Date-native year range picker; Mantine v8's date-string contract stays private
+const YearRangePicker: FC<YearRangePickerProps> = ({
+    value,
+    onChange,
+    ...rest
+}) => {
+    const handleChange = useCallback(
+        (range: MantineDateRange) => onChange(parseMantineDateRange(range)),
+        [onChange],
+    );
+
+    return (
+        <YearPicker
+            {...rest}
+            type="range"
+            value={formatMantineDateRange(value)}
+            onChange={handleChange}
+        />
+    );
+};
+
+export default YearRangePicker;

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
@@ -17,8 +17,10 @@ import {
     Popover,
     Tooltip,
 } from '@mantine-8/core';
-import { DatePicker, MonthPicker, YearPicker } from '@mantine-8/dates';
 import { useCallback, useEffect, useRef, type FC } from 'react';
+import CalendarRangePicker from '../../../../components/common/DatePickers/CalendarRangePicker';
+import MonthRangePicker from '../../../../components/common/DatePickers/MonthRangePicker';
+import YearRangePicker from '../../../../components/common/DatePickers/YearRangePicker';
 import useTracking from '../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../types/Events';
 import { useAppSelector } from '../../../sqlRunner/store/hooks';
@@ -245,7 +247,7 @@ export const MetricExploreDatePicker: FC<Props> = ({
                     <Stack gap={0}>
                         <Box px="xs">
                             {calendarConfig?.type === TimeFrames.YEAR ? (
-                                <YearPicker
+                                <YearRangePicker
                                     {...calendarConfig.props}
                                     mih={180}
                                     w="100%"
@@ -253,21 +255,21 @@ export const MetricExploreDatePicker: FC<Props> = ({
                                     size="xs"
                                 />
                             ) : calendarConfig?.type === TimeFrames.MONTH ? (
-                                <MonthPicker
+                                <MonthRangePicker
                                     {...calendarConfig.props}
                                     mih={180}
                                     color="dark"
                                     size="xs"
                                 />
-                            ) : (
-                                <DatePicker
-                                    {...calendarConfig?.props}
+                            ) : calendarConfig ? (
+                                <CalendarRangePicker
+                                    {...calendarConfig.props}
                                     mih={225}
                                     color="dark"
                                     size="xs"
                                     withCellSpacing={false}
                                 />
-                            )}
+                            ) : null}
                         </Box>
                         <Divider color="ldGray.2" />
                         <Box p="sm">

--- a/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.test.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.test.tsx
@@ -50,8 +50,8 @@ describe('useDateRangePicker', () => {
         expect('classNames' in config.props).toBe(true);
         expect('styles' in config.props).toBe(false);
 
-        const monday = config.props.getDayProps?.('2025-01-06');
-        const sunday = config.props.getDayProps?.('2025-01-12');
+        const monday = config.props.getDayProps?.(new Date(2025, 0, 6));
+        const sunday = config.props.getDayProps?.(new Date(2025, 0, 12));
         expect(monday).toMatchObject({ inRange: true, firstInRange: true });
         expect(sunday).toMatchObject({ inRange: true, lastInRange: true });
     });
@@ -69,7 +69,7 @@ describe('useDateRangePicker', () => {
         if (!firstConfig || firstConfig.type !== TimeFrames.WEEK) {
             throw new Error('Expected week picker config');
         }
-        act(() => firstConfig.props.onChange(['2025-01-15', null]));
+        act(() => firstConfig.props.onChange([new Date(2025, 0, 15), null]));
         expect(result.current.tempDateRange).toEqual([
             new Date(2025, 0, 13),
             new Date(2025, 0, 19, 23, 59, 59, 999),
@@ -79,7 +79,7 @@ describe('useDateRangePicker', () => {
         if (!secondConfig || secondConfig.type !== TimeFrames.WEEK) {
             throw new Error('Expected week picker config');
         }
-        act(() => secondConfig.props.onChange(['2025-01-22', null]));
+        act(() => secondConfig.props.onChange([new Date(2025, 0, 22), null]));
         expect(result.current.tempDateRange).toEqual([
             new Date(2025, 0, 13),
             new Date(2025, 0, 26, 23, 59, 59, 999),
@@ -99,7 +99,12 @@ describe('useDateRangePicker', () => {
         if (!config || config.type !== TimeFrames.WEEK) {
             throw new Error('Expected week picker config');
         }
-        act(() => config.props.onChange(['2024-12-30', '2025-01-05']));
+        act(() =>
+            config.props.onChange([
+                new Date(2024, 11, 30),
+                new Date(2025, 0, 5),
+            ]),
+        );
         expect(result.current.tempDateRange).toEqual([
             new Date(2024, 11, 30),
             new Date(2025, 0, 5, 23, 59, 59, 999),
@@ -109,7 +114,12 @@ describe('useDateRangePicker', () => {
         if (!midWeekConfig || midWeekConfig.type !== TimeFrames.WEEK) {
             throw new Error('Expected week picker config');
         }
-        act(() => midWeekConfig.props.onChange(['2025-01-01', '2025-01-08']));
+        act(() =>
+            midWeekConfig.props.onChange([
+                new Date(2025, 0, 1),
+                new Date(2025, 0, 8),
+            ]),
+        );
         expect(result.current.tempDateRange).toEqual([
             new Date(2024, 11, 30),
             new Date(2025, 0, 12, 23, 59, 59, 999),
@@ -136,17 +146,17 @@ describe('useDateRangePicker', () => {
     it.each([
         [
             TimeFrames.MONTH,
-            ['2025-03-15', '2025-04-02'],
+            [new Date(2025, 2, 15), new Date(2025, 3, 2)],
             [new Date(2025, 2, 1), new Date(2025, 3, 30, 23, 59, 59, 999)],
         ],
         [
             TimeFrames.YEAR,
-            ['2024-06-15', '2025-02-02'],
+            [new Date(2024, 5, 15), new Date(2025, 1, 2)],
             [new Date(2024, 0, 1), new Date(2025, 11, 31, 23, 59, 59, 999)],
         ],
     ] as const)(
         'normalizes %s picker ranges at the domain boundary',
-        (timeInterval, mantineRange, expected) => {
+        (timeInterval, calendarRange, expected) => {
             const { result } = renderHook(() =>
                 useDateRangePicker({
                     value: initialValue,
@@ -158,7 +168,7 @@ describe('useDateRangePicker', () => {
             const config = result.current.calendarConfig;
             if (!config) throw new Error('Expected picker config');
             act(() =>
-                config.props.onChange([mantineRange[0], mantineRange[1]]),
+                config.props.onChange([calendarRange[0], calendarRange[1]]),
             );
             expect(result.current.tempDateRange).toEqual(expected);
         },

--- a/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useDateRangePicker.tsx
@@ -4,20 +4,13 @@ import {
     type MetricExplorerDateRange,
     type MetricExplorerPartialDateRange,
 } from '@lightdash/common';
-import {
-    type DatePickerProps,
-    type MonthPickerProps,
-    type YearPickerProps,
-} from '@mantine-8/dates';
 import dayjs from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-    formatMantineDateRange,
-    parseMantineDate,
-    parseMantineDateRange,
-    type MantineDateRange,
-} from '../../../components/common/Filters/FilterInputs/mantineDateAdapter';
+import { type CalendarRangePickerProps } from '../../../components/common/DatePickers/CalendarRangePicker';
+import { type MonthRangePickerProps } from '../../../components/common/DatePickers/MonthRangePicker';
+import { type CalendarDateRange } from '../../../components/common/DatePickers/types';
+import { type YearRangePickerProps } from '../../../components/common/DatePickers/YearRangePicker';
 import { formatDate, getDateRangePresets } from '../utils/metricExploreDate';
 import styles from './useDateRangePicker.module.css';
 
@@ -37,34 +30,24 @@ interface UseDateRangePickerProps {
     timeInterval: TimeFrames;
 }
 
-type BaseCalendarProps = {
-    type: 'range';
-    value: MantineDateRange;
-    onChange: (dates: MantineDateRange) => void;
-};
-
 type DayPickerConfig = {
     type: TimeFrames.DAY;
-    props: BaseCalendarProps &
-        Omit<DatePickerProps<'range'>, 'type' | 'value' | 'onChange'>;
+    props: CalendarRangePickerProps;
 };
 
 type WeekPickerConfig = {
     type: TimeFrames.WEEK;
-    props: BaseCalendarProps &
-        Omit<DatePickerProps<'range'>, 'type' | 'value' | 'onChange'>;
+    props: CalendarRangePickerProps;
 };
 
 type MonthPickerConfig = {
     type: TimeFrames.MONTH;
-    props: BaseCalendarProps &
-        Omit<MonthPickerProps<'range'>, 'type' | 'value' | 'onChange'>;
+    props: MonthRangePickerProps;
 };
 
 type YearPickerConfig = {
     type: TimeFrames.YEAR;
-    props: BaseCalendarProps &
-        Omit<YearPickerProps<'range'>, 'type' | 'value' | 'onChange'>;
+    props: YearRangePickerProps;
 };
 
 type CalendarVisualizationType =
@@ -73,15 +56,6 @@ type CalendarVisualizationType =
     | MonthPickerConfig
     | YearPickerConfig
     | undefined;
-
-const parsePickerRange = (value: unknown): DateRange => {
-    if (!Array.isArray(value)) return [null, null];
-
-    return parseMantineDateRange([
-        typeof value[0] === 'string' ? value[0] : null,
-        typeof value[1] === 'string' ? value[1] : null,
-    ]);
-};
 
 /**
  * Hook to handle the date range picker for the metric peek
@@ -175,15 +149,13 @@ export const useDateRangePicker = ({
                 return {
                     type: TimeFrames.YEAR,
                     props: {
-                        type: 'range',
-                        value: formatMantineDateRange(tempDateRange),
-                        onChange: (dates) => {
-                            const parsedRange = parsePickerRange(dates);
-                            const startDate = parsedRange[0]
-                                ? dayjs(parsedRange[0]).startOf('year').toDate()
+                        value: tempDateRange,
+                        onChange: (dates: CalendarDateRange) => {
+                            const startDate = dates[0]
+                                ? dayjs(dates[0]).startOf('year').toDate()
                                 : null;
-                            const endDate = parsedRange[1]
-                                ? dayjs(parsedRange[1]).endOf('year').toDate()
+                            const endDate = dates[1]
+                                ? dayjs(dates[1]).endOf('year').toDate()
                                 : null;
                             handleDateRangeChange([startDate, endDate]);
                         },
@@ -195,17 +167,13 @@ export const useDateRangePicker = ({
                 return {
                     type: TimeFrames.MONTH,
                     props: {
-                        type: 'range',
-                        value: formatMantineDateRange(tempDateRange),
-                        onChange: (dates) => {
-                            const parsedRange = parsePickerRange(dates);
-                            const startDate = parsedRange[0]
-                                ? dayjs(parsedRange[0])
-                                      .startOf('month')
-                                      .toDate()
+                        value: tempDateRange,
+                        onChange: (dates: CalendarDateRange) => {
+                            const startDate = dates[0]
+                                ? dayjs(dates[0]).startOf('month').toDate()
                                 : null;
-                            const endDate = parsedRange[1]
-                                ? dayjs(parsedRange[1]).endOf('month').toDate()
+                            const endDate = dates[1]
+                                ? dayjs(dates[1]).endOf('month').toDate()
                                 : null;
                             handleDateRangeChange([startDate, endDate]);
                         },
@@ -217,11 +185,8 @@ export const useDateRangePicker = ({
                 return {
                     type: TimeFrames.WEEK,
                     props: {
-                        type: 'range',
-                        value: formatMantineDateRange(tempDateRange),
-                        onChange: (dates) => {
-                            const parsedRange = parsePickerRange(dates);
-
+                        value: tempDateRange,
+                        onChange: (parsedRange: CalendarDateRange) => {
                             const getWeekBoundaries = (date: Date) => {
                                 const weekStart = dayjs(date)
                                     .startOf('isoWeek')
@@ -282,10 +247,7 @@ export const useDateRangePicker = ({
                         firstDayOfWeek: 1,
                         hideOutsideDates: true,
                         // Highlight the week of the selected date
-                        getDayProps: (mantineValue) => {
-                            const date = parseMantineDate(mantineValue);
-                            if (!date) return {};
-
+                        getDayProps: (date: Date) => {
                             const today = dayjs().endOf('day');
                             const isInFuture = dayjs(date).isAfter(today);
 
@@ -316,10 +278,8 @@ export const useDateRangePicker = ({
                 return {
                     type: TimeFrames.DAY,
                     props: {
-                        type: 'range',
-                        value: formatMantineDateRange(tempDateRange),
-                        onChange: (dates) =>
-                            handleDateRangeChange(parsePickerRange(dates)),
+                        value: tempDateRange,
+                        onChange: handleDateRangeChange,
                         numberOfColumns: 2,
                         classNames: styles,
                     },


### PR DESCRIPTION
## Summary

Second PR of the seam chain (stacked on #26113, which is on #26108). Metrics Catalog was the deepest string-seam consumer: `useDateRangePicker` formatted/parsed Mantine date strings in every branch of `calendarConfig`, and its tests asserted against string emissions.

- **`useDateRangePicker` is now fully Date-native.** `calendarConfig.props` speak `Date | null` for values, onChange payloads, and `getDayProps`; the hook no longer imports anything from `@mantine-8/dates` or the adapter. `parsePickerRange` is deleted.
- **New `MonthRangePicker` / `YearRangePicker` wrappers** in `components/common/DatePickers`, and `CalendarRangePicker` gains a Date-native `getDayProps` (the wrapper converts the incoming day string once, privately) for the week-highlight rendering.
- **`MetricExploreDatePicker`** renders the three wrappers instead of raw `DatePicker`/`MonthPicker`/`YearPicker`.
- **Hook tests now cross the Date seam** — `onChange([new Date(...), ...])` instead of `onChange(['2025-01-15', ...])`, `getDayProps(new Date(...))` instead of strings. This is the concrete payoff: the tests can no longer pass while the string layer regresses, because they don't touch it.
- **oxlint guard widened** to `src/features/metricsCatalog/**`; verified the feature has zero remaining `@mantine-8/dates` / adapter imports.

## Behavior / regression analysis

No behavior change intended. The hook's week-snapping, month/year normalization, and preset logic are untouched — only the type at the config boundary moved from string to Date. The parse that previously happened inside the hook (`parsePickerRange`) now happens once inside the wrappers via the same `parseMantineDateRange` call, so emitted Dates are identical. All 8 hook tests (including the WEEK complete-range/year-boundary and cleared-range cases added in #26108's hardening) plus the 5 wrapper contract tests pass unchanged in expectation values.

## Remaining (PR 3)

Extract `ParameterDateInput` (domain string adapter over a calendar wrapper), relocate/promote the project-aware datetime module, make `mantineDateAdapter` private to the wrapper layer, widen the guard to `features/parameters`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMT6FGiBtQY22zupwoocGb