### PR TITLE
fix: expand settings page header to full width on full-width pages

### DIFF
--- a/packages/frontend/src/components/common/Settings/SettingsPage.module.css
+++ b/packages/frontend/src/components/common/Settings/SettingsPage.module.css
@@ -6,8 +6,7 @@
 
 .container {
     width: 100%;
-    max-width: var(--page-content-width);
-    margin-inline: auto;
+    min-width: 0;
 }
 
 .header {


### PR DESCRIPTION
On full-width `Settings.tsx` pages (Ask AI → Issues/Threads, MCP Tools), the header (title + actions) stayed narrower than the containers below it.

The `SettingsPage` header wrapper was pinned to `max-width: var(--page-content-width)` and centered, while the content below has no max-width and fills its parent. On fixed-width settings pages both live inside a `--page-content-width` container so they line up; on full-width pages the parent is unconstrained, leaving the header narrow.

Fix: let the header fill its parent like the content does. On fixed-width pages the parent is already `--page-content-width`, so nothing changes there.

Single CSS change in `SettingsPage.module.css`.