### PR TITLE
fix(echarts): render calendar DATE time axes on the correct day

### DIFF
--- a/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
@@ -8,6 +8,7 @@ import {
 import { describe, expect, test } from 'vitest';
 import {
     applyTimezoneShiftToEchartsOptions,
+    detectCalendarTimeAxisField,
     resolveAxisTimezone,
     type EchartsOptionsShape,
     type TimezoneShiftedField,
@@ -258,6 +259,8 @@ describe('resolveAxisTimezone', () => {
         expect(result.timeAxisField).toBeUndefined();
     });
 
+    // A calendar DATE is never an instant: resolveAxisTimezone must not shift
+    // it. Its ECharts coordinate is handled by detectCalendarTimeAxisField.
     test('does not shift a calendar DATE day bucket', () => {
         const fieldId = 'orders_created_day';
         const result = resolveAxisTimezone({
@@ -271,6 +274,7 @@ describe('resolveAxisTimezone', () => {
             resolvedTimezone: TZ,
         });
         expect(result.timeAxisField).toBeUndefined();
+        expect(result.axisTimezone).toBe(TZ);
     });
 
     test('does not shift a DATE day bucket derived from a TIMESTAMP base (GLITCH-452)', () => {
@@ -292,10 +296,14 @@ describe('resolveAxisTimezone', () => {
         expect(result.timeAxisField).toBeUndefined();
     });
 
-    test('uses yField[0] when flipAxes is true', () => {
+    test('selects xField when flipAxes is true', () => {
+        // Flipped charts keep the time dimension in layout.xField; series
+        // encoding moves it to physical Y. Selecting yField[0] would inspect
+        // the metric and silently skip the shift.
         const result = resolveAxisTimezone({
             validCartesianConfig: makeCartesian({
-                yField: ['orders_created_day', 'other'],
+                xField: 'orders_created_day',
+                yField: ['orders_total'],
                 flipAxes: true,
             }),
             itemsMap,
@@ -315,6 +323,163 @@ describe('resolveAxisTimezone', () => {
             resolvedTimezone: TZ,
         });
         expect(result.timeAxisField).toBeUndefined();
+    });
+});
+
+// The reported bug: UTC project and data viewed from a positive-offset
+// browser labels a calendar DATE one day early because ECharts parses the
+// bare `YYYY-MM-DD` as browser-local midnight. Detection requires flag-on
+// results (non-nullish resolvedTimezone), a calendar item, and the actual
+// physical axis being `time`.
+describe('detectCalendarTimeAxisField', () => {
+    const dateDayField = 'orders_created_day';
+    const itemsMap: ItemsMap = {
+        [dateDayField]: makeTimeDimension(dateDayField, TimeFrames.DAY, {
+            type: DimensionType.DATE,
+        }),
+        orders_date: makeTimeDimension('orders_date', undefined, {
+            type: DimensionType.DATE,
+        }),
+        orders_created_month: makeTimeDimension(
+            'orders_created_month',
+            TimeFrames.MONTH,
+            { type: DimensionType.DATE },
+        ),
+        orders_created_hour: makeTimeDimension(
+            'orders_created_hour',
+            TimeFrames.HOUR,
+        ),
+        orders_total: makeMetric('orders_total'),
+    };
+
+    test.each([['UTC'], [TZ]])(
+        'normalizes a calendar DATE day bucket on a time axis when resolvedTimezone is %s',
+        (resolvedTimezone) => {
+            // The resolved timezone is only the flag-on mode signal: the
+            // coordinate is always anchored to UTC midnight, never shifted.
+            const result = detectCalendarTimeAxisField({
+                validCartesianConfig: makeCartesian({ xField: dateDayField }),
+                itemsMap,
+                resolvedTimezone,
+                physicalAxisType: 'time',
+            });
+            expect(result).toEqual({
+                fieldId: dateDayField,
+                timezone: 'UTC',
+                flipAxes: false,
+            });
+        },
+    );
+
+    test('returns undefined for flag-off results (resolvedTimezone missing)', () => {
+        // Flag-off raw values keep the full ISO representation, which ECharts
+        // already parses at UTC — the legacy path must stay untouched.
+        const result = detectCalendarTimeAxisField({
+            validCartesianConfig: makeCartesian({ xField: dateDayField }),
+            itemsMap,
+            resolvedTimezone: undefined,
+            physicalAxisType: 'time',
+        });
+        expect(result).toBeUndefined();
+    });
+
+    test('normalizes a plain DATE column (no timeInterval)', () => {
+        const result = detectCalendarTimeAxisField({
+            validCartesianConfig: makeCartesian({ xField: 'orders_date' }),
+            itemsMap,
+            resolvedTimezone: 'UTC',
+            physicalAxisType: 'time',
+        });
+        expect(result).toEqual({
+            fieldId: 'orders_date',
+            timezone: 'UTC',
+            flipAxes: false,
+        });
+    });
+
+    test('normalizes a DATE day bucket derived from a TIMESTAMP base (GLITCH-452)', () => {
+        const fieldId = 'orders_ts_day';
+        const result = detectCalendarTimeAxisField({
+            validCartesianConfig: makeCartesian({ xField: fieldId }),
+            itemsMap: {
+                ...itemsMap,
+                [fieldId]: makeTimeDimension(fieldId, TimeFrames.DAY, {
+                    type: DimensionType.DATE,
+                    timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+                }),
+            },
+            resolvedTimezone: 'UTC',
+            physicalAxisType: 'time',
+        });
+        expect(result).toEqual({
+            fieldId,
+            timezone: 'UTC',
+            flipAxes: false,
+        });
+    });
+
+    test('returns undefined when the physical axis is category', () => {
+        // Coarse grains normally render on a category axis with string tick
+        // labels; ECharts never parses those as instants.
+        const result = detectCalendarTimeAxisField({
+            validCartesianConfig: makeCartesian({
+                xField: 'orders_created_month',
+            }),
+            itemsMap,
+            resolvedTimezone: 'UTC',
+            physicalAxisType: 'category',
+        });
+        expect(result).toBeUndefined();
+    });
+
+    test('normalizes a coarse calendar grain when reference lines force a time axis', () => {
+        // getAxisType switches WEEK/MONTH/QUARTER/YEAR back to `time` when the
+        // series carry reference lines; the built axis type is what matters.
+        const result = detectCalendarTimeAxisField({
+            validCartesianConfig: makeCartesian({
+                xField: 'orders_created_month',
+            }),
+            itemsMap,
+            resolvedTimezone: 'UTC',
+            physicalAxisType: 'time',
+        });
+        expect(result).toEqual({
+            fieldId: 'orders_created_month',
+            timezone: 'UTC',
+            flipAxes: false,
+        });
+    });
+
+    test('selects xField and marks flipAxes for flipped charts', () => {
+        const result = detectCalendarTimeAxisField({
+            validCartesianConfig: makeCartesian({
+                xField: dateDayField,
+                yField: ['orders_total'],
+                flipAxes: true,
+            }),
+            itemsMap,
+            resolvedTimezone: 'UTC',
+            physicalAxisType: 'time',
+        });
+        expect(result).toEqual({
+            fieldId: dateDayField,
+            timezone: 'UTC',
+            flipAxes: true,
+        });
+    });
+
+    test('returns undefined for a TIMESTAMP instant field', () => {
+        // Instants belong to the timezone-shift path, not calendar
+        // normalization.
+        const result = detectCalendarTimeAxisField({
+            validCartesianConfig: makeCartesian({
+                xField: 'orders_created_hour',
+            }),
+            itemsMap,
+            resolvedTimezone: TZ,
+            physicalAxisType: 'time',
+        });
+        expect(result).toBeUndefined();
     });
 });
 
@@ -608,6 +773,131 @@ describe('applyTimezoneShiftToEchartsOptions', () => {
 
         expect(result.xAxis).toEqual({ type: 'time' });
         expect(result.yAxis).toEqual({ type: 'value' });
+    });
+});
+
+// Calendar DATE axes reuse the shift machinery with timezone 'UTC': a bare
+// `YYYY-MM-DD` becomes the UTC-midnight epoch, so ECharts (useUTC: true) parses
+// and labels it on the correct day for every browser offset. This is the fix
+// for the day-early axis/tooltip bug on positive-offset browsers.
+describe('applyTimezoneShiftToEchartsOptions calendar DATE anchoring (timezone UTC)', () => {
+    const calendarDay: TimezoneShiftedField = {
+        fieldId: 'orders_created_day',
+        timezone: 'UTC',
+        flipAxes: false,
+    };
+    const shiftedDim = 'orders_created_day_ld_tz_shifted';
+
+    test('anchors a date-only string to its UTC-midnight epoch (no offset)', () => {
+        const options: EchartsOptionsShape = {
+            dataset: {
+                source: [{ orders_created_day: '2024-07-22', orders_total: 5 }],
+            },
+            series: [],
+        };
+
+        const result = applyTimezoneShiftToEchartsOptions(options, calendarDay);
+
+        const source = (result.dataset as { source: Record<string, unknown>[] })
+            .source;
+        expect(source[0][shiftedDim]).toBe(Date.parse('2024-07-22T00:00:00Z'));
+        // Original column is preserved for timezone-agnostic DATE formatting.
+        expect(source[0].orders_created_day).toBe('2024-07-22');
+    });
+});
+
+// Reference lines must ride the same transform as the plotted coordinates:
+// ECharts parses a raw date-only markLine value as browser-local midnight, so
+// an untransformed line sits offset from its (rewritten) bars.
+describe('applyTimezoneShiftToEchartsOptions markLine values', () => {
+    const calendarDay: TimezoneShiftedField = {
+        fieldId: 'orders_created_day',
+        timezone: 'UTC',
+        flipAxes: false,
+    };
+
+    const makeMarkLineSeries = (
+        data: Record<string, unknown>[],
+    ): EchartsOptionsShape => ({
+        dataset: { source: [] },
+        series: [{ markLine: { symbol: 'none', data } }],
+    });
+
+    const getMarkLineData = (result: EchartsOptionsShape) =>
+        (
+            result.series?.[0].markLine as {
+                data: Record<string, unknown>[];
+            }
+        ).data;
+
+    test('anchors a calendar date-only xAxis line to its UTC-midnight epoch', () => {
+        const options = makeMarkLineSeries([
+            { uuid: 'a', xAxis: '2024-07-22', name: 'Launch' },
+        ]);
+
+        const result = applyTimezoneShiftToEchartsOptions(options, calendarDay);
+
+        expect(getMarkLineData(result)).toEqual([
+            {
+                uuid: 'a',
+                xAxis: Date.parse('2024-07-22T00:00:00Z'),
+                name: 'Launch',
+            },
+        ]);
+    });
+
+    test('shifts an instant xAxis line by the project timezone offset', () => {
+        const options = makeMarkLineSeries([
+            { uuid: 'a', xAxis: '2024-01-15T12:00:00Z' },
+        ]);
+
+        const result = applyTimezoneShiftToEchartsOptions(options, {
+            fieldId: 'orders_created_day',
+            timezone: TZ,
+            flipAxes: false,
+        });
+
+        expect(getMarkLineData(result)[0].xAxis).toBe(SHIFTED_MS);
+    });
+
+    test('transforms the yAxis slot and leaves xAxis alone when flipped', () => {
+        const options = makeMarkLineSeries([
+            { uuid: 'a', yAxis: '2024-07-22' },
+            { uuid: 'b', xAxis: '2024-07-23' },
+        ]);
+
+        const result = applyTimezoneShiftToEchartsOptions(options, {
+            ...calendarDay,
+            flipAxes: true,
+        });
+
+        expect(getMarkLineData(result)).toEqual([
+            { uuid: 'a', yAxis: Date.parse('2024-07-22T00:00:00Z') },
+            { uuid: 'b', xAxis: '2024-07-23' },
+        ]);
+    });
+
+    test('leaves value-axis lines and series-relative marks untouched', () => {
+        const data = [
+            { uuid: 'a', yAxis: '50' },
+            { uuid: 'b', type: 'average' },
+        ];
+        const options = makeMarkLineSeries(data);
+
+        const result = applyTimezoneShiftToEchartsOptions(options, calendarDay);
+
+        expect(getMarkLineData(result)).toEqual(data);
+    });
+
+    test('leaves series without markLine untouched', () => {
+        const options: EchartsOptionsShape = {
+            dataset: { source: [] },
+            series: [{ data: [] }],
+        };
+
+        const result = applyTimezoneShiftToEchartsOptions(options, calendarDay);
+
+        expect(result.series?.[0]).toEqual({ data: [] });
     });
 });
 

--- a/packages/frontend/src/hooks/echarts/timezoneShift.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.ts
@@ -1,5 +1,6 @@
 import {
     extractableTimeFrames,
+    isCalendarValueItem,
     isDimension,
     shouldShiftItemTimezone,
     TimeFrames,
@@ -82,9 +83,9 @@ const detectTimezoneShiftedField = ({
         return undefined;
     }
     const flipAxes = !!validCartesianConfig.layout?.flipAxes;
-    const timeFieldId = flipAxes
-        ? validCartesianConfig.layout?.yField?.[0]
-        : validCartesianConfig.layout?.xField;
+    // xField is the semantic time dimension even when flipped: series encoding
+    // and getEchartAxes both move it to the physical Y axis, keyed by fieldId.
+    const timeFieldId = validCartesianConfig.layout?.xField;
     if (!timeFieldId) return undefined;
     const field = itemsMap[timeFieldId];
     if (!field || !isDimension(field)) return undefined;
@@ -132,6 +133,49 @@ export const resolveAxisTimezone = (params: {
         timeAxisField: undefined,
         axisTimezone: params.resolvedTimezone,
         axisDisplayTimezone: undefined,
+    };
+};
+
+// Same shape the option walker consumes, but for a calendar value the 'UTC'
+// target is a zero-offset transport anchor, not a timezone conversion — the
+// DATE itself is never shifted.
+export type CalendarTimeAxisField = TimezoneShiftedField;
+
+// A calendar DATE (plain DATE column, DATE metric/table calc, or a
+// day-or-coarser TIMESTAMP trunc, which compiles to a real DATE) carries no
+// instant. ECharts parses a bare `YYYY-MM-DD` on a `time` axis as
+// browser-LOCAL midnight, so with `useUTC: true` positive-offset browsers
+// label it one day early. Encoding the plotted coordinate as UTC midnight
+// keeps the calendar day fixed for every viewer.
+//
+// Gated on the response's resolvedTimezone: only flag-on results emit bare
+// calendar values (flag-off keeps full ISO strings and must stay untouched).
+// The timezone string is only the mode signal and is never applied to the
+// DATE. physicalAxisType must come from the axis actually built for the
+// field (xAxis[0], or yAxis[0] when flipped) so reference-line-forced time
+// axes on coarse grains are covered and category axes are left alone.
+export const detectCalendarTimeAxisField = ({
+    validCartesianConfig,
+    itemsMap,
+    resolvedTimezone,
+    physicalAxisType,
+}: {
+    validCartesianConfig: CartesianChart | undefined;
+    itemsMap: ItemsMap | undefined;
+    resolvedTimezone: string | undefined;
+    physicalAxisType: string | undefined;
+}): CalendarTimeAxisField | undefined => {
+    if (!resolvedTimezone || physicalAxisType !== 'time') return undefined;
+    if (!validCartesianConfig || !itemsMap) return undefined;
+    // xField is the semantic dimension; flipAxes only moves it to physical Y.
+    const fieldId = validCartesianConfig.layout?.xField;
+    if (!fieldId) return undefined;
+    const field = itemsMap[fieldId];
+    if (!field || !isCalendarValueItem(field)) return undefined;
+    return {
+        fieldId,
+        timezone: 'UTC',
+        flipAxes: !!validCartesianConfig.layout?.flipAxes,
     };
 };
 
@@ -277,6 +321,38 @@ const shiftBareArraySeriesData = (
     });
 };
 
+// Reference lines carry raw axis values that ECharts would parse differently
+// from the rewritten data coordinates, leaving the line offset from its bars.
+// Run the time-axis slot (xAxis, or yAxis when flipped) through the same
+// transform. Value-axis slots and series-relative marks (type 'average' etc.,
+// which carry no axis value) are untouched.
+const shiftSeriesMarkLineValues = (
+    series: EchartsSeriesShape[],
+    shifted: TimezoneShiftedField,
+): EchartsSeriesShape[] => {
+    const axisKey = shifted.flipAxes ? 'yAxis' : 'xAxis';
+    return series.map((s) => {
+        const markLine = s.markLine;
+        if (!isPlainObject(markLine) || !Array.isArray(markLine.data)) {
+            return s;
+        }
+        let mutated = false;
+        const newData = markLine.data.map((entry) => {
+            if (!isPlainObject(entry)) return entry;
+            const raw = entry[axisKey];
+            if (raw === undefined || raw === null) return entry;
+            const shiftedMs = shiftRawToTimezoneWallClockMs(
+                raw,
+                shifted.timezone,
+            );
+            if (shiftedMs === undefined) return entry;
+            mutated = true;
+            return { ...entry, [axisKey]: shiftedMs };
+        });
+        return mutated ? { ...s, markLine: { ...markLine, data: newData } } : s;
+    });
+};
+
 // Run last on the built echarts options — the rest of the pipeline stays in UTC.
 export const applyTimezoneShiftToEchartsOptions = <
     O extends EchartsOptionsShape,
@@ -293,6 +369,9 @@ export const applyTimezoneShiftToEchartsOptions = <
     return {
         ...options,
         dataset: shiftDatasetSources(options.dataset, shifted, shiftedDim),
-        series: shiftBareArraySeriesData(renamedSeries, shifted),
+        series: shiftSeriesMarkLineValues(
+            shiftBareArraySeriesData(renamedSeries, shifted),
+            shifted,
+        ),
     };
 };

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -110,6 +110,7 @@ import { type InfiniteQueryResults } from '../useQueryResults';
 import { getCartesianConditionalFormattingColor } from './cartesianConditionalFormatting';
 import {
     applyTimezoneShiftToEchartsOptions,
+    detectCalendarTimeAxisField,
     resolveAxisTimezone,
     TIME_INTERVALS_FOR_CATEGORY_AXIS,
 } from './timezoneShift';
@@ -3345,6 +3346,26 @@ const useEchartsCartesianConfig = (
         timeAxisField,
     ]);
 
+    // Calendar DATEs plotted on an actual `time` axis get their coordinate
+    // encoded as UTC midnight so ECharts' browser-local parse of the bare
+    // `YYYY-MM-DD` can't move the day. Derived from the built axes so
+    // reference-line-forced time axes are covered, and kept separate from
+    // timeAxisField so isTimeAxisShifted stays instant-shift only.
+    const calendarTimeAxisField = useMemo(() => {
+        const physicalAxis = validCartesianConfig?.layout?.flipAxes
+            ? axes.yAxis[0]
+            : axes.xAxis[0];
+        return detectCalendarTimeAxisField({
+            validCartesianConfig,
+            itemsMap,
+            resolvedTimezone,
+            physicalAxisType:
+                typeof physicalAxis?.type === 'string'
+                    ? physicalAxis.type
+                    : undefined,
+        });
+    }, [validCartesianConfig, itemsMap, resolvedTimezone, axes]);
+
     // Shared by stackedSeriesWithColorAssignments (non-stacked bar styling) and
     // decoratedSeriesForChart (stacked rounded corners). Same inputs in both
     // places — keep the calc in one spot.
@@ -4412,8 +4433,12 @@ const useEchartsCartesianConfig = (
             }),
         };
 
-        return timeAxisField
-            ? applyTimezoneShiftToEchartsOptions(baseOptions, timeAxisField)
+        const plottedCoordinateField = timeAxisField ?? calendarTimeAxisField;
+        return plottedCoordinateField
+            ? applyTimezoneShiftToEchartsOptions(
+                  baseOptions,
+                  plottedCoordinateField,
+              )
             : baseOptions;
     }, [
         sortedAxes,
@@ -4429,6 +4454,7 @@ const useEchartsCartesianConfig = (
         theme?.other.chartFont,
         validCartesianConfig,
         timeAxisField,
+        calendarTimeAxisField,
     ]);
 
     if (


### PR DESCRIPTION
## Problem

With `EnableTimezoneSupport` on, day-or-coarser truncations compile to real warehouse DATEs and the API returns bare `YYYY-MM-DD` raw values. ECharts parses an offset-less string on a `time` axis as **browser-local** midnight, and our global `useUTC: true` then formats that instant in UTC — so for positive-offset browsers the axis tick and axis-pointer label show the **previous day** while the results table shows the correct date. Tuple/stacked tooltips that fall back to `axisValue` expose the same shifted coordinate.

Flag-off results keep the full ISO representation (`2020-07-01T00:00:00Z`), which ECharts parses at UTC — the bug does not exist there (verified empirically with the flag toggled on a UTC+2 emulated browser).

## Fix

Keep `resolveAxisTimezone` as the TIMESTAMP instant-shift resolver and derive calendar normalization separately, after the axes are built. When the response has a `resolvedTimezone` (flag-on results only), the x item is a calendar value (`isCalendarValueItem`), and the actual physical axis is `time`, the plotted coordinate is encoded as UTC midnight through the existing option walker while the raw DATE column is preserved for table/tooltip formatting.

- Inspecting the **built** axis covers reference-line-forced time axes on coarse grains and skips category axes.
- The calendar descriptor does not set `isTimeAxisShifted`, so pinned daily ticks are preserved (the UTC anchor is also an identity for the non-midnight instants that trigger pinning).
- Both detectors now select `layout.xField` for flipped charts — the previous `yField[0]` lookup inspected the metric and silently skipped the transform on horizontal time charts.
- Reference-line (`markLine`) values on the time-axis slot ride the same transform as the plotted coordinates, so lines stay centered on their bars. This also aligns lines on instant-shifted axes, which previously stayed at the raw UTC position while the bars moved to project wall-clock.
- The DATE itself is never shifted: the resolved timezone is only the mode signal; the coordinate anchor is always UTC.

## Testing

- Unit: new `detectCalendarTimeAxisField` suite (flag-off no-op, UTC and non-UTC resolved timezones, GLITCH-452 TIMESTAMP-base DATE truncs, plain DATE, category-axis skip, reference-line-forced time axis, flipped selection, TIMESTAMP exclusion), restored no-shift assertions in `resolveAxisTimezone`, and a `markLine` suite (calendar anchor, instant shift, flipped slot, value-axis/series-relative marks untouched). 50/50 in UTC and under `TZ=Etc/GMT-2`; whole `src/hooks/echarts` suite passes.
- Live browser (CDP timezone override `Etc/GMT-2`, UTC project/data): flag on now renders the same day on table, axis tick, axis-pointer, and tooltip for vertical, flipped, and stacked (multi-series tuple tooltip) charts; a reference line at `2020-07-05` renders centered on the Jul 5 bar (sub-pixel, measured from SVG geometry); flag off is unchanged with the fix in the bundle.

### Before
<img width="1500" height="1100" alt="01-before-day-axis-pointer-shows-04july-utc2" src="https://github.com/user-attachments/assets/69ac7bf1-1553-4add-8f97-96e883578348" />

### After
<img width="1500" height="1100" alt="02-after-day-axis-pointer-and-refline-05july-utc2" src="https://github.com/user-attachments/assets/40dbef5c-dd4b-4fe6-8ec9-68e47fa1c7ab" />

Closes [GLITCH-636](https://linear.app/lightdash/issue/GLITCH-636/day-grain-date-chart-axis-and-tooltip-show-the-previous-day-for)