### PR TITLE
fix: control mixed-chart series z-order from series list order

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -370,6 +370,7 @@ export * from './utils/virtualView';
 export * from './utils/warehouse';
 export * from './visualizations/CartesianChartDataModel';
 export * from './visualizations/helpers/getCartesianAxisFormatterConfig';
+export * from './visualizations/helpers/seriesZOrder';
 export * from './visualizations/helpers/styles/axisStyles';
 export * from './visualizations/helpers/styles/barChartStyles';
 export * from './visualizations/helpers/styles/gridStyles';

--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -22,6 +22,7 @@ import {
     formatNumberValue,
     getCustomFormatFromLegacy,
 } from '../utils/formatting';
+import { assignSeriesZByOrder } from './helpers/seriesZOrder';
 import {
     getAxisLabelStyle,
     getAxisLineStyle,
@@ -899,6 +900,9 @@ export class CartesianChartDataModel {
 
         // Show legend when there are multiple series
         const showLegend = transformedData.valuesColumns.length > 1;
+
+        // Series-list order controls paint order, same as explore charts
+        series = assignSeriesZByOrder(series);
 
         const spec = {
             // Snap time-axis ticks in UTC to match the UTC label formatter;

--- a/packages/common/src/visualizations/helpers/seriesZOrder.ts
+++ b/packages/common/src/visualizations/helpers/seriesZOrder.ts
@@ -1,0 +1,22 @@
+export const SERIES_Z_BASE = 2;
+// Matches the ECharts markLine default; pinned explicitly so persisted config
+// can't sink reference lines below the series band.
+export const REFERENCE_LINE_Z = 5;
+
+type ZOrderableSeries = {
+    z?: number;
+    markLine?: { z?: number; [key: string]: unknown };
+};
+
+// Paint order from series-list position: earlier in the list paints behind.
+// Overrides any persisted per-series z — list position is the source of truth.
+export const assignSeriesZByOrder = <T extends ZOrderableSeries>(
+    series: T[],
+): T[] =>
+    series.map((serie, index) => ({
+        ...serie,
+        z: SERIES_Z_BASE + index / series.length,
+        ...(serie.markLine
+            ? { markLine: { ...serie.markLine, z: REFERENCE_LINE_Z } }
+            : {}),
+    }));

--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -376,7 +376,7 @@ export type EChartsSeries = {
     data?: unknown[];
     showSymbol?: boolean;
     symbolSize?: number;
-    markLine?: Record<string, unknown>;
+    markLine?: { z?: number; [key: string]: unknown };
     colorBy?: 'series' | 'data';
     itemStyle?: {
         borderRadius?: number | number[];
@@ -404,6 +404,8 @@ export type EChartsSeries = {
         baseFieldId: string;
     };
     clip?: boolean;
+    // Paint order, derived from series-list position by assignSeriesZByOrder
+    z?: number;
 };
 
 /**

--- a/packages/e2e/cypress/e2e/app/chartSeriesZOrder.cy.ts
+++ b/packages/e2e/cypress/e2e/app/chartSeriesZOrder.cy.ts
@@ -1,0 +1,197 @@
+import { SEED_PROJECT } from '@lightdash/common';
+
+const apiUrl = '/api/v1';
+
+// Distinct series colours, matched by exact hex on fill/stroke attributes.
+// REF_LINE_COLOR must be high-contrast on white: reference-line colours run
+// through getReadableColor, which rewrites low-contrast colours.
+const BAR_COLOR = '#2f6bff';
+const AREA_COLOR = '#2f9e44';
+const REF_LINE_COLOR = '#0000ff';
+
+const refLine = () => ({
+    symbol: 'none',
+    lineStyle: { color: REF_LINE_COLOR, width: 3, type: 'solid' },
+    label: {},
+    data: [
+        {
+            uuid: 'zorder-ref-line',
+            yAxis: '5',
+            name: 'Ref line',
+            label: { formatter: 'Ref line' },
+            lineStyle: { color: REF_LINE_COLOR },
+        },
+    ],
+});
+
+// The dataset is deliberately tiny (2 series x ~5 status rows) so SimpleChart
+// stays on the SVG renderer (canvas kicks in above 500 data points). In SVG,
+// paint order IS document order, so z-order is assertable from the DOM.
+const barSeries = (withRefLine: boolean) => ({
+    encode: {
+        xRef: { field: 'orders_status' },
+        yRef: { field: 'orders_total_order_amount' },
+    },
+    type: 'bar',
+    yAxisIndex: 0,
+    color: BAR_COLOR,
+    ...(withRefLine ? { markLine: refLine() } : {}),
+});
+
+const areaSeries = (withRefLine: boolean) => ({
+    encode: {
+        xRef: { field: 'orders_status' },
+        yRef: { field: 'orders_average_order_size' },
+    },
+    type: 'line',
+    areaStyle: {},
+    yAxisIndex: 0,
+    color: AREA_COLOR,
+    ...(withRefLine ? { markLine: refLine() } : {}),
+});
+
+const createMixedChart = (name: string, series: unknown[]) =>
+    cy
+        .request({
+            url: `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/saved`,
+            method: 'POST',
+            body: {
+                name,
+                description: 'Mixed chart z-order e2e test',
+                tableName: 'orders',
+                metricQuery: {
+                    exploreName: 'orders',
+                    dimensions: ['orders_status'],
+                    metrics: [
+                        'orders_total_order_amount',
+                        'orders_average_order_size',
+                    ],
+                    filters: {},
+                    sorts: [{ fieldId: 'orders_status', descending: false }],
+                    limit: 500,
+                    tableCalculations: [],
+                    additionalMetrics: [],
+                    customDimensions: [],
+                },
+                chartConfig: {
+                    type: 'cartesian',
+                    config: {
+                        layout: {
+                            flipAxes: false,
+                            xField: 'orders_status',
+                            yField: [
+                                'orders_total_order_amount',
+                                'orders_average_order_size',
+                            ],
+                        },
+                        eChartsConfig: {
+                            series,
+                            // Legend swatches reuse the series colours; hide it
+                            // so colour matches below only hit chart geometry.
+                            legend: { show: false },
+                        },
+                    },
+                },
+                tableConfig: {
+                    columnOrder: [
+                        'orders_status',
+                        'orders_total_order_amount',
+                        'orders_average_order_size',
+                    ],
+                },
+                pivotConfig: { columns: [] },
+            },
+        })
+        .then((r) => {
+            expect(r.status).to.eq(200);
+            return r.body.results.uuid as string;
+        });
+
+// Document-order indices of every SVG path belonging to each series, matched
+// by the distinct colours configured above. Later index = painted on top.
+const paintIndices = ($svg: JQuery) => {
+    const paths = Array.from($svg[0].querySelectorAll('path'));
+    const indices = {
+        bar: [] as number[],
+        area: [] as number[],
+        ref: [] as number[],
+    };
+    paths.forEach((el, i) => {
+        const fill = (el.getAttribute('fill') ?? '').toLowerCase();
+        const stroke = (el.getAttribute('stroke') ?? '').toLowerCase();
+        if (fill === BAR_COLOR) indices.bar.push(i);
+        else if (fill === AREA_COLOR || stroke === AREA_COLOR)
+            indices.area.push(i);
+        else if (stroke === REF_LINE_COLOR) indices.ref.push(i);
+    });
+    return indices;
+};
+
+const visitChart = (chartUuid: string) => {
+    cy.visit(`/projects/${SEED_PROJECT.project_uuid}/saved/${chartUuid}`);
+    cy.contains('Loading chart').should('not.exist');
+};
+
+// Assert that the series listed last paints on top and the reference line
+// paints above all series, from SVG document order (later element = on top).
+const assertPaintOrder = (top: 'bar' | 'area') =>
+    cy.get('.echarts-for-react svg', { timeout: 30000 }).should(($svg) => {
+        const { bar, area, ref } = paintIndices($svg);
+        expect(bar, 'bar paths rendered').to.have.length.greaterThan(0);
+        expect(area, 'area paths rendered').to.have.length.greaterThan(0);
+        expect(ref, 'reference line rendered').to.have.length.greaterThan(0);
+
+        const [topIndices, bottomIndices] =
+            top === 'bar' ? [bar, area] : [area, bar];
+        expect(
+            Math.min(...topIndices),
+            `${top} (listed last) painted on top`,
+        ).to.be.greaterThan(Math.max(...bottomIndices));
+        expect(
+            Math.min(...ref),
+            'reference line painted on top of all series',
+        ).to.be.greaterThan(Math.max(...bar, ...area));
+    });
+
+describe('Mixed chart series z-order', () => {
+    const createdChartUuids: string[] = [];
+
+    beforeEach(() => {
+        cy.login();
+    });
+
+    after(() => {
+        cy.login();
+        createdChartUuids.forEach((uuid) => {
+            cy.request({
+                url: `${apiUrl}/saved/${uuid}`,
+                method: 'DELETE',
+                failOnStatusCode: false,
+            });
+        });
+    });
+
+    it('paints the series listed last on top (bar last => bar over area)', () => {
+        // Ref line hosted on the FIRST (bottom) series: it must still paint on
+        // top of everything, since markLine z stays above all series z.
+        createMixedChart('zorder e2e: bar listed last', [
+            areaSeries(true),
+            barSeries(false),
+        ]).then((chartUuid) => {
+            createdChartUuids.push(chartUuid);
+            visitChart(chartUuid);
+            assertPaintOrder('bar');
+        });
+    });
+
+    it('flipping the list order flips the paint order (area last => area over bar)', () => {
+        createMixedChart('zorder e2e: area listed last', [
+            barSeries(true),
+            areaSeries(false),
+        ]).then((chartUuid) => {
+            createdChartUuids.push(chartUuid);
+            visitChart(chartUuid);
+            assertPaintOrder('area');
+        });
+    });
+});

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -1,7 +1,9 @@
 import {
+    assignSeriesZByOrder,
     CartesianSeriesType,
     createConditionalFormattingConfigWithSingleColor,
     DimensionType,
+    REFERENCE_LINE_Z,
     FieldType,
     FilterOperator,
     TimeFrames,
@@ -2530,5 +2532,81 @@ describe('applyConditionalFormattingToStackedSeries', () => {
 
         expect(result[0]).toBe(flatBar);
         expect(result[1]).toBe(line);
+    });
+});
+
+describe('assignSeriesZByOrder', () => {
+    const mkSeries = (type: CartesianSeriesType, name: string): EChartsSeries =>
+        ({ type, name }) as unknown as EChartsSeries;
+
+    test('assigns a strictly increasing z matching array position', () => {
+        const result = assignSeriesZByOrder([
+            mkSeries(CartesianSeriesType.AREA, 'area'),
+            mkSeries(CartesianSeriesType.BAR, 'bar'),
+        ]);
+
+        expect(result[0].z!).toBe(2);
+        expect(result[1].z!).toBeGreaterThan(result[0].z!);
+    });
+
+    test('later series paint on top regardless of type (bar over area)', () => {
+        const area = mkSeries(CartesianSeriesType.AREA, 'area');
+        const bar = mkSeries(CartesianSeriesType.BAR, 'bar');
+
+        // area first in list -> lower z -> painted behind the bar
+        const result = assignSeriesZByOrder([area, bar]);
+        const areaZ = result.find((s) => s.name === 'area')?.z ?? 0;
+        const barZ = result.find((s) => s.name === 'bar')?.z ?? 0;
+
+        expect(barZ).toBeGreaterThan(areaZ);
+    });
+
+    test('keeps every series z below the reference-line z, even with many series', () => {
+        const many = Array.from({ length: 40 }, (_, i) =>
+            mkSeries(CartesianSeriesType.BAR, `s${i}`),
+        );
+
+        const result = assignSeriesZByOrder(many);
+
+        result.forEach((s) => expect(s.z!).toBeLessThan(REFERENCE_LINE_Z));
+        // still strictly ordered
+        for (let i = 1; i < result.length; i += 1) {
+            expect(result[i].z!).toBeGreaterThan(result[i - 1].z!);
+        }
+    });
+
+    test('pins markLine z so persisted config cannot sink reference lines', () => {
+        const withRefLine = {
+            ...mkSeries(CartesianSeriesType.AREA, 'area'),
+            markLine: { z: 1, data: [{ yAxis: 5 }] },
+        } as unknown as EChartsSeries;
+
+        const result = assignSeriesZByOrder([
+            withRefLine,
+            mkSeries(CartesianSeriesType.BAR, 'bar'),
+        ]);
+
+        expect(result[0].markLine).toMatchObject({
+            z: REFERENCE_LINE_Z,
+            data: [{ yAxis: 5 }],
+        });
+        // series without a markLine don't gain one
+        expect(result[1].markLine).toBeUndefined();
+    });
+
+    test('preserves other series properties and does not mutate the input', () => {
+        const input = [mkSeries(CartesianSeriesType.LINE, 'line')];
+        const result = assignSeriesZByOrder(input);
+
+        expect(result[0]).toMatchObject({
+            type: CartesianSeriesType.LINE,
+            name: 'line',
+            z: 2,
+        });
+        expect(input[0]).not.toHaveProperty('z');
+    });
+
+    test('handles an empty series list', () => {
+        expect(assignSeriesZByOrder([])).toEqual([]);
     });
 });

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2,6 +2,7 @@ import {
     applyCustomFormat,
     applyRoundedCornersToStackData,
     assertUnreachable,
+    assignSeriesZByOrder,
     buildCartesianTooltipFormatter,
     calculateDynamicBorderRadius,
     CartesianSeriesType,
@@ -4427,9 +4428,11 @@ const useEchartsCartesianConfig = (
             xAxis: resolvedLabels.xAxis,
             yAxis: resolvedLabels.yAxis,
             useUTC: true,
-            series: relocateMarkLinesToVisibleSeries(
-                resolvedLabels.series,
-                validCartesianConfigLegend,
+            series: assignSeriesZByOrder(
+                relocateMarkLinesToVisibleSeries(
+                    resolvedLabels.series,
+                    validCartesianConfigLegend,
+                ),
             ),
             animation: !(isInDashboard || minimal),
             legend: legendConfigWithInstructionsTooltip,


### PR DESCRIPTION
## Problem

In a mixed chart (e.g. bar + area or bar + line), area/line series always rendered visually on top of bar series regardless of their position in the Series tab, so users could not send a line/area behind a bar. ECharts assigns line/area a higher default `z` than bar, so the series-array order alone cannot decide cross-type paint order.

## Fix

`assignSeriesZByOrder` (in `@lightdash/common`, `visualizations/helpers/seriesZOrder.ts`) assigns each ECharts series an explicit `z` derived from its position in the final ordered series array. Earlier in the Series list now paints **behind** later series, across all chart types — so the existing drag-and-drop order (and Layout y-axis field order) controls the visual z-order as expected. It is applied in both places cartesian series are assembled:

- **Explore/saved charts** — `useEchartsCartesianConfig`
- **SQL-runner charts** — `CartesianChartDataModel`, so both chart builders behave consistently

The `z` values are kept within `[2, 3)` — deliberately **below** reference lines. The reference-line `z` is **pinned explicitly** to `REFERENCE_LINE_Z = 5` (matching the ECharts `markLine` default) rather than assumed: persisted chart config carrying its own `markLine.z` can no longer sink reference lines below the data.

## Behaviour change

Existing saved combo charts that relied on line/area always rendering on top will change appearance — the Series-list order now decides, per the requested behaviour. Worth a note in release notes.

## Verification

- **Unit tests** in `useEchartsCartesianConfig.test.ts` cover position→`z` ordering, cross-type ordering, the below-reference-line invariant with many series, and the `markLine.z` pinning.
- **New e2e test** `packages/e2e/cypress/e2e/app/chartSeriesZOrder.cy.ts`: creates two mixed charts (bar + area + reference line) via the API that differ only in series-list order, opens each saved-chart page, and asserts the paint order from SVG document order (`SimpleChart` uses the SVG renderer below 500 data points, where paint order is element order). The reference line is hosted on the *bottom* series and must still paint on top. The spec fails against `main` and passes with this fix — verified locally against a full dev stack.
- The fix is renderer-agnostic: zrender sorts by `z` identically for the SVG renderer (default) and the canvas renderer (>500 data points); the canvas path was verified manually with real ECharts 5.6.0.

### Reviewed edge cases

- **Hover emphasis across overlapping series**: ECharts' emphasis lift raises `z2`, which only breaks ties within equal `z`. With distinct per-series `z`, a hovered point on a lower series may stay under a higher series' fill. Not observed in manual testing, but worth a look if hover regressions are reported on dense mixed charts.
- **Canvas progressive rendering**: very large series (beyond `progressiveThreshold`) render in incremental layers; per-element `z` ordering within those layers has not been exhaustively verified.
- **Explicit per-series `z` in persisted config** is intentionally overridden — series-list position is now the single source of truth for paint order.

### Manual QA

Note for maintainers: this PR comes from a fork, so the preview environment and e2e CI stages won't run without a maintainer pushing the branch to origin. To QA manually: open a mixed chart with a bar + an area/line series **and a reference line**, reorder the series in the Series tab, and confirm the paint order follows the list order while the reference line stays on top. The same reorder should also work on a SQL-runner mixed chart.

Closes: PROD-9182
Closes: #26029

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ArdgJygNM4nt8RHoSz3Dj
