### PR TITLE
fix: reject interactive-only Snowflake authentication types when saving project credentials

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -2,6 +2,7 @@ import { Ability } from '@casl/ability';
 import {
     DbtProjectType,
     DbtVersionOptionLatest,
+    DefaultSupportedDbtVersion,
     defineUserAbility,
     DimensionType,
     DownloadFileType,
@@ -20,6 +21,7 @@ import {
     RedshiftAuthenticationType,
     RequestMethod,
     SessionUser,
+    SnowflakeAuthenticationType,
     SupportedDbtAdapter,
     WarehouseTypes,
     type ChartSummary,
@@ -28,6 +30,7 @@ import {
     type Explore,
     type PossibleAbilities,
     type RegisteredAccount,
+    type UpdateProject,
 } from '@lightdash/common';
 import { Readable } from 'stream';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
@@ -3202,6 +3205,71 @@ describe('ProjectService', () => {
                     'file-id',
                 ),
             ).rejects.toThrowError(NotFoundError);
+        });
+    });
+
+    describe('validateConfigSecrets', () => {
+        const projectWithSnowflakeAuth = (
+            authenticationType: SnowflakeAuthenticationType,
+            requireUserCredentials?: boolean,
+        ): UpdateProject => ({
+            name: 'test-project',
+            dbtConnection: { type: DbtProjectType.NONE },
+            dbtVersion: DefaultSupportedDbtVersion,
+            warehouseConnection: {
+                type: WarehouseTypes.SNOWFLAKE,
+                account: 'test-account',
+                user: 'test-user',
+                database: 'test-db',
+                warehouse: 'test-warehouse',
+                schema: 'test-schema',
+                authenticationType,
+                requireUserCredentials,
+            },
+        });
+
+        it('rejects Snowflake OAuth authorization code authentication', () => {
+            expect(() =>
+                service.validateConfigSecrets(
+                    projectWithSnowflakeAuth(
+                        SnowflakeAuthenticationType.OAUTH_AUTHORIZATION_CODE,
+                    ),
+                ),
+            ).toThrowError(ParameterError);
+        });
+
+        it('rejects Snowflake external browser authentication without user credentials', () => {
+            expect(() =>
+                service.validateConfigSecrets(
+                    projectWithSnowflakeAuth(
+                        SnowflakeAuthenticationType.EXTERNAL_BROWSER,
+                    ),
+                ),
+            ).toThrowError(ParameterError);
+        });
+
+        it('allows Snowflake external browser authentication when user credentials are required', () => {
+            expect(() =>
+                service.validateConfigSecrets(
+                    projectWithSnowflakeAuth(
+                        SnowflakeAuthenticationType.EXTERNAL_BROWSER,
+                        true,
+                    ),
+                ),
+            ).not.toThrowError();
+        });
+
+        it.each([
+            SnowflakeAuthenticationType.PASSWORD,
+            SnowflakeAuthenticationType.PRIVATE_KEY,
+            SnowflakeAuthenticationType.SSO,
+            SnowflakeAuthenticationType.NONE,
+        ])('allows Snowflake %s authentication', (authenticationType) => {
+            expect(() =>
+                service.validateConfigSecrets(
+                    projectWithSnowflakeAuth(authenticationType),
+                ),
+            ).not.toThrowError();
         });
     });
 });

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2403,6 +2403,9 @@ export class ProjectService extends BaseService {
             data.warehouseConnection,
             internalProvisioning,
         );
+        ProjectService.assertPersistableSnowflakeAuthentication(
+            data.warehouseConnection,
+        );
 
         await this.validateProjectCreationPermissions(user, data);
 
@@ -2668,6 +2671,9 @@ export class ProjectService extends BaseService {
         }
 
         ProjectService.assertEmbeddedCredentialsAreInternal(
+            data.warehouseConnection,
+        );
+        ProjectService.assertPersistableSnowflakeAuthentication(
             data.warehouseConnection,
         );
 
@@ -3091,8 +3097,45 @@ export class ProjectService extends BaseService {
         }
     }
 
+    /*
+    Interactive Snowflake authentication types need a browser on every
+    connect, so they cannot be used from headless backend/scheduler runs.
+    External browser is still allowed when `requireUserCredentials` is set,
+    since each user then connects with their own credentials and the
+    project-level authentication type is never used to connect.
+    */
+    private static assertPersistableSnowflakeAuthentication(
+        credentials: CreateWarehouseCredentials | undefined,
+    ): void {
+        if (credentials?.type !== WarehouseTypes.SNOWFLAKE) {
+            return;
+        }
+        if (
+            credentials.authenticationType ===
+            SnowflakeAuthenticationType.OAUTH_AUTHORIZATION_CODE
+        ) {
+            throw new ParameterError(
+                'Snowflake OAuth authorization code authentication is only supported in the CLI and cannot be saved on a project',
+            );
+        }
+        if (
+            credentials.authenticationType ===
+                SnowflakeAuthenticationType.EXTERNAL_BROWSER &&
+            !credentials.requireUserCredentials
+        ) {
+            throw new ParameterError(
+                'Snowflake external browser authentication is only supported in the CLI and cannot be saved on a project',
+            );
+        }
+    }
+
     validateConfigSecrets(project: UpdateProject) {
         switch (project.warehouseConnection?.type) {
+            case WarehouseTypes.SNOWFLAKE:
+                ProjectService.assertPersistableSnowflakeAuthentication(
+                    project.warehouseConnection,
+                );
+                break;
             case WarehouseTypes.BIGQUERY:
                 const keyFileContents =
                     project.warehouseConnection?.keyfileContents;


### PR DESCRIPTION
Adds a Snowflake case to project credential validation so authentication types that require a browser on every connect (OAuth authorization code, and external browser unless per-user credentials are required) are rejected on project create/update.

Linear: SPK-581