### PR TITLE
fix: show total calculation errors in table cells

### DIFF
--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -232,6 +232,11 @@ const SimpleTable: FC<SimpleTableProps> = ({
         showSubtotalsExpanded,
         showRowGrouping,
         updateColumnProperty,
+        columnTotalsError,
+        rowTotalsError,
+        grandTotalsError,
+        columnSubtotalsError,
+        rowSubtotalsError,
         isCalculatingColumnTotals,
         isCalculatingRowTotals,
         isCalculatingRowSubtotals,
@@ -333,6 +338,11 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                 isColumnTotalsLoading={
                                     isCalculatingColumnTotals
                                 }
+                                columnTotalsError={columnTotalsError}
+                                rowTotalsError={rowTotalsError}
+                                grandTotalsError={grandTotalsError}
+                                columnSubtotalsError={columnSubtotalsError}
+                                rowSubtotalsError={rowSubtotalsError}
                                 isRowTotalsLoading={isCalculatingRowTotals}
                                 isRowSubtotalsLoading={
                                     isCalculatingRowSubtotals
@@ -364,6 +374,11 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                 isColumnTotalsLoading={
                                     isCalculatingColumnTotals
                                 }
+                                columnTotalsError={columnTotalsError}
+                                rowTotalsError={rowTotalsError}
+                                grandTotalsError={grandTotalsError}
+                                columnSubtotalsError={columnSubtotalsError}
+                                rowSubtotalsError={rowSubtotalsError}
                                 isRowTotalsLoading={isCalculatingRowTotals}
                                 isRowSubtotalsLoading={
                                     isCalculatingRowSubtotals

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -84,6 +84,7 @@ import { CELL_HEIGHT } from '../LightTable/constants';
 import MantineIcon from '../MantineIcon';
 import { ROW_NUMBER_COLUMN_ID } from '../Table/constants';
 import { getGroupedRowModelLightdash } from '../Table/getGroupedRowModelLightdash';
+import TotalCalculationErrorCell from '../Table/TotalCalculationErrorCell';
 import { columnHelper, type TableColumn } from '../Table/types';
 import { useColumnResize } from '../Table/useColumnResize';
 import { countSubRows } from '../Table/utils';
@@ -186,6 +187,16 @@ type PivotTableProps = BoxProps & // TODO: remove this
         showRowGrouping?: boolean;
         /** Column-total footer cells render a loading skeleton while their async query is in flight. */
         isColumnTotalsLoading?: boolean;
+        /** Error returned by the column-total query. */
+        columnTotalsError?: unknown;
+        /** Error returned by the row-total query. */
+        rowTotalsError?: unknown;
+        /** Error returned by the grand-total query. */
+        grandTotalsError?: unknown;
+        /** Error returned by a column-subtotal query. */
+        columnSubtotalsError?: unknown;
+        /** Error returned by a row-subtotal query. */
+        rowSubtotalsError?: unknown;
         /** Row-total cells render a loading skeleton while their async query is in flight. */
         isRowTotalsLoading?: boolean;
         /** Grouped row-total cells render a loading skeleton while row subtotals are in flight. */
@@ -226,6 +237,11 @@ const PivotTable: FC<PivotTableProps> = ({
     showSubtotalsExpanded = false,
     showRowGrouping = false,
     isColumnTotalsLoading = false,
+    columnTotalsError,
+    rowTotalsError,
+    grandTotalsError,
+    columnSubtotalsError,
+    rowSubtotalsError,
     isRowTotalsLoading = false,
     isRowSubtotalsLoading = false,
     isGrandTotalsLoading = false,
@@ -579,6 +595,21 @@ const PivotTable: FC<PivotTableProps> = ({
                                     return null;
                                 }
 
+                                const subtotalError = isRowTotal
+                                    ? rowSubtotalsError
+                                    : columnSubtotalsError;
+                                if (
+                                    subtotalValue === undefined &&
+                                    subtotalError &&
+                                    (isRowTotal || isNumericItem(item))
+                                ) {
+                                    return (
+                                        <TotalCalculationErrorCell
+                                            error={subtotalError}
+                                        />
+                                    );
+                                }
+
                                 if (
                                     subtotalValue === undefined &&
                                     (isRowTotal
@@ -632,6 +663,8 @@ const PivotTable: FC<PivotTableProps> = ({
         parameters,
         isSubtotalsLoading,
         isRowSubtotalsLoading,
+        columnSubtotalsError,
+        rowSubtotalsError,
     ]);
 
     // Minimum table width so auto columns don't get squeezed to zero
@@ -2157,9 +2190,21 @@ const PivotTable: FC<PivotTableProps> = ({
                                           (isDataColumn || isRowTotal) ? (
                                             metricSubtotalValue === undefined &&
                                             (isRowTotal
-                                                ? isRowSubtotalsLoading
-                                                : isSubtotalsLoading) &&
-                                            isNumericItem(item) ? (
+                                                ? rowSubtotalsError
+                                                : columnSubtotalsError) ? (
+                                                <TotalCalculationErrorCell
+                                                    error={
+                                                        isRowTotal
+                                                            ? rowSubtotalsError
+                                                            : columnSubtotalsError
+                                                    }
+                                                />
+                                            ) : metricSubtotalValue ===
+                                                  undefined &&
+                                              (isRowTotal
+                                                  ? isRowSubtotalsLoading
+                                                  : isSubtotalsLoading) &&
+                                              isNumericItem(item) ? (
                                                 <Skeleton
                                                     height={16}
                                                     width="min(60%, 50px)"
@@ -2268,7 +2313,12 @@ const PivotTable: FC<PivotTableProps> = ({
                                             )
                                         ) : cell.getIsPlaceholder() ||
                                           isBlankMergeDataCell ? null : isRowTotal &&
-                                          isRowTotalsLoading ? (
+                                          value?.raw == null &&
+                                          rowTotalsError ? (
+                                            <TotalCalculationErrorCell
+                                                error={rowTotalsError}
+                                            />
+                                        ) : isRowTotal && isRowTotalsLoading ? (
                                             <Skeleton
                                                 height={16}
                                                 width="min(60%, 50px)"
@@ -2414,6 +2464,16 @@ const PivotTable: FC<PivotTableProps> = ({
                                         >
                                             {value.formatted}
                                         </Table.CellHead>
+                                    ) : columnTotalsError ? (
+                                        <Table.CellHead
+                                            key={`column-total-${totalRowIndex}-${totalColIndex}`}
+                                            withAlignRight
+                                            isMinimal={isMinimal}
+                                        >
+                                            <TotalCalculationErrorCell
+                                                error={columnTotalsError}
+                                            />
+                                        </Table.CellHead>
                                     ) : isColumnTotalsLoading ? (
                                         <Table.CellHead
                                             key={`column-total-${totalRowIndex}-${totalColIndex}`}
@@ -2476,6 +2536,18 @@ const PivotTable: FC<PivotTableProps> = ({
                                                       )}
                                                   >
                                                       {value.formatted}
+                                                  </Table.CellHead>
+                                              ) : grandTotalsError ? (
+                                                  <Table.CellHead
+                                                      key={`grand-total-${totalRowIndex}-${index}`}
+                                                      withAlignRight
+                                                      isMinimal={isMinimal}
+                                                  >
+                                                      <TotalCalculationErrorCell
+                                                          error={
+                                                              grandTotalsError
+                                                          }
+                                                      />
                                                   </Table.CellHead>
                                               ) : isGrandTotalsLoading ? (
                                                   <Table.CellHead

--- a/packages/frontend/src/components/common/Table/TotalCalculationErrorCell.tsx
+++ b/packages/frontend/src/components/common/Table/TotalCalculationErrorCell.tsx
@@ -1,0 +1,32 @@
+import { getErrorMessage, isApiError } from '@lightdash/common';
+import { Group, Text, Tooltip } from '@mantine-8/core';
+import { IconAlertCircle } from '@tabler/icons-react';
+import { type FC } from 'react';
+
+const TotalCalculationErrorCell: FC<{ error: unknown }> = ({ error }) => {
+    const message = isApiError(error)
+        ? error.error.message
+        : getErrorMessage(error);
+
+    return (
+        <Tooltip withinPortal multiline maw={500} label={message}>
+            <Group
+                component="span"
+                gap={4}
+                justify="flex-end"
+                wrap="nowrap"
+                c="red.6"
+                w="100%"
+                style={{ cursor: 'help' }}
+                aria-label={`Total calculation error: ${message}`}
+            >
+                <IconAlertCircle size={14} />
+                <Text component="span" size="xs" fw={600} c="inherit">
+                    Error
+                </Text>
+            </Group>
+        </Tooltip>
+    );
+};
+
+export default TotalCalculationErrorCell;

--- a/packages/frontend/src/components/common/Table/TotalCalculationErrorCell.tsx
+++ b/packages/frontend/src/components/common/Table/TotalCalculationErrorCell.tsx
@@ -2,6 +2,7 @@ import { getErrorMessage, isApiError } from '@lightdash/common';
 import { Group, Text, Tooltip } from '@mantine-8/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { type FC } from 'react';
+import MantineIcon from '../MantineIcon';
 
 const TotalCalculationErrorCell: FC<{ error: unknown }> = ({ error }) => {
     const message = isApiError(error)
@@ -20,7 +21,7 @@ const TotalCalculationErrorCell: FC<{ error: unknown }> = ({ error }) => {
                 style={{ cursor: 'help' }}
                 aria-label={`Total calculation error: ${message}`}
             >
-                <IconAlertCircle size={14} />
+                <MantineIcon icon={IconAlertCircle} size={14} />
                 <Text component="span" size="xs" fw={600} c="inherit">
                     Error
                 </Text>

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -21,6 +21,7 @@ import {
     TableHeaderLabelContainer,
     TableHeaderRegularLabel,
 } from '../../components/common/Table/Table.styles';
+import TotalCalculationErrorCell from '../../components/common/Table/TotalCalculationErrorCell';
 import {
     columnHelper,
     type TableColumn,
@@ -39,8 +40,10 @@ type Args = {
     columnOrder: string[];
     totals?: Record<string, number>;
     totalsLoading?: boolean;
+    totalsError?: unknown;
     groupedSubtotals?: Record<string, Record<string, number>[]>;
     subtotalsLoading?: boolean;
+    subtotalsError?: unknown;
     parameters?: ParametersValuesMap;
 };
 
@@ -186,8 +189,10 @@ const getDataAndColumns = ({
     columnOrder,
     totals,
     totalsLoading,
+    totalsError,
     groupedSubtotals,
     subtotalsLoading,
+    subtotalsError,
     parameters,
 }: Args): Array<TableHeader | TableColumn> => {
     // Deduplicate columnOrder to prevent duplicate columns if the same field appears multiple times
@@ -263,6 +268,13 @@ const getDataAndColumns = ({
                                 parameters,
                             );
                         }
+                        if (totalsError && isNumericItem(item)) {
+                            return (
+                                <TotalCalculationErrorCell
+                                    error={totalsError}
+                                />
+                            );
+                        }
                         if (totalsLoading && isNumericItem(item)) {
                             return (
                                 <Skeleton
@@ -318,6 +330,18 @@ const getDataAndColumns = ({
 
                             if (subtotalValue === null) {
                                 return null;
+                            }
+
+                            if (
+                                subtotalValue === undefined &&
+                                subtotalsError &&
+                                isNumericItem(item)
+                            ) {
+                                return (
+                                    <TotalCalculationErrorCell
+                                        error={subtotalsError}
+                                    />
+                                );
                             }
 
                             if (

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -266,13 +266,16 @@ const useTableConfig = (
         isInitialQueryReady &&
         !!resultsData?.queryUuid &&
         !!tableChartConfig?.showColumnCalculation;
-    const { data: asyncTotals, isFetching: isCalculatingColumnTotals } =
-        useAsyncCalculateTotal({
-            projectUuid,
-            sourceQueryUuid: resultsData?.queryUuid,
-            enabled: canFetchAsyncTotals,
-            invalidateCache,
-        });
+    const {
+        data: asyncTotals,
+        error: columnTotalsError,
+        isFetching: isCalculatingColumnTotals,
+    } = useAsyncCalculateTotal({
+        projectUuid,
+        sourceQueryUuid: resultsData?.queryUuid,
+        enabled: canFetchAsyncTotals,
+        invalidateCache,
+    });
 
     // Index dimension field ids the warehouse row-total query groups by — the
     // worker keys each rendered row's total by these. Row totals are exclusively
@@ -290,14 +293,17 @@ const useTableConfig = (
         !!resultsData?.queryUuid &&
         !!tableChartConfig?.showRowCalculation &&
         !!resultsData?.pivotDetails;
-    const { data: asyncRowTotals, isFetching: isCalculatingRowTotals } =
-        useAsyncCalculateRowTotal({
-            projectUuid,
-            sourceQueryUuid: resultsData?.queryUuid,
-            indexFieldIds: rowTotalIndexFieldIds,
-            enabled: canFetchAsyncRowTotals,
-            invalidateCache,
-        });
+    const {
+        data: asyncRowTotals,
+        error: rowTotalsError,
+        isFetching: isCalculatingRowTotals,
+    } = useAsyncCalculateRowTotal({
+        projectUuid,
+        sourceQueryUuid: resultsData?.queryUuid,
+        indexFieldIds: rowTotalIndexFieldIds,
+        enabled: canFetchAsyncRowTotals,
+        invalidateCache,
+    });
 
     const canFetchAsyncGrandTotals =
         isInitialQueryReady &&
@@ -305,39 +311,48 @@ const useTableConfig = (
         !!resultsData?.pivotDetails &&
         !!tableChartConfig?.showColumnCalculation &&
         !!tableChartConfig?.showRowCalculation;
-    const { data: asyncGrandTotals, isFetching: isCalculatingGrandTotals } =
-        useAsyncCalculateGrandTotal({
-            projectUuid,
-            sourceQueryUuid: resultsData?.queryUuid,
-            enabled: canFetchAsyncGrandTotals,
-            invalidateCache,
-        });
+    const {
+        data: asyncGrandTotals,
+        error: grandTotalsError,
+        isFetching: isCalculatingGrandTotals,
+    } = useAsyncCalculateGrandTotal({
+        projectUuid,
+        sourceQueryUuid: resultsData?.queryUuid,
+        enabled: canFetchAsyncGrandTotals,
+        invalidateCache,
+    });
 
-    const { data: groupedSubtotals, isFetching: isCalculatingSubtotals } =
-        useAsyncCalculateSubtotals({
-            projectUuid,
-            sourceQueryUuid: resultsData?.queryUuid,
-            dimensions: resultsData?.metricQuery?.dimensions,
-            columnOrder,
-            pivotDimensions,
-            enabled: isInitialQueryReady && showSubtotals && canUseSubtotals,
-            invalidateCache,
-        });
-    const { data: groupedRowSubtotals, isFetching: isCalculatingRowSubtotals } =
-        useAsyncCalculateRowSubtotals({
-            projectUuid,
-            sourceQueryUuid: resultsData?.queryUuid,
-            dimensions: resultsData?.metricQuery?.dimensions,
-            columnOrder,
-            pivotDimensions,
-            enabled:
-                isInitialQueryReady &&
-                showSubtotals &&
-                canUseSubtotals &&
-                !!tableChartConfig?.showRowCalculation &&
-                (pivotDimensions?.length ?? 0) > 0,
-            invalidateCache,
-        });
+    const {
+        data: groupedSubtotals,
+        error: columnSubtotalsError,
+        isFetching: isCalculatingSubtotals,
+    } = useAsyncCalculateSubtotals({
+        projectUuid,
+        sourceQueryUuid: resultsData?.queryUuid,
+        dimensions: resultsData?.metricQuery?.dimensions,
+        columnOrder,
+        pivotDimensions,
+        enabled: isInitialQueryReady && showSubtotals && canUseSubtotals,
+        invalidateCache,
+    });
+    const {
+        data: groupedRowSubtotals,
+        error: rowSubtotalsError,
+        isFetching: isCalculatingRowSubtotals,
+    } = useAsyncCalculateRowSubtotals({
+        projectUuid,
+        sourceQueryUuid: resultsData?.queryUuid,
+        dimensions: resultsData?.metricQuery?.dimensions,
+        columnOrder,
+        pivotDimensions,
+        enabled:
+            isInitialQueryReady &&
+            showSubtotals &&
+            canUseSubtotals &&
+            !!tableChartConfig?.showRowCalculation &&
+            (pivotDimensions?.length ?? 0) > 0,
+        invalidateCache,
+    });
 
     const columns = useMemo(() => {
         if (!selectedItemIds || !itemsMap) {
@@ -359,8 +374,10 @@ const useTableConfig = (
             columnOrder,
             totals: asyncTotals,
             totalsLoading: isCalculatingColumnTotals,
+            totalsError: columnTotalsError,
             groupedSubtotals,
             subtotalsLoading: isCalculatingSubtotals,
+            subtotalsError: columnSubtotalsError,
             parameters,
         });
     }, [
@@ -375,8 +392,10 @@ const useTableConfig = (
         getFieldLabelOverride,
         asyncTotals,
         isCalculatingColumnTotals,
+        columnTotalsError,
         groupedSubtotals,
         isCalculatingSubtotals,
+        columnSubtotalsError,
         parameters,
     ]);
     const worker = useWorker(createWorker);
@@ -782,6 +801,11 @@ const useTableConfig = (
             isPivotResultStale,
             canUseSubtotals,
             groupedSubtotals,
+            columnTotalsError,
+            rowTotalsError,
+            grandTotalsError,
+            columnSubtotalsError,
+            rowSubtotalsError,
             isCalculatingColumnTotals,
             isCalculatingRowTotals,
             isCalculatingRowSubtotals,
@@ -834,6 +858,11 @@ const useTableConfig = (
             isPivotResultStale,
             canUseSubtotals,
             groupedSubtotals,
+            columnTotalsError,
+            rowTotalsError,
+            grandTotalsError,
+            columnSubtotalsError,
+            rowSubtotalsError,
             isCalculatingColumnTotals,
             isCalculatingRowTotals,
             isCalculatingRowSubtotals,

--- a/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
+++ b/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
@@ -51,14 +51,29 @@ type StartCalculateTotalArgs = {
     invalidateCache?: boolean;
 };
 
+const getMockTotalError = (kind: CalculateTotalKind) => {
+    if (!import.meta.env.DEV) return undefined;
+
+    const mockedKinds = new URLSearchParams(window.location.search)
+        .get('mockTotalErrors')
+        ?.split(',');
+
+    return mockedKinds?.includes('all') || mockedKinds?.includes(kind)
+        ? new Error(`Mock ${kind} calculation error`)
+        : undefined;
+};
+
 const startCalculateTotalQuery = ({
     projectUuid,
     sourceQueryUuid,
     kind,
     subtotalDimensions,
     invalidateCache,
-}: StartCalculateTotalArgs) =>
-    lightdashApi<ApiExecuteAsyncMetricQueryResults>({
+}: StartCalculateTotalArgs) => {
+    const mockError = getMockTotalError(kind);
+    if (mockError) return Promise.reject(mockError);
+
+    return lightdashApi<ApiExecuteAsyncMetricQueryResults>({
         url: `/projects/${projectUuid}/query/${sourceQueryUuid}/calculate-total`,
         version: 'v2',
         method: 'POST',
@@ -68,6 +83,7 @@ const startCalculateTotalQuery = ({
             invalidateCache,
         }),
     });
+};
 
 // Single wide row of totals. Keys are pivoted SQL column names for pivoted
 // sources, plain metric field ids otherwise.

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -48,6 +48,7 @@ import {
     TableHeaderLabelContainer,
     TableHeaderRegularLabel,
 } from '../components/common/Table/Table.styles';
+import TotalCalculationErrorCell from '../components/common/Table/TotalCalculationErrorCell';
 import {
     columnHelper,
     type TableColumn,
@@ -611,17 +612,20 @@ export const useColumns = (): TableColumn[] => {
     // The results table has no explicit "Show column totals" setting, so the
     // `column_totals` project default decides whether the totals query runs
     const totalsEnabledByDefault = useColumnTotalsEnabledByDefault(projectUuid);
-    const { data: totals, isFetching: isCalculatingTotals } =
-        useAsyncCalculateTotal({
-            projectUuid,
-            sourceQueryUuid,
-            enabled:
-                isInitialQueryReady &&
-                !!sourceQueryUuid &&
-                hasMetricFields &&
-                totalsEnabledByDefault,
-            invalidateCache: validQueryArgs?.invalidateCache,
-        });
+    const {
+        data: totals,
+        error: totalsError,
+        isFetching: isCalculatingTotals,
+    } = useAsyncCalculateTotal({
+        projectUuid,
+        sourceQueryUuid,
+        enabled:
+            isInitialQueryReady &&
+            !!sourceQueryUuid &&
+            hasMetricFields &&
+            totalsEnabledByDefault,
+        invalidateCache: validQueryArgs?.invalidateCache,
+    });
 
     return useMemo(() => {
         if (hasNoActiveFields) {
@@ -693,6 +697,13 @@ export const useColumns = (): TableColumn[] => {
                                 false,
                                 parameters,
                                 timezone,
+                            );
+                        }
+                        if (totalsError && isNumericItem(item)) {
+                            return (
+                                <TotalCalculationErrorCell
+                                    error={totalsError}
+                                />
                             );
                         }
                         if (isCalculatingTotals && isNumericItem(item)) {
@@ -771,6 +782,7 @@ export const useColumns = (): TableColumn[] => {
         invalidActiveItems,
         sorts,
         totals,
+        totalsError,
         isCalculatingTotals,
         exploreData,
         parameters,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-9212

### Description:

Shows a compact tooltip-backed error cell when async column totals, row totals, grand totals, column subtotals, or row subtotals fail, while retaining successful table data.
Applies to flat and pivoted table visualizations and Explorer results, with a development-only URL mock for manual verification.

### Before

<img width="1795" height="390" alt="Failed total calculations rendered as blank cells" src="https://github.com/user-attachments/assets/8b5b0bdb-9cee-4f71-954c-51c4733b06ae" />

### After

<img width="1795" height="390" alt="Total calculation error cells" src="https://github.com/user-attachments/assets/c935d2c6-0e20-462e-a046-bf7860bd86b9" />
