### PR TITLE
fix: delete expired warehouse connect codes via a scheduled cleanup job

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -140,6 +140,8 @@ const schedulerWorkerFactory = (context: {
             context.models.getOrganizationSettingsModel(),
         emailWhitelabelService:
             context.serviceRepository.getEmailWhitelabelService(),
+        warehouseConnectCodeModel:
+            context.models.getWarehouseConnectCodeModel(),
         resolveOrganizationName: createOrganizationNameResolver(
             context.models.getOrganizationModel(),
         ),

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -105,6 +105,8 @@ const schedulerWorkerFactory = (context: {
             context.models.getOrganizationSettingsModel(),
         emailWhitelabelService:
             context.serviceRepository.getEmailWhitelabelService(),
+        warehouseConnectCodeModel:
+            context.models.getWarehouseConnectCodeModel(),
         workerHealth: context.workerHealth,
         resolveOrganizationName: createOrganizationNameResolver(
             context.models.getOrganizationModel(),

--- a/packages/backend/src/controllers/warehouseConnectController.ts
+++ b/packages/backend/src/controllers/warehouseConnectController.ts
@@ -70,7 +70,8 @@ export class WarehouseConnectController extends BaseController {
 
     /**
      * Retrieves credentials deposited against a connect code created by the
-     * current user. Returns them once and deletes the code
+     * current user. Returns them until the code expires; expired codes are
+     * deleted by a scheduled cleanup job
      * @summary Claim connect code
      */
     @Middlewares([isAuthenticated])

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -1074,6 +1074,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     context.models.getOrganizationSettingsModel(),
                 emailWhitelabelService:
                     context.serviceRepository.getEmailWhitelabelService(),
+                warehouseConnectCodeModel:
+                    context.models.getWarehouseConnectCodeModel(),
                 managedAgentService:
                     context.serviceRepository.getManagedAgentService<ManagedAgentService>(),
                 appGenerateService:

--- a/packages/backend/src/models/WarehouseConnectCodeModel.test.ts
+++ b/packages/backend/src/models/WarehouseConnectCodeModel.test.ts
@@ -161,4 +161,27 @@ describe('WarehouseConnectCodeModel', () => {
             'database-now',
         );
     });
+
+    it('deletes expired codes without returning them', async () => {
+        const builder = {
+            where: vi.fn(),
+            delete: vi.fn(async () => 2),
+        };
+        builder.where.mockReturnValue(builder);
+        const database = Object.assign(
+            vi.fn(() => builder),
+            {
+                fn: { now: vi.fn(() => 'database-now') },
+            },
+        ) as unknown as Knex;
+        const model = new WarehouseConnectCodeModel({ database });
+
+        await expect(model.deleteExpired()).resolves.toBe(2);
+        expect(builder.where).toHaveBeenCalledWith(
+            'expires_at',
+            '<=',
+            'database-now',
+        );
+        expect(builder.delete).toHaveBeenCalledOnce();
+    });
 });

--- a/packages/backend/src/models/WarehouseConnectCodeModel.ts
+++ b/packages/backend/src/models/WarehouseConnectCodeModel.ts
@@ -82,4 +82,10 @@ export class WarehouseConnectCodeModel {
             .first();
         return row ? WarehouseConnectCodeModel.convertRow(row) : null;
     }
+
+    async deleteExpired(): Promise<number> {
+        return this.database(WarehouseConnectCodeTableName)
+            .where('expires_at', '<=', this.database.fn.now())
+            .delete();
+    }
 }

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -161,6 +161,7 @@ import type { PreAggregateMaterializationService } from '../ee/services/PreAggre
 import Logger from '../logging/logger';
 import type { ExecutionContextInfo } from '../logging/winston';
 import { OrganizationSettingsModel } from '../models/OrganizationSettingsModel';
+import { WarehouseConnectCodeModel } from '../models/WarehouseConnectCodeModel';
 import { AsyncQueryService } from '../services/AsyncQueryService/AsyncQueryService';
 import { SCHEDULER_POLLING_OPTIONS } from '../services/AsyncQueryService/types';
 import type { CatalogService } from '../services/CatalogService/CatalogService';
@@ -238,6 +239,7 @@ export type SchedulerTaskArguments = {
     preAggregateMaterializationService: PreAggregateMaterializationService;
     organizationSettingsModel: OrganizationSettingsModel;
     emailWhitelabelService: EmailWhitelabelService;
+    warehouseConnectCodeModel: WarehouseConnectCodeModel;
 };
 
 /**
@@ -423,6 +425,8 @@ export default class SchedulerTask {
 
     protected readonly emailWhitelabelService: EmailWhitelabelService;
 
+    protected readonly warehouseConnectCodeModel: WarehouseConnectCodeModel;
+
     constructor(args: SchedulerTaskArguments) {
         this.lightdashConfig = args.lightdashConfig;
         this.analytics = args.analytics;
@@ -453,6 +457,7 @@ export default class SchedulerTask {
             args.preAggregateMaterializationService;
         this.organizationSettingsModel = args.organizationSettingsModel;
         this.emailWhitelabelService = args.emailWhitelabelService;
+        this.warehouseConnectCodeModel = args.warehouseConnectCodeModel;
     }
 
     /**

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -240,6 +240,7 @@ const getTagsForTask: {
     [SCHEDULER_TASKS.GENERATE_SLACK_CHANNEL_SYNC_JOBS]: () => ({}),
     [SCHEDULER_TASKS.CHECK_FOR_STUCK_JOBS]: () => ({}),
     [SCHEDULER_TASKS.CLEAN_DEPLOY_SESSIONS]: () => ({}),
+    [SCHEDULER_TASKS.CLEAN_WAREHOUSE_CONNECT_CODES]: () => ({}),
     [SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT]: (payload) => ({
         'project.uuid': payload.projectUuid,
         'managed_agent.triggered_by': payload.triggeredBy ?? 'cron',

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -261,6 +261,14 @@ export class SchedulerWorker extends SchedulerTask {
                     maxAttempts: 1,
                 },
             },
+            {
+                task: SCHEDULER_TASKS.CLEAN_WAREHOUSE_CONNECT_CODES,
+                pattern: '41 * * * *', // Hourly, off the top of the hour
+                options: {
+                    backfillPeriod: 2 * 3600 * 1000, // 2 hours in ms
+                    maxAttempts: 3,
+                },
+            },
             // worker-process pg liveness is driven by a setInterval (see startPgPing);
             // managed-agent heartbeat is self-scheduling (see SchedulerClient.scheduleManagedAgentHeartbeat).
         ];
@@ -1222,6 +1230,24 @@ export class SchedulerWorker extends SchedulerTask {
                 } catch (error) {
                     Logger.error(
                         'Error during deploy sessions cleanup:',
+                        error,
+                    );
+                    throw error;
+                }
+            },
+            [SCHEDULER_TASKS.CLEAN_WAREHOUSE_CONNECT_CODES]: async () => {
+                Logger.info('Starting warehouse connect codes cleanup job');
+
+                try {
+                    const deletedCount =
+                        await this.warehouseConnectCodeModel.deleteExpired();
+
+                    Logger.info(
+                        `Warehouse connect codes cleanup completed. Deleted: ${deletedCount}`,
+                    );
+                } catch (error) {
+                    Logger.error(
+                        'Error during warehouse connect codes cleanup:',
                         error,
                     );
                     throw error;

--- a/packages/backend/src/scheduler/SchedulerWorker.warehouseConnect.test.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.warehouseConnect.test.ts
@@ -1,0 +1,80 @@
+import { ALL_TASK_NAMES, SCHEDULER_TASKS } from '@lightdash/common';
+import { type LightdashConfig } from '../config/parseConfig';
+import {
+    SchedulerWorker,
+    type SchedulerWorkerArguments,
+} from './SchedulerWorker';
+
+class TestableSchedulerWorker extends SchedulerWorker {
+    public exposeFullTaskList() {
+        return this.getFullTaskList();
+    }
+}
+
+const emptyPayload = {
+    organizationUuid: 'org-uuid',
+    projectUuid: 'project-uuid',
+    userUuid: 'user-uuid',
+};
+
+const makeWorkerArgs = (
+    deleteExpired: import('vitest').Mock,
+): SchedulerWorkerArguments =>
+    ({
+        lightdashConfig: {
+            scheduler: {
+                tasks: [...ALL_TASK_NAMES],
+                concurrency: 1,
+                pollInterval: 1000,
+                jobTimeout: 60_000,
+                queryHistory: {
+                    cleanup: {
+                        enabled: false,
+                        schedule: '0 0 * * *',
+                        retentionDays: 30,
+                        batchSize: 100,
+                        delayMs: 0,
+                        maxBatches: 1,
+                    },
+                },
+            },
+            database: { connectionUri: 'postgres://noop' },
+        } as unknown as LightdashConfig,
+        warehouseConnectCodeModel: { deleteExpired },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as unknown as SchedulerWorkerArguments;
+
+describe('SchedulerWorker — warehouse connect codes cleanup', () => {
+    it('registers a cleanup task that purges expired codes', async () => {
+        const deleteExpired = vi.fn(async () => 3);
+        const worker = new TestableSchedulerWorker(
+            makeWorkerArgs(deleteExpired),
+        );
+
+        const task =
+            worker.exposeFullTaskList()[
+                SCHEDULER_TASKS.CLEAN_WAREHOUSE_CONNECT_CODES
+            ];
+        expect(task).toBeDefined();
+
+        await task(emptyPayload, {} as never);
+        expect(deleteExpired).toHaveBeenCalledOnce();
+    });
+
+    it('rethrows purge errors so the job is marked failed', async () => {
+        const deleteExpired = vi.fn(async () => {
+            throw new Error('db down');
+        });
+        const worker = new TestableSchedulerWorker(
+            makeWorkerArgs(deleteExpired),
+        );
+
+        const task =
+            worker.exposeFullTaskList()[
+                SCHEDULER_TASKS.CLEAN_WAREHOUSE_CONNECT_CODES
+            ];
+        await expect(task(emptyPayload, {} as never)).rejects.toThrow(
+            'db down',
+        );
+    });
+});

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -170,6 +170,7 @@ export const SCHEDULER_TASKS = {
     INGEST_PROJECT_CONTEXT: 'ingestProjectContext',
     COMPACT_USAGE_EVENTS: 'compactUsageEvents',
     POLL_EMAIL_WHITELABEL: 'pollEmailWhitelabelVerification',
+    CLEAN_WAREHOUSE_CONNECT_CODES: 'cleanWarehouseConnectCodes',
     ...EE_SCHEDULER_TASKS,
 } as const;
 
@@ -216,6 +217,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.INGEST_PROJECT_CONTEXT]: TraceTaskBase;
     [SCHEDULER_TASKS.COMPACT_USAGE_EVENTS]: TraceTaskBase;
     [SCHEDULER_TASKS.POLL_EMAIL_WHITELABEL]: TraceTaskBase;
+    [SCHEDULER_TASKS.CLEAN_WAREHOUSE_CONNECT_CODES]: TraceTaskBase;
     [SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK]: AiAgentReviewWritebackJobPayload;

--- a/packages/e2e/cypress/e2e/app/userAttributes.cy.ts
+++ b/packages/e2e/cypress/e2e/app/userAttributes.cy.ts
@@ -42,7 +42,7 @@ describe('User attributes sql_filter', () => {
 
     it('Create user attribute', () => {
         cy.visit(`/generalSettings/userAttributes`);
-        cy.findByText('Add new attribute').click();
+        cy.findByText('Add attribute').click();
 
         cy.get('input[name="name"]').type('customer_id');
         cy.findByText('Add user').click();
@@ -143,7 +143,7 @@ describe('User attributes dimension required_attribute', () => {
 
     it('Create user attribute', () => {
         cy.visit(`/generalSettings/userAttributes`);
-        cy.findByText('Add new attribute').click();
+        cy.findByText('Add attribute').click();
 
         cy.get('input[name="name"]').type('is_admin');
         cy.findByText('Add user').click();


### PR DESCRIPTION
Adds WarehouseConnectCodeModel.deleteExpired and an hourly cleanWarehouseConnectCodes scheduler task so expired connect codes are removed instead of lingering past their TTL, and corrects the claim endpoint docs which still described the old claim-once behaviour.

Linear: SPK-582